### PR TITLE
Area link from problem

### DIFF
--- a/conf/general-example
+++ b/conf/general-example
@@ -77,4 +77,7 @@ define('OPTION_ALLOWED_COBRANDS', 'cobrand_one|cobrand_two');
 // How many items are returned in the GeoRSS feeds by default
 define('OPTION_RSS_LIMIT', '20');
 
+// Should problem reports link to the council summary pages?
+define('OPTION_AREA_LINKS_FROM_PROBLEMS', '0');
+
 ?>

--- a/perllib/Page.pm
+++ b/perllib/Page.pm
@@ -588,8 +588,11 @@ sub display_problem_meta_line($$) {
                 $body = join(' and ',
                              map {
                                  my $name = $areas_info->{$_}->{name};
-                                 $q->a({href => "/reports/$name" },
-                                       $name);
+                                 if (mySociety::Config::get('AREA_LINKS_FROM_PROBLEMS')) {
+                                     $q->a({href => "/reports/$name" }, $name);
+                                 } else {
+                                     $name;
+                                 }
                              } @councils);
             }
             $out .= '<small class="council_sent_info">';


### PR DESCRIPTION
Got feedback from one of the council workers who failed to discover the council status pages, and realized that it would be useful if they were linked to directly from the individual problem reports.  This patch implement such change.
