### PR TITLE
Microformat tagging

### DIFF
--- a/perllib/FixMyStreet/Map.pm
+++ b/perllib/FixMyStreet/Map.pm
@@ -64,7 +64,7 @@ sub display_map {
 # http://microformats.org/wiki/geo for the specification
     my ($q, %args) = @_;
     my $mapstr = $map_class->display_map(@_);
-    my $latitude = $args{latittude};
+    my $latitude = $args{latitude};
     my $longitude = $args{longitude};
     $mapstr .= "<div class=\"geo\"><abbr class=\"latitude\" title=\"$latitude\"/><abbr class=\"longitude\" title=\"$longitude\"/></div>\n";
     return $mapstr;

--- a/perllib/FixMyStreet/Map.pm
+++ b/perllib/FixMyStreet/Map.pm
@@ -60,7 +60,14 @@ sub header_js {
 }
 
 sub display_map {
-    return $map_class->display_map(@_);
+# Add geo microformat as part of the map HTML, see
+# http://microformats.org/wiki/geo for the specification
+    my ($q, %args) = @_;
+    my $mapstr = $map_class->display_map(@_);
+    my $latitude = $args{latittude};
+    my $longitude = $args{longitude};
+    $mapstr .= "<div class=\"geo\"><abbr class=\"latitude\" title=\"$latitude\"/><abbr class=\"longitude\" title=\"$longitude\"/></div>\n";
+    return $mapstr;
 }
 
 sub display_map_end {


### PR DESCRIPTION
The microformat specification make it easier for search engines and automatic web page parsers to extract useful information from a web page.  As all FixMyStreet reports are geo located, it seem like a good idea
to make the coordinate available for search engines.  This should allow FixMyStreet reports to show up on Google Maps and Google Earth without any more work done from FixMyStreet.

This branch is a draft testing this approach.  Since a few minutes ago, it is used on www.fiksgatami.no,
to see if the reports show up on Google Maps as soon as Google starts the indexing of the site. :)