### PR TITLE
Force Googe.pm to generate a string version of lat/lon in a known locale

### DIFF
--- a/perllib/FixMyStreet/Geocode/Google.pm
+++ b/perllib/FixMyStreet/Geocode/Google.pm
@@ -75,6 +75,10 @@ sub string {
         my $address = $_->{address};
         next unless $c->cobrand->geocoded_string_check( $address );
         ( $longitude, $latitude ) = @{ $_->{Point}->{coordinates} };
+        mySociety::Locale::in_gb_locale {
+            $longitude = "$longitude";
+            $latitude = "$latitude";
+        };
         push (@$error, { address => $address, latitude => $latitude, longitude => $longitude });
         push (@valid_locations, $_);
     }


### PR DESCRIPTION
Fixes comma/dot problem for Fiksgatami
