### PR TITLE
Oxfordshire location search improvements

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -39,6 +39,7 @@ sub disambiguate_location {
     my $string  = shift;
     return {
         %{ $self->SUPER::disambiguate_location() },
+        town   => 'Oxfordshire',
         centre => '51.765765,-1.322324',
         span   => '0.709058,0.849434',
         bounds => [ 51.459413, -1.719500, 52.168471, -0.870066 ],


### PR DESCRIPTION
In order to fix the search issues @mikejamesthompson raised in #508 I've added a `town` property to Oxfordshire's `disambiguate_location`, I've also fixed the `span` using the data from mapit.

This raises the question of whether `town` is actually the correct name for this parameter, but perhaps that should be a separate question.

Closes #508 
