### PR TITLE
Create link to graphs using current request, not BASE_URL. 

### DIFF
--- a/templates/web/default/admin/index.html
+++ b/templates/web/default/admin/index.html
@@ -29,7 +29,7 @@
 
 [% IF c.cobrand.admin_show_creation_graph -%]
     <p>
-        <a href="[% c.config.BASE_URL %]/fms-live-creation.png">[% loc('Graph of problem creation by status over time') %]</a>
+        <a href="[% c.uri_for("/fms-live-creation.png") %]">[% loc('Graph of problem creation by status over time') %]</a>
     </p>
 [% END -%]
 


### PR DESCRIPTION
Means correct url used on dev server (includes port).

Not sure if using `c.config.BASE_URL` was deliberate though.
