### PR TITLE
[Revised] Updated Google Geocoding from 2.0 to 3.0

### DIFF
--- a/perllib/FixMyStreet/Geocode/Google.pm
+++ b/perllib/FixMyStreet/Geocode/Google.pm
@@ -70,14 +70,14 @@ sub string {
         $latitude = $_->{geometry}->{location}->{lat};
         $longitude = $_->{geometry}->{location}->{lng};
         # These co-ordinates are output as query parameters in a URL, make sure they have a "."
-	mySociety::Locale::in_gb_locale {
+        mySociety::Locale::in_gb_locale {
             push(@$error, {
                 address => $address,
                 latitude => sprintf('%0.6f', $latitude),
-		longitude => sprintf('%0.6f', $longitude)      
-	    });
-	};
-	push (@valid_locations, $_);
+                longitude => sprintf('%0.6f', $longitude)      
+            });
+        };
+        push (@valid_locations, $_);
     }
     return { latitude => $latitude, longitude => $longitude } if scalar @valid_locations == 1;
     return { error => $error };


### PR DESCRIPTION
This is the update following the advice from https://github.com/mysociety/fixmystreet/pull/553#issuecomment-24225567

UK specific Google Geocoding API call is no longer needed (The problem doesn't exist only in UK for the new API). 
Using components=country:COUNTRY_CODE solved the problem, making the API call giving accurate results.
I've added back parts of the original code.

Somehow my unconfigured emacs kept making the spaces in to tabs. (I'm not a frequent perl programmer, so it was not configure). Thanks for telling me :)

API key is no longer needed in the latest API.
