### PR TITLE
[Revised] Updated Google Geocoding from 2.0 to 3.0

### DIFF
--- a/perllib/FixMyStreet/Geocode/Google.pm
+++ b/perllib/FixMyStreet/Geocode/Google.pm
@@ -39,7 +39,7 @@ sub string {
         $url .=  '&components=country:' . $params->{country};
     }
     $url .=  '&language=' . $params->{lang} if $params->{lang};
-    $url .= '&sensor=false' . ;
+    $url .= '&sensor=false';
 
     my $cache_dir = FixMyStreet->config('GEO_CACHE') . 'google/';
     my $cache_file = $cache_dir . md5_hex($url);


### PR DESCRIPTION
This is the update following the advice from https://github.com/mysociety/fixmystreet/pull/553#issuecomment-24225567
UK specific Google Geocoding API call is no longer needed (The problem doesn't exist only in UK for the new API). 
Using components=country:COUNTRY_CODE solved the problem, making the API call giving accurate results.
I've added back parts of the original code.

Somehow my unconfigured emacs kept making the spaces in to tabs. (I'm not a frequent perl programmer, so it was not configure). Thanks for telling me :)

API key is no longer needed in the latest API.

Found out there's a typo in the code after I submitted the pull request just now. That's why I closed the previous one and start a new.
