### PR TITLE
[Zurich] Remove phone number requirement for mobile app reports

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -956,7 +956,11 @@ sub check_for_errors : Private {
         delete $field_errors{name};
         my $report = $c->stash->{report};
         $report->title( Utils::cleanup_text( substr($report->detail, 0, 25) ) );
-        if ( ! $c->req->param('phone') ) {
+
+        # We only want to validate the phone number web requests (where the
+        # service parameter is blank) because previous versions of the mobile
+        # apps don't validate the presence of a phone number.
+        if ( ! $c->req->param('phone') and ! $c->req->param('service') ) {
             $field_errors{phone} = _("This information is required");
         }
     }


### PR DESCRIPTION
The phone number was made mandatory in #541. To make this change
compatible with older versions of the mobile app I've had to drop
server side validation of the phone number for requests that come in
from mobile apps.

To determine if it's a mobile request I'm checking the 'service'
parameter in the request, which is [only set in requests from the mobile
apps](https://github.com/mysociety/zurich_mobile/blob/1fec2bc21dad9326819105cdbf5d47183e7503ba/www/js/models.js#L75).

The phone validation will still happen client side for the newer
versions of the app, and the web app will continue to work with the
server side validations.

Closes mysociety/FixMyStreet-Commercial#427
