### PR TITLE
If only one cobrand given, always use it.

### DIFF
--- a/conf/Vagrantfile.example
+++ b/conf/Vagrantfile.example
@@ -38,14 +38,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     apt-get install -qq -y curl >/dev/null
     curl -s -O https://raw.github.com/mysociety/commonlib/master/bin/install-site.sh
     sh install-site.sh --dev fixmystreet vagrant 127.0.0.1.xip.io
-    # Assume a developer will want to run the tests.
-    # TODO The tests should be further altered to work regardless of
-    # configuration file settings
-    sed -i -r \
-        -e "s,(MAPIT_URL:) '',\\1 'http://mapit.mysociety.org/'," \
-        -e "s,  - cobrand_one,  - barnet\\n  - bromley\\n  - emptyhomes\\n  - fiksgatami\\n  - fixmybarangay\\n  - lichfielddc\\n  - reading\\n  - seesomething\\n  - southampton\\n  - zurich," \
-        -e "s,  - cobrand_two: 'hostname_substring2',  - fixmystreet: '.'," \
-        fixmystreet/conf/general.yml
     # All done
     echo "****************"
     echo "You can now ssh into your vagrant box: vagrant ssh"

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -121,16 +121,28 @@ GEOCODING_DISAMBIGUATION: ''
 MAP_TYPE: 'OSM'
 
 # FixMyStreet uses a templating cobrand system to provide different looks for
-# different installations. If your site was at moon.example.org, and your templates
-# were in the templates/web/moon directory, you would use:
+# different installations. In the common case, if your templates are in the
+# templates/web/moon directory and CSS in web/cobrands/moon, you just specify:
 #   ALLOWED_COBRANDS:
-#     - moon: 'moon.example.org'
+#     - moon
+# If you wish to use multiple cobrands, specify them in a list, optionally with
+# hostname-matching regular expressions if the name of the cobrand is not
+# enough. For example:
+#   ALLOWED_COBRANDS:
+#     - moon
+#     - venus
+# Any hostname with 'moon' in it will use the moon cobrand, any with 'venus'
+# the venus cobrand (any other the Default cobrand). Whereas:
+#   ALLOWED_COBRANDS:
+#     - moon: 'orbital'
+#     - venus
+# Any hostname with 'orbital' in it will use the moon cobrand.
 # This also allows development servers to map to different cobrands if needed,
 # using DNS subdomains for example.
 ALLOWED_COBRANDS:
-  - cobrand_one
-  - cobrand_two: 'hostname_substring2'
-  - cobrand_three
+  - cobrand1
+  - cobrand2: 'hostname_substring2'
+  - cobrand3
 
 # This is only used in "offensive report" emails to provide a link directly to
 # the admin interface. If wanted, set to the full URL of your admin interface.

--- a/perllib/FixMyStreet/Cobrand.pm
+++ b/perllib/FixMyStreet/Cobrand.pm
@@ -8,6 +8,7 @@ use warnings;
 
 use FixMyStreet;
 use Carp;
+use Moose;
 
 use Module::Pluggable
   sub_name    => '_cobrands',
@@ -38,7 +39,10 @@ Simply returns the config variable (so this function can be overridden in test s
 =cut
 
 sub _get_allowed_cobrands {
-    return FixMyStreet->config('ALLOWED_COBRANDS') || [];
+    my $allowed = FixMyStreet->config('ALLOWED_COBRANDS') || [];
+    # If the user has supplied a string, convert to an arrayref
+    $allowed = [ $allowed ] unless ref $allowed;
+    return $allowed;
 }
 
 =head2 available_cobrand_classes
@@ -92,7 +96,14 @@ sub get_class_for_host {
     my $class = shift;
     my $host  = shift;
 
-    foreach my $avail ( $class->available_cobrand_classes ) {
+    my @available = $class->available_cobrand_classes;
+
+    # If only one entry, always use it
+    return class($available[0]) if 1 == @available;
+
+    # If more than one entry, pick first whose regex (or
+    # name by default) matches hostname
+    foreach my $avail ( @available ) {
         return class($avail) if $host =~ /$avail->{host}/;
     }
 

--- a/t/app/controller/questionnaire.t
+++ b/t/app/controller/questionnaire.t
@@ -384,7 +384,7 @@ for my $test (
 }
 
 FixMyStreet::override_config {
-    ALLOWED_COBRANDS => [ 'emptyhomes' ],
+    ALLOWED_COBRANDS => [ 'emptyhomes', 'fixmystreet' ],
 }, sub {
     # EHA extra checking
     ok $mech->host("reportemptyhomes.com"), 'change host to reportemptyhomes';


### PR DESCRIPTION
If the ALLOWED_COBRANDS configuration variable only contains one entry (and also work if it's a string rather than a list), always use that cobrand, no matter what the hostname is.

The example Vagrantfile no longer needs the configuration changes at all.

This fixes #598 by doing what you'd hope it does by default.
