### PR TITLE
Don't display categories for deleted bodies

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -585,7 +585,7 @@ sub setup_categories_and_bodies : Private {
     my $first_area = ( values %$all_areas )[0];
 
     my @bodies = $c->model('DB::Body')->search(
-        { 'body_areas.area_id' => [ keys %$all_areas ] },
+        { 'body_areas.area_id' => [ keys %$all_areas ], deleted => 0 },
         { join => 'body_areas' }
     )->all;
     my %bodies = map { $_->id => $_ } @bodies;

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -1459,6 +1459,24 @@ subtest "test SeeSomething" => sub {
     $bus_contact->delete;
 };
 
+subtest "categories from deleted bodies shouldn't be visible for new reports" => sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ { fixmystreet => '.' } ],
+        MAPIT_URL => 'http://mapit.mysociety.org/',
+    }, sub {
+        $mech->get_ok('/report/new/ajax?latitude=51.89&longitude=-2.09'); # Cheltenham
+        ok $mech->content_contains( $contact3->category );
+
+        # Delete the body which the contact belongs to.
+        $contact3->body->update( { deleted => 1 } );
+
+        $mech->get_ok('/report/new/ajax?latitude=51.89&longitude=-2.09'); # Cheltenham
+        ok $mech->content_lacks( $contact3->category );
+
+        $contact3->body->update( { deleted => 0 } );
+    };
+};
+
 $contact1->delete;
 $contact2->delete;
 $contact3->delete;


### PR DESCRIPTION
When a body has been marked as deleted (currently only exposed in the
Zurich cobrand's admin) the categories for that body should not be
available on the report_new form.

Prior to this change there was an error running the
`zurich-overdue-alert` script, because it wasn't expecting the
`bodies_str` field to have any entries in the format `x|y,z`, this
prevents this problem from happening in the future (though it doesn't
fix any existing entries with this issue).
