### PR TITLE
Simplify .content width/margins.

### DIFF
--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -247,8 +247,6 @@ body.mappage {
   }
   #user-meta {
     max-width: none;
-    left: 0;
-    margin-left: 1em;
   }
 }
 .ie6, .ie7 {
@@ -529,13 +527,13 @@ body.twothirdswidthpage {
 #user-meta{
   display:block;
   position: relative;
-  max-width: 57em;
-  margin:0 auto;
-  left: 1em;
+  max-width: 60em;
+  margin: 0 auto;
   p {
     @include inline-block;
-    position:absolute;
-    top:1em;
+    position: absolute;
+    top: 1em;
+    left: 1em;
     height:2em;
     padding:0.25em 6em 0.5em 0.5em;
     @include box-shadow(rgba(0, 0, 0, 0.6) 0px 0px 4px 1px);
@@ -561,9 +559,8 @@ body.twothirdswidthpage {
   }
 }
 .ie6 #user-meta {
-  width:57em; //ie6 doesn't like max-width
+  width: 60em; //ie6 doesn't like max-width
 }
-
 
 
 // Wraps around #key-tools box - sticks to the bottom of the screen on desktop
@@ -811,8 +808,9 @@ body.frontpage {
   #user-meta {
     z-index:10;
     p {
-      top:-4em;
-      right:0;
+      top: -4em;
+      left: auto;
+      right: 0;
       color:$primary;
       background:none;
       @include box-shadow(rgba(0, 0, 0, 0) 0 0 0);
@@ -857,8 +855,8 @@ body.frontpage {
   margin: 0;
   padding: 1em;
   #front-main-container {
-    max-width: 57em;
-    margin:0 auto;
+    max-width: 60em;
+    margin: 0 auto;
   }
   h2 {
     font-style:normal;


### PR DESCRIPTION
Reduce magic numbers by switching fixed width to a margin elsewhere.
This has the added bonus of making the 'middle-width' .content
have a pleasing right margin.
