### PR TITLE
[Zurich] stats export include 'hidden'

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -693,7 +693,7 @@ sub admin_stats {
 
     if ( $c->req->params->{export} ) {
         my $problems = $c->model('DB::Problem')->search(
-            {%params},
+            {%date_params},
             {
                 columns => [
                     'id',       'created',


### PR DESCRIPTION
Closes https://github.com/mysociety/FixMyStreet-Commercial/issues/461

Again, we just need to substitute the %params line (which elides
hidden reports) for the less restrictive %date_params.

This commit includes very basic tests for the previously untested
?export=1 functionality.
