### PR TITLE
[Zurich] admin template to respect closed_overdue

### DIFF
--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -280,7 +280,11 @@ subtest "report_edit" => sub {
     is ( $report->extra->{closed_overdue},    0, 'Marking hidden from scratch also set closed_overdue' );
     is get_moderated_count(), 1;
 
-    reset_report_state($report);
+    is (FixMyStreet::Cobrand::Zurich->new->get_or_check_overdue($report), 0, 'sanity check');
+    $report->update({ created => $created->clone->subtract(days => 10) });
+    is (FixMyStreet::Cobrand::Zurich->new->get_or_check_overdue($report), 0, 'overdue call not increased');
+
+    reset_report_state($report, $created);
 };
 
 FixMyStreet::override_config {

--- a/templates/web/zurich/admin/problem_row.html
+++ b/templates/web/zurich/admin/problem_row.html
@@ -3,7 +3,7 @@
     <tr[%
         SET classes = [];
         classes.push('adminhidden') IF problem.state == 'hidden';
-        classes.push('overdue') IF c.cobrand.overdue( problem );
+        classes.push('overdue') IF c.cobrand.get_or_check_overdue( problem );
         classes.push('row-link') IF NOT no_edit;
         ' class="' _ classes.join(' ') _ '"' IF classes.size;
     %]>


### PR DESCRIPTION
This value is now cached, but the template calls the function,
calculating it anew, so for old reports (closed within SLA) the
problem_row.html template showed these as overdue.  Instead, we point
the template at a function which first checks the cached value.

(Attempting to roll this functionality into the .overdue() method itself
caused a fair amount of collateral test breakage, and it seems safest to
extract the caching function for now.)

Closes https://github.com/mysociety/FixMyStreet-Commercial/issues/462
