### PR TITLE
[Bromley] Reduce detail field character limit to 1750

### DIFF
--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -389,8 +389,9 @@ sub check_for_errors {
     }
 
     if ( $self->bodies_str && $self->detail ) {
-        if ( $self->bodies_str eq '2482' && length($self->detail) > 2000 ) {
-            $errors{detail} = sprintf( _('Reports are limited to %s characters in length. Please shorten your report'), 2000 );
+        # Barnet Council custom character limit.
+        if ( $self->bodies_str eq '2482' && length($self->detail) > 1750 ) {
+            $errors{detail} = sprintf( _('Reports are limited to %s characters in length. Please shorten your report'), 1750 );
         }
 
         if ( $self->bodies_str eq '2237' && length($self->detail) > 1700 ) {


### PR DESCRIPTION
Anjum from Bromley requested this change:

> Regarding the fault description / update text box length, can it  maximum length be further reduced to 1750 characters? The length of 2000 characters is causing some issues in the underline back office application.
