### PR TITLE
Explanatory text/link on /my with no reports

### DIFF
--- a/perllib/FixMyStreet/App/Controller/My.pm
+++ b/perllib/FixMyStreet/App/Controller/My.pm
@@ -45,6 +45,7 @@ sub my : Path : Args(0) {
     } )->page( $p_page );
 
     while ( my $problem = $rs->next ) {
+        $c->stash->{has_content}++;
         push @$pins, {
             latitude  => $problem->latitude,
             longitude => $problem->longitude,
@@ -64,7 +65,9 @@ sub my : Path : Args(0) {
             order_by => { -desc => 'confirmed' },
             rows => 50
         } )->page( $u_page );
+
     my @updates = $rs->all;
+    $c->stash->{has_content} += scalar @updates;
     $c->stash->{updates} = \@updates;
     $c->stash->{updates_pager} = $rs->pager;
 

--- a/templates/web/default/my/my.html
+++ b/templates/web/default/my/my.html
@@ -13,6 +13,11 @@
 
 <h1>[% loc('Your Reports') %]</h1>
 
+[% IF ! has_content %]
+[% tprintf( loc('You haven&rsquo;t created any reports yet.  <a href="%s">Report a problem now.</a>'),
+    c.uri_for('/') ) %]
+[% END %]
+
 [% INCLUDE 'pagination.html',
     pager = problems_pager,
     param = 'p'

--- a/templates/web/fixmystreet/my/my.html
+++ b/templates/web/fixmystreet/my/my.html
@@ -13,6 +13,11 @@
 
 <h1>[% loc('Your Reports') %]</h1>
 
+[% IF ! has_content %]
+[% tprintf( loc('You haven&rsquo;t created any reports yet.  <a href="%s">Report a problem now.</a>'),
+    c.uri_for('/') ) %]
+[% END %]
+
 [% IF c.cobrand.moniker == 'fixmybarangay' %]
     [% INCLUDE '_barangay_buttons.html' %]
 [% END %]


### PR DESCRIPTION
Usually you won't get to "Your Reports" page without any
content (reports or updates) but it's possible to do so,
as we just discovered in a client meeting, logging into
that page, and arriving on a screen of blank content with
no guidance.  This patch shows some text and a link to
create a new report, if there aren't any problems/updates.

Fixes #671
