### PR TITLE
[Zurich] revert "email templates point to surveys"

### DIFF
--- a/templates/email/zurich/problem-closed.txt
+++ b/templates/email/zurich/problem-closed.txt
@@ -15,8 +15,6 @@ Ihre Meldung lautet:
 [% problem.detail %]
 
 
-Haben Sie schon an der Umfrage zu <<Züe neu>> (Dauer: 1 min.) teilgenommen?
-	https://www.zueriwieneu.ch/umfrage
 
 Freundliche Grüsse
 

--- a/templates/email/zurich/problem-external.txt
+++ b/templates/email/zurich/problem-external.txt
@@ -15,8 +15,6 @@ Ihre Meldung lautet:
 [% problem.detail %]
 
 
-Haben Sie schon an der Umfrage zu <<Züe neu>> (Dauer: 1 min.) teilgenommen?
-	https://www.zueriwieneu.ch/umfrage
 
 Freundliche Grüsse
 


### PR DESCRIPTION
This reverts commit 5cd2ed3be27629842d7ae072c2b4c9a86c020d52.

as per Tobias's instructions today.
