### PR TITLE
Mock a date for dashboard tests

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -106,6 +106,7 @@ requires 'Sort::Key';
 requires 'Sub::Override';
 requires 'Test::Exception';
 requires 'Test::LongString';
+requires 'Test::MockTime';
 requires 'Test::More', '0.88';
 requires 'Test::Warn';
 requires 'Test::WWW::Mechanize::Catalyst';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -5404,6 +5404,15 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 6.03
       Test::More 0
+  Test-MockTime-0.12
+    pathname: D/DD/DDICK/Test-MockTime-0.12.tar.gz
+    provides:
+      Test::MockTime 0.12
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test::More 0
+      Time::Local 0
+      Time::Piece 1.08
   Test-NoWarnings-1.04
     pathname: A/AD/ADAMK/Test-NoWarnings-1.04.tar.gz
     provides:

--- a/t/app/controller/dashboard.t
+++ b/t/app/controller/dashboard.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Test::MockTime ':all';
 
 use FixMyStreet::TestMech;
 use Web::Scraper;
@@ -24,6 +25,9 @@ my $p_user = FixMyStreet::App->model('DB::User')->find_or_create( {
     email => 'p_user@example.com'
 } );
 
+# Dashboard tests assume we are not too early in year, to allow reporting
+# within same year, as a convenience.
+set_absolute_time('2014-03-01T12:00:00');
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ { fixmystreet => '.' } ],
     MAPIT_URL => 'http://mapit.mysociety.org/',
@@ -610,7 +614,7 @@ FixMyStreet::override_config {
         is scalar @lines, 6, '1 (header) + 5 (reports) = 6 lines';
     };
 };
-
+restore_time;
 
 sub make_problem {
     my $args = shift;


### PR DESCRIPTION
Fixes #365 (how appropriate) by mocking datetime to allow the
dashboard test's assumptions (that we're not so near beginning
of year that a report from X days ago isn't still in same year)
to hold.

The mocking lets us bypass @struan's suggestion to rethink how the tests work -- on reflection, I think this is a Good Thing (e.g. we're just using test mocking to make sure that the current assumptions hold.)

NB: Tested this fix by `sudo date -s` on my vagrant box (with some config to make sure virtualbox doesn't "helpfully" sync the date to host's) to verify failure, and rerunning with the mocked version. e.g. there's no automated test for the test.
