### PR TITLE
[Bromley] disambiguation for Beckenham

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -48,6 +48,19 @@ sub disambiguate_location {
 
     $town = '' if $string =~ /orpington/i;
 
+    # If "Beckenhham" (but NOT "Beckenham Road") passed, then set town to BR3
+    # We do this with "Bromley Road" too, which is within Beckenham.
+    # We do this with the Knoll too, avoiding Bing geocoding bug which prefers
+    # "Knole, Sevenoaks"...
+    # In addition, Bromley Road
+    if (
+        $string =~ /beckenham\s+(?!road|rd)/i  # ?! lookahead NOT followed by Road
+        or $string =~/\bknoll\b/i
+        or $string =~/bromley\s+(?:road|rd)/i  # IS followed by Road
+    ) {
+        $town = 'BR3';
+    }
+
     return {
         %{ $self->SUPER::disambiguate_location() },
         town => $town,


### PR DESCRIPTION
Also disambiguate "The Knoll" as we know that this will otherwise
resolve to "The Knole, Sevenoaks".

Fixes https://github.com/mysociety/FixMyStreet-Commercial/issues/495