### PR TITLE
Fix cron email errors on See Something Say Something

### DIFF
--- a/perllib/FixMyStreet/DB/ResultSet/Problem.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Problem.pm
@@ -348,6 +348,8 @@ sub send_reports {
 
             if ( $row->subcategory ) {
                 $h{subcategory_line} = sprintf(_("Subcategory: %s"), $row->subcategory) . "\n\n";
+            } else {
+                $h{subcategory_line} = "\n\n";
             }
 
             $h{councils_name} = join(_(' and '), @dear);


### PR DESCRIPTION
The centro FMS breaks when sending emails for reports without a subcategory
because the template expects it. @struan suggested I fix this in this way.

Closes: https://github.com/mysociety/FixMyStreet-Commercial/issues/503
