### PR TITLE
Add MAPIT_GENERATION variable, to pin whitelist.

### DIFF
--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -74,9 +74,12 @@ MAPIT_TYPES: [ 'ZZZ' ]
 
 # If you are using global MapIt, you might want to restrict FixMyStreet usage
 # to only one or more areas, rather than all O04, for example. Provide MapIt
-# IDs here in a list that FixMyStreet should recognise.
+# IDs here in a list that FixMyStreet should recognise, along with the MapIt
+# generation those IDs are in.
 #   MAPIT_ID_WHITELIST: [ 240838, 246176, 246733 ]
+#   MAPIT_GENERATION: 2
 MAPIT_ID_WHITELIST: []
+MAPIT_GENERATION: 0
 
 # If your MapIt has the concept of council wards (subareas of councils, where
 # people can sign up for alerts, but not report things), then you can give the

--- a/perllib/FixMyStreet/App/Controller/Council.pm
+++ b/perllib/FixMyStreet/App/Controller/Council.pm
@@ -53,10 +53,16 @@ sub load_and_check_areas : Private {
     my $short_longitude = Utils::truncate_coordinate($longitude);
 
     my $all_areas;
+
+    my %params;
+    $params{generation} = $c->config->{MAPIT_GENERATION}
+        if $c->config->{MAPIT_GENERATION};
+
     if ( $c->stash->{fetch_all_areas} ) {
         my %area_types = map { $_ => 1 } @$area_types;
         $all_areas =
-          mySociety::MaPit::call( 'point', "4326/$short_longitude,$short_latitude" );
+          mySociety::MaPit::call( 'point',
+            "4326/$short_longitude,$short_latitude", %params );
         $c->stash->{all_areas_mapit} = $all_areas;
         $all_areas = {
             map { $_ => $all_areas->{$_} }
@@ -65,7 +71,8 @@ sub load_and_check_areas : Private {
         };
     } else {
         $all_areas =
-          mySociety::MaPit::call( 'point', "4326/$short_longitude,$short_latitude",
+          mySociety::MaPit::call( 'point',
+            "4326/$short_longitude,$short_latitude", %params,
             type => $area_types );
     }
     if ($all_areas->{error}) {


### PR DESCRIPTION
Otherwise, when MapIt Global is updated, the 'point' lookup, as it only
returns the current generation by default, might no longer return the
areas present in the whitelist.
