### PR TITLE
Link through from all reports page to sub categories

### DIFF
--- a/perllib/FixMyStreet/DB/Result/Body.pm
+++ b/perllib/FixMyStreet/DB/Result/Body.pm
@@ -98,9 +98,9 @@ __PACKAGE__->has_many(
 # DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:hTOxxiiHmC8nmQK/p8dXhQ
 
 sub url {
-    my ( $self, $c ) = @_;
+    my ( $self, $c, $args ) = @_;
     # XXX $areas_info was used here for Norway parent - needs body parents, I guess
-    return $c->uri_for( '/reports/' . $c->cobrand->short_name( $self ) );
+    return $c->uri_for( '/reports/' . $c->cobrand->short_name( $self ), $args || {} );
 }
 
 sub areas {

--- a/templates/web/default/reports/index.html
+++ b/templates/web/default/reports/index.html
@@ -28,11 +28,11 @@
 [%- ELSIF ! (loop.count % 2) %] class="a"
 [%- END %]>
 <td class="title"><a href="[% body.url(c) %]">[% body.name %]</a></td>
-<td class="data">[% open.${body.id}.new or 0 %]</td>
-<td class="data">[% open.${body.id}.older or 0 %]</td>
-<td class="data">[% open.${body.id}.unknown or 0 %]</td>
-<td class="data">[% fixed.${body.id}.new or 0 %]</td>
-<td class="data">[% fixed.${body.id}.old or 0 %]</td>
+<td class="data">[% IF open.${body.id}.new %]<a href="[% body.url(c, { t => 'new' }) %]">[% open.${body.id}.new %]</a>[% ELSE %]0[% END %]</td>
+<td class="data">[% IF open.${body.id}.older %]<a href="[% body.url(c, { t => 'older' }) %]">[% open.${body.id}.older %]</a>[% ELSE %]0[% END %]</td>
+<td class="data">[% IF open.${body.id}.unknown %]<a href="[% body.url(c, { t => 'unknown' }) %]">[% open.${body.id}.unknown %]</a>[% ELSE %]0[% END %]</td>
+<td class="data">[% IF fixed.${body.id}.new %]<a href="[% body.url(c, { t => 'fixed' }) %]">[% fixed.${body.id}.new %]</a>[% ELSE %]0[% END %]</td>
+<td class="data">[% IF fixed.${body.id}.old %]<a href="[% body.url(c, { t => 'older_fixed' }) %]">[% fixed.${body.id}.old %]</a>[% ELSE %]0[% END %]</td>
 </tr>
 [% TRY %][% PROCESS "reports/_extras.html" %][% CATCH file %][% END %]
 [% END %]


### PR DESCRIPTION
Add a type parameter to the /reports/body page to restrict list by
problem category.
Only link to report categories that have entries.

Fixes #798
