### PR TITLE
Better spotting of signing in on /auth form.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Auth.pm
+++ b/perllib/FixMyStreet/App/Controller/Auth.pm
@@ -37,8 +37,10 @@ sub general : Path : Args(0) {
     return unless $req->method eq 'POST';
 
     # decide which action to take
-    $c->detach('email_sign_in') if $req->param('email_sign_in')
-        || $c->req->param('name') || $c->req->param('password_register');
+    my $has_password = $req->param('sign_in') || $req->param('password_sign_in');
+    my $has_email = $req->param('email_sign_in') || $req->param('name') || $req->param('password_register');
+
+    $c->detach('email_sign_in') if $has_email && !$has_password;
 
        $c->forward( 'sign_in' )
     && $c->detach( 'redirect_on_signin', [ $req->param('r') ] );

--- a/t/app/controller/auth.t
+++ b/t/app/controller/auth.t
@@ -213,10 +213,28 @@ $mech->submit_form_ok(
         },
         button => 'sign_in',
     },
-    "sign in with '$test_email' & '$test_password"
+    "sign in with '$test_email' & 'not the password'"
 );
 is $mech->uri->path, '/auth', "redirected to correct page";
 $mech->content_contains( 'problem with your email/password combination', 'found error message' );
+
+subtest "sign in but have email form autofilled" => sub {
+    $mech->get_ok('/auth');
+    $mech->submit_form_ok(
+        {
+            form_name => 'general_auth',
+            fields    => {
+                email    => $test_email,
+                password_sign_in => $test_password,
+                name => 'Auto-completed from elsewhere',
+            },
+            button => 'sign_in',
+        },
+        "sign in with '$test_email' and auto-completed name"
+    );
+    is $mech->uri->path, '/my', "redirected to correct page";
+};
+
 
 # more test:
 # TODO: test that email are always lowercased


### PR DESCRIPTION
If your browser autocompleted form fields, you could fill in the signing
in part of the form but still be sent a confirmation email.  This commit
will now default to trying to sign in if the sign in button is clicked
or there is data in the signing in password field.

Fixes #816.
