### PR TITLE
Bromley. signature and FAQ tweaks

### DIFF
--- a/templates/email/bromley/signature.txt
+++ b/templates/email/bromley/signature.txt
@@ -1,3 +1,3 @@
 Customer Service Centre  
 London Borough of Bromley  
-Email: csc@bromley.gov.uk
+https://fix.bromley.gov.uk/faq

--- a/templates/web/bromley/faq/faq-en-gb.html
+++ b/templates/web/bromley/faq/faq-en-gb.html
@@ -28,6 +28,11 @@
 
     </dd>
 
+    <dt> What do I do if I'm having problems logging a report or using FixMyStreet?</dt>
+    <dd> If you encounter issues in logging your report you can email Bromley
+    at <a href="mailto:csc@bromley.gov.uk">csc@bromley.gov.uk</a> and we will
+    look into any problems you may have experienced.</dd>
+
     <dt><a name="emergencies"></a>Reporting emergencies (out of hours)</dt>
     <dd>
     <p>Please do not report problems which present an immediate risk to life, for example missing manhole covers or a fallen lamp column.</p>
@@ -35,20 +40,23 @@
 
     </dd>
 
-        <dt>How do I report a problem here?</dt>
-        <dd>After entering a postcode or location, you are shown
+    <dt>How do I report a problem here?</dt>
+    <dd>After entering a postcode or location, you are shown
 a map of that area. You can view problems already reported in that area,
 or report ones of your own by clicking on the map at the location of
 the problem.</dd>
-        <dt>How are the problems solved?</dt>
-        <dd>They are reported directly to us so we can then resolve the problem.
-        You can also discuss the problem on the website with others if you wish.</dd>
+    <dt>How are the problems solved?</dt>
+    <dd>They are reported directly to us so we can then resolve the problem.
+    You can also discuss the problem on the website with others if you wish.</dd>
 
-        <dt>Do you remove silly or illegal content?</dt>
-        <dd>Bromley Council and FixMyStreet are not responsible for the content and accuracy
-of material submitted by its users. We reserve the right to edit or remove any
-problems or updates which we consider to be inappropriate upon being informed
-by a user of the site.</dd>
+    <dt>Do you remove or redact content?</dt>
+    <dd> Bromley Council and FixMyStreet are not responsible for the
+    content and accuracy of material submitted by its users, however we
+    reserve the right to edit or remove any problems or updates which we
+    consider to be inappropriate. Reports or comments deemed sensitive,
+    personal, political, libellous or contentious in nature may be edited
+    or removed from the site.
+    </dd>
 
     <dt>Can I use FixMyStreet on my mobile?</dt>
     <dd>Yes a special mobile friendly version is available to report problem in Bromley’s streets or parks.


### PR DESCRIPTION
As per mysociety/FixMyStreet-Commercial#524 to stem the flow of
people responding to verification emails by clicking the support
email at the bottom of Bromley's signature, we are instead redirecting
to the FAQ -- which is also updated to contain the support email
address, so the people can still find a contact if they need to.

Also tweaking moderation FAQ line, in preparation for moderation
trial.
