### PR TITLE
Gracefully handle error on prettify_dt

### DIFF
--- a/perllib/Utils.pm
+++ b/perllib/Utils.pm
@@ -225,6 +225,11 @@ sub cleanup_text {
 
 sub prettify_dt {
     my ( $dt, $type ) = @_;
+
+    return '' unless $dt; 
+        # this is plastering over crack but it's not correct for this utility
+        # sub to be dying here.  Perhaps better would be croak for more info?
+
     $type ||= '';
     $type = 'short' if $type eq '1';
 


### PR DESCRIPTION
prettify_dt now returns the empty string '' if we try to call it
on a non date.

This situation occasionally happens on development DB.

NOTE: I'm not certain this is the correct behaviour.  Might be better to `croak` or confess here, to get more diagnostics?  (Either way, _some_ code is needed here, to avoid simply dying with a confusing error in perllib/Utils.pm)  What do you think?
