### PR TITLE
[Bromley] disambiguation for White Horse Hill

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -19,10 +19,17 @@ sub disambiguate_location {
     my $string  = shift;
 
     my $town = 'Bromley';
+
     # Bing turns High St Bromley into Bromley High St which is in 
     # Bromley by Bow.
     $town .= ', BR1' if $string =~ /^high\s+st(reet)?$/i;
+
+    # White Horse Hill is on boundary with Greenwich, so need a 
+    # specific postcode
+    $town = 'chislehurst, BR7 6DH' if $string =~ /^white\s+horse/i;
+
     $town = '' if $string =~ /orpington/i;
+
     return {
         %{ $self->SUPER::disambiguate_location() },
         town => $town,


### PR DESCRIPTION
This street is on boundary of Bromley with Greenwich, so a simple
disambiguation of $town = "chislehurst" falls foul of UKCouncils->
area_check.

It may be worth overriding area_check in general, but in mean time,
setting a specific postcode (on the Bromley side of the administrative
boundary) allows the map to be seen.
