### PR TITLE
Tweak summary output on bodies page.

### DIFF
--- a/templates/web/base/admin/bodies.html
+++ b/templates/web/base/admin/bodies.html
@@ -17,14 +17,15 @@
         [% IF c.cobrand.moniker == 'zurich' %]
           <th>[% loc('Email') %]</th>
         [% ELSE %]
-          <th>[% loc('Category') %]</th>
+          <th>[% loc('Summary') %]</th>
         [% END %]
           <th>[% loc('Deleted') %]</th>
       </tr>
   [%- FOREACH body IN bodies %]
       [%- SET id = body.id %]
       [% NEXT IF c.cobrand.moniker == 'zurich' AND admin_type == 'dm' AND (body.parent OR body.bodies) %]
-      <tr[% IF body.deleted %] class="adminhidden"[% END %]>
+      <tr[% IF body.deleted %] class="adminhidden"[% END %]
+        [% IF NOT counts.$id OR counts.$id.deleted == counts.$id.c %] class="is-deleted"[% END %]>
           <td>
             [% IF c.cobrand.moniker == 'zurich' %]
               [% FILTER repeat(4*body.api_key) %]&nbsp;[% END %]
@@ -43,14 +44,17 @@
       [% ELSE %]
           <td>
           [% IF counts.$id %]
-              [% tprintf( loc('%d addresses'), counts.$id.c) IF c.cobrand.moniker != 'emptyhomes' %]
-              [% IF counts.$id.deleted %]
-                  (1+ deleted)
-              [% ELSIF counts.$id.confirmed != counts.$id.c %]
-                  (some unconfirmed)
+              [% tprintf( nget('%d address', '%d addresses', counts.$id.c), counts.$id.c) %]
+              [% IF counts.$id.deleted == counts.$id.c %]
+                  (all deleted; reports will not be sent)
+              [% ELSIF counts.$id.deleted %]
+                  ([% counts.$id.deleted %] deleted)
+              [% END %]
+              [% IF counts.$id.confirmed != counts.$id.c %]
+                  ([% counts.$id.c-counts.$id.confirmed %] unconfirmed)
               [% END %]
           [% ELSE %]
-              no categories
+              No categories, reports will not be sent
           [% END %]
           </td>
       [% END %]


### PR DESCRIPTION
Show more detail of unconfirmed/deleted categories; highlight and warn
if no categories, or if all categories are deleted. Fixes #516.
