### PR TITLE
UK. Generic problems_clause for two-tier councils

### DIFF
--- a/perllib/FixMyStreet/Cobrand/EastSussex.pm
+++ b/perllib/FixMyStreet/Cobrand/EastSussex.pm
@@ -10,14 +10,6 @@ sub council_name { return 'East Sussex County Council'; }
 sub council_url { return 'eastsussex'; }
 sub is_two_tier { return 1; }
 
-# Different to councils parent due to this being a two-tier council.
-# This is now specialised for Hart, Oxfordshire, ESCC, and should
-# be genericised in the parent...
-# see https://github.com/mysociety/FixMyStreet-Commercial/issues/603
-sub problems_clause {
-    return { bodies_str => { like => '%2224%' } };
-}
-
 sub path_to_web_templates {
     my $self = shift;
     return [

--- a/perllib/FixMyStreet/Cobrand/Hart.pm
+++ b/perllib/FixMyStreet/Cobrand/Hart.pm
@@ -10,12 +10,6 @@ sub council_name { return 'Hart Council'; }
 sub council_url { return 'hart'; }
 sub is_two_tier { return 1; }
 
-# Different to councils parent due to this being a two-tier council. If we get
-# more, this can be genericised in the parent.
-sub problems_clause {
-    return { bodies_str => { like => '%2333%' } };
-}
-
 sub disambiguate_location {
     my $self    = shift;
     my $string  = shift;

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -15,12 +15,6 @@ sub base_url {
     return 'http://fixmystreet.oxfordshire.gov.uk';
 }
 
-# Different to councils parent due to this being a two-tier council. If we get
-# more, this can be genericised in the parent.
-sub problems_clause {
-    return { bodies_str => { like => '%2237%' } };
-}
-
 sub enter_postcode_text {
     my ($self) = @_;
     return 'Enter an Oxfordshire postcode, or street name and area';

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -27,7 +27,15 @@ sub restriction {
 # Different function to site_restriction due to two-tier use
 sub problems_clause {
     my $self = shift;
-    return { bodies_str => sprintf('%d', $self->council_id) };
+
+    if ($self->is_two_tier) {
+        return { bodies_str => {
+            like => ('%' . $self->council_id . '%')
+        }};
+    }
+    else {
+        return { bodies_str => sprintf('%d', $self->council_id) };
+    }
 }
 
 sub problems {

--- a/t/cobrand/two_tier.t
+++ b/t/cobrand/two_tier.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use Test::More;
+
+use FixMyStreet;
+use FixMyStreet::Cobrand;
+
+my @cobrands = (
+    [ hart => '%2333%' ],
+    [ oxfordshire => '%2237%' ],
+    [ eastsussex  => '%2224%' ],
+    [ stevenage   => '%2347%' ],
+);
+
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => [ map $_->[0], @cobrands ],
+}, sub {
+
+    for my $c (@cobrands) {
+        my ($m, $like) = @$c;
+        my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker($m);
+        my $problems_clause = $cobrand->problems_clause;
+        is_deeply $problems_clause,
+            { bodies_str => { like => $like } }, "problems_clause for $m";
+    }
+};
+
+done_testing;


### PR DESCRIPTION
Replace copy-pasted problems_cause declarations in Hart,
Oxfordshire, and East Sussex with a generic override in
UKCouncils.pm

After https://github.com/mysociety/FixMyStreet-Commercial/issues/603 I applied a basic patch to East Sussex with copy/pasted code.  This patch makes this generic, now that 3 separate UK councils have this issue.
