### PR TITLE
Fix bug in sending of reports to bodies not passing in cobrand

### DIFF
--- a/perllib/FixMyStreet/SendReport/Email.pm
+++ b/perllib/FixMyStreet/SendReport/Email.pm
@@ -89,6 +89,7 @@ sub send {
     }
 
     my ($verbose, $nomail) = CronFns::options();
+    my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker($row->cobrand)->new();
     my $result = FixMyStreet::App->send_email_cron(
         {
             _template_ => $self->get_template( $row ),
@@ -98,7 +99,8 @@ sub send {
         },
         mySociety::Config::get('CONTACT_EMAIL'),
         \@recips,
-        $nomail
+        $nomail,
+        $cobrand
     );
 
     if ( $result == mySociety::EmailUtil::EMAIL_SUCCESS ) {


### PR DESCRIPTION
`send_email_cron` accepts a cobrand parameter which it then uses to find the
right templates for emails sent to bodies. SendReport/Email.pm didn't pass
this in, so the signature always used the default cobrand's wording. This
PR fixes that so that the row's cobrand is used instead and the emails don't
say "From the FixMyStreet Team" at the bottom.

Closes mysociety/FixMyStreet-Commercial#621
