### PR TITLE
[Zurich] Show "new category" errors in admin.

### DIFF
--- a/templates/web/zurich/admin/body.html
+++ b/templates/web/zurich/admin/body.html
@@ -2,12 +2,13 @@
 [% PROCESS 'admin/report_blocks.html' %]
 
 [% IF updated %]
-<p>
-<em>[% updated %]</em>
-</p>
+  <p>
+    <em>[% updated %]</em>
+  </p>
 [% END %]
 
 [% IF admin_type == 'super' AND body.parent AND NOT body.parent.parent # A division %]
+  [% IF NOT errors %]
     <table cellspacing="0" cellpadding="2" border="1">
         <tr>
             <th>[% loc('Category') %]</th>
@@ -16,29 +17,34 @@
             <th>[% loc('Note') %]</th>
             <th>[% loc('When edited') %]</th>
         </tr>
-        [% WHILE ( contact = contacts.next ) %]
-            <tr>
-                <td><a href="[% c.uri_for( 'body_edit', body_id, contact.category ) %]">[% contact.category %]</a></td>
-                <td>[% contact.email | html %]</td>
-                <td>[% contact.editor %]</td>
-                <td>[% contact.note | html %]</td>
-                <td>[% PROCESS format_date this_date=contact.whenedited %]</td>
+        [% WHILE ( cat = contacts.next ) %]
+            <tr[% IF cat.deleted %] class="is-deleted"[% END %]>
+                <td><a href="[% c.uri_for( 'body_edit', body_id, cat.category ) %]">[% cat.category %]</a></td>
+                <td>[% cat.email | html %]</td>
+                <td>[% cat.editor %]</td>
+                <td>[% cat.note | html %]</td>
+                <td>[% PROCESS format_date this_date=cat.whenedited %]</td>
             </tr>
         [% END %]
     </table>
 
     <h2>[% loc('Add new category') %]</h2>
+  [% END %][%# Only show all the above if no errors with below form %]
+
+  [% IF errors %]
+    <div class="fms-admin-warning">
+        [% errors.values.join('<br>') %]
+    </div>
+  [% END %]
 
     <form method="post" action="[% c.uri_for('body', body_id ) %]" enctype="application/x-www-form-urlencoded" accept-charset="utf-8">
 
-        [% IF c.cobrand.moniker != 'emptyhomes' %]
         <p>
-        <strong>[% loc('Category:') %] </strong><input type="text" name="category" size="30">
+          <strong>[% loc('Category:') %] </strong><input type="text" name="category" size="30" value="[% contact.category | html %]">
         </p>
-        [% END %]
 
         <p>
-        <strong>[% loc('Email:') %] </strong><input type="text" name="email" size="30">
+        <strong>[% loc('Email:') %] </strong><input type="text" name="email" size="30" value="[% contact.email | html %]">
         </p>
 
         <input type="hidden" name="confirmed" value="1" id="confirmed"> 
@@ -50,7 +56,7 @@
         <p>
         <input type="hidden" name="posted" value="new" >
         <input type="hidden" name="token" value="[% token %]" >
-        <input type="submit" name="Create category" value="[% loc('Create category') %]" >
+        <input type="submit" name="Create category" value="[% errors ? loc('Save changes') : loc('Create category') %]">
         </p>
 
         <div>
@@ -61,7 +67,9 @@
 
 [% END %]
 
+[% IF NOT errors %]
     <h2>[% loc('Edit body details') %]</h2>
     [% INCLUDE 'admin/body-form.html' %]
+[% END %]
 
 [% INCLUDE 'admin/footer.html' %]


### PR DESCRIPTION
Error handling and changes to the base template were added in f0621930,
so an error would cause the form to reshow in the cobrand, but not
display the errors.
