### PR TITLE
Fix js-disabled submission in Chrome/Firefox

### DIFF
--- a/templates/web/base/around/display_location.html
+++ b/templates/web/base/around/display_location.html
@@ -39,7 +39,7 @@
 %]
 
 [% IF allow_creation %]
-<form action="[% c.uri_for('/report/new') %]" method="post" name="mapForm" id="mapForm" enctype="multipart/form-data" class="validate">
+<form action="[% c.uri_for('/report/new') %]" method="post" name="mapForm" id="mapForm" enctype="multipart/form-data" class="validate" novalidate="novalidate">
     [% IF c.req.params.map_override %]
         <input type="hidden" name="map_override" value="[% c.req.params.map_override | html %]">
     [% END %]

--- a/templates/web/seesomething/around/display_location.html
+++ b/templates/web/seesomething/around/display_location.html
@@ -19,7 +19,7 @@
 
 %]
 
-<form action="[% c.uri_for('/report/new') %]" method="post" name="mapForm" id="mapForm" enctype="multipart/form-data" class="validate">
+<form action="[% c.uri_for('/report/new') %]" method="post" name="mapForm" id="mapForm" enctype="multipart/form-data" class="validate" novalidate="novalidate">
     [% IF c.req.params.map_override %]
         <input type="hidden" name="map_override" value="[% c.req.params.map_override | html %]">
     [% END %]

--- a/web/js/fixmystreet.js
+++ b/web/js/fixmystreet.js
@@ -203,6 +203,10 @@ $(function(){
         });
     });
 
+    // Map form doesn't work in some browsers with HTML5 validation and hidden form, so
+    // we disable validation by default, and add it in the JS case.
+    // For some reason, the removeAttr doesn't work if we place it at beginning.
+    $('#mapForm').removeAttr('novalidate').attr({ validate: 'validate' });
 });
 
 })(jQuery);


### PR DESCRIPTION
NOTE: I've tested in Firefox (works with/without javascript) but couldn't test in Chrome, due to browser bug whereby I can't reliably disable javascript -- please test if you can!

Fixes #932, which is caused by HTML5 validation firing for hidden
elements.

Sets #mapForm to novalidate by default, and reverts this in
fixmystreet.js.

(Note that the attributes 'validate' and 'novalidate', which are
honoured by the browsers' HTML5 validation) aren't to be confused with
the class (class="validate") which is presumably only picked up by
javascript, and therefore not problematic for the no-js case.
