### PR TITLE
for ESCC, use Dynamics-friendly format for location

### DIFF
--- a/perllib/FixMyStreet/DB/ResultSet/Problem.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Problem.pm
@@ -303,10 +303,14 @@ sub send_reports {
             ( $h{easting}, $h{northing} ) = Utils::convert_latlon_to_en( $h{latitude}, $h{longitude} );
 
             # email templates don't have conditionals so we need to farmat this here
-            $h{easting_northing}                             #
+            if ($row->bodies_str =~ /\b2224\b/) { # East Sussex County Council
+              # East Sussex's Dynamics: convenient to cut-and-past with a slash
+              $h{easting_northing} = "Easting/Northing: $h{easting}/$h{northing}\n\n";
+            } else {
+              $h{easting_northing}                             #
               = "Easting: $h{easting}\n\n"                   #
               . "Northing: $h{northing}\n\n";
-
+            }
         }
 
         if ( $row->used_map ) {


### PR DESCRIPTION
Potentially close #997... but maybe this shouldn't just be ESCC?

Not sure about selecting the council here: not only do I not know if this is really the best way to do it, but should this be conditional at all since it may benefit anyone else using Dynamics without back-end integration? Does it break anything to either add it as a third line of easting/northing info?