### PR TITLE
Make sure all co-ordinates are stringified.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Alert.pm
+++ b/perllib/FixMyStreet/App/Controller/Alert.pm
@@ -441,11 +441,6 @@ sub determine_location : Private {
         $c->go('index');
     }
 
-    # truncate the lat,lon for nicer urls
-    ( $c->stash->{latitude}, $c->stash->{longitude} ) =
-      map { Utils::truncate_coordinate($_) }
-      ( $c->stash->{latitude}, $c->stash->{longitude} );
-
     my $dist =
       mySociety::Gaze::get_radius_containing_population( $c->stash->{latitude},
         $c->stash->{longitude}, 200000 );

--- a/perllib/FixMyStreet/App/Controller/Council.pm
+++ b/perllib/FixMyStreet/App/Controller/Council.pm
@@ -49,9 +49,6 @@ sub load_and_check_areas : Private {
         $area_types = $c->cobrand->area_types;
     }
 
-    my $short_latitude  = Utils::truncate_coordinate($latitude);
-    my $short_longitude = Utils::truncate_coordinate($longitude);
-
     my $all_areas;
 
     my %params;
@@ -62,7 +59,7 @@ sub load_and_check_areas : Private {
         my %area_types = map { $_ => 1 } @$area_types;
         $all_areas =
           mySociety::MaPit::call( 'point',
-            "4326/$short_longitude,$short_latitude", %params );
+            "4326/$longitude,$latitude", %params );
         $c->stash->{all_areas_mapit} = $all_areas;
         $all_areas = {
             map { $_ => $all_areas->{$_} }
@@ -72,7 +69,7 @@ sub load_and_check_areas : Private {
     } else {
         $all_areas =
           mySociety::MaPit::call( 'point',
-            "4326/$short_longitude,$short_latitude", %params,
+            "4326/$longitude,$latitude", %params,
             type => $area_types );
     }
     if ($all_areas->{error}) {

--- a/perllib/FixMyStreet/App/Controller/Questionnaire.pm
+++ b/perllib/FixMyStreet/App/Controller/Questionnaire.pm
@@ -279,10 +279,6 @@ sub display : Private {
 
     my $problem = $c->stash->{questionnaire}->problem;
 
-    ( $c->stash->{short_latitude}, $c->stash->{short_longitude} ) =
-      map { Utils::truncate_coordinate($_) }
-      ( $problem->latitude, $problem->longitude );
-
     $c->stash->{updates} = [ $c->model('DB::Comment')->search(
         { problem_id => $problem->id, state => 'confirmed' },
         { order_by => 'confirmed' }

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -159,7 +159,7 @@ sub format_problem_for_display : Private {
 
     my $problem = $c->stash->{problem};
 
-    ( $c->stash->{short_latitude}, $c->stash->{short_longitude} ) =
+    ( $c->stash->{latitude}, $c->stash->{longitude} ) =
       map { Utils::truncate_coordinate($_) }
       ( $problem->latitude, $problem->longitude );
 

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -540,8 +540,8 @@ sub determine_location_from_tile_click : Private {
     );
 
     # store it on the stash
-    $c->stash->{latitude}  = $latitude;
-    $c->stash->{longitude} = $longitude;
+    ($c->stash->{latitude}, $c->stash->{longitude}) =
+        map { Utils::truncate_coordinate($_) } ($latitude, $longitude);
 
     # set a flag so that the form is not considered submitted. This will prevent
     # errors showing on the fields.
@@ -1089,10 +1089,6 @@ sub generate_map : Private {
     my ( $self, $c ) = @_;
     my $latitude  = $c->stash->{latitude};
     my $longitude = $c->stash->{longitude};
-
-    ( $c->stash->{short_latitude}, $c->stash->{short_longitude} ) =
-      map { Utils::truncate_coordinate($_) }
-      ( $c->stash->{latitude}, $c->stash->{longitude} );
 
     # Don't do anything if the user skipped the map
     if ( $c->stash->{report}->used_map ) {

--- a/perllib/FixMyStreet/Geocode.pm
+++ b/perllib/FixMyStreet/Geocode.pm
@@ -12,6 +12,7 @@ use FixMyStreet::Geocode::Bing;
 use FixMyStreet::Geocode::Google;
 use FixMyStreet::Geocode::OSM;
 use FixMyStreet::Geocode::Zurich;
+use Utils;
 
 # lookup STRING CONTEXT
 # Given a user-inputted string, try and convert it into co-ordinates using either
@@ -21,6 +22,11 @@ use FixMyStreet::Geocode::Zurich;
 sub lookup {
     my ($s, $c) = @_;
     my $data = $c->cobrand->geocode_postcode($s);
+    if (defined $data->{latitude}) {
+        ( $data->{latitude}, $data->{longitude} ) =
+            map { Utils::truncate_coordinate($_) }
+            ( $data->{latitude}, $data->{longitude} );
+    }
     $data = string($s, $c)
         unless $data->{error} || defined $data->{latitude};
     $data->{error} = _('Sorry, we could not find that location.')

--- a/perllib/FixMyStreet/Geocode/Bing.pm
+++ b/perllib/FixMyStreet/Geocode/Bing.pm
@@ -13,7 +13,7 @@ use File::Path ();
 use LWP::Simple;
 use Digest::MD5 qw(md5_hex);
 
-use mySociety::Locale;
+use Utils;
 
 # string STRING CONTEXT
 # Looks up on Bing Maps API, and caches, a user-inputted location.
@@ -71,15 +71,14 @@ sub string {
                 || $valid_locations[-1]{address}{locality} eq $_->{address}{locality}
                );
 
-        ( $latitude, $longitude ) = @{ $_->{point}->{coordinates} };
-        # These co-ordinates are output as query parameters in a URL, make sure they have a "."
-        mySociety::Locale::in_gb_locale {
-            push (@$error, {
-                address => $address,
-                latitude => sprintf('%0.6f', $latitude),
-                longitude => sprintf('%0.6f', $longitude)
-            });
-        };
+        ( $latitude, $longitude ) =
+            map { Utils::truncate_coordinate($_) }
+            @{ $_->{point}->{coordinates} };
+        push (@$error, {
+            address => $address,
+            latitude => $latitude,
+            longitude => $longitude
+        });
         push (@valid_locations, $_);
     }
 

--- a/perllib/FixMyStreet/Geocode/FixaMinGata.pm
+++ b/perllib/FixMyStreet/Geocode/FixaMinGata.pm
@@ -14,7 +14,6 @@ package FixMyStreet::Geocode::FixaMinGata;
 
 use warnings;
 use strict;
-use Data::Dumper;
 
 use Digest::MD5 qw(md5_hex);
 use Encode;
@@ -23,7 +22,7 @@ use File::Path ();
 use LWP::Simple qw($ua);
 use Memcached;
 use XML::Simple;
-use mySociety::Locale;
+use Utils;
 
 my $osmapibase    = "http://www.openstreetmap.org/api/";
 my $nominatimbase = "http://nominatim.openstreetmap.org/";
@@ -45,8 +44,8 @@ sub string {
     my %query_params = (
         q => $s,
         format => 'json',
-	addressdetails => 1,
-	limit => 20,
+        addressdetails => 1,
+        limit => 20,
         #'accept-language' => '',
         email => 'info' . chr(64) . 'morus.se',
     );
@@ -77,32 +76,25 @@ sub string {
 
     my ( %locations, $error, @valid_locations, $latitude, $longitude );
     foreach (@$js) {
-        # These co-ordinates are output as query parameters in a URL, make sure they have a "."
-	next if $_->{class} eq "boundary";
-
-	my @s = split(/,/, $_->{display_name});
-
-	my $address = join(",", @s[0,1,2]);
-
+        next if $_->{class} eq "boundary";
+        my @s = split(/,/, $_->{display_name});
+        my $address = join(",", @s[0,1,2]);
         $locations{$address} = [$_->{lat}, $_->{lon}];
     }
 
-    my ($key) = keys %locations;
-
-    return { latitude => $locations{$key}[0], longitude => $locations{$key}[1] } if scalar keys %locations == 1;
-    return { error => _('Sorry, we could not find that location.') } if scalar keys %locations == 0;
-
-    foreach $key (keys %locations) {
-        ( $latitude, $longitude ) = ($locations{$key}[0], $locations{$key}[1]);
-        mySociety::Locale::in_gb_locale {
-            push (@$error, {
-		address => $key,
-                latitude => sprintf('%0.6f', $latitude),
-                longitude => sprintf('%0.6f', $longitude)
-            });
-        };
+    foreach my $key (keys %locations) {
+        ( $latitude, $longitude ) =
+            map { Utils::truncate_coordinate($_) }
+            ($locations{$key}[0], $locations{$key}[1]);
+        push (@$error, {
+            address => $key,
+            latitude => $latitude,
+            longitude => $longitude
+        });
+        push (@valid_locations, $_);
     }
 
+    return { latitude => $latitude, longitude => $longitude } if scalar @valid_locations == 1;
     return { error => $error };
 }
 

--- a/perllib/FixMyStreet/Geocode/Google.pm
+++ b/perllib/FixMyStreet/Geocode/Google.pm
@@ -12,7 +12,7 @@ use File::Slurp;
 use File::Path ();
 use LWP::Simple;
 use Digest::MD5 qw(md5_hex);
-use mySociety::Locale;
+use Utils;
 
 # string STRING CONTEXT
 # Looks up on Google Maps API, and caches, a user-inputted location.
@@ -78,15 +78,14 @@ sub string {
         next unless $_->{AddressDetails}->{Accuracy} >= 4;
         my $address = $_->{address};
         next unless $c->cobrand->geocoded_string_check( $address );
-        ( $longitude, $latitude ) = @{ $_->{Point}->{coordinates} };
-        # These co-ordinates are output as query parameters in a URL, make sure they have a "."
-        mySociety::Locale::in_gb_locale {
-            push (@$error, {
-                address => $address,
-                latitude => sprintf('%0.6f', $latitude),
-                longitude => sprintf('%0.6f', $longitude)
-            });
-        };
+        ( $longitude, $latitude ) =
+            map { Utils::truncate_coordinate($_) }
+            @{ $_->{Point}->{coordinates} };
+        push (@$error, {
+            address => $address,
+            latitude => $latitude,
+            longitude => $longitude
+        });
         push (@valid_locations, $_);
     }
     return { latitude => $latitude, longitude => $longitude } if scalar @valid_locations == 1;

--- a/perllib/FixMyStreet/Geocode/OSM.pm
+++ b/perllib/FixMyStreet/Geocode/OSM.pm
@@ -16,7 +16,7 @@ use File::Path ();
 use LWP::Simple qw($ua);
 use Memcached;
 use XML::Simple;
-use mySociety::Locale;
+use Utils;
 
 my $osmapibase    = "http://www.openstreetmap.org/api/";
 my $nominatimbase = "http://nominatim.openstreetmap.org/";
@@ -68,15 +68,14 @@ sub string {
 
     my ( $error, @valid_locations, $latitude, $longitude );
     foreach (@$js) {
-        # These co-ordinates are output as query parameters in a URL, make sure they have a "."
-        ( $latitude, $longitude ) = ( $_->{lat}, $_->{lon} );
-        mySociety::Locale::in_gb_locale {
-            push (@$error, {
-                address => $_->{display_name},
-                latitude => sprintf('%0.6f', $latitude),
-                longitude => sprintf('%0.6f', $longitude)
-            });
-        };
+        ( $latitude, $longitude ) =
+            map { Utils::truncate_coordinate($_) }
+            ( $_->{lat}, $_->{lon} );
+        push (@$error, {
+            address => $_->{display_name},
+            latitude => $latitude,
+            longitude => $longitude
+        });
         push (@valid_locations, $_);
     }
 

--- a/perllib/FixMyStreet/Geocode/Zurich.pm
+++ b/perllib/FixMyStreet/Geocode/Zurich.pm
@@ -15,7 +15,7 @@ use Digest::MD5 qw(md5_hex);
 use File::Path ();
 use Geo::Coordinates::CH1903;
 use Storable;
-use mySociety::Locale;
+use Utils;
 
 my ($soap, $method, $security);
 
@@ -92,14 +92,14 @@ sub string {
 
     my ( $error, @valid_locations, $latitude, $longitude );
     foreach (@$results) {
-        ($latitude, $longitude) = Geo::Coordinates::CH1903::to_latlon($_->{easting}, $_->{northing});
-        mySociety::Locale::in_gb_locale {
-            push (@$error, {
-                address => $_->{text},
-                latitude => sprintf('%0.6f', $latitude),
-                longitude => sprintf('%0.6f', $longitude)
-            });
-        };
+        ($latitude, $longitude) =
+            map { Utils::truncate_coordinate($_) }
+            Geo::Coordinates::CH1903::to_latlon($_->{easting}, $_->{northing});
+        push (@$error, {
+            address => $_->{text},
+            latitude => $latitude,
+            longitude => $longitude
+        });
         push (@valid_locations, $_);
         last if lc($_->{text}) eq lc($s);
     }

--- a/t/MapIt.pm
+++ b/t/MapIt.pm
@@ -1,0 +1,36 @@
+package t::MapIt;
+
+use JSON;
+use Web::Simple;
+
+use mySociety::Locale;
+
+has json => (
+    is => 'lazy',
+    default => sub {
+        JSON->new->pretty->allow_blessed->convert_blessed;
+    },
+);
+
+sub dispatch_request {
+    my $self = shift;
+
+    sub (GET + /postcode/*) {
+        my ($self, $postcode) = @_;
+        my $response = $self->postcode($postcode);
+        # We must make sure we output correctly for testing purposes, we might
+        # be within a different locale here...
+        my $json = mySociety::Locale::in_gb_locale {
+            $self->json->encode($response) };
+        return [ 200, [ 'Content-Type' => 'application/json' ], [ $json ] ];
+    },
+}
+
+sub postcode {
+    my ($self, $postcode) = @_;
+    return {
+        wgs84_lat => 51.5, wgs84_lon => 2.1, postcode => $postcode,
+    };
+}
+
+__PACKAGE__->run_if_script;

--- a/templates/web/base/around/display_location.html
+++ b/templates/web/base/around/display_location.html
@@ -6,14 +6,14 @@
     rss_url
         = pc
         ? c.uri_for( "/rss/pc", pc )
-        : c.uri_for( "/rss/l/$short_latitude,$short_longitude" );
+        : c.uri_for( "/rss/l/$latitude,$longitude" );
             
     email_url = c.uri_for(
         '/alert/list',
         {
-            lat  => short_latitude,
-            lon  => short_longitude,
-            feed => "local:$short_latitude:$short_longitude",
+            lat  => latitude,
+            lon  => longitude,
+            feed => "local:$latitude:$longitude",
         }
     );
 
@@ -21,8 +21,8 @@
         '/report/new',
         {
             pc         => pc
-            latitude   => short_latitude,
-            longitude  => short_longitude,
+            latitude   => latitude,
+            longitude  => longitude,
             skipped    => 1,
         }
     );
@@ -45,8 +45,8 @@
     [% END %]
     <input type="hidden" name="pc" value="[% pc | html %]">
 
-    <input type="hidden" name="latitude" id="fixmystreet.latitude" value="[% short_latitude | html %]">
-    <input type="hidden" name="longitude" id="fixmystreet.longitude" value="[% short_longitude | html %]">
+    <input type="hidden" name="latitude" id="fixmystreet.latitude" value="[% latitude | html %]">
+    <input type="hidden" name="longitude" id="fixmystreet.longitude" value="[% longitude | html %]">
 [% END %]
 
     [% map_html %]

--- a/templates/web/base/report/display.html
+++ b/templates/web/base/report/display.html
@@ -31,7 +31,7 @@
 
 [% IF c.cobrand.moniker != 'emptyhomes' %]
 <p style="padding-bottom: 0.5em; border-bottom: dotted 1px #999999;" align="right">
-    <a href="[% c.uri_for( '/around', { lat => short_latitude, lon => short_longitude } ) %]">[% loc( 'More problems nearby' ) %]</a>
+    <a href="[% c.uri_for( '/around', { lat => latitude, lon => longitude } ) %]">[% loc( 'More problems nearby' ) %]</a>
 </p>
 
 <div id="alert_links">

--- a/templates/web/base/report/new/fill_in_details.html
+++ b/templates/web/base/report/new/fill_in_details.html
@@ -22,8 +22,8 @@
 
 [% END %]
 
-    <input type="hidden" name="latitude" id="fixmystreet.latitude" value="[% short_latitude | html %]">
-    <input type="hidden" name="longitude" id="fixmystreet.longitude" value="[% short_longitude | html %]">
+    <input type="hidden" name="latitude" id="fixmystreet.latitude" value="[% latitude | html %]">
+    <input type="hidden" name="longitude" id="fixmystreet.longitude" value="[% longitude | html %]">
 
     [% IF report.used_map %]
         [% map_html %]

--- a/templates/web/bromley/report/display.html
+++ b/templates/web/bromley/report/display.html
@@ -25,7 +25,7 @@
     <ul id="key-tools">
         <li><a rel="nofollow" id="key-tool-report-abuse" class="abuse" href="[% c.uri_for( '/contact', { id => problem.id } ) %]">[% loc('Report abuse') %]</a></li>
         <li><a rel="nofollow" id="key-tool-report-updates" class="feed" href="[% c.uri_for( '/alert/subscribe', { id => problem.id } ) %]">[% loc('Get updates' ) %]</a></li>
-        <li><a class="chevron" id="key-tool-problems-nearby" href="[% c.uri_for( '/around', { lat => short_latitude, lon => short_longitude } ) %]">[% loc( 'Problems nearby' ) %]</a></li>
+        <li><a class="chevron" id="key-tool-problems-nearby" href="[% c.uri_for( '/around', { lat => latitude, lon => longitude } ) %]">[% loc( 'Problems nearby' ) %]</a></li>
     </ul>
 
 <div id="report-updates-data" class="hidden-js">

--- a/templates/web/fixmystreet/report/display.html
+++ b/templates/web/fixmystreet/report/display.html
@@ -38,9 +38,9 @@
         <li><a rel="nofollow" id="key-tool-report-share" class="share" href="#report-share">[% loc('Share') %]</a></li>
         [% END %]
       [% IF c.cobrand.moniker == 'zurich' %]
-        <li><a class="chevron" id="key-tool-problems-nearby" href="[% c.uri_for( '/around', { lat => short_latitude, lon => short_longitude } ) %]">[% loc( 'Problems on the map' ) %]</a></li>
+        <li><a class="chevron" id="key-tool-problems-nearby" href="[% c.uri_for( '/around', { lat => latitude, lon => longitude } ) %]">[% loc( 'Problems on the map' ) %]</a></li>
       [% ELSE %]
-        <li><a class="chevron" id="key-tool-problems-nearby" href="[% c.uri_for( '/around', { lat => short_latitude, lon => short_longitude } ) %]">[% loc( 'Problems nearby' ) %]</a></li>
+        <li><a class="chevron" id="key-tool-problems-nearby" href="[% c.uri_for( '/around', { lat => latitude, lon => longitude } ) %]">[% loc( 'Problems nearby' ) %]</a></li>
       [% END %]
     </ul>
 

--- a/templates/web/seesomething/around/display_location.html
+++ b/templates/web/seesomething/around/display_location.html
@@ -4,8 +4,8 @@
         '/report/new',
         {
             pc         => pc
-            latitude   => short_latitude,
-            longitude  => short_longitude,
+            latitude   => latitude,
+            longitude  => longitude,
             skipped    => 1,
         }
     );
@@ -25,8 +25,8 @@
     [% END %]
     <input type="hidden" name="pc" value="[% pc | html %]">
 
-    <input type="hidden" name="latitude" id="fixmystreet.latitude" value="[% short_latitude | html %]">
-    <input type="hidden" name="longitude" id="fixmystreet.longitude" value="[% short_longitude | html %]">
+    <input type="hidden" name="latitude" id="fixmystreet.latitude" value="[% latitude | html %]">
+    <input type="hidden" name="longitude" id="fixmystreet.longitude" value="[% longitude | html %]">
 
     [% map_html %]
 

--- a/templates/web/zerotb/report/display.html
+++ b/templates/web/zerotb/report/display.html
@@ -25,7 +25,7 @@
 
 <div class="shadow-wrap">
     <ul id="key-tools">
-        <li><a class="chevron" id="key-tool-problems-nearby" href="[% c.uri_for( '/around', { lat => short_latitude, lon => short_longitude } ) %]">[% loc( 'Clinics nearby' ) %]</a></li>
+        <li><a class="chevron" id="key-tool-problems-nearby" href="[% c.uri_for( '/around', { lat => latitude, lon => longitude } ) %]">[% loc( 'Clinics nearby' ) %]</a></li>
     </ul>
 
 </div>


### PR DESCRIPTION
This includes MapIt postcode lookups, geocoding, query parameters, tile
clicks. This way, we no longer need any "short" versions anywhere, and
the JSON response always uses a decimal point regardless of locale.

Fixes https://github.com/mysociety/fixmystreet-mobile/issues/190