### PR TITLE
Remove need to have to specify en-gb in LANGUAGES.

### DIFF
--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -49,7 +49,6 @@ EXAMPLE_PLACES: [ 'High Street', 'Main Street' ]
 
 # An array of languages for the site, in the following format:
 # <language code>,<pretty name>,<locale>
-# Do not remove the en-gb line as it is needed for correct operation.
 LANGUAGES:
   - 'en-gb,English,en_GB'
 

--- a/perllib/FixMyStreet/Cobrand/BellaVistaEnAccion.pm
+++ b/perllib/FixMyStreet/Cobrand/BellaVistaEnAccion.pm
@@ -12,7 +12,7 @@ sub example_places {
     return ( 'Dominica, Recoleta', 'Pio Nono' );
 }
 
-sub languages { [ 'es-cl,Castellano,es_CL', 'en-gb,English,en_GB' ] }
+sub languages { [ 'es-cl,Castellano,es_CL' ] }
 
 sub disambiguate_location {
     return {

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -7,6 +7,7 @@ use FixMyStreet;
 use FixMyStreet::Geocode::Bing;
 use DateTime;
 use Encode;
+use List::Util 'none';
 use URI;
 use Digest::MD5 qw(md5_hex);
 
@@ -157,7 +158,9 @@ Set the language and domain of the site based on the cobrand and host.
 sub set_lang_and_domain {
     my ( $self, $lang, $unicode, $dir ) = @_;
 
-    my $languages = join('|', @{$self->languages});
+    my @languages = @{$self->languages};
+    push @languages, 'en-gb,English,en_GB' if none { /en-gb/ } @languages;
+    my $languages = join('|', @languages);
     my $lang_override = $self->language_override || $lang;
     my $lang_domain = $self->language_domain || 'FixMyStreet';
 
@@ -174,7 +177,7 @@ sub set_lang_and_domain {
 
     return $set_lang;
 }
-sub languages { FixMyStreet->config('LANGUAGES') || [ 'en-gb,English,en_GB' ] }
+sub languages { FixMyStreet->config('LANGUAGES') || [] }
 sub language_domain { }
 sub language_override { }
 

--- a/perllib/FixMyStreet/Cobrand/FiksGataMi.pm
+++ b/perllib/FixMyStreet/Cobrand/FiksGataMi.pm
@@ -12,7 +12,7 @@ sub country {
     return 'NO';
 }
 
-sub languages { [ 'en-gb,English,en_GB', 'nb,Norwegian,nb_NO' ] }
+sub languages { [ 'nb,Norwegian,nb_NO' ] }
 sub language_override { 'nb' }
 
 sub enter_postcode_text {

--- a/perllib/FixMyStreet/Cobrand/FixMindelo.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMindelo.pm
@@ -8,7 +8,7 @@ sub country {
     return 'CV';
 }
 
-sub languages { [ 'pt-cv,Portuguese,pt_CV', 'en-gb,English,en_GB' ] }
+sub languages { [ 'pt-cv,Portuguese,pt_CV' ] }
 sub language_override { 'pt-cv' }
 
 sub disambiguate_location {

--- a/perllib/FixMyStreet/Cobrand/FixaMinGata.pm
+++ b/perllib/FixMyStreet/Cobrand/FixaMinGata.pm
@@ -13,7 +13,7 @@ sub country {
     return 'SE';
 }
 
-sub languages { [ 'en-gb,English,en_GB', 'sv,Swedish,sv_SE' ] }
+sub languages { [ 'sv,Swedish,sv_SE' ] }
 sub language_override { 'sv' }
 
 sub enter_postcode_text {

--- a/perllib/FixMyStreet/Cobrand/ZeroTB.pm
+++ b/perllib/FixMyStreet/Cobrand/ZeroTB.pm
@@ -10,9 +10,6 @@ sub country {
     return 'IN';
 }
 
-sub languages { [ 'en-gb,English,en_GB' ] }
-sub language_override { 'en-gb' }
-
 sub disambiguate_location {
     return {
         country => 'in',

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -76,7 +76,7 @@ sub example_places {
     return [ 'Langstrasse', 'Basteiplatz' ];
 }
 
-sub languages { [ 'de-ch,Deutsch,de_CH', 'en-gb,English,en_GB' ] }
+sub languages { [ 'de-ch,Deutsch,de_CH' ] }
 sub language_override { 'de-ch' }
 
 # If lat/lon are in the URI, we must have zoom as well, otherwise OpenLayers defaults to 0.


### PR DESCRIPTION
Instead, add it if not present at the negotiation stage. Even if not negotiated, we currently need it to be present for the in_gb_locale() calls to work.