### PR TITLE
Allow categories to make photos mandatory

### DIFF
--- a/bin/setup-contacts
+++ b/bin/setup-contacts
@@ -1,0 +1,28 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+require 5.8.0;
+use feature 'say';
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../setenv.pl";
+}
+
+use FixMyStreet::App;
+
+my $moniker = $ARGV[0];
+
+my $c = FixMyStreet::App->new();
+my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker($moniker)->new({ c => $c });
+
+die "Not a staging site, bailing out" unless $cobrand->{c}->config->{STAGING_SITE}; # TODO, allow override via --force
+say "Applying contacts for $cobrand";
+
+
+$cobrand->ensure_bodies;
+$cobrand->setup_contacts;
+

--- a/bin/update-schema
+++ b/bin/update-schema
@@ -195,6 +195,7 @@ else {
 # By querying the database schema, we can see where we're currently at
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
+    return '0033' if column_exists('admin_log', 'time_spent');
     return '0032' if table_exists('moderation_original_data');
     return '0031' if column_exists('body', 'external_url');
     return '0030' if ! constraint_exists('admin_log_action_check');

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -452,7 +452,8 @@ create table admin_log (
     action text not null,
     whenedited timestamp not null default ms_current_timestamp(),
     user_id int references users(id) null,
-    reason text not null default ''
+    reason text not null default '',
+    time_spent int not null default 0
 ); 
 
 create table moderation_original_data (

--- a/db/schema_0033-time-spent.sql
+++ b/db/schema_0033-time-spent.sql
@@ -1,0 +1,2 @@
+alter table admin_log 
+    add column time_spent int not null default 0;

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -372,6 +372,21 @@ sub update_contacts : Private {
         $contact->api_key( $c->req->param('api_key') );
         $contact->send_method( $c->req->param('send_method') );
 
+        # Set the photo_required flag in extra to the appropriate value
+        my $extra = eval {
+            @{ $contact->extra }[0];
+        };
+        if ( $c->req->param('photo_required') ) {
+            if ( $extra ) {
+                $extra->{photo_required} = 1;
+            } else {
+                $extra = {photo_required => 1};
+            }
+        } elsif ( $extra && $extra->{photo_required} ) {
+            delete $extra->{photo_required};
+        }
+        $contact->extra([ $extra ]);
+
         if ( %errors ) {
             $c->stash->{updated} = _('Please correct the errors below');
             $c->stash->{contact} = $contact;

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -1269,12 +1269,24 @@ Adds an entry into the admin_log table using the current user.
 
 sub log_edit : Private {
     my ( $self, $c, $id, $object_type, $action ) = @_;
+
+    my $time_spent = $c->req->param('time_spent') || 0;
+    $time_spent = $time_spent + 0;
+    $time_spent = 0 if $time_spent < 0;
+
+    my $user_object = do {
+        my $auth_user = $c->user;
+        $auth_user ? $auth_user->get_object : undef;
+    };
+
     $c->model('DB::AdminLog')->create(
         {
             admin_user => $c->forward('get_user'),
+            $user_object ? ( user => $user_object ) : (), # as (rel => undef) doesn't work
             object_type => $object_type,
             action => $action,
             object_id => $id,
+            time_spent => $time_spent,
         }
     )->insert();
 }

--- a/perllib/FixMyStreet/App/Controller/Photo.pm
+++ b/perllib/FixMyStreet/App/Controller/Photo.pm
@@ -143,6 +143,7 @@ sub process_photo : Private {
     return
          $c->forward('process_photo_upload')
       || $c->forward('process_photo_cache')
+      || $c->forward('process_photo_required')
       || 1;    # always return true
 }
 
@@ -215,6 +216,41 @@ sub process_photo_cache : Private {
     return unless -e $file;
 
     $c->stash->{upload_fileid} = $fileid;
+    return 1;
+}
+
+=head2 process_photo_required
+
+Checks that a report has a photo attached if any of its Contacts
+require it (by setting extra->photo_required == 1). Puts an error in
+photo_error on the stash if it's required and missing, otherwise returns
+true.
+
+=cut
+
+sub process_photo_required : Private {
+    my ( $self, $c ) = @_;
+
+    # load the report
+    my $report = $c->stash->{report};
+    my $bodies = $c->stash->{bodies};
+    my @contacts = $c->       #
+      model('DB::Contact')    #
+      ->not_deleted           #
+      ->search(
+        {
+            body_id => [ keys %$bodies ],
+            category => $report->category
+        }
+      )->all;
+      foreach my $contact ( @contacts ) {
+          my $extra = $contact->extra;
+          if ( eval { @$extra[0]->{photo_required} } ) {
+              $c->stash->{photo_error} = _("Photo is required.");
+              return;
+          }
+      }
+
     return 1;
 }
 

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -649,8 +649,9 @@ sub setup_categories_and_bodies : Private {
             unless ( $seen{$contact->category} ) {
                 push @category_options, $contact->category;
 
-                $category_extras{ $contact->category } = $contact->extra
-                    if $contact->extra;
+                if ( $contact->extra && $c->cobrand->moniker ne 'zurich' ) {
+                    $category_extras{ $contact->category } = $contact->extra;
+                }
 
                 $non_public_categories{ $contact->category } = 1 if $contact->non_public;
             }

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -889,31 +889,33 @@ sub process_report : Private {
             if $body_string && @{ $c->stash->{missing_details_bodies} };
         $report->bodies_str($body_string);
 
-        my @extra = ();
-        my $metas = $contacts[0]->extra;
-
-        foreach my $field ( @$metas ) {
-            if ( lc( $field->{required} ) eq 'true' ) {
-                unless ( $c->request->param( $field->{code} ) ) {
-                    $c->stash->{field_errors}->{ $field->{code} } = _('This information is required');
-                }
-            }
-            push @extra, {
-                name => $field->{code},
-                description => $field->{description},
-                value => $c->request->param( $field->{code} ) || '',
-            };
-        }
-
         if ( $c->stash->{non_public_categories}->{ $report->category } ) {
             $report->non_public( 1 );
         }
 
-        $c->cobrand->process_extras( $c, $contacts[0]->body_id, \@extra );
+        if ($c->cobrand->moniker ne 'zurich') {
+            my @extra = ();
+            my $metas = $contacts[0]->extra;
 
-        if ( @extra ) {
-            $c->stash->{report_meta} = { map { $_->{name} => $_ } @extra };
-            $report->extra( \@extra );
+            foreach my $field ( @$metas ) {
+                if ( lc( $field->{required} ) eq 'true' ) {
+                    unless ( $c->request->param( $field->{code} ) ) {
+                        $c->stash->{field_errors}->{ $field->{code} } = _('This information is required');
+                    }
+                }
+                push @extra, {
+                    name => $field->{code},
+                    description => $field->{description},
+                    value => $c->request->param( $field->{code} ) || '',
+                };
+            }
+
+            $c->cobrand->process_extras( $c, $contacts[0]->body_id, \@extra );
+
+            if ( @extra ) {
+                $c->stash->{report_meta} = { map { $_->{name} => $_ } @extra };
+                $report->extra( \@extra );
+            }
         }
     } elsif ( @{ $c->stash->{bodies_to_list} } ) {
 

--- a/perllib/FixMyStreet/App/Model/PhotoSet.pm
+++ b/perllib/FixMyStreet/App/Model/PhotoSet.pm
@@ -4,18 +4,50 @@ package FixMyStreet::App::Model::PhotoSet;
 
 use Moose;
 use Path::Tiny 'path';
+use Image::Magick;
+use Scalar::Util 'openhandle';
+use Digest::SHA qw(sha1_hex);
 
 has c => (
     is => 'ro',
 );
 
-has data => ( # generic data from field
+has item => (
     is => 'ro',
 );
 
+has data => ( # generic data from DB field
+    is => 'rw',
+);
+
+has data_items => ( # either a) split from data or b) provided by photo upload
+    isa => 'ArrayRef',
+    is => 'rw',
+    traits => ['Array'],
+    lazy => 1,
+    handles => {
+        map_data_items => 'map',
+    },
+    default => sub {
+        my $self = shift;
+        my $data = $self->data
+            or return [];
+
+        return [$data] if (_jpeg_magic($data));
+
+        return [ split ',' => $data ];
+    },
+);
+
+sub _jpeg_magic {
+    $_[0] =~ /^\x{ff}\x{d8}/; # JPEG
+    # NB: should we also handle \x{89}\x{50} (PNG, 15 results in live DB) ?
+    #     and \x{49}\x{49} (Tiff, 3 results in live DB) ?
+}
+
 has images => ( # jpeg data for actual image
     isa => 'ArrayRef',
-    is => 'ro',
+    is => 'rw',
     traits => ['Array'],
     lazy => 1,
     handles => {
@@ -24,40 +56,80 @@ has images => ( # jpeg data for actual image
     },
     default => sub {
         my $self = shift;
-        my $data = $self->data
-            or return [];
-        if ($data =~ /^\x{ff}\x{d8}/) { # JPEG
-            # NB: should we also handle \x{89}\x{50} (PNG, 15 results in live DB) ?
-            #     and \x{49}\x{49} (Tiff, 3 results in live DB) ?
-            return [$data];
-        }
-        my @photos = map 
-            {
-                my $part = $_;
-                if (length($part) == 40) {
-                    my $file = path( $self->c->config->{UPLOAD_DIR}, "$part.jpeg" );
-                    my $photo = $file->slurp;
-                    $photo;
-                }
-                else {
-                    warn sprintf "Received photo hash of length %d", length($part);
-                    ();
-                }
+        my @photos = $self->map_data_items( sub {
+            my $part = $_;
+
+            if (_jpeg_magic($part)) {
+                my $filename = $self->save_photo( $part );
+                return [$filename, $part];
             }
-            split ',' => $data;
+            if (length($part) == 40) {
+                my $file = path( $self->c->config->{UPLOAD_DIR}, "$part.jpeg" );
+                my $photo = $file->slurp;
+                [$part, $photo];
+            }
+            else {
+                warn sprintf "Received photo hash of length %d", length($part);
+                ();
+            }
+        });
         return \@photos;
     },
 );
 
+sub save_photo { return 'TODO' }
+
 sub get_image_data {
     my ($self, %args) = @_;
     my $num = $args{num} || 1;
-    # my $data = $self->get_raw_image_data($num-1); # should work, but doesn't???
-    #
-    # my $dummy = $self->num_images; # force lazy attribute
-    my $data = $self->get_raw_image_data( 0 ); # for test 
 
-    return $data;
+    my $data = $self->get_raw_image_data( 0 ) # for test, because of broken IE/Windows caching
+        or return;
+
+    my ($name, $photo) = @$data;
+
+    my $size = $args{size};
+    if ( $size eq 'tn' ) {
+        $photo = _shrink( $photo, 'x100' );
+    } elsif ( $size eq 'fp' ) {
+        $photo = _crop( $photo );
+    } elsif ( $size eq 'full' ) {
+        # do nothing
+    } else {
+        $photo = _shrink( $photo, $self->c->cobrand->default_photo_resize || '250x250' );
+    }
+
+    return $photo;
+}
+
+# NB: These 2 subs stolen from A::C::Photo, should be purged from there!
+#
+# Shrinks a picture to the specified size, but keeping in proportion.
+sub _shrink {
+    my ($photo, $size) = @_;
+    my $image = Image::Magick->new;
+    $image->BlobToImage($photo);
+    my $err = $image->Scale(geometry => "$size>");
+    throw Error::Simple("resize failed: $err") if "$err";
+    $image->Strip();
+    my @blobs = $image->ImageToBlob();
+    undef $image;
+    return $blobs[0];
+}
+
+# Shrinks a picture to 90x60, cropping so that it is exactly that.
+sub _crop {
+    my ($photo) = @_;
+    my $image = Image::Magick->new;
+    $image->BlobToImage($photo);
+    my $err = $image->Resize( geometry => "90x60^" );
+    throw Error::Simple("resize failed: $err") if "$err";
+    $err = $image->Extent( geometry => '90x60', gravity => 'Center' );
+    throw Error::Simple("resize failed: $err") if "$err";
+    $image->Strip();
+    my @blobs = $image->ImageToBlob();
+    undef $image;
+    return $blobs[0];
 }
 
 1;

--- a/perllib/FixMyStreet/Cobrand/Base.pm
+++ b/perllib/FixMyStreet/Cobrand/Base.pm
@@ -51,5 +51,228 @@ sub is_default {
     return $self->moniker eq 'default';
 }
 
+=head2 setup_contacts, ensure_bodies
+
+routines to update extra data for contacts.  These can be called by
+a script:
+
+    bin/setup-contacts zurich
+
+=cut
+
+
+sub get_body_for_contact {
+    my ($self, $contact_data) = @_;
+    if (my $body_name = $contact_data->{body_name}) {
+        return $self->{c}->model('DB::Body')->find({ name => $body_name });
+    }
+    return;
+    # TODO: for UK Councils use
+    #   $self->{c}->model('DB::Body')->find(id => $self->council_id); 
+    #   # NB: (or better that's the area in BodyAreas)
+}
+
+sub ensure_bodies {
+    my ($self, $contact_data, $description) = @_;
+
+    my @bodies = $self->body_details_data;
+
+    my $bodies_rs = $self->{c}->model('DB::Body');
+
+    for my $body (@bodies) {
+        # following should work (having added Unique name/parent constraint, but doesn't)
+        # $bodies_rs->find_or_create( $body, { $parent ? ( key => 'body_name_parent_key' ) : () }  );
+        # let's keep it simple and just allow unique names
+        next if $bodies_rs->search({ name => $body->{name} })->count;
+        if (my $area_id = delete $body->{area_id}) {
+            $body->{body_areas} = [ { area_id => $area_id } ];
+        }
+        my $parent = $body->{parent};
+        if ($parent and ! ref $parent) {
+            $body->{parent} = { name => $parent };
+        }
+        $bodies_rs->find_or_create( $body );
+    }
+}
+
+=head2 body_details_data
+
+Returns a list of bodies to create with ensure_body.  These
+are mostly just passed to ->find_or_create, but there is some
+pre-processing so that you can enter:
+
+    area_id => 123,
+    parent => 'Big Town',
+
+instead of
+
+    body_areas => [ { area_id => 123 } ],
+    parent => { name => 'Big Town' },
+
+For example:
+
+    return (
+        {
+            name => 'Big Town',
+        },
+        {
+            name => 'Small town',
+            parent => 'Big Town',
+            area_id => 1234,
+        },
+            
+
+=cut
+
+sub body_details_data {
+    return ();
+}
+
+=head2 contact_details_data
+
+Returns a list of contact_data to create with setup_contacts.
+See Zurich for an example.
+
+=cut
+
+sub contact_details_data {
+    return ()
+}
+
+sub ensure_contact {
+    my ($self, $contact_data, $description) = @_;
+
+    my $category = $contact_data->{category} or die "No category provided";
+    $description ||= "Ensure contact exists $category";
+
+    my $email = $self->temp_email_to_update; # will only be set if newly created
+
+    my $body = $self->get_body_for_contact($contact_data) or die "No body found for $category";
+
+    my $contact_rs = $self->{c}->model('DB::Contact');
+
+    my $category_details = $contact_data->{category_details} || {};
+
+    if (my $old_name = delete $contact_data->{rename_from}) {
+        if (my $category = $contact_rs->find({
+                category => $old_name,
+            ,   body => $body,
+            })) {
+            $category->update({
+                category => $category,
+                whenedited => \'NOW()',
+                note => "Renamed $description",
+                %{ $category_details || {} },
+            });
+            return $category;
+        }
+    }
+
+    if ($contact_data->{delete}) {
+        warn "$body / $category";
+        my $contact = $contact_rs->search({
+            body_id => $body->id,
+            category => $category,
+            deleted => 0
+        });
+        if ($contact->count) {
+            print sprintf "Deleting: %s\n", $category;
+            $contact->update({
+                deleted => 1,
+                editor => 'automated script',
+                whenedited => \'NOW()',
+                note => "Deleted by script $description",
+            });
+        }
+        return;
+    }
+
+    return $contact_rs->find_or_create(
+        {
+            body => $body,
+            category => $category,
+
+            confirmed => 1,
+            deleted => 0,
+            email => $email,
+            editor => 'automated script',
+            note => 'created by automated script',
+            send_method => '',
+            whenedited => \'NOW()',
+            %{ $category_details || {} },
+        },
+        {
+            key => 'contacts_body_id_category_idx'
+        }
+    );
+}
+
+sub setup_contacts {
+    my ($self, $description) = @_;
+
+    my $c = $self->{c};
+    die "Not a staging site, bailing out" unless $c->config->{STAGING_SITE}; # TODO, allow override via --force
+
+    my @contact_details = $self->contact_details_data;
+
+    for my $detail (@contact_details) {
+        $self->update_contact( $detail, $description );
+    }
+}
+
+sub update_contact {
+    my ($self, $contact_data, $description) = @_; 
+
+    my $contact_rs = $self->{c}->model('DB::Contact');
+
+    my $category = $contact_data->{category} or die "No category provided";
+    $description ||= "Update contact";
+
+    my $contact = $self->ensure_contact($contact_data, $description)
+        or return; # e.g. nothing returned if deleted
+
+    if (my $fields = $contact_data->{fields}) {
+
+        my @fields = map { $self->get_field_extra($_) } @$fields;
+        my $note = sprintf 'Fields edited by automated script%s', $description ? " ($description)" : '';
+        $contact->update({
+            extra => \@fields,
+            confirmed => 1,
+            deleted => 0,
+            editor => 'automated script',
+            whenedited => \'NOW()',
+            note => "Updated fields $description",
+        });
+    }
+}
+
+sub get_field_extra {
+    my ($self, $field) = @_;
+
+    my %default = (
+        variable => 'true',
+        order => '1',
+        required => 'no',
+        datatype => 'string',
+        datatype_description => 'a string',
+    );
+
+    if ($field->{datatype} || '' eq 'boolean') {
+        %default = (
+            %default,
+            datatype => 'singlevaluelist',
+            datatype_description => 'Yes or No',
+            values => { value => [ 
+                    { key => ['No'],  name => ['No'] },
+                    { key => ['Yes'], name => ['Yes'] }, 
+            ] },
+        );
+    }
+
+    return { %default, %$field };
+}
+
+sub temp_email_to_update { 'test@example.com' } 
+
 1;
 

--- a/perllib/FixMyStreet/Cobrand/Base.pm
+++ b/perllib/FixMyStreet/Cobrand/Base.pm
@@ -169,7 +169,6 @@ sub ensure_contact {
     }
 
     if ($contact_data->{delete}) {
-        warn "$body / $category";
         my $contact = $contact_rs->search({
             body_id => $body->id,
             category => $category,

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -4,6 +4,7 @@ use base 'FixMyStreet::Cobrand::Default';
 use DateTime;
 use POSIX qw(strcoll);
 use RABX;
+use DateTime::Format::Pg;
 
 use strict;
 use warnings;
@@ -714,7 +715,10 @@ sub admin_stats {
     if ($y && $m) {
         $c->stash->{start_date} = DateTime->new( year => $y, month => $m, day => 1 );
         $c->stash->{end_date} = $c->stash->{start_date} + DateTime::Duration->new( months => 1 );
-        $date_params{created} = { '>=', $c->stash->{start_date}, '<', $c->stash->{end_date} };
+        $date_params{created} = {
+            '>=', DateTime::Format::Pg->format_datetime($c->stash->{start_date}), 
+            '<',  DateTime::Format::Pg->format_datetime($c->stash->{end_date}),
+        };
     }
 
     my %params = (
@@ -726,12 +730,15 @@ sub admin_stats {
         my $problems = $c->model('DB::Problem')->search(
             {%date_params},
             {
+                join => 'admin_log_entries',
+                distinct => 1,
                 columns => [
                     'id',       'created',
                     'latitude', 'longitude',
                     'cobrand',  'category',
                     'state',    'user_id',
-                    'external_body'
+                    'external_body',
+                    { sum_time_spent => { sum => 'admin_log_entries.time_spent' } },
                 ]
             }
         );
@@ -746,8 +753,9 @@ sub admin_stats {
                 $report->id,           $report->created,
                 $report->local_coords, $report->category,
                 $report->state,        $report->user_id,
-                "\"$body_name\"" )
-              . "\n";
+                "\"$body_name\"",
+                $report->get_column('sum_time_spent') || 0,
+            ) . "\n";
         }
         $c->res->content_type('text/csv; charset=utf-8');
         $c->res->body($body);

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -862,86 +862,6 @@ sub admin_stats {
     return 1;
 }
 
-=head2 setup_contacts
-
-TODO: refactor into cobrand
-
-routines to update the extra for potholes (temporary setup hack, cargo-culted
-from Eastsussex/Harrogate, may in future be superseded either by
-Open311/integration or a better mechanism for creating rich contacts).
-
-Can run with a script or command line like:
-
- bin/cron-wrapper perl -MFixMyStreet::App -MFixMyStreet::Cobrand::Zurich -e \
- 'FixMyStreet::Cobrand::Zurich->new({c => FixMyStreet::App->new})->setup_contacts'
-
-=cut
-
-sub get_body_for_contact {
-    my ($self, $contact_data) = @_;
-    if (my $body_name = $contact_data->{body_name}) {
-        return $self->{c}->model('DB::Body')->find({ name => $body_name });
-    }
-    return;
-    # TODO: for UK Councils use
-    #   $self->{c}->model('DB::Body')->find(id => $self->council_id); 
-    #   # NB: (or better that's the area in BodyAreas)
-}
-
-sub ensure_bodies {
-    my ($self, $contact_data, $description) = @_;
-
-    die "Not a staging site, bailing out" unless $self->{c}->config->{STAGING_SITE}; # TODO, allow override via --force
-
-    my @bodies = $self->body_details_data;
-
-    my $bodies_rs = $self->{c}->model('DB::Body');
-
-    for my $body (@bodies) {
-        # following should work (having added Unique name/parent constraint, but doesn't)
-        # $bodies_rs->find_or_create( $body, { $parent ? ( key => 'body_name_parent_key' ) : () }  );
-        # let's keep it simple and just allow unique names
-        next if $bodies_rs->search({ name => $body->{name} })->count;
-        if (my $area_id = delete $body->{area_id}) {
-            $body->{body_areas} = [ { area_id => $area_id } ];
-        }
-        my $parent = $body->{parent};
-        if ($parent and ! ref $parent) {
-            $body->{parent} = { name => $parent };
-        }
-        $bodies_rs->find_or_create( $body );
-    }
-}
-
-=head2 body_details_data
-
-Returns a list of bodies to create with ensure_body.  These
-are mostly just passed to ->find_or_create, but there is some
-pre-processing so that you can enter:
-
-    area_id => 123,
-    parent => 'Big Town',
-
-instead of
-
-    body_areas => [ { area_id => 123 } ],
-    parent => { name => 'Big Town' },
-
-For example:
-
-    return (
-        {
-            name => 'Big Town',
-        },
-        {
-            name => 'Small town',
-            parent => 'Big Town',
-            area_id => 1234,
-        },
-            
-
-=cut
-
 sub body_details_data {
     return (
         {
@@ -978,136 +898,6 @@ sub body_details_data {
             area_id => 423017,
         },
     );
-}
-
-sub ensure_contact {
-    my ($self, $contact_data, $description) = @_;
-
-    my $category = $contact_data->{category} or die "No category provided";
-    my $email = $self->temp_email_to_update; # will only be set if newly created
-
-    my $body = $self->get_body_for_contact($contact_data) or die "No body found for $category";
-
-    my $contact_rs = $self->{c}->model('DB::Contact');
-
-    my $category_details = $contact_data->{category_details} || {};
-
-    if (my $old_name = delete $contact_data->{rename_from}) {
-        if (my $category = $contact_rs->find({
-                category => $old_name,
-            ,   body => $body,
-            })) {
-            $category->update({
-                category => $category,
-                whenedited => \'NOW()',
-                note => "Renamed $description",
-                %{ $category_details || {} },
-            });
-            return $category;
-        }
-    }
-
-    if ($contact_data->{delete}) {
-        my $contact = $contact_rs->search({
-            body => $body,
-            category => $category,
-            deleted => 0
-        });
-        if ($contact) {
-            say sprintf "Deleting: %s", $category;
-            $contact->update({
-                deleted => 1,
-                editor => 'automated script',
-                whenedited => \'NOW()',
-                note => "Deleted by script $description",
-            });
-        }
-        return;
-    }
-
-    return $contact_rs->find_or_create(
-        {
-            body => $body,
-            category => $category,
-
-            confirmed => 1,
-            deleted => 0,
-            email => $email,
-            editor => 'automated script',
-            note => 'created by automated script',
-            send_method => '',
-            whenedited => \'NOW()',
-            %{ $category_details || {} },
-        },
-        {
-            key => 'contacts_body_id_category_idx'
-        }
-    );
-}
-
-sub setup_contacts {
-    my ($self, $description) = @_;
-
-    my $c = $self->{c};
-    die "Not a staging site, bailing out" unless $c->config->{STAGING_SITE}; # TODO, allow override via --force
-
-    my @contact_details = $self->contact_details_data;
-
-    for my $detail (@contact_details) {
-        my ($category, $field, $category_details) = @$detail;
-        $self->update_contact( $category, $field, $category_details, $description );
-    }
-}
-
-sub update_contact {
-    my ($self, $contact_data, $description) = @_; 
-
-    my $contact_rs = $self->{c}->model('DB::Contact');
-
-    my $category = $contact_data->{category} or die "No category provided";
-
-    my $contact = $self->ensure_contact($category, $contact_data->{category_details})
-        or return; # e.g. nothing returned if deleted
-
-    if (my $fields = $contact_data->{fields}) {
-
-        my @fields = map { $self->get_field_extra($_) } @$fields;
-        my $note = sprintf 'Fields edited by automated script%s', $description ? " ($description)" : '';
-        $contact->update({
-            extra => \@fields,
-            confirmed => 1,
-            deleted => 0,
-            editor => 'automated script',
-            whenedited => \'NOW()',
-            note => "Updated fields $description",
-        });
-    }
-}
-
-sub get_field_extra {
-    my ($self, $field) = @_;
-
-    my %default = (
-        variable => 'true',
-        order => '1',
-        required => 'no',
-        datatype => 'string',
-        datatype_description => 'a string',
-    );
-
-    if ($field->{datatype} || '' eq 'boolean') {
-        %default = (
-            %default,
-            datatype => 'singlevaluelist',
-            datatype_description => 'Yes or No',
-            values => { value => [ 
-                    { key => ['No'],  name => ['No'] },
-                    { key => ['Yes'], name => ['Yes'] }, 
-            ] },
-        );
-    }
-
-    return { %default, %$field };
 }
 
 sub contact_details_data {
@@ -1158,6 +948,13 @@ sub contact_details_data {
     );
 }
 
-sub temp_email_to_update { 'test@example.com' } 
+sub get_body_for_contact {
+    my ($self, $contact) = @_;
+    # temporary measure to assign un-bodied contacts to parent
+    # (this isn't at all how things will be setup in live, but is
+    # handy during dev.)
+    return $self->SUPER::get_body_for_contact($contact) || 
+        $self->{c}->model('DB::Body')->find({ name => 'Stadt Zurich' });
+}
 
 1;

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -317,11 +317,13 @@ sub admin_pages {
     my $c = $self->{c};
 
     my $type = $c->stash->{admin_type};
+
     my $pages = {
         'summary' => [_('Summary'), 0],
         'reports' => [_('Reports'), 2],
         'report_edit' => [undef, undef],
         'update_edit' => [undef, undef],
+        'stats' => [_('Stats'), 4],
     };
     return $pages if $type eq 'sdm';
 
@@ -333,7 +335,6 @@ sub admin_pages {
 
     $pages = { %$pages,
         'users' => [_('Users'), 3],
-        'stats' => [_('Stats'), 4],
         'user_edit' => [undef, undef],
     };
     return $pages if $type eq 'super';

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -273,11 +273,41 @@ sub get_or_check_overdue {
     return $self->overdue($problem);
 }
 
+=head1 C<set_problem_state>
+
+If the state has changed, sets the state and calls C::Admin's C<log_edit> action.
+If the state hasn't changed, defers to update_admin_log (to update time_spent if any).
+
+Returns either undef or the AdminLog entry created.
+
+=cut
+
 sub set_problem_state {
     my ($self, $c, $problem, $new_state) = @_;
-    return if $new_state eq $problem->state;
+    return $self->update_admin_log($c, $problem) if $new_state eq $problem->state;
     $problem->state( $new_state );
     $c->forward( 'log_edit', [ $problem->id, 'problem', "state change to $new_state" ] );
+}
+
+=head1 C<update_admin_log>
+
+Calls C::Admin's C<log_edit> if either a) text is provided, or b) there has
+been time_spent on the task.  As set_problem_state will already call log_edit
+if required, don't call this as well.
+
+Returns either undef or the AdminLog entry created.
+
+=cut
+
+sub update_admin_log {
+    my ($self, $c, $problem, $text) = @_;
+
+    if (!$text) {
+        return unless $c->req->param('time_spent');
+        $text = "Logging time_spent";
+    }
+
+    $c->forward( 'log_edit', [ $problem->id, 'problem', $text ] );
 }
 
 # Specific administrative displays
@@ -491,6 +521,7 @@ sub admin_report_edit {
             $problem->whensent( undef );
             $extra->{changed_category} = 1;
             $internal_note_text = "Weitergeleitet von $old_cat an $new_cat";
+            $self->update_admin_log($c, $problem, "Changed category from $old_cat to $new_cat");
             $redirect = 1 if $cat->body_id ne $body->id;
         } elsif ( my $subdiv = $c->req->params->{body_subdivision} ) {
             $extra->{moderated_overdue} //= $self->overdue( $problem );
@@ -523,6 +554,9 @@ sub admin_report_edit {
                 if ( $state eq 'hidden' && $c->req->params->{send_rejected_email} ) {
                     _admin_send_email( $c, 'problem-rejected.txt', $problem );
                 }
+            }
+            else {
+                $self->update_admin_log($c, $problem); # just update if time_spent
             }
         }
 
@@ -629,6 +663,9 @@ sub admin_report_edit {
                 $self->set_problem_state($c, $problem, 'planned');
                 $problem->update;
                 $c->res->redirect( '/admin/summary' );
+            }
+            else {
+                $self->update_admin_log($c, $problem); # just update if time_spent
             }
         }
 

--- a/perllib/FixMyStreet/DB/Result/AdminLog.pm
+++ b/perllib/FixMyStreet/DB/Result/AdminLog.pm
@@ -36,6 +36,8 @@ __PACKAGE__->add_columns(
   { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
   "reason",
   { data_type => "text", default_value => "", is_nullable => 0 },
+  "time_spent",
+  { data_type => "integer", default_value => "0", is_nullable => 0 },
 );
 __PACKAGE__->set_primary_key("id");
 __PACKAGE__->belongs_to(

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -821,9 +821,11 @@ sub latest_moderation_log_entry {
 
 =head2 get_photoset
 
-Return a Photo-set object for all photos attached to this field
+Return a PhotoSet object for all photos attached to this field
 
-    $obj->get_photoset( $c );
+    my $photoset = $obj->get_photoset( $c );
+    print $photoset->num_images;
+    return $photoset->get_image_data(num => 0, size => 'full');
 
 =cut
 
@@ -834,15 +836,9 @@ sub get_photoset {
     return $class->new({
         c => $c,
         data => $self->photo,
+        item => $self,
     });
 }
-
-=head2 number_of_photos
-
-Return the number of photos attached to an entry
-
-=cut
-
 
 __PACKAGE__->has_many(
   "admin_log_entries",

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -228,38 +228,6 @@ sub closed_states {
 
 =head2
 
-    @states = FixMyStreet::DB::Problem::visible_states();
-
-Get a list of states that should be visible on the site. If called in
-array context then returns an array of names, otherwise returns a
-HASHREF.
-
-=cut
-
-my $visible_states = {
-    'confirmed'                   => 1,
-    'investigating'               => 1,
-    'in progress'                 => 1,
-    'planned'                     => 1,
-    'action scheduled'            => 1,
-    'fixed'                       => 1,
-    'fixed - council'             => 1,
-    'fixed - user'                => 1,
-    'unable to fix'               => 1,
-    'not responsible'             => 1,
-    'duplicate'                   => 1,
-    'closed'                      => 1,
-    'internal referral'           => 1,
-};
-sub visible_states {
-    return wantarray ? keys %{$visible_states} : $visible_states;
-}
-sub visible_states_add_unconfirmed {
-    $visible_states->{unconfirmed} = 1;
-}
-
-=head2
-
     @states = FixMyStreet::DB::Problem::all_states();
 
 Get a list of all states that a problem can have. If called in
@@ -289,6 +257,51 @@ sub all_states {
     };
 
     return wantarray ? keys %{$states} : $states;
+}
+
+=head2
+
+    @states = FixMyStreet::DB::Problem::visible_states();
+
+Get a list of states that should be visible on the site. If called in
+array context then returns an array of names, otherwise returns a
+HASHREF.
+
+=cut
+
+my $hidden_states = {
+    'hidden' => 1,
+    'partial' => 1,
+    'unconfirmed' => 1,
+};
+
+my $visible_states = {
+    map {
+        $hidden_states->{$_} ? () : ($_ => 1)
+    } all_states()
+};
+    ## e.g.:
+    # 'confirmed'                   => 1,
+    # 'investigating'               => 1,
+    # 'in progress'                 => 1,
+    # 'planned'                     => 1,
+    # 'action scheduled'            => 1,
+    # 'fixed'                       => 1,
+    # 'fixed - council'             => 1,
+    # 'fixed - user'                => 1,
+    # 'unable to fix'               => 1,
+    # 'not responsible'             => 1,
+    # 'duplicate'                   => 1,
+    # 'closed'                      => 1,
+    # 'internal referral'           => 1,
+
+sub visible_states {
+    return wantarray ? keys %{$visible_states} : $visible_states;
+}
+
+sub visible_states_add_unconfirmed {
+    delete $hidden_states->{unconfirmed};
+    $visible_states->{unconfirmed} = 1;
 }
 
 =head2

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -299,9 +299,24 @@ sub visible_states {
     return wantarray ? keys %{$visible_states} : $visible_states;
 }
 
+sub visible_states_add {
+    my ($self, @states) = @_;
+    for my $state (@states) {
+        delete $hidden_states->{$state};
+        $visible_states->{$state} = 1;
+    }
+}
+
+sub visible_states_remove {
+    my ($self, @states) = @_;
+    for my $state (@states) {
+        delete $visible_states->{$state};
+        $hidden_states->{$state} = 1;
+    }
+}
+
 sub visible_states_add_unconfirmed {
-    delete $hidden_states->{unconfirmed};
-    $visible_states->{unconfirmed} = 1;
+    $_[0]->visible_states_add('unconfirmed')
 }
 
 =head2

--- a/t/app/model/photoset.t
+++ b/t/app/model/photoset.t
@@ -53,6 +53,7 @@ sub make_report {
 
 
 subtest 'Photoset with photo inline in DB' => sub {
+    warn length($image_path->slurp);
     my $report = make_report( $image_path->slurp );
     my $photoset = $report->get_photoset($c);
     is $photoset->num_images, 1, 'Found just 1 image';

--- a/t/app/model/photoset.t
+++ b/t/app/model/photoset.t
@@ -53,7 +53,6 @@ sub make_report {
 
 
 subtest 'Photoset with photo inline in DB' => sub {
-    warn length($image_path->slurp);
     my $report = make_report( $image_path->slurp );
     my $photoset = $report->get_photoset($c);
     is $photoset->num_images, 1, 'Found just 1 image';

--- a/t/app/model/problem.t
+++ b/t/app/model/problem.t
@@ -33,6 +33,23 @@ my $problem = $problem_rs->new(
     }
 );
 
+my $visible_states = $problem->visible_states;
+is_deeply $visible_states, {
+    'confirmed'                   => 1,
+    'investigating'               => 1,
+    'in progress'                 => 1,
+    'planned'                     => 1,
+    'action scheduled'            => 1,
+    'fixed'                       => 1,
+    'fixed - council'             => 1,
+    'fixed - user'                => 1,
+    'unable to fix'               => 1,
+    'not responsible'             => 1,
+    'duplicate'                   => 1,
+    'closed'                      => 1,
+    'internal referral'           => 1,
+    }, 'visible_states is correct';
+
 is $problem->confirmed,  undef, 'inflating null confirmed ok';
 is $problem->whensent,   undef, 'inflating null confirmed ok';
 is $problem->lastupdate, undef, 'inflating null confirmed ok';

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -61,6 +61,7 @@ $division->parent( $zurich->id );
 $division->send_method( 'Zurich' );
 $division->endpoint( 'division@example.org' );
 $division->update;
+$division->body_areas->find_or_create({ area_id => 274456 });
 my $subdivision = $mech->create_body_ok( 3, 'Subdivision A' );
 $subdivision->parent( $division->id );
 $subdivision->send_method( 'Zurich' );
@@ -633,6 +634,41 @@ subtest "hidden report email are only sent when requested" => sub {
         $mech->email_count_is(0);
         $mech->clear_emails_ok;
         $mech->log_out_ok;
+    };
+};
+
+subtest "photo must be supplied for categories that require it" => sub {
+    FixMyStreet::App->model('DB::Contact')->find_or_create({
+        body => $division,
+        category => "Graffiti - photo required",
+        email => "graffiti\@example.org",
+        confirmed => 1,
+        deleted => 0,
+        editor => "editor",
+        whenedited => DateTime->now(),
+        note => "note for graffiti",
+        extra => [ { photo_required => 1 } ]
+    });
+    FixMyStreet::override_config {
+        MAPIT_TYPES => [ 'O08' ],
+        MAPIT_URL => 'http://global.mapit.mysociety.org/',
+        ALLOWED_COBRANDS => [ 'zurich' ],
+        MAPIT_ID_WHITELIST => [ 274456 ],
+        MAPIT_GENERATION => 2,
+    }, sub {
+        $mech->post_ok( '/report/new', {
+            detail => 'Problem-Bericht',
+            lat => 47.381817,
+            lon => 8.529156,
+            email => 'user@example.org',
+            pc => '',
+            name => '',
+            category => 'Graffiti - photo required',
+            photo => '',
+            submit_problem => 1,
+        });
+        is $mech->res->code, 200, "missing photo shouldn't return anything but 200";
+        $mech->content_contains("Photo is required", 'response should contain photo error message');
     };
 };
 

--- a/templates/web/base/admin/category_edit.html
+++ b/templates/web/base/admin/category_edit.html
@@ -39,7 +39,7 @@
         <input type="checkbox" name="non_public" value="1" id="non_public"[% ' checked' IF contact.non_public %]>
         <label class="inline" for="non_public">[% loc('Private') %]</label>
       [% ELSE %]
-        <input type="checkbox" name="photo_required" value="1" id="photo_required"[% ' checked' IF contact.extra.photo_required %]>
+        <input type="checkbox" name="photo_required" value="1" id="photo_required"[% ' checked' IF contact.extra.0.photo_required %]>
         <label class="inline" for="photo_required">[% loc('Photo required') %]</label>
       [% END %]
     </p>

--- a/templates/web/base/admin/category_edit.html
+++ b/templates/web/base/admin/category_edit.html
@@ -38,6 +38,9 @@
       [% IF c.cobrand.moniker != 'zurich' %]
         <input type="checkbox" name="non_public" value="1" id="non_public"[% ' checked' IF contact.non_public %]>
         <label class="inline" for="non_public">[% loc('Private') %]</label>
+      [% ELSE %]
+        <input type="checkbox" name="photo_required" value="1" id="photo_required"[% ' checked' IF contact.extra.photo_required %]>
+        <label class="inline" for="photo_required">[% loc('Photo required') %]</label>
       [% END %]
     </p>
 

--- a/templates/web/zurich/admin/report_edit.html
+++ b/templates/web/zurich/admin/report_edit.html
@@ -214,6 +214,18 @@ Ihre Stadt Zürich
 
 [% END %]
 
+<p>
+<label for="time_spent">[% loc('Time spent (in minutes):') %]</label>
+<input type="text" name="time_spent" id="form_time_spent" style="width: 4em" value="0">
+<script>
+    $('#form_time_spent').spinner({
+        spin: function (e, ui) {
+            if (ui.value < 0) { return false }
+        }
+    });
+</script>
+</p>
+
 <p align="right">
 [% IF problem.state == 'planned' %]
 <input type="submit" name="publish_response" value="[% loc('Publish the response') %]">

--- a/templates/web/zurich/admin/report_edit.html
+++ b/templates/web/zurich/admin/report_edit.html
@@ -218,10 +218,12 @@ Ihre Stadt Zürich
 <label for="time_spent">[% loc('Time spent (in minutes):') %]</label>
 <input type="text" name="time_spent" id="form_time_spent" style="width: 4em" value="0">
 <script>
-    $('#form_time_spent').spinner({
-        spin: function (e, ui) {
-            if (ui.value < 0) { return false }
-        }
+    $(function () {
+        $('#form_time_spent').spinner({
+            spin: function (e, ui) {
+                if (ui.value < 0) { return false }
+            }
+        });
     });
 </script>
 </p>

--- a/templates/web/zurich/header.html
+++ b/templates/web/zurich/header.html
@@ -68,10 +68,10 @@
             <li [% IF pagename == 'users' OR pagename == 'user_edit' %]class="current"[% END %]>
                 <a href="/admin/users">[% loc('Users') %]</a>
             </li>
+            [% END %]
             <li [% IF pagename == 'stats' %]class="current"[% END %]>
                 <a href="/admin/stats">[% loc('Stats') %]</a>
             </li>
-            [% END %]
             <li class="search-box">
                 <form method="get" action="[% c.uri_for('reports') %]" enctype="application/x-www-form-urlencoded" accept-charset="utf-8">
                     <input type="text" name="search" size="20" id="search" placeholder="[% loc('Search reports') %]">


### PR DESCRIPTION
This PR:

 * Adds a 'photo required' tick box to the form for editing a contact/category
 * Enforces photo upload for new reports in categories that demand a photo
 * Includes a failing test that my Perl-fu isn't yet sufficient to fix

The last point requires some input from somebody else - all tips gratefully received.