### PR TITLE
Order 'all reports' page by confirmation date

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -430,7 +430,7 @@ sub load_and_group_problems : Private {
     my $problems = $c->cobrand->problems->search(
         $where,
         {
-            order_by => { -desc => 'lastupdate' },
+            order_by => $c->cobrand->reports_ordering,
             rows => $c->cobrand->reports_per_page,
         }
     )->page( $page );

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -337,6 +337,16 @@ sub reports_per_page {
     return FixMyStreet->config('ALL_REPORTS_PER_PAGE') || 100;
 }
 
+=head2 reports_ordering
+
+The order_by clause to use for reports on all reports page
+
+=cut
+
+sub reports_ordering {
+    return { -desc => 'lastupdate' };
+}
+
 =head2 on_map_list_limit
 
 Return the maximum number of items to be given in the list of reports on the map

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -53,6 +53,9 @@ sub pin_colour {
     return 'green' if $p->is_fixed || $p->is_closed;
     return 'red' if $p->state eq 'confirmed';
     return 'yellow';
+
+sub reports_ordering {
+    return { -desc => 'confirmed' };
 }
 
 1;


### PR DESCRIPTION
This PR:

 * Allows cobrands to specify their own `order_by` clause for the `/reports/[body]` page
 * Makes the Oxfordshire cobrand order reports by descending order of creation date

Closes mysociety/FixMyStreet-Commercial#681