### PR TITLE
Use config variable for setting proxy trust.

### DIFF
--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -24,6 +24,10 @@ FMS_DB_PASS: ''
 BASE_URL: 'http://www.example.org'
 # Use the below if you're using the Catalyst development server
 #   BASE_URL: 'http://localhost:3000'
+SECURE_PROXY_SSL_HEADER: ''
+# If you're behind a proxy, set this to a two-element list containing the
+# trusted HTTP header and the required value. For example:
+#   SECURE_PROXY_SSL_HEADER: [ 'X-Forwarded-Proto', 'https' ]
 
 # Email domain used for emails, and contact name/email for admin use.
 EMAIL_DOMAIN: 'example.org'

--- a/perllib/FixMyStreet/App.pm
+++ b/perllib/FixMyStreet/App.pm
@@ -89,15 +89,15 @@ __PACKAGE__->config(
 # Start the application
 __PACKAGE__->setup();
 
-# Due to some current issues with proxyings, need to manually
-# tell the code we're secure if we are.
+# If your site is secure but running behind a proxy, you might need to set the
+# SECURE_PROXY_SSL_HEADER configuration variable so this can be spotted.
 after 'prepare_headers' => sub {
     my $self = shift;
     my $base_url = $self->config->{BASE_URL};
+    my $ssl_header = $self->config->{SECURE_PROXY_SSL_HEADER};
     my $host = $self->req->headers->header('Host');
-    $self->req->secure( 1 ) if $base_url eq 'https://www.zueriwieneu.ch';
-    $self->req->secure( 1 ) if $base_url eq 'https://www.fixmystreet.com'
-        && ( $host eq 'fix.bromley.gov.uk' || $host eq 'www.fixmystreet.com' );
+    $self->req->secure(1) if $ssl_header && ref $ssl_header eq 'ARRAY'
+        && @$ssl_header == 2 && $self->req->header($ssl_header->[0]) eq $ssl_header->[1];
 };
 
 # set up DB handle for old code


### PR DESCRIPTION
Rather than hardcoding domain names, add a SECURE_PROXY_SSL_HEADER variable that provides a trusted HTTP header and value that can be used to determine if we're behind a HTTPS proxy.