### PR TITLE
Add expected response time to report page

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -899,4 +899,3 @@ sub get_country_for_ip_address {
 }
 
 1;
-

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -47,5 +47,46 @@ sub users_can_hide { return 1; }
 
 sub default_show_name { 0 }
 
-1;
+=head2 problem_response_days
 
+Returns the number of working days that are expected to elapse
+between the problem being reported and it being responded to by
+the council/body.
+
+=cut
+
+sub problem_response_days {
+    my $self = shift;
+    my $p = shift;
+
+    return 10 if $p->category eq 'Bridges';
+    return 10 if $p->category eq 'Carriageway Defect'; # phone if urgent
+    return 10 if $p->category eq 'Debris/Spillage';
+    return 10 if $p->category eq 'Drainage';
+    return 10 if $p->category eq 'Fences';
+    return 10 if $p->category eq 'Flyposting';
+    return 10 if $p->category eq 'Footpaths/ Rights of way (usually not tarmac)';
+    return 10 if $p->category eq 'Gully and Catchpits';
+    return 10 if $p->category eq 'Ice/Snow'; # phone if urgent
+    return 10 if $p->category eq 'Manhole';
+    return 10 if $p->category eq 'Mud and Debris'; # phone if urgent
+    return 10 if $p->category eq 'Oil Spillage';  # phone if urgent
+    return 10 if $p->category eq 'Pavements';
+    return 10 if $p->category eq 'Pothole'; # phone if urgent
+    return 10 if $p->category eq 'Property Damage';
+    return 10 if $p->category eq 'Public rights of way';
+    return 10 if $p->category eq 'Road Marking';
+    return 10 if $p->category eq 'Road traffic signs';
+    return 10 if $p->category eq 'Roads/highways';
+    return 10 if $p->category eq 'Skips and scaffolding';
+    return 10 if $p->category eq 'Street lighting';
+    return 10 if $p->category eq 'Traffic lights'; # phone if urgent
+    return 10 if $p->category eq 'Traffic';
+    return 10 if $p->category eq 'Trees';
+    return 10 if $p->category eq 'Utilities';
+    return 10 if $p->category eq 'Vegetation';
+
+    return undef;
+}
+
+1;

--- a/templates/web/oxfordshire/report/_council_sent_info.html
+++ b/templates/web/oxfordshire/report/_council_sent_info.html
@@ -3,6 +3,14 @@
         [% IF problem.whensent %]
         [% problem.duration_string(c) %]<br>
         [% END %]
+        [% IF c.cobrand.problem_response_days(problem) > 0 %]
+            Problems in the
+            [% problem.category %]
+            category are generally responded to within
+            [% c.cobrand.problem_response_days(problem) %]
+            working days.
+            <br />
+        [% END %]
         <strong>
         [% IF problem.can_display_external_id %]
             [% IF problem.whensent %]


### PR DESCRIPTION

 * Adds a new `problem_response_days` to the `Default` cobrand that subclasses can override to provide an expected response time based on a problem's category.
 * OCC-provided response time figures are implemented in the `Oxfordshire` cobrand.
 * The response time is displayed at the top of the report when viewed in the Oxfordshire cobrand.

Fixes mysociety/FixMyStreet-Commercial#680.