### PR TITLE
Allow cobrands to specify report ordering on 'all reports' page

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -430,7 +430,7 @@ sub load_and_group_problems : Private {
     my $problems = $c->cobrand->problems->search(
         $where,
         {
-            order_by => { -desc => 'lastupdate' },
+            order_by => $c->cobrand->reports_ordering,
             rows => $c->cobrand->reports_per_page,
         }
     )->page( $page );

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -340,6 +340,16 @@ sub reports_per_page {
     return FixMyStreet->config('ALL_REPORTS_PER_PAGE') || 100;
 }
 
+=head2 reports_ordering
+
+The order_by clause to use for reports on all reports page
+
+=cut
+
+sub reports_ordering {
+    return { -desc => 'lastupdate' };
+}
+
 =head2 on_map_list_limit
 
 Return the maximum number of items to be given in the list of reports on the map

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -89,4 +89,8 @@ sub problem_response_days {
     return undef;
 }
 
+sub reports_ordering {
+    return { -desc => 'confirmed' };
+}
+
 1;


### PR DESCRIPTION
 * Adds a new `reports_ordering` sub to the `Default` cobrand that's used to control ordering of reports in `Reports.load_and_group_problems`.
 * Orders reports by confirmed date in the `Oxfordshire` cobrand.

Fixes mysociety/FixMyStreet-Commercial#681.