### PR TITLE
Zurich: 'photo required' functionality issues/commercial/665

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -370,6 +370,14 @@ sub update_contacts : Private {
         $contact->api_key( $c->req->param('api_key') );
         $contact->send_method( $c->req->param('send_method') );
 
+        # Set the photo_required flag in extra to the appropriate value
+        if ( $c->req->param('photo_required') ) {
+            $contact->set_extra_metadata_if_undefined(  photo_required => 1 );
+        }
+        else {
+            $contact->unset_extra_metadata( 'photo_required' );
+        }
+
         if ( %errors ) {
             $c->stash->{updated} = _('Please correct the errors below');
             $c->stash->{contact} = $contact;

--- a/perllib/FixMyStreet/App/Controller/Photo.pm
+++ b/perllib/FixMyStreet/App/Controller/Photo.pm
@@ -143,6 +143,7 @@ sub process_photo : Private {
 
     return
          $c->forward('process_photo_upload_or_cache')
+      || $c->forward('process_photo_required')
       || 1;    # always return true
 }
 
@@ -164,6 +165,44 @@ sub process_photo_upload_or_cache : Private {
     my $fileid = $photoset->data;
 
     $c->stash->{upload_fileid} = $fileid or return;
+    return 1;
+}
+
+=head2 process_photo_required
+
+Checks that a report has a photo attached if any of its Contacts
+require it (by setting extra->photo_required == 1). Puts an error in
+photo_error on the stash if it's required and missing, otherwise returns
+true.
+
+(Note that as we have reached this action, we *know* that the photo
+is missing, otherwise it would have already been handled.)
+
+=cut
+
+sub process_photo_required : Private {
+    my ( $self, $c ) = @_;
+
+    # load the report
+    my $report = $c->stash->{report} or return 1; # don't check photo for updates
+    my $bodies = $c->stash->{bodies};
+
+    my @contacts = $c->       #
+      model('DB::Contact')    #
+      ->not_deleted           #
+      ->search(
+        {
+            body_id => [ keys %$bodies ],
+            category => $report->category
+        }
+      )->all;
+      foreach my $contact ( @contacts ) {
+          if ( $contact->get_extra_metadata('photo_required') ) {
+              $c->stash->{photo_error} = _("Photo is required.");
+              return;
+          }
+      }
+
     return 1;
 }
 

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -69,6 +69,7 @@ $division->parent( $zurich->id );
 $division->send_method( 'Zurich' );
 $division->endpoint( 'division@example.org' );
 $division->update;
+$division->body_areas->find_or_create({ area_id => 274456 });
 my $subdivision = $mech->create_body_ok( 3, 'Subdivision A' );
 $subdivision->parent( $division->id );
 $subdivision->send_method( 'Zurich' );
@@ -641,6 +642,41 @@ subtest "hidden report email are only sent when requested" => sub {
         $mech->email_count_is(0);
         $mech->clear_emails_ok;
         $mech->log_out_ok;
+    };
+};
+
+subtest "photo must be supplied for categories that require it" => sub {
+    FixMyStreet::App->model('DB::Contact')->find_or_create({
+        body => $division,
+        category => "Graffiti - photo required",
+        email => "graffiti\@example.org",
+        confirmed => 1,
+        deleted => 0,
+        editor => "editor",
+        whenedited => DateTime->now(),
+        note => "note for graffiti",
+        extra => { photo_required => 1 }
+    });
+    FixMyStreet::override_config {
+        MAPIT_TYPES => [ 'O08' ],
+        MAPIT_URL => 'http://global.mapit.mysociety.org/',
+        ALLOWED_COBRANDS => [ 'zurich' ],
+        MAPIT_ID_WHITELIST => [ 274456 ],
+        MAPIT_GENERATION => 2,
+    }, sub {
+        $mech->post_ok( '/report/new', {
+            detail => 'Problem-Bericht',
+            lat => 47.381817,
+            lon => 8.529156,
+            email => 'user@example.org',
+            pc => '',
+            name => '',
+            category => 'Graffiti - photo required',
+            photo => '',
+            submit_problem => 1,
+        });
+        is $mech->res->code, 200, "missing photo shouldn't return anything but 200";
+        $mech->content_contains(_("Photo is required"), 'response should contain photo error message');
     };
 };
 

--- a/templates/web/base/admin/category_edit.html
+++ b/templates/web/base/admin/category_edit.html
@@ -38,6 +38,9 @@
       [% IF c.cobrand.moniker != 'zurich' %]
         <input type="checkbox" name="non_public" value="1" id="non_public"[% ' checked' IF contact.non_public %]>
         <label class="inline" for="non_public">[% loc('Private') %]</label>
+      [% ELSE %]
+        <input type="checkbox" name="photo_required" value="1" id="photo_required"[% ' checked' IF contact.get_extra_metadata('photo_required') %]>
+        <label class="inline" for="photo_required">[% loc('Photo required') %]</label>
       [% END %]
     </p>
 


### PR DESCRIPTION
Work for https://github.com/mysociety/FixMyStreet-Commercial/issues/665
Builds on https://github.com/mysociety/FixMyStreet-Commercial/issues/664, so PR is to that in first instance. 

(you should probably look at #1050 first, sorry for counterintuitive order of PR)

- Save 'photo_required' value in Contact->extra from admin edit form
 - Enforce per-category photo requirement on new reports
    A new step has been added to the photo upload process that
    ensures a photo is present if any of the categories chosen for
    the report require it.
    If the photo is missing an error is displayed to the user in the
    same manner as if the photo upload was invalid.
 - Add test of mandatory photo categories