### PR TITLE
Stats19 checkbox on Collideoscope /around page

### DIFF
--- a/perllib/FixMyStreet.pm
+++ b/perllib/FixMyStreet.pm
@@ -170,7 +170,8 @@ sub dbic_connect_info {
         # adding this should makeabunch of
         # $c->model('DB')->schema->storage->sql_maker->quote_char() 
         # etc. wrangling obsolete?
-        quote_names => 1, 
+        # BUT causes hilarious consequences, needs major test/refactor
+        ## quote_names => 1, 
     };
 
     return [ $dsn, $user, $password, $dbi_args, $dbic_args ];

--- a/templates/web/smidsy/around/tabbed_lists.html
+++ b/templates/web/smidsy/around/tabbed_lists.html
@@ -1,7 +1,15 @@
 <p class="report-list-filters">
-  <label>
-    <input type="checkbox"> Include Stats19 reports
-  </label>
+  <input id="show_stats19_checkbox" type="checkbox" [% IF c.req.params.all_pins %]checked[% END %]>
+  <label>Show reports from the Department of Transport</label>
+      <script>
+          $(function () {
+              $('#show_stats19_checkbox').change( function () {
+                  // for now, defer to #all_pins_link functionality
+                  // we will replace this hack when we have proper backend plumbing for it
+                  $('#all_pins_link').click();
+              });
+          });
+      </script>
   <a href="/faq#stats19" title="What is Stats19?">(?)</a>
 </p>
 

--- a/templates/web/smidsy/around/tabbed_lists.html
+++ b/templates/web/smidsy/around/tabbed_lists.html
@@ -1,5 +1,10 @@
-<h2 class="incident-list-header">Incidents in this area:</h2>
+<p class="report-list-filters">
+  <label>
+    <input type="checkbox"> Include Stats19 reports
+  </label>
+  <a href="/faq#stats19" title="What is Stats19?">(?)</a>
+</p>
 
-<ul class="incident-list">
+<ul class="incident-list" style="display:none">
     [% INCLUDE "around/combined_map_list_items.html" %]
 </ul>

--- a/web/cobrands/smidsy/base.scss
+++ b/web/cobrands/smidsy/base.scss
@@ -445,3 +445,7 @@ dt:target {
         background-color: $color-neutral-cream;
     }
 }
+
+// for expediency, we are relabelling this functionality in Collideoscope for
+// Stats19 data, so hide the link to avoid confusing interactions
+#sub_map_links a#all_pins_link { display: none }

--- a/web/cobrands/smidsy/layout.scss
+++ b/web/cobrands/smidsy/layout.scss
@@ -307,6 +307,25 @@ body.mappage {
   }
 }
 
+.report-list-filters {
+    padding: 15px;
+    margin-bottom: 10px;
+    border-bottom: 1px solid mix(#ccc, $color-neutral-raincloud);
+
+    label {
+        display: inline;
+        margin: 0;
+        color: $color-neutral-slategrey;
+        font-weight: normal;
+
+        input {
+            margin-left: 10px; // line up with the report icons in the list underneath
+            margin-right: 0.2em;
+            vertical-align: 1px;
+        }
+    }
+}
+
 #report-a-problem-main {
     .form-box {
         margin: 1.5em -1em 0.25em -1em;


### PR DESCRIPTION
This is the markup and styling for a checkbox that lets the user show or hide Stats19 data in the Collideoscope cobrand.

![screen shot 2015-03-10 at 16 21 22](https://cloud.githubusercontent.com/assets/739624/6579615/2858a156-c743-11e4-872b-639e30a4ccb8.png)

@osfameron needs to add the backend logic that makes the checkbox work.

@BenJam needs to decide, with our partners, whether "Stats19 reports" is the right wording to use. Maybe "reports from the Department for Transport" might be clearer?

![screen shot 2015-03-10 at 16 22 19](https://cloud.githubusercontent.com/assets/739624/6579611/240aba9e-c743-11e4-8f72-c2fa5e4ad383.png)