### PR TITLE
Oxfordshire: Filter reports on map by status & category

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -167,6 +167,7 @@ sub display_location : Private {
 
     # Filter by report category
     my $category = $c->req->param('category');
+    $c->stash->{category} = $category;
 
     # get the map features
     my ( $on_map_all, $on_map, $around_map, $distance ) =

--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -165,10 +165,13 @@ sub display_location : Private {
     $c->stash->{all_pins} = $all_pins;
     my $interval = $all_pins ? undef : $c->cobrand->on_map_default_max_pin_age;
 
+    # Filter by report category
+    my $category = $c->req->param('category');
+
     # get the map features
     my ( $on_map_all, $on_map, $around_map, $distance ) =
       FixMyStreet::Map::map_features( $c, $latitude, $longitude,
-        $interval );
+        $interval, $category );
 
     # copy the found reports to the stash
     $c->stash->{on_map}     = $on_map;

--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -165,14 +165,13 @@ sub display_location : Private {
     $c->stash->{all_pins} = $all_pins;
     my $interval = $all_pins ? undef : $c->cobrand->on_map_default_max_pin_age;
 
-    # Filter by report category
-    my $category = $c->req->param('category');
-    $c->stash->{category} = $category;
+    # Check the category to filter by, if any, is valid
+    $c->forward('check_category_is_valid');
 
     # get the map features
     my ( $on_map_all, $on_map, $around_map, $distance ) =
       FixMyStreet::Map::map_features( $c, $latitude, $longitude,
-        $interval, $category );
+        $interval, $c->stash->{category} );
 
     # copy the found reports to the stash
     $c->stash->{on_map}     = $on_map;
@@ -223,6 +222,36 @@ sub check_location_is_acceptable : Private {
     $c->stash->{area_check_action} = 'submit_problem';
     $c->stash->{remove_redundant_areas} = 1;
     return $c->forward('/council/load_and_check_areas');
+}
+
+=head2 check_category_is_valid
+
+Check that the 'category' query param is valid, if it's present.
+
+=cut
+
+sub check_category_is_valid : Private {
+    my ( $self, $c ) = @_;
+
+    my $category = $c->req->param('category');
+    if ( $category ) {
+        my $all_areas = $c->stash->{all_areas};
+        my @bodies = $c->model('DB::Body')->search(
+            { 'body_areas.area_id' => [ keys %$all_areas ], deleted => 0 },
+            { join => 'body_areas' }
+        )->all;
+        my %bodies = map { $_->id => $_ } @bodies;
+
+        my $count = $c->model('DB::Contact')->not_deleted->search(
+            {
+                body_id => [ keys %bodies ],
+                category => $category
+            }
+        )->count;
+        if ( $count ) {
+            $c->stash->{category} = $category;
+        }
+    }
 }
 
 =head2 /ajax

--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -164,7 +164,20 @@ sub display_location : Private {
     my $all_pins = $c->req->param('all_pins') ? 1 : undef;
     $c->stash->{all_pins} = $all_pins;
     my $interval = $all_pins ? undef : $c->cobrand->on_map_default_max_pin_age;
+
     my $states = $c->cobrand->on_map_default_states;
+    $c->stash->{filter_status} = $c->cobrand->on_map_default_status;
+    my $status = $c->req->param('status');
+    if ( !defined $states || $status eq 'all' ) {
+        $states = FixMyStreet::DB::Result::Problem->visible_states();
+        $c->stash->{filter_status} = 'all';
+    } elsif ( $status eq 'open' ) {
+        $states = FixMyStreet::DB::Result::Problem->open_states();
+        $c->stash->{filter_status} = 'open';
+    } elsif ( $status eq 'fixed' ) {
+        $states = FixMyStreet::DB::Result::Problem->fixed_states();
+        $c->stash->{filter_status} = 'fixed';
+    }
 
     # Check the category to filter by, if any, is valid
     $c->forward('check_category_is_valid');

--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -185,7 +185,7 @@ sub display_location : Private {
     # get the map features
     my ( $on_map_all, $on_map, $around_map, $distance ) =
       FixMyStreet::Map::map_features( $c, $latitude, $longitude,
-        $interval, $c->stash->{category}, $states );
+        $interval, $c->stash->{filter_category}, $states );
 
     # copy the found reports to the stash
     $c->stash->{on_map}     = $on_map;
@@ -241,21 +241,36 @@ sub check_location_is_acceptable : Private {
 =head2 check_category_is_valid
 
 Check that the 'category' query param is valid, if it's present.
+Puts all the valid categories in filter_categories on the stash.
 
 =cut
 
 sub check_category_is_valid : Private {
     my ( $self, $c ) = @_;
 
+    my $all_areas = $c->stash->{all_areas};
+    my @bodies = $c->model('DB::Body')->search(
+        { 'body_areas.area_id' => [ keys %$all_areas ], deleted => 0 },
+        { join => 'body_areas' }
+    )->all;
+    my %bodies = map { $_->id => $_ } @bodies;
+
+    my @contacts = $c->model('DB::Contact')->not_deleted->search(
+        {
+            body_id => [ keys %bodies ],
+        },
+        {
+            columns => [ 'category' ],
+            order_by => [ 'category' ],
+            distinct => 1
+        }
+    )->all;
+    my @categories = map { $_->category } @contacts;
+    $c->stash->{filter_categories} = \@categories;
+
+
     my $category = $c->req->param('category');
     if ( $category ) {
-        my $all_areas = $c->stash->{all_areas};
-        my @bodies = $c->model('DB::Body')->search(
-            { 'body_areas.area_id' => [ keys %$all_areas ], deleted => 0 },
-            { join => 'body_areas' }
-        )->all;
-        my %bodies = map { $_->id => $_ } @bodies;
-
         my $count = $c->model('DB::Contact')->not_deleted->search(
             {
                 body_id => [ keys %bodies ],
@@ -263,7 +278,7 @@ sub check_category_is_valid : Private {
             }
         )->count;
         if ( $count ) {
-            $c->stash->{category} = $category;
+            $c->stash->{filter_category} = $category;
         }
     }
 }

--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -164,6 +164,7 @@ sub display_location : Private {
     my $all_pins = $c->req->param('all_pins') ? 1 : undef;
     $c->stash->{all_pins} = $all_pins;
     my $interval = $all_pins ? undef : $c->cobrand->on_map_default_max_pin_age;
+    my $states = $c->cobrand->on_map_default_states;
 
     # Check the category to filter by, if any, is valid
     $c->forward('check_category_is_valid');
@@ -171,7 +172,7 @@ sub display_location : Private {
     # get the map features
     my ( $on_map_all, $on_map, $around_map, $distance ) =
       FixMyStreet::Map::map_features( $c, $latitude, $longitude,
-        $interval, $c->stash->{category} );
+        $interval, $c->stash->{category}, $states );
 
     # copy the found reports to the stash
     $c->stash->{on_map}     = $on_map;

--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -167,7 +167,7 @@ sub display_location : Private {
 
     my $states = $c->cobrand->on_map_default_states;
     $c->stash->{filter_status} = $c->cobrand->on_map_default_status;
-    my $status = $c->req->param('status');
+    my $status = $c->req->param('status') || '';
     if ( !defined $states || $status eq 'all' ) {
         $states = FixMyStreet::DB::Result::Problem->visible_states();
         $c->stash->{filter_status} = 'all';

--- a/perllib/FixMyStreet/App/Controller/My.pm
+++ b/perllib/FixMyStreet/App/Controller/My.pm
@@ -55,6 +55,7 @@ sub my : Path : Args(0) {
         };
         my $state = $problem->is_fixed ? 'fixed' : $problem->is_closed ? 'closed' : 'confirmed';
         push @{ $problems->{$state} }, $problem;
+        push @{ $problems->{all} }, $problem;
     }
     $c->stash->{problems_pager} = $rs->pager;
     $c->stash->{problems} = $problems;

--- a/perllib/FixMyStreet/App/Controller/My.pm
+++ b/perllib/FixMyStreet/App/Controller/My.pm
@@ -54,6 +54,12 @@ sub my : Path : Args(0) {
         %$params
     } if $c->cobrand->problems_clause;
 
+    my $category = $c->req->param('category');
+    if ( $category ) {
+        $params->{category} = $category;
+        $c->stash->{filter_category} = $category;
+    }
+
     my $rs = $c->user->problems->search( $params, {
         order_by => { -desc => 'confirmed' },
         rows => 50
@@ -86,6 +92,14 @@ sub my : Path : Args(0) {
     $c->stash->{has_content} += scalar @updates;
     $c->stash->{updates} = \@updates;
     $c->stash->{updates_pager} = $rs->pager;
+
+    my @categories = $c->user->problems->search( undef, {
+        columns => [ 'category' ],
+        distinct => 1,
+        order_by => [ 'category' ],
+    } )->all;
+    @categories = map { $_->category } @categories;
+    $c->stash->{filter_categories} = \@categories;
 
     $c->stash->{page} = 'my';
     FixMyStreet::Map::display_map(

--- a/perllib/FixMyStreet/App/Controller/My.pm
+++ b/perllib/FixMyStreet/App/Controller/My.pm
@@ -28,11 +28,26 @@ sub my : Path : Args(0) {
     my $p_page = $c->req->params->{p} || 1;
     my $u_page = $c->req->params->{u} || 1;
 
+    my $states = $c->cobrand->on_map_default_states;
+    $c->stash->{filter_status} = $c->cobrand->on_map_default_status;
+    my $status = $c->req->param('status') || '';
+    if ( !defined $states || $status eq 'all' ) {
+        $states = FixMyStreet::DB::Result::Problem->visible_states();
+        $c->stash->{filter_status} = 'all';
+    } elsif ( $status eq 'open' ) {
+        $states = FixMyStreet::DB::Result::Problem->open_states();
+        $c->stash->{filter_status} = 'open';
+    } elsif ( $status eq 'fixed' ) {
+        $states = FixMyStreet::DB::Result::Problem->fixed_states();
+        $c->stash->{filter_status} = 'fixed';
+    }
+
     my $pins = [];
     my $problems = {};
 
+
     my $params = {
-        state => [ FixMyStreet::DB::Result::Problem->visible_states() ],
+        state => [ keys %$states ],
     };
     $params = {
         %{ $c->cobrand->problems_clause },

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -130,6 +130,15 @@ sub ward : Path : Args(2) {
         $c->stash->{filter_status} = 'fixed';
     }
 
+    my @categories = $c->stash->{body}->contacts->search( undef, {
+        columns => [ 'category' ],
+        distinct => 1,
+        order_by => [ 'category' ],
+    } )->all;
+    @categories = map { $_->category } @categories;
+    $c->stash->{filter_categories} = \@categories;
+    $c->stash->{filter_category} = $c->req->param('category');
+
     my $pins = $c->stash->{pins};
 
     $c->stash->{page} = 'reports'; # So the map knows to make clickable pins

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -120,6 +120,16 @@ sub ward : Path : Args(2) {
 
     $c->stash->{stats} = $c->cobrand->get_report_stats();
 
+    $c->stash->{filter_status} = $c->cobrand->on_map_default_status;
+    my $status = $c->req->param('status') || '';
+    if ( !defined $c->cobrand->on_map_default_states || $status eq 'all' ) {
+        $c->stash->{filter_status} = 'all';
+    } elsif ( $status eq 'open' ) {
+        $c->stash->{filter_status} = 'open';
+    } elsif ( $status eq 'fixed' ) {
+        $c->stash->{filter_status} = 'fixed';
+    }
+
     my $pins = $c->stash->{pins};
 
     $c->stash->{page} = 'reports'; # So the map knows to make clickable pins

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -366,6 +366,15 @@ Return the default maximum age for pins.
 
 sub on_map_default_max_pin_age { return '6 months'; }
 
+=head2 on_map_default_states
+
+Return the default filter to use for report states on map page.
+Return undef to show all visible reports.
+
+=cut
+
+sub on_map_default_states { return undef; }
+
 =head2 allow_photo_upload
 
 Return a boolean indicating whether the cobrand allows photo uploads

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -375,6 +375,14 @@ Return undef to show all visible reports.
 
 sub on_map_default_states { return undef; }
 
+=head2 on_map_default_status
+
+Return the default ?status= query parameter to use for filter on map page.
+
+=cut
+
+sub on_map_default_status { return 'all'; }
+
 =head2 allow_photo_upload
 
 Return a boolean indicating whether the cobrand allows photo uploads

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -101,4 +101,6 @@ sub pin_colour {
     return 'yellow';
 }
 
+sub on_map_default_states { return FixMyStreet::DB::Result::Problem->open_states(); }
+
 1;

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -103,4 +103,6 @@ sub pin_colour {
 
 sub on_map_default_states { return FixMyStreet::DB::Result::Problem->open_states(); }
 
+sub on_map_default_status { return 'open'; }
+
 1;

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -655,14 +655,14 @@ sub processed_summary_string {
     }
     if ($problem->can_display_external_id) {
         if ($duration_clause) {
-            $external_ref_clause = sprintf(_('council ref:&nbsp;%s'), $problem->external_id);
+            $external_ref_clause = '<strong>' . sprintf(_('Council ref:&nbsp;%s'), $problem->external_id) . '.</strong>';
         } else {
-            $external_ref_clause = sprintf(_('%s ref:&nbsp;%s'), $problem->external_body, $problem->external_id);
+            $external_ref_clause = '<strong>' . sprintf(_('%s ref:&nbsp;%s'), $problem->external_body, $problem->external_id) . '.</strong>';
         }
     }
     if ($duration_clause and $external_ref_clause) {
-        return "$duration_clause, $external_ref_clause"
-    } else { 
+        return "$duration_clause. $external_ref_clause"
+    } else {
         return $duration_clause || $external_ref_clause
     }
 }

--- a/perllib/FixMyStreet/DB/ResultSet/Nearby.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Nearby.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 sub nearby {
-    my ( $rs, $c, $dist, $ids, $limit, $mid_lat, $mid_lon, $interval ) = @_;
+    my ( $rs, $c, $dist, $ids, $limit, $mid_lat, $mid_lon, $interval, $category ) = @_;
 
     my $params = {
         non_public => 0,
@@ -19,6 +19,7 @@ sub nearby {
         %{ $c->cobrand->problems_clause },
         %$params
     } if $c->cobrand->problems_clause;
+    $params->{category} = $category if $category;
 
     my $attrs = {
         prefetch => 'problem',

--- a/perllib/FixMyStreet/DB/ResultSet/Nearby.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Nearby.pm
@@ -5,11 +5,15 @@ use strict;
 use warnings;
 
 sub nearby {
-    my ( $rs, $c, $dist, $ids, $limit, $mid_lat, $mid_lon, $interval, $category ) = @_;
+    my ( $rs, $c, $dist, $ids, $limit, $mid_lat, $mid_lon, $interval, $category, $states ) = @_;
+
+    unless ( $states ) {
+        $states = FixMyStreet::DB::Result::Problem->visible_states();
+    }
 
     my $params = {
         non_public => 0,
-        state => [ FixMyStreet::DB::Result::Problem::visible_states() ],
+        state => [ keys %$states ],
     };
     $params->{'current_timestamp-lastupdate'} = { '<', \"'$interval'::interval" }
         if $interval;

--- a/perllib/FixMyStreet/DB/ResultSet/Problem.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Problem.pm
@@ -131,15 +131,19 @@ sub _recent {
 # Problems around a location
 
 sub around_map {
-    my ( $rs, $min_lat, $max_lat, $min_lon, $max_lon, $interval, $limit, $category ) = @_;
+    my ( $rs, $min_lat, $max_lat, $min_lon, $max_lon, $interval, $limit, $category, $states ) = @_;
     my $attr = {
         order_by => { -desc => 'created' },
     };
     $attr->{rows} = $limit if $limit;
 
+    unless ( $states ) {
+        $states = FixMyStreet::DB::Result::Problem->visible_states();
+    }
+
     my $q = {
             non_public => 0,
-            state => [ FixMyStreet::DB::Result::Problem->visible_states() ],
+            state => [ keys %$states ],
             latitude => { '>=', $min_lat, '<', $max_lat },
             longitude => { '>=', $min_lon, '<', $max_lon },
     };

--- a/perllib/FixMyStreet/DB/ResultSet/Problem.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Problem.pm
@@ -131,7 +131,7 @@ sub _recent {
 # Problems around a location
 
 sub around_map {
-    my ( $rs, $min_lat, $max_lat, $min_lon, $max_lon, $interval, $limit ) = @_;
+    my ( $rs, $min_lat, $max_lat, $min_lon, $max_lon, $interval, $limit, $category ) = @_;
     my $attr = {
         order_by => { -desc => 'created' },
     };
@@ -145,6 +145,7 @@ sub around_map {
     };
     $q->{'current_timestamp - lastupdate'} = { '<', \"'$interval'::interval" }
         if $interval;
+    $q->{category} = $category if $category;
 
     my @problems = mySociety::Locale::in_gb_locale { $rs->search( $q, $attr )->all };
     return \@problems;

--- a/perllib/FixMyStreet/Map.pm
+++ b/perllib/FixMyStreet/Map.pm
@@ -55,7 +55,7 @@ sub display_map {
 }
 
 sub map_features {
-    my ( $c, $lat, $lon, $interval, $category ) = @_;
+    my ( $c, $lat, $lon, $interval, $category, $states ) = @_;
 
    # TODO - be smarter about calculating the surrounding square
    # use deltas that are roughly 500m in the UK - so we get a 1 sq km search box
@@ -65,12 +65,12 @@ sub map_features {
         $c, $lat, $lon,
         $lon - $lon_delta, $lat - $lat_delta,
         $lon + $lon_delta, $lat + $lat_delta,
-        $interval, $category
+        $interval, $category, $states
     );
 }
 
 sub map_features_bounds {
-    my ( $c, $min_lon, $min_lat, $max_lon, $max_lat, $interval, $category ) = @_;
+    my ( $c, $min_lon, $min_lat, $max_lon, $max_lat, $interval, $category, $states ) = @_;
 
     my $lat = ( $max_lat + $min_lat ) / 2;
     my $lon = ( $max_lon + $min_lon ) / 2;
@@ -78,20 +78,21 @@ sub map_features_bounds {
         $c, $lat, $lon,
         $min_lon, $min_lat,
         $max_lon, $max_lat,
-        $interval, $category
+        $interval, $category,
+        $states
     );
 }
 
 sub _map_features {
-    my ( $c, $lat, $lon, $min_lon, $min_lat, $max_lon, $max_lat, $interval, $category ) = @_;
+    my ( $c, $lat, $lon, $min_lon, $min_lat, $max_lon, $max_lat, $interval, $category, $states ) = @_;
 
     # list of problems around map can be limited, but should show all pins
     my $around_limit = $c->cobrand->on_map_list_limit || undef;
 
     my @around_args = ( $min_lat, $max_lat, $min_lon, $max_lon, $interval );
-    my $around_map      = $c->cobrand->problems->around_map( @around_args, undef, $category );
+    my $around_map      = $c->cobrand->problems->around_map( @around_args, undef, $category, $states );
     my $around_map_list = $around_limit
-        ? $c->cobrand->problems->around_map( @around_args, $around_limit, $category )
+        ? $c->cobrand->problems->around_map( @around_args, $around_limit, $category, $states )
         : $around_map;
 
     my $dist;
@@ -105,7 +106,7 @@ sub _map_features {
     my $limit  = 20;
     my @ids    = map { $_->id } @$around_map_list;
     my $nearby = $c->model('DB::Nearby')->nearby(
-        $c, $dist, \@ids, $limit, $lat, $lon, $interval, $category
+        $c, $dist, \@ids, $limit, $lat, $lon, $interval, $category, $states
     );
 
     return ( $around_map, $around_map_list, $nearby, $dist );
@@ -118,8 +119,17 @@ sub map_pins {
     my ( $min_lon, $min_lat, $max_lon, $max_lat ) = split /,/, $bbox;
     my $category = $c->req->param('category');
 
+    # Filter reports by status, if present in query params
+    my $status = $c->req->param('status') || '';
+    my $states;
+    if ( $status eq 'open' ) {
+        $states = FixMyStreet::DB::Result::Problem->open_states();
+    } elsif ( $status eq 'fixed' ) {
+        $states = FixMyStreet::DB::Result::Problem->fixed_states();
+    }
+
     my ( $around_map, $around_map_list, $nearby, $dist ) =
-      FixMyStreet::Map::map_features_bounds( $c, $min_lon, $min_lat, $max_lon, $max_lat, $interval, $category );
+      FixMyStreet::Map::map_features_bounds( $c, $min_lon, $min_lat, $max_lon, $max_lat, $interval, $category, $states );
 
     # create a list of all the pins
     my @pins = map {

--- a/perllib/FixMyStreet/Map.pm
+++ b/perllib/FixMyStreet/Map.pm
@@ -120,9 +120,11 @@ sub map_pins {
     my $category = $c->req->param('category');
 
     # Filter reports by status, if present in query params
+    my $states = $c->cobrand->on_map_default_states;
     my $status = $c->req->param('status') || '';
-    my $states;
-    if ( $status eq 'open' ) {
+    if ( !defined $states || $status eq 'all' ) {
+        $states = FixMyStreet::DB::Result::Problem->visible_states();
+    } elsif ( $status eq 'open' ) {
         $states = FixMyStreet::DB::Result::Problem->open_states();
     } elsif ( $status eq 'fixed' ) {
         $states = FixMyStreet::DB::Result::Problem->fixed_states();

--- a/perllib/FixMyStreet/TestMech.pm
+++ b/perllib/FixMyStreet/TestMech.pm
@@ -320,6 +320,7 @@ sub extract_problem_meta {
     my $result = scraper {
         process 'div#side p em', 'meta', 'TEXT';
         process '.problem-header p em', 'meta', 'TEXT';
+        process '.problem-header p.report_meta_info', 'meta', 'TEXT';
     }
     ->scrape( $mech->response );
 

--- a/templates/web/base/report/_council_sent_info.html
+++ b/templates/web/base/report/_council_sent_info.html
@@ -1,5 +1,5 @@
 [% IF problem.whensent || problem.can_display_external_id %]
-    <small class="council_sent_info"><br>
+    <p class="council_sent_info">
         [% problem.processed_summary_string(c) %]
-    </small>
+    </p>
 [% END %]

--- a/templates/web/base/report/_main.html
+++ b/templates/web/base/report/_main.html
@@ -52,18 +52,19 @@
     </div>
     [% END %]
 
-    <p><em>
-    [% problem.meta_line(c) | html %]
-    [%- IF !problem.used_map AND c.cobrand.moniker != 'emptyhomes' %]; <strong>[% loc('there is no pin shown as the user did not use the map') %]</strong>[% END %]
+    <p class="report_meta_info">
+        [% problem.meta_line(c) | html %]
+        [%- IF !problem.used_map AND c.cobrand.moniker != 'emptyhomes' %]; <strong>([% loc('there is no pin shown as the user did not use the map') %])</strong>[% END %]
+    </p>
     [% IF problem.bodies_str %]
         [% INCLUDE 'report/_council_sent_info.html' %]
     [% ELSE %]
-        <br><small>[% loc('Not reported to council') %]</small>
+        <p class="council_sent_info">[% loc('Not reported to council') %]</p>
     [% END %]
     [% mlog = problem.latest_moderation_log_entry(); IF mlog %]
-        <br /> Moderated by [% mlog.user.from_body.name %] at [% prettify_dt(mlog.whenedited) %]
+        <p>Moderated by [% mlog.user.from_body.name %] at [% prettify_dt(mlog.whenedited) %]</p>
     [% END %]
-    </em></p>
+
     [% INCLUDE 'report/_support.html' %]
 
     [% INCLUDE 'report/photo.html' object=problem %]

--- a/templates/web/base/reports/_problem-list.html
+++ b/templates/web/base/reports/_problem-list.html
@@ -1,0 +1,17 @@
+<section class="full-width">
+    [% INCLUDE column
+        problems = problems.${body.id}
+    %]
+</section>
+
+[% BLOCK column %]
+[% IF problems %]
+
+<ul class="issue-list-a">
+[% FOREACH problem IN problems %]
+    [% INCLUDE 'reports/_list-entry.html' %]
+[% END %]
+</ul>
+
+[% END %]
+[% END %]

--- a/templates/web/base/reports/body.html
+++ b/templates/web/base/reports/body.html
@@ -88,26 +88,9 @@
 
 [% INCLUDE 'pagination.html', param = 'p' %]
 
-<section class="full-width">
-    [% INCLUDE column
-        problems = problems.${body.id}
-    %]
-</section>
+[% INCLUDE 'reports/_problem-list.html' %]
 
 [% INCLUDE 'pagination.html', param = 'p' %]
 
 </div>
 [% INCLUDE 'footer.html' %]
-
-[% BLOCK column %]
-[% IF problems %]
-
-<ul class="issue-list-a">
-[% FOREACH problem IN problems %]
-    [% INCLUDE 'reports/_list-entry.html' %]
-[% END %]
-</ul>
-
-[% END %]
-[% END %]
-

--- a/templates/web/fixmystreet/my/_problem-list.html
+++ b/templates/web/fixmystreet/my/_problem-list.html
@@ -1,0 +1,27 @@
+[% FOREACH p = problems.confirmed %]
+    [% IF loop.first %]<h2>[% loc('Open reports') %]</h2>[% END %]
+    [% INCLUDE problem %]
+[% END %]
+
+[% FOREACH p = problems.fixed %]
+    [% IF loop.first %]<h2>[% loc('Fixed reports') %]</h2>[% END %]
+    [% INCLUDE problem %]
+[% END %]
+
+[% FOREACH p = problems.closed %]
+    [% IF loop.first %]<h2>[% loc('Closed reports') %]</h2>[% END %]
+    [% INCLUDE problem %]
+[% END %]
+
+[%# FOREACH p = problems.unconfirmed;
+    IF loop.first;
+        '<h2>' _ loc('Unconfirmed reports') _ '</h2>';
+    END;
+    INCLUDE problem;
+END %]
+
+[% BLOCK problem %]
+    [% "<ul class='issue-list-a full-width'>" IF loop.first %]
+    [% INCLUDE 'report/_item.html', problem = p, no_fixed =1 %]
+    [% "</ul>" IF loop.last %]
+[% END %]

--- a/templates/web/fixmystreet/my/my.html
+++ b/templates/web/fixmystreet/my/my.html
@@ -34,27 +34,7 @@
     param = 'p'
 %]
 
-[% FOREACH p = problems.confirmed %]
-    [% IF loop.first %]<h2>[% loc('Open reports') %]</h2>[% END %]
-    [% INCLUDE problem %]
-[% END %]
-
-[% FOREACH p = problems.fixed %]
-    [% IF loop.first %]<h2>[% loc('Fixed reports') %]</h2>[% END %]
-    [% INCLUDE problem %]
-[% END %]
-
-[% FOREACH p = problems.closed %]
-    [% IF loop.first %]<h2>[% loc('Closed reports') %]</h2>[% END %]
-    [% INCLUDE problem %]
-[% END %]
-
-[%# FOREACH p = problems.unconfirmed;
-    IF loop.first;
-        '<h2>' _ loc('Unconfirmed reports') _ '</h2>';
-    END;
-    INCLUDE problem;
-END %]
+[% INCLUDE 'my/_problem-list.html' %]
 
 [% FOREACH u IN updates %]
     [% IF loop.first %]
@@ -78,13 +58,3 @@ END %]
 </div>
 
 [% INCLUDE 'footer.html' %]
-
-[% BLOCK problem %]
-    [% "<ul class='issue-list-a full-width'>" IF loop.first %]
-    [% IF c.cobrand.moniker == 'oxfordshire' %]
-        [% INCLUDE 'reports/_list-entry.html', problem = p, no_fixed =1 %]
-    [% ELSE %]
-        [% INCLUDE 'report/_item.html', problem = p, no_fixed =1 %]
-    [% END %]
-    [% "</ul>" IF loop.last %]
-[% END %]

--- a/templates/web/oxfordshire/my/_problem-list.html
+++ b/templates/web/oxfordshire/my/_problem-list.html
@@ -1,0 +1,9 @@
+[% FOREACH p = problems.all %]
+    [% INCLUDE problem %]
+[% END %]
+
+[% BLOCK problem %]
+    [% "<ul class='issue-list-a full-width'>" IF loop.first %]
+    [% INCLUDE 'reports/_list-entry.html', problem = p, no_fixed =1 %]
+    [% "</ul>" IF loop.last %]
+[% END %]

--- a/templates/web/oxfordshire/my/_problem-list.html
+++ b/templates/web/oxfordshire/my/_problem-list.html
@@ -1,12 +1,14 @@
-[% FOREACH p = problems.all %]
-    [% INCLUDE problem %]
-[% END %]
-
-[% BLOCK problem %]
-    [% "<ul class='issue-list-a full-width'>" IF loop.first %]
-    [% INCLUDE 'reports/_list-entry.html', problem = p, no_fixed =1 %]
-    [% "</ul>" IF loop.last %]
-[% END %]
+<ul class='issue-list-a full-width'>
+    [% IF problems.all %]
+        [% FOREACH p = problems.all %]
+            [% INCLUDE 'reports/_list-entry.html', problem = p, no_fixed =1 %]
+        [% END %]
+    [% ELSE %]
+        <li class="empty">
+            <p>[% loc('There are no reports to show.') %]</p>
+        </li>
+    [% END %]
+</ul>
 
 [% IF ! problems.size %]
 <!-- Preserve behaviour of map filters despite map not being shown -->

--- a/templates/web/oxfordshire/my/_problem-list.html
+++ b/templates/web/oxfordshire/my/_problem-list.html
@@ -7,3 +7,17 @@
     [% INCLUDE 'reports/_list-entry.html', problem = p, no_fixed =1 %]
     [% "</ul>" IF loop.last %]
 [% END %]
+
+[% IF ! problems.size %]
+<!-- Preserve behaviour of map filters despite map not being shown -->
+<script type="text/javascript">
+    (function($) {
+        $(function() {
+            $(".report-list-filters [type=submit]").hide();
+            $(".report-list-filters select").change(function() {
+                $(this).closest("form").submit();
+            });
+        })
+    })(window.jQuery);
+</script>
+[% END %]

--- a/templates/web/oxfordshire/report/_council_sent_info.html
+++ b/templates/web/oxfordshire/report/_council_sent_info.html
@@ -1,24 +1,24 @@
 [% IF problem.whensent || problem.can_display_external_id %]
-    <small class="council_sent_info"><br>
-        [% IF problem.whensent %]
-        [% problem.duration_string(c) %]<br>
-        [% END %]
-        [% IF c.cobrand.problem_response_days(problem) > 0 %]
+    <div class="council_info_box">
+      [% IF problem.can_display_external_id %]
+        <h3>
+          [% IF problem.whensent %]
+              Council ref:&nbsp;[% problem.external_id %]
+          [% ELSE %]
+              [% problem.external_body %] ref:&nbsp;[% problem.external_id %]
+          [% END %]
+        </h3>
+      [% END %]
+
+      [% IF c.cobrand.problem_response_days(problem) > 0 %]
+        <p>
             Problems in the
             [% problem.category %]
             category are generally responded to within
             [% c.cobrand.problem_response_days(problem) %]
             working days.
-            <br />
-        [% END %]
-        <strong>
-        [% IF problem.can_display_external_id %]
-            [% IF problem.whensent %]
-                Council ref:&nbsp;[% problem.external_id %]
-            [% ELSE %]
-                [% problem.external_body %] ref:&nbsp;[% problem.external_id %]
-            [% END %]
-        [% END %]
-        </strong>
-    </small>
+        </p>
+      [% END %]
+
+    </div>
 [% END %]

--- a/templates/web/oxfordshire/report/_main.html
+++ b/templates/web/oxfordshire/report/_main.html
@@ -1,0 +1,98 @@
+[% moderating = c.user && c.user.has_permission_to('moderate', problem.bodies_str) %]
+
+[% IF moderating %]
+[%# TODO: extract stylesheet! %]
+<style>
+    .moderate-edit label {
+        display: inline-block;
+        height: 1em;
+        margin-top: 0;
+    }
+
+    .moderate-edit input {
+        display: inline-block;
+    }
+
+    .moderate-edit { display: none }
+    .moderate-edit :disabled {
+        background: #ddd;
+    }
+    br {
+        line-height: 0.5em;
+    }
+</style>
+[% END %]
+
+<div class="problem-header cf" problem-id="[% problem.id %]">
+  [% IF moderating %]
+    [% original = problem.moderation_original_data %]
+    <form method="post" action="/moderate/report/[% problem.id %]">
+        <input type="button" class="btn moderate moderate-display" value="moderate">
+        <div class="moderate-edit">
+            <input type="checkbox" class="hide-document" name="problem_hide">
+            <label for="problem_hide">Hide report completely?</label>
+            <br />
+            <input type="checkbox" name="problem_show_name" [% problem.anonymous ? '' : 'checked' %]>
+            <label for="problem_show_name">Show name publicly?</label>
+            [% IF problem.photo or original.photo %]
+                <br />
+                <input type="checkbox" name="problem_show_photo" [% problem.photo ? 'checked' : '' %]>
+                <label for="problem_show_photo">Show Photo?</label>
+            [% END %]
+        </div>
+  [% END %]
+    <h1 class="moderate-display">[% problem.title | html %]</h1>
+    [% IF moderating %]
+    <div class="moderate-edit">
+        [% IF problem.title != original.title %]
+        <input type="checkbox" name="problem_revert_title" class="revert-title">
+        <label for="problem_revert_title">Revert to original title</label>
+        [% END %]
+    <h1><input type="text" name="problem_title" value="[% problem.title | html %]"></h1>
+    </div>
+    [% END %]
+
+    <p class="report_meta_info">
+        [% problem.meta_line(c) | html %]
+        [%- IF !problem.used_map AND c.cobrand.moniker != 'emptyhomes' %]; <strong>([% loc('there is no pin shown as the user did not use the map') %])</strong>[% END %]
+    </p>
+    [% IF problem.whensent %]
+        <p class="council_sent_info">[% problem.duration_string(c) %]</p>
+    [% END %]
+    [% mlog = problem.latest_moderation_log_entry(); IF mlog %]
+        <p>Moderated by [% mlog.user.from_body.name %] at [% prettify_dt(mlog.whenedited) %]</p>
+    [% END %]
+
+    [% INCLUDE 'report/_support.html' %]
+
+    [% INCLUDE 'report/photo.html' object=problem %]
+    <div class="moderate-display">
+        [% add_links( problem.detail ) | html_para %]
+    </div>
+
+    [% IF moderating %]
+        <div class="moderate-edit">
+        [% IF problem.detail != original.detail %]
+        <input type="checkbox" name="problem_revert_detail" class="revert-textarea">
+        <label for="problem_revert_detail">Revert to original text</label>
+        [% END %]
+        <textarea name="problem_detail">[% add_links( problem.detail ) %]</textarea>
+        </div>
+
+        <div class="moderate-edit">
+            <label for="moderation_reason">Moderation reason:</label>
+            <input type="text" name="moderation_reason" placeholder="Describe why you are moderating this">
+            <input type="submit" class="red-btn" value="Moderate it">
+            <input type="button" class="btn cancel" value="cancel">
+        </div>
+    </form>
+  [% END %]
+
+  [% IF problem.bodies_str %]
+      [% INCLUDE 'report/_council_sent_info.html' %]
+  [% ELSE %]
+      <div class="council_info_box">
+          <p>[% loc('Not reported to council') %]</p>
+      </div>
+  [% END %]
+</div>

--- a/templates/web/oxfordshire/reports/_list-filters.html
+++ b/templates/web/oxfordshire/reports/_list-filters.html
@@ -6,10 +6,10 @@
         <p class="report-list-filters">
             <label>
                 Show
-                <select id="statuses">
-                    <option value="">all reports</option>
-                    <option value="open" selected>unfixed reports</option>
-                    <option value="fixed">fixed reports</option>
+                <select name="status" id="statuses">
+                    <option value="all"[% ' selected' IF filter_status == 'all' %]>all reports</option>
+                    <option value="open"[% ' selected' IF filter_status == 'open' %]>unfixed reports</option>
+                    <option value="fixed"[% ' selected' IF filter_status == 'fixed' %]>fixed reports</option>
                 </select>
             </label>
             <label>

--- a/templates/web/oxfordshire/reports/_list-filters.html
+++ b/templates/web/oxfordshire/reports/_list-filters.html
@@ -14,19 +14,16 @@
             </label>
             <label>
                 about
-                [% IF category %]
-                    <select name="category" id="categories">
-                        <option value="[% category | html %]" selected>
+                <select name="category" id="categories">
+                    <option value="">Everything</option>
+                    [% FOR category IN filter_categories %]
+                        <option value="[% category | html %]"[% ' selected' IF filter_category == category %]>
                             [% category | html %]
                         </option>
-                    </select>
-                [% ELSE %]
-                    <select name="category" id="categories">
-                        <option value="">Everything</option>
-                    </select>
-                [% END %]
+                    [% END %]
+                </select>
             </label>
-            <input type=submit value="go" />
+            <input type=submit value="Go" />
         </p>
 
 [% IF use_section_wrapper %]

--- a/templates/web/oxfordshire/reports/_list-filters.html
+++ b/templates/web/oxfordshire/reports/_list-filters.html
@@ -14,13 +14,17 @@
             </label>
             <label>
                 about
-                <select name="category">
-                    <option value="">anything</option>
-                    <option value="">bridges</option>
-                    <option value="">carriageway defect</option>
-                    <option value="">debris/spillage</option>
-                    <option value="">…</option>
-                </select>
+                [% IF category %]
+                    <select name=category id="categories">
+                        <option value="[% category | html %]" selected>
+                            [% category | html %]
+                        </option>
+                    </select>
+                [% ELSE %]
+                    <select name=category id="categories" disabled>
+                        <option value="">loading&hellip;</option>
+                    </select>
+                [% END %]
             </label>
             <input type=submit value="go" />
         </p>

--- a/templates/web/oxfordshire/reports/_list-filters.html
+++ b/templates/web/oxfordshire/reports/_list-filters.html
@@ -8,7 +8,7 @@
                 Show
                 <select id="statuses">
                     <option value="">all reports</option>
-                    <option value="open">unfixed reports</option>
+                    <option value="open" selected>unfixed reports</option>
                     <option value="fixed">fixed reports</option>
                 </select>
             </label>

--- a/templates/web/oxfordshire/reports/_list-filters.html
+++ b/templates/web/oxfordshire/reports/_list-filters.html
@@ -21,8 +21,8 @@
                         </option>
                     </select>
                 [% ELSE %]
-                    <select name=category id="categories" disabled>
-                        <option value="">loading&hellip;</option>
+                    <select name=category id="categories">
+                        <option value="">Everything</option>
                     </select>
                 [% END %]
             </label>

--- a/templates/web/oxfordshire/reports/_list-filters.html
+++ b/templates/web/oxfordshire/reports/_list-filters.html
@@ -6,7 +6,7 @@
         <p class="report-list-filters">
             <label>
                 Show
-                <select name="status">
+                <select id="statuses">
                     <option value="">all reports</option>
                     <option value="open">unfixed reports</option>
                     <option value="fixed">fixed reports</option>
@@ -15,13 +15,13 @@
             <label>
                 about
                 [% IF category %]
-                    <select name=category id="categories">
+                    <select name="category" id="categories">
                         <option value="[% category | html %]" selected>
                             [% category | html %]
                         </option>
                     </select>
                 [% ELSE %]
-                    <select name=category id="categories">
+                    <select name="category" id="categories">
                         <option value="">Everything</option>
                     </select>
                 [% END %]

--- a/templates/web/oxfordshire/reports/_problem-list.html
+++ b/templates/web/oxfordshire/reports/_problem-list.html
@@ -1,0 +1,19 @@
+<section class="full-width">
+    [% INCLUDE column
+        problems = problems.${body.id}
+    %]
+</section>
+
+[% BLOCK column %]
+    <ul class="issue-list-a">
+        [% IF problems %]
+            [% FOREACH problem IN problems %]
+                [% INCLUDE 'reports/_list-entry.html' %]
+            [% END %]
+        [% ELSE %]
+            <li class="empty">
+                <p>[% loc('There are no reports to show.') %]</p>
+            </li>
+        [% END %]
+    </ul>
+[% END %]

--- a/web/cobrands/oxfordshire/base.scss
+++ b/web/cobrands/oxfordshire/base.scss
@@ -54,3 +54,24 @@ dd, p {
   line-height: 1em;
 }
 
+.council_info_box {
+  border-top: 1px solid #ccc;
+  padding: 1em;
+  margin: 0 -1em -1em -1em; // counteract 1em padding on sidebar without using .full-width which sets an explicit width
+
+  h3 {
+    font-weight: bold;
+    font-size: 1em;
+    margin: 0 0 0.5em 0;
+  }
+
+  p {
+    color: #666;
+    margin: 0 0 0.5em 0;
+    font-size: 0.9em;
+  }
+
+  & > :last-child {
+    margin-bottom: 0;
+  }
+}

--- a/web/cobrands/oxfordshire/layout.scss
+++ b/web/cobrands/oxfordshire/layout.scss
@@ -372,6 +372,35 @@ body.mappage {
   }
 }
 
+h4.static-with-rule {
+  margin-top: 1em; // down from default 2em, avoid extra space between heading and .council_info_box
+  margin-bottom: 0; // no space between this and the .issue-list items
+  background: transparent; // rather than light grey
+  padding: 0.75em 1em * (1/0.875); // compensate for 0.875 font-size
+}
+
+.issue-list li {
+  background: transparent;
+  margin-top: 0; // no space between list items
+
+  // Replicate .report-list styling, a bit
+  border-top: 1px solid $oxfordshire_mid_grey_green;
+  padding: 1em 1em 1em 0;
+  margin-left: 1em;
+
+  .update-wrap .update-text > :last-child {
+    margin-bottom: 0;
+  }
+
+  .meta-2 {
+    font-style: normal;
+  }
+}
+
+.form-box {
+  background-color: darken($oxfordshire_very_light_green, 5%);
+}
+
 .shadow-wrap {
     width: 432px;
 

--- a/web/cobrands/oxfordshire/layout.scss
+++ b/web/cobrands/oxfordshire/layout.scss
@@ -430,7 +430,7 @@ input.green-btn{
 
 .click-the-map {
   color: #000;
-  margin: 0 -1em;
+  margin: -10px -1em 0 -1em; // overlap padding on parents
   padding: 18px;
   border-bottom: 1px solid $oxfordshire_mid_grey_green;
   background: #fff url('/cobrands/oxfordshire/images/click-map-chevron-big.gif') 90% 12px no-repeat;

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -982,6 +982,19 @@ a:hover.button-left {
     margin-bottom: 0.5em;
 }
 
+.report_meta_info,
+.council_sent_info {
+  font-size: 0.9em;
+}
+
+.council_sent_info {
+  color: #666;
+
+  p + & {
+    margin-top: -0.6em; // partly counteract margin-bottom on previous paragraph
+  }
+}
+
 // map stuff
 #map_box{
   @extend .full-width;

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -29,6 +29,14 @@ function fixmystreet_update_pin(lonlat) {
             if ( lb.length === 0 ) { lb = $('#form_name').prev(); }
             lb.before(data.extra_name_info);
         }
+        // If the category filter appears on the map and the user has selected
+        // something from it, then pre-fill the category field in the report
+        if ($("select#categories").length) {
+            var category = $("#categories").val();
+            if (!!category && $("#form_category option[value="+category+"]")) {
+                $("#form_category").val(category);
+            }
+        }
     });
 
     if (!$('#side-form-error').is(':visible')) {

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -196,7 +196,7 @@ function fixmystreet_onload() {
     if (fixmystreet.page == 'around') {
         fixmystreet.bbox_strategy = fixmystreet.bbox_strategy || new OpenLayers.Strategy.BBOX({ ratio: 1 });
         pin_layer_options.strategies = [ fixmystreet.bbox_strategy ];
-        pin_layer_options.protocol = new OpenLayers.Protocol.HTTP({
+        pin_layer_options.protocol = new OpenLayers.Protocol.FixMyStreet({
             url: '/ajax',
             params: fixmystreet.all_pins ? { all_pins: 1 } : { },
             format: new OpenLayers.Format.FixMyStreet()
@@ -488,6 +488,19 @@ OpenLayers.Control.PermalinkFMSz = OpenLayers.Class(OpenLayers.Control.Permalink
     updateLink: function() {
         this._updateLink(1);
     }
+});
+
+/* Pan data request handler */
+OpenLayers.Protocol.FixMyStreet = OpenLayers.Class(OpenLayers.Protocol.HTTP, {
+    read: function(options) {
+        var category = $("#categories").val();
+        if (!!category) {
+            options.params = options.params || {};
+            options.params.category = category;
+        }
+        return OpenLayers.Protocol.HTTP.prototype.read.apply(this, [options]);
+    },
+    CLASS_NAME: "OpenLayers.Protocol.FixMyStreet"
 });
 
 /* Pan data handler */

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -424,6 +424,12 @@ $(function(){
     // to refresh the map when the filter inputs are changed.
     $(".report-list-filters [type=submit]").hide();
 
+    if (fixmystreet.page == "my" || fixmystreet.page == "reports") {
+        $(".report-list-filters select").change(function() {
+            $(this).closest("form").submit();
+        });
+    }
+
     // Vector layers must be added onload as IE sucks
     if ($.browser.msie) {
         $(window).load(fixmystreet_onload);

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -109,6 +109,12 @@ function fms_markers_resize() {
     fixmystreet.markers.redraw();
 }
 
+function fms_categories_changed() {
+    // If the category has changed we need to re-fetch markers that match
+    // the new value
+    fixmystreet.markers.refresh({force: true});
+}
+
 function fixmystreet_onload() {
     if ( fixmystreet.area.length ) {
         for (var i=0; i<fixmystreet.area.length; i++) {
@@ -240,6 +246,12 @@ function fixmystreet_onload() {
         fixmystreet.map.addControl( fixmystreet.select_feature );
         fixmystreet.select_feature.activate();
         fixmystreet.map.events.register( 'zoomend', null, fms_markers_resize );
+
+        // If the category filter dropdown exists on the page set up the
+        // event handlers to populate it and react to it changing
+        if ($("select#categories").length) {
+            $("body").on("change", "#categories", fms_categories_changed);
+        }
     } else if (fixmystreet.page == 'new') {
         fixmystreet_activate_drag();
     }
@@ -397,6 +409,10 @@ $(function(){
         fixmystreet.page = 'around';
     });
 
+    // Hide the pin filter submit button. Not needed because we'll use JS
+    // to refresh the map when the filter inputs are changed.
+    $(".report-list-filters [type=submit]").hide();
+
     // Vector layers must be added onload as IE sucks
     if ($.browser.msie) {
         $(window).load(fixmystreet_onload);
@@ -518,8 +534,7 @@ OpenLayers.Format.FixMyStreet = OpenLayers.Class(OpenLayers.Format.JSON, {
         if (typeof(obj.current_near) != 'undefined' && (current_near = document.getElementById('current_near'))) {
             current_near.innerHTML = obj.current_near;
         }
-        var markers = fms_markers_list( obj.pins, false );
-        return markers;
+        return fms_markers_list( obj.pins, false );
     },
     CLASS_NAME: "OpenLayers.Format.FixMyStreet"
 });

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -117,9 +117,8 @@ function fms_markers_resize() {
     fixmystreet.markers.redraw();
 }
 
-function fms_categories_changed() {
-    // If the category has changed we need to re-fetch markers that match
-    // the new value
+function fms_categories_or_status_changed() {
+    // If the category or status has changed we need to re-fetch map markers
     fixmystreet.markers.refresh({force: true});
 }
 
@@ -258,7 +257,11 @@ function fixmystreet_onload() {
         // If the category filter dropdown exists on the page set up the
         // event handlers to populate it and react to it changing
         if ($("select#categories").length) {
-            $("body").on("change", "#categories", fms_categories_changed);
+            $("body").on("change", "#categories", fms_categories_or_status_changed);
+        }
+        // Do the same for the status dropdown
+        if ($("select#statuses").length) {
+            $("body").on("change", "#statuses", fms_categories_or_status_changed);
         }
     } else if (fixmystreet.page == 'new') {
         fixmystreet_activate_drag();
@@ -521,6 +524,11 @@ OpenLayers.Protocol.FixMyStreet = OpenLayers.Class(OpenLayers.Protocol.HTTP, {
         if (!!category) {
             options.params = options.params || {};
             options.params.category = category;
+        }
+        var status = $("#statuses").val();
+        if (!!status) {
+            options.params = options.params || {};
+            options.params.status = status;
         }
         return OpenLayers.Protocol.HTTP.prototype.read.apply(this, [options]);
     },


### PR DESCRIPTION
This PR:

 * Enables the use of the status & category fields at the top of the report list to filter the visible reports on the map by status and category.
 * This is provided by adding `status` and `category` params to the `/ajax` URL to filter server-side.
 * Allows the `/around` URL to include a `category` parameter, which can be used to provide an initial value for the filter.
 * Preselects the category to match that used by the filter when clicking the map to reveal the new report form.

Fixes mysociety/FixMyStreet-Commercial#682.
Fixes mysociety/FixMyStreet-Commercial#685.