### PR TITLE
Simplify .update-img layout

### DIFF
--- a/templates/web/base/report/update.html
+++ b/templates/web/base/report/update.html
@@ -6,10 +6,11 @@
         [% INCLUDE meta_line %]
     </em></p></div>
 [% IF NOT update.whenanswered %]
+
+    [% INCLUDE 'report/photo.html' object=update %]
+
     <div class="update-text">
         [% add_links( update.text ) | html_para %]
-
-        [% INCLUDE 'report/photo.html' object=update %]
 
         [% IF c.cobrand.allow_update_reporting %]
         <p align="right">
@@ -17,6 +18,7 @@
         </p>
         [% END %]
     </div>
+
 [% END %]
     </div>
 [% '</div>' IF loop.last %]

--- a/templates/web/fixmystreet/report/update.html
+++ b/templates/web/fixmystreet/report/update.html
@@ -28,6 +28,7 @@
                     <p class="meta-2"> [% INCLUDE meta_line %] </p>
                 </div>
             [% ELSE %]
+                [% INCLUDE 'report/photo.html' object=update %]
                 <div class="update-text">
                     <div class="moderate-display">
                         [% add_links( update.text ) | html_para %]
@@ -50,7 +51,6 @@
                         [% END %]
                     </p>
                 </div>
-                [% INCLUDE 'report/photo.html' object=update %]
             [% END %]
             </div>
             [% IF moderating %]

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -822,35 +822,14 @@ a:hover.button-left {
     padding: 0.5em 1em;
     display:block;
     .update-wrap {
-      display:table;
-      width:100%;
-      .update-text,
-      .update-img {
-        display:table-cell;
-        vertical-align:top;
-        p {
-          margin-bottom: 0.5em;
-        }
-      }
-      .update-img {
-        text-align:right;
-        img {
-          margin:-0.5em -1em 0 0.5em;
-          height:auto;
-        }
-      }
+      @include clearfix;
     }
-  }
-}
-//display:table fixes
-.ie7, .ie7 {
-  .issue-list li .update-wrap {
-    .update-text {
-      float:left;
-      width:19em;
+    .update-text p {
+      margin-bottom: 0.5em;
     }
     .update-img {
-      float:right;
+      float: right;
+      margin: 0.5em 0 0.5em 1em; // gutter between text and floated image
     }
   }
 }
@@ -965,12 +944,6 @@ a:hover.button-left {
       opacity: 1;
     }
   }
-}
-//bit of a hack - as we can't use em's, push the span out to the right
-//by how much it would be if the user did not resize the text
-.issue-list li .update-wrap .update-img a span {
-  right:-16px;
-  top:-8px;
 }
 
 .problem-header {


### PR DESCRIPTION
Fixes #424.

Primary improvement is that images no longer shrink into oblivion when they're next to a very wordy update:

![screen shot 2015-04-21 at 12 39 42](https://cloud.githubusercontent.com/assets/739624/7251542/40722468-e824-11e4-8a03-4c72f2a0f6c8.png)

Using a float rather than table-cell styling also means we no longer have to work around IE7 table display support.

Works for short updates with images too:

![screen shot 2015-04-21 at 12 46 00](https://cloud.githubusercontent.com/assets/739624/7251565/75d9554a-e824-11e4-8c75-fa2631716429.png)
