### PR TITLE
Fix multiple body areas

### DIFF
--- a/perllib/FixMyStreet/App.pm
+++ b/perllib/FixMyStreet/App.pm
@@ -560,7 +560,8 @@ sub get_param_list {
     my ($c, $param) = @_;
     my $value = $c->req->params->{$param};
     return @$value if ref $value;
-    return ($value);
+    return ($value) if defined $value;
+    return ();
 }
 
 =head2 set_param

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -253,12 +253,9 @@ sub bodies : Path('bodies') : Args(0) {
 
         my $params = $c->forward('body_params');
         my $body = $c->model('DB::Body')->create( $params );
-        my $area_ids = $c->get_param('area_ids');
-        if ($area_ids) {
-            $area_ids = [ $area_ids ] unless ref $area_ids;
-            foreach (@$area_ids) {
-                $c->model('DB::BodyArea')->create( { body => $body, area_id => $_ } );
-            }
+        my @area_ids = $c->get_param_list('area_ids');
+        foreach (@area_ids) {
+            $c->model('DB::BodyArea')->create( { body => $body, area_id => $_ } );
         }
 
         $c->stash->{updated} = _('New body added');
@@ -413,13 +410,10 @@ sub update_contacts : Private {
         $c->stash->{body}->update( $params );
         my @current = $c->stash->{body}->body_areas->all;
         my %current = map { $_->area_id => 1 } @current;
-        my $area_ids = $c->get_param('area_ids');
-        if ($area_ids) {
-            $area_ids = [ $area_ids ] unless ref $area_ids;
-            foreach (@$area_ids) {
-                $c->model('DB::BodyArea')->find_or_create( { body => $c->stash->{body}, area_id => $_ } );
-                delete $current{$_};
-            }
+        my @area_ids = $c->get_param_list('area_ids');
+        foreach (@area_ids) {
+            $c->model('DB::BodyArea')->find_or_create( { body => $c->stash->{body}, area_id => $_ } );
+            delete $current{$_};
         }
         # Remove any others
         $c->stash->{body}->body_areas->search( { area_id => [ keys %current ] } )->delete;


### PR DESCRIPTION
This PR:

 - Fixes a bug in `App::get_param_list` that would cause a non-empty list to be returned if the param was missing from the request
 - Fixes a bug meaning only the first of the selected areas would be associated with the body when updating or creating it.