### PR TITLE
Show admin notes in the Zurich admin

### DIFF
--- a/templates/web/zurich/admin/header.html
+++ b/templates/web/zurich/admin/header.html
@@ -1,5 +1,5 @@
 [%
-    SET bodyclass = bodyclass || 'fullwidthpage';
+    SET bodyclass = bodyclass || 'fullwidthpage show-admin-notes';
     INCLUDE 'header.html' admin = 1, bodyclass = bodyclass _ ' admin';
 
     states = {


### PR DESCRIPTION
https://github.com/mysociety/FixMyStreet-Commercial/issues/706 notes that no
error messages are being shown in the zurich admin. This is because the
document body doesn't have the `show-admin-notes` class that stops them being
hidden by CSS. I've updated the `zurich/admin/header.html` template to fix
this.

Was this just an oversight, or was it intentional for some reason?

Fixes https://github.com/mysociety/FixMyStreet-Commercial/issues/706