### PR TITLE
Drop .show-admin-notes class and associated code

### DIFF
--- a/templates/web/base/admin/header.html
+++ b/templates/web/base/admin/header.html
@@ -1,4 +1,4 @@
-[% INCLUDE 'header.html' admin = 1, bodyclass = 'fullwidthpage admin show-admin-notes' %]
+[% INCLUDE 'header.html' admin = 1, bodyclass = 'fullwidthpage admin' %]
 <style type="text/css">
 dt { clear: left; float: left; font-weight: bold; }
 dd { margin-left: 8em; }

--- a/web/cobrands/sass/_admin.scss
+++ b/web/cobrands/sass/_admin.scss
@@ -70,83 +70,75 @@ $button_bg_col: #a1a1a1;  // also search bar (tables)
         margin-top: 0;
       }
     }
-  .fms-admin-warning, .fms-admin-info, .admin-hint, .admin-offsite-link {
-    display: none; // don't display admin-notes unless .show-admin-notes class is present
+  .admin-offsite-link {
+    display: inline;
   }
-  &.show-admin-notes {
-    .fms-admin-warning, .fms-admin-info, .admin-hint {
-      display: block;
+  .fms-admin-warning, .fms-admin-info {
+    padding: 1em;
+    font-size: 90%;
+    border-style: solid;
+    border-width: 1px;
+    border-left-width: 1em;
+    margin-bottom: 1em;
+  }
+  .fms-admin-warning {
+      border-color: #f99;
+      background-color: #ffe1e1;
+  }
+  .fms-admin-info {
+      border-color: #9f9;
+      background-color: #e1ffe1;
+  }
+  .admin-open311-only {
+    border:1px solid #666;
+    padding:1em;
+    margin: 1em 0;
+  }
+  .admin-hint {
+    font-size: 80%; // little question marks are small
+    cursor: pointer;
+    display: block;
+    float:left;
+    overflow: hidden;
+    padding: 0.2em;
+    margin-right: 0.666em;
+    text-align: center;
+    color: #fff;
+    font-weight: bold;
+    background-color: #f93;
+    -moz-border-radius: 0.333em;
+    -webkit-border-radius: 0.333em;
+    border-radius: 0.333em;
+    p {
+      display:none;
     }
-    .admin-offsite-link {
-      display: inline;
-    }
-    .fms-admin-warning, .fms-admin-info {
-      padding: 1em;
+    &:before { content: "?" }
+    &.admin-hint-show {
       font-size: 90%;
-      border-style: solid;
-      border-width: 1px;
-      border-left-width: 1em;
-      margin-bottom: 1em;
-    }
-    .fms-admin-warning {
-        border-color: #f99;
-        background-color: #ffe1e1;
-    }
-    .fms-admin-info {
-        border-color: #9f9;
-        background-color: #e1ffe1;
-    }
-    .admin-open311-only {
-      border:1px solid #666;
-      padding:1em;
-      margin: 1em 0;
-    }
-    .admin-hint {
-      font-size: 80%; // little question marks are small
-      cursor: pointer;
+      text-align: left;
       display: block;
-      float:left;
-      overflow: hidden;
-      padding: 0.2em;
-      margin-right: 0.666em;
-      text-align: center;
-      color: #fff;
-      font-weight: bold;
-      background-color: #f93;
-      -moz-border-radius: 0.333em;
-      -webkit-border-radius: 0.333em;
-      border-radius: 0.333em;
+      float:none;
+      margin:1em 0;
+      &:before { content: "" }
+      background-color: inherit !important;
       p {
-        display:none;
-      }
-      &:before { content: "?" }
-      &.admin-hint-show {
-        font-size: 90%;
-        text-align: left;
+        font-weight: normal;
         display: block;
-        float:none;
-        margin:1em 0;
-        &:before { content: "" }
-        background-color: inherit !important;
-        p {
-          font-weight: normal;
-          display: block;
-          background-color: #ff9;
-          color: #000;
-          border-style: solid;
-          border-width: 1px;
-          border-left-width: 1em;
-          border-color: #f93;
-          padding:1em;
-          margin: 0;
-        }
+        background-color: #ff9;
+        color: #000;
+        border-style: solid;
+        border-width: 1px;
+        border-left-width: 1em;
+        border-color: #f93;
+        padding:1em;
+        margin: 0;
       }
     }
-    .admin-offsite-link {
-      padding-right: 12px;
-      background-image: url(../../i/external-link.png);
-      background-position: right top;
-      background-repeat: no-repeat;
-    }
+  }
+  .admin-offsite-link {
+    padding-right: 12px;
+    background-image: url(../../i/external-link.png);
+    background-position: right top;
+    background-repeat: no-repeat;
   }
 }

--- a/web/js/fixmystreet-admin.js
+++ b/web/js/fixmystreet-admin.js
@@ -3,7 +3,7 @@ $(function(){
 
     // hide the open311_only section and reveal it only when send_method is relevant
     var $open311_only = $('.admin-open311-only');
- 
+
     function hide_or_show_open311(hide_fast) {
         var send_method = $('#send_method').val();
         var show_open311 = false;
@@ -28,34 +28,32 @@ $(function(){
         hide_or_show_open311(true);
     }
 
-    if ($('body').hasClass("show-admin-notes")) {
 
-        // admin hints: maybe better implemented as tooltips?
-        $(".admin-hint").on('click', function(){
-            if ($(this).hasClass('admin-hint-show')) {
-                $(this).removeClass('admin-hint-show');
+    // admin hints: maybe better implemented as tooltips?
+    $(".admin-hint").on('click', function(){
+        if ($(this).hasClass('admin-hint-show')) {
+            $(this).removeClass('admin-hint-show');
+        } else {
+            $(this).addClass('admin-hint-show');
+        }
+    });
+
+    // on a body's page, hide/show deleted contact categories
+    var $table_with_deleted_contacts = $('table tr.is-deleted td.contact-category').closest('table');
+    if ($table_with_deleted_contacts.length == 1) {
+        var $toggle_deleted_btn = $("<input type='submit' class='btn' value='Hide deleted contacts' id='toggle-deleted-contacts-btn' style='margin:1em 0;'/>");
+        $table_with_deleted_contacts.before($toggle_deleted_btn);
+        $toggle_deleted_btn.on('click', function(e){
+            e.preventDefault();
+            var $cols = $table_with_deleted_contacts.find('tr.is-deleted');
+            if ($cols.first().is(':visible')) {
+                $cols.hide();
+                $(this).prop("value", 'Show deleted contacts');
             } else {
-                $(this).addClass('admin-hint-show');
+                $cols.show();
+                $(this).prop("value", 'Hide deleted contacts');
             }
         });
-
-        // on a body's page, hide/show deleted contact categories
-        var $table_with_deleted_contacts = $('table tr.is-deleted td.contact-category').closest('table');
-        if ($table_with_deleted_contacts.length == 1) {
-            var $toggle_deleted_btn = $("<input type='submit' class='btn' value='Hide deleted contacts' id='toggle-deleted-contacts-btn' style='margin:1em 0;'/>");
-            $table_with_deleted_contacts.before($toggle_deleted_btn);
-            $toggle_deleted_btn.on('click', function(e){
-                e.preventDefault();
-                var $cols = $table_with_deleted_contacts.find('tr.is-deleted');
-                if ($cols.first().is(':visible')) {
-                    $cols.hide();
-                    $(this).prop("value", 'Show deleted contacts');
-                } else {
-                    $cols.show();
-                    $(this).prop("value", 'Hide deleted contacts');
-                }
-            });
-        }
     }
 
     $( "#start_date" ).datepicker({


### PR DESCRIPTION
As per @dracos and @davewhiteland's comments on https://github.com/mysociety/fixmystreet/pull/1160
this removes the show-admin-notes css and makes admin notes and errors display
all the time.

Closes #1161

This will need to be backported to Zurich to close https://github.com/mysociety/FixMyStreet-Commercial/issues/706 too.