### PR TITLE
[East Sussex, Greenwich] Add contact email addresses

### DIFF
--- a/perllib/FixMyStreet/Cobrand/EastSussex.pm
+++ b/perllib/FixMyStreet/Cobrand/EastSussex.pm
@@ -48,16 +48,16 @@ Can run with a script or command line like:
 =cut
 
 use constant POTHOLE_SIZES => [
-    {'key' => ['Blank'],    'name' => ['--']}, 
-    {'key' => ['golf'],     'name' => ['Golf ball sized']}, 
-    {'key' => ['tennis'],   'name' => ['Tennis ball sized']}, 
+    {'key' => ['Blank'],    'name' => ['--']},
+    {'key' => ['golf'],     'name' => ['Golf ball sized']},
+    {'key' => ['tennis'],   'name' => ['Tennis ball sized']},
     {'key' => ['football'], 'name' => ['Football sized']},
     {'key' => ['larger'],   'name' => ['Larger']}
 ];
 
 use constant POTHOLE_DICT => {
     map {
-        @{ $_->{key} }, 
+        @{ $_->{key} },
         @{ $_->{name} },
     } @{ POTHOLE_SIZES() },
 };
@@ -86,7 +86,7 @@ sub temp_update_potholes_contact {
             'description' => 'Size of the pothole?',
             'required' => 'true',
             'datatype' => 'singlevaluelist',
-            'datatype_description' => {}, 
+            'datatype_description' => {},
             'values' => {
                 'value' => $self->POTHOLE_SIZES,
             },
@@ -121,6 +121,11 @@ sub pin_colour {
 
 sub send_questionnaires {
     return 0;
+}
+
+sub contact_email {
+    my $self = shift;
+    return join( '@', 'highways', 'eastsussex.gov.uk' );
 }
 
 1;

--- a/perllib/FixMyStreet/Cobrand/Greenwich.pm
+++ b/perllib/FixMyStreet/Cobrand/Greenwich.pm
@@ -44,4 +44,9 @@ sub pin_colour {
     return 'yellow';
 }
 
+sub contact_email {
+    my $self = shift;
+    return join( '@', 'fixmystreet', 'royalgreenwich.gov.uk' );
+}
+
 1;

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -103,4 +103,9 @@ sub pin_colour {
 
 sub on_map_default_status { return 'open'; }
 
+sub contact_email {
+    my $self = shift;
+    return join( '@', 'highway.enquiries', 'oxfordshire.gov.uk' );
+}
+
 1;

--- a/perllib/FixMyStreet/Cobrand/Stevenage.pm
+++ b/perllib/FixMyStreet/Cobrand/Stevenage.pm
@@ -29,5 +29,10 @@ sub default_map_zoom { return 3; }
 
 sub users_can_hide { return 1; }
 
+sub contact_email {
+    my $self = shift;
+    return join( '@', 'csc', 'stevenage.gov.uk' );
+}
+
 1;
 


### PR DESCRIPTION
Overrides `contact_email` in the East Sussex and Greenwich cobrands so that emails from the
`/contact` page get sent to the council, rather than us.

~~This is hopefully very simple, I'm just making it a PR so that someone can
tell me if I've misunderstood all the implications of doing this (I have 4
more cobrands to update this on soon).~~

Fixes https://github.com/mysociety/FixMyStreet-Commercial/issues/619, https://github.com/mysociety/FixMyStreet-Commercial/issues/726