### PR TITLE
[East Sussex] Stop the header scrolling off the screen on the map page

### DIFF
--- a/web/cobrands/eastsussex/base.scss
+++ b/web/cobrands/eastsussex/base.scss
@@ -253,3 +253,9 @@ styling, but this doesn't dtrt with span, so adding ourselves */
     padding: 2px;
     cursor: default;
 }
+
+// Stop the big green banner (it's not even green) at the top of map pages
+// overriding the header in the z-index
+.big-green-banner {
+    z-index: auto;
+}

--- a/web/cobrands/eastsussex/layout.scss
+++ b/web/cobrands/eastsussex/layout.scss
@@ -70,12 +70,12 @@ body.mappage {
     }
 
     #fms_pan_zoom {
-        top: 16em!important;
+        top: 18em!important;
     }
 
     #mysociety {
         margin-top: 0;
-        padding-top: 0;
+        padding-top: 16em;
         padding-bottom: 0;
         width: auto;
         background: transparent;
@@ -100,6 +100,13 @@ body.mappage {
 
     #report-a-problem-sidebar {
         top: 1em;
+    }
+
+    // Keep the headers fixed at the top on the map page
+    #site-header {
+        position: fixed;
+        width: 100%;
+        z-index: 2;
     }
 }
 


### PR DESCRIPTION
This is a bit of a hacky way to fix it, because the cobrand html/css is a bit
non-standard, but it does the trick I think.

Closes https://github.com/mysociety/FixMyStreet-Commercial/issues/542