### PR TITLE
Add some admin things

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -425,7 +425,7 @@ sub update_contacts : Private {
 sub body_params : Private {
     my ( $self, $c ) = @_;
 
-    my @fields = qw/name endpoint jurisdiction api_key send_method send_comments suppress_alerts send_extended_statuses comment_user_id can_be_devolved parent deleted/;
+    my @fields = qw/name endpoint jurisdiction api_key send_method external_url/;
     my %defaults = map { $_ => '' } @fields;
     %defaults = ( %defaults,
         send_comments => 0,
@@ -436,7 +436,7 @@ sub body_params : Private {
         parent => undef,
         deleted => 0,
     );
-    my %params = map { $_ => $c->get_param($_) || $defaults{$_} } @fields;
+    my %params = map { $_ => $c->get_param($_) || $defaults{$_} } keys %defaults;
     return \%params;
 }
 

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -705,6 +705,13 @@ sub report_edit : Path('report_edit') : Args(1) {
 
         $c->forward( 'log_edit', [ $id, 'problem', 'resend' ] );
     }
+    elsif ( $c->get_param('mark_sent') ) {
+        $c->forward('check_token');
+        $problem->whensent(\'ms_current_timestamp()');
+        $problem->update();
+        $c->stash->{status_message} = '<p><em>' . _('That problem has been marked as sent.') . '</em></p>';
+        $c->forward( 'log_edit', [ $id, 'problem', 'marked sent' ] );
+    }
     elsif ( $c->get_param('flaguser') ) {
         $c->forward('flag_user');
         $c->stash->{problem}->discard_changes;

--- a/t/app/controller/admin.t
+++ b/t/app/controller/admin.t
@@ -1083,7 +1083,7 @@ subtest 'report search' => sub {
 
 subtest 'search abuse' => sub {
     $mech->get_ok( '/admin/users?search=example' );
-    $mech->content_like(qr{test4\@example.com.*</td>\s*<td>.*?</td>\s*<td>\(Email in abuse table});
+    $mech->content_like(qr{test4\@example.com.*</td>\s*<td>.*?</td>\s*<td>\(Email in abuse table}s);
 };
 
 subtest 'show flagged entries' => sub {

--- a/t/app/controller/admin.t
+++ b/t/app/controller/admin.t
@@ -568,7 +568,7 @@ foreach my $test (
 
         $report->discard_changes;
 
-        if ( $report->state eq 'confirmed' ) {
+        if ($report->state eq 'confirmed' && $report->whensent) {
             $mech->content_contains( 'type="submit" name="resend"', 'resend button' );
         } else {
             $mech->content_lacks( 'type="submit" name="resend"', 'no resend button' );

--- a/templates/web/base/admin/bodies.html
+++ b/templates/web/base/admin/bodies.html
@@ -35,13 +35,13 @@
             [% IF c.cobrand.moniker == 'zurich' %]
               [% FILTER repeat(4*body.api_key) %]&nbsp;[% END %]
               [% IF admin_type == 'super' %]
-                <a href="[% c.uri_for( 'body', id ) %]">[% body.name %]</a>
+                <a href="[% c.uri_for( 'body', id ) %]">[% body.name | html %]</a>
               [% ELSE %]
-                [% body.name %]
+                [% body.name | html %]
               [% END %]
             [% ELSE %] [%# not Zurich: all bodies should be links %]
-              <a href="[% c.uri_for( 'body', id ) %]">[% body.name %]</a>
-              [%- ', ' _ body.parent.name IF body.parent -%]
+              <a href="[% c.uri_for( 'body', id ) %]">[% body.name | html%]</a>
+              [%- IF body.parent %], [% body.parent.name | html %][% END -%]
             [% END %]
           </td>
       [% IF c.cobrand.moniker == 'zurich' %]

--- a/templates/web/base/admin/body-form.html
+++ b/templates/web/base/admin/body-form.html
@@ -184,6 +184,9 @@
     <p>
         <label for"comment_user_id">User ID to attribute fetched comments to</label>
         <input type="text" name="comment_user_id" value="[% body.comment_user_id %]">
+        [% IF body.comment_user_id %]
+        <a href="[% c.uri_for('user_edit', body.comment_user_id) %]">[% loc('edit user') %]</a>
+        [% END %]
     </p>
 
     <div class="admin-hint">

--- a/templates/web/base/admin/body-form.html
+++ b/templates/web/base/admin/body-form.html
@@ -16,7 +16,7 @@
     </div>
     <p>
         <label for="name">[% loc('Name') %]</label>
-        <input type="text" name="name" id="name" value="[% body.name %]" size="50">
+        <input type="text" name="name" id="name" value="[% body.name | html %]" size="50">
     </p>
 
     <div class="admin-hint">
@@ -72,17 +72,21 @@
             [% SET body_areas = body.areas %]
             [% FOR area IN areas %]
             [% SET aid = area.id %]
-            <option value="[% area.id %]"[% ' selected' IF body_areas.$aid %]>[% area.name %]</option>
+            <option value="[% area.id %]"[% ' selected' IF body_areas.$aid %]>[% area.name | html %]</option>
             [% END %]
         </select>
     </p>
 
+    <p>
+        <label for="external_url">[% loc('External URL') %]</label>
+        <input type="text" name="external_url" id="external_url" value="[% body.external_url | html %]" size="50">
+    </p>
     <div class="admin-hint">
       <p>[% loc( "You can mark a body as deleted if you do not want it to be active on the site." ) %]</p>
     </div>
     <p>
-        <label for="deleted">[% loc('Flag as deleted') %]</label>
         <input type="checkbox" name="deleted" id="deleted" value="1"[% ' checked' IF body.deleted %]>
+        <label for="deleted" class="inline">[% loc('Flag as deleted') %]</label>
     </p>
 
     <div class="admin-hint">
@@ -124,7 +128,7 @@
       </div>
     <p>
         <label for="endpoint">[% loc('Endpoint') %]</label>
-        <input type="text" name="endpoint" id="endpoint" value="[% body.endpoint %]" size="50">
+        <input type="text" name="endpoint" id="endpoint" value="[% body.endpoint | html %]" size="50">
     </p>
 
     <div class="admin-hint">
@@ -137,7 +141,7 @@
     </div>
     <p>
         <label for="jurisdiction">Open311 Jurisdiction</label>
-        <input type="text" name="jurisdiction" id="jurisdiction" value="[% body.jurisdiction %]" size="50">
+        <input type="text" name="jurisdiction" id="jurisdiction" value="[% body.jurisdiction | html %]" size="50">
     </p>
 
     <div class="admin-hint">
@@ -150,7 +154,7 @@
     </div>
     <p>
         <label for="api_key">Open311 API Key</label>
-        <input type="text" name="api_key" id="api_key" value="[% body.api_key %]" size="25">
+        <input type="text" name="api_key" id="api_key" value="[% body.api_key | html %]" size="25">
     </p>
 
     <div class="admin-hint">

--- a/templates/web/base/admin/body.html
+++ b/templates/web/base/admin/body.html
@@ -65,7 +65,7 @@
     </tr>
     [% WHILE ( cat = contacts.next ) %]
       <tr [% IF cat.deleted %]class="is-deleted"[% END %]>
-        <td class="contact-category"><a href="[% c.uri_for( 'body', body_id, cat.category ) %]">[% cat.category %]</a>
+        <td class="contact-category"><a href="[% c.uri_for( 'body', body_id, cat.category ) %]">[% cat.category | html %]</a>
             <br>[% cat.email | html %]</td>
         <td>
             [% loc('Confirmed') %]:&nbsp;
@@ -79,10 +79,10 @@
             <br>[% loc('Devolved') %]:&nbsp;
             [%- IF body.can_be_devolved AND cat.send_method %][% loc('Yes') %][% ELSE %][% loc('No') %][% END %]
         </td>
-        <td>[% cat.editor %]
+        <td>[% cat.editor | html %]
             <br><small>[% PROCESS format_time time=cat.whenedited %]</small></td>
         <td>[% cat.note | html %]</td>
-        <td><input type="checkbox" name="confirmed" value="[% cat.category %]"></td>
+        <td><input type="checkbox" name="confirmed" value="[% cat.category | html %]"></td>
       </tr>
     [% END %]
   </table>

--- a/templates/web/base/admin/body.html
+++ b/templates/web/base/admin/body.html
@@ -13,13 +13,21 @@
   [% IF example_pc %]
     <a href="[% c.uri_for_email( '/around', { pc => example_pc } ) %]" class="admin-offsite-link">[% tprintf( loc('Example postcode %s'), example_pc ) | html %]</a> |
   [% END %]
-  [% IF c.cobrand.moniker == 'emptyhomes' %]
-    <a href="[% c.uri_for( 'reports', search => 'body:' _ body_id ) %]">[% loc('List all reported problems' ) %]</a> |
-  [% ELSE %]
+    [% loc('Area covered') %]:
+    [% SET body_areas = body.areas %]
+    [% FOR area IN areas %]
+      [% SET aid = area.id %]
+      [% IF body_areas.$aid %]
+        <a href="[% c.config.MAPIT_URL %][%
+        '/' UNLESS c.config.MAPIT_URL.search('/$')
+        %]area/[% aid %].html" class="admin-offsite-link">[% area.name | html %]</a>
+      [% END %]
+    [% END %]
+<br>
     <a href="[% c.uri_for_email( '/reports/' _ body_id ) %]" class="admin-offsite-link">[% loc('List all reported problems' ) %]</a> |
-  [% END %]
-  <a href="[% c.uri_for( 'body', body_id, { text => 1 } ) %]">[% loc('Text only version') %]</a>
+    <a href="[% c.uri_for( 'body', body_id, { text => 1 } ) %]">[% loc('Text only version') %]</a>
 </p>
+
 
 [% IF body.send_method == 'Open311' %]
   <h2>

--- a/templates/web/base/admin/category_edit.html
+++ b/templates/web/base/admin/category_edit.html
@@ -23,6 +23,11 @@
     <p><strong>[% loc('Category:') %] </strong>[% contact.category | html %]
     <input type="hidden" name="category" value="[% contact.category | html %]" >
     <input type="hidden" name="token" value="[% token %]" >
+  [% IF contact.extra %]
+    <p><strong>[% loc('Extra data:') %] </strong>
+    [% USE Dumper %]
+    [% Dumper.dump(contact.extra) | html %]</p>
+  [% END %]
     <p><strong>[% loc('Email:') %] </strong>
     <input type="text" name="email" value="[% contact.email | html %]" size="30"> 
 

--- a/templates/web/base/admin/category_edit.html
+++ b/templates/web/base/admin/category_edit.html
@@ -48,17 +48,17 @@
     <form method="post" action="[% c.uri_for('body', body_id ) %]" enctype="application/x-www-form-urlencoded" accept-charset="utf-8">
     <p>
         <label for="endpoint">Endpoint</label>
-        <input type="text" name="endpoint" id="endpoint" value="[% contact.endpoint %]" size="50">
+        <input type="text" name="endpoint" id="endpoint" value="[% contact.endpoint | html %]" size="50">
     </p>
 
     <p>
         <label for="jurisdiction">Jurisdiction</label>
-        <input type="text" name="jurisdiction" id="jurisdiction" value="[% contact.jurisdiction %]" size="50">
+        <input type="text" name="jurisdiction" id="jurisdiction" value="[% contact.jurisdiction | html %]" size="50">
     </p>
 
     <p>
         <label for="api_key">Api Key</label>
-        <input type="text" name="api_key" id="api_key" value="[% contact.api_key %]" size="25">
+        <input type="text" name="api_key" id="api_key" value="[% contact.api_key | html %]" size="25">
     </p>
 
     <p>
@@ -93,7 +93,7 @@
         <td>[% PROCESS highlightchanged old=prev new=contact value='email' %]</td>
         <td>[% PROCESS highlightchanged_yesno old=prev new=contact value='confirmed' %]</td>
         <td>[% PROCESS highlightchanged_yesno old=prev new=contact value='deleted' %]</td>
-        <td>[% contact.editor %]</td>
+        <td>[% contact.editor | html %]</td>
         <td>[% contact.note | html %]</td>
     </tr>
         [%- prev = contact %]

--- a/templates/web/base/admin/report_edit.html
+++ b/templates/web/base/admin/report_edit.html
@@ -31,7 +31,16 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
 %],
 [% IF problem.used_map %][% loc('used map') %][% ELSE %][% loc("didn't use map") %][% END %])</li>
 
-<li>[% loc('For council(s):') %] [% IF problem.bodies_str %][% problem.bodies_str %][% ELSE %]<em>[% loc('None' ) %]</em>[% END %] ([% loc('other areas:') %] [% problem.areas | remove('^,') | remove( ',$' ) %])</li>
+<li>[% loc('Body:') %]
+  [% IF problem.bodies_str %]
+    [% FOREACH body IN problem.bodies.values %]
+      <a href="[% c.uri_for('body', body.id) %]">[% body.name | html %]</a>
+      [%- ',' IF NOT loop.last %]
+    [% END %]
+  [% ELSE %]
+    <em>[% loc('None' ) %]</em>
+  [% END %]
+  ([% loc('other areas:') %] [% problem.areas | remove('^,') | remove( ',$' ) %])</li>
 [% IF problem.extra.address %]
 <li>[% loc('Property address:') %] [% problem.extra.address | html %]</li>
 [% END %]

--- a/templates/web/base/admin/report_edit.html
+++ b/templates/web/base/admin/report_edit.html
@@ -68,7 +68,10 @@
 <li>[% loc('Phone:') %] [% problem.user.phone | html %]</li>
 <li>[% loc('Created:') %] [% PROCESS format_time time=problem.created %]</li>
 <li>[% loc('Confirmed:') %] [% PROCESS format_time time=problem.confirmed no_time='-' %]</li>
-<li>[% loc('Sent:') %] [% PROCESS format_time time=problem.whensent %] [% IF problem.state == 'confirmed' %]<input onclick="return confirm('[% loc('You really want to resend?') %]')" type="submit" name="resend" value="[% loc('Resend report') %]">[% END %]</li>
+<li>[% loc('Sent:') %] [% PROCESS format_time time=problem.whensent %]
+[% IF problem.state == 'confirmed' AND problem.whensent %]<input onclick="return confirm('[% loc('You really want to resend?') %]')" type="submit" name="resend" value="[% loc('Resend report') %]">[% END %]
+[% IF NOT problem.whensent %]<input type="submit" name="mark_sent" value="[% loc('Mark as sent') %]">[% END %]
+</li>
 <li>[% loc('Last update:') %] [% PROCESS format_time time=problem.lastupdate %]</li>
 <li>[% loc('Service:') %] [% problem.service %]</li>
 <li>[% loc('Cobrand:') %] [% problem.cobrand %]</li>

--- a/templates/web/base/admin/report_edit.html
+++ b/templates/web/base/admin/report_edit.html
@@ -20,7 +20,11 @@
 <li><label for='detail'>[% loc('Details:') %]</label>
 <textarea name='detail' id='detail' cols=60 rows=10>[% problem.detail | html %]</textarea></li>
 
-<li>[% loc('Co-ordinates:') %] [% problem.latitude %], [% problem.longitude %]
+<li>[% loc('Co-ordinates:') %]
+<a href="[% c.config.MAPIT_URL %][%
+    '/' UNLESS c.config.MAPIT_URL.search('/$')
+%]point/4326/[% problem.longitude %],[% problem.latitude %].html"
+class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
 ( [%
     SET postcode_safe = problem.postcode | html;
     tprintf( loc('originally entered: &ldquo;%s&rdquo;'), postcode_safe )

--- a/templates/web/base/admin/user-form.html
+++ b/templates/web/base/admin/user-form.html
@@ -34,8 +34,9 @@
         [% FOR body IN bodies %]
             <option value="[% body.id %]"[% ' selected' IF body.id == user.from_body.id %]>[% body.name %]</option>
         [% END %]
-        </li>
         </select>
+        [% IF user.from_body AND user.has_permission_to('moderate', user.from_body.id) %]*[% END %]
+        </li>
       [% IF c.cobrand.moniker != 'zurich' %]
         <li>
           <div class="admin-hint">

--- a/templates/web/base/admin/users.html
+++ b/templates/web/base/admin/users.html
@@ -24,7 +24,9 @@
     <tr>
         <td>[% PROCESS value_or_nbsp value=user.name %]</td> 
         <td><a href="[% c.uri_for( 'reports', search => user.email ) %]">[% PROCESS value_or_nbsp value=user.email %]</a></td> 
-        <td>[% PROCESS value_or_nbsp value=user.from_body.name %]</td>
+        <td>[% PROCESS value_or_nbsp value=user.from_body.name %]
+            [% IF user.from_body AND user.has_permission_to('moderate', user.from_body.id) %] * [% END %]
+        </td>
       [% IF c.cobrand.moniker != 'zurich' %]
         <td>[% user.flagged == 2 ? loc('(Email in abuse table)') : user.flagged ? loc('Yes') : '&nbsp;' %]</td>
       [% END %]

--- a/web/js/fixmystreet-admin.js
+++ b/web/js/fixmystreet-admin.js
@@ -9,7 +9,7 @@ $(function(){
         var show_open311 = false;
         if ($('#endpoint').val()) {
             show_open311 = true; // always show the form if there is an endpoint value
-        } else if (send_method && send_method.toLowerCase() != 'email') {
+        } else if (send_method && !send_method.match(/^(email|emptyhomes|noop|refused)$/i)) {
             show_open311 = true;
         }
         if (show_open311) {


### PR DESCRIPTION
This PR allows a body's external URL to be edited in the admin (no ticket). While it's there, it adds a mark as sent button (fixes #601); adds a link to a body's comment_user_id (fixes #580); adds mapit links to body/report pages (fixes #638); shows category extra data (fixes #517, fixes #920); lists report bodies more nicely on a report page, with links (no ticket); stars users who have moderate permission (fixes #990), and tweaks the display of body form a bit.