### PR TITLE
bin/make_css now follows symlinks

### DIFF
--- a/bin/make_css
+++ b/bin/make_css
@@ -20,7 +20,7 @@ fi
 
 DIRECTORY=$(cd "$DIR"/../web && pwd)
 
-DIRS=${@:-`find $DIRECTORY -name "*.scss" -exec dirname {} \; | uniq`}
+DIRS=${@:-`find -L $DIRECTORY -name "*.scss" -exec dirname {} \; | uniq`}
 
 for dir in $DIRS; do
     if [ -e "$dir/config.rb" ]; then


### PR DESCRIPTION
The [fixmystreet-international](https://github.com/mysociety/fixmystreet-international) installation instructions make use of symlinks in, among other places, `web/cobrands/`. This means that `bin/make_css` needs to follow symlinks when looking for scss files to compile.