### PR TITLE
[Collideoscope] Proper stats19 filtering on the /around page

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -169,10 +169,13 @@ sub display_location : Private {
     # Check the category to filter by, if any, is valid
     $c->forward('check_and_stash_category');
 
+    # Allow the cobrand to add in any additional query parameters
+    my $extra_params = $c->cobrand->display_location_extra_params($c);
+
     # get the map features
     my ( $on_map_all, $on_map, $around_map, $distance ) =
       FixMyStreet::Map::map_features( $c, $latitude, $longitude,
-        $interval, $c->stash->{filter_category}, $c->stash->{filter_problem_states} );
+        $interval, $c->stash->{filter_category}, $c->stash->{filter_problem_states}, $extra_params );
 
     # copy the found reports to the stash
     $c->stash->{on_map}     = $on_map;
@@ -290,12 +293,15 @@ sub ajax : Path('/ajax') {
     my $all_pins = $c->get_param('all_pins') ? 1 : undef;
     my $interval = $all_pins ? undef : $c->cobrand->on_map_default_max_pin_age;
 
+    # Allow the cobrand to add in any additional query parameters
+    my $extra_params = $c->cobrand->display_location_extra_params($c);
+
     # Need to be the class that can handle it
     FixMyStreet::Map::set_map_class( 'OSM' );
 
     # extract the data from the map
     my ( $pins, $on_map, $around_map, $dist ) =
-      FixMyStreet::Map::map_pins( $c, $interval );
+      FixMyStreet::Map::map_pins( $c, $interval, $extra_params );
 
     # render templates to get the html
     my $on_map_list_html = $c->render_fragment(

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -940,4 +940,16 @@ sub subject_line_for_contact_email {
     return 'FMS message: ' . $subject;
 }
 
+=head2 display_location_extra_params
+
+Return any additional Problem query parameters for use in showing problems on
+the /around page during the
+FixMyStreet::App::Controller::Around::display_location action.
+
+=cut
+sub display_location_extra_params {
+    my ($self, $c) = @_;
+    return 0;
+}
+
 1;

--- a/perllib/FixMyStreet/Cobrand/Smidsy.pm
+++ b/perllib/FixMyStreet/Cobrand/Smidsy.pm
@@ -500,4 +500,33 @@ sub send_questionnaires {
     return 0;
 }
 
+=head2 display_location_extra_params
+
+Return additional Problem query parameters for use in showing problems on
+the /around page during the
+FixMyStreet::App::Controller::Around::display_location action.
+
+Specialised to return a flag to filter problems by the external_body field if
+the user would like to see Stats19 problems.
+
+=cut
+sub display_location_extra_params {
+    my ($self, $c) = @_;
+    if ($c->get_param('show_stats19')) {
+        # Stash this for later
+        $c->stash->{show_stats19} = $c->get_param('show_stats19');
+        return {
+            external_body => 'stats19',
+            # TODO - this is needed to override the default interval that's
+            # provided (1 Month). I'm not sure if there's an easier way to do
+            # it and actually unset this value perhaps?
+            'current_timestamp - lastupdate' => { '<', \"'100 years'::interval" }
+        }
+    } else {
+        return {
+            external_body => {'!=' => 'stats19'},
+        }
+    }
+}
+
 1;

--- a/perllib/FixMyStreet/DB/ResultSet/Nearby.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Nearby.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 sub nearby {
-    my ( $rs, $c, $dist, $ids, $limit, $mid_lat, $mid_lon, $interval, $category, $states ) = @_;
+    my ( $rs, $c, $dist, $ids, $limit, $mid_lat, $mid_lon, $interval, $category, $states, $extra_params ) = @_;
 
     unless ( $states ) {
         $states = FixMyStreet::DB::Result::Problem->visible_states();
@@ -24,6 +24,9 @@ sub nearby {
         %$params
     } if $c->cobrand->problems_clause;
     $params->{category} = $category if $category;
+
+    # Add in any optional extra query parameters
+    $params = { %$params, %$extra_params } if $extra_params;
 
     my $attrs = {
         prefetch => 'problem',

--- a/perllib/FixMyStreet/DB/ResultSet/Problem.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Problem.pm
@@ -131,7 +131,7 @@ sub _recent {
 # Problems around a location
 
 sub around_map {
-    my ( $rs, $min_lat, $max_lat, $min_lon, $max_lon, $interval, $limit, $category, $states ) = @_;
+    my ( $rs, $min_lat, $max_lat, $min_lon, $max_lon, $interval, $limit, $category, $states, $extra_params ) = @_;
     my $attr = {
         order_by => { -desc => 'created' },
     };
@@ -150,6 +150,9 @@ sub around_map {
     $q->{'current_timestamp - lastupdate'} = { '<', \"'$interval'::interval" }
         if $interval;
     $q->{category} = $category if $category;
+
+    # Add in any optional extra query parameters
+    $q = { %$q, %$extra_params } if $extra_params;
 
     my @problems = mySociety::Locale::in_gb_locale { $rs->search( $q, $attr )->all };
     return \@problems;

--- a/perllib/FixMyStreet/Map.pm
+++ b/perllib/FixMyStreet/Map.pm
@@ -55,7 +55,7 @@ sub display_map {
 }
 
 sub map_features {
-    my ( $c, $lat, $lon, $interval, $category, $states ) = @_;
+    my ( $c, $lat, $lon, $interval, $category, $states, $extra_params ) = @_;
 
    # TODO - be smarter about calculating the surrounding square
    # use deltas that are roughly 500m in the UK - so we get a 1 sq km search box
@@ -65,12 +65,12 @@ sub map_features {
         $c, $lat, $lon,
         $lon - $lon_delta, $lat - $lat_delta,
         $lon + $lon_delta, $lat + $lat_delta,
-        $interval, $category, $states
+        $interval, $category, $states, $extra_params
     );
 }
 
 sub map_features_bounds {
-    my ( $c, $min_lon, $min_lat, $max_lon, $max_lat, $interval, $category, $states ) = @_;
+    my ( $c, $min_lon, $min_lat, $max_lon, $max_lat, $interval, $category, $states, $extra_params ) = @_;
 
     my $lat = ( $max_lat + $min_lat ) / 2;
     my $lon = ( $max_lon + $min_lon ) / 2;
@@ -79,20 +79,21 @@ sub map_features_bounds {
         $min_lon, $min_lat,
         $max_lon, $max_lat,
         $interval, $category,
-        $states
+        $states,
+        $extra_params
     );
 }
 
 sub _map_features {
-    my ( $c, $lat, $lon, $min_lon, $min_lat, $max_lon, $max_lat, $interval, $category, $states ) = @_;
+    my ( $c, $lat, $lon, $min_lon, $min_lat, $max_lon, $max_lat, $interval, $category, $states, $extra_params ) = @_;
 
     # list of problems around map can be limited, but should show all pins
     my $around_limit = $c->cobrand->on_map_list_limit || undef;
 
     my @around_args = ( $min_lat, $max_lat, $min_lon, $max_lon, $interval );
-    my $around_map      = $c->cobrand->problems->around_map( @around_args, undef, $category, $states );
+    my $around_map      = $c->cobrand->problems->around_map( @around_args, undef, $category, $states, $extra_params );
     my $around_map_list = $around_limit
-        ? $c->cobrand->problems->around_map( @around_args, $around_limit, $category, $states )
+        ? $c->cobrand->problems->around_map( @around_args, $around_limit, $category, $states, $extra_params )
         : $around_map;
 
     my $dist;
@@ -106,14 +107,14 @@ sub _map_features {
     my $limit  = 20;
     my @ids    = map { $_->id } @$around_map_list;
     my $nearby = $c->model('DB::Nearby')->nearby(
-        $c, $dist, \@ids, $limit, $lat, $lon, $interval, $category, $states
+        $c, $dist, \@ids, $limit, $lat, $lon, $interval, $category, $states, $extra_params
     );
 
     return ( $around_map, $around_map_list, $nearby, $dist );
 }
 
 sub map_pins {
-    my ($c, $interval) = @_;
+    my ($c, $interval, $extra_params) = @_;
 
     my $bbox = $c->get_param('bbox');
     my ( $min_lon, $min_lat, $max_lon, $max_lat ) = split /,/, $bbox;
@@ -123,7 +124,7 @@ sub map_pins {
     my $states = $c->stash->{filter_problem_states};
 
     my ( $around_map, $around_map_list, $nearby, $dist ) =
-      FixMyStreet::Map::map_features_bounds( $c, $min_lon, $min_lat, $max_lon, $max_lat, $interval, $category, $states );
+      FixMyStreet::Map::map_features_bounds( $c, $min_lon, $min_lat, $max_lon, $max_lat, $interval, $category, $states, $extra_params );
 
     # create a list of all the pins
     my @pins = map {

--- a/templates/web/smidsy/around/around_map_list_items.html
+++ b/templates/web/smidsy/around/around_map_list_items.html
@@ -1,0 +1,5 @@
+[%# This template intentionally left blank because on_map_list_items.html
+    merges and displays both lists of pins for Collideoscope, and we don't
+    the server to have to bother rendering something that won't be displayed
+    (this template is used when generating ajax responses too).
+%]

--- a/templates/web/smidsy/around/on_map_list_items.html
+++ b/templates/web/smidsy/around/on_map_list_items.html
@@ -1,6 +1,5 @@
 [% all_incidents = on_map.merge(around_map) %]
 [% IF all_incidents.size %]
-    [% IF all_incidents.size > 10; all_incidents = all_incidents.slice(0,9); END %]
     [% FOREACH p IN all_incidents %]
         <li>
             [% UNLESS p.title; p = p.problem; END %]

--- a/templates/web/smidsy/around/tabbed_lists.html
+++ b/templates/web/smidsy/around/tabbed_lists.html
@@ -1,16 +1,12 @@
 <p class="report-list-filters">
-  <input id="show_stats19_checkbox" type="checkbox" [% IF c.req.params.all_pins %]checked[% END %]>
-  <label>Show reports from the Department of Transport</label>
-      <script>
-          $(function () {
-              $('#show_stats19_checkbox').change( function () {
-                  // for now, defer to #all_pins_link functionality
-                  // we will replace this hack when we have proper backend plumbing for it
-                  $('#all_pins_link').click();
-              });
-          });
-      </script>
-  <a href="/faq#stats19" title="What is Stats19?">(?)</a>
+    <a class="stats-19"
+    [% IF c.req.params.show_stats19 %]
+        href="[% c.uri_with( { show_stats19 => 0 } ) %]">Hide reports from the Department of Transport
+    [% ELSE %]
+        href="[% c.uri_with( { show_stats19 => 1 } ) %]">Show reports from the Department of Transport
+    [% END %]
+    </a>
+    <a href="/faq#stats19" title="What is Stats19?">(?)</a>
 </p>
 
 <ul class="incident-list">

--- a/templates/web/smidsy/around/tabbed_lists.html
+++ b/templates/web/smidsy/around/tabbed_lists.html
@@ -1,5 +1,5 @@
 <p class="report-list-filters">
-    <a class="stats-19"
+    <a id="stats-19"
     [% IF c.req.params.show_stats19 %]
         href="[% c.uri_with( { show_stats19 => 0 } ) %]">Hide reports from the Department of Transport
     [% ELSE %]

--- a/templates/web/smidsy/around/tabbed_lists.html
+++ b/templates/web/smidsy/around/tabbed_lists.html
@@ -9,6 +9,6 @@
     <a href="/faq#stats19" title="What is Stats19?">(?)</a>
 </p>
 
-<ul class="incident-list">
-    [% INCLUDE "around/combined_map_list_items.html" %]
+<ul id="current" class="incident-list">
+    [% INCLUDE "around/on_map_list_items.html" %]
 </ul>

--- a/templates/web/smidsy/maps/osm-toner-lite.html
+++ b/templates/web/smidsy/maps/osm-toner-lite.html
@@ -11,5 +11,8 @@
 
 [% map_html = BLOCK %]
 [% INCLUDE maps/openlayers.html %]
-<script type="text/javascript">fixmystreet.show_stats19 = '[% show_stats19 %]';</script>
+<script type="text/javascript">
+    var fixmystreet = fixmystreet || {};
+    fixmystreet.show_stats19 = '[% show_stats19 | escape_js | html %]';
+</script>
 [% END %]

--- a/templates/web/smidsy/maps/osm-toner-lite.html
+++ b/templates/web/smidsy/maps/osm-toner-lite.html
@@ -1,0 +1,15 @@
+[% map_js = BLOCK %]
+<script type="text/javascript" src="[% version('/js/OpenLayers.fixmystreet.js') %]"></script>
+<script type="text/javascript" src="https://stamen-maps.a.ssl.fastly.net/js/tile.stamen.js?v1.3.0"></script>
+<script type="text/javascript" src="[% version('/js/map-OpenLayers.js') %]"></script>
+<script type="text/javascript" src="[% version('/js/map-toner-lite.js') %]"></script>
+<script type="text/javascript" src="[% version('/js/jquery.ba-hashchange.min.js') %]"></script>
+<!--[if lte IE 6]>
+  <link rel="stylesheet" href="/js/OpenLayers-2.13.1/theme/default/ie6-style.css" type="text/css">
+<![endif]-->
+[% END %]
+
+[% map_html = BLOCK %]
+[% INCLUDE maps/openlayers.html %]
+<script type="text/javascript">fixmystreet.show_stats19 = '[% show_stats19 %]';</script>
+[% END %]

--- a/web/cobrands/smidsy/js/report.js
+++ b/web/cobrands/smidsy/js/report.js
@@ -18,7 +18,7 @@ $(function() {
                 // But it does call callback so hide when complete.
                 // (We hide on callback, to avoid the hide killing the slide
                 // animation entirely.)
-                function () { $(this).hide() }
+                function () { $(this).hide(); }
             );
         }
     }).change(); // and call on page load

--- a/web/cobrands/smidsy/js/report.js
+++ b/web/cobrands/smidsy/js/report.js
@@ -50,4 +50,40 @@ $(function() {
         }
     });
 
+    // Deal with toggling stats19 data on and off on the /around page
+    var $stats19Link = $('#stats-19');
+    var showText = 'Show reports from the Department of Transport';
+    var hideText = 'Hide reports from the Department of Transport';
+    var toggleStats19Link = function toggleStats19Link($link){
+      if ($link.data('show-stats19')) {
+        $link.data({'show-stats19': 0});
+        $link.html(hideText);
+      } else {
+        $link.data({'show-stats19': 1});
+        $link.html(showText);
+      }
+    };
+    if (window.fixmystreet.show_stats19 === '1') {
+      // Force a load of the pins with the stats_19 param set up on first
+      // load because FMS' default _onload function won't know about it.
+      window.fixmystreet.markers.protocol.options.params.show_stats19 = '[% show_stats19 %]';
+      window.fixmystreet.markers.refresh( { force: true } );
+      // Initialise the data variable we use to keep track of whether
+      // stats19 data is being shown
+      toggleStats19Link();
+    } else {
+      // Initialise the data variable we use to keep track of whether
+      // stats19 data is being shown
+      $stats19Link.data({'show-stats19': 1});
+    }
+    // Handle future clicks on the stats19 link
+    $stats19Link.click(function(e) {
+      e.preventDefault();
+      window.fixmystreet.markers.setVisibility(true);
+      window.fixmystreet.markers.protocol.options.params.show_stats19 = $stats19Link.data('show-stats19');
+      window.fixmystreet.markers.refresh( { force: true } );
+      toggleStats19Link($stats19Link);
+      return false;
+    });
+
 });

--- a/web/cobrands/smidsy/js/report.js
+++ b/web/cobrands/smidsy/js/report.js
@@ -66,7 +66,7 @@ $(function() {
     if (window.fixmystreet.show_stats19 === '1') {
       // Force a load of the pins with the stats_19 param set up on first
       // load because FMS' default _onload function won't know about it.
-      window.fixmystreet.markers.protocol.options.params.show_stats19 = '[% show_stats19 %]';
+      window.fixmystreet.markers.protocol.options.params.show_stats19 = '1';
       window.fixmystreet.markers.refresh( { force: true } );
       // Initialise the data variable we use to keep track of whether
       // stats19 data is being shown


### PR DESCRIPTION
This PR:

On the FMS side:
- Adds a mechanism for cobrands to supply extra query parameters when getting
  problems on the map page. This requires changes to the /around and /ajax
  controller actions that produce lists of features and pins for the /around
  page, so that they call the cobrand for an extra hash and then insert it
  into the necessary queries. I've probably named this badly, need to document
  it somewhere, and might have missed a place where the params should be used.
  Thoughts welcome!

On the collideoscope side:
- Uses this new mechanism in the smidsy cobrand to filter by `external_body`
  and to lift the time interval restriction on problems, so that it can
  display all of the stats19 problems.
- Removes the old js code that connected the "show stats19 problems" checkbox
  to the 'show old pins' button as a hacky way of approximating it and
  replaces the checkbox with a link, because it's an easier way of making it
  work when there's no JS.
- Fixes a somewhat related bug where the sidebar wasn't getting updated with
  a list of problems that were on the map because it was missing an ID, and
  when that was fixed, another bug where the list generated didn't use quite
  the right styles because the standard FMS templates weren't being used.
- Adds some new js to make the stats19 link do things when it's clicked.

@Benjam, @zarino I've obviously taken a little liberty here with the styling.
I _could_ re-implement the checkbox in JS only if you think it matters? (Or
alternatively make it look like a button or something else appropriate). It
can't be a form element and work without JS though, because the whole sidebar
gets wrapped in a form and it will break.

Fixes https://github.com/mysociety/FixMyStreet-Commercial/issues/712
