### PR TITLE
Use base URL in cobrand alert for no-body report.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Rss.pm
+++ b/perllib/FixMyStreet/App/Controller/Rss.pm
@@ -264,11 +264,7 @@ sub add_row : Private {
     (my $link = $alert_type->item_link) =~ s/{{(.*?)}}/$row->{$1}/g;
     (my $desc = _($alert_type->item_description)) =~ s/{{(.*?)}}/$row->{$1}/g;
 
-    my $hashref_restriction = $c->cobrand->body_restriction;
-    my $base_url = $c->cobrand->base_url;
-    if ( $hashref_restriction && $row->{bodies_str} && $row->{bodies_str} ne $hashref_restriction ) {
-        $base_url = $c->config->{BASE_URL};
-    }
+    my $base_url = $c->cobrand->base_url_for_report($row);
     my $url = $base_url . $link;
 
     my %item = (

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -108,7 +108,8 @@ sub base_url { FixMyStreet->config('BASE_URL') }
 =head2 base_url_for_report
 
 Return the base url for a report (might be different in a two-tier county, but
-most of the time will be same as base_url).
+most of the time will be same as base_url). Report may be an object, or a
+hashref.
 
 =cut
 

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -109,8 +109,15 @@ sub recent_photos {
 # Returns true if the cobrand owns the problem.
 sub owns_problem {
     my ($self, $report) = @_;
-    my $bodies = $report->bodies;
-    my %areas = map { %{$_->areas} } values %$bodies;
+    my @bodies;
+    if (ref $report eq 'HASH') {
+        return unless $report->{bodies_str};
+        @bodies = split /,/, $report->{bodies_str};
+        @bodies = FixMyStreet::App->model('DB::Body')->search({ id => \@bodies })->all;
+    } else { # Object
+        @bodies = values %{$report->bodies};
+    }
+    my %areas = map { %{$_->areas} } @bodies;
     return $areas{$self->council_id} ? 1 : undef;
 }
 

--- a/perllib/FixMyStreet/DB/ResultSet/AlertType.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/AlertType.pm
@@ -88,11 +88,7 @@ sub email_alerts ($) {
                 $data{state_message} = _("This report is currently marked as open.");
             }
 
-            my $hashref_restriction = $cobrand->body_restriction;
-            my $url = $cobrand->base_url( $row->{alert_cobrand_data} );
-            if ( $hashref_restriction && $row->{bodies_str} ne $hashref_restriction ) {
-                $url = mySociety::Config::get('BASE_URL');
-            }
+            my $url = $cobrand->base_url_for_report($row);
             # this is currently only for new_updates
             if ($row->{item_text}) {
                 if ( $cobrand->moniker ne 'zurich' && $row->{alert_user_id} == $row->{user_id} ) {
@@ -171,7 +167,6 @@ sub email_alerts ($) {
 
         my $longitude = $alert->parameter;
         my $latitude  = $alert->parameter2;
-        my $hashref_restriction = $cobrand->body_restriction;
         my $d = mySociety::Gaze::get_radius_containing_population($latitude, $longitude, 200000);
         # Convert integer to GB locale string (with a ".")
         $d = mySociety::Locale::in_gb_locale {
@@ -195,10 +190,7 @@ sub email_alerts ($) {
                 alert_id  => $alert->id,
                 parameter => $row->{id},
             } );
-            my $url = $cobrand->base_url( $alert->cobrand_data );
-            if ( $hashref_restriction && $row->{bodies_str} ne $hashref_restriction ) {
-                $url = mySociety::Config::get('BASE_URL');
-            }
+            my $url = $cobrand->base_url_for_report($row);
             $data{data} .= $url . "/report/" . $row->{id} . " - $row->{title}\n\n";
             if ( exists $row->{geocode} && $row->{geocode} ) {
                 my $nearest_st = _get_address_from_gecode( $row->{geocode} );

--- a/t/app/controller/rss.t
+++ b/t/app/controller/rss.t
@@ -127,11 +127,14 @@ $mech->content_contains( '18 North Bridge, Edinburgh' );
 
 $report->delete();
 
+my $council = $mech->create_body_ok(2333, 'Hart Council');
+my $county = $mech->create_body_ok(2227, 'Hampshire Council');
+
 my $now = DateTime->now();
 my $report_to_council = FixMyStreet::App->model('DB::Problem')->find_or_create(
     {
         postcode           => 'GU51 4AE',
-        bodies_str         => '2333',
+        bodies_str         => $council->id,
         areas              => ',2333,2227,',
         category           => 'Other',
         title              => 'council report',
@@ -155,7 +158,7 @@ my $report_to_council = FixMyStreet::App->model('DB::Problem')->find_or_create(
 my $report_to_county_council = FixMyStreet::App->model('DB::Problem')->find_or_create(
     {
         postcode           => 'GU51 4AE',
-        bodies_str         => '2227',
+        bodies_str         => $county->id,
         areas              => ',2333,2227,',
         category           => 'Other',
         title              => 'county report',


### PR DESCRIPTION
If a cobrand has a body restriction, then a report without any body
won't be shown on it, so we need to make sure links to the report (in
email alerts and RSS) are to the base URL, not the cobrand.