### PR TITLE
Improve accessibility of map pages.

### DIFF
--- a/templates/web/base/maps/openlayers.html
+++ b/templates/web/base/maps/openlayers.html
@@ -28,7 +28,7 @@ var fixmystreet = {
     'pins': [% INCLUDE maps/pins_js.html %]
 }
 </script>
-<div id="map_box">
+<div id="map_box" aria-hidden="true">
     [% pre_map %]
     <div id="map"><noscript>
         <div id="drag"><[% map.img_type %]

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -178,8 +178,7 @@ $(function(){
     });
 
     //move 'skip this step' link on mobile
-    $('.mobile #skip-this-step').hide();
-    $('.mobile #skip-this-step a').addClass('chevron').wrap('<li>').appendTo('#key-tools');
+    $('.mobile #skip-this-step').addClass('chevron').wrap('<li>').parent().appendTo('#key-tools');
 
     /*
      * Tabs
@@ -369,12 +368,12 @@ $.fn.drawer = function(id, ajax) {
 
     // Go directly to RSS feed if RSS button clicked on alert page
     // (due to not wanting around form to submit, though good thing anyway)
-    $('.container').on('click', '#alert_rss_button', function(e){
+    $('body').on('click', '#alert_rss_button', function(e){
         e.preventDefault();
         var feed = $('input[name=feed][type=radio]:checked').nextAll('a').attr('href');
         window.location.href = feed;
     });
-    $('.container').on('click', '#alert_email_button', function(e){
+    $('body').on('click', '#alert_email_button', function(e){
         e.preventDefault();
         var form = $('<form/>').attr({ method:'post', action:"/alert/subscribe" });
         form.append($('<input name="alert" value="Subscribe me to an email alert" type="hidden" />'));

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -118,11 +118,16 @@ h1 {
     top:-3.25em;
   }
 }
-#nav-link,
-#report-cta {
+
+#nav-link {
   #{$right}: auto;
   #{$left}: -999999px;
 }
+
+#report-cta {
+    display: none;
+}
+
 #main-nav{
   margin: 0 auto;
   padding: 0em;


### PR DESCRIPTION
Hide the map with aria-hidden, as all report links are duplicated in the main content. Fix skip map link on mobile (it was disappearing). Place delegate handler on body to prevent e.g. VoiceOver announcing everything underneath .container as clickable. Remove header report button rather than hide off-screen, as is a duplicate link to the previous.