### PR TITLE
Process update left as part of questionnaire.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Questionnaire.pm
+++ b/perllib/FixMyStreet/App/Controller/Questionnaire.pm
@@ -234,6 +234,8 @@ sub process_questionnaire : Private {
 
     map { $c->stash->{$_} = $c->get_param($_) || '' } qw(been_fixed reported another update);
 
+    $c->stash->{update} = Utils::cleanup_text($c->stash->{update}, { allow_multiline => 1 });
+
     # EHA questionnaires done for you
     if ($c->cobrand->moniker eq 'emptyhomes') {
         $c->stash->{another} = $c->stash->{num_questionnaire}==1 ? 'Yes' : 'No';

--- a/t/app/controller/questionnaire.t
+++ b/t/app/controller/questionnaire.t
@@ -191,6 +191,16 @@ foreach my $test (
         },
     },
     {
+        desc => 'Fixed report, reopened, reported before, blank update, no further questionnaire',
+        problem_state => 'fixed',
+        fields => {
+            been_fixed => 'No',
+            reported => 'Yes',
+            another => 'No',
+            update => '   ',
+        },
+    },
+    {
         desc => 'Closed report, said fixed, reported before, no update, no further questionnaire',
         problem_state => 'closed',
         fields => {


### PR DESCRIPTION
Treat an update left during a questionnaire the same as one left on a
report page, ie. pass it through cleanup_text. This will also make sure
updates left that are wholly whitespace are errored, or replaced with
the default text.