### PR TITLE
Exclude deleted categories from the all reports page filters

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -121,7 +121,7 @@ sub ward : Path : Args(2) {
 
     $c->stash->{stats} = $c->cobrand->get_report_stats();
 
-    my @categories = $c->stash->{body}->contacts->search( undef, {
+    my @categories = $c->stash->{body}->contacts->not_deleted->search( undef, {
         columns => [ 'category' ],
         distinct => 1,
         order_by => [ 'category' ],

--- a/t/app/controller/reports.t
+++ b/t/app/controller/reports.t
@@ -216,5 +216,28 @@ subtest "test fiksgatami all reports page" => sub {
     }
 };
 
+subtest "test greenwich all reports page" => sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'greenwich' ],
+        MAPIT_URL => 'http://mapit.mysociety.org/'
+    }, sub {
+        my $body = $mech->create_body_ok(2493, 'Royal Borough of Greenwich');
+        my $deleted_contact = $mech->create_contact_ok(
+            body_id => $body->id,
+            category => 'Deleted',
+            email => 'deleted@example.com',
+            deleted => 1
+        );
+        ok $mech->host("greenwich.fixmystreet.com"), 'change host to greenwich';
+        $mech->get_ok('/reports/Royal+Borough+of+Greenwich');
+        # There should not be deleted categories in the list
+        my $category_select = $mech->forms()->[0]->find_input('filter_category');
+        is $category_select->possible_values, 1, 'deleted categories are not shown';
+
+        # Clean up after the test
+        $deleted_contact->delete;
+    }
+};
+
 done_testing();
 


### PR DESCRIPTION
Adds `is_deleted` to the ORM query that pulls out the list of categories for
the filters on the new combined reports page that Greenwich/Oxfordshire/Bromley
use. I've included a basic test too.

Closes #1239