### PR TITLE
Don't set whole background style in issue-list css

### DIFF
--- a/web/cobrands/greenwich/base.scss
+++ b/web/cobrands/greenwich/base.scss
@@ -30,7 +30,7 @@ body.frontpage #site-logo,
 }
 
 .issue-list-a li, .list-a li, #user-meta p, #front-main #postcodeForm {
-    background: $greenwich_light_grey;
+    background-color: $greenwich_light_grey;
 }
 
 label[for=pc] {

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -843,7 +843,7 @@ input.final-submit {
   border-bottom: 0.25em solid $primary;
   li{
     list-style: none;
-    background: #f6f6f6;
+    background-color: #f6f6f6;
     margin: 0.25em 0 0;
     padding: 0.5em 1em;
     display:block;
@@ -871,20 +871,20 @@ input.final-submit {
       margin: 0.25em 0 0;
       /* see note below about this */
       display:table;
-      background: #f6f6f6;
+      background-color: #f6f6f6;
       color:#222222;
       width:100%;
       &:hover {
         text-decoration:none;
         color:#222222;
-        background:#e6e6e6;
+        background-color:#e6e6e6;
       }
       a {
           color:#222222;
       }
       a:hover {
           color:#222222;
-          background:#e6e6e6;
+          background-color:#e6e6e6;
           text-decoration: none;
       }
       .text {
@@ -915,7 +915,7 @@ input.final-submit {
     >p {
       margin: 0.25em 0 0;
       padding: 0.5em 1em;
-      background: #f6f6f6;
+      background-color: #f6f6f6;
     }
   }
 }


### PR DESCRIPTION
The use of the background shorthand was causing cobrands which override this
to have unexpected styling issues because it only set a colour, not the other
background properties.

This commit makes it more specific by just using background-color.

Fixes #1238