### PR TITLE
Fix non-working scripts when CDPATH is set.

### DIFF
--- a/bin/install_perl_modules
+++ b/bin/install_perl_modules
@@ -2,7 +2,7 @@
 
 set -e
 
-DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd | sed -e 's/\/bin$//' )"
+DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd | sed -e 's/\/bin$//' )"
 
 $DIR/vendor/bin/carton install --deployment --without uk --without zurich --without open311-endpoint
 

--- a/bin/make_css
+++ b/bin/make_css
@@ -11,14 +11,14 @@
 
 COMPASS=compass
 SASS=sass
-DIR=$(cd "$(dirname "$0")" && pwd -P)
-PARENT=$(cd "$DIR"/../.. && pwd)
+DIR=$(cd "$(dirname "$0")" >/dev/null && pwd -P)
+PARENT=$(cd "$DIR"/../.. >/dev/null && pwd)
 if [ -f "$PARENT/gem-bin/compass" ]; then
     COMPASS=$PARENT/gem-bin/compass
     SASS=$PARENT/gem-bin/sass
 fi
 
-DIRECTORY=$(cd "$DIR"/../web && pwd)
+DIRECTORY=$(cd "$DIR"/../web >/dev/null && pwd)
 
 DIRS=${@:-`find -L $DIRECTORY -name "*.scss" -exec dirname {} \; | uniq`}
 


### PR DESCRIPTION
If the CDPATH environment variable is set (so cd can look in multiple
places), cd prints out the resulting directory when used. This confuses
a command sequence used in a couple of places doing (cd && pwd) to get
a directory path. Make sure we ignore any output from cd.