### PR TITLE
Add Module::Pluggable to cpanfile snapshot.

### DIFF
--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -3858,6 +3858,18 @@ DISTRIBUTIONS
       vars 0
       version 0.87
       warnings 0
+  Module-Pluggable-4.7
+    pathname: S/SI/SIMONW/Module-Pluggable-4.7.tar.gz
+    provides:
+      Devel::InnerPackage 0.4
+      Module::Pluggable 4.7
+      Module::Pluggable::Object 4.6
+    requirements:
+      File::Basename 0
+      File::Spec 3.00
+      Module::Build 0.38
+      Test::More 0.62
+      if 0
   Module-Runtime-0.013
     pathname: Z/ZE/ZEFRAM/Module-Runtime-0.013.tar.gz
     provides:


### PR DESCRIPTION
Module::Pluggable is marked as deprecated in Perl 5.18, to be removed
from core in a later version. cpanminus, which is called from carton,
ignores core modules that have been deprecated - running a deployment
install under 5.18 therefore caused a warning to be shown saying that
it could not find Module::Pluggable as no version was included in the
snapshot.