### PR TITLE
Adds the ability to limit the all reports index page by cobrand

### DIFF
--- a/bin/update-all-reports
+++ b/bin/update-all-reports
@@ -40,7 +40,7 @@ my $problems = FixMyStreet::DB->resultset('Problem')->search(
     },
     {
         columns => [
-            'id', 'bodies_str', 'state', 'areas',
+            'id', 'bodies_str', 'state', 'areas', 'cobrand',
             { duration => { extract => "epoch from current_timestamp-lastupdate" } },
             { age      => { extract => "epoch from current_timestamp-$age_column"  } },
         ]
@@ -49,10 +49,12 @@ my $problems = FixMyStreet::DB->resultset('Problem')->search(
 $problems = $problems->cursor; # Raw DB cursor for speed
 
 my ( %fixed, %open );
-my @cols = ( 'id', 'bodies_str', 'state', 'areas', 'duration', 'age' );
+my @cols = ( 'id', 'bodies_str', 'state', 'areas','cobrand', 'duration', 'age' );
 while ( my @problem = $problems->next ) {
     my %problem = zip @cols, @problem;
     my @bodies;
+    my $cobrand = $problem{cobrand};
+    
     if ( !$problem{bodies_str} ) {
         # Problem was not sent to any bodies, add to all areas
         @bodies = grep { $_ } split( /,/, $problem{areas} );
@@ -70,9 +72,11 @@ while ( my @problem = $problems->next ) {
         if (FixMyStreet::DB::Result::Problem->fixed_states()->{$problem{state}} || FixMyStreet::DB::Result::Problem->closed_states()->{$problem{state}}) {
             # Fixed problems are either old or new
             $fixed{$body}{$duration_str}++;
+            $fixed{$cobrand}{$body}{$duration_str}++;
         } else {
             # Open problems are either unknown, older, or new
             $open{$body}{$type}++;
+            $open{$cobrand}{$body}{$type}++;
         }
     }
 }


### PR DESCRIPTION
Updates the all-reports.json file to include cobrands meaning that users can choose to limit the results if multiple cobrands are running on the same database