### PR TITLE
Default the Google map view to hybrid

### DIFF
--- a/templates/web/base/maps/google-ol.html
+++ b/templates/web/base/maps/google-ol.html
@@ -1,5 +1,5 @@
 [% map_js = BLOCK %]
-<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?v=3.20"></script>
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
 <script type="text/javascript" src="[% version('/js/OpenLayers.fixmystreet.google.js') %]"></script>
 <script type="text/javascript" src="[% version('/js/map-OpenLayers.js') %]"></script>
 <script type="text/javascript" src="[% version('/js/map-google-ol.js') %]"></script>
@@ -10,7 +10,7 @@
 [% END %]
 
 [% map_sub_links = BLOCK %]
-<a class="hidden-nojs" id="map_layer_toggle" href="">[% loc('Satellite') %]</a>
+<a class="hidden-nojs" id="map_layer_toggle" href="">[% loc('Map') %]</a>
 [% END %]
 
 [% map_html = BLOCK %]

--- a/web/js/map-google-ol.js
+++ b/web/js/map-google-ol.js
@@ -4,13 +4,13 @@ $(function(){
         var $t = $(this), text = $t.text();
         if (text == translation_strings.map_map) {
             $t.text(translation_strings.map_satellite);
-            fixmystreet.map.setBaseLayer(fixmystreet.map.layers[0]);
+            fixmystreet.map.setBaseLayer(fixmystreet.map.layers[1]);
         } else {
             $t.text(translation_strings.map_map);
-            fixmystreet.map.setBaseLayer(fixmystreet.map.layers[1]);
+            fixmystreet.map.setBaseLayer(fixmystreet.map.layers[0]);
         }
     });
-    if (typeof fixmystreet_google_default !== 'undefined' && fixmystreet_google_default == 'satellite') {
+    if (typeof fixmystreet_google_default !== 'undefined' && fixmystreet_google_default == 'map') {
         $('#map_layer_toggle').click();
     }
 });
@@ -34,8 +34,8 @@ function set_map_config(perm) {
     };
 
     fixmystreet.layer_options = [
-        {},
-        { type: google.maps.MapTypeId.HYBRID }
+        { type: google.maps.MapTypeId.HYBRID },
+        {}
     ];
 }
 


### PR DESCRIPTION
A repeat of cc6a278; Google have now dropped version 3.20 of their Maps API, which we were using. Version 3.21 is the oldest available version, and only appears to work if you start off in hybrid view.

According to https://developers.google.com/maps/documentation/javascript/versions, in three months 3.21 will be dropped; 3.22 does not currently work with our OpenLayers code at all. Looking at http://dev.openlayers.org/releases/OpenLayers-2.13.1/examples/google-v3.html the maps do still appear if you first switch to the Satellite layer. So investigation will be needed to find out why that happens and if it can be worked around.