### PR TITLE
Move alert page "recent photos" out of sidebar

### DIFF
--- a/templates/web/base/alert/index.html
+++ b/templates/web/base/alert/index.html
@@ -1,4 +1,4 @@
-[% INCLUDE 'header.html', title = loc('Local RSS feeds and email alerts'), bodyclass = 'twothirdswidthpage' %]
+[% INCLUDE 'header.html', title = loc('Local RSS feeds and email alerts'), bodyclass = 'fullwidthpage' %]
 
 <h1>[% loc('Local RSS feeds and email alerts') %]</h1>
 
@@ -37,16 +37,16 @@ within a certain distance of a particular location.', "%s is the site name"), si
 </form>
 
 [% IF photos.size %]
-<div id="alert_recent">
-  <aside>
-    <h2>[% loc('Some photos of recent reports') %]</h2>
-    [% FOREACH p IN photos;
-        photo = p.get_photo_params;
-    %]
-        <a href="/report/[% p.id %]"><img border="0" height="100"
-            src="[% photo.url_tn %]" alt="[% p.title | html %]" title="[% p.title | html %]"></a>
-    [% END %]
-  </aside>
+<h2>[% loc('Some photos of recent reports') %]</h2>
+<div class="alerts__nearby-activity__photos">
+  [% FOREACH p IN photos;
+    photo = p.get_photo_params;
+  %]
+    <a href="/report/[% p.id %]">
+        <img border="0" height="100" src="[% photo.url_tn %]"
+        alt="[% p.title | html %]" title="[% p.title | html %]">
+    </a>
+  [% END %]
 </div>
 [% END %]
 

--- a/templates/web/base/alert/list.html
+++ b/templates/web/base/alert/list.html
@@ -6,7 +6,7 @@
     END;
 %]
 
-[% INCLUDE 'header.html', title = title, bodyclass = 'twothirdswidthpage' %]
+[% INCLUDE 'header.html', title = title, bodyclass = 'fullwidthpage' %]
 
 [% IF pretty_pc %]
     [%
@@ -18,21 +18,23 @@
 
 <h1>[% title %]</h1>
 
-<form id="alerts" name="alerts" method="post" action="/alert/subscribe">
-
-  [% IF photos.size %]
-    <div id="alert_photos">
-      <aside>
-        <h2>[% loc('Photos of recent nearby reports') %]</h2>
-        [% FOREACH p IN photos;
-            photo = p.get_photo_params;
-        %]
-            <a href="/report/[% p.id %]"><img border="0" height="100"
-                src="[% photo.url_tn %]" alt="[% p.title | html %]" title="[% p.title | html %]"></a>
-        [% END %]
-      </aside>
+[% IF photos.size %]
+<div class="alerts__nearby-activity">
+    <h2>[% loc('Photos of recent nearby reports') %]</h2>
+    <div class="alerts__nearby-activity__photos">
+      [% FOREACH p IN photos;
+        photo = p.get_photo_params;
+      %]
+        <a href="/report/[% p.id %]">
+            <img border="0" height="100" src="[% photo.url_tn %]"
+            alt="[% p.title | html %]" title="[% p.title | html %]">
+        </a>
+      [% END %]
     </div>
-  [% END %]
+</div>
+[% END %]
+
+<form id="alerts" name="alerts" method="post" action="/alert/subscribe">
 
   [% INCLUDE 'alert/_list.html' %]
 

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1566,6 +1566,26 @@ table.nicetable {
     }
 }
 
+.alerts__nearby-activity {
+    background-color: #f6f6f6;
+    margin: 1em -1em;
+    padding: 1em;
+
+    & > :first-child {
+        margin-top: 0;
+    }
+}
+
+.alerts__nearby-activity__photos {
+    white-space: nowrap;
+    overflow: hidden;
+
+    a {
+        margin-right: 0.5em;
+        text-decoration: none; // avoid underline showing between images
+    }
+}
+
 .confirmation-header {
   padding: 140px 0 2em;
   text-align: center;


### PR DESCRIPTION
Fixes #1168 (sidebar overlapping footer) by avoiding the sidebar entirely.

![screen shot 2016-01-04 at 17 27 29](https://cloud.githubusercontent.com/assets/739624/12095692/78d39e68-b308-11e5-98d7-f4c21f0f5f19.png)

Photos are presented in a single row, with wrapping disabled. Grey background makes them recede a little, in an effort to make them less distracting.

I'm not convinced of the value of the photos without any anchoring text (lots of shots of potholes doesn't really serve as a glamorous advertisement for the alerts service) but in lieu of a major rethink for the alerts pages, this is a quick fix that avoids the footer overlap problem and reduces the number of pages using one of those smartypants fixed sidebars by two, which can only be a good thing.