### PR TITLE
Tidy up banner CSS and fix overlap bug

### DIFF
--- a/templates/web/fixmystreet.com/front/international_banner.html
+++ b/templates/web/fixmystreet.com/front/international_banner.html
@@ -1,13 +1,11 @@
 [% country = c.cobrand.get_country_for_ip_address(c.req.address) -%]
 [%- IF country AND country != 'GB' -%]
-<div id="country_banner">
-    <a href="#" id="message_close">Close</a>
-    <p id="international_message">
-    <span id="message">
+<div class="top_banner top_banner--country">
+    <a href="#" class="top_banner__close">Close</a>
+    <p>
     This site is for reporting <strong>problems in the UK</strong>. There are FixMyStreet sites
     <a href="http://www.fixmystreet.org/sites/">all over the world</a>, or you
     could set up your own using the <a href="http://www.fixmystreet.org/">FixMyStreet Platform</a>.
-    </span>
     </p>
 </div>
 [%- END -%]

--- a/templates/web/fixmystreet.com/report/new/unresponsive_body.html
+++ b/templates/web/fixmystreet.com/report/new/unresponsive_body.html
@@ -5,7 +5,7 @@
       [% IF category %]
         <span class="refused-category">[% category | html %]</span>
       [% END %]
-        reports.
+        reports from third party reporting sites such as FixMyStreet.
     </p>
     <p>We can make your report public, but we can’t send it to the council.</p>
     <a href="/unresponsive?body=[% body_id %][% IF category %];category=[% category | uri %][% END %]">What can I do instead?</a>

--- a/web/cobrands/fixmystreet.com/base.scss
+++ b/web/cobrands/fixmystreet.com/base.scss
@@ -13,19 +13,38 @@
     display: none;
 }
 
-#country_banner {
-    display: none;
+.top_banner {
     color: $primary_text;
     background: $primary;
-    p#international_message {
+    p {
         margin: auto;
         padding: 0.5em 2em;
-        max-width: 40em;
+        max-width: 50em;
         text-align: center;
     }
-    #message_close {
-        float: $right;
+    a {
+        color: $primary_text;
+        text-decoration: underline;
     }
+}
+
+.top_banner--donate {
+    background: #bef;
+}
+
+// The banner interferes with the map moving/placement on mobile, and the top
+// bar navigation on desktop (which both assume that .wrapper is at the top of
+// the page) so hide there for now
+.mappage .top_banner--donate {
+    display: none;
+}
+
+// This banner is only shown via JavaScript AJAX call
+.top_banner--country {
+    display: none;
+}
+.top_banner__close {
+    float: $right;
 }
 
 #site-logo {

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -509,8 +509,8 @@ $.fn.drawer = function(id, ajax) {
         }).fadeOut(500);
     });
 
-    $('#message_close').live('click', function() {
-        $('#country_banner').hide();
+    $('.top_banner__close').live('click', function() {
+        $('.top_banner--country').hide();
         $.cookie('has_seen_country_message', 1, {expires: 365, path: '/'});
     });
 
@@ -521,7 +521,7 @@ $.fn.drawer = function(id, ajax) {
                 success: function(data) {
                     if ( data ) {
                         $('body').prepend(data);
-                        $('#country_banner').slideDown('slow');
+                        $('.top_banner--country').slideDown('slow');
                     }
                 }
             });

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -520,7 +520,6 @@ $.fn.drawer = function(id, ajax) {
                 url: '/country_message',
                 success: function(data) {
                     if ( data ) {
-                        $('#site-header').css('position', 'relative');
                         $('body').prepend(data);
                         $('#country_banner').slideDown('slow');
                     }

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -536,8 +536,17 @@ p.label-valid {
 .wrapper {
   width:100%;
   display:table;
-  caption-side:bottom;
+  // The 'caption' at large widths will be top, moving the menu up magically
+  caption-side: bottom;
+  // This is so absolutely positioned header stuff doesn't overlap banner...
+  position: relative;
 }
+// ...however position: relative stops the map being clickable (?), so better
+// revert it there
+body.mappage .wrapper {
+  position: static;
+}
+
 // this is the user's logged in details or the login link etc
 #user-meta {
   p {

--- a/web/cobrands/warwickshire/layout.scss
+++ b/web/cobrands/warwickshire/layout.scss
@@ -45,6 +45,7 @@ body.mappage {
         padding: 0;
         width: auto;
         display: block;
+        position: relative;
     }
 }
 


### PR DESCRIPTION
If the country banner was displayed, it would overlap e.g. the mobile header. Fix this and tidy up CSS at same time.