### PR TITLE
Consistent styling for updates on report page and /my page

### DIFF
--- a/templates/web/base/my/my.html
+++ b/templates/web/base/my/my.html
@@ -46,11 +46,21 @@
         <ul class="item-list item-list--updates full-width">
     [% END %]
 
-    <li>&ldquo;[% u.text | html %]&rdquo;
-    &ndash; <a href="[% c.uri_for( '/report', u.problem_id ) %]#update_[% u.id %]">[% u.problem.title | html %]</a>.
-        <p><small class="council_sent_info">
-        [% tprintf( loc("Added %s"), prettify_dt( u.confirmed, 'date' ) ) %]
-        </small></p>
+    <li class="item-list__item item-list__item--updates">
+        <div class="item-list__update-wrap">
+            [% INCLUDE 'report/photo.html' object=u %]
+            <div class="item-list__update-text">
+                [% add_links( u.text ) | html_para %]
+
+                <p class="meta-2">
+                    [% tprintf( loc("Added %s"), prettify_dt( u.confirmed, 'date' ) ) %]
+                    &ndash;
+                    <a href="[% c.uri_for( '/report', u.problem_id ) %]#update_[% u.id %]">
+                        [% u.problem.title | html %]
+                    </a>
+                </p>
+            </div>
+        </div>
     </li>
     [% "</ul>" IF loop.last %]
 [% END %]


### PR DESCRIPTION
Fixes #1312.

Updates on the `/my` page now have the same styling as updates on the report page.

(At some point we might want these to share the same partial/template – but that felt like a bigger change than was necessary for this ticket. Thoughts, @dracos?)

![screen shot 2016-02-04 at 11 54 14](https://cloud.githubusercontent.com/assets/739624/12814319/137ef86e-cb36-11e5-9daa-0b1fcb125357.png)
