### PR TITLE
Show remembered uploaded photos when Back used.

### DIFF
--- a/templates/web/base/questionnaire/index.html
+++ b/templates/web/base/questionnaire/index.html
@@ -80,10 +80,6 @@
 
     <div id="form_photos">
       [% IF upload_fileid %]
-        <script>
-            var fixmystreet = fixmystreet || {};
-            fixmystreet.uploaded_files = "[% upload_fileid %]".split(',');
-        </script>
         <p>[% loc('You have already attached photos to this update.  Note that you can attach a maximum of 3 to this update (if you try to upload more, the oldest will be removed).') %]</p>
         [% FOREACH id IN upload_fileid.split(',') %]
         <img align="right" src="/photo/[% id %].temp.jpeg" alt="">

--- a/templates/web/base/report/new/form_report.html
+++ b/templates/web/base/report/new/form_report.html
@@ -29,10 +29,6 @@
 
     <div id="form_photos">
       [% IF upload_fileid %]
-        <script>
-            var fixmystreet = fixmystreet || {};
-            fixmystreet.uploaded_files = "[% upload_fileid %]".split(',');
-        </script>
         <p>[% loc('You have already attached photos to this report.  Note that you can attach a maximum of 3 to this report (if you try to upload more, the oldest will be removed).') %]</p>
         [% FOREACH id IN upload_fileid.split(',') %]
         <img align="right" src="/photo/[% id %].temp.jpeg" alt="">

--- a/templates/web/base/report/update/form_update.html
+++ b/templates/web/base/report/update/form_update.html
@@ -11,10 +11,6 @@
 
     <div id="form_photos">
       [% IF upload_fileid %]
-        <script>
-            var fixmystreet = fixmystreet || {};
-            fixmystreet.uploaded_files = "[% upload_fileid %]".split(',');
-        </script>
         <p>[% loc('You have already attached photos to this update.  Note that you can attach a maximum of 3 to this update (if you try to upload more, the oldest will be removed).') %]</p>
         [% FOREACH id IN upload_fileid.split(',') %]
         <img align="right" src="/photo/[% id %].temp.jpeg" alt="">

--- a/templates/web/bromley/report/display.html
+++ b/templates/web/bromley/report/display.html
@@ -70,10 +70,6 @@
 
             <div id="form_photos">
               [% IF upload_fileid %]
-                <script>
-                    var fixmystreet = fixmystreet || {};
-                    fixmystreet.uploaded_files = "[% upload_fileid %]".split(',');
-                </script>
                 <p>[% loc('You have already attached photos to this update.  Note that you can attach a maximum of 3 to this update (if you try to upload more, the oldest will be removed).') %]</p>
                 [% FOREACH id IN upload_fileid.split(',') %]
                 <img align="right" src="/photo/[% id %].temp.jpeg" alt="">

--- a/templates/web/bromley/report/new/fill_in_details_form.html
+++ b/templates/web/bromley/report/new/fill_in_details_form.html
@@ -58,10 +58,6 @@
 
             <div id="form_photos">
               [% IF upload_fileid %]
-                <script>
-                    var fixmystreet = fixmystreet || {};
-                    fixmystreet.uploaded_files = "[% upload_fileid %]".split(',');
-                </script>
                 <p>[% loc('You have already attached photos to this report.  Note that you can attach a maximum of 3 to this report (if you try to upload more, the oldest will be removed).') %]</p>
                 [% FOREACH id IN upload_fileid.split(',') %]
                 <img align="right" src="/photo/[% id %].temp.jpeg" alt="">

--- a/templates/web/eastsussex/report/update-form.html
+++ b/templates/web/eastsussex/report/update-form.html
@@ -70,10 +70,6 @@
 
             <div id="form_photos">
               [% IF upload_fileid %]
-                <script>
-                    var fixmystreet = fixmystreet || {};
-                    fixmystreet.uploaded_files = "[% upload_fileid %]".split(',');
-                </script>
                 <p>[% loc('You have already attached photos to this update.  Note that you can attach a maximum of 3 to this update (if you try to upload more, the oldest will be removed).') %]</p>
                 [% FOREACH id IN upload_fileid.split(',') %]
                 <img align="right" src="/photo/[% id %].temp.jpeg" alt="">

--- a/templates/web/zurich/report/new/fill_in_details_form.html
+++ b/templates/web/zurich/report/new/fill_in_details_form.html
@@ -52,10 +52,6 @@
 
             <div id="form_photos">
               [% IF upload_fileid %]
-                <script>
-                    var fixmystreet = fixmystreet || {};
-                    fixmystreet.uploaded_files = "[% upload_fileid %]".split(',');
-                </script>
                 <p>[% loc('You have already attached photos to this report.  Note that you can attach a maximum of 3 to this report (if you try to upload more, the oldest will be removed).') %]</p>
                 [% FOREACH id IN upload_fileid.split(',') %]
                 <img align="right" src="/photo/[% id %].temp.jpeg" alt="">

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -246,15 +246,16 @@ $(function(){
         }
       });
 
-      if (typeof fixmystreet !== 'undefined') {
-        $.each(fixmystreet.uploaded_files || [], function(i, f) {
-          var mockFile = { name: f, server_id: f };
-          photodrop.emit("addedfile", mockFile);
-          photodrop.createThumbnailFromUrl(mockFile, '/photo/' + f + '.temp.jpeg');
-          photodrop.emit("complete", mockFile);
-          photodrop.options.maxFiles -= 1;
-        });
-      }
+      $.each($('input[name=upload_fileid]').val().split(','), function(i, f) {
+        if (!f) {
+            return;
+        }
+        var mockFile = { name: f, server_id: f };
+        photodrop.emit("addedfile", mockFile);
+        photodrop.createThumbnailFromUrl(mockFile, '/photo/' + f + '.temp.jpeg');
+        photodrop.emit("complete", mockFile);
+        photodrop.options.maxFiles -= 1;
+      });
     }
 
     /*


### PR DESCRIPTION
The uploaded_files solution in cbdfcad6, to show already uploaded files
stored in upload_fileid, worked if you submitted the form to the server
and had it returned, but did not show remembered photos if you used the
browser's Back button to return to the form from another page.

Instead, always read the data from upload_fileid, which works whichever
way you have come to the page. Fixes #1332.