### PR TITLE
Don't double-decode geocoded addresses.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -351,8 +351,10 @@ sub _geocode : Private {
     } else {
         if ( ref($suggestions) eq 'ARRAY' ) {
             foreach (@$suggestions) {
-                push @addresses, decode_utf8($_->{address});
-                push @locations, { address => decode_utf8($_->{address}), lat => $_->{latitude}, long => $_->{longitude} };
+                my $address = $_->{address};
+                $address = decode_utf8($address) if !utf8::is_utf8($address);
+                push @addresses, $address;
+                push @locations, { address => $address, lat => $_->{latitude}, long => $_->{longitude} };
             }
             $response = { suggestions => \@addresses, locations => \@locations };
         } else {

--- a/perllib/FixMyStreet/App/Controller/Location.pm
+++ b/perllib/FixMyStreet/App/Controller/Location.pm
@@ -95,7 +95,8 @@ sub determine_location_from_pc : Private {
     # $error doubles up to return multiple choices by being an array
     if ( ref($error) eq 'ARRAY' ) {
         foreach (@$error) {
-            my $a = decode_utf8($_->{address});
+            my $a = $_->{address};
+            $a = decode_utf8($a) if !utf8::is_utf8($a);
             $a =~ s/, United Kingdom//;
             $a =~ s/, UK//;
             $_->{address} = $a;


### PR DESCRIPTION
Perl 5.20 introduced a version of Encode that errors on decoding already
decoded content (rather than returning the same string). Whilst this is
in some way a bug in the code (although it exists because some versions
of FastCGI silently UTF-8 encode the content), in the Perl changelog,
this is covered only by the line: "Encode has been upgraded from version
2.49 to 2.60."