### PR TITLE
Refactor email

### DIFF
--- a/bin/handlemail
+++ b/bin/handlemail
@@ -22,7 +22,6 @@ BEGIN {
 use FixMyStreet;
 use FixMyStreet::DB;
 use FixMyStreet::Email;
-use mySociety::Email;
 use mySociety::EmailUtil;
 use mySociety::HandleMail;
 use mySociety::SystemMisc qw(print_log);
@@ -168,14 +167,13 @@ sub handle_non_bounce_to_null_address {
     $fp->close;
 
     # We generate this as a bounce.
-    my $mail = mySociety::Email::construct_email({
+    my $mail = FixMyStreet::Email::construct_email({
         From => [ FixMyStreet->config('CONTACT_EMAIL'), 'FixMyStreet' ],
         To => $data{return_path},
         _template_ => $template,
         _parameters_ => { },
-        _line_indent => '',
     });
-    send_mail($mail, '<>', $data{return_path});
+    send_mail($mail->as_string, '<>', $data{return_path});
 }
 
 sub forward_on_to {

--- a/cpanfile
+++ b/cpanfile
@@ -51,7 +51,6 @@ requires 'Digest::SHA';
 requires 'Email::MIME';
 requires 'Email::Send';
 requires 'Email::Send::SMTP';
-requires 'Email::Simple';
 requires 'Email::Valid';
 requires 'Error';
 requires 'FCGI';

--- a/perllib/FixMyStreet/App/Controller/Contact.pm
+++ b/perllib/FixMyStreet/App/Controller/Contact.pm
@@ -242,8 +242,7 @@ sub send_email : Private {
 
     my $from = [ $c->stash->{em}, $c->stash->{form_name} ];
     my $params = {
-        to      => [ [ $recipient, _($recipient_name) ] ],
-        subject => 'FMS message: ' . $c->stash->{subject},
+        to => [ [ $recipient, _($recipient_name) ] ],
     };
     if (FixMyStreet::Email::test_dmarc($c->stash->{em})) {
         $params->{'Reply-To'} = [ $from ];

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -1029,7 +1029,7 @@ sub munge_sendreport_params {
                 },
             }
         } (0..$num-1);
-        $params->{attachments} = \@attachments;
+        $params->{_attachments_} = \@attachments;
     }
 }
 

--- a/perllib/FixMyStreet/Email.pm
+++ b/perllib/FixMyStreet/Email.pm
@@ -1,6 +1,8 @@
 package FixMyStreet::Email;
 
+use Email::MIME;
 use Encode;
+use POSIX qw();
 use Template;
 use Digest::HMAC_SHA1 qw(hmac_sha1_hex);
 use mySociety::Email;
@@ -105,15 +107,10 @@ sub send_cron {
     $site_name = Utils::trim_text(Encode::decode('utf8', $site_name));
     $params->{_parameters_}->{site_name} = $site_name;
 
-    $params->{_line_indent} = '';
-    my $attachments = delete $params->{attachments};
-
-    my $email = mySociety::Locale::in_gb_locale { mySociety::Email::construct_email($params) };
-
-    $email = munge_attachments($email, $attachments) if $attachments;
+    my $email = mySociety::Locale::in_gb_locale { construct_email($params) };
 
     if ($nomail) {
-        print $email;
+        print $email->as_string;
         return 1; # Failure
     } else {
         my $result = FixMyStreet::EmailSend->new({ env_from => $env_from })->send($email);
@@ -121,41 +118,152 @@ sub send_cron {
     }
 }
 
-sub munge_attachments {
-    my ($message, $attachments) = @_;
-    # $attachments should be an array_ref of things that can be parsed to Email::MIME,
-    # for example
-    #    [
-    #      body => $binary_data,
-    #      attributes => {
-    #          content_type => 'image/jpeg',
-    #          encoding => 'base64',
-    #          filename => '1234.1.jpeg',
-    #          name     => '1234.1.jpeg',
-    #      },
-    #      ...
-    #    ]
-    #
-    # XXX: mySociety::Email::construct_email isn't using a MIME library and
-    # requires more analysis to refactor, so for now, we'll simply parse the
-    # generated MIME and add attachments.
-    #
-    # (Yes, this means that the email is constructed by Email::Simple, munged
-    # manually by custom code, turned back into Email::Simple, and then munged
-    # with Email::MIME.  What's your point?)
+=item construct_email SPEC
 
-    require Email::MIME;
-    my $mime = Email::MIME->new($message);
-    $mime->parts_add([ map { Email::MIME->create(%$_)} @$attachments ]);
-    my $data = $mime->as_string;
+Construct an email message according to SPEC, which is an associative array
+containing elements as given below. Returns an Email::MIME email.
 
-    # unsure why Email::MIME adds \r\n. Possibly mail client should handle
-    # gracefully, BUT perhaps as the segment constructed by
-    # mySociety::Email::construct_email strips to \n, they seem not to.
-    # So we re-run the same regexp here to the added part.
-    $data =~ s/\r\n/\n/gs;
+=over 4
 
-    return $data;
+=item _template_, _parameters_
+
+Templated body text and an associative array of template parameters. _template
+contains optional substititutions <?=$values['name']?>, each of which is
+replaced by the value of the corresponding named value in _parameters_. It is
+an error to use a substitution when the corresponding parameter is not present
+or undefined. The first line of the template will be interpreted as contents of
+the Subject: header of the mail if it begins with the literal string 'Subject:
+' followed by a blank line. The templated text will be word-wrapped to produce
+lines of appropriate length.
+
+=item _attachments_
+
+An arrayref of hashrefs that can be passed to Email::MIME.
+
+=item To
+
+Contents of the To: header, as a literal UTF-8 string or an array of addresses
+or [address, name] pairs.
+
+=item From
+
+Contents of the From: header, as an email address or an [address, name] pair.
+
+=item Cc
+
+Contents of the Cc: header, as for To.
+
+=item Reply-To
+
+Contents of the Reply-To: header, as for To.
+
+=item Subject
+
+Contents of the Subject: header, as a UTF-8 string.
+
+=item I<any other element>
+
+interpreted as the literal value of a header with the same name.
+
+=back
+
+If no Date is given, the current date is used. If no To is given, then the
+string "Undisclosed-Recipients: ;" is used. It is an error to fail to give a
+templated body, From or Subject (perhaps from the template).
+
+=cut
+sub construct_email ($) {
+    my $p = shift;
+
+    throw mySociety::Email::Error("Must specify both '_template_' and '_parameters_'")
+        if !exists($p->{_template_}) || !exists($p->{_parameters_});
+    throw mySociety::Email::Error("Template parameters '_parameters_' must be an associative array")
+        if (ref($p->{_parameters_}) ne 'HASH');
+
+    (my $subject, $body) = mySociety::Email::do_template_substitution($p->{_template_}, $p->{_parameters_}, '');
+    $p->{Subject} = $subject if defined($subject);
+
+    if (!exists($p->{Subject})) {
+        # XXX Try to find out what's causing this very occasionally
+        (my $error = $body) =~ s/\n/ | /g;
+        $error = "missing field 'Subject' in MESSAGE - $error";
+        throw mySociety::Email::Error($error);
+    }
+    throw mySociety::Email::Error("missing field 'From' in MESSAGE") unless exists($p->{From});
+
+    # Construct email headers
+    my %hdr;
+
+    foreach my $h (grep { exists($p->{$_}) } qw(To Cc Reply-To)) {
+        if (ref($p->{$h}) eq '') {
+            # Interpret as a literal string in UTF-8, so all we need to do is
+            # escape it.
+            $hdr{$h} = $p->{$h};
+        } elsif (ref($p->{$h}) eq 'ARRAY') {
+            # Array of addresses or [address, name] pairs.
+            $hdr{$h} = join(', ', map { mailbox($_, $h) } @{$p->{$h}});
+        } else {
+            throw mySociety::Email::Error("Field '$h' in MESSAGE should be single value or an array");
+        }
+    }
+
+    foreach my $h (grep { exists($p->{$_}) } qw(From Sender)) {
+        $hdr{$h} = mailbox($p->{$h}, $h);
+    }
+
+    # Some defaults
+    $hdr{To} ||= 'Undisclosed-recipients: ;';
+    $hdr{Date} ||= POSIX::strftime("%a, %d %h %Y %T %z", localtime(time()));
+
+    # Other headers, including Subject
+    foreach (keys(%$p)) {
+        $hdr{$_} = $p->{$_} if ($_ !~ /^_/ && !exists($hdr{$_}));
+    }
+
+    my $parts = [
+        _mime_create(
+            body_str => $body,
+            attributes => {
+                charset => 'utf-8',
+                encoding => 'quoted-printable',
+            },
+        ),
+    ];
+
+    if ($p->{_attachments_}) {
+        push @$parts, map { _mime_create(%$_) } @{$p->{_attachments_}};
+    }
+
+    my $email = Email::MIME->create(
+        header_str => [ %hdr ],
+        parts => $parts,
+        attributes => {
+            charset => 'utf-8',
+        },
+    );
+
+    return $email;
+}
+
+# Handle being given a string, or an arrayref of [ name, email ]
+sub mailbox {
+    my ($e, $header) = @_;
+    if (ref($e) eq '') {
+        return $e;
+    } elsif (ref($e) ne 'ARRAY' || @$e != 2) {
+        throw mySociety::Email::Error("'$header' field should be string or 2-element array");
+    } else {
+        return Email::Address->new($e->[1], $e->[0]);
+    }
+}
+
+# Don't want Date/MIME-Version headers that Email::MIME adds to all parts
+sub _mime_create {
+    my %h = @_;
+    my $e = Email::MIME->create(%h);
+    $e->header_set('Date');
+    $e->header_set('MIME-Version');
+    return $e;
 }
 
 1;

--- a/t/app/01app.t
+++ b/t/app/01app.t
@@ -16,12 +16,16 @@ use Encode qw(encode);
 
 ok( request('/')->is_success, 'Request should succeed' );
 
+SKIP: {
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'tester' ],
 }, sub {
+    skip 'Test will not pass on Mac OS', 1 if $^O eq 'darwin';
+
     my $page = get('/');
     my $num = encode('UTF-8', "12\N{NO-BREAK SPACE}345");
     like $page, qr/$num/;
 };
+}
 
 done_testing();

--- a/t/app/controller/questionnaire.t
+++ b/t/app/controller/questionnaire.t
@@ -63,8 +63,8 @@ my $email = $mech->get_email;
 ok $email, "got an email";
 like $email->body, qr/fill in our short questionnaire/i, "got questionnaire email";
 
-like $email->body, qr/Testing =96 Detail/, 'email contains encoded character';
-is $email->header('Content-Type'), 'text/plain; charset="windows-1252"', 'in the right character set';
+like $email->body_str, qr/Testing \x{2013} Detail/, 'email contains encoded character';
+is $email->header('Content-Type'), 'text/plain; charset="utf-8"', 'in the right character set';
 
 my ($token) = $email->body =~ m{http://.*?/Q/(\S+)};
 ok $token, "extracted questionnaire token '$token'";
@@ -461,9 +461,9 @@ FixMyStreet::override_config {
     ok $email, "got an email";
     $mech->clear_emails_ok;
 
-    like $email->body, qr/Testing =96 Detail/, 'email contains encoded character from user';
-    like $email->body, qr/sak p=E5 FiksGataMi/, 'email contains encoded character from template';
-    is $email->header('Content-Type'), 'text/plain; charset="windows-1252"', 'email is in right encoding';
+    like $email->body_str, qr/Testing \x{2013} Detail/, 'email contains encoded character from user';
+    like $email->body_str, qr/sak p\xe5 FiksGataMi/, 'email contains encoded character from template';
+    is $email->header('Content-Type'), 'text/plain; charset="utf-8"', 'email is in right encoding';
 };
 
 $mech->delete_user('test@example.com');

--- a/t/app/helpers/send_email.t
+++ b/t/app/helpers/send_email.t
@@ -41,8 +41,7 @@ my $email = Email::MIME->new($email_as_string);
 
 my $expected_email_content =   path(__FILE__)->parent->child('send_email_sample.txt')->slurp;
 my $name = FixMyStreet->config('CONTACT_NAME');
-$name = "\"$name\"" if $name =~ / /;
-my $sender = $name . ' <' . FixMyStreet->config('DO_NOT_REPLY_EMAIL') . '>';
+my $sender = '"' . $name . '" <' . FixMyStreet->config('DO_NOT_REPLY_EMAIL') . '>';
 $expected_email_content =~ s{CONTACT_EMAIL}{$sender};
 my $expected_email = Email::MIME->new($expected_email_content);
 

--- a/t/app/helpers/send_email_sample.txt
+++ b/t/app/helpers/send_email_sample.txt
@@ -1,5 +1,5 @@
 MIME-Version: 1.0
-Subject: test email =?utf-8?Q?=E2=98=BA?=
+Subject: =?UTF-8?B?dGVzdCBlbWFpbCDimLo=?=
 Content-Type: text/plain; charset="utf-8"
 To: test@recipient.com
 Content-Transfer-Encoding: quoted-printable
@@ -24,5 +24,3 @@ culpa qui officia deserunt mollit anim id est laborum.
 
 Yours,=20=20
 FixMyStreet.=20=
-
-

--- a/t/app/helpers/send_email_sample_mime.txt
+++ b/t/app/helpers/send_email_sample_mime.txt
@@ -1,5 +1,5 @@
 MIME-Version: 1.0
-Subject: test email =?utf-8?Q?=E2=98=BA?=
+Subject: =?UTF-8?B?dGVzdCBlbWFpbCDimLo=?=
 Content-Type: multipart/mixed; boundary="BOUNDARY"
 To: test@recipient.com
 Content-Transfer-Encoding: 7bit
@@ -7,12 +7,8 @@ From: CONTACT_EMAIL
 
 
 --BOUNDARY
-MIME-Version: 1.0
-Subject: test email =?utf-8?Q?=E2=98=BA?=
 Content-Type: text/plain; charset="utf-8"
-To: test@recipient.com
 Content-Transfer-Encoding: quoted-printable
-From: CONTACT_EMAIL
 
 Hello,
 
@@ -34,10 +30,7 @@ culpa qui officia deserunt mollit anim id est laborum.
 Yours,=20=20
 FixMyStreet.=20=
 
-
-
 --BOUNDARY
-MIME-Version: 1.0
 Content-Type: image/gif; name="foo.gif"
 Content-Disposition: inline; filename="foo.gif"
 Content-Transfer-Encoding: quoted-printable
@@ -46,7 +39,6 @@ GIF89a=01=00=01=00=80=00=00=00=00=00=CC=CC=CC,=00=00=00=00=01=00=01=00=00=
 =02=01L=00;=
 
 --BOUNDARY
-MIME-Version: 1.0
 Content-Type: image/gif; name="bar.gif"
 Content-Disposition: inline; filename="bar.gif"
 Content-Transfer-Encoding: quoted-printable

--- a/t/app/model/alert_type.t
+++ b/t/app/model/alert_type.t
@@ -287,7 +287,7 @@ foreach my $test (
         desc        => 'address only',
         addressLine => '18 North Bridge',
         locality    => undef,
-        nearest     => qr/: 18 North Bridge\n/,
+        nearest     => qr/: 18 North Bridge\r?\n/,
     },
     {
         desc        => 'no fields',

--- a/t/cobrand/fixamingata.t
+++ b/t/cobrand/fixamingata.t
@@ -46,10 +46,10 @@ FixMyStreet::override_config {
     FixMyStreet::DB->resultset('Problem')->send_reports();
 };
 my $email = $mech->get_email;
-like $email->header('Content-Type'), qr/iso-8859-1/, 'encoding looks okay';
+like $email->header('Content-Type'), qr/utf-8/, 'encoding looks okay';
 like $email->header('Subject'), qr/Ny rapport: Test Test/, 'subject looks okay';
 like $email->header('To'), qr/other\@example.org/, 'to line looks correct';
-like $email->body, qr/V=E4nligen,/, 'signature looks correct';
+like $email->body_str, qr/V\xe4nligen,/, 'signature looks correct';
 $mech->clear_emails_ok;
 
 my $user =
@@ -91,8 +91,8 @@ FixMyStreet::override_config {
 
 $mech->email_count_is(1);
 $email = $mech->get_email;
-like $email->header('Content-Type'), qr/iso-8859-1/, 'encoding looks okay';
-like $email->body, qr/V=E4nligen,/, 'signature looks correct';
+like $email->header('Content-Type'), qr/utf-8/, 'encoding looks okay';
+like $email->body_str, qr/V\xe4nligen,/, 'signature looks correct';
 $mech->clear_emails_ok;
 
 subtest "Test ajax decimal points" => sub {

--- a/t/cobrand/zurich_attachments.txt
+++ b/t/cobrand/zurich_attachments.txt
@@ -3,28 +3,21 @@ Subject: =?iso-8859-1?Q?Z=FCri?= wie neu: Weitergeleitete Meldung #REPORT_ID
 Content-Type: multipart/mixed; boundary="BOUNDARY"
 To: "External Body" <external_body@example.org>
 Content-Transfer-Encoding: 7bit
-From: FixMyStreet <division@example.org>
+From: "FixMyStreet" <division@example.org>
 
 
 --BOUNDARY
-MIME-Version: 1.0
-Subject: =?iso-8859-1?Q?Z=FCri?= wie neu: Weitergeleitete Meldung #REPORT_ID
-Content-Type: text/plain; charset="iso-8859-1"
-To: "External Body" <external_body@example.org>
+Content-Type: text/plain; charset="utf-8"
 Content-Transfer-Encoding: quoted-printable
-From: FixMyStreet <division@example.org>
 
-Gr=FCezi External Body,
+Gr=C3=BCezi External Body,
 
-=D6ffentliche URL: http://www.example.org/report/REPORT_ID
+=C3=96ffentliche URL: http://www.example.org/report/REPORT_ID
 
-Bei Fragen zu "Z=FCri wie neu" wenden Sie sich bitte an
+Bei Fragen zu "Z=C3=BCri wie neu" wenden Sie sich bitte an
 gis-zentrum@zuerich.ch.=
 
-
-
 --BOUNDARY
-MIME-Version: 1.0
 Content-Type: image/jpeg; name="REPORT_ID.0.jpeg"
 Content-Disposition: inline; filename="REPORT_ID.0.jpeg"
 Content-Transfer-Encoding: base64

--- a/t/i18n.t
+++ b/t/i18n.t
@@ -56,7 +56,7 @@ my @EN_sorted      = qw( A Å Ø Z );
 my @NO_sorted      = qw( A Z Ø Å );
 my @default_sorted = qw( A Z Å Ø );
 
-{
+SKIP: {
 
     mySociety::Locale::negotiate_language(    #
         'en-gb,English,en_GB|cy,Cymraeg,cy_GB', 'en_GB'
@@ -71,12 +71,16 @@ my @default_sorted = qw( A Z Å Ø );
     is_deeply( [ keysort { $_ } @random_sorted ],
         \@default_sorted, "keysort correctly with no locale" );
 
+    skip 'Will not pass on Mac', 1 if $^O eq 'darwin';
+
     # Note - this obeys the locale
     is_deeply( [ sort { strcoll( $a, $b ) } @random_sorted ],
         \@EN_sorted, "sort strcoll correctly with no locale (to 'en_GB')" );
 }
 
-{
+SKIP: {
+    skip 'Will not pass on Mac', 2 if $^O eq 'darwin';
+
     mySociety::Locale::negotiate_language(    #
         'en-gb,English,en_GB|cy,Cymraeg,cy_GB', 'en_GB'
     );
@@ -93,7 +97,9 @@ my @default_sorted = qw( A Z Å Ø );
         \@EN_sorted, "sort strcoll correctly with use locale 'en_GB'" );
 }
 
-{
+SKIP: {
+    skip 'Will not pass on Mac', 2 if $^O eq 'darwin';
+
     mySociety::Locale::negotiate_language(    #
         'nb-no,Norwegian,nb_NO', 'nb_NO'
     );


### PR DESCRIPTION
The code was using Email::Simple for headers, then creating an on-the-wire email with nice encoded handling, then using Email::MIME if there were attachments. Switch to only using Email::MIME (slightly less nice encoded handling, but whatevs). A step to using same template handling for all email templates.