### PR TITLE
[Oxfordshire] Open311 update timestamps should be in UTC

### DIFF
--- a/bin/oxfordshire/open311_service_request_update.cgi
+++ b/bin/oxfordshire/open311_service_request_update.cgi
@@ -102,7 +102,7 @@ XML
     foreach my $row(@{$ary_ref})  {
         if (defined $row) {
             my ($id, $service_req_id, $updated_at, $status, $desc) = map { prepare_for_xml($_) } @$row;
-            $updated_at=~s/(\d{4}-\d\d-\d\d) (\d\d:\d\d:\d\d)/${1}T${2}Z/; # for now assume OCC in Zulu time
+            $updated_at = get_utc_iso8601_string($updated_at); # value from the DB is in server-local time, convert to UTC.
             $xml.= <<XML;
     <request_update>
         <update_id>$id</update_id>

--- a/bin/oxfordshire/open311_services.pm
+++ b/bin/oxfordshire/open311_services.pm
@@ -10,6 +10,8 @@ use CGI;
 use Encode qw(from_to);
 use DBI;
 use Time::Piece;
+use Time::Local qw(timelocal);
+use POSIX qw(strftime);
 
 
 ###################################################################
@@ -145,6 +147,20 @@ sub get_date_or_nothing {
     return $d;
 }
 
+#------------------------------------------------------------------
+# get_utc_iso8601_string
+# Takes a local date/time string and converts it to UTC, returning
+# a ISO8601-format string.
+# expected format: YYYY-MM-DD HH:MM:SS
+# e.g.: 2016-04-01 13:37:42 -> 2016-04-01T12:37:42Z
+#------------------------------------------------------------------
+sub get_utc_iso8601_string {
+    my $datetime = shift;
+    $datetime =~ s{(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)}{
+        strftime "%Y-%m-%dT%H:%M:%SZ", gmtime(timelocal($6, $5, $4, $3, int($2)-1, int($1)-1900));
+    }e;
+    return $datetime;
+}
 
 
 1;


### PR DESCRIPTION
The timestamps returned from the database are in server-local time, not UTC.
Because FMS expects timestamps in Open311 responses to be UTC, the timestamps
of updates from OCC appear one hour ahead when DST is in effect.

This commit converts the timestamps to UTC before outputting them.

Fixes mysociety/FixMyStreet-Commercial#499
