### PR TITLE
Quieten Open311 errors

### DIFF
--- a/perllib/FixMyStreet/SendReport/Angus.pm
+++ b/perllib/FixMyStreet/SendReport/Angus.pm
@@ -160,7 +160,6 @@ sub send {
         }
     } catch {
         my $e = $_;
-        print "Caught an error: $e\n";
         $self->error( "Error sending to Angus: $e" );
     };
     $self->success( !$return );

--- a/perllib/FixMyStreet/SendReport/EastHants.pm
+++ b/perllib/FixMyStreet/SendReport/EastHants.pm
@@ -52,7 +52,6 @@ sub send {
         $return = 0 if $result eq 'Report received';
     } catch {
         my $e = $_;
-        print "Caught an error: $e\n";
         $self->error( "Error sending to East Hants: $e" );
     };
     $self->success( !$return );

--- a/perllib/FixMyStreet/SendReport/Open311.pm
+++ b/perllib/FixMyStreet/SendReport/Open311.pm
@@ -144,10 +144,11 @@ sub send {
             $self->success( 1 );
         } else {
             $result *= 1;
+            $self->error( "Failed to send over Open311\n" ) unless $self->error;
+            $self->error( $self->error . "\n" . $open311->error );
         }
     }
 
-    $self->error( 'Failed to send over Open311' ) unless $self->success;
 
     return $result;
 }

--- a/perllib/FixMyStreet/SendReport/Open311.pm
+++ b/perllib/FixMyStreet/SendReport/Open311.pm
@@ -144,10 +144,6 @@ sub send {
             $self->success( 1 );
         } else {
             $result *= 1;
-            # temporary fix to resolve some issues with west berks
-            if ( $row->bodies_str =~ /2619/ ) {
-                $result *= 0;
-            }
         }
     }
 


### PR DESCRIPTION
This should stop the "read timeout" emails.
And also store the actual server error in the database for easier debugging.