### PR TITLE
Use only one templating system for emails.

### DIFF
--- a/bin/handlemail
+++ b/bin/handlemail
@@ -170,8 +170,7 @@ sub handle_non_bounce_to_null_address {
     my $mail = FixMyStreet::Email::construct_email({
         From => [ FixMyStreet->config('CONTACT_EMAIL'), 'FixMyStreet' ],
         To => $data{return_path},
-        _template_ => $template,
-        _parameters_ => { },
+        _body_ => $template,
     });
     send_mail($mail->as_string, '<>', $data{return_path});
 }

--- a/bin/zurich/overdue-alert
+++ b/bin/zurich/overdue-alert
@@ -52,9 +52,6 @@ sub loop_through {
         $to_send{$row->bodies_str} .= '* ' . $row->id . ": '" . $row->title . "'\n\n";
     }
 
-    my $template_path = FixMyStreet->path_to( "templates", "email", "zurich", $template )->stringify;
-    $template = Utils::read_file( $template_path );
-
     foreach my $body_id (keys %to_send) {
         send_alert( $template, $body_id, $to_send{$body_id}, $include_parent );
     }
@@ -80,14 +77,15 @@ sub send_alert {
 
     FixMyStreet::Email::send_cron(
         FixMyStreet::DB->storage->schema,
+        $template,
+        $h,
         {
-            _template_ => $template,
-            _parameters_ => $h,
             To => $to,
             From => [ FixMyStreet->config('CONTACT_EMAIL'), FixMyStreet->config('CONTACT_NAME') ],
         },
         FixMyStreet->config('CONTACT_EMAIL'),
-        $nomail
+        $nomail,
+        $cobrand, 'de-ch',
     );
 }
 

--- a/perllib/FixMyStreet.pm
+++ b/perllib/FixMyStreet.pm
@@ -190,23 +190,6 @@ sub configure_mysociety_dbhandle {
 
 }
 
-=head2 get_email_template
-
-=cut
-
-sub get_email_template {
-    # TODO further refactor this by just using Template path
-    my ($class, $cobrand, $lang, $template) = @_;
-
-    my $template_path = FixMyStreet->path_to( "templates", "email", $cobrand, $lang, $template )->stringify;
-    $template_path = FixMyStreet->path_to( "templates", "email", $cobrand, $template )->stringify
-        unless -e $template_path;
-    $template_path = FixMyStreet->path_to( "templates", "email", "default", $template )->stringify
-        unless -e $template_path;
-    $template = Utils::read_file( $template_path );
-    return $template;
-}
-
 my $tz;
 my $tz_f;
 

--- a/perllib/FixMyStreet/App.pm
+++ b/perllib/FixMyStreet/App.pm
@@ -320,8 +320,7 @@ sub send_email {
 
     my $email = mySociety::Locale::in_gb_locale { FixMyStreet::Email::construct_email(
         {
-            _template_ => $c->view('Email')->render( $c, $template, $vars ),
-            _parameters_ => {},
+            _body_ => $c->view('Email')->render( $c, $template, $vars ),
             _attachments_ => $extra_stash_values->{attachments},
             From => $vars->{from},
             To => $vars->{to},

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -587,14 +587,6 @@ sub admin_report_edit {
         #    2) setting $problem->whensent(undef) may make it eligible for generating an email
         #   to the body (internal or external).  See DBRS::Problem->send_reports for Zurich-
         #   specific categories which are eligible for this.
-        #
-        #   It looks like both of these will do:
-        #       a) TT processing of [% ... %] directives, in FMS::App->send_email(_cron)
-        #       b) pseudo-PHP substitution of <?=$values['name']?> which is done as
-        #       naive substitution
-        #       commonlib mySociety::Email
-        #
-        #   So it makes sense to add new parameters as the more powerful TT (a).
 
         my $redirect = 0;
         my $new_cat = $c->get_param('category') || '';

--- a/perllib/FixMyStreet/Script/Alerts.pm
+++ b/perllib/FixMyStreet/Script/Alerts.pm
@@ -248,8 +248,6 @@ sub _send_aggregated_alert_email(%) {
     } );
     $data{unsubscribe_url} = $cobrand->base_url( $data{cobrand_data} ) . '/A/' . $token->token;
 
-    my $template = FixMyStreet->get_email_template($cobrand->moniker, $data{lang}, "$data{template}.txt");
-
     my $sender = sprintf('<fms-%s@%s>',
         FixMyStreet::Email::generate_verp_token('alert', $data{alert_id}),
         FixMyStreet->config('EMAIL_DOMAIN')
@@ -257,9 +255,9 @@ sub _send_aggregated_alert_email(%) {
 
     my $result = FixMyStreet::Email::send_cron(
         $data{schema},
+        "$data{template}.txt",
+        \%data,
         {
-            _template_ => $template,
-            _parameters_ => \%data,
             To => $data{alert_email},
         },
         $sender,

--- a/perllib/FixMyStreet/Script/Questionnaires.pm
+++ b/perllib/FixMyStreet/Script/Questionnaires.pm
@@ -52,8 +52,6 @@ sub send_questionnaires_period {
         # call checks if this is the host that sends mail for this cobrand.
         next unless $cobrand->email_host;
 
-        my $template = FixMyStreet->get_email_template($cobrand->moniker, $row->lang, 'questionnaire.txt');
-
         my %h = map { $_ => $row->$_ } qw/name title detail category/;
         $h{created} = Utils::prettify_duration( time() - $row->confirmed->epoch, 'week' );
 
@@ -78,14 +76,15 @@ sub send_questionnaires_period {
 
         my $result = FixMyStreet::Email::send_cron(
             $rs->result_source->schema,
+            'questionnaire.txt',
+            \%h,
             {
-                _template_ => $template,
-                _parameters_ => \%h,
                 To => [ [ $row->user->email, $row->name ] ],
             },
             undef,
             $params->{nomail},
-            $cobrand
+            $cobrand,
+            $row->lang,
         );
         unless ($result) {
             print "  ...success\n" if $params->{verbose};

--- a/perllib/FixMyStreet/Script/Reports.pm
+++ b/perllib/FixMyStreet/Script/Reports.pm
@@ -289,19 +289,18 @@ sub _send_report_sent_email {
     my $nomail = shift;
     my $cobrand = shift;
 
-    my $template = FixMyStreet->get_email_template($row->cobrand, $row->lang, 'confirm_report_sent.txt');
-
     FixMyStreet::Email::send_cron(
         $row->result_source->schema,
+        'confirm_report_sent.txt',
+        $h,
         {
-            _template_ => $template,
-            _parameters_ => $h,
             To => $row->user->email,
             From => [ FixMyStreet->config('CONTACT_EMAIL'), $cobrand->contact_name ],
         },
         FixMyStreet->config('CONTACT_EMAIL'),
         $nomail,
-        $cobrand
+        $cobrand,
+        $row->lang,
     );
 }
 

--- a/perllib/FixMyStreet/SendReport/Zurich.pm
+++ b/perllib/FixMyStreet/SendReport/Zurich.pm
@@ -59,8 +59,6 @@ sub get_template {
         }
     }
 
-    my $template_path = FixMyStreet->path_to( "templates", "email", "zurich", $template )->stringify;
-    $template = Utils::read_file( $template_path );
     return $template;
 }
 

--- a/t/app/helpers/send_email_sample.txt
+++ b/t/app/helpers/send_email_sample.txt
@@ -23,4 +23,4 @@ pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
 culpa qui officia deserunt mollit anim id est laborum.
 
 Yours,=20=20
-FixMyStreet.=20=
+FixMyStreet.=

--- a/t/app/helpers/send_email_sample_mime.txt
+++ b/t/app/helpers/send_email_sample_mime.txt
@@ -28,7 +28,7 @@ pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
 culpa qui officia deserunt mollit anim id est laborum.
 
 Yours,=20=20
-FixMyStreet.=20=
+FixMyStreet.=
 
 --BOUNDARY
 Content-Type: image/gif; name="foo.gif"

--- a/templates/email/bromley/questionnaire.txt
+++ b/templates/email/bromley/questionnaire.txt
@@ -1,22 +1,22 @@
-Subject: Questionnaire about '<?=$values['title']?>'
+Subject: Questionnaire about '[% title %]'
 
-Hi <?=$values['name']?>,
+Hi [% name %],
 
-<?=$values['created']?> ago, you reported a problem. To keep the
-site up to date and relevant, please fill in a short questionnaire
+[% created %] ago, you reported a problem. To keep the site
+up to date and relevant, please fill in a short questionnaire
 updating the status of your problem:
 
-    <?=$values['url']?>
+    [% url %]
 
 This email has been sent automatically from an unmonitored
 mailbox, please do not reply.
 
-[% INCLUDE 'signature.txt' %]
+[% signature %]
 
 
 Your problem was as follows:
 
-<?=$values['title']?>
+[% title %]
 
-<?=$values['detail']?>
+[% detail %]
 

--- a/templates/email/default/alert-problem-area.txt
+++ b/templates/email/default/alert-problem-area.txt
@@ -1,22 +1,22 @@
-Subject: New <?=$values['site_name']?> reports in <?=$values['area_name']?>
+Subject: New [% site_name %] reports in [% area_name %]
 
-The following new <?=$values['site_name']?> reports have been added in
-the <?=$values['area_name']?> area:
+The following new [% site_name %] reports have been added in
+the [% area_name %] area:
 
-<?=$values['data']?>
+[% data %]
 
-<?=$values['signature']?>
+[% signature %]
 
 
 Unsubscribe?
 
-You asked us to send you an email when someone makes a new <?=$values['site_name']?>
-report in <?=$values['area_name']?>. This is a free service from <?=$values['site_name']?>.
+You asked us to send you an email when someone makes a new [% site_name %]
+report in [% area_name %]. This is a free service from [% site_name %].
 
 If you no longer wish to receive an email whenever there are new reports in
-the <?=$values['area_name']?> area, please follow this link:
+the [% area_name %] area, please follow this link:
 
-<?=$values['unsubscribe_url']?>
+[% unsubscribe_url %]
 
 This email was sent automatically, from an unmonitored email account - so please
 do not reply to it.

--- a/templates/email/default/alert-problem-council.txt
+++ b/templates/email/default/alert-problem-council.txt
@@ -1,22 +1,22 @@
-Subject: New <?=$values['site_name']?> reports to <?=$values['area_name']?>
+Subject: New [% site_name %] reports to [% area_name %]
 
-The following new <?=$values['site_name']?> reports have been sent to
-<?=$values['area_name']?>:
+The following new [% site_name %] reports have been sent to
+[% area_name %]:
 
-<?=$values['data']?>
+[% data %]
 
-<?=$values['signature']?>
+[% signature %]
 
 
 Unsubscribe?
 
-You asked us to send you an email when someone makes a new <?=$values['site_name']?>
-report to <?=$values['area_name']?>. This is a free service from <?=$values['site_name']?>.
+You asked us to send you an email when someone makes a new [% site_name %]
+report to [% area_name %]. This is a free service from [% site_name %].
 
 If you no longer wish to receive an email whenever there are new reports made to
-<?=$values['area_name']?>, please follow this link:
+[% area_name %], please follow this link:
 
-<?=$values['unsubscribe_url']?>
+[% unsubscribe_url %]
 
 This email was sent automatically, from an unmonitored email account - so please
 do not reply to it.

--- a/templates/email/default/alert-problem-nearby.txt
+++ b/templates/email/default/alert-problem-nearby.txt
@@ -1,22 +1,22 @@
-Subject: New reports on <?=$values['site_name']?>
+Subject: New reports on [% site_name %]
 
-The following <?=$values['site_name']?> reports have been made within the area
+The following [% site_name %] reports have been made within the area
 you specified:
 
-<?=$values['data']?>
+[% data %]
 
-<?=$values['signature']?>
+[% signature %]
 
 
 Unsubscribe?
 
-You asked us to send you an email when someone makes a new <?=$values['site_name']?>
-report within your chosen area. This is a free service from <?=$values['site_name']?>.
+You asked us to send you an email when someone makes a new [% site_name %]
+report within your chosen area. This is a free service from [% site_name %].
 
 If you no longer wish to receive an email whenever there are new reports within
 this area, please follow this link:
 
-<?=$values['unsubscribe_url']?>
+[% unsubscribe_url %]
 
 This email was sent automatically, from an unmonitored email account - so please
 do not reply to it.

--- a/templates/email/default/alert-problem-ward.txt
+++ b/templates/email/default/alert-problem-ward.txt
@@ -1,24 +1,24 @@
-Subject: New <?=$values['site_name']?> reports to <?=$values['area_name']?> within <?=$values['ward_name']?>
+Subject: New [% site_name %] reports to [% area_name %] within [% ward_name %]
 
-The following new <?=$values['site_name']?> reports have been sent to <?=$values['area_name']?>
-within <?=$values['ward_name']?>:
+The following new [% site_name %] reports have been sent to [% area_name %]
+within [% ward_name %]:
 
-<?=$values['data']?>
+[% data %]
 
-<?=$values['signature']?>
+[% signature %]
 
 
 Unsubscribe?
 
-You subscribed to receive an email every time someone makes a new <?=$values['site_name']?>
-report to <?=$values['area_name']?> within <?=$values['ward_name']?>.This is a
-free service from <?=$values['site_name']?>.
+You subscribed to receive an email every time someone makes a new [% site_name %]
+report to [% area_name %] within [% ward_name %]. This is a
+free service from [% site_name %].
 
 If you no longer wish to receive an email whenever there are new reports to
-<?=$values['area_name']?> within <?=$values['ward_name']?>, please follow
+[% area_name %] within [% ward_name %], please follow
 this link:
 
-<?=$values['unsubscribe_url']?>
+[% unsubscribe_url %]
 
 This email was sent automatically, from an unmonitored email account - so please
 do not reply to it.

--- a/templates/email/default/alert-problem.txt
+++ b/templates/email/default/alert-problem.txt
@@ -1,21 +1,21 @@
-Subject: New reports on <?=$values['site_name']?>
+Subject: New reports on [% site_name %]
 
-The following new reports have been added to <?=$values['site_name']?>:
+The following new reports have been added to [% site_name %]:
 
-<?=$values['data']?>
+[% data %]
 
-<?=$values['signature']?>
+[% signature %]
 
 
 Unsubscribe?
 
-You subscribed to receive an email when someone makes a new <?=$values['site_name']?>
-report. This is a free service from <?=$values['site_name']?>.
+You subscribed to receive an email when someone makes a new [% site_name %]
+report. This is a free service from [% site_name %].
 
-If you no longer wish to receive an email whenever there are new <?=$values['site_name']?>
+If you no longer wish to receive an email whenever there are new [% site_name %]
 reports please follow this link:
 
-<?=$values['unsubscribe_url']?>
+[% unsubscribe_url %]
 
 This email was sent automatically, from an unmonitored email account - so please
 do not reply to it.

--- a/templates/email/default/alert-update.txt
+++ b/templates/email/default/alert-update.txt
@@ -1,27 +1,27 @@
-Subject: New <?=$values['site_name']?> updates on report: '<?=$values['title']?>'
+Subject: New [% site_name %] updates on report: '[% title %]'
 
 You asked us to send you an email every time an update was made to the
-<?=$values['site_name']?> report: <?=$values['title']?>.
+[% site_name %] report: [% title %].
 
 The following updates have been left on this report:
 
-<?=$values['data']?>
+[% data %]
 
-<?=$values['state_message']?>
+[% state_message %]
 
 If you would like to view or reply to these updates, please visit the following URL:
-    <?=$values['problem_url']?>
+    [% problem_url %]
 
 This email was sent automatically, from an unmonitored email account - so
 please do not reply to it.
 
-<?=$values['signature']?>
+[% signature %]
 
 
 Unsubscribe?
 
 We currently email you whenever someone leaves an update on the
-<?=$values['site_name']?> report: <?=$values['title']?>.
+[% site_name %] report: [% title %].
 
 If you no longer wish to receive an email whenever this report is updated,
-please follow this link: <?=$values['unsubscribe_url']?>
+please follow this link: [% unsubscribe_url %]

--- a/templates/email/default/confirm_report_sent.txt
+++ b/templates/email/default/confirm_report_sent.txt
@@ -1,14 +1,14 @@
-Subject: <?=$values['site_name']?> Report Sent: <?=$values['title']?>
+Subject: [% site_name %] Report Sent: [% title %]
 
 Hello,
 
-Thank you for using <?=$values['site_name']?> to submit your report
-"<?=$values['title']?>".
+Thank you for using [% site_name %] to submit your report
+"[% title %]".
 
-This is to confirm that it has now been sent to <?=$values['bodies_name']?>,
+This is to confirm that it has now been sent to [% bodies_name %],
 who should respond to you directly.
 
-Your report is also on <?=$values['url']?>, where others may read, comment or
+Your report is also on [% url %], where others may read, comment or
 offer advice.
 
 You should also feel free to add updates to that page, although note that they
@@ -19,7 +19,7 @@ can respond to them directly.
 
 Good luck in getting your problem fixed.
 
-<?=$values['signature']?>
+[% signature %]
 
 This email was sent automatically, from an unmonitored email account - so
 please do not reply to it.

--- a/templates/email/default/questionnaire.txt
+++ b/templates/email/default/questionnaire.txt
@@ -1,24 +1,24 @@
-Subject: Questionnaire about your <?=$values['site_name']?> report: '<?=$values['title']?>'
+Subject: Questionnaire about your [% site_name %] report: '[% title %]'
 
-Hello <?=$values['name']?>,
+Hello [% name %],
 
-<?=$values['created']?> ago, you reported a problem using <?=$values['site_name']?>.
+[% created %] ago, you reported a problem using [% site_name %].
 
 The details of that report are at the end of this email.
 
-To keep <?=$values['site_name']?> up to date and relevant, we'd appreciate it
+To keep [% site_name %] up to date and relevant, we'd appreciate it
 if you could follow the link below and fill in our short questionnaire
 updating the status of your problem:
 
-    <?=$values['url']?>
+    [% url %]
 
-<?=$values['signature']?>
+[% signature %]
 
 Your report was as follows:
 
-<?=$values['title']?>
+[% title %]
 
-<?=$values['detail']?>
+[% detail %]
 
 This email was sent automatically, from an unmonitored email account - so
 please do not reply to it.

--- a/templates/email/default/submit.txt
+++ b/templates/email/default/submit.txt
@@ -1,38 +1,38 @@
-Subject: Problem Report: <?=$values['title']?>
+Subject: Problem Report: [% title %]
 
-Dear <?=$values['bodies_name']?>,
+Dear [% bodies_name %],
 
-<?=$values['missing']?><?=$values['multiple']?>A user of
-<?=$values['site_name']?> has submitted the following report
+[% missing %][% multiple %]A user of
+[% site_name %] has submitted the following report
 of a local problem that they believe might require your attention.
 
-<?=$values['fuzzy']?>, or to provide an update on the problem,
+[% fuzzy %], or to provide an update on the problem,
 please visit the following link:
 
-    <?=$values['url']?>
+    [% url %]
 
-<?=$values['has_photo']?>----------
+[% has_photo %]----------
 
-Name: <?=$values['name']?>
+Name: [% name %]
 
-Email: <?=$values['email']?>
+Email: [% email %]
 
-<?=$values['phone_line']?><?=$values['category_line']?>Subject: <?=$values['title']?>
+[% phone_line %][% category_line %]Subject: [% title %]
 
-Details: <?=$values['detail']?>
+Details: [% detail %]
 
-<?=$values['easting_northing']?>Latitude: <?=$values['latitude']?>
+[% easting_northing %]Latitude: [% latitude %]
 
-Longitude: <?=$values['longitude']?>
+Longitude: [% longitude %]
 
-View OpenStreetMap of this location: <?=$values['osm_url']?>
+View OpenStreetMap of this location: [% osm_url %]
 
-<?=$values['closest_address']?>----------
+[% closest_address %]----------
 
 Replies to this email will go to the user who submitted the problem.
 
-<?=$values['signature']?>
+[% signature %]
 
 If there is a more appropriate email address for messages about
-<?=$values['category_footer']?>, please let us know. This will help improve the
+[% category_footer %], please let us know. This will help improve the
 service for local people. We also welcome any other feedback you may have.

--- a/templates/email/fiksgatami/alert-problem-area.txt
+++ b/templates/email/fiksgatami/alert-problem-area.txt
@@ -1,13 +1,13 @@
-Subject: Nye saker i <?=$values['area_name']?> hos FiksGataMi.no
+Subject: Nye saker i [% area_name %] hos FiksGataMi.no
 
 Følgende saker er sendt til
-<?=$values['area_name']?>:
+[% area_name %]:
 
-<?=$values['data']?>
+[% data %]
 
 Vennlig hilsen,  
 FiksGataMi-gruppen
 
 Hvis du ikke ønsker å motta e-post om saker som er sendt til
-<?=$values['area_name']?> i fremtiden, klikk på følgende lenke: 
-<?=$values['unsubscribe_url']?>
+[% area_name %] i fremtiden, klikk på følgende lenke: 
+[% unsubscribe_url %]

--- a/templates/email/fiksgatami/alert-problem-council.txt
+++ b/templates/email/fiksgatami/alert-problem-council.txt
@@ -1,12 +1,12 @@
-Subject: Nye saker sendt til <?=$values['area_name']?> via FiksGataMi.no
+Subject: Nye saker sendt til [% area_name %] via FiksGataMi.no
 
-Følgende saker er sendt til <?=$values['area_name']?>:
+Følgende saker er sendt til [% area_name %]:
 
-<?=$values['data']?>
+[% data %]
 
 Vennlig hilsen,  
 FiksGataMi-gruppen
 
 Hvis du ikke ønsker å motta e-post om saker som er sendt til
-<?=$values['area_name']?> i fremtiden, klikk på følgende lenke: 
-<?=$values['unsubscribe_url']?>
+[% area_name %] i fremtiden, klikk på følgende lenke: 
+[% unsubscribe_url %]

--- a/templates/email/fiksgatami/alert-problem-nearby.txt
+++ b/templates/email/fiksgatami/alert-problem-nearby.txt
@@ -2,10 +2,10 @@ Subject: Nye saker i nærheten på FiksGataMi.no
 
 Følgende saker i nærheten er lagt inn på FiksGataMi.no:
 
-<?=$values['data']?>
+[% data %]
 
 Vennlig hilsen,  
 FiksGataMi-gruppen
 
 Hvis du ikke ønsker å motta e-post om ny problemer i nærheten,
-klikk på følgende lenke: <?=$values['unsubscribe_url']?>
+klikk på følgende lenke: [% unsubscribe_url %]

--- a/templates/email/fiksgatami/alert-problem-ward.txt
+++ b/templates/email/fiksgatami/alert-problem-ward.txt
@@ -1,13 +1,13 @@
-Subject: Nye saker sendt til <?=$values['area_name']?> innenfor <?=$values['ward_name']?> via FiksGataMi.no
+Subject: Nye saker sendt til [% area_name %] innenfor [% ward_name %] via FiksGataMi.no
 
-Følgende saker er sendt til <?=$values['area_name']?>
-innenfor <?=$values['ward_name']?>:
+Følgende saker er sendt til [% area_name %]
+innenfor [% ward_name %]:
 
-<?=$values['data']?>
+[% data %]
 
 Vennlig hilsen,  
 FiksGataMi-gruppen
 
 Hvis du ikke ønsker å motta e-post om saker som er sendt til
-<?=$values['area_name']?> innenfor <?=$values['ward_name']?>,
-klikk på denne linken: <?=$values['unsubscribe_url']?>
+[% area_name %] innenfor [% ward_name %],
+klikk på denne linken: [% unsubscribe_url %]

--- a/templates/email/fiksgatami/alert-problem.txt
+++ b/templates/email/fiksgatami/alert-problem.txt
@@ -2,10 +2,10 @@ Subject: Nye saker på FiksGataMi.no
 
 Følgende nye saker er lagt til:
 
-<?=$values['data']?>
+[% data %]
 
 Vennlig hilsen,  
 FiksGataMi-gruppen
 
 Hvis du ikke ønsker å motta e-post om nye saker,
-klikk på følgende lenke: <?=$values['unsubscribe_url']?>
+klikk på følgende lenke: [% unsubscribe_url %]

--- a/templates/email/fiksgatami/alert-update.txt
+++ b/templates/email/fiksgatami/alert-update.txt
@@ -1,13 +1,13 @@
-Subject: Nye oppdateringer for problem - '<?=$values['title']?>'
+Subject: Nye oppdateringer for problem - '[% title %]'
 
 Følgende oppdateringer har blitt lagt inn for dette problemet:
 
-<?=$values['data']?>
+[% data %]
 
-<?=$values['state_message']?>
+[% state_message %]
 
 For å se på eller svare på disse oppdateringene, besøk denne lenken:
-    <?=$values['problem_url']?>
+    [% problem_url %]
 
 Du kan ikke kontakte noen ved å svare på denne e-posten.
 
@@ -15,4 +15,4 @@ Vennlig hilsen,
 Fiksgata-gruppen
 
 For å slutte å motta e-post ved nye oppdateringer om dette
-problemet, følg denne lenken: <?=$values['unsubscribe_url']?>
+problemet, følg denne lenken: [% unsubscribe_url %]

--- a/templates/email/fiksgatami/nn/alert-problem-area.txt
+++ b/templates/email/fiksgatami/nn/alert-problem-area.txt
@@ -1,13 +1,13 @@
-Subject: Nye saker i <?=$values['area_name']?> hos FiksGataMi.no
+Subject: Nye saker i [% area_name %] hos FiksGataMi.no
 
 Følgjande saker er sendt til
-<?=$values['area_name']?>:
+[% area_name %]:
 
-<?=$values['data']?>
+[% data %]
 
 Venleg helsing,  
 FiksGataMi-gruppa
 
 Viss du ikkje ynskjer å motta e-post om saker som er sendt til
-<?=$values['area_name']?> i framtida, klikk på følgjande lenkje: 
-<?=$values['unsubscribe_url']?>
+[% area_name %] i framtida, klikk på følgjande lenkje: 
+[% unsubscribe_url %]

--- a/templates/email/fiksgatami/nn/alert-problem-council.txt
+++ b/templates/email/fiksgatami/nn/alert-problem-council.txt
@@ -1,12 +1,12 @@
-Subject: Nye saker sendt til <?=$values['area_name']?> via FiksGataMi.no
+Subject: Nye saker sendt til [% area_name %] via FiksGataMi.no
 
-Følgjande saker er sendt til <?=$values['area_name']?>:
+Følgjande saker er sendt til [% area_name %]:
 
-<?=$values['data']?>
+[% data %]
 
 Venleg helsing,  
 FiksGataMi-gruppa
 
 Viss du ikkje ynskjer å motta e-post om saker som er sendt til
-<?=$values['area_name']?> i framtida, klikk på følgjande lenkje: 
-<?=$values['unsubscribe_url']?>
+[% area_name %] i framtida, klikk på følgjande lenkje: 
+[% unsubscribe_url %]

--- a/templates/email/fiksgatami/nn/alert-problem-nearby.txt
+++ b/templates/email/fiksgatami/nn/alert-problem-nearby.txt
@@ -2,10 +2,10 @@ Subject: Nye saker i nærleiken på FiksGataMi.no
 
 Følgjande saker i nærleiken er lagd inn på FiksGataMi.no:
 
-<?=$values['data']?>
+[% data %]
 
 Venleg helsing,  
 FiksGataMi-gruppa
 
 Viss du ikkje ynskjer å motta e-post om nye problem i nærleiken,
-klikk på følgjande lenkje: <?=$values['unsubscribe_url']?>
+klikk på følgjande lenkje: [% unsubscribe_url %]

--- a/templates/email/fiksgatami/nn/alert-problem-ward.txt
+++ b/templates/email/fiksgatami/nn/alert-problem-ward.txt
@@ -1,13 +1,13 @@
-Subject: Nye saker sendt til <?=$values['area_name']?> innanfor <?=$values['ward_name']?> via FiksGataMi.no
+Subject: Nye saker sendt til [% area_name %] innanfor [% ward_name %] via FiksGataMi.no
 
-Følgjande saker er sendt til <?=$values['area_name']?>
-innanfor <?=$values['ward_name']?>:
+Følgjande saker er sendt til [% area_name %]
+innanfor [% ward_name %]:
 
-<?=$values['data']?>
+[% data %]
 
 Venleg helsing,  
 FiksGataMi-gruppa
 
 Viss du ikkje ynskjer å motta e-post om saker som er sendt til
-<?=$values['area_name']?> innanfor <?=$values['ward_name']?>,
-klikk på følgjande lenkje: <?=$values['unsubscribe_url']?>
+[% area_name %] innanfor [% ward_name %],
+klikk på følgjande lenkje: [% unsubscribe_url %]

--- a/templates/email/fiksgatami/nn/alert-problem.txt
+++ b/templates/email/fiksgatami/nn/alert-problem.txt
@@ -2,10 +2,10 @@ Subject: Nye saker på FiksGataMi.no
 
 Følgjande nye saker er lagt til:
 
-<?=$values['data']?>
+[% data %]
 
 Venleg helsing,  
 FiksGataMi-gruppa
 
 Viss du ikkje ynskjer å motta e-post om nye saker,
-klikk på følgjande lenkje: <?=$values['unsubscribe_url']?>
+klikk på følgjande lenkje: [% unsubscribe_url %]

--- a/templates/email/fiksgatami/nn/alert-update.txt
+++ b/templates/email/fiksgatami/nn/alert-update.txt
@@ -1,13 +1,13 @@
-Subject: Nye oppdateringar for problem – '<?=$values['title']?>'
+Subject: Nye oppdateringar for problem – '[% title %]'
 
 Følgjande oppdateringar har vorte lagt inn for dette problemet:
 
-<?=$values['data']?>
+[% data %]
 
-<?=$values['state_message']?>
+[% state_message %]
 
 For å sjå på eller svara på desse oppdateringane, besøk denne lenkja:
-    <?=$values['problem_url']?>
+    [% problem_url %]
 
 Du kan ikkje kontakta nokon ved å svara på denne e-posten.
 
@@ -15,4 +15,4 @@ Venleg helsing,
 Fiksgata-gruppa
 
 For å slutta å motta e-post ved nye oppdateringar om dette
-problemet, følg denne lenkja: <?=$values['unsubscribe_url']?>
+problemet, følg denne lenkja: [% unsubscribe_url %]

--- a/templates/email/fiksgatami/nn/questionnaire.txt
+++ b/templates/email/fiksgatami/nn/questionnaire.txt
@@ -1,13 +1,13 @@
 Subject: Spørjeskjema for saka di på FiksGataMi
 
-Hei <?=$values['name']?>,
+Hei [% name %],
 
-for <?=$values['created']?> sidan, la du til ei sak på FiksGataMi.no
+for [% created %] sidan, la du til ei sak på FiksGataMi.no
 med detaljane som vist i denne e-posten. For å halda nettsida vår
 oppdatert og relevant, vil vi setja pris på om du kunne fylla ut
 følgjande skjema for å oppdatera saka:
 
-    <?=$values['url']?>
+    [% url %]
 
 Ver venleg og ikkje svar på denne e-posten; det er mogleg å kommentera
 i skjemaet.
@@ -17,8 +17,8 @@ FiksGataMi-gruppa
 
 Saka du la til var som følgjer:
 
-<?=$values['title']?>
+[% title %]
 
-<?=$values['detail']?>
+[% detail %]
 
 

--- a/templates/email/fiksgatami/nn/submit.txt
+++ b/templates/email/fiksgatami/nn/submit.txt
@@ -1,31 +1,31 @@
-Subject: Problemrapport: <?=$values['title']?>
+Subject: Problemrapport: [% title %]
 
-Til <?=$values['bodies_name']?>,
+Til [% bodies_name %],
 
-<?=$values['missing']?><?=$values['multiple']?>Ein brukar av
+[% missing %][% multiple %]Ein brukar av
 FiksGataMi har sendt inn følgjande rapport om eit lokalt problem som
 vi trur treng merksemda deira.
 
-<?=$values['fuzzy']?>, eller for å bidra med ei oppdatering om
+[% fuzzy %], eller for å bidra med ei oppdatering om
 problemet, ver venleg og besøk følgjande lenkje:
 
-    <?=$values['url']?>
+    [% url %]
 
-<?=$values['has_photo']?>----------
+[% has_photo %]----------
 
-Namn: <?=$values['name']?>
+Namn: [% name %]
 
-E-post: <?=$values['email']?>
+E-post: [% email %]
 
-<?=$values['phone_line']?><?=$values['category_line']?>Tema: <?=$values['title']?>
+[% phone_line %][% category_line %]Tema: [% title %]
 
-Detaljer: <?=$values['detail']?>
+Detaljer: [% detail %]
 
-<?=$values['easting_northing']?>Breiddegrad: <?=$values['latitude']?>
+[% easting_northing %]Breiddegrad: [% latitude %]
 
-Lengdegrad: <?=$values['longitude']?>
+Lengdegrad: [% longitude %]
 
-<?=$values['closest_address']?>----------
+[% closest_address %]----------
 
 Svar på denne e-posten går til brukaren som sende inn problemet.
 
@@ -34,7 +34,7 @@ FiksGataMi-gruppa
 
 [ Denne meldinga vart send inn via FiksGataMi, eit prosjekt hos foreininga NUUG.
 Viss det er ei meir passande e-postadresse for meldingar om
-<?=$values['category_footer']?>, ver så snill å gje oss melding ved å vitja
+[% category_footer %], ver så snill å gje oss melding ved å vitja
 <http://www.fiksgatami.no/contact>.
 Dette vil bidra til å forbetra tenesta for lokalbefolkinga. Vi
 tek òg gjerne imot andre tilbakemeldingar. ]

--- a/templates/email/fiksgatami/questionnaire.txt
+++ b/templates/email/fiksgatami/questionnaire.txt
@@ -1,13 +1,13 @@
 Subject: Spørreskjema for din sak på FiksGataMi
 
-Hei <?=$values['name']?>,
+Hei [% name %],
 
-for <?=$values['created']?> siden, la du til en sak på FiksGataMi.no
+for [% created %] siden, la du til en sak på FiksGataMi.no
 med detaljene som vist i denne e-posten. For å holde vår nettside oppdatert
 og relevant, vil vi sette pris på om du kunne fylle ut følgende skjema for å
 oppdatere saken:
 
-    <?=$values['url']?>
+    [% url %]
 
 Vennligst ikke svar på denne e-posten; det er muligheter for å kommentere i skjemaet.
 
@@ -16,8 +16,8 @@ FiksGataMi-gruppen
 
 Saken du la til var som følger:
 
-<?=$values['title']?>
+[% title %]
 
-<?=$values['detail']?>
+[% detail %]
 
 

--- a/templates/email/fiksgatami/submit.txt
+++ b/templates/email/fiksgatami/submit.txt
@@ -1,31 +1,31 @@
-Subject: Problemrapport: <?=$values['title']?>
+Subject: Problemrapport: [% title %]
 
-Til <?=$values['bodies_name']?>,
+Til [% bodies_name %],
 
-<?=$values['missing']?><?=$values['multiple']?>En bruker av
+[% missing %][% multiple %]En bruker av
 FiksGataMi har sendt inn følgende rapport om et lokalt
 problem som vi tror trenger deres oppmerksomhet.
 
-<?=$values['fuzzy']?>, eller for å bidra med en oppdatering om problemet,
+[% fuzzy %], eller for å bidra med en oppdatering om problemet,
 vennligst besøk følgende lenke:
 
-    <?=$values['url']?>
+    [% url %]
 
-<?=$values['has_photo']?>----------
+[% has_photo %]----------
 
-Navn: <?=$values['name']?>
+Navn: [% name %]
 
-E-post: <?=$values['email']?>
+E-post: [% email %]
 
-<?=$values['phone_line']?><?=$values['category_line']?>Tema: <?=$values['title']?>
+[% phone_line %][% category_line %]Tema: [% title %]
 
-Detajer: <?=$values['detail']?>
+Detajer: [% detail %]
 
-<?=$values['easting_northing']?>Breddegrad: <?=$values['latitude']?>
+[% easting_northing %]Breddegrad: [% latitude %]
 
-Lengegrad: <?=$values['longitude']?>
+Lengegrad: [% longitude %]
 
-<?=$values['closest_address']?>----------
+[% closest_address %]----------
 
 Svar på denne e-posten går til brukeren som sendte inn problemet.
 
@@ -34,7 +34,7 @@ FiksGataMi-gruppen
 
 [ Denne meldingen ble sendt inn via FiksGataMi, et prosjekt hos foreningen NUUG.
 Hvis det er en mer passende e-postadresse for meldinger om
-<?=$values['category_footer']?>, vær så snill å gi oss beskjed ved å besøke
+[% category_footer %], vær så snill å gi oss beskjed ved å besøke
 <http://www.fiksgatami.no/contact>.
 Dette vil bidra til å forbedre tjenesten for lokalbefolkningen. Vi
 tar også gjerne imot andre tilbakemeldinger. ]

--- a/templates/email/fixamingata/alert-problem-area.txt
+++ b/templates/email/fixamingata/alert-problem-area.txt
@@ -1,10 +1,10 @@
-Subject: Nya rapporter i <?=$values['area_name']?> på FixaMinGata
+Subject: Nya rapporter i [% area_name %] på FixaMinGata
 
-Följande nya rapporter har lagts till inom <?=$values['area_name']?>:
+Följande nya rapporter har lagts till inom [% area_name %]:
 
-<?=$values['data']?>
+[% data %]
 
-<?=$values['signature']?>
+[% signature %]
 
-Om du vill avsluta din prenumeration på nya rapporter i <?=$values['area_name']?>
-kan du klickan på följande länk: <?=$values['unsubscribe_url']?>
+Om du vill avsluta din prenumeration på nya rapporter i [% area_name %]
+kan du klickan på följande länk: [% unsubscribe_url %]

--- a/templates/email/fixamingata/alert-problem-council.txt
+++ b/templates/email/fixamingata/alert-problem-council.txt
@@ -1,10 +1,10 @@
-Subject: Nya rapporter i <?=$values['area_name']?> på FixaMinGata
+Subject: Nya rapporter i [% area_name %] på FixaMinGata
 
-Följande nya rapporter har lagts till inom <?=$values['area_name']?>:
+Följande nya rapporter har lagts till inom [% area_name %]:
 
-<?=$values['data']?>
+[% data %]
 
-<?=$values['signature']?>
+[% signature %]
 
-Om du vill avsluta din prenumeration på nya rapporter i <?=$values['area_name']?>
-kan du klickan på följande länk: <?=$values['unsubscribe_url']?>
+Om du vill avsluta din prenumeration på nya rapporter i [% area_name %]
+kan du klickan på följande länk: [% unsubscribe_url %]

--- a/templates/email/fixamingata/alert-problem-nearby.txt
+++ b/templates/email/fixamingata/alert-problem-nearby.txt
@@ -2,9 +2,9 @@ Subject: Nya rapporter på FixMyStreet
 
 Följande rapporter har nyligen lagts till på:
 
-<?=$values['data']?>
+[% data %]
 
-<?=$values['signature']?>
+[% signature %]
 
 Om du vill avsluta din prenumeration på nya rapporter
-kan du klickan på följande länk: <?=$values['unsubscribe_url']?>
+kan du klickan på följande länk: [% unsubscribe_url %]

--- a/templates/email/fixamingata/alert-problem-ward.txt
+++ b/templates/email/fixamingata/alert-problem-ward.txt
@@ -1,10 +1,10 @@
-Subject: Nya rapporter i <?=$values['area_name']?> på FixaMinGata
+Subject: Nya rapporter i [% area_name %] på FixaMinGata
 
-Följande nya rapporter har lagts till inom <?=$values['area_name']?>:
+Följande nya rapporter har lagts till inom [% area_name %]:
 
-<?=$values['data']?>
+[% data %]
 
-<?=$values['signature']?>
+[% signature %]
 
-Om du vill avsluta din prenumeration på nya rapporter i <?=$values['area_name']?>
-kan du klickan på följande länk: <?=$values['unsubscribe_url']?>
+Om du vill avsluta din prenumeration på nya rapporter i [% area_name %]
+kan du klickan på följande länk: [% unsubscribe_url %]

--- a/templates/email/fixamingata/alert-problem.txt
+++ b/templates/email/fixamingata/alert-problem.txt
@@ -2,9 +2,9 @@ Subject: Nya rapporter på FixMyStreet
 
 Följande rapporter har nyligen lagts till på:
 
-<?=$values['data']?>
+[% data %]
 
-<?=$values['signature']?>
+[% signature %]
 
 Om du vill avsluta din prenumeration på nya rapporter
-kan du klickan på följande länk: <?=$values['unsubscribe_url']?>
+kan du klickan på följande länk: [% unsubscribe_url %]

--- a/templates/email/fixamingata/alert-update.txt
+++ b/templates/email/fixamingata/alert-update.txt
@@ -1,18 +1,18 @@
-Subject: Ny uppdatering - '<?=$values['title']?>'
+Subject: Ny uppdatering - '[% title %]'
 
 OBS! Du kan inte svara på detta brev. För att se eller svara på dessa
 uppdateringar, klicka på följande länk:
 
-<?=$values['problem_url']?>
+[% problem_url %]
 
 Följande uppdatering har lämnats för rapporten
-<?=$values['title']?>:
+[% title %]:
 
-<?=$values['data']?>
+[% data %]
 
-<?=$values['state_message']?>
+[% state_message %]
 
-<?=$values['signature']?>
+[% signature %]
 
 För att avsluta din prenumeration på nya uppdateringar kring denna
-rapport, klicka på följande länk: <?=$values['unsubscribe_url']?>
+rapport, klicka på följande länk: [% unsubscribe_url %]

--- a/templates/email/fixamingata/questionnaire.txt
+++ b/templates/email/fixamingata/questionnaire.txt
@@ -1,13 +1,13 @@
-Subject: Frågeformulär om '<?=$values['title']?>'
+Subject: Frågeformulär om '[% title %]'
 
-Hej <?=$values['name']?>,
+Hej [% name %],
 
 OBS! Du kan inte svara på detta brev. För att se eller svara på dessa
 uppdateringar, klicka på följande länk:
 
-<?=$values['url']?>
+[% url %]
 
-<?=$values['created']?> sedan lämnade du en rapport på FixaMinGata. För
+[% created %] sedan lämnade du en rapport på FixaMinGata. För
 att hålla alla rapporter uppdaterade skulle vi uppskatta om du kunde
 klicka på länken nedan och svara på ett par korta frågor om det problem
 du rapporterade.
@@ -15,10 +15,10 @@ du rapporterade.
 Var snäll och svara inte på det här brevet. Använd istället
 kommentarsfältet i frågeformuläret.
 
-<?=$values['signature']?>
+[% signature %]
 
 Ditt rapporterade problem var enligt nedan:
 
-<?=$values['title']?>
+[% title %]
 
-<?=$values['detail']?>
+[% detail %]

--- a/templates/email/fixamingata/submit.txt
+++ b/templates/email/fixamingata/submit.txt
@@ -1,40 +1,40 @@
-Subject: Ny rapport: <?=$values['title']?>
+Subject: Ny rapport: [% title %]
 
-Till <?=$values['bodies_name']?>,
+Till [% bodies_name %],
 
 Det här meddelandet rör en rapport om ett problem i gatumiljön som en
 medborgare lämnat via tjänsten FixaMinGata.
 
-<?=$values['missing']?><?=$values['multiple']?>Följande rapport
+[% missing %][% multiple %]Följande rapport
 tror medborgaren behöver er uppmärksamhet.
 
-<?=$values['fuzzy']?> eller uppdatera problemet, klicka på följande länk:
+[% fuzzy %] eller uppdatera problemet, klicka på följande länk:
 
-    <?=$values['url']?>
+    [% url %]
 
-<?=$values['has_photo']?>
+[% has_photo %]
 
 ** Uppgiftslämnare
 
-Namn: <?=$values['name']?>
+Namn: [% name %]
 
-Epost: <?=$values['email']?>
+Epost: [% email %]
 
-<?=$values['phone_line']?>
+[% phone_line %]
 
 ** Information om ärendet
 
-<?=$values['category_line']?>Ärende: <?=$values['title']?>
+[% category_line %]Ärende: [% title %]
 
-<?=$values['detail']?>
+[% detail %]
 
 ** Geografisk position
 
-<?=$values['easting_northing']?>Latitude: <?=$values['latitude']?>
+[% easting_northing %]Latitude: [% latitude %]
 
-Longitude: <?=$values['longitude']?>
+Longitude: [% longitude %]
 
-<?=$values['closest_address']?>----------
+[% closest_address %]----------
 
 Svar på det här brevet kommer att skickas till den person som lämnade
 rapporten.
@@ -57,5 +57,5 @@ Kontakta Föreningen Sambruk via:
 
   <http://fixamingata.se/contact>
 
-<?=$values['signature']?>
+[% signature %]
 

--- a/templates/email/fixmystreet/submit-oxfordshire.txt
+++ b/templates/email/fixmystreet/submit-oxfordshire.txt
@@ -1,41 +1,41 @@
-Subject: FMS Problem Report: <?=$values['title']?>
+Subject: FMS Problem Report: [% title %]
 
-Dear <?=$values['bodies_name']?>,
+Dear [% bodies_name %],
 
-<?=$values['missing']?><?=$values['multiple']?>A user of
+[% missing %][% multiple %]A user of
 FixMyStreet has submitted the following report
 of a local problem that they believe might require your attention.
 
-<?=$values['fuzzy']?>, or to provide an update on the problem,
+[% fuzzy %], or to provide an update on the problem,
 please visit the following link:
 
-    <?=$values['url']?>
+    [% url %]
 
-<?=$values['has_photo']?>----------
+[% has_photo %]----------
 
-Name: <?=$values['name']?>
+Name: [% name %]
 
-Email: <?=$values['email']?>
+Email: [% email %]
 
-<?=$values['phone_line']?><?=$values['category_line']?>Subject: <?=$values['title']?>
+[% phone_line %][% category_line %]Subject: [% title %]
 
-Details: <?=$values['detail']?>
+Details: [% detail %]
 
-<?=$values['easting_northing']?>Latitude: <?=$values['latitude']?>
+[% easting_northing %]Latitude: [% latitude %]
 
-Longitude: <?=$values['longitude']?>
+Longitude: [% longitude %]
 
-View OpenStreetMap of this location: <?=$values['osm_url']?>
+View OpenStreetMap of this location: [% osm_url %]
 
-<?=$values['closest_address']?>----------
+[% closest_address %]----------
 
 Replies to this email will go to the user who submitted the problem.
 
-<?=$values['signature']?>
+[% signature %]
 
 This message was sent via FixMyStreet, a project of UKCOD, registered charity
 number 1076346. If there is a more appropriate email address for messages about
-<?=$values['category_footer']?>, please let us know by visiting <https://www.fixmystreet.com/contact>.
+[% category_footer %], please let us know by visiting <https://www.fixmystreet.com/contact>.
 This will help improve the service for local people. We
 also welcome any other feedback you may have.
 

--- a/templates/email/fixmystreet/submit.txt
+++ b/templates/email/fixmystreet/submit.txt
@@ -1,41 +1,41 @@
-Subject: Problem Report: <?=$values['title']?>
+Subject: Problem Report: [% title %]
 
-Dear <?=$values['bodies_name']?>,
+Dear [% bodies_name %],
 
-<?=$values['missing']?><?=$values['multiple']?>A user of
+[% missing %][% multiple %]A user of
 FixMyStreet has submitted the following report
 of a local problem that they believe might require your attention.
 
-<?=$values['fuzzy']?>, or to provide an update on the problem,
+[% fuzzy %], or to provide an update on the problem,
 please visit the following link:
 
-    <?=$values['url']?>
+    [% url %]
 
-<?=$values['has_photo']?>----------
+[% has_photo %]----------
 
-Name: <?=$values['name']?>
+Name: [% name %]
 
-Email: <?=$values['email']?>
+Email: [% email %]
 
-<?=$values['phone_line']?><?=$values['category_line']?>Subject: <?=$values['title']?>
+[% phone_line %][% category_line %]Subject: [% title %]
 
-Details: <?=$values['detail']?>
+Details: [% detail %]
 
-<?=$values['easting_northing']?>Latitude: <?=$values['latitude']?>
+[% easting_northing %]Latitude: [% latitude %]
 
-Longitude: <?=$values['longitude']?>
+Longitude: [% longitude %]
 
-View OpenStreetMap of this location: <?=$values['osm_url']?>
+View OpenStreetMap of this location: [% osm_url %]
 
-<?=$values['closest_address']?>----------
+[% closest_address %]----------
 
 Replies to this email will go to the user who submitted the problem.
 
-<?=$values['signature']?>
+[% signature %]
 
 This message was sent via FixMyStreet, a project of UKCOD, registered charity
 number 1076346. If there is a more appropriate email address for messages about
-<?=$values['category_footer']?>, please let us know by visiting <https://www.fixmystreet.com/contact>.
+[% category_footer %], please let us know by visiting <https://www.fixmystreet.com/contact>.
 This will help improve the service for local people. We
 also welcome any other feedback you may have.
 

--- a/templates/email/harrogate/submit.txt
+++ b/templates/email/harrogate/submit.txt
@@ -1,43 +1,45 @@
-Subject: Problem Report: <?=$values['title']?>
+Subject: Problem Report: [% title %]
 
-Dear <?=$values['bodies_name']?>,
+Dear [% bodies_name %],
 
-<?=$values['missing']?><?=$values['multiple']?>A user of
+[% missing %][% multiple %]A user of
 FixMyStreet has submitted the following report
 of a local problem that they believe might require your attention.
 
-<?=$values['fuzzy']?>, or to provide an update on the problem,
+[% fuzzy %], or to provide an update on the problem,
 please visit the following link:
 
-    <?=$values['url']?>
+    [% url %]
 
-<?=$values['has_photo']?>----------
+[% has_photo %]----------
 
-Name: <?=$values['name']?>
+Name: [% name %]
 
-Email: <?=$values['email']?>
+Email: [% email %]
 
-<?=$values['phone_line']?><?=$values['category_line']?>Subject: <?=$values['title']?>
+[% phone_line %][% category_line %]Subject: [% title %]
 
-<?=$values['detail']?> <?=$values['additional_information']?>
+[% detail %] [% additional_information %]
 
-<?=$values['easting_northing']?>Latitude: <?=$values['latitude']?>
+[% easting_northing %]Latitude: [% latitude %]
 
-Longitude: <?=$values['longitude']?>
+Longitude: [% longitude %]
 
-<?=$values['closest_address']?>----------
+View OpenStreetMap of this location: [% osm_url %]
+
+[% closest_address %]----------
 
 Replies to this email will go to the user who submitted the problem.
 
-<?=$values['signature']?>
+[% signature %]
 
 This message was sent via FixMyStreet, a project of UKCOD, registered charity
 number 1076346. If there is a more appropriate email address for messages about
-<?=$values['category_footer']?>, please let us know by visiting <https://www.fixmystreet.com/contact>.
+[% category_footer %], please let us know by visiting <https://www.fixmystreet.com/contact>.
 This will help improve the service for local people. We
 also welcome any other feedback you may have.
 
 FixMyStreet is now available for full integration into council
 websites, making life easier for both you and your residents.
-Read more here: https://www.mysociety.org/services/fixmystreet-for-councils/
+Read more here: https://www.fixmystreet.com/council
 

--- a/templates/email/oxfordshire/submit.txt
+++ b/templates/email/oxfordshire/submit.txt
@@ -1,39 +1,41 @@
-Subject: FMS Problem Report: <?=$values['title']?>
+Subject: FMS Problem Report: [% title %]
 
-Dear <?=$values['bodies_name']?>,
+Dear [% bodies_name %],
 
-<?=$values['missing']?><?=$values['multiple']?>A user of
+[% missing %][% multiple %]A user of
 FixMyStreet has submitted the following report
 of a local problem that they believe might require your attention.
 
-<?=$values['fuzzy']?>, or to provide an update on the problem,
+[% fuzzy %], or to provide an update on the problem,
 please visit the following link:
 
-    <?=$values['url']?>
+    [% url %]
 
-<?=$values['has_photo']?>----------
+[% has_photo %]----------
 
-Name: <?=$values['name']?>
+Name: [% name %]
 
-Email: <?=$values['email']?>
+Email: [% email %]
 
-<?=$values['phone_line']?><?=$values['category_line']?>Subject: <?=$values['title']?>
+[% phone_line %][% category_line %]Subject: [% title %]
 
-Details: <?=$values['detail']?>
+Details: [% detail %]
 
-<?=$values['easting_northing']?>Latitude: <?=$values['latitude']?>
+[% easting_northing %]Latitude: [% latitude %]
 
-Longitude: <?=$values['longitude']?>
+Longitude: [% longitude %]
 
-<?=$values['closest_address']?>----------
+View OpenStreetMap of this location: [% osm_url %]
+
+[% closest_address %]----------
 
 Replies to this email will go to the user who submitted the problem.
 
-<?=$values['signature']?>
+[% signature %]
 
 This message was sent via FixMyStreet, a project of UKCOD, registered charity
 number 1076346. If there is a more appropriate email address for messages about
-<?=$values['category_footer']?>, please let us know by visiting <https://www.fixmystreet.com/contact>.
+[% category_footer %], please let us know by visiting <https://www.fixmystreet.com/contact>.
 This will help improve the service for local people. We
 also welcome any other feedback you may have.
 

--- a/templates/email/seesomething/submit.txt
+++ b/templates/email/seesomething/submit.txt
@@ -4,22 +4,22 @@ A user of
 See Something, Say Something has submitted the following report
 of a problem that they believe might require your attention.
 
-<?=$values['image_url']?>
+[% image_url %]
 ----------
 
-<?=$values['user_details']?>
+[% user_details %]
 
-<?=$values['phone_line']?><?=$values['category_line']?><?=$values['subcategory_line']?>
+[% phone_line %][% category_line %][% subcategory_line %]
 
-Details: <?=$values['detail']?>
+Details: [% detail %]
 
-<?=$values['easting_northing']?>Latitude: <?=$values['latitude']?>
+[% easting_northing %]Latitude: [% latitude %]
 
-Longitude: <?=$values['longitude']?>
+Longitude: [% longitude %]
 
-<?=$values['closest_address']?>----------
+[% closest_address %]----------
 
 Replies to this email will go to the user who submitted the problem
 unless it is an anonymous report in which case they will be discarded.
 
-<?=$values['signature']?>
+[% signature %]

--- a/templates/email/zurich/alert-moderation-overdue.txt
+++ b/templates/email/zurich/alert-moderation-overdue.txt
@@ -2,8 +2,8 @@ Subject: eskalierte Meldungen auf Züri wie neu
 
 Die folgenden Meldungen auf <<Züri wie neu>> sind älter als einen Tag und müssen dringend bearbeitet werden:
 
-<?=$values['data']?>
+[% data %]
 
 Um diese Meldungen zu moderieren, klicken Sie auf folgende URL:
 
-<?=$values['admin_url']?>
+[% admin_url %]

--- a/templates/email/zurich/alert-overdue.txt
+++ b/templates/email/zurich/alert-overdue.txt
@@ -2,8 +2,8 @@ Subject: Rückmeldung erforderlich auf Züri wie neu
 
 Die folgenden Meldungen wurden eskaliert, da sie nicht innerhalb von fünf Tagen beantwortet worden sind:
 
-<?=$values['data']?>
+[% data %]
 
 Um diese Meldungen zu bearbeiten, klicken Sie auf folgende URL:
 
-<?=$values['admin_url']?>
+[% admin_url %]

--- a/templates/email/zurich/alert-update.txt
+++ b/templates/email/zurich/alert-update.txt
@@ -1,11 +1,11 @@
-Subject: New update on report - '<?=$values['title']?>'
+Subject: New update on report - '[% title %]'
 
 The following update has been left on this report:
 
-<?=$values['data']?>
+[% data %]
 
 To view this report on the site, please visit the following URL:
-    <?=$values['problem_url']?>
+    [% problem_url %]
 
-<?=$values['signature']?>
+[% signature %]
 

--- a/templates/email/zurich/submit-external-personal.txt
+++ b/templates/email/zurich/submit-external-personal.txt
@@ -1,17 +1,17 @@
-Subject: Züri wie neu: Weitergeleitete Meldung #<?=$values['id']?>
+Subject: Züri wie neu: Weitergeleitete Meldung #[% id %]
 
-Grüezi <?=$values['bodies_name']?>,
+Grüezi [% bodies_name %],
 
-<?=$values['external_message']?>
+[% external_message %]
 
 
-Öffentliche URL: <?=$values['url']?>
+Öffentliche URL: [% url %]
 
-Name des Meldenden: <?=$values['name']?>
+Name des Meldenden: [% name %]
 
-Email des Meldenden: <?=$values['email']?>
+Email des Meldenden: [% email %]
 
-Telefonnummer des Meldenden: <?=$values['phone']?>
+Telefonnummer des Meldenden: [% phone %]
 
 
 Bei Fragen zu "Züri wie neu" wenden Sie sich bitte an gis-zentrum@zuerich.ch.

--- a/templates/email/zurich/submit-external-wish.txt
+++ b/templates/email/zurich/submit-external-wish.txt
@@ -1,20 +1,20 @@
-Subject: Züri wie neu: Weitergeleitete Meldung #<?=$values['id']?>
+Subject: Züri wie neu: Weitergeleitete Meldung #[% id %]
 
-Grüezi <?=$values['bodies_name']?>,
+Grüezi [% bodies_name %],
 
-<?=$values['external_message']?>
+[% external_message %]
 
 
-Name des Meldenden: <?=$values['name']?>
+Name des Meldenden: [% name %]
 
-Email des Meldenden: <?=$values['email']?>
+Email des Meldenden: [% email %]
 
-Telefonnummer des Meldenden: <?=$values['phone']?>
+Telefonnummer des Meldenden: [% phone %]
 
-Meldung: <?=$values['detail']?>
+Meldung: [% detail %]
 
 Standort in AV-Online anzeigen:
-http://webgis.intra.stzh.ch/AV_Online/Direct.asp?Map=AV&Search=Koord&West=<?=$values['west']?>&Nord=<?=$values['nord']?>&B=300
+http://webgis.intra.stzh.ch/AV_Online/Direct.asp?Map=AV&Search=Koord&West=[% west %]&Nord=[% nord %]&B=300
 
 
 Bei Fragen zu "Züri wie neu" wenden Sie sich bitte an gis-zentrum@zuerich.ch.

--- a/templates/email/zurich/submit-external.txt
+++ b/templates/email/zurich/submit-external.txt
@@ -1,11 +1,11 @@
-Subject: Züri wie neu: Weitergeleitete Meldung #<?=$values['id']?>
+Subject: Züri wie neu: Weitergeleitete Meldung #[% id %]
 
-Grüezi <?=$values['bodies_name']?>,
+Grüezi [% bodies_name %],
 
-<?=$values['external_message']?>
+[% external_message %]
 
 
-Öffentliche URL: <?=$values['url']?>
+Öffentliche URL: [% url %]
 
 
 Bei Fragen zu "Züri wie neu" wenden Sie sich bitte an gis-zentrum@zuerich.ch.

--- a/templates/email/zurich/submit-feedback-pending.txt
+++ b/templates/email/zurich/submit-feedback-pending.txt
@@ -1,10 +1,10 @@
-Subject: Züri wie neu: Meldung #<?=$values['id']?> bereit für Feedback
+Subject: Züri wie neu: Meldung #[% id %] bereit für Feedback
 
-Guten Tag <?=$values['bodies_name']?>,
+Guten Tag [% bodies_name %],
 
 Diese Meldung wurde vom Fachbereich abschliessend beantwortet und kann nun auf <<Züri wie neu>> beantwortet und abgeschlossen werden.
 
-Öffentliche URL: <?=$values['url']?>
+Öffentliche URL: [% url %]
 
-Admin URL: <?=$values['admin_url']?>
+Admin URL: [% admin_url %]
 

--- a/templates/email/zurich/submit-in-progress.txt
+++ b/templates/email/zurich/submit-in-progress.txt
@@ -1,10 +1,10 @@
-Subject: Züri wie neu: Neue Meldung #<?=$values['id']?>
+Subject: Züri wie neu: Neue Meldung #[% id %]
 
-Guten Tag <?=$values['bodies_name']?>,
+Guten Tag [% bodies_name %],
 
 Diese Meldung wurde Ihnen von Ihrer <<Züri wie neu>>-Kommunikationsstelle zugeteilt.
 
-Öffentliche URL: <?=$values['url']?>
+Öffentliche URL: [% url %]
 
-Admin URL: <?=$values['admin_url']?>
+Admin URL: [% admin_url %]
 

--- a/templates/email/zurich/submit.txt
+++ b/templates/email/zurich/submit.txt
@@ -1,10 +1,10 @@
-Subject: Züri wie neu: Neue Meldung #<?=$values['id']?>
+Subject: Züri wie neu: Neue Meldung #[% id %]
 
-Guten Tag <?=$values['bodies_name']?>,
+Guten Tag [% bodies_name %],
 
 Eine neue Meldung wurde erfasst:
 
-Öffentliche URL: <?=$values['url']?>
+Öffentliche URL: [% url %]
 
-Admin URL: <?=$values['admin_url']?>
+Admin URL: [% admin_url %]
 


### PR DESCRIPTION
Historically, emails sent offline (alerts, questionnaires, etc) used a
different templating system from those sent by the website (e.g. login
emails), though the newer system was also being used for the site name
and signature of offline emails.

Fixes #1410.