### PR TITLE
Redirect correctly if filter used sans JavaScript.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -83,8 +83,9 @@ sub report_new : Path : Args(0) {
     $c->forward('initialize_report');
 
     # work out the location for this report and do some checks
+    # Also show map if we're just updating the filters
     return $c->forward('redirect_to_around')
-      unless $c->forward('determine_location');
+      if $c->get_param('filter_update') || !$c->forward('determine_location');
 
     # create a problem from the submitted details
     $c->stash->{template} = "report/new/fill_in_details.html";
@@ -1229,10 +1230,12 @@ sub redirect_to_around : Private {
     my ( $self, $c ) = @_;
 
     my $params = {
-        pc => ( $c->stash->{pc} || $c->get_param('pc') || '' ),
         lat => $c->stash->{latitude},
         lon => $c->stash->{longitude},
     };
+    foreach (qw(pc zoom status filter_category)) {
+        $params->{$_} = $c->get_param($_);
+    }
 
     # delete empty values
     for ( keys %$params ) {

--- a/templates/web/base/reports/_list-filters.html
+++ b/templates/web/base/reports/_list-filters.html
@@ -24,7 +24,7 @@
 
         <p class="report-list-filters">
             [% tprintf(loc('<label>Show %s</label> <label>about %s</label>', 'The first %s is a dropdown of all/fixed/etc, the second is a dropdown of categories'), select_status, select_category) %]
-            <input type="submit" value="[% loc('Go') %]">
+            <input type="submit" name="filter_update" value="[% loc('Go') %]">
         </p>
 
 [% IF use_form_wrapper %]


### PR DESCRIPTION
It was being treated as a new report and showing errors, rather than
showing you the same page with updated filters. Fixes #1422.