### PR TITLE
Remove default box-shadow from .content and aside

### DIFF
--- a/web/cobrands/bristol/layout.scss
+++ b/web/cobrands/bristol/layout.scss
@@ -111,7 +111,6 @@ body.frontpage, body.twothirdswidthpage, body.fullwidthpage, body.authpage {
   // Put FAQ side nav at correct vertical position
   .content .sticky-sidebar aside {
     top: 14.5em;
-    box-shadow: none;
   }
 }
 

--- a/web/cobrands/eastsussex/layout.scss
+++ b/web/cobrands/eastsussex/layout.scss
@@ -180,10 +180,6 @@ body.frontpage {
     width: auto;
 }
 
-body.twothirdswidthpage .content aside {
-    box-shadow: 0 0 12px 0 #dae1e5;
-}
-
 .banner p#fixed {
     background-position: -328px -333px;
 }

--- a/web/cobrands/fixmystreet.com/posters.scss
+++ b/web/cobrands/fixmystreet.com/posters.scss
@@ -129,7 +129,6 @@ body.goodies {
           padding: 0;
 
           aside {
-            box-shadow: none;
             background-color: inherit;
           }
         }

--- a/web/cobrands/harrogate/layout.scss
+++ b/web/cobrands/harrogate/layout.scss
@@ -54,7 +54,6 @@ body.fullwidthpage .container .content {
 
 body.twothirdswidthpage .content aside {
     margin-top: 2em;
-    @include box-shadow(none);
 }
 
 

--- a/web/cobrands/hart/layout.scss
+++ b/web/cobrands/hart/layout.scss
@@ -10,16 +10,9 @@
 }
 
 body.twothirdswidthpage .content {
-    aside {
-        @include box-shadow(none);
-    }
     .sticky-sidebar {
         aside {
             top: 14em;
         }
     }
-}
-
-.content {
-    @include box-shadow(none);
 }

--- a/web/cobrands/oxfordshire/layout.scss
+++ b/web/cobrands/oxfordshire/layout.scss
@@ -37,24 +37,15 @@ body, body a {
   display: none;
 }
 
-// White background, so no shadow or margin needed.
-.content {
+// White background, so no margin needed.
+.content,
+.iel8 .content {
     margin: 0;
-    @include box-shadow(none);
-}
-.iel8 {
-    .content {
-        margin: 0;
-        border: none;
-    }
 }
 
 // Fix location of aside sidebar
 body.twothirdswidthpage {
     .content {
-        aside {
-            @include box-shadow(none);
-        }
         .sticky-sidebar {
             aside {
                 position: fixed;
@@ -111,7 +102,7 @@ body.mappage {
     background-color: #069b01; // picked from header.jpg
     background-position: 100% 40%;
     overflow: auto;
-    box-shadow: 0 0 5px rgba(0,0,0,0.3);
+    @include box-shadow(0 0 5px rgba(0,0,0,0.3));
 
     & > * {
       display: none;
@@ -276,9 +267,7 @@ h4.static-with-rule {
 
 .shadow-wrap {
     ul#key-tools {
-        -webkit-box-shadow: 0em 0px 1em 1em $oxfordshire_very_light_green;
-        -moz-box-shadow: 0em 0px 1em 1em $oxfordshire_very_light_green;
-        box-shadow: 0em 0px 1em 1em $oxfordshire_very_light_green;
+        @include box-shadow(0 0 1em 1em $oxfordshire_very_light_green);
         border-top-width: 2px;
     }
 }
@@ -307,9 +296,10 @@ input.green-btn{
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;
-  -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
-  -moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
+  @include box-shadow(
+    inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    0 1px 2px rgba(0, 0, 0, 0.05)
+  );
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   font-weight: normal;
   cursor: pointer;

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -214,12 +214,9 @@ h1 {
   padding: 1em 1em 3em;
   background: #fff;
   color: #222;
-  @include box-shadow(0 0 10px rgba(0,0,0,0.5));
 }
 .iel8 {
   .content {
-    // If no box-shadow, just want a boring black border to stand it out from the map.
-    border: 1px solid #666;
     //take off margins so we line up properly
     margin: 0 0.5em;
   }
@@ -420,7 +417,6 @@ body.twothirdswidthpage,
 body.fullwidthpage {
     .container {
         .content {
-            box-shadow: none;
             padding: 1em;
             margin-bottom: 0em;
             footer {
@@ -466,10 +462,6 @@ body.fullwidthpage {
 .iel8 {
   body.twothirdswidthpage,
   body.fullwidthpage {
-    .content {
-      border: 0px;
-    }
-
     .container .content footer a.platform-logo {
       color: #ffffff;
       background: none;
@@ -498,7 +490,6 @@ body.twothirdswidthpage {
       z-index: -1;
       width:13em;
       padding:1em;
-      @include box-shadow(0px 0px 6px 1px #000);
       h2 {
         margin-top: 0;
       }
@@ -526,7 +517,6 @@ body.authpage {
     margin-#{$left}: auto;
     margin-#{$right}: auto;
     margin-bottom: 0;
-    box-shadow: none;
     padding: 1em; // same as .twothirdswidthpage .content
   }
 }
@@ -575,7 +565,6 @@ body.authpage {
   border-#{$right}: 1em solid transparent;
   background:none;
   padding:0;
-  @include box-shadow(inset rgba(0, 0, 0, 0) 0 0 0);
   h2 {
     color:#222;
     margin-top:0;
@@ -689,7 +678,7 @@ body.authpage {
   ul#key-tools {
     border-top: 0.25em solid $primary;
     margin: 0;
-    @include box-shadow(-0em 0px 1em 1em #fff);
+    @include box-shadow(0 0 1em 1em #fff);
     li {
       border:none;
       a, input[type=submit] {

--- a/web/cobrands/sass/_mixins.scss
+++ b/web/cobrands/sass/_mixins.scss
@@ -71,16 +71,16 @@ $right: right;
   @include experimental(border-radius, $radius, -moz, -webkit, not -o, not -ms, official);
 }
 
-@mixin box-shadow($shadow) {
-  @include experimental(box-shadow, $shadow, -moz, -webkit, not -o, not -ms, official);
+@mixin box-shadow($shadows...) {
+  @include experimental(box-shadow, $shadows, -moz, -webkit, not -o, not -ms, official);
 }
 
 @mixin experimental($property, $value, $moz: true, $webkit: true, $o: true, $ms: true, $official: true) {
-  @if $webkit   { -webkit-#{$property} : $value; }
-  @if $moz      {    -moz-#{$property} : $value; }
-  @if $ms       {     -ms-#{$property} : $value; }
-  @if $o        {      -o-#{$property} : $value; }
-  @if $official {         #{$property} : $value; }
+  @if $webkit   { -webkit-#{$property} : #{$value}; }
+  @if $moz      {    -moz-#{$property} : #{$value}; }
+  @if $ms       {     -ms-#{$property} : #{$value}; }
+  @if $o        {      -o-#{$property} : #{$value}; }
+  @if $official {         #{$property} : #{$value}; }
 }
 
 @mixin inline-block($alignment: middle) {

--- a/web/cobrands/stevenage/layout.scss
+++ b/web/cobrands/stevenage/layout.scss
@@ -80,7 +80,6 @@
 // d523b431
 body.fullwidthpage {
     .content {
-        @include box-shadow(none);
         background: none;
     }
 }

--- a/web/cobrands/zurich/layout.scss
+++ b/web/cobrands/zurich/layout.scss
@@ -7,36 +7,26 @@ $mappage-header-height: 7em;
 
 // Things to override from parent stylesheet
 
-// White background, so no shadow or margin needed.
 .content {
     color: #3c3c3c;
-    @include box-shadow(none);
 }
-.iel8 {
-    .content {
-        border: none;
-    }
-}
-// Except on map pages (which includes the front page)
-body.mappage .content, body.frontpage .content {
+
+// Front page content needs a shadow.
+// (Purely decorative: No need for border fallback for IE8)
+body.frontpage .content {
     @include box-shadow(0 0 6px 1px #000);
 }
-.iel8 {
-    body.mappage .content, body.frontpage .content {
-        border: 1px solid #666;
-    }
-}
-/* The header on a map page needs a shadow too */
+// The header on a map page needs a shadow too
 body.mappage .nav-wrapper .nav-wrapper-2 {
     @include box-shadow(0 0 6px 1px #000);
     z-index: 2; // One more than #zurich-main-nav so it's on top
 }
-/* Except on admin pages where there's an admin nav directly underneath it */
+// Except on admin pages where there's an admin nav directly underneath it
 body.mappage.admin .nav-wrapper-2 {
     @include box-shadow(none);
 }
 
-/* Fix positioning of images in the admin */
+// Fix positioning of images in the admin
 body.admin .admin-nav-wrapper {
     z-index: 1;
 }
@@ -205,9 +195,6 @@ body.mappage {
 
 body.twothirdswidthpage {
     .content {
-        aside {
-            @include box-shadow(none);
-        }
         .sticky-sidebar aside {
           top: 14em; // overrides default value, due to Zurich nav at top of content
         }


### PR DESCRIPTION
Fixes #1419.

The main change was removing `box-shadow` from `.content` and `.content aside` in `sass/_layout.scss`. All the rest is just removing all the places that cobrands overrode these shadows with their own `box-shadow: none`.