### PR TITLE
[UK Councils] Clarify who receives messages from the contact form.

### DIFF
--- a/templates/web/fixmystreet-uk-councils/contact/blurb.html
+++ b/templates/web/fixmystreet-uk-councils/contact/blurb.html
@@ -1,0 +1,9 @@
+<p>
+[% tprintf( loc("It's often quickest to <a href=\"%s\">check our FAQs</a> and see if the answer is there."), c.uri_for('/faq') ) %]
+</p>
+
+<p>
+[% loc('Please do <strong>not</strong> report problems through this form; messages go to
+the technical team behind this site. To report a problem,
+please <a href="/">go to the front page</a> and follow the instructions.') %]
+</p>


### PR DESCRIPTION
The default wording says messages do not go to a council, which is not true for
UK council cobrands.