### PR TITLE
[Bristol] Only show Open311 categories on Bristol cobrand

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -602,12 +602,12 @@ sub setup_categories_and_bodies : Private {
     my %bodies = map { $_->id => $_ } @bodies;
     my $first_body = ( values %bodies )[0];
 
-    my @contacts                #
+    my $contacts                #
       = $c                      #
       ->model('DB::Contact')    #
       ->not_deleted             #
-      ->search( { body_id => [ keys %bodies ] } )
-      ->all;
+      ->search( { body_id => [ keys %bodies ] } );
+    my @contacts = $c->cobrand->categories_restriction($contacts)->all;
 
     # variables to populate
     my %bodies_to_list = ();       # Bodies with categories assigned
@@ -669,15 +669,6 @@ sub setup_categories_and_bodies : Private {
 
     $c->cobrand->munge_category_list(\@category_options, \@contacts, \%category_extras)
         if $c->cobrand->can('munge_category_list');
-
-    if ($c->cobrand->can('hidden_categories')) {
-        my %hidden_categories = map { $_ => 1 }
-            $c->cobrand->hidden_categories;
-
-        @category_options = grep { 
-            !$hidden_categories{$_} 
-            } @category_options;
-    }
 
     # put results onto stash for display
     $c->stash->{bodies} = \%bodies;

--- a/perllib/FixMyStreet/Cobrand/Bristol.pm
+++ b/perllib/FixMyStreet/Cobrand/Bristol.pm
@@ -55,4 +55,14 @@ sub send_questionnaires {
     return 0;
 }
 
+sub categories_restriction {
+    my ($self, $rs) = @_;
+    # Categories covering the Bristol area have a mixture of Open311 and Email
+    # send methods. Bristol only want Open311 categories to be visible on their
+    # cobrand, not the email categories from FMS.com. We've set up the
+    # Email categories with a devolved send_method, so can identify Open311
+    # categories as those which have a blank send_method.
+    return $rs->search( { send_method => undef } );
+}
+
 1;

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -103,6 +103,17 @@ sub updates_restriction {
     return $rs;
 }
 
+=head1 categories_restriction
+
+Used to restrict categories available when making new report in a cobrand in a
+particular way. Do nothing by default.
+
+=cut
+
+sub categories_restriction {
+    my ($self, $rs) = @_;
+    return $rs;
+}
 
 sub site_key { return 0; }
 

--- a/perllib/FixMyStreet/Cobrand/Hart.pm
+++ b/perllib/FixMyStreet/Cobrand/Hart.pm
@@ -30,10 +30,9 @@ sub example_places {
     return ( 'GU51 4JX', 'Primrose Drive' );
 }
 
-sub hidden_categories {
-    return (
-        'Graffiti on bridges/subways',
-    );
+sub categories_restriction {
+    my ($self, $rs) = @_;
+    return $rs->search( { category => { '!=' => 'Graffiti on bridges/subways' } } );
 }
 
 sub send_questionnaires {


### PR DESCRIPTION
This adds a new Cobrand::Default::categories_restriction method that can be used
to limit what categories are available when making a new report on a per-cobrand
basis.

This is used by Cobrand::Bristol to only show Open311 categories when making a
new report on fixmystreet.bristol.gov.uk but allowing all categories on FMS.com.

Also removes the Hart::hidden_categories and uses the new categories_restriction
method to achieve the same thing.