### PR TITLE
Let council users submit reports/updates as another user, or as the council

### DIFF
--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -243,6 +243,14 @@ sub has_permission_to {
     return $permission ? 1 : undef;
 }
 
+sub contributing_as {
+    my ($self, $other, $c, $bodies) = @_;
+    $bodies = join(',', keys %$bodies) if ref $bodies eq 'HASH';
+    $c->log->error("Bad data $bodies passed to contributing_as") if ref $bodies;
+    my $form_as = $c->get_param('form_as') || '';
+    return 1 if $form_as eq $other && $self->has_permission_to("contribute_as_$other", $bodies);
+}
+
 sub adopt {
     my ($self, $other) = @_;
 

--- a/perllib/FixMyStreet/TestMech.pm
+++ b/perllib/FixMyStreet/TestMech.pm
@@ -165,6 +165,7 @@ sub delete_user {
     }
     $_->delete for $user->comments;
     $_->delete for $user->admin_logs;
+    $_->delete for $user->user_body_permissions;
     $user->delete;
 
     return 1;

--- a/t/app/controller/report_as_other.t
+++ b/t/app/controller/report_as_other.t
@@ -1,0 +1,194 @@
+use strict;
+use warnings;
+use Test::More;
+use LWP::Protocol::PSGI;
+
+use t::Mock::MapIt;
+use FixMyStreet::TestMech;
+use FixMyStreet::App;
+
+# disable info logs for this test run
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $body = $mech->create_body_ok(2245, 'Wiltshire Council');
+my $contact1 = $mech->create_contact_ok( body_id => $body->id, category => 'Street lighting', email => 'highways@example.com' );
+my $contact2 = $mech->create_contact_ok( body_id => $body->id, category => 'Potholes', email => 'potholes@example.com' );
+
+my $test_email = 'body-user@example.net';
+my $user = $mech->log_in_ok($test_email);
+$user->update({ from_body => $body->id, name => 'Body User' });
+
+my ($report_to_update) = $mech->create_problems_for_body(1, $body->id, 'Title');
+
+subtest "Body user, no permissions, no special reporting tools shown" => sub {
+    start_report();
+    dropdown_shown(0);
+    start_update();
+    dropdown_shown(0, 'updateForm');
+};
+
+subtest "Body user, has permission to add report as council" => sub {
+    my $report = add_report(
+        'contribute_as_body',
+        form_as => 'body',
+        title => "Test Report",
+        detail => 'Test report details.',
+        category => 'Street lighting',
+    );
+    is $report->name, 'Wiltshire Council', 'report name is body';
+    is $report->user->name, 'Body User', 'user name unchanged';
+    is $report->user->id, $user->id, 'user matches';
+    is $report->anonymous, 0, 'report not anonymous';
+};
+
+my @users;
+subtest "Body user, has permission to add report as another user" => sub {
+    my $report = add_report(
+        'contribute_as_another_user',
+        form_as => 'another_user',
+        title => "Test Report",
+        detail => 'Test report details.',
+        category => 'Potholes',
+        name => 'Another User',
+        email => 'another@example.net',
+    );
+    is $report->name, 'Another User', 'report name is given name';
+    is $report->user->name, 'Another User', 'user name matches';
+    is $report->user->email, 'another@example.net', 'user email correct';
+    isnt $report->user->id, $user->id, 'user does not match';
+    like $mech->get_text_body_from_email, qr/Your report to Wiltshire Council has been logged/;
+    push @users, $report->user;
+};
+
+subtest "Body user, has permission to add report as another (existing) user" => sub {
+    $mech->create_user_ok('existing@example.net', name => 'Existing User');
+    my $report = add_report(
+        'contribute_as_another_user',
+        form_as => 'another_user',
+        title => "Test Report",
+        detail => 'Test report details.',
+        category => 'Potholes',
+        name => 'Existing Yooser',
+        email => 'existing@example.net',
+    );
+    is $report->name, 'Existing Yooser', 'report name is given name';
+    is $report->user->name, 'Existing User', 'user name remains same';
+    is $report->user->email, 'existing@example.net', 'user email correct';
+    isnt $report->user->id, $user->id, 'user does not match';
+    like $mech->get_text_body_from_email, qr/Your report to Wiltshire Council has been logged/;
+    push @users, $report->user;
+};
+
+subtest "Body user, has permission to add update as council" => sub {
+    my $update = add_update(
+        'contribute_as_body',
+        form_as => 'body',
+        update => 'Test Update',
+    );
+    is $update->name, 'Wiltshire Council', 'update name is body';
+    is $update->user->name, 'Body User', 'user name unchanged';
+    is $update->user->id, $user->id, 'user matches';
+    is $update->anonymous, 0, 'update not anonymous';
+};
+
+subtest "Body user, has permission to add update as another user" => sub {
+    my $update = add_update(
+        'contribute_as_another_user',
+        form_as => 'another_user',
+        update => 'Test Update',
+        name => 'Another User',
+        rznvy => 'another2@example.net',
+    );
+    is $update->name, 'Another User', 'update name is given name';
+    is $update->user->name, 'Another User', 'user name matches';
+    is $update->user->email, 'another2@example.net', 'user email correct';
+    isnt $update->user->id, $user->id, 'user does not match';
+    like $mech->get_text_body_from_email, qr/Your update has been logged/;
+    push @users, $update->user;
+};
+
+subtest "Body user, has permission to add update as another (existing) user" => sub {
+    my $update = add_update(
+        'contribute_as_another_user',
+        form_as => 'another_user',
+        update => 'Test Update',
+        name => 'Existing Yooser',
+        rznvy => 'existing@example.net',
+    );
+    is $update->name, 'Existing Yooser', 'update name is given name';
+    is $update->user->name, 'Existing User', 'user name remains same';
+    is $update->user->email, 'existing@example.net', 'user email correct';
+    isnt $update->user->id, $user->id, 'user does not match';
+    like $mech->get_text_body_from_email, qr/Your update has been logged/;
+};
+
+done_testing();
+
+END {
+    $mech->delete_body($body);
+    $mech->delete_user($_) for @users;
+}
+
+sub start_report {
+    my $permission = shift;
+    LWP::Protocol::PSGI->register(t::Mock::MapIt->run_if_script, host => 'mapit.uk');
+    $_->delete for $user->user_body_permissions;
+    $user->user_body_permissions->create({ body => $body, permission_type => $permission })
+        if $permission;
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'fixmystreet' ],
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $mech->get_ok('/report/new?latitude=51.7549262252&longitude=-1.25617899435');
+    };
+}
+
+sub add_report {
+    my ($permission, %fields) = @_;
+    start_report($permission);
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'fixmystreet' ],
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        dropdown_shown(1);
+        $mech->submit_form_ok({
+            with_fields => \%fields,
+        }, "submit details");
+    };
+    $mech->content_contains('Thank you for reporting this issue');
+    my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+    ok $report, "Found the report";
+    is $report->state, 'confirmed', "report is now confirmed";
+    return $report;
+}
+
+sub start_update {
+    my $permission = shift;
+    $_->delete for $user->user_body_permissions;
+    $user->user_body_permissions->create({ body => $body, permission_type => $permission })
+        if $permission;
+    $mech->get_ok('/report/' . $report_to_update->id);
+}
+
+sub add_update {
+    my ($permission, %fields) = @_;
+    start_update($permission);
+    dropdown_shown(1, 'updateForm');
+    $mech->submit_form_ok({
+        with_fields => \%fields,
+    }, "submit details");
+    $mech->content_contains('Thank you for updating this issue');
+    my $update = FixMyStreet::DB->resultset("Comment")->search(undef, { order_by => { -desc => 'id' } })->first;
+    ok $update, "Found the update";
+    is $update->state, 'confirmed', "update is now confirmed";
+    return $update;
+}
+
+sub dropdown_shown {
+    my ($shown, $name) = @_;
+    is grep({ $_ eq 'form_as' } keys %{$mech->visible_form_values($name)}), $shown, "Dropdown shown = $shown";
+}
+

--- a/templates/email/default/other-reported.html
+++ b/templates/email/default/other-reported.html
@@ -1,0 +1,30 @@
+[%
+
+email_summary = "Thanks for logging your report";
+email_columns = 2;
+
+PROCESS '_email_settings.html';
+INCLUDE '_email_top.html';
+
+%]
+
+<th style="[% td_style %][% primary_column_style %]" id="primary_column">
+  [% start_padded_box %]
+  <h1 style="[% h1_style %]">Your report has been&nbsp;logged</h1>
+  <p style="[% p_style %]">Your report to [% report.body %] has been logged on [% site_name %].
+[% IF c.cobrand.is_council && !c.cobrand.owns_problem( report ) %]
+Please note that [% c.cobrand.council_name %] is not responsible for this type
+of report, so it will instead be sent to [% report.body %].
+[% END %]
+  </p>
+  <p style="margin: 20px auto; text-align: center">
+  <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.url %]">View my report</a>
+  </p>
+  [% end_padded_box %]
+</th>
+[% WRAPPER '_email_sidebar.html' object = report %]
+    <h2 style="[% h2_style %]">[% report.title | html %]</h2>
+    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+[% END %]
+
+[% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/other-reported.txt
+++ b/templates/email/default/other-reported.txt
@@ -1,0 +1,27 @@
+Subject: Your report has been logged: [% report.title %]
+
+Hello [% report.name %],
+
+Your report to [% report.body %] has been logged on [% site_name %].
+
+[% IF c.cobrand.is_council && !c.cobrand.owns_problem( report ) %]
+Please note that [% c.cobrand.council_name %] is not responsible for this type
+of report, so it will instead be sent to [% report.body %].
+[% END %]
+
+It is available to view at:
+
+[% cobrand.base_url_for_report(report) %][% report.url %]
+
+Your report has the title:
+
+[% report.title %]
+
+And details:
+
+[% report.detail %]
+
+[% INCLUDE 'signature.txt' %]
+
+This email was sent automatically, from an unmonitored email account - so
+please do not reply to it.

--- a/templates/email/default/other-updated.html
+++ b/templates/email/default/other-updated.html
@@ -1,0 +1,26 @@
+[%
+
+email_summary = "Thanks for logging your update";
+email_columns = 2;
+
+PROCESS '_email_settings.html';
+INCLUDE '_email_top.html';
+
+%]
+
+<th style="[% td_style %][% primary_column_style %]" id="primary_column">
+  [% start_padded_box %]
+  <h1 style="[% h1_style %]">Your update has been&nbsp;logged</h1>
+  <p style="[% p_style %]">Your update has been logged on [% site_name %]:</p>
+  <p style="margin: 20px auto; text-align: center">
+  <a style="[% button_style %]" href="[% cobrand.base_url_for_report(problem) %][% problem.url %]#update_[% update.id %]">View my update</a>
+  </p>
+  [% end_padded_box %]
+</th>
+[% WRAPPER '_email_sidebar.html'
+    object = update
+    report = problem %]
+    <p style="[% secondary_p_style %]">[% update.text | html %]</p>
+[% END %]
+
+[% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/other-updated.txt
+++ b/templates/email/default/other-updated.txt
@@ -1,0 +1,16 @@
+Subject: Your update has been logged
+
+Hello [% update.name %],
+
+Your update has been logged on [% site_name %]:
+
+[% cobrand.base_url_for_report(problem) %][% problem.url %]#update_[% update.id %]
+
+Your update reads:
+
+[% update.text %]
+
+[% INCLUDE 'signature.txt' %]
+
+This email was sent automatically, from an unmonitored email account - so
+please do not reply to it.

--- a/templates/web/base/report/new/form_user_loggedin.html
+++ b/templates/web/base/report/new/form_user_loggedin.html
@@ -1,7 +1,29 @@
 <div class="form-box" id="form-box--logged-in-name">
 
-    <label for="form_email">[% loc('Your email') %]</label>
-    <input disabled type="text" value="[% c.user.email | html %]">
+  [% can_contribute_as_another_user = c.user.has_permission_to("contribute_as_another_user", bodies.keys.join(",")) %]
+  [% can_contribute_as_body = c.user.from_body AND c.user.has_permission_to("contribute_as_body", bodies.keys.join(",")) %]
+
+  [% IF can_contribute_as_another_user OR can_contribute_as_body %]
+    <label for="form_as">[% loc('Report as') %]</label>
+    <select id="form_as" class="js-contribute-as" name="form_as">
+        <option value="myself" selected>[% loc('Yourself') %]</option>
+      [% IF can_contribute_as_another_user %]
+        <option value="another_user">[% loc('Another user') %]</option>
+      [% END %]
+      [% IF can_contribute_as_body %]
+        <option value="body">[% c.user.from_body.name %]</option>
+      [% END %]
+    </select>
+  [% END %]
+
+    <label for="form_email">[% loc('Email address') %]</label>
+    <input id="form_email"
+    [%- IF can_contribute_as_another_user OR can_contribute_as_body -%]
+    name="email"
+    [%- ELSE -%]
+    disabled
+    [%- END -%]
+    type="text" value="[% c.user.email | html %]">
 
     [% INCLUDE 'report/new/extra_name.html' %]
     [% PROCESS 'user/_anonymity.html' anonymous = report.anonymous %]
@@ -15,7 +37,7 @@
     [% IF field_errors.name %]
         <p class='form-error'>[% field_errors.name %]</p>
     [% END %]
-    <input type="text" class="validName" value="[% report.name | html %]" name="name" id="form_name" placeholder="[% loc('Your name') %]">
+    <input type="text" class="validName" value="[% report.name | html %]" name="name" id="form_name">
 
     [%# if there is nothing in the name field then set check box as default on form %]
     <div class="checkbox-group">
@@ -24,7 +46,7 @@
     </div>
 
     <label for="form_phone">[% loc('Phone number (optional)') %]</label>
-    <input class="" type="text" value="[% report.user.phone | html %]" name="phone" id="form_phone" placeholder="[% loc('Your phone number') %]">
+    <input class="" type="text" value="[% report.user.phone | html %]" name="phone" id="form_phone">
 
     <div class="general-notes">
         <p>[% loc('We never show your email address or phone number.') %]</p>

--- a/templates/web/base/report/update/form_name.html
+++ b/templates/web/base/report/update/form_name.html
@@ -2,6 +2,24 @@
 
 [% PROCESS 'user/_anonymity.html' anonymous = update.anonymous %]
 
+  [% can_contribute_as_another_user = c.user.has_permission_to("contribute_as_another_user", problem.bodies_str) %]
+  [% can_contribute_as_body = c.user.from_body AND c.user.has_permission_to("contribute_as_body", problem.bodies_str) %]
+
+  [% IF can_contribute_as_another_user OR can_contribute_as_body %]
+    <label for="form_as">[% loc('Provide update as') %]</label>
+    <select id="form_as" class="js-contribute-as" name="form_as">
+        <option value="myself" selected>[% loc('Yourself') %]</option>
+      [% IF can_contribute_as_another_user %]
+        <option value="another_user">[% loc('Another user') %]</option>
+      [% END %]
+      [% IF can_contribute_as_body %]
+        <option value="body">[% c.user.from_body.name %]</option>
+      [% END %]
+    </select>
+    <label for="form_email">[% loc('Email address') %]</label>
+    <input name="rznvy" id="form_email" type="text" value="[% c.user.email | html %]">
+  [% END %]
+
 <label for="form_name">[% loc('Name') %]</label>
 [% IF field_errors.name %]
     <p class='form-error'>[% field_errors.name %]</p>

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -397,6 +397,34 @@ $.extend(fixmystreet.set_up, {
     $('#mapForm').removeAttr('novalidate');
   },
 
+  contribute_as: function() {
+    $('.js-contribute-as').on('change', function(){
+        var opt = this.options[this.selectedIndex],
+            val = opt.value,
+            txt = opt.text;
+        var $emailInput = $('#form_email');
+        var $nameInput = $('#form_name');
+        var $showNameCheckbox = $('#form_may_show_name');
+        var $addAlertCheckbox = $('#form_add_alert');
+        if (val === 'myself') {
+            $emailInput.val($emailInput.prop('defaultValue')).prop('disabled', true);
+            $nameInput.val($nameInput.prop('defaultValue')).prop('disabled', false);
+            $showNameCheckbox.prop('checked', false).prop('disabled', false);
+            $addAlertCheckbox.prop('checked', true).prop('disabled', false);
+        } else if (val === 'another_user') {
+            $emailInput.val('').prop('disabled', false);
+            $nameInput.val('').prop('disabled', false);
+            $showNameCheckbox.prop('checked', false).prop('disabled', false);
+            $addAlertCheckbox.prop('checked', true).prop('disabled', false);
+        } else if (val === 'body') {
+            $emailInput.val('-').prop('disabled', true);
+            $nameInput.val(txt).prop('disabled', true);
+            $showNameCheckbox.prop('checked', true).prop('disabled', true);
+            $addAlertCheckbox.prop('checked', false).prop('disabled', true);
+        }
+    }).change();
+  },
+
   on_resize: function() {
     var last_type;
     $(window).on('resize', function() {


### PR DESCRIPTION
Part of mysociety/fixmystreetforcouncils#10 and mysociety/fixmystreetforcouncils#11.

Todo:

- [x] Markup and javascript for dropdown on new report form, and new update form.
- [x] Get `contribute_as_another_user` and `contribute_as_council` from the user object.
- [x] Populate the "as_council" dropdown option with the council name.
- [x] Make sure switching to the council fills the correct council email address and name.
- [x] Make sure switching back to "yourself" option re-fills the correct email address and name.
- [x] Server side stuff to hook up correct information and add to report if allowed
- [x] Work without JavaScript (default email/name to editable, then deal appropriately on server?)
- [x] If reporting as another user/council, auto-confirm the report
- [x] Decide what email to use for 'reporting as council' - do we just use the logged in person's account, setting the name to the council and not subscribing them to an alert? That should work, does it have any issues?
- [x] If reporting as someone else, send them a notification email
- [x] Tests

![dropdown](https://cloud.githubusercontent.com/assets/739624/17371098/9a55c806-5996-11e6-9602-cf1cf58f8cdb.gif)