### PR TITLE
HTML email fixes

### DIFF
--- a/perllib/FixMyStreet/App.pm
+++ b/perllib/FixMyStreet/App.pm
@@ -338,7 +338,8 @@ sub send_email {
     $data->{_html_images_} = \@inline_images if @inline_images;
 
     my $email = mySociety::Locale::in_gb_locale { FixMyStreet::Email::construct_email($data) };
-    $c->model('EmailSend')->send($email);
+    my $return = $c->model('EmailSend')->send($email);
+    $c->log->error("$return") if !$return;
 
     return $email;
 }

--- a/templates/email/default/_email_bottom.html
+++ b/templates/email/default/_email_bottom.html
@@ -1,11 +1,11 @@
           </tr>
           <tr>
             <th colspan="[% email_columns %]" style="[% td_style %][% hint_style %]" class="hint">
-              [% IF email_footer %]
+              [%~ IF email_footer %]
                 [% email_footer %]
-              [% ELSE %]
+              [%~ ELSE %]
                 This email was sent automatically, from an unmonitored email account. Please do not reply to it.
-              [% END %]
+              [%~ END %]
             </th>
           </tr>
         </table>

--- a/templates/email/default/_email_comment_list.html
+++ b/templates/email/default/_email_comment_list.html
@@ -1,13 +1,13 @@
 [% FOR update IN data %]
     <div style="[% list_item_style %]">
-    [% IF update.item_photo %]
+    [%~ IF update.item_photo %]
       <a href="[% problem_url %]">
         <img style="[% list_item_photo_style %]" src="[% inline_image(update.get_first_image_fp) %]" alt="">
       </a>
-    [% END %]
+    [%~ END %]
       <p style="[% list_item_p_style %]">&ldquo;[% update.item_text | html %]&rdquo;</p>
       <p style="[% list_item_date_style %]">
-        [% update.item_name | html IF update.item_name AND NOT update.item_anonymous -%]
+        [%~ update.item_name | html IF update.item_name AND NOT update.item_anonymous -%]
         [% '(' _ cobrand.prettify_dt(update.confirmed) _ ') ' IF cobrand.include_time_in_update_alerts -%]
       </p>
     </div>

--- a/templates/email/default/_email_settings.html
+++ b/templates/email/default/_email_settings.html
@@ -65,8 +65,8 @@ link_hover_style = "text-decoration: none; color: $link_hover_text_color;"
 
 td_style = "font-family: $body_font_family; font-size: 16px; line-height: 21px; font-weight: normal; text-align: left;"
 
-body_style = "margin: 0; background: $body_background_color;"
-wrapper_style = "$td_style background: $body_background_color;"
+body_style = "margin: 0;"
+wrapper_style = "$td_style background: $body_background_color; color: $body_text_color;"
 
 hint_style = "padding: ${ column_padding }px 0; color: $body_text_color; font-size: 12px; line-height: 18px;"
 header_style = "padding: $header_padding; background: $header_background_color; color: $header_text_color;"

--- a/templates/email/default/_email_sidebar.html
+++ b/templates/email/default/_email_sidebar.html
@@ -1,0 +1,10 @@
+[% DEFAULT report = object ~%]
+<th style="[% td_style %][% secondary_column_style %]" id="secondary_column">
+  <img style="[% map_image_style %]" src="[% inline_image(report.static_map, 'map.jpeg') %]" width="310" height="200" alt="">
+  [% start_padded_box %]
+    [%~ IF object.photo %]
+      <img style="[% preview_photo_style %]" src="[% inline_image(object.get_first_image_fp) %]" alt="" align="right">
+    [%~ END %]
+    [%~ content %]
+  [% end_padded_box %]
+</th>

--- a/templates/email/default/_email_top.html
+++ b/templates/email/default/_email_top.html
@@ -14,7 +14,7 @@
   <title></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <style type="text/css">
-  [% # Styles here will be applied by everything except Gmail.com %]
+  [%~ # Styles here will be applied by everything except Gmail.com %]
   a { [% link_style %] }
   a:hover { [% link_hover_style %] }
 
@@ -22,7 +22,7 @@
     font-family: [% body_font_family %] !important;
   }
 
-  [% # 550px = 5+5+5+520+5+5+5 %]
+  [%~ # 550px = 5+5+5+520+5+5+5 %]
   @media only screen and (max-width: 549px) {
     #main {
       min-width: 0 !important;
@@ -58,7 +58,7 @@
                 <img src="[% inline_image('web/cobrands/' _ img_dir _ '/images/email-logo.gif') %]" width="[% logo_width %]" height="[% logo_height %]" alt="[% site_name %]" style="[% logo_style %]"/>
               [%~ ELSE ~%]
                 <span style="[% logo_style %]">[% site_name %]</span>
-              [% END %]
+              [%~ END %]
             </th>
           </tr>
           <tr>

--- a/templates/email/default/alert-problem-area.html
+++ b/templates/email/default/alert-problem-area.html
@@ -11,7 +11,7 @@ INCLUDE '_email_top.html';
 
 <th style="[% td_style %][% only_column_style %]">
   <h1 style="[% h1_style %]">New reports in [% area_name %]</h1>
-  [% INCLUDE '_email_report_list.html' %]
+  [%~ INCLUDE '_email_report_list.html' %]
 
   <p style="[% p_style %]"><a href="[% unsubscribe_url %]">Unsubscribe from alerts about new reports in this area</a></p>
 </th>

--- a/templates/email/default/alert-problem-council.html
+++ b/templates/email/default/alert-problem-council.html
@@ -11,7 +11,7 @@ INCLUDE '_email_top.html';
 
 <th style="[% td_style %][% only_column_style %]">
   <h1 style="[% h1_style %]">New reports to [% area_name %]</h1>
-  [% INCLUDE '_email_report_list.html' %]
+  [%~ INCLUDE '_email_report_list.html' %]
 
   <p style="[% p_style %]"><a href="[% unsubscribe_url %]">Unsubscribe from alerts about new reports to this area</a></p>
 </th>

--- a/templates/email/default/alert-problem-nearby.html
+++ b/templates/email/default/alert-problem-nearby.html
@@ -11,7 +11,7 @@ INCLUDE '_email_top.html';
 
 <th style="[% td_style %][% only_column_style %]">
   <h1 style="[% h1_style %]">New reports within your area</h1>
-  [% INCLUDE '_email_report_list.html' %]
+  [%~ INCLUDE '_email_report_list.html' %]
 
   <p style="[% p_style %]"><a href="[% unsubscribe_url %]">Unsubscribe from alerts about new reports in this area</a></p>
 </th>

--- a/templates/email/default/alert-problem-ward.html
+++ b/templates/email/default/alert-problem-ward.html
@@ -11,7 +11,7 @@ INCLUDE '_email_top.html';
 
 <th style="[% td_style %][% only_column_style %]">
     <h1 style="[% h1_style %]">New reports to [% area_name %] within [% ward_name %]</h1>
-  [% INCLUDE '_email_report_list.html' %]
+  [%~ INCLUDE '_email_report_list.html' %]
 
   <p style="[% p_style %]"><a href="[% unsubscribe_url %]">Unsubscribe from alerts about new reports in this area</a></p>
 </th>

--- a/templates/email/default/alert-problem.html
+++ b/templates/email/default/alert-problem.html
@@ -11,7 +11,7 @@ INCLUDE '_email_top.html';
 
 <th style="[% td_style %][% only_column_style %]">
   <h1 style="[% h1_style %]">New reports on [% site_name %]</h1>
-  [% INCLUDE '_email_report_list.html' %]
+  [%~ INCLUDE '_email_report_list.html' %]
 
   <p style="[% p_style %]"><a href="[% unsubscribe_url %]">Unsubscribe from alerts about new [% site_name %] reports</a></p>
 </th>

--- a/templates/email/default/alert-update.html
+++ b/templates/email/default/alert-update.html
@@ -17,15 +17,9 @@ INCLUDE '_email_top.html';
   <p style="[% p_style %]"><a href="[% unsubscribe_url %]">Unsubscribe from alerts about this report</a></p>
   [% end_padded_box %]
 </th>
-<th style="[% td_style %][% secondary_column_style %]" id="secondary_column">
-  <img style="[% map_image_style %]" src="[% inline_image(report.static_map, 'map.jpeg') %]" width="310" height="200" alt="">
-  [% start_padded_box %]
-  [%~ IF photo %]
-    <img style="[% preview_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="" align="right">
-  [%~ END %]
+[% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% title | html %]</h2>
     <p style="[% secondary_p_style %]">[% detail | html %]</p>
-  [% end_padded_box %]
-</th>
+[% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/alert-update.html
+++ b/templates/email/default/alert-update.html
@@ -13,16 +13,16 @@ INCLUDE '_email_top.html';
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
   [% start_padded_box %]
   <h1 style="[% h1_style %]">New updates on <a href="[% problem_url %]">[% title %]</a></h1>
-  [% INCLUDE '_email_comment_list.html' %]
+  [%~ INCLUDE '_email_comment_list.html' %]
   <p style="[% p_style %]"><a href="[% unsubscribe_url %]">Unsubscribe from alerts about this report</a></p>
   [% end_padded_box %]
 </th>
 <th style="[% td_style %][% secondary_column_style %]" id="secondary_column">
   <img style="[% map_image_style %]" src="[% inline_image(report.static_map, 'map.jpeg') %]" width="310" height="200" alt="">
   [% start_padded_box %]
-  [% IF photo %]
+  [%~ IF photo %]
     <img style="[% preview_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="" align="right">
-  [% END %]
+  [%~ END %]
     <h2 style="[% h2_style %]">[% title | html %]</h2>
     <p style="[% secondary_p_style %]">[% detail | html %]</p>
   [% end_padded_box %]

--- a/templates/email/default/contact.html
+++ b/templates/email/default/contact.html
@@ -26,13 +26,13 @@ INCLUDE '_email_top.html';
 <th style="[% td_style %][% only_column_style %]">
   <h1 style="[% h1_style %]">[% subject | html %]</h1>
   <p style="[% p_style %]">[% message | html %]</p>
-  [% IF complaint %]
+  [%~ IF complaint %]
   <p style="[% secondary_p_style %]">
     [% complaint | html %]
     - <a href="[% problem_url %]">Report</a>
     - <a href="[% admin_url %]">Admin</a>
   </p>
-  [% END %]
+  [%~ END %]
 </th>
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/contact.html
+++ b/templates/email/default/contact.html
@@ -3,6 +3,7 @@
 subject_html = subject | html;
 name = form_name | html;
 email_summary = "&ldquo;" _ subject_html _ "&rdquo; &ndash; Message from " _ name _ " on " _ host;
+email_footer = "Sent via " _ host _ ", IP " _ ip;
 email_columns = 1;
 
 PROCESS '_email_settings.html';
@@ -16,14 +17,6 @@ INCLUDE '_email_top.html';
     <tr>
       <th style="[% contact_th_style %]">From</th>
       <td style="[% contact_td_style %]">[% name %] &lt;<a href="mailto:[% em | html %]">[% em | html %]</a>&gt;</td>
-    </tr>
-    <tr>
-      <th style="[% contact_th_style %]">IP address</th>
-      <td style="[% contact_td_style %]">[% ip %]</td>
-    </tr>
-    <tr>
-      <th style="[% contact_th_style %]">To</th>
-      <td style="[% contact_td_style %]">[% host %] administrators</td>
     </tr>
   </table>
 </th>

--- a/templates/email/default/problem-confirm-not-sending.html
+++ b/templates/email/default/problem-confirm-not-sending.html
@@ -25,9 +25,9 @@ council.</p>
 <th style="[% td_style %][% secondary_column_style %]" id="secondary_column">
   <img style="[% map_image_style %]" src="[% inline_image(report.static_map, 'map.jpeg') %]" width="310" height="200" alt="">
   [% start_padded_box %]
-  [% IF report.photo %]
+  [%~ IF report.photo %]
     <img style="[% preview_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="" align="right">
-  [% END %]
+  [%~ END %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
     <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
   [% end_padded_box %]

--- a/templates/email/default/problem-confirm-not-sending.html
+++ b/templates/email/default/problem-confirm-not-sending.html
@@ -22,15 +22,9 @@ council.</p>
   <p style="[% p_style %]">If you no longer wish to publish this report, please take no further action.</p>
   [% end_padded_box %]
 </th>
-<th style="[% td_style %][% secondary_column_style %]" id="secondary_column">
-  <img style="[% map_image_style %]" src="[% inline_image(report.static_map, 'map.jpeg') %]" width="310" height="200" alt="">
-  [% start_padded_box %]
-  [%~ IF report.photo %]
-    <img style="[% preview_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="" align="right">
-  [%~ END %]
+[% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
     <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
-  [% end_padded_box %]
-</th>
+[% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/problem-confirm.html
+++ b/templates/email/default/problem-confirm.html
@@ -28,9 +28,9 @@ of problem, so it will instead be sent to [% report.body %].
 <th style="[% td_style %][% secondary_column_style %]" id="secondary_column">
   <img style="[% map_image_style %]" src="[% inline_image(report.static_map, 'map.jpeg') %]" width="310" height="200" alt="">
   [% start_padded_box %]
-  [% IF report.photo %]
+  [%~ IF report.photo %]
     <img style="[% preview_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="" align="right">
-  [% END %]
+  [%~ END %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
     <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
   [% end_padded_box %]

--- a/templates/email/default/problem-confirm.html
+++ b/templates/email/default/problem-confirm.html
@@ -25,15 +25,9 @@ of problem, so it will instead be sent to [% report.body %].
   <p style="[% p_style %]">If you no longer wish to send this report, please take no further action.</p>
   [% end_padded_box %]
 </th>
-<th style="[% td_style %][% secondary_column_style %]" id="secondary_column">
-  <img style="[% map_image_style %]" src="[% inline_image(report.static_map, 'map.jpeg') %]" width="310" height="200" alt="">
-  [% start_padded_box %]
-  [%~ IF report.photo %]
-    <img style="[% preview_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="" align="right">
-  [%~ END %]
+[% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
     <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
-  [% end_padded_box %]
-</th>
+[% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/problem-moderated.html
+++ b/templates/email/default/problem-moderated.html
@@ -27,9 +27,9 @@ the team at <a href="[% report_complain_uri %]">[% report_complain_uri %]</a></p
 <th style="[% td_style %][% secondary_column_style %]" id="secondary_column">
   <img style="[% map_image_style %]" src="[% inline_image(problem.static_map, 'map.jpeg') %]" width="310" height="200" alt="">
   [% start_padded_box %]
-  [% IF problem.photo %]
+  [%~ IF problem.photo %]
     <img style="[% preview_photo_style %]" src="[% inline_image(problem.get_first_image_fp) %]" alt="" align="right">
-  [% END %]
+  [%~ END %]
     <h2 style="[% h2_style %]">[% problem.moderation_original_data.title | html %]</h2>
     <p style="[% secondary_p_style %]">[% problem.moderation_original_data.detail | html %]</p>
   [% end_padded_box %]

--- a/templates/email/default/problem-moderated.html
+++ b/templates/email/default/problem-moderated.html
@@ -24,15 +24,9 @@ INCLUDE '_email_top.html';
 the team at <a href="[% report_complain_uri %]">[% report_complain_uri %]</a></p>
   [% end_padded_box %]
 </th>
-<th style="[% td_style %][% secondary_column_style %]" id="secondary_column">
-  <img style="[% map_image_style %]" src="[% inline_image(problem.static_map, 'map.jpeg') %]" width="310" height="200" alt="">
-  [% start_padded_box %]
-  [%~ IF problem.photo %]
-    <img style="[% preview_photo_style %]" src="[% inline_image(problem.get_first_image_fp) %]" alt="" align="right">
-  [%~ END %]
+[% WRAPPER '_email_sidebar.html' object = problem %]
     <h2 style="[% h2_style %]">[% problem.moderation_original_data.title | html %]</h2>
     <p style="[% secondary_p_style %]">[% problem.moderation_original_data.detail | html %]</p>
-  [% end_padded_box %]
-</th>
+[% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/questionnaire.html
+++ b/templates/email/default/questionnaire.html
@@ -22,15 +22,9 @@ INCLUDE '_email_top.html';
   <p style="[% p_style %]">Thank you! Your feedback is really valuable.</p>
   [% end_padded_box %]
 </th>
-<th style="[% td_style %][% secondary_column_style %]" id="secondary_column">
-  <img style="[% map_image_style %]" src="[% inline_image(report.static_map, 'map.jpeg') %]" width="310" height="200" alt="">
-  [% start_padded_box %]
-  [%~ IF report.photo %]
-    <img style="[% preview_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="" align="right">
-  [%~ END %]
+[% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% title %]</h2>
     <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
-  [% end_padded_box %]
-</th>
+[% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/questionnaire.html
+++ b/templates/email/default/questionnaire.html
@@ -25,9 +25,9 @@ INCLUDE '_email_top.html';
 <th style="[% td_style %][% secondary_column_style %]" id="secondary_column">
   <img style="[% map_image_style %]" src="[% inline_image(report.static_map, 'map.jpeg') %]" width="310" height="200" alt="">
   [% start_padded_box %]
-  [% IF report.photo %]
+  [%~ IF report.photo %]
     <img style="[% preview_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="" align="right">
-  [% END %]
+  [%~ END %]
     <h2 style="[% h2_style %]">[% title %]</h2>
     <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
   [% end_padded_box %]

--- a/templates/email/default/submit.html
+++ b/templates/email/default/submit.html
@@ -39,12 +39,7 @@ of a local problem that they believe might require your attention.</p>
   <p style="[% p_style %] margin-top: 0.5em;">Replies to this message will go directly to [% name | html %], the user who reported the problem.</p>
   [% end_padded_box %]
 </th>
-<th style="[% td_style %][% secondary_column_style %]" id="secondary_column">
-  <img style="[% map_image_style %]" src="[% inline_image(report.static_map, 'map.jpeg') %]" width="310" height="200" alt="">
-  [% start_padded_box %]
-  [%~ IF has_photo %]
-    <img style="[% preview_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="" align="right">
-  [%~ END %]
+[% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% title | html %]</h2>
     [%~ IF category_line %]
     <p style="[% secondary_p_style %]">[% category | html %]</p>
@@ -57,7 +52,6 @@ of a local problem that they believe might require your attention.</p>
       </a>
       [% IF closest_address %]<br>[% closest_address | trim | replace("\n\n", "<br>") %][% END %]
     </p>
-  [% end_padded_box %]
-</th>
+[% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/submit.html
+++ b/templates/email/default/submit.html
@@ -29,12 +29,12 @@ of a local problem that they believe might require your attention.</p>
       <th style="[% contact_th_style %]">Email</th>
       <td style="[% contact_td_style %]"><a href="mailto:[% email | html %]">[% email | html %]</a></td>
     </tr>
-    [% IF phone %]
+    [%~ IF phone %]
       <tr>
         <th style="[% contact_th_style %]">Phone</th>
         <td style="[% contact_td_style %]"><a href="tel:[% phone | html %]">[% phone | html %]</a></td>
       </tr>
-    [% END %]
+    [%~ END %]
   </table>
   <p style="[% p_style %] margin-top: 0.5em;">Replies to this message will go directly to [% name | html %], the user who reported the problem.</p>
   [% end_padded_box %]
@@ -42,13 +42,13 @@ of a local problem that they believe might require your attention.</p>
 <th style="[% td_style %][% secondary_column_style %]" id="secondary_column">
   <img style="[% map_image_style %]" src="[% inline_image(report.static_map, 'map.jpeg') %]" width="310" height="200" alt="">
   [% start_padded_box %]
-  [% IF has_photo %]
+  [%~ IF has_photo %]
     <img style="[% preview_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="" align="right">
-  [% END %]
+  [%~ END %]
     <h2 style="[% h2_style %]">[% title | html %]</h2>
-    [% IF category_line %]
+    [%~ IF category_line %]
     <p style="[% secondary_p_style %]">[% category | html %]</p>
-    [% END %]
+    [%~ END %]
     <p style="[% secondary_p_style %]">[% detail | html %]</p>
     <p style="[% secondary_p_style %]">
       <strong>Location:</strong>

--- a/templates/email/default/update-confirm.html
+++ b/templates/email/default/update-confirm.html
@@ -23,9 +23,9 @@ INCLUDE '_email_top.html';
 <th style="[% td_style %][% secondary_column_style %]" id="secondary_column">
   <img style="[% map_image_style %]" src="[% inline_image(problem.static_map, 'map.jpeg') %]" width="310" height="200" alt="">
   [% start_padded_box %]
-  [% IF update.photo %]
+  [%~ IF update.photo %]
     <img style="[% preview_photo_style %]" src="[% inline_image(update.get_first_image_fp) %]" alt="" align="right">
-  [% END %]
+  [%~ END %]
     <p style="[% secondary_p_style %]">[% update.text | html %]</p>
   [% end_padded_box %]
 </th>

--- a/templates/email/default/update-confirm.html
+++ b/templates/email/default/update-confirm.html
@@ -20,14 +20,10 @@ INCLUDE '_email_top.html';
   <p style="[% p_style %]">If you no longer wish to confirm this update, please take no further action.</p>
   [% end_padded_box %]
 </th>
-<th style="[% td_style %][% secondary_column_style %]" id="secondary_column">
-  <img style="[% map_image_style %]" src="[% inline_image(problem.static_map, 'map.jpeg') %]" width="310" height="200" alt="">
-  [% start_padded_box %]
-  [%~ IF update.photo %]
-    <img style="[% preview_photo_style %]" src="[% inline_image(update.get_first_image_fp) %]" alt="" align="right">
-  [%~ END %]
+[% WRAPPER '_email_sidebar.html'
+    object = update
+    report = problem %]
     <p style="[% secondary_p_style %]">[% update.text | html %]</p>
-  [% end_padded_box %]
-</th>
+[% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/fixmystreet.com/submit.html
+++ b/templates/email/fixmystreet.com/submit.html
@@ -39,12 +39,7 @@ of a local problem that they believe might require your attention.</p>
   <p style="[% p_style %] margin-top: 0.5em;">Replies to this message will go directly to [% name | html %], the user who reported the problem.</p>
   [% end_padded_box %]
 </th>
-<th style="[% td_style %][% secondary_column_style %]" id="secondary_column">
-  <img style="[% map_image_style %]" src="[% inline_image(report.static_map, 'map.jpeg') %]" width="310" height="200" alt="">
-  [% start_padded_box %]
-  [%~ IF has_photo %]
-    <img style="[% preview_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="" align="right">
-  [%~ END %]
+[% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% title | html %]</h2>
     [%~ IF category_line %]
     <p style="[% secondary_p_style %]">[% category | html %]</p>
@@ -63,7 +58,6 @@ of a local problem that they believe might require your attention.</p>
       </a>)
       [% IF closest_address %]<br>[% closest_address | trim | replace("\n\n", "<br>") %][% END %]
     </p>
-  [% end_padded_box %]
-</th>
+[% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/fixmystreet.com/submit.html
+++ b/templates/email/fixmystreet.com/submit.html
@@ -29,12 +29,12 @@ of a local problem that they believe might require your attention.</p>
       <th style="[% contact_th_style %]">Email</th>
       <td style="[% contact_td_style %]"><a href="mailto:[% email | html %]">[% email | html %]</a></td>
     </tr>
-    [% IF phone %]
+    [%~ IF phone %]
       <tr>
         <th style="[% contact_th_style %]">Phone</th>
         <td style="[% contact_td_style %]"><a href="tel:[% phone | html %]">[% phone | html %]</a></td>
       </tr>
-    [% END %]
+    [%~ END %]
   </table>
   <p style="[% p_style %] margin-top: 0.5em;">Replies to this message will go directly to [% name | html %], the user who reported the problem.</p>
   [% end_padded_box %]
@@ -42,17 +42,17 @@ of a local problem that they believe might require your attention.</p>
 <th style="[% td_style %][% secondary_column_style %]" id="secondary_column">
   <img style="[% map_image_style %]" src="[% inline_image(report.static_map, 'map.jpeg') %]" width="310" height="200" alt="">
   [% start_padded_box %]
-  [% IF has_photo %]
+  [%~ IF has_photo %]
     <img style="[% preview_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="" align="right">
-  [% END %]
+  [%~ END %]
     <h2 style="[% h2_style %]">[% title | html %]</h2>
-    [% IF category_line %]
+    [%~ IF category_line %]
     <p style="[% secondary_p_style %]">[% category | html %]</p>
-    [% END %]
+    [%~ END %]
     <p style="[% secondary_p_style %]">[% detail | html %]</p>
-    [% IF additional_information %]
+    [%~ IF additional_information %]
     <p style="[% secondary_p_style %]">[% additional_information %]</p>
-    [% END %]
+    [%~ END %]
     <p style="[% secondary_p_style %]">
       <strong>Location:</strong>
       <br>Easting/Northing


### PR DESCRIPTION
* White body background for HTML emails (avoids illegible replies in Outlook)
* Tweak contact HTML footer.
* Log email sending failure from site
* Try and remove all end line spaces from emails
* Factor out sidebar to template

Fixes #1469.