### PR TITLE
[UK] Record map zoom when clicking map to make new report

### DIFF
--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -746,6 +746,12 @@ OpenLayers.Control.Click = OpenLayers.Class(OpenLayers.Control, {
 
         if ( typeof ga !== 'undefined' && window.cobrand == 'fixmystreet' ) {
             ga('send', 'pageview', { 'page': '/map_click' } );
+            ga('send', {
+                hitType: 'event',
+                eventCategory: 'Map',
+                eventAction: 'click',
+                eventLabel: 'zoom level ' + fixmystreet.map.getZoom()
+            });
         }
     }
 });


### PR DESCRIPTION
Discussion around https://github.com/mysociety/fixmystreetforcouncils/issues/41 raised the question of what zoom level people are creating reports from.

This would be super handy data to collect.

We already track map clicks by sending a fake `/map_click` pageview to Google Analytics. Really this should be an event rather than a fake pageview – but we've got a goal already set up based on it being a pageview, so I'm introducing the event *alongside* the pageview. This way, we can record them both in tandem for a while, and then, later, change the Goal to monitor for the event, and remove the fake pageview.