### PR TITLE
Response template management

### DIFF
--- a/bin/update-schema
+++ b/bin/update-schema
@@ -194,6 +194,7 @@ else {
 # By querying the database schema, we can see where we're currently at
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
+    return '0044' if table_exists('contact_response_templates');
     return '0043' if column_exists('users', 'area_id');
     return '0042' if table_exists('user_planned_reports');
     return '0041' if column_exists('users', 'is_superuser') && ! constraint_exists('user_body_permissions_permission_type_check');

--- a/db/downgrade_0044---0043.sql
+++ b/db/downgrade_0044---0043.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE response_templates DROP COLUMN auto_response;
+
+DROP TABLE contact_response_templates;
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -473,5 +473,12 @@ create table response_templates (
     title text not null,
     text text not null,
     created timestamp not null default current_timestamp,
+    auto_response boolean NOT NULL DEFAULT 'f',
     unique(body_id, title)
+);
+
+CREATE TABLE contact_response_templates (
+    id serial NOT NULL PRIMARY KEY,
+    contact_id int REFERENCES contacts(id) NOT NULL,
+    response_template_id int REFERENCES response_templates(id) NOT NULL
 );

--- a/db/schema_0044-contact_response_templates.sql
+++ b/db/schema_0044-contact_response_templates.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+CREATE TABLE contact_response_templates (
+    id serial NOT NULL PRIMARY KEY,
+    contact_id int REFERENCES contacts(id) NOT NULL,
+    response_template_id int REFERENCES response_templates(id) NOT NULL
+);
+
+ALTER TABLE response_templates
+  ADD COLUMN auto_response boolean NOT NULL DEFAULT 'f';
+
+COMMIT;

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -982,9 +982,8 @@ sub load_template_body : Private {
     my ($self, $c, $body_id) = @_;
 
     my $zurich_user = $c->user->from_body && $c->cobrand->moniker eq 'zurich';
-    my $has_permission = $c->user->from_body &&
-                         $c->user->from_body->id eq $body_id &&
-                         $c->user->has_permission_to('template_edit', $body_id);
+    my $has_permission = $c->user->has_body_permission_to('template_edit') &&
+                         $c->user->from_body->id eq $body_id;
 
     unless ( $c->user->is_superuser || $zurich_user || $has_permission ) {
         $c->detach( '/page_error_404_not_found' );
@@ -1212,7 +1211,7 @@ sub user_edit : Path('user_edit') : Args(1) {
     my $user = $c->cobrand->users->find( { id => $id } );
     $c->detach( '/page_error_404_not_found' ) unless $user;
 
-    unless ( $c->user->is_superuser || ( $c->user->has_permission_to('user_edit', $c->user->from_body->id) ) ) {
+    unless ( $c->user->is_superuser || $c->user->has_body_permission_to('user_edit') ) {
         $c->detach('/page_error_403_access_denied', []);
     }
 
@@ -1249,7 +1248,7 @@ sub user_edit : Path('user_edit') : Args(1) {
         # set from_body to the same value as their own from_body.
         if ( $c->user->is_superuser ) {
             $user->from_body( $c->get_param('body') || undef );
-        } elsif ( $c->user->has_permission_to('user_assign_body', $c->user->from_body->id ) &&
+        } elsif ( $c->user->has_body_permission_to('user_assign_body') &&
                   $c->get_param('body') && $c->get_param('body') eq $c->user->from_body->id ) {
             $user->from_body( $c->user->from_body );
         } else {

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -309,7 +309,7 @@ sub body : Path('body') : Args(1) {
         $c->forward('update_contacts');
     }
 
-    $c->forward('display_contacts');
+    $c->forward('fetch_contacts');
 
     return 1;
 }
@@ -457,14 +457,14 @@ sub check_body_params : Private {
     }
 }
 
-sub display_contacts : Private {
+sub fetch_contacts : Private {
     my ( $self, $c ) = @_;
 
     my $contacts = $c->stash->{body}->contacts->search(undef, { order_by => [ 'category' ] } );
     $c->stash->{contacts} = $contacts;
     $c->stash->{live_contacts} = $contacts->search({ deleted => 0 });
 
-    if ( $c->get_param('text') && $c->get_param('text') == 1 ) {
+    if ( $c->get_param('text') && $c->get_param('text') eq '1' ) {
         $c->stash->{template} = 'admin/council_contacts.txt';
         $c->res->content_type('text/plain; charset=utf-8');
         return 1;
@@ -893,71 +893,25 @@ sub categories_for_point : Private {
 sub templates : Path('templates') : Args(0) {
     my ( $self, $c ) = @_;
 
-    $c->detach( '/page_error_404_not_found' )
-        unless $c->cobrand->moniker eq 'zurich';
-
     my $user = $c->user;
 
-    $self->templates_for_body($c, $user->from_body );
+    if ($user->is_superuser) {
+        $c->forward('fetch_all_bodies');
+        $c->stash->{template} = 'admin/templates_index.html';
+    } elsif ( $user->from_body ) {
+        $c->forward('load_template_body', [ $user->from_body->id ]);
+        $c->res->redirect( $c->uri_for( 'templates', $c->stash->{body}->id ) );
+    } else {
+        $c->detach( '/page_error_404_not_found' );
+    }
 }
 
 sub templates_view : Path('templates') : Args(1) {
     my ($self, $c, $body_id) = @_;
 
-    $c->detach( '/page_error_404_not_found' )
-        unless $c->cobrand->moniker eq 'zurich';
+    $c->forward('load_template_body', [ $body_id ]);
 
-    # e.g. for admin
-
-    my $body = $c->model('DB::Body')->find($body_id)
-        or $c->detach( '/page_error_404_not_found' );
-
-    $self->templates_for_body($c, $body);
-}
-
-sub template_edit : Path('templates') : Args(2) {
-    my ( $self, $c, $body_id, $template_id ) = @_;
-
-    $c->detach( '/page_error_404_not_found' )
-        unless $c->cobrand->moniker eq 'zurich';
-
-    my $body = $c->model('DB::Body')->find($body_id)
-        or $c->detach( '/page_error_404_not_found' );
-    $c->stash->{body} = $body;
-
-    my $template;
-    if ($template_id eq 'new') {
-        $template = $body->response_templates->new({});
-    }
-    else {
-        $template = $body->response_templates->find( $template_id )
-            or $c->detach( '/page_error_404_not_found' );
-    }
-
-    if ($c->req->method eq 'POST') {
-        if ($c->get_param('delete_template') eq _("Delete template")) {
-            $template->delete;
-        } else {
-            $template->title( $c->get_param('title') );
-            $template->text ( $c->get_param('text') );
-            $template->update_or_insert;
-        }
-
-        $c->res->redirect( $c->uri_for( 'templates', $body->id ) );
-    }
-
-    $c->stash->{response_template} = $template;
-
-    $c->stash->{template} = 'admin/template_edit.html';
-}
-
-
-sub templates_for_body {
-    my ( $self, $c, $body ) = @_;
-
-    $c->stash->{body} = $body;
-
-    my @templates = $body->response_templates->search(
+    my @templates = $c->stash->{body}->response_templates->search(
         undef,
         {
             order_by => 'title'
@@ -967,6 +921,82 @@ sub templates_for_body {
     $c->stash->{response_templates} = \@templates;
 
     $c->stash->{template} = 'admin/templates.html';
+}
+
+sub template_edit : Path('templates') : Args(2) {
+    my ( $self, $c, $body_id, $template_id ) = @_;
+
+    $c->forward('load_template_body', [ $body_id ]);
+
+    my $template;
+    if ($template_id eq 'new') {
+        $template = $c->stash->{body}->response_templates->new({});
+    }
+    else {
+        $template = $c->stash->{body}->response_templates->find( $template_id )
+            or $c->detach( '/page_error_404_not_found' );
+    }
+
+    $c->forward('fetch_contacts');
+    my @contacts = $template->contacts->all;
+    my @live_contacts = $c->stash->{live_contacts}->all;
+    my %active_contacts = map { $_->id => 1 } @contacts;
+    my @all_contacts = map { {
+        id => $_->id,
+        category => $_->category,
+        active => $active_contacts{$_->id},
+    } } @live_contacts;
+    $c->stash->{contacts} = \@all_contacts;
+
+    if ($c->req->method eq 'POST') {
+        if ($c->get_param('delete_template') && $c->get_param('delete_template') eq _("Delete template")) {
+            $template->contact_response_templates->delete_all;
+            $template->delete;
+        } else {
+            $template->title( $c->get_param('title') );
+            $template->text( $c->get_param('text') );
+            $template->auto_response( $c->get_param('auto_response') ? 1 : 0 );
+            $template->update_or_insert;
+
+            my @live_contact_ids = map { $_->id } @live_contacts;
+            my @new_contact_ids = grep { $c->get_param("contacts[$_]") } @live_contact_ids;
+            $template->contact_response_templates->search({
+                contact_id => { '!=' => \@new_contact_ids },
+            })->delete;
+            foreach my $contact_id (@new_contact_ids) {
+                $template->contact_response_templates->find_or_create({
+                    contact_id => $contact_id,
+                });
+            }
+        }
+
+        $c->res->redirect( $c->uri_for( 'templates', $c->stash->{body}->id ) );
+    }
+
+    $c->stash->{response_template} = $template;
+
+    $c->stash->{template} = 'admin/template_edit.html';
+}
+
+sub load_template_body : Private {
+    my ($self, $c, $body_id) = @_;
+
+    my $zurich_user = $c->user->from_body && $c->cobrand->moniker eq 'zurich';
+    my $has_permission = $c->user->from_body &&
+                         $c->user->from_body->id eq $body_id &&
+                         $c->user->has_permission_to('template_edit', $body_id);
+
+    unless ( $c->user->is_superuser || $zurich_user || $has_permission ) {
+        $c->detach( '/page_error_404_not_found' );
+    }
+
+    # Regular users can only view their own body's templates
+    if ( !$c->user->is_superuser && $body_id ne $c->user->from_body->id ) {
+        $c->res->redirect( $c->uri_for( 'templates', $c->user->from_body->id ) );
+    }
+
+    $c->stash->{body} = $c->model('DB::Body')->find($body_id)
+        or $c->detach( '/page_error_404_not_found' );
 }
 
 sub users: Path('users') : Args(0) {

--- a/perllib/FixMyStreet/App/Controller/My.pm
+++ b/perllib/FixMyStreet/App/Controller/My.pm
@@ -41,7 +41,7 @@ sub planned : Local : Args(0) {
     my ( $self, $c ) = @_;
 
     $c->detach('/page_error_403_access_denied', [])
-        unless $c->user->from_body && $c->user->has_permission_to('planned_reports', $c->user->from_body->id);
+        unless $c->user->has_body_permission_to('planned_reports');
 
     $c->stash->{problems_rs} = $c->user->active_planned_reports;
     $c->forward('get_problems');

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -646,7 +646,7 @@ sub admin_pages {
          'summary' => [_('Summary'), 0],
          'bodies' => [_('Bodies'), 1],
          'reports' => [_('Reports'), 2],
-         'timeline' => [_('Timeline'), 3],
+         'timeline' => [_('Timeline'), 4],
          'users' => [_('Users'), 5],
          'flagged'  => [_('Flagged'), 6],
          'stats'  => [_('Stats'), 7],
@@ -661,6 +661,12 @@ sub admin_pages {
     if ( $user->is_superuser ) {
         $pages->{config} = [ _('Configuration'), 8];
     };
+    # And some that need special permissions
+    if ( $user->is_superuser || $user->has_body_permission_to('template_edit') ) {
+        $pages->{templates} = [_('Templates'), 3],
+        $pages->{template_edit} = [undef, undef],
+    };
+
 
     return $pages;
 }
@@ -710,6 +716,9 @@ sub available_permissions {
             user_manage_permissions => _("Edit other users' permissions"),
             user_assign_body => _("Grant access to the admin"),
             user_assign_areas => _("Assign users to areas"), # future use
+        },
+        _("Bodies") => {
+            template_edit => _("Add/edit response templates"),
         },
     };
 }

--- a/perllib/FixMyStreet/DB/Result/Contact.pm
+++ b/perllib/FixMyStreet/DB/Result/Contact.pm
@@ -55,10 +55,16 @@ __PACKAGE__->belongs_to(
   { id => "body_id" },
   { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
 );
+__PACKAGE__->has_many(
+  "contact_response_templates",
+  "FixMyStreet::DB::Result::ContactResponseTemplate",
+  { "foreign.contact_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2013-09-10 17:11:54
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:hq/BFHDEu4OUI4MSy3OyHg
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2016-08-24 11:29:04
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:CXUabm3Yd11OoIYJceSPag
 
 __PACKAGE__->load_components("+FixMyStreet::DB::RABXColumn");
 __PACKAGE__->rabx_column('extra');
@@ -67,6 +73,8 @@ use Moo;
 use namespace::clean -except => [ 'meta' ];
 
 with 'FixMyStreet::Roles::Extra';
+
+__PACKAGE__->many_to_many( response_templates => 'contact_response_templates', 'response_template' );
 
 sub get_metadata_for_input {
     my $self = shift;

--- a/perllib/FixMyStreet/DB/Result/ContactResponseTemplate.pm
+++ b/perllib/FixMyStreet/DB/Result/ContactResponseTemplate.pm
@@ -1,0 +1,46 @@
+use utf8;
+package FixMyStreet::DB::Result::ContactResponseTemplate;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+__PACKAGE__->load_components("FilterColumn", "InflateColumn::DateTime", "EncodedColumn");
+__PACKAGE__->table("contact_response_templates");
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "contact_response_templates_id_seq",
+  },
+  "contact_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
+  "response_template_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
+);
+__PACKAGE__->set_primary_key("id");
+__PACKAGE__->belongs_to(
+  "contact",
+  "FixMyStreet::DB::Result::Contact",
+  { id => "contact_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+__PACKAGE__->belongs_to(
+  "response_template",
+  "FixMyStreet::DB::Result::ResponseTemplate",
+  { id => "response_template_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2016-08-24 11:29:04
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:d6niNsxi2AsijhvJSuQeKw
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/perllib/FixMyStreet/DB/Result/ResponseTemplate.pm
+++ b/perllib/FixMyStreet/DB/Result/ResponseTemplate.pm
@@ -31,6 +31,8 @@ __PACKAGE__->add_columns(
     is_nullable   => 0,
     original      => { default_value => \"now()" },
   },
+  "auto_response",
+  { data_type => "boolean", default_value => \"false", is_nullable => 0 },
 );
 __PACKAGE__->set_primary_key("id");
 __PACKAGE__->add_unique_constraint("response_templates_body_id_title_key", ["body_id", "title"]);
@@ -40,11 +42,18 @@ __PACKAGE__->belongs_to(
   { id => "body_id" },
   { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
 );
+__PACKAGE__->has_many(
+  "contact_response_templates",
+  "FixMyStreet::DB::Result::ContactResponseTemplate",
+  { "foreign.response_template_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2016-07-20 14:38:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ECFQLMxOFGwv7cwfHLlszw
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2016-08-24 11:29:04
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:KRm0RHbtrzuxzH0S/UAsdw
 
+__PACKAGE__->many_to_many( contacts => 'contact_response_templates', 'contact' );
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 1;

--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -254,6 +254,29 @@ sub has_permission_to {
     return $permission ? 1 : undef;
 }
 
+=head2 has_body_permission_to
+
+Checks if the User has a from_body set, and the specified permission on that body.
+
+Instead of saying:
+
+    ($user->from_body && $user->has_permission_to('user_edit', $user->from_body->id))
+
+You can just say:
+
+    $user->has_body_permission_to('user_edit')
+
+NB unlike has_permission_to, this doesn't blindly return 1 if the user is a superuser.
+
+=cut
+
+sub has_body_permission_to {
+    my ($self, $permission_type) = @_;
+    return unless $self->from_body;
+
+    return $self->has_permission_to($permission_type, $self->from_body->id);
+}
+
 sub contributing_as {
     my ($self, $other, $c, $bodies) = @_;
     $bodies = join(',', keys %$bodies) if ref $bodies eq 'HASH';

--- a/perllib/FixMyStreet/TestMech.pm
+++ b/perllib/FixMyStreet/TestMech.pm
@@ -600,10 +600,19 @@ sub delete_body {
     my $body = shift;
 
     $mech->delete_problems_for_body($body->id);
-    $body->contacts->delete;
+    $mech->delete_contact($_) for $body->contacts;
     $mech->delete_user($_) for $body->users;
+    $_->delete for $body->response_templates;
     $body->body_areas->delete;
     $body->delete;
+}
+
+sub delete_contact {
+    my $mech = shift;
+    my $contact = shift;
+
+    $contact->contact_response_templates->delete_all;
+    $contact->delete;
 }
 
 sub delete_problems_for_body {

--- a/t/app/controller/admin_permissions.t
+++ b/t/app/controller/admin_permissions.t
@@ -167,7 +167,7 @@ FixMyStreet::override_config {
             "permissions[user_assign_areas]" => undef,
         } } );
 
-        ok $user2->has_permission_to("moderate", $user2->from_body->id), "user2 has been granted moderate permission";
+        ok $user2->has_body_permission_to("moderate"), "user2 has been granted moderate permission";
     };
 
     $oxfordshireuser->user_body_permissions->create({

--- a/templates/web/base/admin/response_templates_select.html
+++ b/templates/web/base/admin/response_templates_select.html
@@ -1,6 +1,6 @@
 <div class="response_templates_select">
     <select id="templates_for_[% for %]" class="js-template-name" data-for="[% for %]">
-        <option value="">[% loc('Choose a template') %]</option>
+        <option value="">[% loc('--Choose a template--') %]</option>
       [% FOR t IN problem.response_templates %]
         <option value="[% t.text | html %]"> [% t.title | html %] </option>
       [% END %]

--- a/templates/web/base/admin/template_edit.html
+++ b/templates/web/base/admin/template_edit.html
@@ -1,0 +1,50 @@
+[% INCLUDE 'admin/header.html' title=tprintf(loc('Response Template for %s'), body.name) -%]
+[% rt = response_template %]
+
+[% UNLESS rt.id %]<h3>[% loc('New template') %]</h3>[% END %]
+
+<form method="post"
+    action="[% c.uri_for('templates', body.id, rt.id || 'new' ) %]"
+    enctype="application/x-www-form-urlencoded"
+    accept-charset="utf-8"
+    class="validate">
+
+    <p>
+        <strong>[% loc('Title:') %] </strong>
+        <input type="text" name="title" class="required" size="30" value="[% rt.title| html %]">
+    </p>
+    <p>
+        <strong>[% loc('Text:') %] </strong>
+        <textarea name="text" class="required">[% rt.text |html %]</textarea>
+    </p>
+    <p>
+      <label>
+        <strong>[% loc('Auto-response:') %]</strong>
+        <input type="checkbox" name="auto_response" [% 'checked' IF rt.auto_response %] />
+      </label>
+    </p>
+    <p>
+      <strong>[% loc('Categories:') %]</strong>
+      <ul>
+        [% FOR contact IN contacts %]
+          <li>
+            <label>
+              <input type="checkbox" name="contacts[[% contact.id %]]" [% 'checked' IF contact.active %]/>
+              [% contact.category %]
+            </label>
+          </li>
+        [% END %]
+      </ul>
+    </p>
+    <p>
+      <input type="hidden" name="token" value="[% csrf_token %]" >
+      <input type="submit" name="Edit templates" value="[% rt.id ? loc('Save changes') : loc('Create template') %]" >
+    </p>
+    [% IF rt.id %]
+        <p>
+            <input class="delete" type="submit" name="delete_template" value="[% loc('Delete template') %]">
+        </p>
+    [% END %]
+</form>
+
+[% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/admin/templates.html
+++ b/templates/web/base/admin/templates.html
@@ -1,6 +1,8 @@
 [% INCLUDE 'admin/header.html' title=tprintf(loc('Response Templates for %s'), body.name) -%]
 
-<h2> [% tprintf(loc('Response Templates for %s'), body.name) %] </h2>
+[% IF c.cobrand.moniker == 'zurich' %]
+  <h2> [% tprintf(loc('Response Templates for %s'), body.name) %] </h2>
+[% END %]
 
 <table>
     <thead>

--- a/templates/web/base/admin/templates_index.html
+++ b/templates/web/base/admin/templates_index.html
@@ -1,0 +1,11 @@
+[% INCLUDE 'admin/header.html' title=loc('Response Templates') -%]
+
+<ul>
+    [% FOR body IN bodies %]
+        <li>
+            <a href="/admin/templates/[% body.id %]">[% body.name %]</a>
+        </li>
+    [% END %]
+</ul>
+
+[% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/admin/user-form.html
+++ b/templates/web/base/admin/user-form.html
@@ -49,7 +49,7 @@
                 [% loc("Staff users have permission to log in to the admin.") %]
               </p>
             </div>
-            [% loc('Staff:') %] <input type="checkbox" id="body" name="body" value="[% c.user.from_body.id %]" [% user.from_body.id == c.user.from_body.id ? ' checked' : '' %] [% 'disabled' UNLESS c.user.has_permission_to('user_assign_body', c.user.from_body.id) %]>
+            [% loc('Staff:') %] <input type="checkbox" id="body" name="body" value="[% c.user.from_body.id %]" [% user.from_body.id == c.user.from_body.id ? ' checked' : '' %] [% 'disabled' UNLESS c.user.is_superuser OR c.user.has_body_permission_to('user_assign_body') %]>
           </li>
         [% END %]
 
@@ -116,7 +116,7 @@
                 [% FOREACH permission IN group.value %]
                   <li>
                     <label>
-                      <input type="checkbox" id="perms_[% permission.key %]" name="permissions[[% permission.key %]]" [% "checked" IF user.has_permission_to(permission.key, user.from_body.id) %]>
+                      <input type="checkbox" id="perms_[% permission.key %]" name="permissions[[% permission.key %]]" [% "checked" IF user.has_body_permission_to(permission.key) %]>
                       [% permission.value %]
                     </label>
                   </li>

--- a/templates/web/base/admin/users.html
+++ b/templates/web/base/admin/users.html
@@ -25,7 +25,7 @@
         <td>[% PROCESS value_or_nbsp value=user.name %]</td> 
         <td><a href="[% c.uri_for( 'reports', search => user.email ) %]">[% PROCESS value_or_nbsp value=user.email %]</a></td> 
         <td>[% PROCESS value_or_nbsp value=user.from_body.name %]
-            [% IF user.from_body AND user.has_permission_to('moderate', user.from_body.id) %] * [% END %]
+            [% IF user.has_body_permission_to('moderate') %] * [% END %]
         </td>
       [% IF c.cobrand.moniker != 'zurich' %]
         <td>[% user.flagged == 2 ? loc('(Email in abuse table)') : user.flagged ? loc('Yes') : '&nbsp;' %]</td>

--- a/templates/web/base/report/update/form_update.html
+++ b/templates/web/base/report/update/form_update.html
@@ -25,6 +25,9 @@
 [% END %]
 
 <label for="form_update">[% loc( 'Update' ) %]</label>
+[% IF c.user && c.user.belongs_to_body( problem.bodies_str ) %]
+  [% INCLUDE 'admin/response_templates_select.html' for='form_update' %]
+[% END %]
 [% IF field_errors.update %]
     <div class='form-error'>[% field_errors.update %]</div>
 [% END %]

--- a/templates/web/oxfordshire/header.html
+++ b/templates/web/oxfordshire/header.html
@@ -42,7 +42,7 @@
                             <[% IF c.req.uri.path == '/my' OR ( c.req.uri.path == '/auth' AND c.req.params.r == 'my' ) %]span[% ELSE %]a href="/my"[% END
                              %]>[% c.user_exists ? loc("Your account") : loc("Sign in") %]</[% ( c.req.uri.path == '/my' OR ( c.req.uri.path == '/auth' AND c.req.params.r == 'my' ) ) ? 'span' : 'a' %]>
                         </li>
-                        [% IF c.user_exists AND c.user.has_permission_to('planned_reports', c.user.from_body.id) %]
+                        [% IF c.user_exists AND c.user.has_body_permission_to('planned_reports') %]
                         <li>
                             <[% IF c.req.uri.path == '/my/planned' %]span[% ELSE %]a href="/my/planned"[% END
                              %]>[% loc('Planned reports') %]</[% c.req.uri.path == '/my/planned' ? 'span' : 'a' %]>

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -856,6 +856,13 @@ $.extend(fixmystreet.set_up, {
       }
       add_handlers( $('.problem-header'), 'problem' );
       add_handlers( $('.item-list__item--updates'), 'update' );
+  },
+
+  response_templates: function() {
+      $('.js-template-name').change(function() {
+          var $this = $(this);
+          $('#' + $this.data('for')).val($this.val());
+      });
   }
 });
 
@@ -1079,6 +1086,7 @@ fixmystreet.display = {
             fixmystreet.set_up.dropzone($sideReport);
             fixmystreet.set_up.form_focus_triggers();
             fixmystreet.set_up.moderation();
+            fixmystreet.set_up.response_templates();
 
             window.selected_problem_id = reportId;
             var marker = fixmystreet.maps.get_marker_by_id(reportId);

--- a/web/cobrands/oxfordshire/layout.scss
+++ b/web/cobrands/oxfordshire/layout.scss
@@ -62,7 +62,7 @@ body.twothirdswidthpage {
 
 // To prevent font size larger interfering with the fixed Oxfordshire layout
 .container { width: auto; }
-.full-width { width: 464px; }
+body:not(.admin) .full-width { width: 464px; }
 .shadow-wrap { width: 464px; }
 
 .content { width: 432px; }


### PR DESCRIPTION
This extends the Zürich response template admin functionality to all cobrands, and adds:

 - Templates have an 'auto-response' flag, for automatically adding an update when a problem is left (future functionality)
 - Templates can be assigned to individual categories in addition to bodies
 - Managing templates requires the `template_edit` permission.

For mysociety/fixmystreetforcouncils#31