### PR TITLE
Add manage screen for editing priority/category.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -52,7 +52,7 @@ sub index : Path : Args(0) {
     }
 
     # Check to see if the spot is covered by a area - if not show an error.
-    return unless $c->forward('check_location_is_acceptable');
+    return unless $c->forward('check_location_is_acceptable', []);
 
     # If we have a partial - redirect to /report/new so that it can be
     # completed.

--- a/perllib/FixMyStreet/App/Controller/Council.pm
+++ b/perllib/FixMyStreet/App/Controller/Council.pm
@@ -36,7 +36,7 @@ there are no areas then return false.
 =cut
 
 sub load_and_check_areas : Private {
-    my ( $self, $c ) = @_;
+    my ( $self, $c, $prefetched_all_areas ) = @_;
 
     my $latitude  = $c->stash->{latitude};
     my $longitude = $c->stash->{longitude};
@@ -55,10 +55,10 @@ sub load_and_check_areas : Private {
     $params{generation} = $c->config->{MAPIT_GENERATION}
         if $c->config->{MAPIT_GENERATION};
 
-    if ($c->stash->{prefetched_all_areas}) {
+    if ($prefetched_all_areas) {
         $all_areas = {
             map { $_ => { id => $_ } }
-            @{$c->stash->{prefetched_all_areas}}
+            @$prefetched_all_areas
         };
     } elsif ( $c->stash->{fetch_all_areas} ) {
         my %area_types = map { $_ => 1 } @$area_types;

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -481,7 +481,7 @@ sub determine_location : Private {
               || $c->forward('/location/determine_location_from_coords')
               || $c->forward('determine_location_from_report')
           )    #
-          && $c->forward('/around/check_location_is_acceptable');
+          && $c->forward('/around/check_location_is_acceptable', []);
     return;
 }
 

--- a/t/app/controller/report_inspect.t
+++ b/t/app/controller/report_inspect.t
@@ -1,0 +1,97 @@
+use strict;
+use warnings;
+use Test::More;
+
+use FixMyStreet::TestMech;
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $brum = $mech->create_body_ok(2514, 'Birmingham City Council');
+my $oxon = $mech->create_body_ok(2237, 'Oxfordshire County Council');
+my $contact = $mech->create_contact_ok( body_id => $oxon->id, category => 'Cows', email => 'cows@example.net' );
+my $rp = FixMyStreet::DB->resultset("ResponsePriority")->create({
+    body => $oxon,
+    name => 'High Priority',
+});
+FixMyStreet::DB->resultset("ContactResponsePriority")->create({
+    contact => $contact,
+    response_priority => $rp,
+});
+
+my ($report) = $mech->create_problems_for_body(1, $oxon->id, 'Test', {
+    category => 'Cows', cobrand => 'fixmystreet', areas => ',2237,' });
+my $report_id = $report->id;
+
+my $user = $mech->log_in_ok('test@example.com');
+$user->update( { from_body => $oxon } );
+
+FixMyStreet::override_config {
+    MAPIT_URL => 'http://mapit.mysociety.org/',
+    ALLOWED_COBRANDS => 'fixmystreet',
+}, sub {
+    subtest "test inspect page" => sub {
+        $mech->get_ok("/report/$report_id");
+        $mech->content_lacks('Inspect');
+        $mech->content_lacks('Manage');
+
+        $user->user_body_permissions->create({ body => $oxon, permission_type => 'report_edit_priority' });
+        $mech->get_ok("/report/$report_id");
+        $mech->content_contains('Manage');
+        $mech->follow_link_ok({ text => 'Manage' });
+
+        $user->user_body_permissions->create({ body => $oxon, permission_type => 'report_inspect' });
+        $mech->get_ok("/report/$report_id");
+        $mech->content_contains('Inspect');
+        $mech->follow_link_ok({ text => 'Inspect' });
+    };
+
+    subtest "test basic inspect submission" => sub {
+        $mech->submit_form_ok({ button => 'save', with_fields => { traffic_information => 'Lots', state => 'Planned' } });
+        $report->discard_changes;
+        is $report->state, 'planned', 'report state changed';
+        is $report->get_extra_metadata('traffic_information'), 'Lots', 'report data changed';
+    };
+
+    subtest "test location changes" => sub {
+        $mech->get_ok("/report/$report_id/inspect");
+        $mech->submit_form_ok({ button => 'save', with_fields => { latitude => 55, longitude => -2 } });
+        $mech->content_contains('Invalid location');
+        $mech->submit_form_ok({ button => 'save', with_fields => { latitude => 51.754926, longitude => -1.256179 } });
+        $mech->content_lacks('Invalid location');
+    };
+
+    foreach my $test (
+        { type => 'report_edit_priority', priority => 1 },
+        { type => 'report_edit_category', category => 1 },
+        { type => 'report_inspect', priority => 1, category => 1, detailed => 1 },
+    ) {
+        subtest "test $test->{type} permission" => sub {
+            $user->user_body_permissions->delete;
+            $user->user_body_permissions->create({ body => $oxon, permission_type => $test->{type} });
+            $mech->get_ok("/report/$report_id/inspect");
+            has_or_lacks($test->{priority}, 'Priority');
+            has_or_lacks($test->{priority}, 'High');
+            has_or_lacks($test->{category}, 'Category');
+            has_or_lacks($test->{detailed}, 'Detailed problem information');
+            $mech->submit_form_ok({
+                button => 'save',
+                with_fields => {
+                    $test->{priority} ? (priority => 1) : (),
+                    $test->{category} ? (category => 'Cows') : (),
+                    $test->{detailed} ? (detailed_information => 'Highland ones') : (),
+                }
+            });
+        };
+    }
+};
+
+END {
+    $mech->delete_body($oxon);
+    $mech->delete_body($brum);
+    done_testing();
+}
+
+sub has_or_lacks {
+    my ($flag, $text) = @_;
+    $flag ? $mech->content_contains($text) : $mech->content_lacks($text);
+}

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -1,4 +1,5 @@
 [% PROCESS 'admin/report_blocks.html'; # For the report state dropdown %]
+[% permissions = c.user.permissions(c, problem.bodies_str) %]
 [% second_column = BLOCK -%]
   <div id="side-report-secondary">
     <div class="problem-inspector-fields clearfix">
@@ -7,6 +8,8 @@
           <label for="problem_id">[% loc('Report ID:') %]</label>
           <input type="text" readonly id="problem_id" value="[% problem.id %]">
         </p>
+
+[% IF permissions.report_edit_priority OR permissions.report_inspect %]
         <p class="right">
           <label for="problem_priority">[% loc('Priority:') %]</label>
           <select name="priority" id="problem_priority">
@@ -16,6 +19,9 @@
             [% END %]
           </select>
         </p>
+[% END %]
+
+[% IF permissions.report_inspect %]
         <p class="left">
           <label for="state">[% loc('State:') %]</label>
             [%# XXX this is duplicated from admin/report_edit.html, should be refactored %]
@@ -29,6 +35,9 @@
             [% END %]
           </select>
         </p>
+[% END %]
+
+[% IF permissions.report_edit_category OR permissions.report_inspect %]
         <p class="right">
           <label for="category">[% loc('Category:') %]</label>
             [%# XXX this is duplicated from admin/report_edit.html, should be refactored %]
@@ -47,6 +56,8 @@
             [% END %]
           </select>
         </p>
+[% END %]
+
         <p>
           [% SET local_coords = problem.local_coords; %]
           <strong>[% loc('Easting/Northing:') %]</strong>
@@ -59,6 +70,8 @@
           <a href="#" id="geolocate_link">[% loc('Use my current location') %]</a>,
           [% loc('or drag the pin on the map') %] &raquo;
         </p>
+
+[% IF permissions.report_inspect %]
         <p>
           <label for="detailed_information">[% loc('Detailed problem location:') %]</label>
           <textarea rows="2" name="detailed_location">[% problem.get_extra_metadata('detailed_location') | html %]</textarea>
@@ -71,6 +84,8 @@
           <label for="traffic_information">[% loc('Traffic management information:') %]</label>
           <textarea rows="2" name="traffic_information">[% problem.get_extra_metadata('traffic_information') | html %]</textarea>
         </p>
+[% END %]
+
         <p>
           <input type="hidden" name="token" value="[% csrf_token %]">
           <a href="[% c.uri_for( '/report', problem.id ) %]" class="btn">[% loc('Cancel') %]</a>

--- a/templates/web/base/report/_main.html
+++ b/templates/web/base/report/_main.html
@@ -1,5 +1,6 @@
-[% can_moderate = c.user && c.user.has_permission_to('moderate', problem.bodies_str) %]
-[% can_inspect = c.user && c.user.has_permission_to('report_inspect', problem.bodies_str) && !hide_inspect_button %]
+[% IF c.user_exists %]
+    [% DEFAULT permissions = c.user.permissions(c, problem.bodies_str) %]
+[%- END %]
 
 <a href="[% c.uri_for( '/around', { lat => latitude, lon => longitude } ) %]"
     class="problem-back js-back-to-report-list">[% loc('Back to all reports') %]</a>
@@ -23,7 +24,7 @@
 </form>
 [% END %]
 
-  [% IF can_moderate %]
+  [% IF permissions.moderate %]
     [% original = problem_original %]
     <form method="post" action="/moderate/report/[% problem.id %]">
         <input type="hidden" name="token" value="[% csrf_token %]">
@@ -31,7 +32,7 @@
 
     <h1 class="moderate-display">[% problem.title | html %]</h1>
 
-  [% IF can_moderate %]
+  [% IF permissions.moderate %]
     <div class="moderate-edit">
       [% IF problem.title != original.title %]
         <label>
@@ -60,7 +61,7 @@
 
     [% INCLUDE 'report/_support.html' %]
 
-  [% IF can_moderate %]
+  [% IF permissions.moderate %]
     [% IF problem.photo or original.photo %]
         <p class="moderate-edit">
             <label>
@@ -76,7 +77,7 @@
         [% problem.detail | add_links | html_para %]
     </div>
 
-  [% IF can_moderate %]
+  [% IF permissions.moderate %]
     <p class="moderate-edit">
       [% IF problem.detail != original.detail %]
         <label>
@@ -105,18 +106,24 @@
     </div>
   [% END %]
 
-  [% IF can_moderate OR can_inspect %]
+  [% IF permissions.keys.grep('moderate|report_inspect|report_edit_category|report_edit_priority').size %]
     <p class="moderate-display">
-      [% IF can_moderate %]
+      [% IF permissions.moderate %]
         <input type="button" class="btn moderate" value="Moderate this report">
       [% END %]
-      [% IF can_inspect %]
-        <a href="/report/[% problem.id %]/inspect" class="btn inspect">Inspect</a>
+      [% IF !hide_inspect_button AND permissions.keys.grep('report_inspect|report_edit_category|report_edit_priority').size %]
+          <a href="/report/[% problem.id %]/inspect" class="btn inspect">
+          [%- IF permissions.report_inspect %]
+            [%- loc('Inspect') %]
+          [%- ELSE %]
+            [%- loc('Manage') %]
+          [%- END ~%]
+          </a>
       [% END %]
     </p>
   [% END %]
 
-  [% IF can_moderate %]
+  [% IF permissions.moderate %]
     </form>
   [% END %]
 


### PR DESCRIPTION
This is a cut-down version of the full inspect screen. There is a "manage" button if the user has either the edit category or edit priority permissions.

Not sure I like bits of this code-wise, e.g. hardcoded superuser for all permissions, but the alternative was more `can_*` variables in the template. Perhaps that would be simpler anyway, or 'inspect or edit these bits' could be given a single name ("manage" best I can think of) and wrapped in a function.
Anyway, does the job for the two perms given, plus allows pin moving, as that seemed related enough to either?

<img src="https://cloud.githubusercontent.com/assets/154364/18279440/7ddca7ea-744d-11e6-806e-47f5f4464c72.png" width="45%"> <img src="https://cloud.githubusercontent.com/assets/154364/18279454/8ce27288-744d-11e6-89f6-bce92e625cb5.png" width="45%">
