### PR TITLE
Response priority management in admin

### DIFF
--- a/bin/update-schema
+++ b/bin/update-schema
@@ -194,6 +194,7 @@ else {
 # By querying the database schema, we can see where we're currently at
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
+    return '0045' if table_exists('response_priorities');
     return '0044' if table_exists('contact_response_templates');
     return '0043' if column_exists('users', 'area_id');
     return '0042' if table_exists('user_planned_reports');

--- a/db/downgrade_0045---0044.sql
+++ b/db/downgrade_0045---0044.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE problem DROP COLUMN response_priority_id;
+DROP TABLE contact_response_priorities;
+DROP TABLE response_priorities;
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -127,6 +127,15 @@ create trigger contacts_update_trigger after update on contacts
 create trigger contacts_insert_trigger after insert on contacts
     for each row execute procedure contacts_updated();
 
+-- Problems can have priorities. This table must be created before problem.
+CREATE TABLE response_priorities (
+    id serial not null primary key,
+    body_id int references body(id) not null,
+    deleted boolean not null default 'f',
+    name text not null,
+    unique(body_id, name)
+);
+
 -- Problems reported by users of site
 create table problem (
     id serial not null primary key,
@@ -185,7 +194,8 @@ create table problem (
     extra text, -- extra fields required for open311
     flagged boolean not null default 'f',
     geocode bytea,
-    
+    response_priority_id int REFERENCES response_priorities(id),
+
     -- logging sending failures (used by webservices)
     send_fail_count integer not null default 0, 
     send_fail_reason text, 
@@ -481,4 +491,10 @@ CREATE TABLE contact_response_templates (
     id serial NOT NULL PRIMARY KEY,
     contact_id int REFERENCES contacts(id) NOT NULL,
     response_template_id int REFERENCES response_templates(id) NOT NULL
+);
+
+CREATE TABLE contact_response_priorities (
+    id serial NOT NULL PRIMARY KEY,
+    contact_id int REFERENCES contacts(id) NOT NULL,
+    response_priority_id int REFERENCES response_priorities(id) NOT NULL
 );

--- a/db/schema_0045-response-priorities.sql
+++ b/db/schema_0045-response-priorities.sql
@@ -1,0 +1,20 @@
+BEGIN;
+
+CREATE TABLE response_priorities (
+    id serial not null primary key,
+    body_id int references body(id) not null,
+    name text not null,
+    deleted boolean not null default 'f',
+    unique(body_id, name)
+);
+
+CREATE TABLE contact_response_priorities (
+    id serial NOT NULL PRIMARY KEY,
+    contact_id int REFERENCES contacts(id) NOT NULL,
+    response_priority_id int REFERENCES response_priorities(id) NOT NULL
+);
+
+ALTER TABLE problem
+    ADD COLUMN response_priority_id int REFERENCES response_priorities(id);
+
+COMMIT;

--- a/perllib/FixMyStreet/App/Controller/Admin/ResponsePriorities.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/ResponsePriorities.pm
@@ -1,0 +1,107 @@
+package FixMyStreet::App::Controller::Admin::ResponsePriorities;
+use Moose;
+use namespace::autoclean;
+
+BEGIN { extends 'Catalyst::Controller'; }
+
+
+sub begin : Private {
+    my ( $self, $c ) = @_;
+
+    $c->forward('/admin/begin');
+}
+
+sub index : Path : Args(0) {
+    my ( $self, $c ) = @_;
+
+    my $user = $c->user;
+
+    if ($user->is_superuser) {
+        $c->forward('fetch_all_bodies');
+    } elsif ( $user->from_body ) {
+        $c->forward('load_user_body', [ $user->from_body->id ]);
+        $c->res->redirect( $c->uri_for( '', $c->stash->{body}->id ) );
+    } else {
+        $c->detach( '/page_error_404_not_found' );
+    }
+}
+
+sub list : Path : Args(1) {
+    my ($self, $c, $body_id) = @_;
+
+    $c->forward('load_user_body', [ $body_id ]);
+
+    my @priorities = $c->stash->{body}->response_priorities->search(
+        undef,
+        {
+            order_by => 'name'
+        }
+    );
+
+    $c->stash->{response_priorities} = \@priorities;
+}
+
+sub edit : Path : Args(2) {
+    my ( $self, $c, $body_id, $priority_id ) = @_;
+
+    $c->forward('load_user_body', [ $body_id ]);
+
+    my $priority;
+    if ($priority_id eq 'new') {
+        $priority = $c->stash->{body}->response_priorities->new({});
+    }
+    else {
+        $priority = $c->stash->{body}->response_priorities->find( $priority_id )
+            or $c->detach( '/page_error_404_not_found' );
+    }
+
+    $c->forward('/admin/fetch_contacts');
+    my @contacts = $priority->contacts->all;
+    my @live_contacts = $c->stash->{live_contacts}->all;
+    my %active_contacts = map { $_->id => 1 } @contacts;
+    my @all_contacts = map { {
+        id => $_->id,
+        category => $_->category,
+        active => $active_contacts{$_->id},
+    } } @live_contacts;
+    $c->stash->{contacts} = \@all_contacts;
+
+    if ($c->req->method eq 'POST') {
+        $priority->deleted( $c->get_param('deleted') ? 1 : 0 );
+        $priority->name( $c->get_param('name') );
+        $priority->update_or_insert;
+
+        my @live_contact_ids = map { $_->id } @live_contacts;
+        my @new_contact_ids = grep { $c->get_param("contacts[$_]") } @live_contact_ids;
+        $priority->contact_response_priorities->search({
+            contact_id => { '!=' => \@new_contact_ids },
+        })->delete;
+        foreach my $contact_id (@new_contact_ids) {
+            $priority->contact_response_priorities->find_or_create({
+                contact_id => $contact_id,
+            });
+        }
+
+        $c->res->redirect( $c->uri_for( '', $c->stash->{body}->id ) );
+    }
+
+    $c->stash->{response_priority} = $priority;
+}
+
+sub load_user_body : Private {
+    my ($self, $c, $body_id) = @_;
+
+    my $has_permission = $c->user->has_body_permission_to('responsepriority_edit') &&
+                         $c->user->from_body->id eq $body_id;
+
+    unless ( $c->user->is_superuser || $has_permission ) {
+        $c->detach( '/page_error_404_not_found' );
+    }
+
+    $c->stash->{body} = $c->model('DB::Body')->find($body_id)
+        or $c->detach( '/page_error_404_not_found' );
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -646,10 +646,10 @@ sub admin_pages {
          'summary' => [_('Summary'), 0],
          'bodies' => [_('Bodies'), 1],
          'reports' => [_('Reports'), 2],
-         'timeline' => [_('Timeline'), 4],
-         'users' => [_('Users'), 5],
-         'flagged'  => [_('Flagged'), 6],
-         'stats'  => [_('Stats'), 7],
+         'timeline' => [_('Timeline'), 5],
+         'users' => [_('Users'), 6],
+         'flagged'  => [_('Flagged'), 7],
+         'stats'  => [_('Stats'), 8],
          'user_edit' => [undef, undef],
          'body' => [undef, undef],
          'report_edit' => [undef, undef],
@@ -659,12 +659,16 @@ sub admin_pages {
 
     # There are some pages that only super users can see
     if ( $user->is_superuser ) {
-        $pages->{config} = [ _('Configuration'), 8];
+        $pages->{config} = [ _('Configuration'), 9];
     };
     # And some that need special permissions
     if ( $user->is_superuser || $user->has_body_permission_to('template_edit') ) {
-        $pages->{templates} = [_('Templates'), 3],
-        $pages->{template_edit} = [undef, undef],
+        $pages->{templates} = [_('Templates'), 3];
+        $pages->{template_edit} = [undef, undef];
+    };
+    if ( $user->is_superuser || $user->has_body_permission_to('responsepriority_edit') ) {
+        $pages->{responsepriorities} = [_('Priorities'), 4];
+        $pages->{responsepriority_edit} = [undef, undef];
     };
 
 
@@ -719,6 +723,7 @@ sub available_permissions {
         },
         _("Bodies") => {
             template_edit => _("Add/edit response templates"),
+            responsepriority_edit => _("Add/edit response priorities"),
         },
     };
 }

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -99,15 +99,6 @@ sub problem_response_days {
     return undef;
 }
 
-sub problem_response_priorities {
-    return {
-        cat1a => 'Cat 1A (4 hours)',
-        cat1b => 'Cat 1B (24 hours)',
-        cat2 => 'Cat 2 (2 days)',
-        cat3 => 'Cat 3 (10 days)',
-    };
-}
-
 sub reports_ordering {
     return { -desc => 'confirmed' };
 }

--- a/perllib/FixMyStreet/DB/Result/Body.pm
+++ b/perllib/FixMyStreet/DB/Result/Body.pm
@@ -87,6 +87,12 @@ __PACKAGE__->belongs_to(
   },
 );
 __PACKAGE__->has_many(
+  "response_priorities",
+  "FixMyStreet::DB::Result::ResponsePriority",
+  { "foreign.body_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+__PACKAGE__->has_many(
   "response_templates",
   "FixMyStreet::DB::Result::ResponseTemplate",
   { "foreign.body_id" => "self.id" },
@@ -106,8 +112,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2015-02-19 16:13:43
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:d6GuQm8vrNmCc4NWw58srA
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2016-09-06 15:33:04
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ZuzscnLqcx0k512cTZ/kdg
 
 sub url {
     my ( $self, $c, $args ) = @_;

--- a/perllib/FixMyStreet/DB/Result/Contact.pm
+++ b/perllib/FixMyStreet/DB/Result/Contact.pm
@@ -11,6 +11,22 @@ use base 'DBIx::Class::Core';
 __PACKAGE__->load_components("FilterColumn", "InflateColumn::DateTime", "EncodedColumn");
 __PACKAGE__->table("contacts");
 __PACKAGE__->add_columns(
+  "body_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
+  "email",
+  { data_type => "text", is_nullable => 0 },
+  "editor",
+  { data_type => "text", is_nullable => 0 },
+  "whenedited",
+  { data_type => "timestamp", is_nullable => 0 },
+  "note",
+  { data_type => "text", is_nullable => 0 },
+  "confirmed",
+  { data_type => "boolean", is_nullable => 0 },
+  "category",
+  { data_type => "text", default_value => "Other", is_nullable => 0 },
+  "deleted",
+  { data_type => "boolean", is_nullable => 0 },
   "id",
   {
     data_type         => "integer",
@@ -18,22 +34,6 @@ __PACKAGE__->add_columns(
     is_nullable       => 0,
     sequence          => "contacts_id_seq",
   },
-  "body_id",
-  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
-  "category",
-  { data_type => "text", default_value => "Other", is_nullable => 0 },
-  "email",
-  { data_type => "text", is_nullable => 0 },
-  "confirmed",
-  { data_type => "boolean", is_nullable => 0 },
-  "deleted",
-  { data_type => "boolean", is_nullable => 0 },
-  "editor",
-  { data_type => "text", is_nullable => 0 },
-  "whenedited",
-  { data_type => "timestamp", is_nullable => 0 },
-  "note",
-  { data_type => "text", is_nullable => 0 },
   "extra",
   { data_type => "text", is_nullable => 1 },
   "non_public",
@@ -56,6 +56,12 @@ __PACKAGE__->belongs_to(
   { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
 );
 __PACKAGE__->has_many(
+  "contact_response_priorities",
+  "FixMyStreet::DB::Result::ContactResponsePriority",
+  { "foreign.contact_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+__PACKAGE__->has_many(
   "contact_response_templates",
   "FixMyStreet::DB::Result::ContactResponseTemplate",
   { "foreign.contact_id" => "self.id" },
@@ -63,8 +69,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2016-08-24 11:29:04
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:CXUabm3Yd11OoIYJceSPag
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2016-09-06 15:33:04
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ocmQGeFJtO3wmvyx6W+EKQ
 
 __PACKAGE__->load_components("+FixMyStreet::DB::RABXColumn");
 __PACKAGE__->rabx_column('extra');
@@ -75,6 +81,7 @@ use namespace::clean -except => [ 'meta' ];
 with 'FixMyStreet::Roles::Extra';
 
 __PACKAGE__->many_to_many( response_templates => 'contact_response_templates', 'response_template' );
+__PACKAGE__->many_to_many( response_priorities => 'contact_response_priorities', 'response_priority' );
 
 sub get_metadata_for_input {
     my $self = shift;

--- a/perllib/FixMyStreet/DB/Result/ContactResponsePriority.pm
+++ b/perllib/FixMyStreet/DB/Result/ContactResponsePriority.pm
@@ -1,0 +1,46 @@
+use utf8;
+package FixMyStreet::DB::Result::ContactResponsePriority;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+__PACKAGE__->load_components("FilterColumn", "InflateColumn::DateTime", "EncodedColumn");
+__PACKAGE__->table("contact_response_priorities");
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "contact_response_priorities_id_seq",
+  },
+  "contact_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
+  "response_priority_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
+);
+__PACKAGE__->set_primary_key("id");
+__PACKAGE__->belongs_to(
+  "contact",
+  "FixMyStreet::DB::Result::Contact",
+  { id => "contact_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+__PACKAGE__->belongs_to(
+  "response_priority",
+  "FixMyStreet::DB::Result::ResponsePriority",
+  { id => "response_priority_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2016-09-06 15:33:04
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:kM/9jY1QSgakyPTvutS+hw
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/perllib/FixMyStreet/DB/Result/ResponsePriority.pm
+++ b/perllib/FixMyStreet/DB/Result/ResponsePriority.pm
@@ -1,0 +1,57 @@
+use utf8;
+package FixMyStreet::DB::Result::ResponsePriority;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+__PACKAGE__->load_components("FilterColumn", "InflateColumn::DateTime", "EncodedColumn");
+__PACKAGE__->table("response_priorities");
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "response_priorities_id_seq",
+  },
+  "body_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
+  "name",
+  { data_type => "text", is_nullable => 0 },
+  "deleted",
+  { data_type => "boolean", default_value => \"false", is_nullable => 0 },
+);
+__PACKAGE__->set_primary_key("id");
+__PACKAGE__->add_unique_constraint("response_priorities_body_id_name_key", ["body_id", "name"]);
+__PACKAGE__->belongs_to(
+  "body",
+  "FixMyStreet::DB::Result::Body",
+  { id => "body_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+__PACKAGE__->has_many(
+  "contact_response_priorities",
+  "FixMyStreet::DB::Result::ContactResponsePriority",
+  { "foreign.response_priority_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+__PACKAGE__->has_many(
+  "problems",
+  "FixMyStreet::DB::Result::Problem",
+  { "foreign.response_priority_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2016-09-07 11:01:40
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:B1swGtQzC3qRa0LUM4IyzA
+
+__PACKAGE__->many_to_many( contacts => 'contact_response_priorities', 'contact' );
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/perllib/FixMyStreet/TestMech.pm
+++ b/perllib/FixMyStreet/TestMech.pm
@@ -603,6 +603,7 @@ sub delete_body {
     $mech->delete_contact($_) for $body->contacts;
     $mech->delete_user($_) for $body->users;
     $_->delete for $body->response_templates;
+    $_->delete for $body->response_priorities;
     $body->body_areas->delete;
     $body->delete;
 }
@@ -612,6 +613,7 @@ sub delete_contact {
     my $contact = shift;
 
     $contact->contact_response_templates->delete_all;
+    $contact->contact_response_priorities->delete_all;
     $contact->delete;
 }
 

--- a/templates/web/base/admin/responsepriorities/edit.html
+++ b/templates/web/base/admin/responsepriorities/edit.html
@@ -1,0 +1,41 @@
+[% INCLUDE 'admin/header.html' title=tprintf(loc('Response Priority for %s'), body.name) -%]
+[% rp = response_priority %]
+
+[% UNLESS rp.id %]<h3>[% loc('New priority') %]</h3>[% END %]
+
+<form method="post"
+    action="[% c.uri_for('', body.id, rp.id || 'new' ) %]"
+    enctype="application/x-www-form-urlencoded"
+    accept-charset="utf-8"
+    class="validate">
+
+    <p>
+        <strong>[% loc('Name:') %] </strong>
+        <input type="text" name="name" class="required" size="30" value="[% rp.name | html %]">
+    </p>
+    <p>
+      <strong>[% loc('Categories:') %]</strong>
+      <ul>
+        [% FOR contact IN contacts %]
+          <li>
+            <label>
+              <input type="checkbox" name="contacts[[% contact.id %]]" [% 'checked' IF contact.active %]/>
+              [% contact.category %]
+            </label>
+          </li>
+        [% END %]
+      </ul>
+    </p>
+    <p>
+        <label>
+          <input type="checkbox" name="deleted" id="deleted" value="1"[% ' checked' IF rp.deleted %]>
+          [% loc('Flag as deleted') %]
+        </label>
+    </p>
+    <p>
+      <input type="hidden" name="token" value="[% csrf_token %]" >
+      <input type="submit" name="Edit priorities" value="[% rp.id ? loc('Save changes') : loc('Create priority') %]" >
+    </p>
+</form>
+
+[% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/admin/responsepriorities/index.html
+++ b/templates/web/base/admin/responsepriorities/index.html
@@ -1,0 +1,11 @@
+[% INCLUDE 'admin/header.html' title=loc('Response Priorities') -%]
+
+<ul>
+    [% FOR body IN bodies %]
+        <li>
+            <a href="/admin/responsepriorities/[% body.id %]">[% body.name %]</a>
+        </li>
+    [% END %]
+</ul>
+
+[% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/admin/responsepriorities/list.html
+++ b/templates/web/base/admin/responsepriorities/list.html
@@ -1,0 +1,22 @@
+[% INCLUDE 'admin/header.html' title=tprintf(loc('Response Priorities for %s'), body.name) -%]
+
+<table>
+    <thead>
+    <tr>
+        <th>  [% loc('Name') %] </th>
+        <th>  &nbsp; </th>
+    </tr>
+    </thead>
+    <tbody>
+      [% FOR p IN response_priorities %]
+          <tr [% 'class="is-deleted"' IF p.deleted %]>
+              <td>  [% p.name %] </td>
+              <td> <a href="/admin/responsepriorities/[% body.id %]/[% p.id %]" class="btn">[% loc('Edit') %]</a> </td>
+          </tr>
+      [% END %]
+    </tbody>
+</table>
+
+<a href="[% c.uri_for('', body.id, 'new') %]" class="btn">[% loc('New priority') %]</a>
+
+[% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -10,9 +10,9 @@
         <p class="right">
           <label for="problem_priority">[% loc('Priority:') %]</label>
           <select name="priority" id="problem_priority">
-            <option value="" [% 'selected' UNLESS problem.get_extra_metadata('priority') %]>-</option>
-            [% FOREACH priority IN priorities %]
-              <option value="[% priority.key %]" [% 'selected' IF problem.get_extra_metadata('priority') == priority.key %]>[% priority.value %]</option>
+            <option value="" [% 'selected' UNLESS problem.response_priority_id %]>-</option>
+            [% FOREACH priority IN problem.response_priorities %]
+              <option value="[% priority.id %]" [% 'selected' IF problem.response_priority_id == priority.id %] [% 'disabled' IF priority.deleted %]>[% priority.name %]</option>
             [% END %]
           </select>
         </p>


### PR DESCRIPTION
This PR upgrades the hard-coded `Oxfordshire::problem_response_priorities` method into a fully-fledged `ResponsePriority` model which can be managed via the admin. Priorities are assigned to bodies and categories, and Problems can optionally have a priority set.

For mysociety/fixmystreetforcouncils#66