### PR TITLE
[Oxfordshire] Display confirmed reports as received by the Council

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -10,6 +10,11 @@ sub council_name { return 'Oxfordshire County Council'; }
 sub council_url { return 'oxfordshire'; }
 sub is_two_tier { return 1; }
 
+sub is_council_with_case_management {
+    # XXX Change this to return 1 when OCC FMSfC goes live.
+    return FixMyStreet->config('STAGING_SITE');
+}
+
 sub map_type { 'OSM' }
 
 sub base_url {

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -678,6 +678,13 @@ sub duration_string {
     } else {
         $body = $problem->body( $c );
     }
+    if ( $c->cobrand->can('get_body_handler_for_problem') ) {
+        my $handler = $c->cobrand->get_body_handler_for_problem( $problem );
+        if ( $handler->can('is_council_with_case_management') && $handler->is_council_with_case_management ) {
+            return sprintf(_('Received by %s moments later'), $body);
+        }
+    }
+    return unless $problem->whensent;
     return sprintf(_('Sent to %s %s later'), $body,
         Utils::prettify_duration($problem->whensent->epoch - $problem->confirmed->epoch, 'minute')
     );

--- a/templates/web/base/report/_council_sent_info.html
+++ b/templates/web/base/report/_council_sent_info.html
@@ -1,6 +1,6 @@
-[% IF problem.whensent || problem.can_display_external_id %]
+[% SET duration_clause = problem.duration_string(c) %]
+[% IF duration_clause || problem.can_display_external_id %]
     <p class="council_sent_info">
-    [% SET duration_clause = problem.duration_string(c) IF problem.whensent %]
     [%- IF problem.can_display_external_id %]
         [%- IF duration_clause %]
             [%- external_ref_clause = tprintf(loc('Council ref:&nbsp;%s'), problem.external_id) %]

--- a/templates/web/oxfordshire/report/_main_sent_info.html
+++ b/templates/web/oxfordshire/report/_main_sent_info.html
@@ -1,3 +1,4 @@
-[% IF problem.whensent %]
-    <p class="council_sent_info">[% problem.duration_string(c) %]</p>
+[% SET duration_clause = problem.duration_string(c) %]
+[% IF duration_clause %]
+    <p class="council_sent_info">[% duration_clause %]</p>
 [% END %]


### PR DESCRIPTION
This introduces a new `is_council_with_case_management` flag for Cobrands, that,
when active, considers any report that's been confirmed as having been received
by the Council in question.

See mysociety/fixmystreetforcouncils#65