### PR TITLE
Improve "Summary" and "Description" form guidance

### DIFF
--- a/templates/web/base/report/new/form_report.html
+++ b/templates/web/base/report/new/form_report.html
@@ -12,11 +12,11 @@
     [% need_to_show_category_selector = 1 %]
 [% END %]
 
-    <label for="form_title">[% loc('One-line summary') %] [% INCLUDE 'report/public_label.html' %]</label>
+    <label for="form_title">[% loc('Summarise the problem') %] [% INCLUDE 'report/public_label.html' %]</label>
 [% IF field_errors.title %]
     <p class='form-error'>[% field_errors.title %]</p>
 [% END %]
-    <input type="text" value="[% report.title | html %]" name="title" id="form_title" placeholder="[% loc('What’s the issue, and where is it?') %]" required>
+    <input type="text" value="[% report.title | html %]" name="title" id="form_title" placeholder="[% loc('10 inch pothole on Example St, near post box') %]" required>
 
 [% IF c.cobrand.allow_photo_upload %]
     <input type="hidden" name="upload_fileid" value="[% upload_fileid %]">
@@ -44,11 +44,11 @@
 
 [% TRY %][% PROCESS 'report/new/after_photo.html' %][% CATCH file %][% END %]
 
-    <label for="form_detail">[% loc('Description') %] [% INCLUDE 'report/public_label.html' %]</label>
+    <label for="form_detail">[% loc('Explain what’s wrong') %] [% INCLUDE 'report/public_label.html' %]</label>
 [% IF field_errors.detail %]
     <p class='form-error'>[% field_errors.detail %]</p>
 [% END %]
-    <textarea rows="7" cols="26" name="detail" id="form_detail" placeholder="[% loc('Explain what’s wrong, exactly where it is, and how long it’s been there…') %]" required>[% report.detail | html %]</textarea>
+    <textarea rows="7" cols="26" name="detail" id="form_detail" placeholder="[% loc('This pothole has been here for two months and…') %]" required>[% report.detail | html %]</textarea>
 
 [% TRY %][% PROCESS 'report/new/inline-tips.html' %][% CATCH file %][% END %]
 


### PR DESCRIPTION
Part of mysociety/fixmystreetforcouncils#41.

![screen shot 2016-09-08 at 13 05 41](https://cloud.githubusercontent.com/assets/739624/18348730/0d124154-75c5-11e6-8420-af15056783b8.png)

Form labels now describe what the user should do, and placeholders
give a supporting example of what their input should look like.

Placeholder text in the "Summary" box now suggests that people
include a location in their summary. Likewise with a timescale in
the "Description" box.

Placeholders use potholes as an example, since potholes are the most
common complaint on FMS. Maybe eventually we might want to change the
placeholder text based on the category the user selects…