### PR TITLE
Issues/forcouncils/57 trusted users

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -687,7 +687,7 @@ sub report_edit : Path('report_edit') : Args(1) {
 
     unless (
         $c->cobrand->moniker eq 'zurich'
-        || $c->user->has_permission_to(report_edit => $problem->bodies_str)
+        || $c->user->has_permission_to(report_edit => $problem->bodies_str_ids)
     ) {
         $c->detach( '/page_error_403_access_denied', [] );
     }

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -1276,14 +1276,14 @@ sub user_edit : Path('user_edit') : Args(1) {
 
         if (!$user->from_body) {
             # Non-staff users aren't allowed any permissions or to be in an area
-            $user->user_body_permissions->delete_all;
+            $user->admin_user_body_permissions->delete;
             $user->area_id(undef);
             delete $c->stash->{areas};
             delete $c->stash->{fetched_areas_body_id};
         } elsif ($c->stash->{available_permissions}) {
             my @all_permissions = map { keys %$_ } values %{ $c->stash->{available_permissions} };
             my @user_permissions = grep { $c->get_param("permissions[$_]") ? 1 : undef } @all_permissions;
-            $user->user_body_permissions->search({
+            $user->admin_user_body_permissions->search({
                 body_id => $user->from_body->id,
                 permission_type => { '!=' => \@user_permissions },
             })->delete;
@@ -1299,6 +1299,35 @@ sub user_edit : Path('user_edit') : Args(1) {
             my %valid_areas = map { $_->{id} => 1 } @{ $c->stash->{areas} };
             my $new_area = $c->get_param('area_id');
             $user->area_id( $valid_areas{$new_area} ? $new_area : undef );
+        }
+
+        # Handle 'trusted' flag(s)
+        my @trusted_bodies = $c->get_param_list('trusted_bodies');
+        if ( $c->user->is_superuser ) {
+            $user->user_body_permissions->search({
+                body_id => { '!=' => \@trusted_bodies },
+                permission_type => 'trusted',
+            })->delete;
+            foreach my $body_id (@trusted_bodies) {
+                $user->user_body_permissions->find_or_create({
+                    body_id => $body_id,
+                    permission_type => 'trusted',
+                });
+            }
+        } elsif ( $c->user->from_body ) {
+            my %trusted = map { $_ => 1 } @trusted_bodies;
+            my $body_id = $c->user->from_body->id;
+            if ( $trusted{$body_id} ) {
+                $user->user_body_permissions->find_or_create({
+                    body_id => $body_id,
+                    permission_type => 'trusted',
+                });
+            } else {
+                $user->user_body_permissions->search({
+                    body_id => $body_id,
+                    permission_type => 'trusted',
+                })->delete;
+            }
         }
 
         unless ($user->email) {

--- a/perllib/FixMyStreet/App/Controller/Moderate.pm
+++ b/perllib/FixMyStreet/App/Controller/Moderate.pm
@@ -54,7 +54,7 @@ sub report : Chained('moderate') : PathPart('report') : CaptureArgs(1) {
 
     # ... and immediately, if the user isn't authorized
     $c->detach unless $c->user_exists;
-    $c->detach unless $c->user->has_permission_to(moderate => $problem->bodies_str);
+    $c->detach unless $c->user->has_permission_to(moderate => $problem->bodies_str_ids);
 
     $c->forward('/auth/check_csrf_token');
 

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -133,7 +133,7 @@ sub load_problem_or_display_error : Private {
     }
 
     $c->stash->{problem} = $problem;
-    if ( $c->user_exists && $c->user->has_permission_to(moderate => $problem->bodies_str) ) {
+    if ( $c->user_exists && $c->user->has_permission_to(moderate => $problem->bodies_str_ids) ) {
         $c->stash->{problem_original} = $problem->find_or_new_related(
             moderation_original_data => {
                 title => $problem->title,
@@ -401,7 +401,7 @@ to the current Problem in $c->stash->{problem}. Shows the 403 page if not.
 sub check_has_permission_to : Private {
     my ( $self, $c, @permissions ) = @_;
 
-    my $bodies = $c->stash->{problem}->bodies_str;
+    my $bodies = $c->stash->{problem}->bodies_str_ids;
 
     my %permissions = map { $_ => $c->user->has_permission_to($_, $bodies) } @permissions
         if $c->user_exists;

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -188,9 +188,9 @@ sub report_form_ajax : Path('ajax') : Args(0) {
 
     my $contribute_as = {};
     if ($c->user_exists) {
-        my $bodies = join(',', keys %{$c->stash->{bodies}});
-        my $ca_another_user = $c->user->has_permission_to('contribute_as_another_user', $bodies);
-        my $ca_body = $c->user->has_permission_to('contribute_as_body', $bodies);
+        my @bodies = keys %{$c->stash->{bodies}};
+        my $ca_another_user = $c->user->has_permission_to('contribute_as_another_user', \@bodies);
+        my $ca_body = $c->user->has_permission_to('contribute_as_body', \@bodies);
         $contribute_as->{another_user} = $ca_another_user if $ca_another_user;
         $contribute_as->{body} = $ca_body if $ca_body;
     }

--- a/perllib/FixMyStreet/App/Controller/Report/Update.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/Update.pm
@@ -113,7 +113,7 @@ sub process_user : Private {
     if ( $c->user_exists ) { {
         my $user = $c->user->obj;
 
-        if ($c->stash->{contributing_as_another_user} = $user->contributing_as('another_user', $c, $update->problem->bodies_str)) {
+        if ($c->stash->{contributing_as_another_user} = $user->contributing_as('another_user', $c, $update->problem->bodies_str_ids)) {
             # Act as if not logged in (and it will be auto-confirmed later on)
             last;
         }
@@ -276,7 +276,7 @@ sub process_update : Private {
     $update->mark_fixed($params{fixed} ? 1 : 0);
     $update->mark_open($params{reopen} ? 1 : 0);
 
-    $c->stash->{contributing_as_body} = $c->user_exists && $c->user->contributing_as('body', $c, $update->problem->bodies_str);
+    $c->stash->{contributing_as_body} = $c->user_exists && $c->user->contributing_as('body', $c, $update->problem->bodies_str_ids);
     if ($c->stash->{contributing_as_body}) {
         $update->name($c->user->from_body->name);
         $update->anonymous(0);
@@ -286,7 +286,7 @@ sub process_update : Private {
     }
 
     if ( $params{state} ) {
-        $params{state} = 'fixed - council' 
+        $params{state} = 'fixed - council'
             if $params{state} eq 'fixed' && $c->user && $c->user->belongs_to_body( $update->problem->bodies_str );
         $update->problem_state( $params{state} );
     } else {

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -720,6 +720,12 @@ sub available_permissions {
             planned_reports => _("Manage planned reports list"),
             contribute_as_another_user => _("Create reports/updates on a user's behalf"),
             contribute_as_body => _("Create reports/updates as the council"),
+
+            # NB this permission is special in that it can be assigned to users
+            # without their from_body being set. It's included here for
+            # reference, but left commented out because it's not assigned in the
+            # same way as other permissions.
+            # trusted => _("Trusted to make reports that don't need to be inspected"),
         },
         _("Users") => {
             user_edit => _("Edit other users' details"),

--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -292,6 +292,22 @@ sub has_body_permission_to {
     return $self->has_permission_to($permission_type, $self->from_body->id);
 }
 
+=head2 admin_user_body_permissions
+
+Some permissions aren't managed in the normal way via the admin, e.g. the
+'trusted' permission. This method returns a query that excludes such exceptional
+permissions.
+
+=cut
+
+sub admin_user_body_permissions {
+    my $self = shift;
+
+    return $self->user_body_permissions->search({
+        permission_type => { '!=' => 'trusted' },
+    });
+}
+
 sub contributing_as {
     my ($self, $other, $c, $bodies) = @_;
     $bodies = [ keys %$bodies ] if ref $bodies eq 'HASH';

--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -257,15 +257,14 @@ sub permissions {
 }
 
 sub has_permission_to {
-    my ($self, $permission_type, $body_id) = @_;
+    my ($self, $permission_type, $body_ids) = @_;
 
     return 1 if $self->is_superuser;
+    return 0 unless $body_ids;
 
-    return 0 unless $self->belongs_to_body($body_id);
-
-    my $permission = $self->user_body_permissions->find({ 
+    my $permission = $self->user_body_permissions->find({
             permission_type => $permission_type,
-            body_id => $self->from_body->id,
+            body_id => $body_ids,
         });
     return $permission ? 1 : 0;
 }
@@ -295,8 +294,7 @@ sub has_body_permission_to {
 
 sub contributing_as {
     my ($self, $other, $c, $bodies) = @_;
-    $bodies = join(',', keys %$bodies) if ref $bodies eq 'HASH';
-    $c->log->error("Bad data $bodies passed to contributing_as") if ref $bodies;
+    $bodies = [ keys %$bodies ] if ref $bodies eq 'HASH';
     my $form_as = $c->get_param('form_as') || '';
     return 1 if $form_as eq $other && $self->has_permission_to("contribute_as_$other", $bodies);
 }

--- a/perllib/FixMyStreet/Script/Reports.pm
+++ b/perllib/FixMyStreet/Script/Reports.pm
@@ -144,9 +144,14 @@ sub send(;$) {
             $reporters{ $sender } ||= $sender->new();
 
             my $inspection_required = $sender_info->{contact}->get_extra_metadata('inspection_required') if $sender_info->{contact};
-            if ( $inspection_required && !$row->get_extra_metadata('inspected') ) {
-                $skip = 1;
-                debug_print("skipped because not yet inspected", $row->id) if $debug_mode;
+            if ( $inspection_required ) {
+                unless (
+                        $row->get_extra_metadata('inspected') ||
+                        $row->user->has_permission_to( trusted => $row->bodies_str )
+                ) {
+                    $skip = 1;
+                    debug_print("skipped because not yet inspected", $row->id) if $debug_mode;
+                }
             }
 
             if ( $reporters{ $sender }->should_skip( $row ) ) {

--- a/t/app/controller/admin.t
+++ b/t/app/controller/admin.t
@@ -1165,6 +1165,7 @@ my %default_perms = (
     "permissions[template_edit]" => undef,
     "permissions[responsepriority_edit]" => undef,
     "permissions[category_edit]" => undef,
+    trusted_bodies => undef,
 );
 
 FixMyStreet::override_config {

--- a/templates/web/base/admin/user-form.html
+++ b/templates/web/base/admin/user-form.html
@@ -85,9 +85,32 @@
               [% loc("You can add an abusive user's email to the abuse list, which automatically hides (and never sends) reports they create.") %]
             </p>
           </div>
-          
+
           [% loc('Flagged:') %] <input type="checkbox" id="flagged" name="flagged"[% user.flagged ? ' checked' : '' %]>
         </li>
+
+        [% UNLESS user.is_superuser %]
+          <li>
+            <div class="admin-hint">
+              <p>
+                [% loc("Reports made by trusted users will be sent to the responsible body without being inspected first.") %]
+              </p>
+            </div>
+            [% IF c.user.is_superuser %]
+              [% loc('Trusted by bodies:') %]<br />
+              <select id='body' name='trusted_bodies' multiple>
+                [% FOR body IN bodies %]
+                  <option value="[% body.id %]"[% ' selected' IF user.has_permission_to('trusted', body.id) %]>[% body.name %]</option>
+                [% END %]
+              </select>
+            [% ELSE %]
+              <label>
+                [% loc('Trusted:') %]
+                <input type="checkbox" id="trusted_bodies" name="trusted_bodies" value="[% c.user.from_body.id %]" [% 'checked' IF user.has_permission_to('trusted', c.user.from_body.id) %]>
+              </label>
+            [% END %]
+          </li>
+        [% END %]
 
         [% IF c.user.is_superuser %]
           <li>

--- a/templates/web/base/report/_main.html
+++ b/templates/web/base/report/_main.html
@@ -7,7 +7,7 @@
 
 <div class="problem-header clearfix" problem-id="[% problem.id %]">
 
-[% IF c.user.has_permission_to('planned_reports', problem.bodies_str) %]
+[% IF c.user.has_permission_to('planned_reports', problem.bodies_str_ids) %]
 <form method="post" action="/my/planned/change" id="planned_form">
     <input type="hidden" name="id" value="[% problem.id %]">
     <input type="hidden" name="token" value="[% csrf_token %]">

--- a/templates/web/base/report/new/form_user_loggedin.html
+++ b/templates/web/base/report/new/form_user_loggedin.html
@@ -5,8 +5,8 @@
     [% INCLUDE form_as %]
   </div>
 [% ELSE %]
-  [% can_contribute_as_another_user = c.user.has_permission_to("contribute_as_another_user", bodies.keys.join(",")) %]
-  [% can_contribute_as_body = c.user.from_body AND c.user.has_permission_to("contribute_as_body", bodies.keys.join(",")) %]
+  [% can_contribute_as_another_user = c.user.has_permission_to("contribute_as_another_user", bodies.keys) %]
+  [% can_contribute_as_body = c.user.from_body AND c.user.has_permission_to("contribute_as_body", bodies.keys) %]
   [% IF can_contribute_as_another_user OR can_contribute_as_body %]
     [% INCLUDE form_as %]
   [% END %]

--- a/templates/web/base/report/update.html
+++ b/templates/web/base/report/update.html
@@ -1,4 +1,4 @@
-[% moderating = c.user && c.user.has_permission_to('moderate', problem.bodies_str) %]
+[% moderating = c.user && c.user.has_permission_to('moderate', problem.bodies_str_ids) %]
 
 [% IF loop.first %]
 <section class="full-width">

--- a/templates/web/base/report/update/form_name.html
+++ b/templates/web/base/report/update/form_name.html
@@ -2,8 +2,8 @@
 
 [% PROCESS 'user/_anonymity.html' anonymous = update.anonymous %]
 
-  [% can_contribute_as_another_user = c.user.has_permission_to("contribute_as_another_user", problem.bodies_str) %]
-  [% can_contribute_as_body = c.user.from_body AND c.user.has_permission_to("contribute_as_body", problem.bodies_str) %]
+  [% can_contribute_as_another_user = c.user.has_permission_to("contribute_as_another_user", problem.bodies_str_ids) %]
+  [% can_contribute_as_body = c.user.from_body AND c.user.has_permission_to("contribute_as_body", problem.bodies_str_ids) %]
 
   [% IF can_contribute_as_another_user OR can_contribute_as_body %]
     <label for="form_as">[% loc('Provide update as') %]</label>


### PR DESCRIPTION
Adds UI to the user edit form allowing users to be given 'trusted' status to make reports that are sent to the external body/contractor without being inspected first.

This uses the `UserBodyPermission` model, meaning a user's trusted status is applied on a per-body basis. For superusers the admin UI is a multiselect for all bodies, but regular admin users can only assign trusted status for their own body.

This also removes the requirement for users to have a `from_body` set in `User::has_permission_to`, because trusted users don't have a `from_body`.

For mysociety/fixmystreetforcouncils#57