### PR TITLE
Add user reputation for automatic report sending

### DIFF
--- a/bin/update-schema
+++ b/bin/update-schema
@@ -194,6 +194,7 @@ else {
 # By querying the database schema, we can see where we're currently at
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
+    return '0046' if column_exists('users', 'extra');
     return '0045' if table_exists('response_priorities');
     return '0044' if table_exists('contact_response_templates');
     return '0043' if column_exists('users', 'area_id');

--- a/db/downgrade_0046---0045.sql
+++ b/db/downgrade_0046---0045.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE users
+    DROP COLUMN extra;
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -31,7 +31,8 @@ create table users (
     title           text,
     twitter_id      bigint  unique,
     facebook_id     bigint  unique,
-    area_id         integer
+    area_id         integer,
+    extra           text
 );
 
 -- Record details of reporting bodies, including open311 configuration details

--- a/db/schema_0046-user-add-extra.sql
+++ b/db/schema_0046-user-add-extra.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE users
+    ADD COLUMN extra TEXT;
+
+COMMIT;

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -385,6 +385,9 @@ sub update_contacts : Private {
         else {
             $contact->unset_extra_metadata( 'inspection_required' );
         }
+        if ( $c->get_param('reputation_threshold') ) {
+            $contact->set_extra_metadata( reputation_threshold => int($c->get_param('reputation_threshold')) );
+        }
 
         if ( %errors ) {
             $c->stash->{updated} = _('Please correct the errors below');

--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -378,4 +378,12 @@ sub is_planned_report {
     return $self->active_planned_reports->find({ id => $problem->id });
 }
 
+sub update_reputation {
+    my ( $self, $change ) = @_;
+
+    my $reputation = $self->get_extra_metadata('reputation') || 0;
+    $self->set_extra_metadata( reputation => $reputation + $change);
+    $self->update;
+}
+
 1;

--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -26,20 +26,22 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 1 },
   "password",
   { data_type => "text", default_value => "", is_nullable => 0 },
-  "flagged",
-  { data_type => "boolean", default_value => \"false", is_nullable => 0 },
   "from_body",
   { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
+  "flagged",
+  { data_type => "boolean", default_value => \"false", is_nullable => 0 },
   "title",
   { data_type => "text", is_nullable => 1 },
-  "facebook_id",
-  { data_type => "bigint", is_nullable => 1 },
   "twitter_id",
+  { data_type => "bigint", is_nullable => 1 },
+  "facebook_id",
   { data_type => "bigint", is_nullable => 1 },
   "is_superuser",
   { data_type => "boolean", default_value => \"false", is_nullable => 0 },
   "area_id",
   { data_type => "integer", is_nullable => 1 },
+  "extra",
+  { data_type => "text", is_nullable => 1 },
 );
 __PACKAGE__->set_primary_key("id");
 __PACKAGE__->add_unique_constraint("users_email_key", ["email"]);
@@ -100,11 +102,17 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2016-08-03 13:52:28
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:SX8BS91mWHoOm2oWdNth1w
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2016-09-16 14:22:10
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:7wfF1VnZax2QTXCIPXr+vg
+
+__PACKAGE__->load_components("+FixMyStreet::DB::RABXColumn");
+__PACKAGE__->rabx_column('extra');
 
 use Moo;
 use mySociety::EmailUtil;
+use namespace::clean -except => [ 'meta' ];
+
+with 'FixMyStreet::Roles::Extra';
 
 __PACKAGE__->many_to_many( planned_reports => 'user_planned_reports', 'report' );
 

--- a/perllib/FixMyStreet/Script/Reports.pm
+++ b/perllib/FixMyStreet/Script/Reports.pm
@@ -145,9 +145,16 @@ sub send(;$) {
 
             my $inspection_required = $sender_info->{contact}->get_extra_metadata('inspection_required') if $sender_info->{contact};
             if ( $inspection_required ) {
+                my $reputation_threshold = $sender_info->{contact}->get_extra_metadata('reputation_threshold') || 0;
+                my $reputation_threshold_met = 0;
+                if ( $reputation_threshold > 0 ) {
+                    my $user_reputation = $row->user->get_extra_metadata('reputation') || 0;
+                    $reputation_threshold_met = $user_reputation >= $reputation_threshold;
+                }
                 unless (
                         $row->get_extra_metadata('inspected') ||
-                        $row->user->has_permission_to( trusted => $row->bodies_str_ids )
+                        $row->user->has_permission_to( trusted => $row->bodies_str_ids ) ||
+                        $reputation_threshold_met
                 ) {
                     $skip = 1;
                     debug_print("skipped because not yet inspected", $row->id) if $debug_mode;

--- a/templates/web/base/admin/category_edit.html
+++ b/templates/web/base/admin/category_edit.html
@@ -19,7 +19,7 @@
 [% END %]
 </p>
 
-<form method="post" action="[% c.uri_for('body', body_id ) %]" enctype="application/x-www-form-urlencoded" accept-charset="utf-8">
+<form method="post" action="[% c.uri_for('body', body_id ) %]" enctype="application/x-www-form-urlencoded" accept-charset="utf-8" id="category_edit">
     <p><strong>[% loc('Category:') %] </strong>[% contact.category | html %]
     <input type="hidden" name="category" value="[% contact.category | html %]" >
     <input type="hidden" name="token" value="[% csrf_token %]" >
@@ -46,6 +46,15 @@
         <label class="inline" for="photo_required">[% loc('Photo required') %]</label>
       [% END %]
     </p>
+
+    [% IF c.cobrand.moniker != 'zurich' %]
+      <p [% 'class=hidden' UNLESS contact.get_extra_metadata('inspection_required') %]>
+        <label>
+          [% loc('Reputation threshold:') %]
+          <input type="text" name="reputation_threshold" id="reputation_threshold" value="[% contact.get_extra_metadata('reputation_threshold') | html %]" size="30">
+        </label>
+      </p>
+    [% END %]
 
     <p><strong>[% loc('Note:') %] </strong><textarea name="note" rows="3" cols="40"></textarea>
 

--- a/templates/web/base/admin/user-form.html
+++ b/templates/web/base/admin/user-form.html
@@ -110,6 +110,14 @@
               </label>
             [% END %]
           </li>
+          <li>
+            <div class="admin-hint">
+              <p>
+                [% loc("Reports from users with high enough reputation will be sent immediately without requiring inspection. Each category's threshold can be managed on its edit page. Users earn reputation when a report they have made is marked as inspected by inspectors.") %]
+              </p>
+            </div>
+            [% loc('Reputation:') %] [% user.get_extra_metadata('reputation') %]
+          </li>
         [% END %]
 
         [% IF c.user.is_superuser %]

--- a/templates/web/base/report/display_tools.html
+++ b/templates/web/base/report/display_tools.html
@@ -3,7 +3,7 @@
         [% IF c.user_exists AND c.cobrand.users_can_hide AND c.user.belongs_to_body( problem.bodies_str ) %]
         <li><form method="post" action="/report/delete/[% problem.id %]" id="remove-from-site-form">
             <input type="hidden" name="token" value="[% csrf_token %]">
-            <input type="submit" id="key-tool-report-abuse" class="abuse" data-confirm="[% loc('Are you sure?') %]" value="[% loc('Remove from site') %]">
+            <input type="submit" id="key-tool-report-abuse" class="abuse" data-confirm="[% loc('Are you sure?') %]" name="remove_from_site" value="[% loc('Remove from site') %]">
         </form></li>
         [% ELSIF c.cobrand.moniker != 'zurich' %]
         <li><a rel="nofollow" id="key-tool-report-abuse" class="abuse" href="[% c.uri_for( '/contact', { id => problem.id } ) %]">[% loc('Report abuse' ) %]</a></li>

--- a/web/js/fixmystreet-admin.js
+++ b/web/js/fixmystreet-admin.js
@@ -79,5 +79,15 @@ $(function(){
         var show_area = $(this).val() == $(this).find("[data-originally-selected]").val();
         $("form#user_edit select#area_id").closest("li").toggle(show_area);
     });
+
+    // On category edit page, hide the reputation input if inspection isn't required
+    $("form#category_edit #inspection_required").change(function() {
+        var $p = $("form#category_edit #reputation_threshold").closest("p");
+        if (this.checked) {
+            $p.removeClass("hidden");
+        } else {
+            $p.addClass("hidden");
+        }
+    });
 });
 


### PR DESCRIPTION
This PR adds the ability for users to gain reputation if they make high-quality reports, and lose it if their reports are duplicates/otherwise rejected or removed from the site.

The purpose of reputation is to allow reports to be sent immediately without any need for inspection/instruction for those categories that require inspection. It operates in a similar way to the 'trusted' flag.

 - User's reputation is stored in the newly-added `extra` column.
 - Categories requiring inspection can have a reputation threshold set, below which reports must still be inspected before being sent.
 - When a report is inspected and sent on to be fixed the user gains a reputation point.
 - ~~When a report is rejected (e.g. has its state set to hidden/duplicate/not responsible) at the inspection stage the user's reputation is reduced by a point.~~
 - If a report is removed from the site entirely via the 'Remove from site' link, the user's reputation is decremented.

For mysociety/fixmystreetforcouncils#56.