### PR TITLE
[fixmystreet.com] Update privacy policy to allow Google Analytics demographics

### DIFF
--- a/templates/web/fixmystreet.com/about/privacy.html
+++ b/templates/web/fixmystreet.com/about/privacy.html
@@ -75,7 +75,9 @@ the cookies and services that this site can use.
 
 <p>We use Google Analytics to collect information about how people use this
 site. We do this to make sure it’s meeting its users’ needs and to understand
-how we could do it better. Google Analytics stores information such as what
+how we could do it better.
+
+<p>Google Analytics stores information such as what
 pages you visit, how long you are on the site, how you got here, what you click
 on, and information about your web browser. IP addresses are masked (only a
 portion is stored) and personal information is only reported in aggregate. We
@@ -83,18 +85,25 @@ do not allow Google to use or share our analytics data for any purpose besides
 providing us with analytics information, and we recommend that any user of
 Google Analytics does the same.
 
-<p>If you’re unhappy with data about your visit to be used in this way, you can
-install the <a href="http://tools.google.com/dlpage/gaoptout">official browser
-plugin for blocking Google Analytics</a>.
+<p>We have also enabled the Advertising Features of Google
+Analytics. In particular, we use <b>Demographics and Interest
+reporting</b> to identify trends in the types of users visiting our
+site, which may be used for internal reporting and improvement of
+the site content.
 
-<p>The cookies set by Google Analytics are as follows:
-
-<table cellpadding=5>
-<tr align="left"><th scope="col">Name</th><th scope="col">Typical Content</th><th scope="col">Expires</th></tr>
-<tr><td>_ga</td><td>Used to distinguish users</td><td>2 years</td></tr>
-<tr><td>_gat</td><d>Used to throtle request rate</td><td>10 minutes</td></tr>
-<tr><td>__utmx / __utmxx</td><td>Which variation of a page you are seeing if we are testing different versions to see which is best</td><td>2&nbsp;years</td></tr>
-</table>
+<p>In technical speak, this allows Google to collect data about your
+traffic via Google
+<a href="https://www.google.com/policies/technologies/types/">advertising
+cookies</a> and
+<a href="https://www.google.com/policies/privacy/key-terms/#toc-terms-identifier">anonymous
+identifiers</a>, in addition to data collected through a standard
+Google Analytics implementation. Regardless of the source of the
+data, we strictly adhere to
+<a href="https://support.google.com/analytics/answer/2700409">Google&rsquo;s
+policy requirements</a> in our treatment of your data. We do not
+facilitate the merging of personally-identifiable information with
+non-personally identifiable information collected through any Google
+advertising product or feature.
 
 <h4>Google’s Official Statement about Analytics Data</h4>
 
@@ -115,8 +124,22 @@ this you may not be able to use the full functionality of this website. By
 using this website, you consent to the processing of data about you by Google
 in the manner and for the purposes set out above.”</p>
 
-<p><a href="https://www.mysociety.org/privacy-online/">More general information
-on how third party services work</a></p>
+<h3>Opting out</h3>
+<p>If you’re unhappy with the idea of sharing the fact you
+visited our site (and any other sites) with Google, you can
+<a href="https://tools.google.com/dlpage/gaoptout/">install the
+official browser plugin for blocking Google Analytics</a>.
+
+<p>If you want to disable advertising-based tracking, you can
+<a href="https://www.google.com/settings/ads">adjust your Google Ads
+Settings</a>, or opt out of advertising-based tracking across a
+number of providers in one go using the
+<a href="http://www.networkadvertising.org/choices/">Network
+Advertising Initiative’s opt-out form</a>.
+
+<p>Rest assured, we only track usage data for one reason: to help us
+understand how we can make the site work better for you, our
+users.
 
 <h2>Credits</h2>
 


### PR DESCRIPTION
Update the privacy policy for fixmystreet.com to allow us to switch on demographic tracking in Google Analytics. This is a direct lift of the [policy from TheyWorkForYou](https://www.theyworkforyou.com/privacy/), which we're already confident allows this sort of thing. As part of this it removes the table of Google cookies, adds a bit on opt-out tools, and retains the Google statement.