### PR TITLE
Let users hide their name on published reports and updates

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Contact.pm
+++ b/perllib/FixMyStreet/App/Controller/Contact.pm
@@ -168,8 +168,7 @@ sub prepare_params_for_email : Private {
 
     if ( $c->stash->{update} ) {
 
-        $c->stash->{problem_url} = $base_url . '/report/' . $c->stash->{update}->problem_id
-            . '#update_' . $c->stash->{update}->id;
+        $c->stash->{problem_url} = $base_url . $c->stash->{update}->url;
         $c->stash->{admin_url} = $admin_url . '/update_edit/' . $c->stash->{update}->id;
         $c->stash->{complaint} = sprintf(
             "Complaint about update %d on report %d",

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -181,8 +181,10 @@ sub load_updates : Private {
     @combined = map { $_->[1] } sort { $a->[0] <=> $b->[0] } @combined;
     $c->stash->{updates} = \@combined;
 
-    if ($c->sessionid && $c->flash->{alert_to_reporter}) {
-        $c->stash->{alert_to_reporter} = 1;
+    if ($c->sessionid) {
+        foreach (qw(alert_to_reporter anonymized)) {
+            $c->stash->{$_} = $c->flash->{$_} if $c->flash->{$_};
+        }
     }
 
     return 1;

--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -149,6 +149,11 @@ sub confirm {
     $self->confirmed( \'current_timestamp' );
 }
 
+sub url {
+    my $self = shift;
+    return "/report/" . $self->problem_id . '#update_' . $self->id;
+}
+
 sub photos {
     my $self = shift;
     my $photoset = $self->get_photoset;

--- a/perllib/FixMyStreet/TestMech.pm
+++ b/perllib/FixMyStreet/TestMech.pm
@@ -1,8 +1,16 @@
 package FixMyStreet::TestMech;
-use base qw(Test::WWW::Mechanize::Catalyst Test::Builder::Module);
+use parent qw(Test::WWW::Mechanize::Catalyst Test::Builder::Module);
 
 use strict;
-use warnings;
+use warnings FATAL => 'all';
+use utf8;
+
+sub import {
+    strict->import;
+    warnings->import(FATAL => 'all');
+    utf8->import;
+    Test::More->export_to_level(1);
+}
 
 BEGIN {
     use FixMyStreet;

--- a/t/app/controller/about.t
+++ b/t/app/controller/about.t
@@ -1,11 +1,6 @@
-use utf8;
-use strict;
-use warnings;
+use FixMyStreet::TestMech;
 
-use Test::More;
-use Test::WWW::Mechanize::Catalyst 'FixMyStreet::App';
-
-ok( my $mech = Test::WWW::Mechanize::Catalyst->new, 'Created mech object' );
+ok( my $mech = FixMyStreet::TestMech->new, 'Created mech object' );
 
 # check that we can get the page
 $mech->get_ok('/faq');

--- a/t/app/controller/admin.t
+++ b/t/app/controller/admin.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use FixMyStreet::TestMech;
 
 my $mech = FixMyStreet::TestMech->new;

--- a/t/app/controller/admin_permissions.t
+++ b/t/app/controller/admin_permissions.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use FixMyStreet::TestMech;
 
 my $mech = FixMyStreet::TestMech->new;

--- a/t/app/controller/alert.t
+++ b/t/app/controller/alert.t
@@ -1,6 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
 use LWP::Protocol::PSGI;
 
 use FixMyStreet::TestMech;

--- a/t/app/controller/alert_new.t
+++ b/t/app/controller/alert_new.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use FixMyStreet::TestMech;
 use FixMyStreet::App;
 

--- a/t/app/controller/around.t
+++ b/t/app/controller/around.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;
 

--- a/t/app/controller/auth.t
+++ b/t/app/controller/auth.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-
-use Test::More;
 use Test::MockModule;
 
 use FixMyStreet::TestMech;

--- a/t/app/controller/auth_social.t
+++ b/t/app/controller/auth_social.t
@@ -1,6 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
 use Test::MockModule;
 use LWP::Protocol::PSGI;
 use LWP::Simple;

--- a/t/app/controller/contact.t
+++ b/t/app/controller/contact.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use FixMyStreet::TestMech;
 
 my $mech = FixMyStreet::TestMech->new;

--- a/t/app/controller/dashboard.t
+++ b/t/app/controller/dashboard.t
@@ -1,6 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
 use Test::MockTime ':all';
 
 use FixMyStreet::TestMech;

--- a/t/app/controller/index.t
+++ b/t/app/controller/index.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;
 

--- a/t/app/controller/json.t
+++ b/t/app/controller/json.t
@@ -1,8 +1,3 @@
-use strict;
-use warnings;
-
-use Test::More;
-
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;
 

--- a/t/app/controller/moderate.t
+++ b/t/app/controller/moderate.t
@@ -1,8 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-use utf8;
-
 use FixMyStreet::TestMech;
 use FixMyStreet::App;
 use Data::Dumper;

--- a/t/app/controller/my.t
+++ b/t/app/controller/my.t
@@ -1,8 +1,3 @@
-use strict;
-use warnings;
-
-use Test::More;
-
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;
 

--- a/t/app/controller/my.t
+++ b/t/app/controller/my.t
@@ -4,9 +4,14 @@ my $mech = FixMyStreet::TestMech->new;
 $mech->get_ok('/my');
 is $mech->uri->path, '/auth', "got sent to the sign in page";
 
-$mech->create_problems_for_body(1, 1234, 'Test Title');
+$mech->get_ok('/my/anonymize');
+is $mech->uri->path, '/auth', "got sent to the sign in page";
+
+my @problems = $mech->create_problems_for_body(3, 1234, 'Test Title');
+$problems[1]->update({anonymous => 1});
+
 my $other_user = FixMyStreet::DB->resultset('User')->find_or_create({ email => 'another@example.com' });
-$mech->create_problems_for_body(1, 1234, 'Another Title', { user => $other_user });
+my @other = $mech->create_problems_for_body(1, 1234, 'Another Title', { user => $other_user });
 
 my $user = $mech->log_in_ok( 'test@example.com' );
 $mech->get_ok('/my');
@@ -14,6 +19,48 @@ is $mech->uri->path, '/my', "stayed on '/my' page";
 
 $mech->content_contains('Test Title');
 $mech->content_lacks('Another Title');
+
+my @update;
+my $i = 0;
+foreach ($user, $user, $other_user) {
+    $update[$i] = FixMyStreet::App->model('DB::Comment')->create({
+        text => 'this is an update',
+        user => $_,
+        state => 'confirmed',
+        problem => $problems[0],
+        mark_fixed => 0,
+        confirmed => \'current_timestamp',
+        anonymous => $i % 2,
+    });
+    $i++;
+}
+
+foreach (
+    { type => 'problem', id => 0, result => 404, desc => 'nothing' },
+    { type => 'problem', obj => $problems[0], result => 200, desc => 'own report' },
+    { type => 'problem', obj => $problems[1], result => 400, desc => 'already anon report' },
+    { type => 'problem', obj => $other[0], result => 400, desc => 'other user report' },
+    { type => 'update', id => -1, result => 400, desc => 'non-existent update' },
+    { type => 'update', obj => $update[0], result => 200, desc => 'own update' },
+    { type => 'update', obj => $update[1], result => 400, desc => 'already anon update' },
+    { type => 'update', obj => $update[2], result => 400, desc => 'other user update' },
+) {
+    my $id = $_->{id} // $_->{obj}->id;
+    $mech->get("/my/anonymize?$_->{type}=$id");
+    is $mech->res->code, $_->{result}, "Got $_->{result} fetching $_->{desc}";
+    if ($_->{result} == 200) {
+        $mech->submit_form_ok( { button => 'hide' }, 'Submit button to hide name' );
+        $_->{obj}->discard_changes;
+        is $_->{obj}->anonymous, 1, 'Object now made anonymous';
+        $_->{obj}->update({anonymous => 0});
+    }
+}
+
+$mech->get("/my/anonymize?problem=" . $problems[0]->id);
+$mech->submit_form_ok( { button => 'hide_everywhere' }, 'Submit button to hide name everywhere' );
+is $problems[0]->discard_changes->anonymous, 1, 'Problem from form made anonymous';
+is $problems[2]->discard_changes->anonymous, 1, 'Other user problem made anonymous';
+is $update[0]->discard_changes->anonymous, 1, 'User update made anonymous';
 
 done_testing();
 

--- a/t/app/controller/my_planned.t
+++ b/t/app/controller/my_planned.t
@@ -1,8 +1,3 @@
-use strict;
-use warnings;
-
-use Test::More;
-
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;
 

--- a/t/app/controller/open311.t
+++ b/t/app/controller/open311.t
@@ -1,8 +1,3 @@
-use strict;
-use warnings;
-
-use Test::More;
-
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;
 

--- a/t/app/controller/photo.t
+++ b/t/app/controller/photo.t
@@ -1,10 +1,3 @@
-use strict;
-use utf8; # sign in error message has &ndash; in it
-use warnings;
-use feature 'say';
-use Test::More;
-use utf8;
-
 use FixMyStreet::TestMech;
 use FixMyStreet::App;
 use Web::Scraper;

--- a/t/app/controller/questionnaire.t
+++ b/t/app/controller/questionnaire.t
@@ -1,6 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
 use DateTime;
 
 use FixMyStreet::TestMech;

--- a/t/app/controller/report_as_other.t
+++ b/t/app/controller/report_as_other.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use FixMyStreet::TestMech;
 use FixMyStreet::App;
 

--- a/t/app/controller/report_display.t
+++ b/t/app/controller/report_display.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use FixMyStreet::TestMech;
 use Web::Scraper;
 use Path::Class;

--- a/t/app/controller/report_display.t
+++ b/t/app/controller/report_display.t
@@ -547,14 +547,14 @@ subtest "check user details show when a user has correct permissions" => sub {
     $mech->log_in_ok( $oxfordshireuser->email );
     ok $mech->get("/report/$report_id"), "get '/report/$report_id'";
     is $mech->extract_problem_meta,
-      'Reported in the Roads category by Oxfordshire County Council (Council User) at 15:17, Tue 10 January 2012',
+      'Reported in the Roads category by Oxfordshire County Council (Council User) at 15:17, Tue 10 January 2012 (Hide your name?)',
       'correct problem meta information';
 
     ok $oxfordshireuser->user_body_permissions->delete_all, "Remove view_body_contribute_details permissions";
 
     ok $mech->get("/report/$report_id"), "get '/report/$report_id'";
     is $mech->extract_problem_meta,
-      'Reported in the Roads category by Oxfordshire County Council at 15:17, Tue 10 January 2012',
+      'Reported in the Roads category by Oxfordshire County Council at 15:17, Tue 10 January 2012 (Hide your name?)',
       'correct problem meta information for user without relevant permissions';
 
     $mech->log_out_ok;
@@ -574,7 +574,7 @@ subtest "check brackets don't appear when username and report name are the same"
     $mech->log_in_ok( $oxfordshireuser->email );
     ok $mech->get("/report/$report_id"), "get '/report/$report_id'";
     is $mech->extract_problem_meta,
-      'Reported in the Roads category by Council User at 15:17, Tue 10 January 2012',
+      'Reported in the Roads category by Council User at 15:17, Tue 10 January 2012 (Hide your name?)',
       'correct problem meta information';
 };
 

--- a/t/app/controller/report_import.t
+++ b/t/app/controller/report_import.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use FixMyStreet::TestMech;
 use FixMyStreet::App;
 use Web::Scraper;

--- a/t/app/controller/report_inspect.t
+++ b/t/app/controller/report_inspect.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use FixMyStreet::TestMech;
 
 my $mech = FixMyStreet::TestMech->new;

--- a/t/app/controller/report_interest_count.t
+++ b/t/app/controller/report_interest_count.t
@@ -1,6 +1,3 @@
-use strict;
-use warnings;
-
 package FixMyStreet::Cobrand::Tester;
 
 use parent 'FixMyStreet::Cobrand::Default';
@@ -10,8 +7,6 @@ sub can_support_problems {
 }
 
 package main;
-
-use Test::More;
 
 use FixMyStreet::TestMech;
 use Web::Scraper;

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -1,8 +1,3 @@
-use strict;
-use utf8; # sign in error message has &ndash; in it
-use warnings;
-use Test::More;
-
 use FixMyStreet::TestMech;
 use FixMyStreet::App;
 use Web::Scraper;

--- a/t/app/controller/report_new_mobile.t
+++ b/t/app/controller/report_new_mobile.t
@@ -1,4 +1,3 @@
-use Test::More;
 use FixMyStreet::TestMech;
 use LWP::Protocol::PSGI;
 use t::Mock::MapItZurich;

--- a/t/app/controller/report_new_open311.t
+++ b/t/app/controller/report_new_open311.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use FixMyStreet::TestMech;
 use FixMyStreet::App;
 use Web::Scraper;

--- a/t/app/controller/report_updates.t
+++ b/t/app/controller/report_updates.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use FixMyStreet::TestMech;
 use Web::Scraper;
 use Path::Class;

--- a/t/app/controller/report_updates.t
+++ b/t/app/controller/report_updates.t
@@ -716,11 +716,11 @@ for my $test (
         my $update_meta = $mech->extract_update_metas;
         my $meta_state = $test->{meta} || $test->{fields}->{state};
         if ( $test->{reopened} ) {
-            like $update_meta->[0], qr/reopened$/, 'update meta says reopened';
+            like $update_meta->[0], qr/reopened/, 'update meta says reopened';
         } elsif ( $test->{state} eq 'duplicate' ) {
-            like $update_meta->[0], qr/closed as $meta_state$/, 'update meta includes state change';
+            like $update_meta->[0], qr/closed as $meta_state/, 'update meta includes state change';
         } else {
-            like $update_meta->[0], qr/marked as $meta_state$/, 'update meta includes state change';
+            like $update_meta->[0], qr/marked as $meta_state/, 'update meta includes state change';
         }
 
         if ($test->{view_username}) {
@@ -755,24 +755,24 @@ subtest 'check meta correct for comments marked confirmed but not marked open' =
 
     $mech->get_ok( "/report/" . $report->id );
     my $update_meta = $mech->extract_update_metas;
-    unlike $update_meta->[0], qr/reopened$/,
+    unlike $update_meta->[0], qr/reopened/,
       'update meta does not say reopened';
 
     $comment->update( { mark_open => 1, problem_state => undef } );
     $mech->get_ok( "/report/" . $report->id );
     $update_meta = $mech->extract_update_metas;
 
-    unlike $update_meta->[0], qr/marked as open$/,
+    unlike $update_meta->[0], qr/marked as open/,
       'update meta does not says marked as open';
-    like $update_meta->[0], qr/reopened$/, 'update meta does say reopened';
+    like $update_meta->[0], qr/reopened/, 'update meta does say reopened';
 
     $comment->update( { mark_open => 0, problem_state => undef } );
     $mech->get_ok( "/report/" . $report->id );
     $update_meta = $mech->extract_update_metas;
 
-    unlike $update_meta->[0], qr/marked as open$/,
+    unlike $update_meta->[0], qr/marked as open/,
       'update meta does not says marked as open';
-    unlike $update_meta->[0], qr/reopened$/, 'update meta does not say reopened';
+    unlike $update_meta->[0], qr/reopened/, 'update meta does not say reopened';
 };
 
 subtest "check first comment with no status change has no status in meta" => sub {
@@ -911,7 +911,7 @@ subtest 'check meta correct for second comment marking as reopened' => sub {
 
     $mech->get_ok( "/report/" . $report->id );
     my $update_meta = $mech->extract_update_metas;
-    like $update_meta->[0], qr/fixed$/, 'update meta says fixed';
+    like $update_meta->[0], qr/fixed/, 'update meta says fixed';
 
     $comment = FixMyStreet::App->model('DB::Comment')->create(
         {
@@ -929,7 +929,7 @@ subtest 'check meta correct for second comment marking as reopened' => sub {
 
     $mech->get_ok( "/report/" . $report->id );
     $update_meta = $mech->extract_update_metas;
-    like $update_meta->[1], qr/reopened$/, 'update meta says reopened';
+    like $update_meta->[1], qr/reopened/, 'update meta says reopened';
 };
 
 $user->from_body(undef);

--- a/t/app/controller/reports.t
+++ b/t/app/controller/reports.t
@@ -1,6 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
 use FixMyStreet::TestMech;
 use mySociety::MaPit;
 use FixMyStreet::App;

--- a/t/app/controller/rss.t
+++ b/t/app/controller/rss.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use FixMyStreet::TestMech;
 use FixMyStreet::App;
 

--- a/t/app/controller/token.t
+++ b/t/app/controller/token.t
@@ -1,8 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-use utf8;
-
 use FixMyStreet::TestMech;
 use FixMyStreet::App;
 

--- a/t/app/helpers/send_email.t
+++ b/t/app/helpers/send_email.t
@@ -1,20 +1,10 @@
-use strict;
-use warnings;
-use utf8;
-
 package FixMyStreet::Cobrand::Tester;
 use parent 'FixMyStreet::Cobrand::Default';
 sub path_to_email_templates { [ FixMyStreet->path_to( 't', 'app', 'helpers', 'emails') ] }
 
 package main;
 
-BEGIN {
-    use FixMyStreet;
-    FixMyStreet->test_mode(1);
-}
-
 use Email::MIME;
-use Test::More;
 use Test::LongString;
 
 use Catalyst::Test 'FixMyStreet::App';

--- a/t/app/load_general_config.t
+++ b/t/app/load_general_config.t
@@ -3,8 +3,8 @@ use warnings;
 
 use Test::More tests => 2;
 
-use_ok 'FixMyStreet::App';
+use_ok 'FixMyStreet';
 
-is FixMyStreet::App->config->{GAZE_URL},
+is FixMyStreet->config('GAZE_URL'),
   'https://gaze.mysociety.org/gaze',
   "check that known config param is loaded";

--- a/t/app/model/alert_type.t
+++ b/t/app/model/alert_type.t
@@ -1,6 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
 use FixMyStreet::TestMech;
 
 mySociety::Locale::gettext_domain( 'FixMyStreet' );

--- a/t/app/model/defecttype.t
+++ b/t/app/model/defecttype.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use FixMyStreet::App;
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;

--- a/t/app/model/extra.t
+++ b/t/app/model/extra.t
@@ -4,7 +4,6 @@ use Test::More;
 use utf8;
 
 use FixMyStreet::DB;
-use Data::Dumper;
 use DateTime;
 
 my $db = FixMyStreet::DB->connect;

--- a/t/app/model/moderation.t
+++ b/t/app/model/moderation.t
@@ -5,7 +5,6 @@ use Test::Exception;
 use utf8;
 
 use FixMyStreet::DB;
-use Data::Dumper;
 use DateTime;
 
 my $dt = DateTime->now;

--- a/t/app/model/problem.t
+++ b/t/app/model/problem.t
@@ -1,8 +1,3 @@
-use strict;
-use warnings;
-
-use Test::More;
-
 use FixMyStreet::TestMech;
 use FixMyStreet;
 use FixMyStreet::App;

--- a/t/app/model/questionnaire.t
+++ b/t/app/model/questionnaire.t
@@ -1,8 +1,3 @@
-use strict;
-use warnings;
-
-use Test::More;
-
 use FixMyStreet;
 use FixMyStreet::TestMech;
 

--- a/t/app/model/user.t
+++ b/t/app/model/user.t
@@ -1,8 +1,3 @@
-use strict;
-use warnings;
-
-use Test::More;
-
 use FixMyStreet::TestMech;
 use FixMyStreet::DB;
 

--- a/t/app/model/user_planned_report.t
+++ b/t/app/model/user_planned_report.t
@@ -1,8 +1,3 @@
-use strict;
-use warnings;
-
-use Test::More;
-
 use FixMyStreet::TestMech;
 use FixMyStreet::DB;
 

--- a/t/app/script/archive_old_enquiries.t
+++ b/t/app/script/archive_old_enquiries.t
@@ -1,6 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
 use FixMyStreet::TestMech;
 use FixMyStreet::Script::ArchiveOldEnquiries;
 

--- a/t/app/sendreport/email.t
+++ b/t/app/sendreport/email.t
@@ -1,8 +1,3 @@
-use strict;
-use warnings;
-
-use Test::More;
-
 use FixMyStreet;
 use FixMyStreet::DB;
 use FixMyStreet::SendReport::Email;

--- a/t/app/sendreport/inspection_required.t
+++ b/t/app/sendreport/inspection_required.t
@@ -1,8 +1,3 @@
-use strict;
-use warnings;
-
-use Test::More;
-
 use FixMyStreet;
 use FixMyStreet::DB;
 use FixMyStreet::TestMech;
@@ -31,13 +26,13 @@ my @reports = $mech->create_problems_for_body( 1, $body->id, 'Test', {
 });
 my $report = $reports[0];
 
-subtest 'Report isn’t sent if uninspected' => sub {
+subtest "Report isn't sent if uninspected" => sub {
     $mech->clear_emails_ok;
 
     FixMyStreet::DB->resultset('Problem')->send_reports();
 
     $mech->email_count_is( 0 );
-    is $report->whensent, undef, 'Report hasn’t been sent';
+    is $report->whensent, undef, "Report hasn't been sent";
 };
 
 subtest 'Report is sent when inspected' => sub {
@@ -72,7 +67,7 @@ subtest 'Uninspected report is sent when made by trusted user' => sub {
     is $report->get_extra_metadata('inspected'), undef, 'Report not marked as inspected';
 };
 
-subtest 'Uninspected report isn’t sent when user rep is too low' => sub {
+subtest "Uninspected report isn't sent when user rep is too low" => sub {
     $mech->clear_emails_ok;
     $report->whensent( undef );
     $report->update;
@@ -88,7 +83,7 @@ subtest 'Uninspected report isn’t sent when user rep is too low' => sub {
 
     $report->discard_changes;
     $mech->email_count_is( 0 );
-    is $report->whensent, undef, 'Report hasn’t been sent';
+    is $report->whensent, undef, "Report hasn't been sent";
 };
 
 subtest 'Uninspected report is sent when user rep is high enough' => sub {

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use CGI::Simple;
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;

--- a/t/cobrand/closest.t
+++ b/t/cobrand/closest.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-
-use Test::More;
 use t::Mock::Bing;
 
 use mySociety::Locale;

--- a/t/cobrand/councils.t
+++ b/t/cobrand/councils.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;
 

--- a/t/cobrand/fixamingata.t
+++ b/t/cobrand/fixamingata.t
@@ -1,12 +1,4 @@
-use strict;
-use warnings;
-use Test::More;
 use Test::MockModule;
-
-BEGIN {
-    use FixMyStreet;
-    FixMyStreet->test_mode(1);
-}
 
 use mySociety::Locale;
 

--- a/t/cobrand/form_extras.t
+++ b/t/cobrand/form_extras.t
@@ -1,6 +1,3 @@
-use strict;
-use warnings;
-
 package FixMyStreet::Cobrand::Tester;
 use parent 'FixMyStreet::Cobrand::FixMyStreet';
 
@@ -18,7 +15,6 @@ sub path_to_web_templates {
 
 package main;
 
-use Test::More;
 use FixMyStreet::TestMech;
 
 # disable info logs for this test run

--- a/t/cobrand/hart.t
+++ b/t/cobrand/hart.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;
 

--- a/t/cobrand/oxfordshire.t
+++ b/t/cobrand/oxfordshire.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;
 
@@ -61,7 +57,7 @@ subtest 'Exor RDI download appears on Oxfordshire cobrand admin' => sub {
     }
 };
 
-subtest 'Exor RDI download doesn’t appear outside of Oxfordshire cobrand admin' => sub {
+subtest "Exor RDI download doesn't appear outside of Oxfordshire cobrand admin" => sub {
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => [ { 'fixmystreet' => '.' } ],
     }, sub {

--- a/t/cobrand/restriction.t
+++ b/t/cobrand/restriction.t
@@ -17,7 +17,6 @@ sub updates_restriction {
 
 package main;
 
-use Test::More;
 use FixMyStreet::TestMech;
 
 my $c = FixMyStreet::App->new;

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -1,15 +1,14 @@
 # TODO
 # Overdue alerts
 
-use strict;
-use warnings;
 use DateTime;
 use Email::MIME;
 use LWP::Protocol::PSGI;
-use Test::More;
 use Test::LongString;
 use Path::Tiny;
 use t::Mock::MapItZurich;
+use FixMyStreet::TestMech;
+my $mech = FixMyStreet::TestMech->new;
 
 # Check that you have the required locale installed - the following
 # should return a line with de_CH.utf8 in. If not install that locale.
@@ -52,9 +51,6 @@ sub reset_report_state {
     $report->created($created) if $created;
     $report->update;
 }
-
-use FixMyStreet::TestMech;
-my $mech = FixMyStreet::TestMech->new;
 
 # Front page test
 ok $mech->host("zurich.example.com"), "change host to Zurich";

--- a/t/map/tilma/original.t
+++ b/t/map/tilma/original.t
@@ -1,6 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
 use FixMyStreet::DB;
 use FixMyStreet::Map;
 use FixMyStreet::TestMech;

--- a/t/sendreport/open311.t
+++ b/t/sendreport/open311.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use CGI::Simple;
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;

--- a/templates/email/default/other-updated.html
+++ b/templates/email/default/other-updated.html
@@ -13,7 +13,7 @@ INCLUDE '_email_top.html';
   <h1 style="[% h1_style %]">Your update has been&nbsp;logged</h1>
   <p style="[% p_style %]">Your update has been logged on [% site_name %]:</p>
   <p style="margin: 20px auto; text-align: center">
-  <a style="[% button_style %]" href="[% cobrand.base_url_for_report(problem) %][% problem.url %]#update_[% update.id %]">View my update</a>
+  <a style="[% button_style %]" href="[% cobrand.base_url_for_report(problem) %][% update.url %]">View my update</a>
   </p>
   [% end_padded_box %]
 </th>

--- a/templates/email/default/other-updated.txt
+++ b/templates/email/default/other-updated.txt
@@ -4,7 +4,7 @@ Hello [% update.name %],
 
 Your update has been logged on [% site_name %]:
 
-[% cobrand.base_url_for_report(problem) %][% problem.url %]#update_[% update.id %]
+[% cobrand.base_url_for_report(problem) %][% update.url %]
 
 Your update reads:
 

--- a/templates/web/base/my/anonymize.html
+++ b/templates/web/base/my/anonymize.html
@@ -1,0 +1,26 @@
+[% INCLUDE 'header.html',
+    title = loc('Hide my name'),
+    bodyclass = 'twothirdswidthpage' %]
+
+<form method="post" action="/my/anonymize" class="box-warning hide-name-form">
+    <input type="hidden" name="token" value="[% csrf_token %]">
+
+  [% IF update %]
+    <input type="hidden" name="update" value="[% update.id %]">
+    <input class="btn-primary" type="submit" name="hide" value="[% loc('Hide my name in this update') %]">
+  [% ELSIF problem %]
+    [% IF problem.bodies_str %]
+      <p>[% tprintf(loc('Your name has already been sent to %s, but we can hide it on this page:'), problem.body(c)) %]</p>
+    [% END %]
+    <input type="hidden" name="problem" value="[% problem.id %]">
+    <input class="btn-primary" type="submit" name="hide" value="[% loc('Hide my name on this report') %]">
+  [% END %]
+
+  [% IF NOT c.user.from_body %]
+    <p>[% loc('Alternatively, we can hide your name on <strong>all of your reports and updates</strong> across the site:') %]</p>
+    <input class="btn" type="submit" name="hide_everywhere" value="[% loc('Hide my name everywhere') %]">
+  [% END %]
+
+</form>
+
+[% INCLUDE 'footer.html' %]

--- a/templates/web/base/my/my.html
+++ b/templates/web/base/my/my.html
@@ -66,7 +66,7 @@
                 <p class="meta-2">
                     [% tprintf( loc("Added %s"), prettify_dt( u.confirmed, 'date' ) ) %]
                     &ndash;
-                    <a href="[% c.uri_for( '/report', u.problem_id ) %]#update_[% u.id %]">
+                    <a href="[% u.url %]">
                         [% u.problem.title | html %]
                     </a>
                 </p>

--- a/templates/web/base/open311/index.html
+++ b/templates/web/base/open311/index.html
@@ -41,7 +41,7 @@ about future-proofing your communication channels in an easy and economical way
 [% IF c.cobrand.moniker == 'fixmystreet' %]
 <p>You may be interested to know about <a
 href="https://www.fixmystreet.com/about/council">FixMyStreet
-for Councils</a>, our hosted service which sits seamlessly on your council
+Professional</a>, our hosted service which sits seamlessly on your council
 website.</p>
 
 <p>We can integrate it with any council back-end system, but if you use

--- a/templates/web/base/report/_main.html
+++ b/templates/web/base/report/_main.html
@@ -64,6 +64,10 @@
         [% INCLUDE 'report/_report_meta_info.html' %]
     </p>
 
+    [% IF anonymized ~%]
+        <p class="form-success">[% anonymized %]</p>
+    [% END ~%]
+
     [% INCLUDE 'report/_main_sent_info.html' %]
     [% mlog = problem.latest_moderation_log_entry(); IF mlog %]
         <p>[% tprintf(loc('Moderated by %s at %s'), mlog.admin_user, prettify_dt(mlog.whenedited)) %]</p>

--- a/templates/web/base/report/_report_meta_info.html
+++ b/templates/web/base/report/_report_meta_info.html
@@ -1,2 +1,5 @@
 [% problem.meta_line(c) | html %]
+[% IF c.user_exists AND c.user.id == problem.user_id AND !problem.anonymous %]
+    <small>(<a href="/my/anonymize?problem=[% problem.id | uri %]" class="js-hide-name">[% loc('Hide your name?') %]</a>)</small>
+[% END %]
 [%- IF !problem.used_map %]; <strong>([% loc('there is no pin shown as the user did not use the map') %])</strong>[% END %]

--- a/templates/web/base/report/update.html
+++ b/templates/web/base/report/update.html
@@ -24,7 +24,7 @@
             <div class="item-list__update-wrap">
             [% IF update.whenanswered %]
                 <div class="item-list__update-text">
-                    <p class="meta-2"> [% INCLUDE meta_line %] </p>
+                    <p class="meta-2">[% INCLUDE meta_line %]</p>
                 </div>
             [% ELSE %]
                 <a name="update_[% update.id %]" class="internal-link-fixed-header"></a>
@@ -45,6 +45,9 @@
 
                     <p class="meta-2">
                         [% INCLUDE meta_line %]
+                        [% IF c.user_exists AND c.user.id == update.user_id AND !update.anonymous %]
+                            <small>(<a href="/my/anonymize?update=[% update.id | uri %]" class="js-hide-name">[% loc('Hide your name?') %]</a>)</small>
+                        [% END %]
                         [% mlog = update.latest_moderation_log_entry(); IF mlog %]
                             <br />[% tprintf(loc('Moderated by %s at %s'), mlog.admin_user, prettify_dt(mlog.whenedited)) %]
                         [% END %]

--- a/templates/web/base/tokens/confirm_update.html
+++ b/templates/web/base/tokens/confirm_update.html
@@ -1,9 +1,10 @@
 [% INCLUDE 'header.html', bodyclass = 'fullwidthpage', title = loc('Confirmation');
 
 DEFAULT problem = update.problem;
-SET problem_url = c.uri_for('/report', problem.id);
 IF update;
-    problem_url = problem_url _ '#update_' _ update.id;
+    SET problem_url = update.url;
+ELSE;
+    SET problem_url = problem.url;
 END;
 
 %]

--- a/templates/web/fixmystreet.com/about/faq-en-gb.html
+++ b/templates/web/fixmystreet.com/about/faq-en-gb.html
@@ -357,7 +357,7 @@ categories if you wish.
 <p>FixMyStreet reports usually come by email. If you reply to the email in your
 normal way, your response will go directly into the user's inbox.
 <p>Your reply is not published on the FixMyStreet website (unless you are a
-FixMyStreet for Councils customer who has chosen this option – see 'Can
+FixMyStreet Professional customer who has chosen this option – see 'Can
 FixMyStreet connect directly with council systems?', below).
 </dd>
 
@@ -397,7 +397,7 @@ FixMyStreet about as easy to use as possible.
 <dt>FixMyStreet is better than our own reporting system</dt>
 <dd>
 <p>Then why not replace it with FixMyStreet? We now offer a <a
-href="/council">complete fault-reporting solution for councils</a>, that
+href="/about/council">complete fault-reporting solution for councils</a>, that
 integrates with your own website.
 <p>It has all the benefits of FixMyStreet's focus on usability, and is a
 robust, economical, cloud-based option.

--- a/templates/web/fixmystreet.com/footer_extra.html
+++ b/templates/web/fixmystreet.com/footer_extra.html
@@ -31,7 +31,7 @@
                             %]>[% loc("Local alerts") %]</[% c.req.uri.path == '/alert' ? 'span' : 'a' %]></li>
                     </ul>
                     <ul>
-                        <li><a href="/about/council">FixMyStreet for Councils</a></li>
+                        <li><a href="/about/council">FixMyStreet Professional</a></li>
                         <li><[% IF c.req.uri.path == '/posters' %]span[% ELSE %]a href="[% base %]/posters"[% END
                             %]>[% loc("FixMyStreet Goodies") %]</[% c.req.uri.path == '/posters' ? 'span' : 'a' %]></li>
                         <li><[% IF c.req.uri.path == '/contact' %]span[% ELSE %]a href="[% base %]/contact"[% END

--- a/templates/web/fixmystreet.com/report/_report_meta_info.html
+++ b/templates/web/fixmystreet.com/report/_report_meta_info.html
@@ -2,4 +2,7 @@
 [% IF c.cobrand.moniker != problem.get_cobrand_logged.moniker AND problem.get_cobrand_logged.is_council %]
     using <a href="https://www.fixmystreet.com/about/council">FixMyStreet Professional</a>
 [% END %]
+[% IF c.user_exists AND c.user.id == problem.user_id AND !problem.anonymous %]
+    <small>(<a href="/my/anonymize?problem=[% problem.id | uri %]" class="js-hide-name">[% loc('Hide your name?') %]</a>)</small>
+[% END %]
 [%- IF !problem.used_map %]; <strong>([% loc('there is no pin shown as the user did not use the map') %])</strong>[% END %]

--- a/templates/web/fixmystreet.com/report/_report_meta_info.html
+++ b/templates/web/fixmystreet.com/report/_report_meta_info.html
@@ -1,5 +1,5 @@
 [% problem.meta_line(c) | html %]
 [% IF c.cobrand.moniker != problem.get_cobrand_logged.moniker AND problem.get_cobrand_logged.is_council %]
-    using <a href="https://www.fixmystreet.com/about/council">FixMyStreet for Councils</a>
+    using <a href="https://www.fixmystreet.com/about/council">FixMyStreet Professional</a>
 [% END %]
 [%- IF !problem.used_map %]; <strong>([% loc('there is no pin shown as the user did not use the map') %])</strong>[% END %]

--- a/templates/web/fixmystreet.com/report/new/unresponsive_body.html
+++ b/templates/web/fixmystreet.com/report/new/unresponsive_body.html
@@ -8,5 +8,5 @@
         reports from third party reporting sites such as FixMyStreet.
     </p>
     <p>We can make your report public, but we can’t send it to the council.</p>
-    <a href="[% c.cobrand.base_url %]/unresponsive?body=[% body_id %][% IF category %];category=[% category | uri %][% END %]">What can I do instead?</a>
+    <a href="[% c.cobrand.base_url %]/unresponsive?body=[% body_id %][% IF category %];category=[% category | uri %][% END %]" class="btn">What can I do instead?</a>
 </div>

--- a/templates/web/fixmystreet.com/reports/_extras.html
+++ b/templates/web/fixmystreet.com/reports/_extras.html
@@ -25,7 +25,7 @@
 <td class="title" colspan="6" style="padding-top:0">
     <small title="This council's online reporting is powered by FixMyStreet">(includes reports from
     <a href="http[% secure.$site %]://[% site %]">[% site %]</a> using
-    <a href="/about/council">FixMyStreet for Councils</a>)</small>
+    <a href="/about/council">FixMyStreet Professional</a>)</small>
 </td>
 </tr>
 [% END %]

--- a/templates/web/stevenage/footer.html
+++ b/templates/web/stevenage/footer.html
@@ -19,7 +19,7 @@
                                     </li>
                                     <li>
                                         <h4>[% loc('Are you from a council?') %]</h4>
-                                        <p>[% loc('Would you like better integration with FixMyStreet? <a href="https://www.fixmystreet.com/about/council">Find out about FixMyStreet for councils</a>.') %]</p>
+                                        <p>[% loc('Would you like better integration with FixMyStreet? <a href="https://www.fixmystreet.com/about/council">Find out about FixMyStreet Professional</a>.') %]</p>
                                     </li>
                                 </ul>
                             </div>

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -434,6 +434,28 @@ $.extend(fixmystreet.set_up, {
     });
   },
 
+  hide_name: function() {
+      $('body').on('click', '.js-hide-name', function(e){
+          e.preventDefault();
+
+          var $p = $(this).parents('p');
+          var $form = $p.next('.hide-name-form'); // might not exist yet
+          var url = $(this).attr('href');
+
+          if ($form.length) {
+              $form.slideUp(function(){
+                  $form.remove();
+              });
+          } else {
+              $.get(url).done(function(html){
+                  $(html).find('.hide-name-form').hide().insertAfter($p).slideDown();
+              }).fail(function(){
+                  window.location.href = url;
+              });
+          }
+      });
+  },
+
   on_resize: function() {
     var last_type;
     $(window).on('resize', function() {

--- a/web/cobrands/oxfordshire/base.scss
+++ b/web/cobrands/oxfordshire/base.scss
@@ -78,7 +78,7 @@ dd, p {
 }
 
 #side-inspect {
-  background-color: #deead2; // darker version of $oxfordshire_very_light_green
+  background-color: mix(#fff, $primary, 85%);
 }
 
 .btn-primary {
@@ -92,6 +92,10 @@ dd, p {
         $oxfordshire_button_border,
         #fff
     );
+}
+
+.box-warning {
+    background-color: mix(#fff, $primary, 85%);
 }
 
 @media print {

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2408,18 +2408,15 @@ table.nicetable {
         margin-bottom: 0.5em;
     }
 
-    a {
-        display: inline-block;
-        margin-top: 0.5em;
-        padding: 0.5em 1em;
-        background-color: #000;
-        color: #fff;
-        border-radius: 0.3em;
+    .btn, .btn-primary {
+        margin: 0.5em 0 1em 0;
 
-        &:hover,
-        &:focus {
-            text-decoration: none;
-            background-color: mix(#000, $primary, 70%);
+        &:first-child {
+            margin-top: 0;
+        }
+
+        &:last-child {
+            margin-bottom: 0;
         }
     }
 }

--- a/web/js/jquery.multi-select.js
+++ b/web/js/jquery.multi-select.js
@@ -2,9 +2,7 @@
 // by mySociety
 // https://github.com/mysociety/jquery-multi-select
 
-;(function($) {
-
-  "use strict";
+(function($) {
 
   var pluginName = "multiSelect",
     defaults = {
@@ -122,7 +120,7 @@
 
       this.$button.empty();
 
-      if (selected.length == 0) {
+      if (selected.length === 0) {
         this.$button.text( this.settings.noneText );
       } else if ( (selected.length === options.length) && this.settings.allText) {
         this.$button.text( this.settings.allText );


### PR DESCRIPTION
Fixes #658.

TODO:
- [x] Prototype
- [x] Get design feedback
- [x] Decide on non-javascript fallback
- [x] Make the buttons work

**How it looks for reports:**

![hide-name](https://cloud.githubusercontent.com/assets/739624/19395841/a7853816-9237-11e6-8fb8-babfaf906947.gif)

(Looks very similar for Updates – just swap the word "report" for "update")
