### PR TITLE
Fix list of response templates for a problem.

### DIFF
--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -658,13 +658,15 @@ order of title.
 =cut
 
 sub response_templates {
-    my $problem = shift;
-    return $problem->result_source->schema->resultset('ResponseTemplate')->search(
+    my $self = shift;
+    return $self->result_source->schema->resultset('ResponseTemplate')->search(
         {
-            body_id => $problem->bodies_str_ids
+            'me.body_id' => $self->bodies_str_ids,
+            'contact.category' => [ $self->category, undef ],
         },
         {
-            order_by => 'title'
+            order_by => 'title',
+            join => { 'contact_response_templates' => 'contact' },
         }
     );
 }

--- a/t/app/model/problem.t
+++ b/t/app/model/problem.t
@@ -749,6 +749,20 @@ subtest 'check reports from abuser not sent' => sub {
     ok $abuse->delete(), 'user removed from abuse table';
 };
 
+subtest 'check response templates' => sub {
+    my $c1 = $mech->create_contact_ok(category => 'Potholes', body_id => $body_ids{2651}, email => 'p');
+    my $c2 = $mech->create_contact_ok(category => 'Graffiti', body_id => $body_ids{2651}, email => 'g');
+    my $t1 = FixMyStreet::DB->resultset('ResponseTemplate')->create({ body_id => $body_ids{2651}, title => "Title 1", text => "Text 1" });
+    my $t2 = FixMyStreet::DB->resultset('ResponseTemplate')->create({ body_id => $body_ids{2651}, title => "Title 2", text => "Text 2" });
+    my $t3 = FixMyStreet::DB->resultset('ResponseTemplate')->create({ body_id => $body_ids{2651}, title => "Title 3", text => "Text 3" });
+    $t1->add_to_contacts($c1);
+    $t2->add_to_contacts($c2);
+    my ($problem) = $mech->create_problems_for_body(1, $body_ids{2651}, 'TITLE');
+    is $problem->response_templates, 1, 'Only the global template returned';
+    ($problem) = $mech->create_problems_for_body(1, $body_ids{2651}, 'TITLE', { category => 'Potholes' });
+    is $problem->response_templates, 2, 'Global and pothole templates returned';
+};
+
 END {
     $problem->comments->delete if $problem;
     $problem->delete if $problem;


### PR DESCRIPTION
Instead of returning all templates for the problem's body, return those
for the problem's category (or with no category).

Fixes mysociety/fixmystreetforcouncils#100