### PR TITLE
Add ‘description’ field to response priorities

### DIFF
--- a/bin/update-schema
+++ b/bin/update-schema
@@ -194,6 +194,7 @@ else {
 # By querying the database schema, we can see where we're currently at
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
+    return '0047' if column_exists('response_priorities', 'description');
     return '0046' if column_exists('users', 'extra');
     return '0045' if table_exists('response_priorities');
     return '0044' if table_exists('contact_response_templates');

--- a/db/downgrade_0047---0046.sql
+++ b/db/downgrade_0047---0046.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE response_priorities
+    DROP COLUMN description;
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -134,6 +134,7 @@ CREATE TABLE response_priorities (
     body_id int references body(id) not null,
     deleted boolean not null default 'f',
     name text not null,
+    description text,
     unique(body_id, name)
 );
 

--- a/db/schema_0047-response-priorities-add-description.sql
+++ b/db/schema_0047-response-priorities-add-description.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE response_priorities
+    ADD COLUMN description TEXT;
+
+COMMIT;

--- a/perllib/FixMyStreet/App/Controller/Admin/ResponsePriorities.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/ResponsePriorities.pm
@@ -69,6 +69,7 @@ sub edit : Path : Args(2) {
     if ($c->req->method eq 'POST') {
         $priority->deleted( $c->get_param('deleted') ? 1 : 0 );
         $priority->name( $c->get_param('name') );
+        $priority->description( $c->get_param('description') );
         $priority->update_or_insert;
 
         my @live_contact_ids = map { $_->id } @live_contacts;

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -681,7 +681,7 @@ sub response_priorities {
     return $self->result_source->schema->resultset('ResponsePriority')->search(
         {
             'me.body_id' => $self->bodies_str_ids,
-            'contact.category' => $self->category,
+            'contact.category' => [ $self->category, undef ],
         },
         {
             order_by => 'name',

--- a/perllib/FixMyStreet/DB/Result/ResponsePriority.pm
+++ b/perllib/FixMyStreet/DB/Result/ResponsePriority.pm
@@ -24,6 +24,8 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 0 },
   "deleted",
   { data_type => "boolean", default_value => \"false", is_nullable => 0 },
+  "description",
+  { data_type => "text", is_nullable => 1 },
 );
 __PACKAGE__->set_primary_key("id");
 __PACKAGE__->add_unique_constraint("response_priorities_body_id_name_key", ["body_id", "name"]);
@@ -47,8 +49,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2016-09-07 11:01:40
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:B1swGtQzC3qRa0LUM4IyzA
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2016-10-17 16:37:28
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:wok3cPA7cPjG4e9lnc1PIg
 
 __PACKAGE__->many_to_many( contacts => 'contact_response_priorities', 'contact' );
 

--- a/t/app/controller/admin.t
+++ b/t/app/controller/admin.t
@@ -1453,6 +1453,7 @@ subtest "response priorities can be added" => sub {
 
     my $fields = {
         name => "Cat 1A",
+        description => "Fixed within 24 hours",
         deleted => undef,
         "contacts[".$oxfordshirecontact->id."]" => 1,
     };
@@ -1466,6 +1467,7 @@ subtest "response priorities can be listed" => sub {
     $mech->get_ok( "/admin/responsepriorities/" . $oxfordshire->id );
 
     $mech->content_contains( $oxfordshire->response_priorities->first->name );
+    $mech->content_contains( $oxfordshire->response_priorities->first->description );
 };
 
 subtest "response priorities are limited by body" => sub {

--- a/templates/web/base/admin/category-checkboxes.html
+++ b/templates/web/base/admin/category-checkboxes.html
@@ -1,0 +1,18 @@
+  <p>
+    <strong>[% loc('Categories:') %]</strong>
+  </p>
+  <ul>
+    <li>
+      [% loc('Select:') %]
+      <a href="#" data-select-all>[% loc('all') %]</a> /
+      <a href="#" data-select-none>[% loc('none') %]</a>
+    </li>
+    [% FOR contact IN contacts %]
+      <li>
+        <label>
+          <input type="checkbox" name="contacts[[% contact.id %]]" [% 'checked' IF contact.active %]/>
+          [% contact.category %]
+        </label>
+      </li>
+    [% END %]
+  </ul>

--- a/templates/web/base/admin/responsepriorities/edit.html
+++ b/templates/web/base/admin/responsepriorities/edit.html
@@ -17,19 +17,14 @@
         <strong>[% loc('Description:') %] </strong>
         <input type="text" name="description" class="form-control" size="30" value="[% rp.description | html %]">
     </p>
-    <p>
-      <strong>[% loc('Categories:') %]</strong>
-      <ul>
-        [% FOR contact IN contacts %]
-          <li>
-            <label>
-              <input type="checkbox" name="contacts[[% contact.id %]]" [% 'checked' IF contact.active %]/>
-              [% contact.category %]
-            </label>
-          </li>
-        [% END %]
-      </ul>
-    </p>
+
+    <div class="admin-hint">
+      <p>
+        [% loc('If you only want this priority to be an option for specific categories, pick them here. By default they will show for all categories.') %]
+      </p>
+    </div>
+    [% INCLUDE 'admin/category-checkboxes.html' %]
+
     <p>
         <label>
           <input type="checkbox" name="deleted" id="deleted" value="1"[% ' checked' IF rp.deleted %]>

--- a/templates/web/base/admin/responsepriorities/edit.html
+++ b/templates/web/base/admin/responsepriorities/edit.html
@@ -14,6 +14,10 @@
         <input type="text" name="name" class="required form-control" size="30" value="[% rp.name | html %]">
     </p>
     <p>
+        <strong>[% loc('Description:') %] </strong>
+        <input type="text" name="description" class="form-control" size="30" value="[% rp.description | html %]">
+    </p>
+    <p>
       <strong>[% loc('Categories:') %]</strong>
       <ul>
         [% FOR contact IN contacts %]

--- a/templates/web/base/admin/responsepriorities/list.html
+++ b/templates/web/base/admin/responsepriorities/list.html
@@ -4,13 +4,15 @@
     <thead>
     <tr>
         <th>  [% loc('Name') %] </th>
+        <th>  [% loc('Description') %] </th>
         <th>  &nbsp; </th>
     </tr>
     </thead>
     <tbody>
       [% FOR p IN response_priorities %]
           <tr [% 'class="is-deleted"' IF p.deleted %]>
-              <td>  [% p.name %] </td>
+              <td>  [% p.name | html %] </td>
+              <td>  [% p.description | html %] </td>
               <td> <a href="[% c.uri_for('', body.id, p.id) %]" class="btn">[% loc('Edit') %]</a> </td>
           </tr>
       [% END %]

--- a/templates/web/base/admin/responsepriorities/list.html
+++ b/templates/web/base/admin/responsepriorities/list.html
@@ -5,6 +5,7 @@
     <tr>
         <th>  [% loc('Name') %] </th>
         <th>  [% loc('Description') %] </th>
+        <th>  [% loc('Categories') %] </th>
         <th>  &nbsp; </th>
     </tr>
     </thead>
@@ -13,6 +14,15 @@
           <tr [% 'class="is-deleted"' IF p.deleted %]>
               <td>  [% p.name | html %] </td>
               <td>  [% p.description | html %] </td>
+              <td>
+                [% UNLESS p.contacts.size %]
+                  <em>[% loc('All categories') %]</em>
+                [% ELSE %]
+                  [% FOR contact IN p.contacts %]
+                    [% contact.category %][% ',' UNLESS loop.last %]
+                  [% END %]
+                [% END %]
+              </td>
               <td> <a href="[% c.uri_for('', body.id, p.id) %]" class="btn">[% loc('Edit') %]</a> </td>
           </tr>
       [% END %]

--- a/templates/web/base/admin/template_edit.html
+++ b/templates/web/base/admin/template_edit.html
@@ -23,19 +23,14 @@
         <input type="checkbox" name="auto_response" [% 'checked' IF rt.auto_response %] />
       </label>
     </p>
-    <p>
-      <strong>[% loc('Categories:') %]</strong>
-      <ul>
-        [% FOR contact IN contacts %]
-          <li>
-            <label>
-              <input type="checkbox" name="contacts[[% contact.id %]]" [% 'checked' IF contact.active %]/>
-              [% contact.category %]
-            </label>
-          </li>
-        [% END %]
-      </ul>
-    </p>
+
+    <div class="admin-hint">
+      <p>
+        [% loc('If you only want this template to be an option for specific categories, pick them here. By default they will show for all categories.') %]
+      </p>
+    </div>
+    [% INCLUDE 'admin/category-checkboxes.html' %]
+
     <p>
       <input type="hidden" name="token" value="[% csrf_token %]" >
       <input type="submit" class="btn" name="Edit templates" value="[% rt.id ? loc('Save changes') : loc('Create template') %]" >

--- a/web/js/fixmystreet-admin.js
+++ b/web/js/fixmystreet-admin.js
@@ -31,6 +31,13 @@ $(function(){
         });
     }
 
+    // Some lists of checkboxes have 'select all/none' links at the top
+    $("a[data-select-none], a[data-select-all]").click(function(e) {
+        e.preventDefault();
+        var checked = $(this).filter('[data-select-all]').length > 0;
+        $(this).closest("ul").find('input[type=checkbox]').prop('checked', checked);
+    });
+
 
     // admin hints: maybe better implemented as tooltips?
     $(".admin-hint").on('click', function(){


### PR DESCRIPTION
 - Adds an internal 'description' field to response priorities in the admin
 - Description is shown on the response priorities list table
 - Adds 'select all/select none' UI atop categories checklist (also for response templates)
 - Matches behaviour introduced in #1555 - empty category list means priority applies to all categories


For mysociety/fixmystreetforcouncils#66.