### PR TITLE
Resend report if changing category also changes body

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ web-based cross-browser testing tools for this project.
         - Hide confirmed column on body page if all categories confirmed. #1565
         - Show any waiting reports on admin index page. #1382
         - Allow user's phone number to be edited, and a report's category. #400
+        - Resend report if changing category changes body. #1560.
         - New user system:
             - /admin requires a user with the `is_superuser` flag. #1463
             - `createsuperuser` command for creating superusers.

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -837,18 +837,6 @@ Handles changing a problem's category and the complexity that comes with it.
 sub report_edit_category : Private {
     my ($self, $c, $problem) = @_;
 
-    # TODO: It's possible to assign a category belonging to a district
-    # council, meaning a 404 when the page is reloaded because the
-    # problem is no longer included in the current cobrand's
-    # problem_restriction.
-    # See mysociety/fixmystreetforcouncils#44
-    # We could
-    #  a) only allow the current body's categories to be chosen,
-    #  b) show a warning about the impending change of body
-    #  c) bounce the user to the report page on fms.com
-    # Not too worried about this right now, as it forms part of a bigger
-    # concern outlined in the above ticket and
-    # mysociety/fixmystreetforcouncils#17
     if ((my $category = $c->get_param('category')) ne $problem->category) {
         $problem->category($category);
         my @contacts = grep { $_->category eq $problem->category } @{$c->stash->{contacts}};

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -390,7 +390,17 @@ sub inspect : Private {
                     anonymous => 0,
                 } );
             }
-            $c->res->redirect( $c->uri_for( '/report', $problem->id ) );
+            # This problem might no longer be visible on the current cobrand,
+            # if its body has changed (e.g. by virtue of the category changing)
+            # so redirect to a cobrand where it can be seen if necessary
+            my $redirect_uri;
+            if ( $c->cobrand->is_council && !$c->cobrand->owns_problem($problem) ) {
+                $redirect_uri = $c->cobrand->base_url_for_report( $problem ) . $problem->url;
+            } else {
+                $redirect_uri = $c->uri_for( $problem->url );
+            }
+            $c->log->debug( "Redirecting to: " . $redirect_uri );
+            $c->res->redirect( $redirect_uri );
         }
     }
 };


### PR DESCRIPTION
Changing the category of a report (via the inspect/manage page or via the admin) might also mean the responsible body for that report has changed.

This PR adds functionality causing the report to be sent again if the body changes.

For mysociety/fixmystreetforcouncils#44.