### PR TITLE
Have report page show inspect form by default

### DIFF
--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -4,7 +4,7 @@
   <div id="side-inspect">
     [% INCLUDE 'errors.html' %]
 
-    <form id="report_inspect_form" method="post" action="[% c.uri_for( '/report', problem.id, 'inspect' ) %]">
+    <form id="report_inspect_form" method="post" action="[% c.uri_for( '/report', problem.id ) %]">
 
       <div class="inspect-section">
         <p>

--- a/templates/web/base/report/_main.html
+++ b/templates/web/base/report/_main.html
@@ -119,23 +119,11 @@
   [% IF
       (permissions.moderate)
      OR
-      (!hide_inspect_button AND
-      permissions.keys.grep('report_inspect|report_edit_category|report_edit_priority').size)
-     OR
        (c.user.has_permission_to('planned_reports', problem.bodies_str_ids))
   %]
     <div class="moderate-display segmented-control" role="menu">
       [% IF permissions.moderate %]
         <a class="js-moderate btn" role="menuitem" aria-label="[% loc('Moderate this report') %]">[% loc('Moderate') %]</a>
-      [% END %]
-      [% IF !hide_inspect_button AND permissions.keys.grep('report_inspect|report_edit_category|report_edit_priority').size %]
-        <a class="btn" href="/report/[% problem.id %]/inspect#side-inspect" role="menuitem">
-          [%~ IF permissions.report_inspect ~%]
-            [%~ loc('Inspect') ~%]
-          [%~ ELSE ~%]
-            [%~ loc('Manage') ~%]
-          [%~ END ~%]
-        </a>
       [% END %]
       [% IF c.user.has_permission_to('planned_reports', problem.bodies_str_ids) %]
           [%~ IF c.user.is_planned_report(problem) ~%]

--- a/templates/web/base/report/inspect.html
+++ b/templates/web/base/report/inspect.html
@@ -2,6 +2,5 @@
   SET bodyclass = 'mappage with-actions';
   SET two_column_sidebar = 1;
   PROCESS 'report/_inspect.html';
-  SET shown_form = 1 UNLESS problem.get_extra_metadata('inspected');
-  INCLUDE 'report/display.html', hide_inspect_button = 1;
+  INCLUDE 'report/display.html'
 %]


### PR DESCRIPTION
This saves an inspector having to click a button to see the form.