### PR TITLE
Assign users to categories

### DIFF
--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -391,4 +391,19 @@ sub update_reputation {
     $self->update;
 }
 
+has categories => (
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        return [] unless $self->get_extra_metadata('categories');
+        my @categories = $self->result_source->schema->resultset("Contact")->search({
+            id => $self->get_extra_metadata('categories'),
+        }, {
+            order_by => 'category',
+        })->get_column('category')->all;
+        return \@categories;
+    },
+);
+
 1;

--- a/t/app/controller/index.t
+++ b/t/app/controller/index.t
@@ -80,7 +80,24 @@ ok $mech->get('/report/' . $edinburgh_problems[2]->id);
 is $mech->res->code, 403, 'page forbidden';
 is $problem_rs->count, $num+5;
 
+my $oxon = $mech->create_body_ok(2237, 'Oxfordshire County Council', id => 2237);
+subtest "prefilters /around if user has categories" => sub {
+    my $user = $mech->log_in_ok('test@example.com');
+    my $categories = [
+        $mech->create_contact_ok( body_id => $oxon->id, category => 'Cows', email => 'cows@example.net' )->id,
+        $mech->create_contact_ok( body_id => $oxon->id, category => 'Potholes', email => 'potholes@example.net' )->id,
+    ];
+    $user->from_body($oxon);
+    $user->set_extra_metadata('categories', $categories);
+    $user->update;
+
+    $mech->get_ok('/');
+    # NB can't use visible_form_values because categories field is hidden
+    $mech->content_contains("Cows,Potholes");
+};
+
 END {
     $mech->delete_problems_for_body( 2651 );
+    $mech->delete_body($oxon);
     done_testing();
 }

--- a/templates/web/base/admin/user-form.html
+++ b/templates/web/base/admin/user-form.html
@@ -142,6 +142,10 @@
             <li>
               [% group.key %]
               <ul class="no-bullets">
+                <li>
+                  (<a href="#" data-select-all>[% loc('all') %]</a> /
+                  <a href="#" data-select-none>[% loc('none') %]</a>)
+                </li>
                 [% FOREACH permission IN group.value %]
                   <li>
                     <label class="inline">

--- a/templates/web/base/admin/user-form.html
+++ b/templates/web/base/admin/user-form.html
@@ -71,6 +71,19 @@
           </li>
         [% END %]
 
+        [% IF contacts AND c.cobrand.moniker != 'zurich'%]
+          <li class="js-user-categories">
+            <div class="admin-hint">
+              <p>
+                [% loc(
+                  "Authorised staff users can be associated with the categories in which they operate.")
+                %]
+              </p>
+            </div>
+            [% INCLUDE 'admin/category-checkboxes.html' %]
+          </li>
+        [% END %]
+
 
       [% IF c.cobrand.moniker != 'zurich' %]
         <li>

--- a/templates/web/base/around/postcode_form.html
+++ b/templates/web/base/around/postcode_form.html
@@ -17,6 +17,9 @@
                 <input type="hidden" name="partial" value="[% partial_token.token %]">
             [% END %]
 
+            [% IF c.user_exists AND c.user.categories.size %]
+              <input type="hidden" name="filter_category" value="[% c.user.categories.join(",") | html %]">
+            [% END %]
         </form>
     </div>
 </div>

--- a/templates/web/base/footer.html
+++ b/templates/web/base/footer.html
@@ -25,7 +25,7 @@
                             %]span[% ELSE %]a href="[% base %]/my"[% END
                             %]>[% c.user_exists ? loc("Your account") : loc("Sign in") %]</[% c.req.uri.path == '/my' ? 'span' : 'a' %]></li>[%
                         %]<li><[% IF c.req.uri.path == '/reports'
-                            %]span[% ELSE %]a href="[% base %]/reports"[% END
+                            %]span[% ELSE %]a href="[% base %]/reports[% IF c.user_exists AND c.user.categories.size %]?filter_category=[% c.user.categories.join(",") | uri | html %][% END %]"[% END
                             %]>[% loc("All reports") %]</[% c.req.uri.path == '/reports' ? 'span' : 'a' %]></li>[%
                         %]<li><[% IF c.req.uri.path == '/alert'
                             %]span[% ELSE %]a href="[% base %]/alert[% pc ? '/list?pc=' : '' %][% pc | uri %]"[% END

--- a/templates/web/oxfordshire/footer.html
+++ b/templates/web/oxfordshire/footer.html
@@ -22,7 +22,7 @@
                         %][% IF c.user_exists AND c.user.has_body_permission_to('planned_reports') %]<li>
                             <[% IF c.req.uri.path == '/my/planned' %]span[% ELSE %]a href="/my/planned"[% END
                              %]>[% loc('Shortlist') %]</[% c.req.uri.path == '/my/planned' ? 'span' : 'a' %]></li>[%
-                        %][% END %]<li><[% IF c.req.uri.path == '/reports' %]span[% ELSE %]a href="/reports"[% END
+                        %][% END %]<li><[% IF c.req.uri.path == '/reports' %]span[% ELSE %]a href="/reports[% IF c.user_exists AND c.user.categories.size %]?filter_category=[% c.user.categories.join(",") | uri | html %][% END %]"[% END
                             %]>[% loc("All reports") %]</[% c.req.uri.path == '/reports' ? 'span' : 'a' %]></li>[%
                         %]<li><[% IF c.req.uri.path == '/alert' %]span[% ELSE %]a href="/alert[% pc ? '/list?pc=' : '' %][% pc | uri %]"[% END
                             %]>[% loc("Local alerts") %]</[% c.req.uri.path == '/alert' ? 'span' : 'a' %]></li>[%

--- a/templates/web/oxfordshire/header.html
+++ b/templates/web/oxfordshire/header.html
@@ -49,7 +49,7 @@
                         </li>
                         [% END %]
                         <li>
-                            <[% IF c.req.uri.path == '/reports/Oxfordshire' %]span[% ELSE %]a href="/reports/Oxfordshire"[% END
+                            <[% IF c.req.uri.path == '/reports/Oxfordshire' %]span[% ELSE %]a href="/reports/Oxfordshire[% IF c.user_exists AND c.user.categories.size %]?filter_category=[% c.user.categories.join(",") | uri | html %][% END %]"[% END
                                  %]>[% loc("All reports") %]</[% c.req.uri.path == '/reports' ? 'span' : 'a' %]>
                         </li>
                         <li>

--- a/web/js/fixmystreet-admin.js
+++ b/web/js/fixmystreet-admin.js
@@ -84,10 +84,11 @@ $(function(){
       }
     });
 
-    // On user edit page, hide the area select field if body changes
+    // On user edit page, hide the area/categories fields if body changes
     $("form#user_edit select#body").change(function() {
         var show_area = $(this).val() == $(this).find("[data-originally-selected]").val();
         $("form#user_edit select#area_id").closest("li").toggle(show_area);
+        $("form#user_edit .js-user-categories").toggle(show_area);
     });
 
     // On category edit page, hide the reputation input if inspection isn't required


### PR DESCRIPTION
- Users can be assigned to one or more of their parent body's categories
- The 'all reports' link is prefiltered with the user's categories, if they have any, on the Oxfordshire cobrand

Left to do:
- [x] Prefilter /around when entering a postcode/location
- [x] Check other places in the site where it makes sense to prefilter

For mysociety/fixmystreetforcouncils#69
