### PR TITLE
Add simple way to return to "everything" in list filters

### DIFF
--- a/templates/web/base/reports/_list-filters.html
+++ b/templates/web/base/reports/_list-filters.html
@@ -1,14 +1,14 @@
 [% select_status = BLOCK %]
-    <select class="form-control" name="status" id="statuses" multiple data-all="[% loc('all reports') %]">
-        <option value="open"[% ' selected' IF filter_status.open %]>[% loc('unfixed reports') %]</option>
-        <option value="closed"[% ' selected' IF filter_status.closed %]>[% loc('closed reports') %]</option>
-        <option value="fixed"[% ' selected' IF filter_status.fixed %]>[% loc('fixed reports') %]</option>
+    <select class="form-control" name="status" id="statuses" multiple data-all="[% loc('All reports') %]">
+        <option value="open"[% ' selected' IF filter_status.open %]>[% loc('Unfixed reports') %]</option>
+        <option value="closed"[% ' selected' IF filter_status.closed %]>[% loc('Closed reports') %]</option>
+        <option value="fixed"[% ' selected' IF filter_status.fixed %]>[% loc('Fixed reports') %]</option>
     </select>
 [% END %]
 
 [% select_category = BLOCK %]
   [% IF filter_categories.size %]
-    <select class="form-control" name="filter_category" id="filter_categories" multiple data-all="[% loc('everything') %]">
+    <select class="form-control" name="filter_category" id="filter_categories" multiple data-all="[% loc('Everything') %]">
         [% FOR cat IN filter_categories %]
             <option value="[% cat | html %]"[% ' selected' IF filter_category.grep(cat).size %]>
                 [% cat | html %]
@@ -16,7 +16,7 @@
         [% END %]
     </select>
   [% ELSE %]
-    [% loc('everything') %]
+    [% loc('Everything') %]
   [% END %]
 [% END %]
 

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -585,7 +585,11 @@ $.extend(fixmystreet.set_up, {
         $id.multiSelect({
             allText: all,
             noneText: all,
-            positionMenuWithin: $('#side')
+            positionMenuWithin: $('#side'),
+            presets: [{
+                name: all,
+                options: []
+            }]
         });
     }
     make_multi('statuses');

--- a/web/cobrands/sass/_multiselect.scss
+++ b/web/cobrands/sass/_multiselect.scss
@@ -11,16 +11,19 @@
     min-width: 100%;
     background: #fff;
     margin: 1em 0;
-    padding: 0.4em 0;
     border: 1px solid #aaa;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
     display: none;
+}
 
-    label {
-        display: block;
-        font-size: 0.875em;
-        padding: 0.3em 1em 0.3em 30px;
-        white-space: nowrap;
+.multi-select-menuitem {
+    display: block;
+    font-size: 0.875em;
+    padding: 0.6em 1em 0.6em 30px;
+    white-space: nowrap;
+
+    & + & {
+        padding-top: 0;
     }
 
     input {
@@ -28,6 +31,10 @@
         margin-top: 0.25em;
         margin-left: -20px;
     }
+}
+
+.multi-select-presets {
+    border-bottom: 1px solid #ddd;
 }
 
 .multi-select-button {


### PR DESCRIPTION
Adds the features from https://github.com/mysociety/jquery-multi-select/pull/7 to FixMyStreet.

Fixes mysociety/fixmystreetforcouncils#115, and gives us a nice user-friendly "presets" interface we could add into #1563 too.

Looks like this in the Oxfordshire cobrand:

![screen shot 2016-10-25 at 12 08 17](https://cloud.githubusercontent.com/assets/739624/19683853/0ccc9de6-9aac-11e6-9ee7-0b60b6977a30.png)
