### PR TITLE
Leave a public update when admin changes category.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ web-based cross-browser testing tools for this project.
         - Show any waiting reports on admin index page. #1382
         - Allow user's phone number to be edited, and a report's category. #400
         - Resend report if changing category changes body. #1560.
+        - Leave a public update if an admin changes a report's category. #1544
         - New user system:
             - /admin requires a user with the `is_superuser` flag. #1463
             - `createsuperuser` command for creating superusers.

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -841,6 +841,7 @@ sub report_edit_category : Private {
     my ($self, $c, $problem) = @_;
 
     if ((my $category = $c->get_param('category')) ne $problem->category) {
+        my $category_old = $problem->category;
         $problem->category($category);
         my @contacts = grep { $_->category eq $problem->category } @{$c->stash->{contacts}};
         my @new_body_ids = map { $_->body_id } @contacts;
@@ -849,6 +850,16 @@ sub report_edit_category : Private {
             $problem->whensent(undef);
         }
         $problem->bodies_str(join( ',', @new_body_ids ));
+        $problem->add_to_comments({
+            text => '*' . sprintf(_('Category changed from ‘%s’ to ‘%s’'), $category_old, $category) . '*',
+            created => \'current_timestamp',
+            confirmed => \'current_timestamp',
+            user_id => $c->user->id,
+            name => $c->user->from_body ? $c->user->from_body->name : $c->user->name,
+            state => 'confirmed',
+            mark_fixed => 0,
+            anonymous => 0,
+        });
     }
 }
 

--- a/perllib/FixMyStreet/App/View/Web.pm
+++ b/perllib/FixMyStreet/App/View/Web.pm
@@ -22,6 +22,7 @@ __PACKAGE__->config(
     FILTERS => {
         add_links => \&add_links,
         escape_js => \&escape_js,
+        markup => [ \&markup_factory, 1 ],
     },
     COMPILE_EXT => '.ttc',
     STAT_TTL    => FixMyStreet->config('STAGING_SITE') ? 1 : 86400,
@@ -96,6 +97,23 @@ sub _space_slash {
     my $t = shift;
     $t =~ s{/(?!$)}{/ }g;
     return $t;
+}
+
+=head2 markup_factory
+
+This returns a function that will allow updates to have markdown-style italics.
+Pass in the user that wrote the text, so we know whether it can be privileged.
+
+=cut
+
+sub markup_factory {
+    my ($c, $user) = @_;
+    return sub {
+        my $text = shift;
+        return $text unless $user && ($user->from_body || $user->is_superuser);
+        $text =~ s{\*(\S.*?\S)\*}{<i>$1</i>};
+        $text;
+    }
 }
 
 =head2 escape_js

--- a/templates/web/base/report/update.html
+++ b/templates/web/base/report/update.html
@@ -31,7 +31,7 @@
                 [% INCLUDE 'report/photo.html' object=update %]
                 <div class="item-list__update-text">
                     <div class="moderate-display">
-                        [% update.text | add_links | html_para %]
+                        [% update.text | add_links | markup(update.user) | html_para %]
                     </div>
                     [% IF moderating %]
                     <div class="moderate-edit">


### PR DESCRIPTION
And add ability for admin users to italic updates, to be used by this.
Fixes #1544.
