### PR TITLE
WIP: UI for handling duplicate reports

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -320,7 +320,7 @@ sub inspect : Private {
         my $reputation_change = 0;
 
         if ($permissions->{report_inspect}) {
-            foreach (qw/detailed_information traffic_information/) {
+            foreach (qw/detailed_information traffic_information duplicate_of/) {
                 $problem->set_extra_metadata( $_ => $c->get_param($_) );
             }
 

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -345,6 +345,9 @@ sub inspect : Private {
             if ( $problem->state eq 'hidden' ) {
                 $problem->get_photoset->delete_cached;
             }
+            if ( $problem->state ne 'duplicate' ) {
+                $problem->unset_extra_metadata('duplicate_of');
+            }
             if ( $problem->state ne $old_state ) {
                 $c->forward( '/admin/log_edit', [ $problem->id, 'problem', 'state_change' ] );
             }

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -314,6 +314,7 @@ sub inspect : Private {
         my $valid = 1;
         my $update_text;
         my $reputation_change = 0;
+        my %update_params = ();
 
         if ($permissions->{report_inspect}) {
             foreach (qw/detailed_information traffic_information duplicate_of/) {
@@ -340,6 +341,11 @@ sub inspect : Private {
             }
             if ( $problem->state eq 'hidden' ) {
                 $problem->get_photoset->delete_cached;
+            }
+            if ( $problem->state eq 'duplicate' && $old_state ne 'duplicate' ) {
+                # If the report is being closed as duplicate, make sure the
+                # update records this.
+                $update_params{problem_state} = "duplicate";
             }
             if ( $problem->state ne 'duplicate' ) {
                 $problem->unset_extra_metadata('duplicate_of');
@@ -388,6 +394,7 @@ sub inspect : Private {
                     state => 'confirmed',
                     mark_fixed => 0,
                     anonymous => 0,
+                    %update_params,
                 } );
             }
             # This problem might no longer be visible on the current cobrand,

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -181,6 +181,7 @@ use namespace::clean -except => [ 'meta' ];
 use Utils;
 use FixMyStreet::Map::FMS;
 use LWP::Simple qw($ua);
+use RABX;
 
 my $IM = eval {
     require Image::Magick;
@@ -1041,6 +1042,17 @@ has duplicate_of => (
         my $duplicate_of = int($self->get_extra_metadata("duplicate_of") || 0);
         return unless $duplicate_of;
         return $self->result_source->schema->resultset('Problem')->search({ id => $duplicate_of })->first;
+    },
+);
+
+has duplicates => (
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my $rabx_id = RABX::serialise( $self->id );
+        my @duplicates = $self->result_source->schema->resultset('Problem')->search({ extra => { like => "\%duplicate_of,$rabx_id%" } })->all;
+        return \@duplicates;
     },
 );
 

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -1037,8 +1037,9 @@ has duplicate_of => (
     lazy => 1,
     default => sub {
         my $self = shift;
-        my $duplicate_of = $self->get_extra_metadata("duplicate_of");
-        return unless defined $duplicate_of;
+        return unless $self->state eq 'duplicate';
+        my $duplicate_of = int($self->get_extra_metadata("duplicate_of") || 0);
+        return unless $duplicate_of;
         return $self->result_source->schema->resultset('Problem')->search({ id => $duplicate_of })->first;
     },
 );

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -1032,4 +1032,15 @@ has shortlisted_user => (
     },
 );
 
+has duplicate_of => (
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my $duplicate_of = $self->get_extra_metadata("duplicate_of");
+        return unless defined $duplicate_of;
+        return $self->result_source->schema->resultset('Problem')->search({ id => $duplicate_of })->first;
+    },
+);
+
 1;

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -942,6 +942,7 @@ sub pin_data {
         id => $self->id,
         title => $opts{private} ? $self->title : $self->title_safe,
         problem => $self,
+        type => $opts{type},
     }
 };
 

--- a/t/app/controller/report_display.t
+++ b/t/app/controller/report_display.t
@@ -117,7 +117,7 @@ subtest "duplicate reports are signposted correctly" => sub {
 
     my $report2_id = $report2->id;
     ok $mech->get("/report/$report2_id"), "get '/report/$report2_id'";
-    $mech->content_contains('This report is a duplicate.');
+    $mech->content_contains('This report is a duplicate');
     $mech->content_contains($report->title);
     $mech->log_out_ok;
 

--- a/t/app/controller/report_display.t
+++ b/t/app/controller/report_display.t
@@ -25,31 +25,16 @@ my $dt = DateTime->new(
     second => 23
 );
 
-my $report = FixMyStreet::App->model('DB::Problem')->find_or_create(
-    {
-        postcode           => 'SW1A 1AA',
-        bodies_str         => '2504',
-        areas              => ',105255,11806,11828,2247,2504,',
-        category           => 'Other',
-        title              => 'Test 2',
-        detail             => 'Test 2 Detail',
-        used_map           => 't',
-        name               => 'Test User',
-        anonymous          => 'f',
-        state              => 'confirmed',
-        confirmed          => $dt->ymd . ' ' . $dt->hms,
-        lang               => 'en-gb',
-        service            => '',
-        cobrand            => 'default',
-        cobrand_data       => '',
-        send_questionnaire => 't',
-        latitude           => '51.5016605453401',
-        longitude          => '-0.142497580865087',
-        user_id            => $user->id,
-    }
-);
+my $westminster = $mech->create_body_ok(2504, 'Westminster City Council');
+my ($report, $report2) = $mech->create_problems_for_body(2, $westminster->id, "Example", {
+    user => $user,
+    confirmed => $dt->ymd . ' ' . $dt->hms,
+});
+$report->update({
+    title => 'Test 2',
+    detail => 'Test 2 Detail'
+});
 my $report_id = $report->id;
-ok $report, "created test report - $report_id";
 
 subtest "check that no id redirects to homepage" => sub {
     $mech->get_ok('/report');
@@ -123,6 +108,22 @@ subtest "check owner of report can view non public reports" => sub {
     $mech->content_contains('That report cannot be viewed on FixMyStreet.');
     $mech->log_out_ok;
     ok $report->update( { non_public => 0 } ), 'make report public';
+};
+
+subtest "duplicate reports are signposted correctly" => sub {
+    $report2->set_extra_metadata(duplicate_of => $report->id);
+    $report2->state('duplicate');
+    $report2->update;
+
+    my $report2_id = $report2->id;
+    ok $mech->get("/report/$report2_id"), "get '/report/$report2_id'";
+    $mech->content_contains('This report is a duplicate.');
+    $mech->content_contains($report->title);
+    $mech->log_out_ok;
+
+    $report2->unset_extra_metadata('duplicate_of');
+    $report2->state('confirmed');
+    $report2->update;
 };
 
 subtest "test a good report" => sub {
@@ -532,5 +533,6 @@ subtest "Zurich banners are displayed correctly" => sub {
 
 END {
     $mech->delete_user('test@example.com');
+    $mech->delete_body($westminster);
     done_testing();
 }

--- a/t/app/controller/report_inspect.t
+++ b/t/app/controller/report_inspect.t
@@ -93,7 +93,7 @@ FixMyStreet::override_config {
         $mech->content_lacks('Invalid location');
     };
 
-    subtest "test duplicate report is shown" => sub {
+    subtest "test duplicate reports are shown" => sub {
         my ($report2) = $mech->create_problems_for_body(1, $oxon->id, 'The other report is a duplicate of this one', {
             category => $report->category, cobrand => 'fixmystreet', areas => ',2237,2420',
             whensent => \'current_timestamp',
@@ -106,6 +106,10 @@ FixMyStreet::override_config {
 
         $mech->get_ok("/report/$report_id");
         $mech->content_contains($report2->title);
+
+        my $report2_id = $report2->id;
+        $mech->get_ok("/report/$report2_id");
+        $mech->content_contains($report->title);
 
         $report->unset_extra_metadata('duplicate_of');
         $report->state($old_state);

--- a/t/app/controller/report_inspect.t
+++ b/t/app/controller/report_inspect.t
@@ -21,12 +21,14 @@ my $wodc = $mech->create_body_ok(2420, 'West Oxfordshire District Council', id =
 $mech->create_contact_ok( body_id => $wodc->id, category => 'Horses', email => 'horses@example.net' );
 
 
-my ($report) = $mech->create_problems_for_body(1, $oxon->id, 'Test', {
+my ($report, $report2) = $mech->create_problems_for_body(2, $oxon->id, 'Test', {
     category => 'Cows', cobrand => 'fixmystreet', areas => ',2237,2420',
     whensent => \'current_timestamp',
     latitude => 51.847693, longitude => -1.355908,
 });
 my $report_id = $report->id;
+my $report2_id = $report2->id;
+
 
 my $user = $mech->log_in_ok('test@example.com');
 $user->update( { from_body => $oxon } );
@@ -94,11 +96,6 @@ FixMyStreet::override_config {
     };
 
     subtest "test duplicate reports are shown" => sub {
-        my ($report2) = $mech->create_problems_for_body(1, $oxon->id, 'The other report is a duplicate of this one', {
-            category => $report->category, cobrand => 'fixmystreet', areas => ',2237,2420',
-            whensent => \'current_timestamp',
-            latitude => 51.847694, longitude => -1.355909,
-        });
         my $old_state = $report->state;
         $report->set_extra_metadata('duplicate_of' => $report2->id);
         $report->state('duplicate');
@@ -107,13 +104,48 @@ FixMyStreet::override_config {
         $mech->get_ok("/report/$report_id");
         $mech->content_contains($report2->title);
 
-        my $report2_id = $report2->id;
         $mech->get_ok("/report/$report2_id");
         $mech->content_contains($report->title);
 
         $report->unset_extra_metadata('duplicate_of');
         $report->state($old_state);
         $report->update;
+    };
+
+    subtest "marking a report as a duplicate with update correctly sets update status" => sub {
+        my $old_state = $report->state;
+        $report->comments->delete_all;
+
+        $mech->get_ok("/report/$report_id");
+        $mech->submit_form_ok({ button => 'save', with_fields => { state => 'Duplicate', duplicate_of => $report2->id, public_update => "This is a duplicate.", save_inspected => "1" } });
+        $report->discard_changes;
+
+        is $report->state, 'duplicate', 'report marked as duplicate';
+        is $report->comments->search({ problem_state => 'duplicate' })->count, 1, 'update marking report as duplicate was left';
+
+        $report->update({ state => $old_state });
+    };
+
+    subtest "marking a report as a duplicate doesn't clobber user-provided update" => sub {
+        my $old_state = $report->state;
+        $report->comments->delete_all;
+
+        $mech->get_ok("/report/$report_id");
+        my $update_text = "This text was entered as an update by the user.";
+        $mech->submit_form_ok({ button => 'save', with_fields => {
+            state => 'Duplicate',
+            duplicate_of => $report2->id,
+            public_update => $update_text,
+            save_inspected => "1",
+        }});
+        $report->discard_changes;
+
+        is $report->state, 'duplicate', 'report marked as duplicate';
+        is $report->comments->search({ problem_state => 'duplicate' })->count, 1, 'update marked report as duplicate';
+        $mech->content_contains($update_text);
+        $mech->content_lacks("Thank you for your report. This problem has already been reported.");
+
+        $report->update({ state => $old_state });
     };
 
     foreach my $test (

--- a/t/app/controller/report_inspect.t
+++ b/t/app/controller/report_inspect.t
@@ -93,6 +93,25 @@ FixMyStreet::override_config {
         $mech->content_lacks('Invalid location');
     };
 
+    subtest "test duplicate report is shown" => sub {
+        my ($report2) = $mech->create_problems_for_body(1, $oxon->id, 'The other report is a duplicate of this one', {
+            category => $report->category, cobrand => 'fixmystreet', areas => ',2237,2420',
+            whensent => \'current_timestamp',
+            latitude => 51.847694, longitude => -1.355909,
+        });
+        my $old_state = $report->state;
+        $report->set_extra_metadata('duplicate_of' => $report2->id);
+        $report->state('duplicate');
+        $report->update;
+
+        $mech->get_ok("/report/$report_id");
+        $mech->content_contains($report2->title);
+
+        $report->unset_extra_metadata('duplicate_of');
+        $report->state($old_state);
+        $report->update;
+    };
+
     foreach my $test (
         { type => 'report_edit_priority', priority => 1 },
         { type => 'report_edit_category', category => 1 },

--- a/t/app/controller/report_updates.t
+++ b/t/app/controller/report_updates.t
@@ -685,6 +685,8 @@ for my $test (
         my $meta_state = $test->{meta} || $test->{fields}->{state};
         if ( $test->{reopened} ) {
             like $update_meta->[0], qr/reopened$/, 'update meta says reopened';
+        } elsif ( $test->{state} eq 'duplicate' ) {
+            like $update_meta->[0], qr/closed as $meta_state$/, 'update meta includes state change';
         } else {
             like $update_meta->[0], qr/marked as $meta_state$/, 'update meta includes state change';
         }

--- a/t/app/model/problem.t
+++ b/t/app/model/problem.t
@@ -763,6 +763,17 @@ subtest 'check response templates' => sub {
     is $problem->response_templates, 2, 'Global and pothole templates returned';
 };
 
+subtest 'check duplicate reports' => sub {
+    my ($problem1, $problem2) = $mech->create_problems_for_body(2, $body_ids{2651}, 'TITLE');
+    $problem1->set_extra_metadata(duplicate_of => $problem2->id);
+    $problem1->state('duplicate');
+    $problem1->update;
+
+    is $problem1->duplicate_of->title, $problem2->title, 'problem1 returns correct problem from duplicate_of';
+    is scalar @{ $problem2->duplicates }, 1, 'problem2 has correct number of duplicates';
+    is $problem2->duplicates->[0]->title, $problem1->title, 'problem2 includes problem1 in duplicates';
+};
+
 END {
     $problem->comments->delete if $problem;
     $problem->delete if $problem;

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -79,10 +79,12 @@
           </p>
           <div id="js-duplicate-reports" class="[% "hidden" UNLESS problem.duplicate_of %]">
             <input type="hidden" name="duplicate_of" value="[% problem.duplicate_of.id %]">
-            [% loc('Which report is it a duplicate of?') %]
+            <p class="[% "hidden" UNLESS problem.duplicate_of %]"><strong>[% loc('Duplicate of') %]</strong></p>
+            <p class="[% "hidden" IF problem.duplicate_of %]">[% loc('Which report is it a duplicate of?') %]</p>
             <ul>
               [% IF problem.duplicate_of %]
-                [% INCLUDE 'report/_item.html' item_extra_class = 'item-list__item--with-pin item-list--reports__item--selected' problem = problem.duplicate_of %]
+                [% INCLUDE 'report/_item.html' item_extra_class = 'item-list--reports__item--selected' problem = problem.duplicate_of %]
+                <li class="item-list__item"><a class="btn" href="#" id="js-change-duplicate-report">[% loc('Choose another') %]</a></li>
               [% END %]
             </ul>
           </div>

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -80,7 +80,7 @@
             <input type="hidden" name="duplicate_of" value="[% problem.duplicate_of.id %]">
             <p class="[% "hidden" UNLESS problem.duplicate_of %]"><strong>[% loc('Duplicate of') %]</strong></p>
             <p class="[% "hidden" IF problem.duplicate_of %]">[% loc('Which report is it a duplicate of?') %]</p>
-            <ul>
+            <ul class="item-list">
               [% IF problem.duplicate_of %]
                 [% INCLUDE 'report/_item.html' item_extra_class = 'item-list--reports__item--selected' problem = problem.duplicate_of %]
                 <li class="item-list__item"><a class="btn" href="#" id="js-change-duplicate-report">[% loc('Choose another') %]</a></li>
@@ -89,7 +89,7 @@
           </div>
           [% IF problem.duplicates.size %]
             <p><strong>[% loc('Duplicates') %]</strong></p>
-            <ul>
+            <ul class="item-list">
               [% FOR duplicate IN problem.duplicates %]
                 [% INCLUDE 'report/_item.html' problem = duplicate %]
               [% END %]

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -158,7 +158,7 @@
         <p>
           <input type="hidden" name="token" value="[% csrf_token %]">
           <a class="btn" href="[% c.uri_for( '/report', problem.id ) %]">[% loc('Cancel') %]</a>
-          <input class="btn btn-primary" type="submit" value="[% loc('Save changes') %]" name="save" />
+          <input class="btn btn-primary" type="submit" value="[% loc('Save changes') %]" data-value-original="[% loc('Save changes') %]" data-value-duplicate="[% loc('Save + close as duplicate') %]" name="save" />
         </p>
       </div>
 

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -9,8 +9,7 @@
       <div class="inspect-section">
         <p>
           <strong>[% loc('Report ID:') %]</strong>
-          [% problem.id %]
-          <input type="hidden" name="report_id" value="[% problem.id | html %]">
+          <span class="js-report-id">[% problem.id %]</span>
         </p>
         <p>
           [% SET local_coords = problem.local_coords; %]

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -10,6 +10,7 @@
         <p>
           <strong>[% loc('Report ID:') %]</strong>
           [% problem.id %]
+          <input type="hidden" name="report_id" value="[% problem.id | html %]">
         </p>
         <p>
           [% SET local_coords = problem.local_coords; %]
@@ -76,10 +77,14 @@
             [% END %]
           </select>
         </p>
-        <div id="js-duplicate-reports" class="hidden">
-          <input type="hidden" name="duplicate_of" value="[% problem.get_extra_metadata('duplicate_of') | html %]">
+        <div id="js-duplicate-reports" class="[% "hidden" UNLESS problem.duplicate_of %]">
+          <input type="hidden" name="duplicate_of" value="[% problem.duplicate_of.id %]">
           Which report is it a duplicate of?
-          <ul></ul>
+          <ul>
+            [% IF problem.duplicate_of %]
+              [% INCLUDE 'report/_item.html' no_fixed = 1 item_extra_class = 'item-list__item--with-pin item-list--reports__item--selected' problem = problem.duplicate_of %]
+            [% END %]
+          </ul>
         </div>
         [% END %]
 

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -76,6 +76,11 @@
             [% END %]
           </select>
         </p>
+        <div id="js-duplicate-reports" class="hidden">
+          <input type="hidden" name="duplicate_of" value="[% problem.get_extra_metadata('duplicate_of') | html %]">
+          Which report is it a duplicate of?
+          <ul></ul>
+        </div>
         [% END %]
 
       </div>

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -64,28 +64,36 @@
         [% END %]
 
         [% IF permissions.report_inspect %]
-        <p>
-          <label for="state">[% loc('State') %]</label>
-            [%# XXX this is duplicated from admin/report_edit.html, should be refactored %]
-          <select name="state" id="state" class="form-control">
-            [% FOREACH group IN state_groups %]
-              <optgroup label="[% group.0 %]">
-                [% FOREACH state IN group.1 %]
-                  <option [% 'selected ' IF state == problem.state %] value="[% state %]">[% state_pretty.$state %]</option>
-                [% END %]
-              </optgroup>
-            [% END %]
-          </select>
-        </p>
-        <div id="js-duplicate-reports" class="[% "hidden" UNLESS problem.duplicate_of %]">
-          <input type="hidden" name="duplicate_of" value="[% problem.duplicate_of.id %]">
-          Which report is it a duplicate of?
-          <ul>
-            [% IF problem.duplicate_of %]
-              [% INCLUDE 'report/_item.html' no_fixed = 1 item_extra_class = 'item-list__item--with-pin item-list--reports__item--selected' problem = problem.duplicate_of %]
-            [% END %]
-          </ul>
-        </div>
+          <p>
+            <label for="state">[% loc('State') %]</label>
+              [%# XXX this is duplicated from admin/report_edit.html, should be refactored %]
+            <select name="state" id="state" class="form-control">
+              [% FOREACH group IN state_groups %]
+                <optgroup label="[% group.0 %]">
+                  [% FOREACH state IN group.1 %]
+                    <option [% 'selected ' IF state == problem.state %] value="[% state %]">[% state_pretty.$state %]</option>
+                  [% END %]
+                </optgroup>
+              [% END %]
+            </select>
+          </p>
+          <div id="js-duplicate-reports" class="[% "hidden" UNLESS problem.duplicate_of %]">
+            <input type="hidden" name="duplicate_of" value="[% problem.duplicate_of.id %]">
+            [% loc('Which report is it a duplicate of?') %]
+            <ul>
+              [% IF problem.duplicate_of %]
+                [% INCLUDE 'report/_item.html' item_extra_class = 'item-list__item--with-pin item-list--reports__item--selected' problem = problem.duplicate_of %]
+              [% END %]
+            </ul>
+          </div>
+          [% IF problem.duplicates.size %]
+            <p><strong>[% loc('Duplicates') %]</strong></p>
+            <ul>
+              [% FOR duplicate IN problem.duplicates %]
+                [% INCLUDE 'report/_item.html' problem = duplicate %]
+              [% END %]
+            </ul>
+          [% END %]
         [% END %]
 
       </div>

--- a/templates/web/base/report/_item.html
+++ b/templates/web/base/report/_item.html
@@ -1,4 +1,4 @@
-<li class="item-list__item item-list--reports__item [% item_extra_class %]">
+<li class="item-list__item item-list--reports__item [% item_extra_class %]" data-report-id="[% problem.id | html %]">
 <a href="[% c.cobrand.base_url_for_report( problem ) %][% problem.url %]">
     [% IF problem.photo %]
         <img class="img" height="60" width="90" src="[% problem.photos.first.url_fp %]" alt="">

--- a/templates/web/base/report/display.html
+++ b/templates/web/base/report/display.html
@@ -40,12 +40,19 @@
 
 [% INCLUDE 'report/banner.html' %]
 [% INCLUDE 'report/_main.html' %]
+
+[% IF problem.duplicate_of %]
+    [% INCLUDE 'report/duplicate-no-updates.html' hide_header = 1 %]
+[% END %]
+
 [% TRY %][% INCLUDE 'report/_message_manager.html' %][% CATCH file %][% END %]
 [% INCLUDE 'report/display_tools.html' %]
 [% TRY %][% INCLUDE 'report/sharing.html' %][% CATCH file %][% END %]
 [% INCLUDE 'report/updates.html' %]
 
-[% IF NOT shown_form %]
+[% IF problem.duplicate_of %]
+    [% INCLUDE 'report/duplicate-no-updates.html' %]
+[% ELSIF NOT shown_form %]
     [% INCLUDE 'report/update-form.html' %]
 [% END %]
 

--- a/templates/web/base/report/duplicate-no-updates.html
+++ b/templates/web/base/report/duplicate-no-updates.html
@@ -1,0 +1,7 @@
+<div>
+    [% UNLESS hide_header %]<h2>[% loc( 'Provide an update') %]</h2>[% END %]
+    <p>[% loc("This report is a duplicate. Please leave updates on the original report:") %]</p>
+    <ul class="item-list">
+      [% INCLUDE 'report/_item.html' item_extra_class = 'item-list__item--with-pin item-list--reports__item--selected' problem = problem.duplicate_of %]
+    </ul>
+</div>

--- a/templates/web/base/report/updates.html
+++ b/templates/web/base/report/updates.html
@@ -54,7 +54,7 @@
         [%- ELSIF state == 'not responsible' %]
             [%- update_state = loc( "marked as not the council's responsibility" ) %]
         [%- ELSIF state == 'duplicate' %]
-            [%- update_state = loc( 'marked as a duplicate report' ) %]
+            [%- update_state = loc( 'closed as a duplicate report' ) %]
         [%- ELSIF state == 'internal referral' %]
             [%- update_state = loc( 'marked as an internal referral' ) %]
         [%- END %]

--- a/templates/web/bromley/report/display.html
+++ b/templates/web/bromley/report/display.html
@@ -21,147 +21,19 @@
 
 [% INCLUDE 'report/banner.html' %]
 [% INCLUDE 'report/_main.html' %]
+
+[% IF problem.duplicate_of %]
+    [% INCLUDE 'report/duplicate-no-updates.html' hide_header = 1 %]
+[% END %]
+
 [% INCLUDE 'report/display_tools.html' %]
 [% INCLUDE 'report/updates.html' %]
 
-<div id="update_form">
-    <h2>[% loc( 'Provide an update') %]</h2>
-
-    [% INCLUDE 'errors.html' %]
-
-    <form method="post" action="[% c.uri_for( '/report/update' ) %]" name="updateForm" class="validate"[% IF c.cobrand.allow_photo_upload %] enctype="multipart/form-data"[% END %]>
-        <input type="hidden" name="token" value="[% csrf_token %]">
-        <fieldset>
-            <input type="hidden" name="submit_update" value="1">
-            <input type="hidden" name="id" value="[% problem.id | html %]">
-
-        [% IF c.cobrand.allow_photo_upload %]
-            <input type="hidden" name="upload_fileid" value="[% upload_fileid %]">
-            <label for="form_photo">
-                <span data-singular="[% loc('Photo') %]" data-plural="[% loc('Photos') %]">[% loc('Photo') %]</span>
-            </label>
-
-              [% IF field_errors.photo %]
-                <p class='form-error'>[% field_errors.photo %]</p>
-              [% END %]
-
-            <div id="form_photos">
-              [% IF upload_fileid %]
-                <p>[% loc('You have already attached photos to this update.  Note that you can attach a maximum of 3 to this update (if you try to upload more, the oldest will be removed).') %]</p>
-                [% FOREACH id IN upload_fileid.split(',') %]
-                <img align="right" src="/photo/temp.[% id %]" alt="">
-                [% END %]
-            [% END %]
-                <input type="file" name="photo1" id="form_photo">
-                <label for="form_photo2">[% loc('Photo') %]</label>
-                <input type="file" name="photo2" id="form_photo2">
-                <label for="form_photo3">[% loc('Photo') %]</label>
-                <input type="file" name="photo3" id="form_photo3">
-            </div>
-        [% END %]
-
-            <label for="form_update">[% loc( 'Update' ) %]</label>
-            [% IF field_errors.update %]
-                <div class='form-error'>[% field_errors.update %]</div>
-            [% END %]
-            <textarea class="form-control" rows="7" cols="30" name="update" id="form_update" placeholder="[% loc('Please write your update here') %]" required>[% update.text | html %]</textarea>
-
-            <div class="general-notes">
-                <p>Please note this comments box can only be used for this report.
-                <br><a href="http://www.bromley.gov.uk/report">Report a different issue</a>
-            </div>
-
-            [% IF c.user && c.user.belongs_to_body( problem.bodies_str ) %]
-                <label for="form_state">[% loc( 'State' ) %]</label>
-                <select name="state" id="form_state" class="form-control">
-                    [% FOREACH state IN [ ['confirmed', loc('Open')], ['investigating',
-                    loc('Investigating')], ['action scheduled', loc('Action Scheduled')],
-                    ['in progress', loc('In Progress')], ['duplicate', loc('Duplicate')],
-                    ['unable to fix', loc('Unable to fix')], ['not responsible', loc('Not Responsible')],
-                    ['fixed', loc('Fixed')] ] %]
-                    <option [% 'selected ' IF state.0 == problem.state_display %] value="[% state.0 %]">[% state.1 %]</option>
-                [% END %]
-                </select>
-            [% ELSE %]
-                [% IF problem.is_fixed AND c.user_exists AND c.user.id == problem.user_id %]
-
-                <input type="checkbox" name="reopen" id="form_reopen" value="1"[% ' checked' IF update.mark_open %]>
-                <label class="inline" for="form_reopen">[% loc('This problem has not been fixed') %]</label>
-
-                [% ELSIF !problem.is_fixed %]
-
-                <div class="checkbox-group">
-                    <input type="checkbox" name="fixed" id="form_fixed" value="1"[% ' checked' IF update.mark_fixed %]>
-                    <label class="inline" for="form_fixed">[% loc('This problem has been fixed') %]</label>
-                </div>
-
-                [% END %]
-            [% END %]
-
-        [% IF c.user_exists %]
-
-            [% INCLUDE name %]
-
-            <input class="final-submit green-btn js-submit_register" type="submit" name="submit_register" value="[% loc('Post') %]">
-
-
-        [% ELSE %]
-
-            <label for="form_rznvy">[% loc('Email' ) %]
-                <span class="muted">([% loc('We never show your email') %])</span>
-            </label>
-
-            [% IF field_errors.email %]
-                <p class='form-error'>[% field_errors.email %]</p>
-            [% END %]
-            <input class="form-control" type="email" name="rznvy" id="form_rznvy" value="[% update.user.email | html %]" placeholder="[% loc('Your email address' ) %]" required>
-
-            <div id="form_sign_in">
-                <p>To submit your update you now need to confirm it either by email or by using a FixMyStreet password.</p>
-
-                <div id="form_sign_in_no" class="form-box">
-                    <h5>Confirm my report by email</h5>
-
-                    [% INCLUDE name %]
-
-                    <label for="password_register">[% loc('Password (optional)') %]</label>
-
-                    <div class="general-notes">
-                        <p>[% loc('Providing a password is optional, but doing so will allow you to more easily report problems, leave updates and manage your reports.') %]</p>
-                    </div>
-
-                    <div class="form-txt-submit-box">
-                        <input type="password" class="form-control" name="password_register" id="password_register" value="" placeholder="[% loc('Enter a password') %]">
-                        <input class="green-btn js-submit_register" type="submit" name="submit_register" value="[% loc('Post') %]">
-                    </div>
-                </div>
-                <div id="form_sign_in_yes" class="form-box">
-                    <h5>Confirm my report with my FixMyStreet password</h5>
-
-                    <label class="hidden-js n" for="password_sign_in">[% loc('Yes I have a password') %]</label>
-                    [% IF field_errors.password %]
-                        <p class='form-error'>[% field_errors.password %]</p>
-                    [% END %]
-                    <div class="form-txt-submit-box">
-                        <input type="password" class="form-control" name="password_sign_in" id="password_sign_in" value="" placeholder="[% loc('Your password') %]">
-                        <input class="green-btn js-submit_sign_in" type="submit" name="submit_sign_in" value="[% loc('Post') %]">
-                    </div>
-
-                    <div class="checkbox-group">
-                        <input type="checkbox" id="remember_me" name="remember_me" value='1'[% ' checked' IF remember_me %]>
-                        <label class="inline n" for="remember_me">[% loc('Keep me signed in on this computer') %]</label>
-                    </div>
-                </div>
-            </div>
-
-        [% END %]
-
-        <p>Your information will only be used in accordance with our <a href="/faq#privacy">privacy policy</a>.</p>
-
-        </fieldset>
-    </form>
-</div>
-
+[% IF problem.duplicate_of %]
+    [% INCLUDE 'report/duplicate-no-updates.html' %]
+[% ELSE %]
+    [% INCLUDE 'report/update-form.html' %]
+[% END %]
 </div>
 
 [% INCLUDE 'footer.html' %]

--- a/templates/web/bromley/report/update-form.html
+++ b/templates/web/bromley/report/update-form.html
@@ -1,0 +1,137 @@
+<div id="update_form">
+    <h2>[% loc( 'Provide an update') %]</h2>
+
+    [% INCLUDE 'errors.html' %]
+
+    <form method="post" action="[% c.uri_for( '/report/update' ) %]" name="updateForm" class="validate"[% IF c.cobrand.allow_photo_upload %] enctype="multipart/form-data"[% END %]>
+        <input type="hidden" name="token" value="[% csrf_token %]">
+        <fieldset>
+            <input type="hidden" name="submit_update" value="1">
+            <input type="hidden" name="id" value="[% problem.id | html %]">
+
+        [% IF c.cobrand.allow_photo_upload %]
+            <input type="hidden" name="upload_fileid" value="[% upload_fileid %]">
+            <label for="form_photo">
+                <span data-singular="[% loc('Photo') %]" data-plural="[% loc('Photos') %]">[% loc('Photo') %]</span>
+            </label>
+
+              [% IF field_errors.photo %]
+                <p class='form-error'>[% field_errors.photo %]</p>
+              [% END %]
+
+            <div id="form_photos">
+              [% IF upload_fileid %]
+                <p>[% loc('You have already attached photos to this update.  Note that you can attach a maximum of 3 to this update (if you try to upload more, the oldest will be removed).') %]</p>
+                [% FOREACH id IN upload_fileid.split(',') %]
+                <img align="right" src="/photo/temp.[% id %]" alt="">
+                [% END %]
+            [% END %]
+                <input type="file" name="photo1" id="form_photo">
+                <label for="form_photo2">[% loc('Photo') %]</label>
+                <input type="file" name="photo2" id="form_photo2">
+                <label for="form_photo3">[% loc('Photo') %]</label>
+                <input type="file" name="photo3" id="form_photo3">
+            </div>
+        [% END %]
+
+            <label for="form_update">[% loc( 'Update' ) %]</label>
+            [% IF field_errors.update %]
+                <div class='form-error'>[% field_errors.update %]</div>
+            [% END %]
+            <textarea class="form-control" rows="7" cols="30" name="update" id="form_update" placeholder="[% loc('Please write your update here') %]" required>[% update.text | html %]</textarea>
+
+            <div class="general-notes">
+                <p>Please note this comments box can only be used for this report.
+                <br><a href="http://www.bromley.gov.uk/report">Report a different issue</a>
+            </div>
+
+            [% IF c.user && c.user.belongs_to_body( problem.bodies_str ) %]
+                <label for="form_state">[% loc( 'State' ) %]</label>
+                <select name="state" id="form_state" class="form-control">
+                    [% FOREACH state IN [ ['confirmed', loc('Open')], ['investigating',
+                    loc('Investigating')], ['action scheduled', loc('Action Scheduled')],
+                    ['in progress', loc('In Progress')], ['duplicate', loc('Duplicate')],
+                    ['unable to fix', loc('Unable to fix')], ['not responsible', loc('Not Responsible')],
+                    ['fixed', loc('Fixed')] ] %]
+                    <option [% 'selected ' IF state.0 == problem.state_display %] value="[% state.0 %]">[% state.1 %]</option>
+                [% END %]
+                </select>
+            [% ELSE %]
+                [% IF problem.is_fixed AND c.user_exists AND c.user.id == problem.user_id %]
+
+                <input type="checkbox" name="reopen" id="form_reopen" value="1"[% ' checked' IF update.mark_open %]>
+                <label class="inline" for="form_reopen">[% loc('This problem has not been fixed') %]</label>
+
+                [% ELSIF !problem.is_fixed %]
+
+                <div class="checkbox-group">
+                    <input type="checkbox" name="fixed" id="form_fixed" value="1"[% ' checked' IF update.mark_fixed %]>
+                    <label class="inline" for="form_fixed">[% loc('This problem has been fixed') %]</label>
+                </div>
+
+                [% END %]
+            [% END %]
+
+        [% IF c.user_exists %]
+
+            [% INCLUDE name %]
+
+            <input class="final-submit green-btn js-submit_register" type="submit" name="submit_register" value="[% loc('Post') %]">
+
+
+        [% ELSE %]
+
+            <label for="form_rznvy">[% loc('Email' ) %]
+                <span class="muted">([% loc('We never show your email') %])</span>
+            </label>
+
+            [% IF field_errors.email %]
+                <p class='form-error'>[% field_errors.email %]</p>
+            [% END %]
+            <input class="form-control" type="email" name="rznvy" id="form_rznvy" value="[% update.user.email | html %]" placeholder="[% loc('Your email address' ) %]" required>
+
+            <div id="form_sign_in">
+                <p>To submit your update you now need to confirm it either by email or by using a FixMyStreet password.</p>
+
+                <div id="form_sign_in_no" class="form-box">
+                    <h5>Confirm my report by email</h5>
+
+                    [% INCLUDE name %]
+
+                    <label for="password_register">[% loc('Password (optional)') %]</label>
+
+                    <div class="general-notes">
+                        <p>[% loc('Providing a password is optional, but doing so will allow you to more easily report problems, leave updates and manage your reports.') %]</p>
+                    </div>
+
+                    <div class="form-txt-submit-box">
+                        <input type="password" class="form-control" name="password_register" id="password_register" value="" placeholder="[% loc('Enter a password') %]">
+                        <input class="green-btn js-submit_register" type="submit" name="submit_register" value="[% loc('Post') %]">
+                    </div>
+                </div>
+                <div id="form_sign_in_yes" class="form-box">
+                    <h5>Confirm my report with my FixMyStreet password</h5>
+
+                    <label class="hidden-js n" for="password_sign_in">[% loc('Yes I have a password') %]</label>
+                    [% IF field_errors.password %]
+                        <p class='form-error'>[% field_errors.password %]</p>
+                    [% END %]
+                    <div class="form-txt-submit-box">
+                        <input type="password" class="form-control" name="password_sign_in" id="password_sign_in" value="" placeholder="[% loc('Your password') %]">
+                        <input class="green-btn js-submit_sign_in" type="submit" name="submit_sign_in" value="[% loc('Post') %]">
+                    </div>
+
+                    <div class="checkbox-group">
+                        <input type="checkbox" id="remember_me" name="remember_me" value='1'[% ' checked' IF remember_me %]>
+                        <label class="inline n" for="remember_me">[% loc('Keep me signed in on this computer') %]</label>
+                    </div>
+                </div>
+            </div>
+
+        [% END %]
+
+        <p>Your information will only be used in accordance with our <a href="/faq#privacy">privacy policy</a>.</p>
+
+        </fieldset>
+    </form>
+</div>

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -414,12 +414,25 @@ $.extend(fixmystreet.set_up, {
         args.latitude = $('input[name="latitude"]').val();
         args.longitude = $('input[name="longitude"]').val();
 
-        console.log(args);
-
         $.getJSON('/ajax', args, function(data) {
-            var $reports = $(data.current);
+            var report_id = $("#report_inspect_form [name=report_id]").val();
+            var duplicate_of = $("#report_inspect_form [name=duplicate_of]").val();
+            var $reports = $(data.current)
+                            .filter("li")
+                            .not("[data-report-id="+report_id+"]")
+                            .slice(0, 5);
+            $reports.filter("[data-report-id="+duplicate_of+"]").addClass("item-list--reports__item--selected");
+
             $("#js-duplicate-reports").removeClass("hidden");
-            $reports.slice(0, 5).appendTo($("#js-duplicate-reports ul").empty());
+            $("#js-duplicate-reports ul").empty().prepend($reports);
+
+            $reports.find("a").click(function() {
+                var report_id = $(this).closest("li").data('reportId');
+                $("#report_inspect_form [name=duplicate_of]").val(report_id);
+                $("#js-duplicate-reports ul li").removeClass("item-list--reports__item--selected");
+                $(this).closest("li").addClass("item-list--reports__item--selected");
+                return false;
+            });
         });
     });
   },

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -391,6 +391,40 @@ $.extend(fixmystreet.set_up, {
   },
 
 
+  state_change: function() {
+    // Deal with changes to report state by inspector/other staff, specifically
+    // displaying nearby reports if it's changed to 'duplicate'.
+    $("#report_inspect_form").on("change.state", "select#state", function() {
+        var state = $(this).val();
+
+        if (state !== "duplicate") {
+            $("#js-duplicate-reports").addClass("hidden");
+            $("#js-duplicate-reports ul").empty();
+            return;
+        }
+
+        var args = {
+            state: state,
+            filter_category: $("#report_inspect_form select#category").val()
+        };
+        var bounds = fixmystreet.map.getExtent();
+        bounds.transform(bounds.transform(fixmystreet.map.getProjectionObject(), new OpenLayers.Projection("EPSG:4326")));
+        args.bbox = bounds.toBBOX();
+
+        args.latitude = $('input[name="latitude"]').val();
+        args.longitude = $('input[name="longitude"]').val();
+
+        console.log(args);
+
+        $.getJSON('/ajax', args, function(data) {
+            var $reports = $(data.current);
+            $("#js-duplicate-reports").removeClass("hidden");
+            $reports.slice(0, 5).appendTo($("#js-duplicate-reports ul").empty());
+        });
+    });
+  },
+
+
   contribute_as: function() {
     $('.content').on('change', '.js-contribute-as', function(){
         var opt = this.options[this.selectedIndex],

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -399,7 +399,6 @@ $.extend(fixmystreet.set_up, {
 
         if (state !== "duplicate") {
             $("#js-duplicate-reports").addClass("hidden");
-            $("#js-duplicate-reports ul").empty();
             return;
         }
 
@@ -414,16 +413,23 @@ $.extend(fixmystreet.set_up, {
         args.latitude = $('input[name="latitude"]').val();
         args.longitude = $('input[name="longitude"]').val();
 
+        $("#js-duplicate-reports").removeClass("hidden");
+
+        var duplicate_of = $("#report_inspect_form [name=duplicate_of]").val();
+        if (!!duplicate_of) {
+            return;
+        }
+
+        $("#js-duplicate-reports ul").html("<li>Loading...</li>");
+
         var report_id = $("#report_inspect_form [name=report_id]").val();
         $.getJSON('/report/'+report_id+'/nearby', args, function(data) {
-            var duplicate_of = $("#report_inspect_form [name=duplicate_of]").val();
             var $reports = $(data.current)
                             .filter("li")
                             .not("[data-report-id="+report_id+"]")
                             .slice(0, 5);
             $reports.filter("[data-report-id="+duplicate_of+"]").addClass("item-list--reports__item--selected");
 
-            $("#js-duplicate-reports").removeClass("hidden");
             $("#js-duplicate-reports ul").empty().prepend($reports);
 
             $reports.find("a").click(function() {

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -390,7 +390,6 @@ $.extend(fixmystreet.set_up, {
     });
   },
 
-
   manage_duplicates: function() {
       // Deal with changes to report state by inspector/other staff, specifically
       // displaying nearby reports if it's changed to 'duplicate'.
@@ -656,6 +655,18 @@ $.extend(fixmystreet.set_up, {
         $("form#report_inspect_form [data-category]:not(" + selector + ")").addClass("hidden");
         $("form#report_inspect_form " + selector).removeClass("hidden");
     });
+
+    // The inspect form submit button can change depending on the selected state
+    $("#report_inspect_form [name=state]").change(function(){
+        var state = $(this).val();
+        var $submit = $("#report_inspect_form input[type=submit]");
+        var value = $submit.attr('data-value-'+state);
+        if (value !== undefined) {
+            $submit.val(value);
+        } else {
+            $submit.val($submit.data('valueOriginal'));
+        }
+    }).change();
 
     $('.js-toggle-public-update').each(function() {
         var $checkbox = $(this);

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -414,8 +414,8 @@ $.extend(fixmystreet.set_up, {
         args.latitude = $('input[name="latitude"]').val();
         args.longitude = $('input[name="longitude"]').val();
 
-        $.getJSON('/ajax', args, function(data) {
-            var report_id = $("#report_inspect_form [name=report_id]").val();
+        var report_id = $("#report_inspect_form [name=report_id]").val();
+        $.getJSON('/report/'+report_id+'/nearby', args, function(data) {
             var duplicate_of = $("#report_inspect_form [name=duplicate_of]").val();
             var $reports = $(data.current)
                             .filter("li")

--- a/web/cobrands/sass/_report_list_pins.scss
+++ b/web/cobrands/sass/_report_list_pins.scss
@@ -50,6 +50,14 @@
     color: #777;
   }
 }
+.item-list--reports__item--selected {
+  background: $base_bg;
+
+  a, a:hover, a:focus {
+    background-color: transparent;
+  }
+}
+
 
 .item-list__item--empty {
   background: none;

--- a/web/js/map-google.js
+++ b/web/js/map-google.js
@@ -56,6 +56,9 @@ fixmystreet.maps = {};
         google.maps.event.trigger(fixmystreet.map, 'idle');
     };
 
+    // This is a noop on Google Maps right now.
+    fixmystreet.maps.markers_highlight = function() {};
+
     function PaddingControl(div) {
         div.style.padding = '40px';
     }


### PR DESCRIPTION
This PR adds functionality for inspectors to be able to mark a report as a duplicate as another and prevents users leaving updates on reports marked as duplicates.

 - [x] Inspector can pick a nearby report when changing the state to 'duplicate'
 - [x] Links back and forth between duplicate/duplicated reports
 - [x] Signposting for users to leave updates on the original report instead of the duplicate
 - [x] Automatic update left when marking report as duplicate if the inspector doesn't provide one
 - [x] Display of nearby reports as pins on the map when selecting duplicated report



For mysociety/fixmystreetforcouncils#18