### PR TITLE
Add 'state' to response templates

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -486,6 +486,7 @@ create table response_templates (
     text text not null,
     created timestamp not null default current_timestamp,
     auto_response boolean NOT NULL DEFAULT 'f',
+    state text,
     unique(body_id, title)
 );
 

--- a/db/schema_0048-response-templates-add-state.sql
+++ b/db/schema_0048-response-templates-add-state.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE response_templates
+    ADD COLUMN state TEXT;
+
+COMMIT;

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -978,6 +978,7 @@ sub template_edit : Path('templates') : Args(2) {
         } else {
             $template->title( $c->get_param('title') );
             $template->text( $c->get_param('text') );
+            $template->state( $c->get_param('state') );
             $template->auto_response( $c->get_param('auto_response') ? 1 : 0 );
             $template->update_or_insert;
 

--- a/perllib/FixMyStreet/DB/Result/ResponseTemplate.pm
+++ b/perllib/FixMyStreet/DB/Result/ResponseTemplate.pm
@@ -33,6 +33,8 @@ __PACKAGE__->add_columns(
   },
   "auto_response",
   { data_type => "boolean", default_value => \"false", is_nullable => 0 },
+  "state",
+  { data_type => "text", is_nullable => 1 },
 );
 __PACKAGE__->set_primary_key("id");
 __PACKAGE__->add_unique_constraint("response_templates_body_id_title_key", ["body_id", "title"]);
@@ -50,8 +52,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2016-08-24 11:29:04
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:KRm0RHbtrzuxzH0S/UAsdw
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2016-12-01 15:10:52
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ySPzQpFwJNki8XBjCNiqZQ
 
 __PACKAGE__->many_to_many( contacts => 'contact_response_templates', 'contact' );
 

--- a/templates/web/base/admin/report_edit.html
+++ b/templates/web/base/admin/report_edit.html
@@ -112,16 +112,10 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
 <li><label for='detail'>[% loc('Details:') %]</label>
 <textarea class="form-control" name='detail' id='detail' cols=60 rows=10>[% problem.detail | html %]</textarea></li>
 
-<li><label class="inline-text" for="state">[% loc('State:') %]</label>
-<select class="form-control" name="state"  id="state">
-[% FOREACH group IN state_groups %]
-    <optgroup label="[% group.0 %]">
-    [% FOREACH state IN group.1 %]
-        <option [% 'selected ' IF state == problem.state %] value="[% state %]">[% state_pretty.$state %]</option>
-    [% END %]
-    </optgroup>
-[% END %]
-</select></li>
+<li>
+    <label class="inline-text" for="state">[% loc('State:') %]</label>
+    [% INCLUDE 'admin/state_groups_select.html' %]
+</li>
 <li><label class="inline-text" for="category">[% loc('Category:') %]</label>
 <select class="form-control" name="category" id="category">
   [% IF NOT problem.category OR NOT categories.grep(problem.category).size %]

--- a/templates/web/base/admin/response_templates_select.html
+++ b/templates/web/base/admin/response_templates_select.html
@@ -3,7 +3,7 @@
     <select id="templates_for_[% for %]" class="form-control js-template-name" data-for="[% for %]" name="response_template">
         <option value="">[% loc('--Choose a template--') %]</option>
       [% FOR t IN problem.response_templates %]
-        <option value="[% t.text | html %]"> [% t.title | html %] </option>
+        <option value="[% t.text | html %]" data-problem-state="[% t.state | html %]"> [% t.title | html %] </option>
       [% END %]
     </select>
 </div>

--- a/templates/web/base/admin/state_groups_select.html
+++ b/templates/web/base/admin/state_groups_select.html
@@ -1,0 +1,14 @@
+[% PROCESS 'admin/report_blocks.html'; # For state_groups %]
+[% DEFAULT current_state = problem.state %]
+<select class="form-control" name="state"  id="state">
+[% IF include_empty %]
+    <option value="">---</option>
+[% END %]
+[% FOREACH group IN state_groups %]
+    <optgroup label="[% group.0 %]">
+    [% FOREACH state IN group.1 %]
+        <option [% 'selected ' IF state == current_state %] value="[% state %]">[% state_pretty.$state %]</option>
+    [% END %]
+    </optgroup>
+[% END %]
+</select>

--- a/templates/web/base/admin/template_edit.html
+++ b/templates/web/base/admin/template_edit.html
@@ -31,6 +31,16 @@
     </div>
     [% INCLUDE 'admin/category-checkboxes.html' %]
 
+    <div class="admin-hint">
+      <p>
+        [% loc('If you want to use this template to prefill the update field when changing a report&rsquo;s state, select the state here.') %]
+      </p>
+    </div>
+    <p>
+      <label for="state">[% loc('State') %]</label>
+      [% INCLUDE 'admin/state_groups_select.html' current_state=rt.state include_empty=1 %]
+    </p>
+
     <p>
       <input type="hidden" name="token" value="[% csrf_token %]" >
       <input type="submit" class="btn" name="Edit templates" value="[% rt.id ? loc('Save changes') : loc('Create template') %]" >

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -1,4 +1,3 @@
-[% PROCESS 'admin/report_blocks.html'; # For the report state dropdown %]
 [% permissions = c.user.permissions(c, problem.bodies_str) %]
 [% second_column = BLOCK -%]
   <div id="side-inspect">
@@ -65,16 +64,7 @@
         [% IF permissions.report_inspect %]
           <p>
             <label for="state">[% loc('State') %]</label>
-              [%# XXX this is duplicated from admin/report_edit.html, should be refactored %]
-            <select name="state" id="state" class="form-control">
-              [% FOREACH group IN state_groups %]
-                <optgroup label="[% group.0 %]">
-                  [% FOREACH state IN group.1 %]
-                    <option [% 'selected ' IF state == problem.state %] value="[% state %]">[% state_pretty.$state %]</option>
-                  [% END %]
-                </optgroup>
-              [% END %]
-            </select>
+            [% INCLUDE 'admin/state_groups_select.html' %]
           </p>
           <div id="js-duplicate-reports" class="[% "hidden" UNLESS problem.duplicate_of %]">
             <input type="hidden" name="duplicate_of" value="[% problem.duplicate_of.id %]">

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -675,12 +675,20 @@ $.extend(fixmystreet.set_up, {
     // The inspect form submit button can change depending on the selected state
     $("#report_inspect_form [name=state]").change(function(){
         var state = $(this).val();
-        var $submit = $("#report_inspect_form input[type=submit]");
+        var $inspect_form = $("#report_inspect_form");
+        var $submit = $inspect_form.find("input[type=submit]");
         var value = $submit.attr('data-value-'+state);
         if (value !== undefined) {
             $submit.val(value);
         } else {
             $submit.val($submit.data('valueOriginal'));
+        }
+
+        // We might also have a response template to preselect for the new state
+        var $select = $inspect_form.find("select.js-template-name");
+        var $option = $select.find("option[data-problem-state='"+state+"']").first();
+        if ($option.length) {
+            $select.val($option.val()).change();
         }
     }).change();
 
@@ -1001,9 +1009,20 @@ $.extend(fixmystreet.set_up, {
   },
 
   response_templates: function() {
+      // If the user has manually edited the contents of an update field,
+      // mark it as dirty so it doesn't get clobbered if we select another
+      // response template. If the field is empty, it's not considered dirty.
+      $('.js-template-name').each(function() {
+          var $input = $('#' + $(this).data('for'));
+          $input.change(function() { $(this).data('dirty', !/^\s*$/.test($(this).val())); });
+      });
+
       $('.js-template-name').change(function() {
           var $this = $(this);
-          $('#' + $this.data('for')).val($this.val());
+          var $input = $('#' + $this.data('for'));
+          if (!$input.data('dirty')) {
+              $input.val($this.val());
+          }
       });
   }
 });


### PR DESCRIPTION
This allows response templates to be associated with a problem state in the admin, and changing a report's state when inspecting/managing a report will automatically prefill the update field with the appropriate response template for the new state, if one exists.

For mysociety/fixmystreetforcouncils#75