### PR TITLE
Update priorities in inspect form on category change.

### DIFF
--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -680,16 +680,7 @@ alphabetical order of name.
 
 sub response_priorities {
     my $self = shift;
-    return $self->result_source->schema->resultset('ResponsePriority')->search(
-        {
-            'me.body_id' => $self->bodies_str_ids,
-            'contact.category' => [ $self->category, undef ],
-        },
-        {
-            order_by => 'name',
-            join => { 'contact_response_priorities' => 'contact' },
-        }
-    );
+    return $self->result_source->schema->resultset('ResponsePriority')->for_bodies($self->bodies_str_ids, $self->category);
 }
 
 # returns true if the external id is the council's ref, i.e., useful to publish it

--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -268,7 +268,7 @@ sub has_permission_to {
     my ($self, $permission_type, $body_ids) = @_;
 
     return 1 if $self->is_superuser;
-    return 0 unless $body_ids;
+    return 0 if !$body_ids || (ref $body_ids && !@$body_ids);
 
     my $permission = $self->user_body_permissions->find({
             permission_type => $permission_type,

--- a/perllib/FixMyStreet/DB/ResultSet/ResponsePriority.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/ResponsePriority.pm
@@ -1,0 +1,22 @@
+package FixMyStreet::DB::ResultSet::ResponsePriority;
+use base 'DBIx::Class::ResultSet';
+
+use strict;
+use warnings;
+
+sub for_bodies {
+    my ($rs, $bodies, $category) = @_;
+    my $attrs = {
+        'me.body_id' => $bodies,
+    };
+    if ($category) {
+        $attrs->{'contact.category'} = [ $category, undef ];
+    }
+    $rs->search($attrs, {
+        order_by => 'name',
+        join => { 'contact_response_priorities' => 'contact' },
+        distinct => 1,
+    });
+}
+
+1;

--- a/t/app/controller/report_inspect.t
+++ b/t/app/controller/report_inspect.t
@@ -102,8 +102,8 @@ FixMyStreet::override_config {
             $user->user_body_permissions->delete;
             $user->user_body_permissions->create({ body => $oxon, permission_type => $test->{type} });
             $mech->get_ok("/report/$report_id");
-            $mech->contains_or_lacks($test->{priority}, 'Priority');
-            $mech->contains_or_lacks($test->{priority}, 'High');
+            $mech->contains_or_lacks($test->{priority}, 'Priority</label>');
+            $mech->contains_or_lacks($test->{priority}, '>High');
             $mech->contains_or_lacks($test->{category}, 'Category');
             $mech->contains_or_lacks($test->{detailed}, 'Extra details');
             $mech->submit_form_ok({

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -52,11 +52,11 @@
           [% cat_prefix = category | lower | replace('[^a-z]', '') %]
           [% cat_prefix = "category_" _ cat_prefix _ "_" %]
           [% IF category == problem.category %]
-            <p data-category="[% category | html %]">
+            <p data-category="[% category | html %]" data-priorities="[% priorities_by_category.$category %]">
               [% INCLUDE 'report/new/category_extras_fields.html' %]
             </p>
-          [% ELSIF category_extras.$category.size %]
-            <p data-category="[% category | html %]" class="hidden">
+          [% ELSE %]
+            <p data-category="[% category | html %]" class="hidden" data-priorities="[% priorities_by_category.$category %]">
               [% INCLUDE 'report/new/category_extras_fields.html' report_meta='' %]
             </p>
           [% END %]
@@ -88,7 +88,7 @@
           <select name="priority" id="problem_priority" class="form-control">
             <option value="" [% 'selected' UNLESS problem.response_priority_id %]>-</option>
             [% FOREACH priority IN problem.response_priorities %]
-              <option value="[% priority.id %]" [% 'selected' IF problem.response_priority_id == priority.id %] [% 'disabled' IF priority.deleted %]>[% priority.name %]</option>
+              <option value="[% priority.id %]" [% 'selected' IF problem.response_priority_id == priority.id %] [% 'disabled' IF priority.deleted %]>[% priority.name | html %]</option>
             [% END %]
           </select>
         </p>

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -573,6 +573,19 @@ $.extend(fixmystreet.set_up, {
             selector = "[data-category='" + category + "']";
         $("form#report_inspect_form [data-category]:not(" + selector + ")").addClass("hidden");
         $("form#report_inspect_form " + selector).removeClass("hidden");
+        // And update the associated priority list
+        var priorities = $("form#report_inspect_form " + selector).data('priorities');
+        var $select = $('#problem_priority'),
+            curr_pri = $select.val();
+        $select.find('option:gt(0)').remove();
+        $.each(priorities.split('&'), function(i, kv) {
+            if (!kv) {
+                return;
+            }
+            kv = kv.split('=', 2);
+            $select.append($('<option>', { value: kv[0], text: decodeURIComponent(kv[1]) }));
+        });
+        $select.val(curr_pri);
     });
 
     $('.js-toggle-public-update').each(function() {


### PR DESCRIPTION
Different categories may have a different list of priorities, so store them all and update as the category changes.