### PR TITLE
Lowercase email when signing in.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Auth.pm
+++ b/perllib/FixMyStreet/App/Controller/Auth.pm
@@ -70,6 +70,7 @@ sub sign_in : Private {
     my ( $self, $c, $email ) = @_;
 
     $email ||= $c->get_param('email') || '';
+    $email = lc $email;
     my $password = $c->get_param('password_sign_in') || '';
     my $remember_me = $c->get_param('remember_me') || 0;
 


### PR DESCRIPTION
This should prevent an issue where e.g. a phone autocorrects oxfordshire.gov.uk to Oxfordshire.
It looks like there are 19 accounts that may need merging.