### PR TITLE
In Edge 14, do all HTTP redirects in HTML instead.

### DIFF
--- a/perllib/FixMyStreet/App.pm
+++ b/perllib/FixMyStreet/App.pm
@@ -4,6 +4,7 @@ use namespace::autoclean;
 
 use Catalyst::Runtime 5.80;
 use FixMyStreet;
+use FixMyStreet::App::Response;
 use FixMyStreet::Cobrand;
 use Memcached;
 use FixMyStreet::Map;
@@ -81,6 +82,8 @@ __PACKAGE__->config(
         },
     },
 );
+
+__PACKAGE__->response_class('FixMyStreet::App::Response');
 
 # Start the application
 __PACKAGE__->setup();

--- a/perllib/FixMyStreet/App/Response.pm
+++ b/perllib/FixMyStreet/App/Response.pm
@@ -1,0 +1,27 @@
+# This package exists to try and work around a big bug in Edge:
+# https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8572187/
+
+package FixMyStreet::App::Response;
+use Moose;
+extends 'Catalyst::Response';
+
+around 'redirect' => sub {
+    my $orig = shift;
+    my $self = shift;
+    my ($location, $status) = @_;
+
+    return $self->$orig() unless @_;  # getter
+
+    my $agent = $self->_context->request->user_agent;
+    return $self->$orig(@_) unless $agent =~ /Edge\/14/;  # Only care about Edge
+
+    # Instead of a redirect, output HTML that redirects
+    $self->body(<<END
+<meta http-equiv="refresh" content="0; url=$location">
+Please follow this link: <a href="$location">$location</a>
+END
+    );
+    return $location;
+};
+
+1;


### PR DESCRIPTION
This is to work around
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8572187/

The horror of this bug is at least matched by the elegance of the workaround :)