### PR TITLE
[Oxfordshire] Exor RDI inspection file download

### DIFF
--- a/bin/update-schema
+++ b/bin/update-schema
@@ -194,6 +194,7 @@ else {
 # By querying the database schema, we can see where we're currently at
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
+    return '0049' if column_exists('response_priorities', 'external_id');
     return '0048' if column_exists('response_templates', 'state');
     return '0047' if column_exists('response_priorities', 'description');
     return '0046' if column_exists('users', 'extra');

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -135,6 +135,7 @@ CREATE TABLE response_priorities (
     deleted boolean not null default 'f',
     name text not null,
     description text,
+    external_id text,
     unique(body_id, name)
 );
 

--- a/db/schema_0049-response-priorities-add-external_id.sql
+++ b/db/schema_0049-response-priorities-add-external_id.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE response_priorities
+    ADD COLUMN external_id TEXT;
+
+COMMIT;

--- a/perllib/FixMyStreet/App.pm
+++ b/perllib/FixMyStreet/App.pm
@@ -163,7 +163,7 @@ sub setup_request {
 
     my $cobrand = $c->cobrand;
 
-    $cobrand->add_response_headers if $cobrand->can('add_response_headers');
+    $cobrand->call_hook('add_response_headers');
 
     # append the cobrand templates to the include path
     $c->stash->{additional_template_paths} = $cobrand->path_to_web_templates;

--- a/perllib/FixMyStreet/App/Controller/Admin/ExorDefects.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/ExorDefects.pm
@@ -1,0 +1,219 @@
+package FixMyStreet::App::Controller::Admin::ExorDefects;
+use Moose;
+use namespace::autoclean;
+
+use Text::CSV;
+use DateTime;
+use mySociety::Random qw(random_bytes);
+
+BEGIN { extends 'Catalyst::Controller'; }
+
+
+sub begin : Private {
+    my ( $self, $c ) = @_;
+
+    $c->forward('/admin/begin');
+}
+
+sub index : Path : Args(0) {
+    my ( $self, $c ) = @_;
+
+    foreach (qw(error_message start_date end_date user_id)) {
+        if ( defined $c->flash->{$_} ) {
+            $c->stash->{$_} = $c->flash->{$_};
+        }
+    }
+
+    my @inspectors = $c->cobrand->users->search({
+        'user_body_permissions.permission_type' => 'report_inspect'
+    }, {
+            join => 'user_body_permissions',
+            distinct => 1,
+        }
+    )->all;
+    $c->stash->{inspectors} = \@inspectors;
+
+    # Default start/end date is today
+    my $now = DateTime->now( time_zone => 
+        FixMyStreet->time_zone || FixMyStreet->local_time_zone );
+    $c->stash->{start_date} ||= $now;
+    $c->stash->{end_date} ||= $now;
+
+}
+
+sub download : Path('download') : Args(0) {
+    my ( $self, $c ) = @_;
+
+    if ( !$c->cobrand->can('exor_rdi_link_id') ) {
+        # This only works on the Oxfordshire cobrand currently.
+        $c->detach( '/page_error_404_not_found', [] );
+    }
+
+    my $parser = DateTime::Format::Strptime->new( pattern => '%d/%m/%Y' );
+    my $start_date = $parser-> parse_datetime ( $c->get_param('start_date') );
+    my $end_date = $parser-> parse_datetime ( $c->get_param('end_date') ) ;
+    my $one_day = DateTime::Duration->new( days => 1 );
+
+    my %params = (
+        -and => [
+            state => [ 'action scheduled' ],
+            'admin_log_entries.action' => 'inspected',
+            'admin_log_entries.whenedited' => { '>=', $start_date },
+            'admin_log_entries.whenedited' => { '<=', $end_date + $one_day },
+        ]
+    );
+
+    my $user;
+    if ( $c->get_param('user_id') ) {
+        my $uid = $c->get_param('user_id');
+        $params{'admin_log_entries.user_id'} = $uid;
+        $user = $c->model('DB::User')->find( { id => $uid } );
+    }
+
+    my $problems = $c->cobrand->problems->search(
+        \%params,
+        {
+            join => 'admin_log_entries',
+            distinct => 1,
+        }
+    );
+
+    if ( !$problems->count ) {
+        if ( defined $user ) {
+            $c->flash->{error_message} = _("No inspections by that inspector in the selected date range.");
+        } else {
+            $c->flash->{error_message} = _("No inspections in the selected date range.");
+        }
+        $c->flash->{start_date} = $start_date;
+        $c->flash->{end_date} = $end_date;
+        $c->flash->{user_id} = $user->id if $user;
+        $c->res->redirect( $c->uri_for( '' ) );
+    }
+
+    # A single RDI file might contain inspections from multiple inspectors, so
+    # we need to group inspections by inspector within G records.
+    my $inspectors = {};
+    my $inspector_initials = {};
+    while ( my $report = $problems->next ) {
+        my $user = $report->inspection_log_entry->user;
+        $inspectors->{$user->id} ||= [];
+        push @{ $inspectors->{$user->id} }, $report;
+        unless ( $inspector_initials->{$user->id} ) {
+            $inspector_initials->{$user->id} = $user->get_extra_metadata('initials');
+        }
+    }
+
+    my $csv = Text::CSV->new({ binary => 1, eol => "" });
+
+    my $p_count = 0;
+    my $link_id = $c->cobrand->exor_rdi_link_id;
+
+    # RDI first line is always the same
+    $csv->combine("1", "1.8", "1.0.0.0", "ENHN", "");
+    my @body = ($csv->string);
+
+    my $i = 0;
+    foreach my $inspector_id (keys %$inspectors) {
+        my $inspections = $inspectors->{$inspector_id};
+        my $initials = $inspector_initials->{$inspector_id};
+
+        $csv->combine(
+            "G", # start of an area/sequence
+            $link_id, # area/link id, fixed value for our purposes
+            "","", # must be empty
+            $initials || "XX", # inspector initials
+            $start_date->strftime("%y%m%d"), # date of inspection yymmdd
+            "0700", # time of inspection hhmm, set to static value for now
+            "D", # inspection variant, should always be D
+            "INS", # inspection type, always INS
+            "N", # Area of the county - north (N) or south (S)
+            "", "", "", "" # empty fields
+        );
+        push @body, $csv->string;
+
+        $csv->combine(
+            "H", # initial inspection type
+            "MC" # minor carriageway (changes depending on activity code)
+        );
+        push @body, $csv->string;
+
+        foreach my $report (@$inspections) {
+            my ($eastings, $northings) = $report->local_coords;
+            my $description = sprintf("%s %s", $report->external_id || "", $report->get_extra_metadata('detailed_information') || "");
+            $csv->combine(
+                "I", # beginning of defect record
+                "MC", # activity code - minor carriageway, also FC (footway)
+                "", # empty field, can also be A (seen on MC) or B (seen on FC)
+                sprintf("%03d", ++$i), # randomised sequence number
+                "${eastings}E ${northings}N", # defect location field, which we don't capture from inspectors
+                $report->inspection_log_entry->whenedited->strftime("%H%M"), # defect time raised
+                "","","","","","","", # empty fields
+                $report->get_extra_metadata('traffic_information') ? 'TM required' : 'TM none', # further description
+                $description, # defect description
+            );
+            push @body, $csv->string;
+
+            $csv->combine(
+                "J", # georeferencing record
+                $report->get_extra_metadata('defect_type') || 'SFP2', # defect type - SFP2: sweep and fill <1m2, POT2 also seen
+                $report->response_priority ?
+                    $report->response_priority->external_id :
+                    "2", # priority of defect
+                "","", # empty fields
+                $eastings, # eastings
+                $northings, # northings
+                "","","","","" # empty fields
+            );
+            push @body, $csv->string;
+
+            $csv->combine(
+                "M", # bill of quantities record
+                "resolve", # permanent repair
+                "","", # empty fields
+                "/CMC", # /C + activity code
+                "", "" # empty fields
+            );
+            push @body, $csv->string;
+        }
+
+        # end this group of defects with a P record
+        $csv->combine(
+            "P", # end of area/sequence
+            0, # always 0
+            999999, # charging code, always 999999 in OCC
+        );
+        push @body, $csv->string;
+        $p_count++;
+    }
+
+    # end the RDI file with an X record
+    my $record_count = $i;
+    $csv->combine(
+        "X", # end of inspection record
+        $p_count,
+        $p_count,
+        $record_count, # number of I records
+        $record_count, # number of J records
+        0, 0, 0, # always zero
+        $record_count, # number of M records
+        0, # always zero
+        $p_count,
+        0, 0, 0 # error counts, always zero
+    );
+    push @body, $csv->string;
+
+    my $start = $start_date->strftime("%Y%m%d");
+    my $end = $end_date->strftime("%Y%m%d");
+    my $filename = sprintf("exor_defects-%s-%s.rdi", $start, $end);
+    if ( $user ) {
+        my $initials = $user->get_extra_metadata("initials") || "";
+        $filename = sprintf("exor_defects-%s-%s-%s.rdi", $start, $end, $initials);
+    }
+    $c->res->content_type('text/csv; charset=utf-8');
+    $c->res->header('content-disposition' => "attachment; filename=$filename");
+    # The RDI format is very weird CSV - each line must be wrapped in
+    # double quotes.
+    $c->res->body( join "", map { "\"$_\"\r\n" } @body );
+}
+
+1;

--- a/perllib/FixMyStreet/App/Controller/Admin/ResponsePriorities.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/ResponsePriorities.pm
@@ -70,6 +70,7 @@ sub edit : Path : Args(2) {
         $priority->deleted( $c->get_param('deleted') ? 1 : 0 );
         $priority->name( $c->get_param('name') );
         $priority->description( $c->get_param('description') );
+        $priority->external_id( $c->get_param('external_id') );
         $priority->update_or_insert;
 
         my @live_contact_ids = map { $_->id } @live_contacts;

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -377,7 +377,9 @@ sub inspect : Private {
                 unless ($problem->get_extra_metadata('inspected')) {
                     $problem->set_extra_metadata( inspected => 1 );
                     $c->forward( '/admin/log_edit', [ $problem->id, 'problem', 'inspected' ] );
-                    $reputation_change = 1;
+                    my $state = $problem->state;
+                    $reputation_change = 1 if $c->cobrand->reputation_increment_states->{$state};
+                    $reputation_change = -1 if $c->cobrand->reputation_decrement_states->{$state};
                 }
             }
         }

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -339,7 +339,7 @@ sub inspect : Private {
         my %update_params = ();
 
         if ($permissions->{report_inspect}) {
-            foreach (qw/detailed_information traffic_information duplicate_of/) {
+            foreach (qw/detailed_information traffic_information duplicate_of defect_type/) {
                 $problem->set_extra_metadata( $_ => $c->get_param($_) );
             }
 

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -659,8 +659,7 @@ sub setup_categories_and_bodies : Private {
         push @category_options, _('Other') if $seen{_('Other')};
     }
 
-    $c->cobrand->munge_category_list(\@category_options, \@contacts, \%category_extras)
-        if $c->cobrand->can('munge_category_list');
+    $c->cobrand->call_hook(munge_category_list => \@category_options, \@contacts, \%category_extras);
 
     # put results onto stash for display
     $c->stash->{bodies} = \%bodies;
@@ -903,7 +902,7 @@ sub contacts_to_bodies : Private {
     if ($c->stash->{unresponsive}{$category} || $c->stash->{unresponsive}{ALL}) {
         [];
     } else {
-        if ( $c->cobrand->can('singleton_bodies_str') && $c->cobrand->singleton_bodies_str ) {
+        if ( $c->cobrand->call_hook('singleton_bodies_str') ) {
             # Cobrands like Zurich can only ever have a single body: 'x', because some functionality
             # relies on string comparison against bodies_str.
             [ $contacts[0]->body ];
@@ -1033,9 +1032,7 @@ sub send_problem_confirm_email : Private {
     $template = 'problem-confirm-not-sending.txt' unless $report->bodies_str;
 
     $c->stash->{token_url} = $c->uri_for_email( '/P', $token->token );
-    if ($c->cobrand->can('problem_confirm_email_extras')) {
-        $c->cobrand->problem_confirm_email_extras($report);
-    }
+    $c->cobrand->call_hook(problem_confirm_email_extras => $report);
 
     $c->send_email( $template, {
         to => [ $report->name ? [ $report->user->email, $report->name ] : $report->user->email ],

--- a/perllib/FixMyStreet/Cobrand/Base.pm
+++ b/perllib/FixMyStreet/Cobrand/Base.pm
@@ -65,6 +65,18 @@ sub is_default {
     return $self->moniker eq 'default';
 }
 
+=head2 call_hook
+
+  $cobrand->call_hook(foo => 1, 2, 3); # calls $cobrand->foo(1, 2, 3) if it exists
+
+=cut
+
+sub call_hook {
+    my ($self, $method_name, @args) = @_;
+    my $method = $self->can($method_name) or return;
+    return $self->$method(@args);
+}
+
 # NB: this Base class is for 'meta' features.  To add base methods for all cobrands,
 # you may want to look at FMS::Cobrand::Default instead!
 

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -1188,6 +1188,16 @@ sub category_extra_hidden {
 	return 0;
 }
 
+=head2 reputation_increment_states/reputation_decrement_states
+
+Get a hashref of states that cause the reporting user's reputation to be
+incremented/decremented, if a report is changed to this state upon inspection.
+
+=cut
+
+sub reputation_increment_states { {} };
+sub reputation_decrement_states { {} };
+
 sub traffic_management_options {
     return [
         _("Yes"),

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -665,7 +665,6 @@ sub admin_pages {
         $pages->{responsepriorities} = [ _('Priorities'), 4 ];
         $pages->{responsepriority_edit} = [ undef, undef ];
     };
-
     if ( $user->has_body_permission_to('user_edit') ) {
         $pages->{users} = [ _('Users'), 6 ];
         $pages->{user_edit} = [ undef, undef ];

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -130,4 +130,14 @@ sub traffic_management_options {
 }
 
 
+sub reputation_increment_states {
+    return {
+        'action scheduled' => 1,
+    };
+}
+
+sub user_extra_fields {
+    return [ 'initials' ];
+}
+
 1;

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -129,6 +129,31 @@ sub traffic_management_options {
     ];
 }
 
+sub admin_pages {
+    my $self = shift;
+
+    my $user = $self->{c}->user;
+
+    my $pages = $self->next::method();
+
+    # Oxfordshire have a custom admin page for downloading reports in an Exor-
+    # friendly format which anyone with report_instruct permission can use.
+    if ( $user->is_superuser || $user->has_body_permission_to('report_instruct') ) {
+        $pages->{exordefects} = [ _('Download Exor RDI'), 10 ];
+    }
+
+    return $pages;
+}
+
+sub defect_types {
+    {
+        SFP2 => "SFP2: sweep and fill <1m2",
+        POT2 => "POT2",
+    };
+}
+
+sub exor_rdi_link_id { 1989169 }
+sub exor_rdi_link_length { 50 }
 
 sub reputation_increment_states {
     return {

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -76,7 +76,7 @@ sub users_restriction {
 
     my $or_query = [
         from_body => $self->council_id,
-        id => [ { -in => $problem_user_ids }, { -in => $update_user_ids } ],
+        'me.id' => [ { -in => $problem_user_ids }, { -in => $update_user_ids } ],
     ];
     if ($self->can('admin_user_domain')) {
         my $domain = $self->admin_user_domain;

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -1100,4 +1100,13 @@ has traffic_management_options => (
     },
 );
 
+has inspection_log_entry => (
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        return $self->admin_log_entries->search({ action => 'inspected' }, { order_by => { -desc => 'whenedited' } })->first;
+    },
+);
+
 1;

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -613,9 +613,7 @@ sub meta_line {
     my $meta = '';
 
     my $category = $problem->category;
-    if ($c->cobrand->can('change_category_text')) {
-        $category = $c->cobrand->change_category_text($category);
-    }
+    $category = $c->cobrand->call_hook(change_category_text => $category) || $category;
 
     if ( $problem->anonymous ) {
         if ( $problem->service and $category && $category ne _('Other') ) {
@@ -748,17 +746,10 @@ sub can_display_external_id {
 
 sub duration_string {
     my ( $problem, $c ) = @_;
-    my $body;
-    if ( $c->cobrand->can('link_to_council_cobrand') ) {
-        $body = $c->cobrand->link_to_council_cobrand($problem);
-    } else {
-        $body = $problem->body( $c );
-    }
-    if ( $c->cobrand->can('get_body_handler_for_problem') ) {
-        my $handler = $c->cobrand->get_body_handler_for_problem( $problem );
-        if ( $handler->can('is_council_with_case_management') && $handler->is_council_with_case_management ) {
-            return sprintf(_('Received by %s moments later'), $body);
-        }
+    my $body = $c->cobrand->call_hook(link_to_council_cobrand => $problem) || $problem->body($c);
+    my $handler = $c->cobrand->call_hook(get_body_handler_for_problem => $problem);
+    if ( $handler && $handler->call_hook('is_council_with_case_management') ) {
+        return sprintf(_('Received by %s moments later'), $body);
     }
     return unless $problem->whensent;
     return sprintf(_('Sent to %s %s later'), $body,

--- a/perllib/FixMyStreet/DB/Result/ResponsePriority.pm
+++ b/perllib/FixMyStreet/DB/Result/ResponsePriority.pm
@@ -26,6 +26,8 @@ __PACKAGE__->add_columns(
   { data_type => "boolean", default_value => \"false", is_nullable => 0 },
   "description",
   { data_type => "text", is_nullable => 1 },
+  "external_id",
+  { data_type => "text", is_nullable => 1 },
 );
 __PACKAGE__->set_primary_key("id");
 __PACKAGE__->add_unique_constraint("response_priorities_body_id_name_key", ["body_id", "name"]);
@@ -49,8 +51,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2016-10-17 16:37:28
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:wok3cPA7cPjG4e9lnc1PIg
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2016-12-14 17:12:09
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:glsO0fLK6fNvg4TmW1DMPg
 
 __PACKAGE__->many_to_many( contacts => 'contact_response_priorities', 'contact' );
 

--- a/perllib/FixMyStreet/Script/Reports.pm
+++ b/perllib/FixMyStreet/Script/Reports.pm
@@ -112,9 +112,7 @@ sub send(;$) {
             $h{user_details} .= sprintf(_('Email: %s'), $row->user->email) . "\n\n";
         }
 
-        if ($cobrand->can('process_additional_metadata_for_email')) {
-            $cobrand->process_additional_metadata_for_email($row, \%h);
-        }
+        $cobrand->call_hook(process_additional_metadata_for_email => $row, \%h);
 
         my $bodies = FixMyStreet::DB->resultset('Body')->search(
             { id => $row->bodies_str_ids },

--- a/perllib/FixMyStreet/SendReport/Email.pm
+++ b/perllib/FixMyStreet/SendReport/Email.pm
@@ -84,7 +84,7 @@ sub send {
         From => $self->send_from( $row ),
     };
 
-    $cobrand->munge_sendreport_params($row, $h, $params) if $cobrand->can('munge_sendreport_params');
+    $cobrand->call_hook(munge_sendreport_params => $row, $h, $params);
 
     $params->{Bcc} = $self->bcc if @{$self->bcc};
 

--- a/t/cobrand/oxfordshire.t
+++ b/t/cobrand/oxfordshire.t
@@ -45,6 +45,29 @@ subtest 'check /ajax defaults to open reports only' => sub {
     }
 };
 
+my $superuser = $mech->create_user_ok('superuser@example.com', name => 'Super User', is_superuser => 1);
+
+subtest 'Exor RDI download appears on Oxfordshire cobrand admin' => sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ { 'oxfordshire' => '.' } ],
+    }, sub {
+        $mech->log_in_ok( $superuser->email );
+        $mech->get_ok('/admin');
+        $mech->content_contains("Download Exor RDI");
+    }
+};
+
+subtest 'Exor RDI download doesn’t appear outside of Oxfordshire cobrand admin' => sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ { 'fixmystreet' => '.' } ],
+    }, sub {
+        $mech->log_in_ok( $superuser->email );
+        $mech->get_ok('/admin');
+        $mech->content_lacks("Download Exor RDI");
+    }
+};
+
 # Clean up
+$mech->delete_user( $superuser );
 $mech->delete_problems_for_body( 2237 );
 done_testing();

--- a/templates/web/base/admin/exordefects/index.html
+++ b/templates/web/base/admin/exordefects/index.html
@@ -1,0 +1,36 @@
+[% INCLUDE 'admin/header.html' title=loc('Download Exor RDI') -%]
+
+[% IF error_message %]
+    <h2>Error</h2>
+    <p>[% error_message %]</p>
+[% END %]
+
+<form method="get" action="[% c.uri_for('download') %]" enctype="application/x-www-form-urlencoded" accept-charset="utf-8">
+    <p>
+    <label for="start_date">[% loc('Start Date:') %]</label><input type="text" class="form-control"
+      placeholder="[% loc('Click here or enter as dd/mm/yyyy') %]" name="start_date" id="start_date"
+      value="[% start_date ? start_date.strftime( '%d/%m/%Y') : '' | html %]" />
+    </p>
+
+    <p>
+    <label for="end_date">[% loc('End Date:') %]</label><input type="text" class="form-control"
+      placeholder="[% loc('Click here or enter as dd/mm/yyyy') %]" name="end_date" id="end_date" size="5"
+      value="[% end_date ? end_date.strftime( '%d/%m/%Y') : '' | html %]" />
+    </p>
+
+    <p>
+    [% loc('Inspector:') %] <select class="form-control" id='user_id' name='user_id'>
+        <option value=''>[% loc('All inspectors') %]</option>
+        [% FOR inspector IN inspectors %]
+            <option value="[% inspector.id %]" [% 'selected' IF user_id == inspector.id %]>[% inspector.name %] ([% inspector.get_extra_metadata('initials') %])</option>
+        [% END %]
+    </select>
+    </p>
+
+    <p>
+    <input type="submit" class="btn" size="30" value="Download RDI file" />
+    </p>
+</form>
+
+
+[% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/admin/responsepriorities/edit.html
+++ b/templates/web/base/admin/responsepriorities/edit.html
@@ -20,6 +20,16 @@
 
     <div class="admin-hint">
       <p>
+        [% loc('If this priority is passed to an external service (e.g. Exor/Confirm) enter the priority code to use with that service here.') %]
+      </p>
+    </div>
+    <p>
+        <strong>[% loc('External ID:') %] </strong>
+        <input type="text" name="external_id" class="form-control" size="30" value="[% rp.external_id | html %]">
+    </p>
+
+    <div class="admin-hint">
+      <p>
         [% loc('If you only want this priority to be an option for specific categories, pick them here. By default they will show for all categories.') %]
       </p>
     </div>

--- a/templates/web/base/admin/user-form.html
+++ b/templates/web/base/admin/user-form.html
@@ -121,14 +121,6 @@
               </label>
             [% END %]
           </li>
-          <li>
-            <div class="admin-hint">
-              <p>
-                [% loc("Reports from users with high enough reputation will be sent immediately without requiring inspection. Each category's threshold can be managed on its edit page. Users earn reputation when a report they have made is marked as inspected by inspectors.") %]
-              </p>
-            </div>
-            [% loc('Reputation:') %] [% user.get_extra_metadata('reputation') %]
-          </li>
         [% END %]
 
         [% IF c.user.is_superuser %]

--- a/templates/web/base/admin/user-form.html
+++ b/templates/web/base/admin/user-form.html
@@ -173,6 +173,7 @@
             </ul>
         [% END %]
       [% END %]
+      [% TRY %][% INCLUDE 'admin/user-form-extra-fields.html' %][% CATCH file %][% END %]
     </ul>
     <input type="submit" class="btn" name="Submit changes" value="[% loc('Submit changes') %]" >
 </form>

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -62,6 +62,18 @@
         [% END %]
 
         [% IF permissions.report_inspect %]
+          [% IF c.cobrand.defect_types %]
+            <p>
+              <label for="defect_type">[% loc('Defect type') %]</label>
+              [% defect_type = problem.get_extra_metadata('defect_type') %]
+              <select id="defect_type" name="defect_type" class="form-control">
+                <option value=""[% ' selected' IF NOT defect_type %]>-</option>
+                [% FOREACH dt IN c.cobrand.defect_types.pairs %]
+                  <option[% ' selected' IF defect_type == dt.key %] value="[% dt.key | html %]">[% dt.value | html %]</option>
+                [% END %]
+              </select>
+            </p>
+          [% END %]
           <p>
             <label for="state">[% loc('State') %]</label>
             [% INCLUDE 'report/inspect/state_groups_select.html' %]

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -127,7 +127,7 @@
         [% IF permissions.report_inspect %]
           <p>
             <label class="label-containing-checkbox">
-              <input type="checkbox" name="save_inspected" value="1" class="js-toggle-public-update" checked>
+              <input type="checkbox" name="include_update" value="1" class="js-toggle-public-update" checked>
               [% loc('Save with a public update') %]
             </label>
           </p>

--- a/templates/web/oxfordshire/admin/user-form-extra-fields.html
+++ b/templates/web/oxfordshire/admin/user-form-extra-fields.html
@@ -1,0 +1,12 @@
+<li>
+  <div class="admin-hint">
+    <p>
+      [% loc(
+        "The user's initials are used when sending inspections to Exor.
+        Only inspectors need to have this field filled in.")
+      %]
+    </p>
+  </div>
+  <label for="initials">[% loc('Initials:') %]</label>
+  <input type='text' class="form-control" name='extra[initials]' id='initials' value='[% user.get_extra_metadata("initials") | html %]'>
+</li>

--- a/templates/web/oxfordshire/admin/user-form-extra-fields.html
+++ b/templates/web/oxfordshire/admin/user-form-extra-fields.html
@@ -1,6 +1,15 @@
 <li>
   <div class="admin-hint">
     <p>
+      [% loc("Reports from users with high enough reputation will be sent immediately without requiring inspection. Each category's threshold can be managed on its edit page. Users earn reputation when a report they have made is marked as inspected by inspectors.") %]
+    </p>
+  </div>
+  [% loc('Reputation:') %] [% user.get_extra_metadata('reputation') %]
+</li>
+
+<li>
+  <div class="admin-hint">
+    <p>
       [% loc(
         "The user's initials are used when sending inspections to Exor.
         Only inspectors need to have this field filled in.")

--- a/web/cobrands/fixmystreet/offline.js
+++ b/web/cobrands/fixmystreet/offline.js
@@ -322,7 +322,7 @@ fixmystreet.offline = (function() {
         if (savedForm) {
             savedForm.replace(/\+/g, '%20').split('&').forEach(function(kv) {
                 kv = kv.split('=', 2);
-                if (kv[0] != 'save_inspected' && kv[0] != 'public_update' && kv[0] != 'save') {
+                if (kv[0] != 'include_update' && kv[0] != 'public_update' && kv[0] != 'save') {
                     $('[name=' + kv[0] + ']').val(decodeURIComponent(kv[1]));
                 }
             });

--- a/web/js/fixmystreet-admin.js
+++ b/web/js/fixmystreet-admin.js
@@ -66,6 +66,18 @@ $(function(){
         });
     }
 
+    // On some cobrands the datepicker ends up beneath items in the header, e.g.
+    // the logo.
+    // This function sets an appropriate z-index when the datepicker is shown.
+    // Sadly there's no way to set the z-index when creating the datepicker, so
+    // we have to run this little helper using the datepicker beforeShow
+    // handler.
+    function fixZIndex() {
+        setTimeout(function() {
+            $('.ui-datepicker').css('z-index', 10);
+        }, 0);
+    }
+
     $( "#start_date" ).datepicker({
       defaultDate: "-1w",
       changeMonth: true,
@@ -73,7 +85,8 @@ $(function(){
       // This sets the other fields minDate to our date
       onClose: function( selectedDate ) {
         $( "#end_date" ).datepicker( "option", "minDate", selectedDate );
-      }
+      },
+      beforeShow: fixZIndex
     });
     $( "#end_date" ).datepicker({
      /// defaultDate: "+1w",
@@ -81,7 +94,8 @@ $(function(){
       dateFormat: 'dd/mm/yy' ,
       onClose: function( selectedDate ) {
         $( "#start_date" ).datepicker( "option", "maxDate", selectedDate );
-      }
+      },
+      beforeShow: fixZIndex
     });
 
     // On user edit page, hide the area/categories fields if body changes


### PR DESCRIPTION
This PR adds a new 'Download Exor RDI' link to the admin on the Oxfordshire cobrand.

The purpose of this feature is to quickly import inspected problems into Exor as defects, using an obscure CSV format.

See mysociety/fixmystreetforcouncils#127 for a detailed discussion of this feature.

To support this feature, some other changes have been made to the inspection workflow:

 - When a report is inspected a new `inspected` AdminLog entry is created.
 - A report is marked as inspected if somebody with the `report_inspect` permission changes its state.
 - In the Oxfordshire cobrand, the admin user edit form includes an 'initials' field, which is required for Exor to link the inspection records to the appropriate users internally.
