### PR TITLE
Use span instead of div to wrap response template

### DIFF
--- a/templates/web/base/admin/response_templates_select.html
+++ b/templates/web/base/admin/response_templates_select.html
@@ -1,10 +1,8 @@
 [% IF problem.response_templates %]
-<div class="response_templates_select">
     <select id="templates_for_[% for %]" class="form-control js-template-name" data-for="[% for %]" name="response_template">
         <option value="">[% loc('--Choose a template--') %]</option>
       [% FOR t IN problem.response_templates %]
         <option value="[% t.text | html %]" data-problem-state="[% t.state | html %]"> [% t.title | html %] </option>
       [% END %]
     </select>
-</div>
 [% END %]

--- a/web/cobrands/zurich/js.js
+++ b/web/cobrands/zurich/js.js
@@ -70,7 +70,7 @@ $(function() {
         // same or different state to the one we started on
         if (state === $(this).data('pstate')) {
             $('input[name=publish_response]').show();
-            $('.response_templates_select').show();
+            $('.js-template-name').show();
             $('#status_update_container').show();
 
             if (state === 'confirmed') {
@@ -85,7 +85,7 @@ $(function() {
         }
         else {
             $('input[name=publish_response]').hide();
-            $('.response_templates_select').hide();
+            $('.js-template-name').hide();
             $('#status_update_container').hide();
 
             $('#assignation__category').hide();


### PR DESCRIPTION
Using a `div` inside a `p` isn't valid, so the DOM was being restructured by the
browser causing the 'save with public update' toggle on the inspect form to not
work.

Fixes mysociety/fixmystreetforcouncils#153