### PR TITLE
Filter by shortlisted problems

### DIFF
--- a/templates/web/base/reports/_list-filters.html
+++ b/templates/web/base/reports/_list-filters.html
@@ -1,5 +1,9 @@
 [% select_status = BLOCK %]
     <select class="form-control js-multiple" name="status" id="statuses" multiple data-all="[% loc('All reports') %]">
+      [% IF c.user_exists AND c.user.has_body_permission_to('planned_reports') AND !shortlist %]
+        <option value="shortlisted"[% ' selected' IF filter_status.shortlisted %]>[% loc('Shortlisted') %]</option>
+        <option value="unshortlisted"[% ' selected' IF filter_status.unshortlisted %]>[% loc('Unshortlisted') %]</option>
+      [% END %]
         <option value="open"[% ' selected' IF filter_status.open %]>[% loc('Unfixed reports') %]</option>
         <option value="closed"[% ' selected' IF filter_status.closed %]>[% loc('Closed reports') %]</option>
         <option value="fixed"[% ' selected' IF filter_status.fixed %]>[% loc('Fixed reports') %]</option>


### PR DESCRIPTION
For mysociety/fixmystreetforcouncils#112

This allows inspectors to access any report listing page (such as /reports, or when #1613 is merged, /my/areas) and filter by if a problem is shortlisted or not.

The only issue I can see so far is that users will be able to click 'shortlisted' and 'unshortlisted', which may give an unexpected result (at the moment, it will default to shortlisted), but as people can click on 'unfixed' and 'fixed' at the moment too, that might be something to file for further improvements.