### PR TITLE
Reorder list based on map view

### DIFF
--- a/templates/web/base/my/_problem-list.html
+++ b/templates/web/base/my/_problem-list.html
@@ -1,3 +1,4 @@
+<ul class="hidden item-list item-list--reports visible-reports"></ul>
 <ul class='item-list item-list--reports'>
     [% IF problems.size %]
         [% FOREACH problem = problems %]

--- a/templates/web/base/my/_problem-list.html
+++ b/templates/web/base/my/_problem-list.html
@@ -1,4 +1,3 @@
-<ul class="hidden item-list item-list--reports visible-reports"></ul>
 <ul class='item-list item-list--reports'>
     [% IF problems.size %]
         [% FOREACH problem = problems %]

--- a/templates/web/base/report/_item.html
+++ b/templates/web/base/report/_item.html
@@ -27,7 +27,7 @@
 [% END %]
 
 <li class="item-list__item item-list--reports__item [% item_extra_class %]"
-    data-report-id="[% problem.id | html %]" data-lastupdate="[% problem.lastupdate %]">
+    data-report-id="[% problem.id | html %]" data-lastupdate="[% problem.lastupdate %]" id="report-[% problem.id | html %]">
 <a href="[% c.cobrand.base_url_for_report( problem ) %][% problem.url %]">
     [% IF problem.photo %]
         <img class="img" height="60" width="90" src="[% problem.photos.first.url_fp %]" alt="">

--- a/templates/web/base/reports/_problem-list.html
+++ b/templates/web/base/reports/_problem-list.html
@@ -4,7 +4,7 @@
 
 [% BLOCK column %]
     [% IF reorder %]
-      <ul class="hidden item-list item-list--reports visible-reports"></ul>
+      <ul class="hidden item-list item-list--reports js-visible-reports"></ul>
     [% END %]
     <ul class="item-list item-list--reports">
         [% IF problems %]

--- a/templates/web/base/reports/_problem-list.html
+++ b/templates/web/base/reports/_problem-list.html
@@ -3,6 +3,7 @@
 %]
 
 [% BLOCK column %]
+    <ul class="hidden item-list item-list--reports visible-reports"></ul>
     <ul class="item-list item-list--reports">
         [% IF problems %]
             [% FOREACH problem IN problems %]

--- a/templates/web/base/reports/_problem-list.html
+++ b/templates/web/base/reports/_problem-list.html
@@ -3,7 +3,9 @@
 %]
 
 [% BLOCK column %]
-    <ul class="hidden item-list item-list--reports visible-reports"></ul>
+    [% IF reorder %]
+      <ul class="hidden item-list item-list--reports visible-reports"></ul>
+    [% END %]
     <ul class="item-list item-list--reports">
         [% IF problems %]
             [% FOREACH problem IN problems %]

--- a/templates/web/base/reports/body.html
+++ b/templates/web/base/reports/body.html
@@ -59,7 +59,7 @@
 [% INCLUDE 'pagination.html', param = 'p' %]
 </div>
 <div id="js-reports-list">
-    [% INCLUDE 'reports/_problem-list.html' %]
+    [% INCLUDE 'reports/_problem-list.html', reorder = 1 %]
 </div>
 <div class="js-pagination">
 [% INCLUDE 'pagination.html', param = 'p' %]

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -119,6 +119,8 @@ var fixmystreet = fixmystreet || {};
           var visible = ''
           var $itemList = $('.item-list');
           var $visibleReports = $('.visible-reports');
+          if ($visibleReports.length == 0) return false;
+
           for (var i = 0; i < fixmystreet.markers.features.length; i++) {
               var feature = fixmystreet.markers.features[i];
               var $listItem = $itemList.find('#report-'+ feature.data.id);

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -125,10 +125,13 @@ var fixmystreet = fixmystreet || {};
               var feature = fixmystreet.markers.features[i];
               var $listItem = $itemList.find('#report-'+ feature.data.id);
               if (feature.onScreen()) {
-                  visible += $listItem[0].outerHTML; // This is faster than using .append()
+                  var clone = $($listItem[0].outerHTML);
+                  clone.attr('id', clone.attr('id') + '-visible');
+                  clone.removeClass('hidden');
+                  visible += clone[0].outerHTML; // This is faster than using .append()
                   $listItem.addClass('hidden');
               } else {
-                  $visibleReports.find('#report-'+ feature.data.id).remove();
+                  $visibleReports.find('#report-'+ feature.data.id + '-visible').remove();
                   $listItem.removeClass('hidden');
               }
           }

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -135,7 +135,7 @@ var fixmystreet = fixmystreet || {};
                   $listItem.removeClass('hidden');
               }
           }
-          if (visible == '') {
+          if (visible === '') {
             $visibleReports.addClass('hidden');
           } else {
             $visibleReports.removeClass('hidden');

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -116,10 +116,11 @@ var fixmystreet = fixmystreet || {};
       },
 
       reorder_visible: function() {
+          if (fixmystreet.page != 'reports') { return; }
+
           var visible = ''
           var $itemList = $('.item-list');
           var $visibleReports = $('.visible-reports');
-          if ($visibleReports.length == 0) return false;
 
           for (var i = 0; i < fixmystreet.markers.features.length; i++) {
               var feature = fixmystreet.markers.features[i];

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -126,7 +126,7 @@ var fixmystreet = fixmystreet || {};
               var feature = fixmystreet.markers.features[i];
               var $listItem = $itemList.find('#report-'+ feature.data.id);
               if (feature.onScreen()) {
-                  var clone = $($listItem[0].outerHTML);
+                  var clone = $listItem.clone();
                   clone.attr('id', clone.attr('id') + '-visible');
                   clone.removeClass('hidden');
                   visible += clone[0].outerHTML; // This is faster than using .append()

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -116,20 +116,26 @@ var fixmystreet = fixmystreet || {};
       },
 
       reorder_visible: function() {
-          $('.visible-reports').removeClass('hidden');
           var visible = ''
+          var $itemList = $('.item-list');
+          var $visibleReports = $('.visible-reports');
           for (var i = 0; i < fixmystreet.markers.features.length; i++) {
               var feature = fixmystreet.markers.features[i];
-              var $listItem = $('.item-list #report-'+ feature.data.id);
+              var $listItem = $itemList.find('#report-'+ feature.data.id);
               if (feature.onScreen()) {
                   visible += $listItem[0].outerHTML; // This is faster than using .append()
                   $listItem.addClass('hidden');
               } else {
-                  $('.visible-reports #report-'+ feature.data.id).remove();
+                  $visibleReports.find('#report-'+ feature.data.id).remove();
                   $listItem.removeClass('hidden');
               }
           }
-          $('.visible-reports').html(visible);
+          if (visible == '') {
+            $visibleReports.addClass('hidden');
+          } else {
+            $visibleReports.removeClass('hidden');
+            $visibleReports.html(visible);
+          }
       },
 
       get_marker_by_id: function(problem_id) {

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -120,7 +120,7 @@ var fixmystreet = fixmystreet || {};
 
           var visible = ''
           var $itemList = $('.item-list');
-          var $visibleReports = $('.visible-reports');
+          var $visibleReports = $('.js-visible-reports');
 
           for (var i = 0; i < fixmystreet.markers.features.length; i++) {
               var feature = fixmystreet.markers.features[i];

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -115,6 +115,23 @@ var fixmystreet = fixmystreet || {};
         fixmystreet.markers.redraw();
       },
 
+      reorder_visible: function() {
+          $('.visible-reports').removeClass('hidden');
+          var visible = ''
+          for (var i = 0; i < fixmystreet.markers.features.length; i++) {
+              var feature = fixmystreet.markers.features[i];
+              var $listItem = $('.item-list #report-'+ feature.data.id);
+              if (feature.onScreen()) {
+                  visible += $listItem[0].outerHTML; // This is faster than using .append()
+                  $listItem.addClass('hidden');
+              } else {
+                  $('.visible-reports #report-'+ feature.data.id).remove();
+                  $listItem.removeClass('hidden');
+              }
+          }
+          $('.visible-reports').html(visible);
+      },
+
       get_marker_by_id: function(problem_id) {
         return fixmystreet.markers.getFeaturesByAttribute('id', problem_id)[0];
       },
@@ -524,6 +541,7 @@ var fixmystreet = fixmystreet || {};
             fixmystreet.map.addControl( fixmystreet.select_feature );
             fixmystreet.select_feature.activate();
             fixmystreet.map.events.register( 'zoomend', null, fixmystreet.maps.markers_resize );
+            fixmystreet.map.events.register( 'moveend', null, fixmystreet.maps.reorder_visible );
 
             // Set up the event handlers to populate the filters and react to them changing
             $("#filter_categories").on("change.filters", categories_or_status_changed);
@@ -844,6 +862,8 @@ OpenLayers.Format.FixMyStreet = OpenLayers.Class(OpenLayers.Format.JSON, {
         if (typeof(obj.pagination) != 'undefined') {
             $('.js-pagination').html(obj.pagination);
         }
+        // Run reorder event to show visible markers first
+        fixmystreet.maps.reorder_visible()
         return fixmystreet.maps.markers_list( obj.pins, false );
     },
     CLASS_NAME: "OpenLayers.Format.FixMyStreet"


### PR DESCRIPTION
Fixes mysociety/fixmystreetforcouncils#152

This loops through all the markers on a map, and, if they're visible, appends the associated list item to another `<ul>` element above the main `.item-list` element, effectively showing the visible elements first. I've added an extra `id` attribute to each item now to, as this is considerably faster than searching by `data` element. 