### PR TITLE
Simplify open and inspect procedure for inspectors

### DIFF
--- a/templates/web/base/report/new/category.html
+++ b/templates/web/base/report/new/category.html
@@ -5,7 +5,7 @@
     <label for='form_category' id="form_category_label">
         [%~ loc('Category') ~%]
     </label>[% =%]
-    <select class="form-control" name='category' id='form_category'>
+    <select class="form-control" name='category' id='form_category' data-role='[% c.user.has_body_permission_to('planned_reports') ? 'inspector' : 'user'  %]' data-body='[% c.user.from_body.name %]'>
         [%~ FOREACH cat_op IN category_options ~%]
         [% cat_op_lc = cat_op | lower =%]
         <option value='[% cat_op | html %]'[% ' selected' IF report.category == cat_op || category_lc == cat_op_lc || (category_options.size == 2 AND loop.last) ~%]

--- a/templates/web/base/report/new/category_wrapper.html
+++ b/templates/web/base/report/new/category_wrapper.html
@@ -1,7 +1,7 @@
 <div id="form_category_row">
 [% IF js %]
     <label for="form_category">[% loc('Category') %]</label>
-    <select class="form-control" name="category" id="form_category" required><option>[% loc('Loading...') %]</option></select>
+    <select class="form-control" name="category" id="form_category" data-role="[% c.user_exists AND c.user.has_body_permission_to('planned_reports') ? 'inspector' : 'user'  %]" data-body="[% c.user.from_body.name %]" required><option>[% loc('Loading...') %]</option></select>
 [% ELSE %]
     [% IF category_options.size %]
         [% IF field_errors.category %]

--- a/templates/web/base/report/new/category_wrapper.html
+++ b/templates/web/base/report/new/category_wrapper.html
@@ -1,7 +1,7 @@
 <div id="form_category_row">
 [% IF js %]
     <label for="form_category">[% loc('Category') %]</label>
-    <select class="form-control" name="category" id="form_category" data-role="[% c.user_exists AND c.user.has_body_permission_to('planned_reports') ? 'inspector' : 'user'  %]" data-body="[% c.user.from_body.name %]" required><option>[% loc('Loading...') %]</option></select>
+    <select class="form-control" name="category" id="form_category" data-role="[% c.user.has_body_permission_to('planned_reports') ? 'inspector' : 'user'  %]" data-body="[% c.user.from_body.name %]" required><option>[% loc('Loading...') %]</option></select>
 [% ELSE %]
     [% IF category_options.size %]
         [% IF field_errors.category %]

--- a/templates/web/base/report/new/form_user_loggedin.html
+++ b/templates/web/base/report/new/form_user_loggedin.html
@@ -15,12 +15,12 @@
 [% BLOCK form_as %]
     <label for="form_as">[% loc('Report as') %]</label>
     <select id="form_as" class="form-control js-contribute-as" name="form_as">
-        <option value="myself" selected>[% loc('Yourself') %]</option>
+        <option value="myself" [% c.user.has_body_permission_to('planned_reports') ? '' : 'selected'  %]>[% loc('Yourself') %]</option>
       [% IF js || can_contribute_as_another_user %]
         <option value="another_user">[% loc('Another user') %]</option>
       [% END %]
       [% IF js || can_contribute_as_body %]
-        <option value="body">[% c.user.from_body.name %]</option>
+        <option value="body" [% c.user.has_body_permission_to('planned_reports') ? 'selected' : ''  %]>[% c.user.from_body.name %]</option>
       [% END %]
     </select>
 [% END %]

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -128,6 +128,8 @@ function isR2L() {
   });
 })(jQuery);
 
+fixmystreet.hooks = fixmystreet.hooks || {};
+
 fixmystreet.mobile_reporting = {
   apply_ui: function() {
     // Creates the "app-like" mobile reporting UI with full screen map
@@ -425,6 +427,10 @@ $.extend(fixmystreet.set_up, {
                 $category_meta.empty();
             }
         });
+
+        if (fixmystreet.hooks.update_problem_fields) {
+            fixmystreet.hooks.update_problem_fields($(this).data('role'), $(this).data('body'), args);
+        }
     });
   },
 

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -342,3 +342,29 @@ $.extend(fixmystreet.set_up, {
     });
   }
 });
+
+$.extend(fixmystreet.hooks, {
+    update_problem_fields: function(role, body, args) {
+        if (role == 'inspector') {
+            var title = args.category + ' problem has been scheduled for fixing';
+            var description = args.category + ' problem found - scheduled for fixing by ' + body;
+
+            var $title_field = $('#form_title');
+            var $description_field = $('#form_detail');
+
+            if ($title_field.val().length === 0 || $title_field.data('autopopulated') === true) {
+                $title_field.val(title);
+                $title_field.data('autopopulated', true);
+            }
+
+            if ($description_field.val().length === 0 || $description_field.data('autopopulated') === true) {
+                $description_field.val(description);
+                $description_field.data('autopopulated', true);
+            }
+
+            $('#form_title, #form_detail').on('keyup', function() {
+              $(this).data('autopopulated', false);
+            });
+        }
+    }
+});


### PR DESCRIPTION
For mysociety/fixmystreetforcouncils#150

This makes it somewhat easier for inspectors who might be reporting a new problem to open a new report and add the inspection details by autocompleting a bunch of stuff for them, and redirecting to the inspection page once the report has been made. The flow now looks like this:

![jshz7qhxkz](https://cloud.githubusercontent.com/assets/109774/22700649/4236563a-ed53-11e6-905d-2442e457449a.gif)

And like this on mobile:

![kir8cximhu](https://cloud.githubusercontent.com/assets/109774/22700780/9f7d0d48-ed53-11e6-9ed4-b5e8ef5afa78.gif)

It doesn't quite address everything in mysociety/fixmystreetforcouncils#150, but goes a long way to reducing the friction.
