### PR TITLE
Clarify purpose of FMS4C contact form

### DIFF
--- a/templates/email/default/submit-example.txt
+++ b/templates/email/default/submit-example.txt
@@ -55,5 +55,5 @@ feedback you may have.
 
 FixMyStreet is now available for full integration into council
 websites, making life easier for both you and your residents.
-Read more here: https://www.fixmystreet.com/council
+Read more here: https://www.fixmystreet.com/about/council
 

--- a/templates/email/fixmystreet.com/_submit_footer.html
+++ b/templates/email/fixmystreet.com/_submit_footer.html
@@ -6,4 +6,4 @@ welcome any other feedback you may have.
 <br><br>
 FixMyStreet is now available for full integration into council websites, making
 life easier for both you and your residents.
-<a href="https://www.fixmystreet.com/council">Read more</a>
+<a href="https://www.fixmystreet.com/about/council">Read more</a>

--- a/templates/email/fixmystreet.com/submit.txt
+++ b/templates/email/fixmystreet.com/submit.txt
@@ -47,5 +47,5 @@ also welcome any other feedback you may have.
 
 FixMyStreet is now available for full integration into council
 websites, making life easier for both you and your residents.
-Read more here: https://www.fixmystreet.com/council
+Read more here: https://www.fixmystreet.com/about/council
 

--- a/templates/web/base/open311/index.html
+++ b/templates/web/base/open311/index.html
@@ -40,7 +40,7 @@ about future-proofing your communication channels in an easy and economical way
 
 [% IF c.cobrand.moniker == 'fixmystreet' %]
 <p>You may be interested to know about <a
-href="https://www.fixmystreet.com/council">FixMyStreet
+href="https://www.fixmystreet.com/about/council">FixMyStreet
 for Councils</a>, our hosted service which sits seamlessly on your council
 website.</p>
 

--- a/templates/web/bromley/front/footer-marketing.html
+++ b/templates/web/bromley/front/footer-marketing.html
@@ -12,7 +12,7 @@
 
     <div id="footer-help">
         <p>
-        Powered by <a class="platform-logo" href="https://fixmystreet.com/council">FixMyStreet Platform</a>
+        Powered by <a class="platform-logo" href="https://fixmystreet.com/about/council">FixMyStreet Platform</a>
         </p>
     </div>
 </div>

--- a/templates/web/fixmystreet.com/about/council.html
+++ b/templates/web/fixmystreet.com/about/council.html
@@ -27,7 +27,7 @@
       <div class="councils-features__grid">
         <div class="councils-features__feature">
           <div class="councils-features__thumb councils-features__thumb--excellence"></div>
-          <h3>Digital Excellence</h3>
+          <h3>Digital excellence</h3>
           <p>FixMyStreet was co-designed with council insiders. We made it into the most user-centred, accessible approach to non-emergency issue reporting available today. And now it’s the leader in its class.</p>
         </div>
         <div class="councils-features__feature">
@@ -114,7 +114,7 @@
       <h2>Works with</h2>
       <div class="councils-compatibility__grid">
         <div class="councils-compatibility__item">
-          <h3>Customer Management</h3>
+          <h3>Customer management</h3>
           <ul>
             <li><a href="http://www.kana.com/lagan-crm/customer-experience-management">Lagan</a></li>
             <li><a href="https://www.microsoft.com/en-gb/dynamics/default.aspx">Microsoft Dynamics</a></li>
@@ -149,12 +149,12 @@
 
           <div class="pricing-table">
             <div class="pricing-table__item">
-              <h3>Simple fault reporting</h3>
+              <h3>Basic FixMyStreet integration</h3>
               <p class="pricing-table__item__price"><strong>&pound;7,500 per year</strong></p>
               <p>The award-winning FixMyStreet experience seamlessly integrated with your site. A responsive web application for reporting, viewing and discussing problems - branded to match your site’s styles and templates. Use FixMyStreet for Councils to keep your residents up to date and route problems by email to the correct individual or team. The internal dashboard eanbles you to manage performance.</p>
             </div>
             <div class="pricing-table__item">
-              <h3>Case&hyphen;management Integration</h3>
+              <h3>Case&hyphen;management integration</h3>
               <p class="pricing-table__item__price"><strong>&pound;15,000 per year</strong></p>
               <p>Our award-winning reporting solution &ndash; your existing processes and systems. We’ll integrate FixMyStreet into your customer, case or asset management system ensuring that there’s minimal impact on your organisation. Accept reports, automatically publish updates and reports from other channels via your existing tools, directly onto FixMyStreet.</p>
               <p>Supported services include: Confirm, Mayrise, MS Dynamics and Exor. If you use an alternative service or your own internal system we’ll scope and implement additional support via our Specialist Cloud Service.</p>
@@ -180,14 +180,14 @@
             <h3>Bring your own, or we can provide</h3>
             <div class="pricing-accordion accordion">
               <div class="accordion-item">
-                <a href="#" class="accordion-switch accordion-switch--closed"><h4>Custom Map Tiles</h4></a>
+                <a href="#" class="accordion-switch accordion-switch--closed"><h4>Custom map tiles</h4></a>
                 <div class="accordion-content">
                   <p class="extra-pricing__price">&pound;1,500 per year</p>
                   <p class="extra-pricing__desc">FixMyStreet comes with OpenStreetMap/Bing geographical base maps as standard. But for a completely unique look, or to key in with your existing mapping visuals, we can support the industry standard WMS maps of your choice.</p>
                 </div>
               </div>
               <div class="accordion-item">
-                <a href="#" class="accordion-switch accordion-switch--closed"><h4>Custom Geocoding</h4></a>
+                <a href="#" class="accordion-switch accordion-switch--closed"><h4>Custom geocoding</h4></a>
                 <div class="accordion-content">
                   <p class="extra-pricing__price">&pound;1,500 per year</p>
                   <p class="extra-pricing__desc">Transforming an address into a point on a map: it’s called geocoding, and we utilise Bing, OpenStreetMap and Google’s services as standard. But if you have your own geocoding system, we can integrate that to ensure a precise location for a given postcode, address or place name.</p>
@@ -223,9 +223,22 @@
 
 <div class="council-order" id="order">
   <div class="councils-content-wrapper">
-    <h2>Order</h2>
+    <h2>Request a free demo</h2>
     <form action="/contact/submit" method="post">
     <div class="council-order__form">
+      <div class="form-group">
+        <label for="product">We are interested in&hellip;</label>
+        <span class="required">required</span>
+        <div class="radio-as-buttons">
+          <label><input name="extra.product" id="product" type="radio" value="simple-fault-reporting" required>Basic FixMyStreet integration <span class="council-order__form__product__price">&pound;7,500 per year</span></label>
+          <label><input name="extra.product" id="product" type="radio" value="case-management-integration">Case-management integration <span class="council-order__form__product__price">&pound;15,000 per year</span></label>
+          <label><input name="extra.product" id="product" type="radio" value="top-to-bottom-case-management">Top-to-bottom case-management <span class="council-order__form__product__price">&pound;35,000 per year</span></label>
+        </div>
+      </div>
+      <div class="form-group">
+        <label for="message">A little more about your requirements</label>
+        <textarea name="message" id="message" required> </textarea>
+      </div>
       <div class="form-group">
         <label for="name">Name</label>
         <span class="required">required</span>
@@ -245,20 +258,8 @@
         <label for="phone">Contact telephone</label>
         <input type="tel" name="extra.phone" id="phone">
       </div>
-      <div class="form-group">
-        <label for="product">Product</label>
-        <span class="required">required</span>
-        <div class="radio-as-buttons">
-          <label><input name="extra.product" id="product" type="radio" value="simple-fault-reporting" required>Simple fault reporting</label>
-          <label><input name="extra.product" id="product" type="radio" value="case-management-integration">Case-management integration</label>
-          <label><input name="extra.product" id="product" type="radio" value="top-to-bottom-case-management">Top-to-bottom case-management</label>
-        </div>
-      </div>
-      <div class="form-group">
-        <label for="message">Message</label>
-        <textarea name="message" id="message" required> </textarea>
-      </div>
       <div class="form-group submit-group">
+        <input type="hidden" name="extra.referer" value="[% c.req.headers.referer | html %]">
         <input type="hidden" name="subject" value="Councils submission">
         <input type="hidden" name="recipient" value="enquiries">
         <input type="hidden" name="dest" value="from_council">

--- a/templates/web/fixmystreet.com/footer_extra.html
+++ b/templates/web/fixmystreet.com/footer_extra.html
@@ -31,7 +31,7 @@
                             %]>[% loc("Local alerts") %]</[% c.req.uri.path == '/alert' ? 'span' : 'a' %]></li>
                     </ul>
                     <ul>
-                        <li><a href="https://www.fixmystreet.com/council">FixMyStreet for Councils</a></li>
+                        <li><a href="/about/council">FixMyStreet for Councils</a></li>
                         <li><[% IF c.req.uri.path == '/posters' %]span[% ELSE %]a href="[% base %]/posters"[% END
                             %]>[% loc("FixMyStreet Goodies") %]</[% c.req.uri.path == '/posters' ? 'span' : 'a' %]></li>
                         <li><[% IF c.req.uri.path == '/contact' %]span[% ELSE %]a href="[% base %]/contact"[% END

--- a/templates/web/fixmystreet.com/front/footer-marketing.html
+++ b/templates/web/fixmystreet.com/front/footer-marketing.html
@@ -7,7 +7,7 @@
                                     </li>
                                     <li>
                                         <h4>[% loc('Are you from a council?') %]</h4>
-                                        <p>[% loc('Would you like better integration with FixMyStreet? <a href="https://www.fixmystreet.com/council">Find out about FixMyStreet for councils</a>.') %]</p>
+                                        <p>[% loc('Would you like better integration with FixMyStreet? <a href="/about/council">Find out about FixMyStreet for councils</a>.') %]</p>
                                     </li>
                                 </ul>
                             </div>

--- a/templates/web/fixmystreet.com/reports/_extras.html
+++ b/templates/web/fixmystreet.com/reports/_extras.html
@@ -25,7 +25,7 @@
 <td class="title" colspan="6" style="padding-top:0">
     <small title="This council's online reporting is powered by FixMyStreet">(includes reports from
     <a href="http[% secure.$site %]://[% site %]">[% site %]</a> using
-    <a href="https://www.fixmystreet.com/council">FixMyStreet for Councils</a>)</small>
+    <a href="/about/council">FixMyStreet for Councils</a>)</small>
 </td>
 </tr>
 [% END %]

--- a/templates/web/greenwich/front/footer-marketing.html
+++ b/templates/web/greenwich/front/footer-marketing.html
@@ -13,7 +13,7 @@
 
     <div id="footer-help">
         <p>
-        Powered by <a class="platform-logo" href="https://fixmystreet.com/council">FixMyStreet Platform</a>
+        Powered by <a class="platform-logo" href="https://fixmystreet.com/about/council">FixMyStreet Platform</a>
         </p>
     </div>
 </div>

--- a/templates/web/hart/footer.html
+++ b/templates/web/hart/footer.html
@@ -66,7 +66,7 @@
                 </footer>
                 <div class="clearfix" id="footer-row-2">
                     <div id="hart-powered-by">
-                        <a href="https://www.fixmystreet.com/council">Powered by <img src="/cobrands/hart/fms-logo.png" alt="FixMyStreet" style="height:20px;"></a>
+                        <a href="https://www.fixmystreet.com/about/council">Powered by <img src="/cobrands/hart/fms-logo.png" alt="FixMyStreet" style="height:20px;"></a>
                     </div>
                     <div id="footer-images">
                         <a href="https://twitter.com/HartCouncil">

--- a/templates/web/oxfordshire/footer.html
+++ b/templates/web/oxfordshire/footer.html
@@ -11,7 +11,7 @@
             <div class="nav-wrapper-2">
                 <div id="main-nav" role="navigation">
                     <ul class="nav-menu nav-menu--mysoc">
-                        <li><a id="mysoc-logo" href="https://www.fixmystreet.com/council">Powered by <img src="/cobrands/oxfordshire/images/fms-logo-105x20.png" alt="FixMyStreet"></a></li>
+                        <li><a id="mysoc-logo" href="https://www.fixmystreet.com/about/council">Powered by <img src="/cobrands/oxfordshire/images/fms-logo-105x20.png" alt="FixMyStreet"></a></li>
                     </ul>
 
                     [% INCLUDE "main_nav.html" body_name=c.cobrand.council_area hide_mysoc_link=1 omit_wrapper=1 hide_privacy_link=1 %]

--- a/templates/web/stevenage/footer.html
+++ b/templates/web/stevenage/footer.html
@@ -19,7 +19,7 @@
                                     </li>
                                     <li>
                                         <h4>[% loc('Are you from a council?') %]</h4>
-                                        <p>[% loc('Would you like better integration with FixMyStreet? <a href="https://www.fixmystreet.com/council">Find out about FixMyStreet for councils</a>.') %]</p>
+                                        <p>[% loc('Would you like better integration with FixMyStreet? <a href="https://www.fixmystreet.com/about/council">Find out about FixMyStreet for councils</a>.') %]</p>
                                     </li>
                                 </ul>
                             </div>

--- a/web/cobrands/fixmystreet.com/fmsforcouncils.scss
+++ b/web/cobrands/fixmystreet.com/fmsforcouncils.scss
@@ -559,7 +559,7 @@ $fms-green: #62b356;
       font-weight: normal;
     }
     textarea {
-      height: 15em;
+      height: 10em;
     }
     textarea,
     input[type="text"],
@@ -589,6 +589,11 @@ $fms-green: #62b356;
         background-color: desaturate(darken(#E65376, 10%), 10%);
       }
     }
+  }
+
+  .council-order__form__product__price {
+      margin-left: 0.5em;
+      color: #999;
   }
 
   .form-group {


### PR DESCRIPTION
* Tweak wording to make it clearer that the form is unsuitable for residents wanting to report street problems.
* Record HTTP Referer when form is submitted, so we can see which pages are leading people to the FMS4C page.
* Tidy up capitalisation elsewhere in headings on the page.
* Replace links to `/council` with `/about/council` to avoid an unnecessary redirect (thanks @davea!) and remove the `www.fixmystreet.com` prefix inside the fixmystreet.com cobrand templates.

Fixes #1553.

![screen shot 2017-02-16 at 15 59 04](https://cloud.githubusercontent.com/assets/739624/23029003/f1c480f4-f460-11e6-9a73-7f228bf9add8.png)
