### PR TITLE
Reduce disc stats

### DIFF
--- a/perllib/FixMyStreet/App/Model/PhotoSet.pm
+++ b/perllib/FixMyStreet/App/Model/PhotoSet.pm
@@ -191,12 +191,7 @@ has ids => ( #  Arrayref of $fileid tuples (always, so post upload/raw data proc
             $type ||= 'jpeg';
             if ($fileid && length($fileid) == 40) {
                 my $file = $self->get_file($fileid, $type);
-                if ($file->exists) {
-                    $file->basename;
-                } else {
-                    warn "File $part doesn't exist";
-                    ();
-                }
+                $file->basename;
             } else {
                 # A bad hash, probably a bot spamming with bad data.
                 ();

--- a/perllib/FixMyStreet/App/View/Web.pm
+++ b/perllib/FixMyStreet/App/View/Web.pm
@@ -155,7 +155,7 @@ sub version {
 
 sub _version_get_mtime {
     my $file = shift;
-    unless ($version_hash{$file} && !FixMyStreet->config('STAGING_SITE')) {
+    unless (defined $version_hash{$file} && !FixMyStreet->config('STAGING_SITE')) {
         my $path = FixMyStreet->path_to('web', $file);
         $version_hash{$file} = ( stat( $path ) )[9] || 0;
     }


### PR DESCRIPTION
Two small things that do a lot of statting.
1. The versioning code wasn't remembering when it had found that a file did not exist, so was checking for them each time.
2. The list code was checking the photo ID given in the database existed on disk – this shouldn't ever not be the case, and if it was, all that would happen would be a broken image when the full photo code looks for it (this is only for e.g. lists of reports).