### PR TITLE
Make sure report Ajax call is not cached by IE11.

### DIFF
--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1301,7 +1301,7 @@ fixmystreet.display = {
   },
 
   report: function(reportPageUrl, reportId, callback) {
-    $.ajax(reportPageUrl).done(function(html, textStatus, jqXHR) {
+    $.ajax(reportPageUrl, { cache: false }).done(function(html, textStatus, jqXHR) {
         var $reportPage = $(html),
             $twoColReport = $reportPage.find('.two_column_sidebar'),
             $sideReport = $reportPage.find('#side-report');


### PR DESCRIPTION
IE11 caches this Ajax call, not calling out to the server at all if it
is made again (e.g. after an update has been made). Fixes #1638.