### PR TITLE
Specify options in 'all' status filter.

### DIFF
--- a/templates/web/base/reports/_list-filters.html
+++ b/templates/web/base/reports/_list-filters.html
@@ -1,5 +1,6 @@
 [% select_status = BLOCK %]
-    <select class="form-control js-multiple" name="status" id="statuses" multiple data-all="[% loc('All reports') %]">
+    <select class="form-control js-multiple" name="status" id="statuses" multiple
+      data-all="[% loc('All reports') %]" data-all-options='["open","closed","fixed"]'>
       [% IF c.user_exists AND c.user.has_body_permission_to('planned_reports') AND !shortlist %]
         <option value="shortlisted"[% ' selected' IF filter_status.shortlisted %]>[% loc('Shortlisted') %]</option>
         <option value="unshortlisted"[% ' selected' IF filter_status.unshortlisted %]>[% loc('Unshortlisted') %]</option>

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -722,14 +722,15 @@ $.extend(fixmystreet.set_up, {
 
     function make_multi(id) {
         var $id = $('#' + id),
-            all = $id.data('all');
+            all = $id.data('all'),
+            allOpts = $id.data('allOptions') || [];
         $id.multiSelect({
             allText: all,
             noneText: all,
             positionMenuWithin: $('#side'),
             presets: [{
                 name: all,
-                options: []
+                options: allOpts
             }]
         });
     }


### PR DESCRIPTION
A cobrand may have a blank default that isn't everything, so the
"All reports" option must specify all the possible options.