### PR TITLE
Do upload_dir check on start up, not each report.

### DIFF
--- a/perllib/FixMyStreet/App.pm
+++ b/perllib/FixMyStreet/App.pm
@@ -11,7 +11,7 @@ use FixMyStreet::Map;
 use FixMyStreet::Email;
 use Utils;
 
-use Path::Class;
+use Path::Tiny 'path';
 use URI;
 use URI::QueryParam;
 
@@ -102,6 +102,13 @@ after 'prepare_headers' => sub {
 # disable debug logging unless in debug mode
 __PACKAGE__->log->disable('debug')    #
   unless __PACKAGE__->debug;
+
+# Check upload_dir
+my $cache_dir = path(FixMyStreet->config('UPLOAD_DIR'))->absolute(FixMyStreet->path_to());
+$cache_dir->mkpath;
+unless ( -d $cache_dir && -w $cache_dir ) {
+    warn "\x1b[31mCan't find/write to photo cache directory '$cache_dir'\x1b[0m\n";
+}
 
 =head1 NAME
 

--- a/perllib/FixMyStreet/App/Model/PhotoSet.pm
+++ b/perllib/FixMyStreet/App/Model/PhotoSet.pm
@@ -67,14 +67,7 @@ has upload_dir => (
     is => 'ro',
     lazy => 1,
     default => sub {
-        my $self = shift;
-        my $cache_dir = path(FixMyStreet->config('UPLOAD_DIR'))->absolute(FixMyStreet->path_to());
-        $cache_dir->mkpath;
-        unless ( -d $cache_dir && -w $cache_dir ) {
-            warn "Can't find/write to photo cache directory '$cache_dir'";
-            return;
-        }
-        $cache_dir;
+        path(FixMyStreet->config('UPLOAD_DIR'))->absolute(FixMyStreet->path_to());
     },
 );
 


### PR DESCRIPTION
If we're chugging through a list of reports, this save on a lot of
pointless statting of the upload directory which we know is there.