### PR TITLE
Upgrade Net::Facebook::Oauth2 to 0.10

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -74,7 +74,7 @@ requires 'MooX::Types::MooseLike';
 requires 'namespace::autoclean';
 requires 'Net::DNS::Resolver';
 requires 'Net::Domain::TLD', '1.75';
-requires 'Net::Facebook::Oauth2';
+requires 'Net::Facebook::Oauth2', '0.10';
 requires 'Net::OAuth';
 requires 'Net::Twitter::Lite::WithAPIv1_1';
 requires 'Path::Class';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -4373,11 +4373,11 @@ DISTRIBUTIONS
       Carp 0
       ExtUtils::MakeMaker 0
       Storable 0
-  Net-Facebook-Oauth2-0.09
-    pathname: M/MA/MAMOD/Net-Facebook-Oauth2-0.09.tar.gz
+  Net-Facebook-Oauth2-0.10
+    pathname: M/MA/MAMOD/Net-Facebook-Oauth2-0.10.tar.gz
     provides:
       MyApp::Controller::Facebook undef
-      Net::Facebook::Oauth2 0.09
+      Net::Facebook::Oauth2 0.10
     requirements:
       Carp 0
       ExtUtils::MakeMaker 0

--- a/t/Mock/Facebook.pm
+++ b/t/Mock/Facebook.pm
@@ -20,14 +20,14 @@ has returns_email => (
 sub dispatch_request {
     my $self = shift;
 
-    sub (GET + /v2.2/dialog/oauth + ?*) {
+    sub (GET + /v2.8/dialog/oauth + ?*) {
         my ($self) = @_;
         return [ 200, [ 'Content-Type' => 'text/html' ], [ 'FB login page' ] ];
     },
 
-    sub (GET + /v2.2/oauth/access_token + ?*) {
+    sub (GET + /v2.8/oauth/access_token + ?*) {
         my ($self) = @_;
-        return [ 200, [ 'Content-Type' => 'text/plain' ], [ 'access_token=access_token&expires=never' ] ];
+        return [ 200, [ 'Content-Type' => 'application/json' ], [ '{"access_token": "access_token"}' ] ];
     },
 
     sub (GET + /me + ?fields=) {


### PR DESCRIPTION
0.09 was communicating with v2.2 of the Facebook API which was switched off
on 25th March 2017, so Facebook logins were no longer working.

Mock::Facebook was updated to correctly return JSON from /oauth/access_token,
to match the behaviour expected since v2.3 of the FB API.

Fixes #1681