### PR TITLE
Allow comma-separated contact emails in the admin

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -7,7 +7,7 @@ BEGIN { extends 'Catalyst::Controller'; }
 use Path::Class;
 use POSIX qw(strftime strcoll);
 use Digest::SHA qw(sha1_hex);
-use mySociety::EmailUtil qw(is_valid_email);
+use mySociety::EmailUtil qw(is_valid_email is_valid_email_list);
 use mySociety::ArrayUtils;
 use DateTime::Format::Strptime;
 use List::Util 'first';
@@ -357,10 +357,11 @@ sub update_contacts : Private {
             }
         );
 
-        my $email = $self->trim( $c->get_param('email') );
+        my $email = $c->get_param('email');
+        $email =~ s/\s+//g;
         my $send_method = $c->get_param('send_method') || $contact->send_method || $contact->body->send_method || "";
         unless ( $send_method eq 'Open311' ) {
-            $errors{email} = _('Please enter a valid email') unless is_valid_email($email) || $email eq 'REFUSED';
+            $errors{email} = _('Please enter a valid email') unless is_valid_email_list($email) || $email eq 'REFUSED';
         }
 
         $contact->email( $email );

--- a/t/app/controller/admin.t
+++ b/t/app/controller/admin.t
@@ -206,7 +206,7 @@ subtest 'check contact creation' => sub {
 subtest 'check contact editing' => sub {
     $mech->get_ok('/admin/body/' . $body->id .'/test%20category');
 
-    $mech->submit_form_ok( { with_fields => { 
+    $mech->submit_form_ok( { with_fields => {
         email    => 'test2@example.com',
         note     => 'test2 note',
         non_public => undef,
@@ -218,7 +218,18 @@ subtest 'check contact editing' => sub {
     $mech->content_contains( 'Private:&nbsp;No' );
 
     $mech->get_ok('/admin/body/' . $body->id . '/test%20category');
-    $mech->submit_form_ok( { with_fields => { 
+    $mech->submit_form_ok( { with_fields => {
+        email    => 'test2@example.com, test3@example.com',
+        note     => 'test3 note',
+    } } );
+
+    $mech->content_contains( 'test2@example.com,test3@example.com' );
+
+    $mech->get_ok('/admin/body/' . $body->id . '/test%20category');
+    $mech->content_contains( '<td><strong>test2@example.com,test3@example.com' );
+
+    $mech->get_ok('/admin/body/' . $body->id . '/test%20category');
+    $mech->submit_form_ok( { with_fields => {
         email    => 'test2@example.com',
         note     => 'test2 note',
         non_public => 'on',


### PR DESCRIPTION
The report-sending code has allowed multiple emails for a long time, but the
admin wouldn't allow you to enter multiple emails for each contact.

Fixes mysociety/FixMyStreet-Commercial#835