### PR TITLE
Don't error when devolved body, blank send methods

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -873,13 +873,11 @@ sub get_body_sender {
 
     # look up via category
     my $contact = $body->contacts->search( { category => $category } )->first;
-    if ( $body->can_be_devolved ) {
-        if ( $contact->send_method ) {
-            return { method => $contact->send_method, config => $contact, contact => $contact };
-        } else {
-            return { method => $body->send_method, config => $body, contact => $contact };
-        }
-    } elsif ( $body->send_method ) {
+    if ( $body->can_be_devolved && $contact->send_method ) {
+        return { method => $contact->send_method, config => $contact, contact => $contact };
+    }
+
+    if ( $body->send_method ) {
         return { method => $body->send_method, config => $body, contact => $contact };
     }
 


### PR DESCRIPTION
The check assumed that if a body was devolved, either the contact
or the body would have a send method. Instead, use a contact send
method if devolved and it exists, a body send method if it exists
or the fallback if neither. Fixes #1374.