### PR TITLE
Better differentiation for Inspector form on report page

### DIFF
--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -1,6 +1,9 @@
 [% permissions = c.user.permissions(c, problem.bodies_str) %]
 [% second_column = BLOCK -%]
   <div id="side-inspect">
+
+    <h2 class="inspect-form-heading">[% loc('Inspect report') %]</h2>
+
     [% INCLUDE 'errors.html' %]
 
     <form id="report_inspect_form" method="post" action="[% c.uri_for( '/report', problem.id ) %]">

--- a/templates/web/base/report/duplicate-no-updates.html
+++ b/templates/web/base/report/duplicate-no-updates.html
@@ -1,5 +1,5 @@
 <div>
-    [% UNLESS hide_header %]<h2>[% loc( 'Provide an update') %]</h2>[% END %]
+    [% UNLESS hide_header %]<h2 class="update-form-heading">[% loc( 'Provide an update') %]</h2>[% END %]
     <p>[% loc("This report is a duplicate. Please leave updates on the original report:") %]</p>
     <ul class="item-list">
       [% INCLUDE 'report/_item.html' item_extra_class = 'item-list__item--with-pin item-list--reports__item--selected' problem = problem.duplicate_of %]

--- a/templates/web/base/report/update-form.html
+++ b/templates/web/base/report/update-form.html
@@ -3,7 +3,7 @@
 
 <div id="update_form">
   [% IF NOT login_success AND NOT oauth_need_email %]
-    <h2>[% loc( 'Provide an update') %]</h2>
+    <h2 class="update-form-heading">[% loc( 'Provide an update') %]</h2>
 
     [% IF c.cobrand.moniker != 'stevenage' %]
     <div class="general-notes">

--- a/templates/web/bromley/report/update-form.html
+++ b/templates/web/bromley/report/update-form.html
@@ -1,5 +1,5 @@
 <div id="update_form">
-    <h2>[% loc( 'Provide an update') %]</h2>
+    <h2 class="update-form-heading">[% loc( 'Provide an update') %]</h2>
 
     [% INCLUDE 'errors.html' %]
 

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -263,6 +263,17 @@ $.extend(fixmystreet.set_up, {
             $("form#report_inspect_form input[name=longitude]").val(latlon.lon);
         });
     }
+
+    // Make the "Provide an update" form toggleable, and hide it by default.
+    // (Inspectors will normally just use the #public_update box instead).
+    var $updateFormH2 = $('.update-form-heading');
+    var $updateFormBtn = $('<button>').insertBefore( $updateFormH2 );
+    $updateFormH2.hide().nextAll().hide();
+    $updateFormBtn.addClass('btn btn--provide-update');
+    $updateFormBtn.text( $updateFormH2.text() );
+    $updateFormBtn.on('click', function(){
+        $updateFormH2.nextAll().toggle();
+    });
   },
 
   moderation: function() {

--- a/web/cobrands/oxfordshire/base.scss
+++ b/web/cobrands/oxfordshire/base.scss
@@ -77,6 +77,10 @@ dd, p {
   }
 }
 
+#side-inspect {
+  background-color: #deead2; // darker version of $oxfordshire_very_light_green
+}
+
 .btn-primary {
     @include button-reset(
         $oxfordshire_button_top,

--- a/web/cobrands/oxfordshire/layout.scss
+++ b/web/cobrands/oxfordshire/layout.scss
@@ -226,10 +226,6 @@ body.mappage {
   background-color: $oxfordshire_very_light_green;
 }
 
-#side-inspect {
-  background-color: #deead2;
-}
-
 .item-list--reports h3 {
   color: $oxfordshire_link_colour;
 }

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -600,17 +600,21 @@ body.mappage .wrapper {
         display: block;
         background-color: #f5f5f5;
         background-repeat: no-repeat;
-        color:#333;
+        color: #333 !important;
         padding:4em 2em 1em;
         text-transform:uppercase;
         font: {
           size:0.6875em;
           family: $meta-font;
+          weight: normal;
         }
+        line-height: 1.2em;
+        white-space: normal;
+        border-radius: 0;
         &:hover, &.hover {
           text-decoration:none;
           background-color:#333;
-          color:#fff;
+          color: #fff !important;
         }
         &.abuse {
           background-image: url($image-sprite);

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1848,6 +1848,18 @@ label .muted {
   }
 }
 
+// The coloured sidebar column on .with-actions pages.
+// On narrow screens, it becomes a full-width section.
+#side-inspect {
+  padding: 1em;
+  margin: 0 -1em;
+  background-color: #E9F2FF;
+}
+
+.inspect-form-heading {
+  margin-top: 0;
+}
+
 .inspect-section {
   border-top: 1px solid rgba(0, 0, 0, 0.2);
   padding-top: 1.5em;

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -837,6 +837,12 @@ input.final-submit {
     }
 }
 
+.btn--provide-update {
+    display: block;
+    width: 100%;
+    margin-bottom: 1em;
+}
+
 .btn--block {
     display: block;
     text-align: center;

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -776,6 +776,7 @@ body.authpage {
       border:none;
       a, input[type=submit] {
         font-size: 0.75em;
+        line-height: 18px; // match `body`
         color:#666;
         padding: flip(0.5em 1.5em 0.5em 0, 0.5em 0 0.5em 1.5em);
         text-transform:none;

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -944,7 +944,11 @@ textarea.form-error {
 
 // The coloured sidebar column on .with-actions pages.
 #side-inspect {
-  background-color: #E9F2FF;
+    margin: 0;
+}
+
+.inspect-form-heading {
+  display: none;
 }
 
 // More general notes


### PR DESCRIPTION
Attempt at fixing mysociety/fixmystreetforcouncils#157.

* Inspect form now has background color on narrow devices
* Inspect form has heading on narrow devices
* When an inspect form is present, the "Provide an update" form is hidden behind a button press

Also includes a quick fix to the `#key-tools` styling, while I was in the vicinity.

![screen shot 2017-05-15 at 15 28 11](https://cloud.githubusercontent.com/assets/739624/26062668/6e420612-3983-11e7-842e-e73748cc03ea.png)
