### PR TITLE
[UK] Stop nearest request with scientific notation

### DIFF
--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -5,6 +5,7 @@ use strict;
 use JSON::MaybeXS;
 use mySociety::MaPit;
 use mySociety::VotingArea;
+use Utils;
 
 sub country             { return 'GB'; }
 sub area_types          { [ 'DIS', 'LBO', 'MTD', 'UTA', 'CTY', 'COI', 'LGD' ] }
@@ -122,7 +123,8 @@ sub find_closest {
     my $data = $self->SUPER::find_closest($problem, $as_data);
 
     my $mapit_url = FixMyStreet->config('MAPIT_URL');
-    my $url = $mapit_url . "nearest/4326/" . $problem->longitude . ',' . $problem->latitude;
+    my ($lat, $lon) = map { Utils::truncate_coordinate($_) } $problem->latitude, $problem->longitude;
+    my $url = $mapit_url . "nearest/4326/$lon,$lat";
     my $j = LWP::Simple::get($url);
     if ($j) {
         $j = JSON->new->utf8->allow_nonref->decode($j);

--- a/t/Mock/Bing.pm
+++ b/t/Mock/Bing.pm
@@ -1,0 +1,37 @@
+package t::Mock::Bing;
+
+use JSON::MaybeXS;
+use Web::Simple;
+use LWP::Protocol::PSGI;
+
+has json => (
+    is => 'lazy',
+    default => sub {
+        JSON->new->pretty->allow_blessed->convert_blessed;
+    },
+);
+
+sub dispatch_request {
+    my $self = shift;
+
+    sub (GET + /REST/v1/Locations/* + ?*) {
+        my ($self, $location, $query) = @_;
+        my $data = {
+            resourceSets => [ {
+                resources => [ {
+                    name => 'Constitution Hill, London, SW1A',
+                    address => {
+                        addressLine => 'Constitution Hill',
+                        locality => 'London',
+                    }
+                } ],
+            } ],
+        };
+        my $json = $self->json->encode($data);
+        return [ 200, [ 'Content-Type' => 'application/json' ], [ $json ] ];
+    },
+}
+
+LWP::Protocol::PSGI->register(t::Mock::Bing->to_psgi_app, host => 'dev.virtualearth.net');
+
+__PACKAGE__->run_if_script;

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -32,6 +32,7 @@ my @PLACES = (
     [ 'GU51 4AE', 51.279456, -0.846216, 2333, 'Hart District Council', 'DIS', 2227, 'Hampshire County Council', 'CTY' ],
     [ 'WS1 4NH', 52.563074, -1.991032, 2535, 'Sandwell Borough Council', 'MTD' ],
     [ 'OX28 4DS', 51.784721, -1.494453 ],
+    [ 'E14 2DN', 51.508536, '0.000001' ],
 );
 
 sub dispatch_request {
@@ -112,7 +113,7 @@ sub dispatch_request {
         foreach (@PLACES) {
             if ($point eq "4326/$_->[2],$_->[1]") {
                 return $self->output({
-                    postcode => { wgs84_lat => $_->[1], wgs84_lon => $_->[2], postcode => $_->[0] },
+                    postcode => { wgs84_lat => $_->[1], wgs84_lon => $_->[2], postcode => $_->[0], distance => 93 },
                 });
             }
         }


### PR DESCRIPTION
If the longitude was very close to 0, it was being sent as e.g. 1e-6
in the request to MapIt. Mock out the Bing query so that this can be
tested (the closest.t tests were previously always being skipped).
Fixes #1695 