### PR TITLE
Fix linting errors

### DIFF
--- a/web/js/map-wmts-bristol.js
+++ b/web/js/map-wmts-bristol.js
@@ -1,4 +1,4 @@
-/* 
+/*
  * Maps for FMS using Bristol City Council's WMTS tile server
  */
 
@@ -102,7 +102,7 @@ fixmystreet.maps.matrix_ids = [
     }
 ];
 
-/* 
+/*
  * maps.config() is called on dom ready in map-OpenLayers.js
  * to setup the way the map should operate.
  */
@@ -125,11 +125,12 @@ fixmystreet.maps.config = function() {
     if ( fixmystreet.page == 'report' ) {
         fixmystreet.controls.push( new OpenLayers.Control.PermalinkFMS('key-tool-problems-nearby', '/around') );
     }
-    
+
     this.setup_wmts_base_map();
 };
 
-fixmystreet.maps.marker_size_for_zoom = function(zoom) {
+fixmystreet.maps.marker_size = function() {
+    var zoom = fixmystreet.map.getZoom() + fixmystreet.zoomOffset;
     if (zoom >= 7) {
         return 'normal';
     } else if (zoom >= 4) {

--- a/web/js/map-wmts-zurich.js
+++ b/web/js/map-wmts-zurich.js
@@ -1,5 +1,5 @@
-/* 
- * Maps for FMZ using Zurich council's WMTS tile server 
+/*
+ * Maps for FMZ using Zurich council's WMTS tile server
  */
 
 // From 'fullExtent' from http://www.gis.stadt-zuerich.ch/maps/rest/services/tiled95/LuftbildHybrid/MapServer?f=pjson
@@ -140,7 +140,7 @@ fixmystreet.maps.matrix_ids = [
 
 })();
 
-/* 
+/*
  * maps.config() is called on dom ready in map-OpenLayers.js
  * to setup the way the map should operate.
  */
@@ -165,7 +165,8 @@ fixmystreet.maps.config = function() {
     fixmystreet.area_format = { fillColor: 'none', strokeWidth: 4, strokeColor: 'black' };
 };
 
-fixmystreet.maps.marker_size_for_zoom = function(zoom) {
+fixmystreet.maps.marker_size = function() {
+    var zoom = fixmystreet.map.getZoom() + fixmystreet.zoomOffset;
     if (zoom >= 6) {
         return 'normal';
     } else if (zoom >= 3) {


### PR DESCRIPTION
The Git JS linting hook didn't used to run on files with `OpenLayers` in the filename, but we've changed this now vendor scripts are in their own subdirectory (#1705). This means that our own map-OpenLayers.js file wasn't being linted before, but now it is. This PR just fixes the issues that the linter's picked up.