### PR TITLE
[Bromley] Restore staff update function

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/Update.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/Update.pm
@@ -342,7 +342,8 @@ sub check_for_errors : Private {
     my ( $self, $c ) = @_;
 
     # they have to be an authority user to update the state
-    if ( my $state = $c->get_param('state') ) {
+    my $state = $c->get_param('state');
+    if ( $state && $state ne $c->stash->{update}->problem->state ) {
         my $error = 0;
         $error = 1 unless $c->user && $c->user->belongs_to_body( $c->stash->{update}->problem->bodies_str );
         $error = 1 unless grep { $state eq $_ } FixMyStreet::DB::Result::Problem->council_states();

--- a/templates/web/base/report/inspect/state_groups_select.html
+++ b/templates/web/base/report/inspect/state_groups_select.html
@@ -5,6 +5,7 @@ SET state_pretty = {
     'in progress' = loc('In progress')
     'action scheduled' = loc('Action Scheduled')
     'fixed - council' = loc('Fixed - Council')
+    'fixed - user' = loc('Fixed - User')
     'unable to fix' = loc('No further action')
     'not responsible' = loc('Not Responsible')
     'duplicate' = loc('Duplicate')

--- a/templates/web/bromley/report/update-form.html
+++ b/templates/web/bromley/report/update-form.html
@@ -46,16 +46,8 @@
             </div>
 
             [% IF c.user && c.user.belongs_to_body( problem.bodies_str ) %]
-                <label for="form_state">[% loc( 'State' ) %]</label>
-                <select name="state" id="form_state" class="form-control">
-                    [% FOREACH state IN [ ['confirmed', loc('Open')], ['investigating',
-                    loc('Investigating')], ['action scheduled', loc('Action Scheduled')],
-                    ['in progress', loc('In Progress')], ['duplicate', loc('Duplicate')],
-                    ['unable to fix', loc('No further action')], ['not responsible', loc('Not Responsible')],
-                    ['fixed', loc('Fixed')] ] %]
-                    <option [% 'selected ' IF state.0 == problem.state_display %] value="[% state.0 %]">[% state.1 %]</option>
-                [% END %]
-                </select>
+                <label for="state">[% loc( 'State' ) %]</label>
+                [% INCLUDE 'report/inspect/state_groups_select.html' %]
             [% ELSE %]
                 [% IF problem.is_fixed AND c.user_exists AND c.user.id == problem.user_id %]
 


### PR DESCRIPTION
The Bromley update form needed to be updated to use the new <select> template.
This also fixes a situation where staff users (on all cobrands) wouldn't be able
to leave updates on problems with state 'fixed - user'.