### PR TITLE
[Borsetshire] Fix incorrect map page header height

### DIFF
--- a/web/cobrands/borsetshire/_council-header.scss
+++ b/web/cobrands/borsetshire/_council-header.scss
@@ -9,9 +9,9 @@
 .site-header__fake-nav {
     display: block;
     position: absolute;
-    top: 0;
+    top: 1em;
     right: 1em;
-    height: 48px;
+    height: $mappage-header-height - 2em;
     margin: 0 -1em;
     @include flex-container();
     @include flex-align(center);
@@ -59,7 +59,7 @@
     }
 
     #main-nav {
-        min-height: 5em;
+        min-height: $mappage-header-height;
     }
 
     #site-subheader,

--- a/web/cobrands/borsetshire/base.scss
+++ b/web/cobrands/borsetshire/base.scss
@@ -13,7 +13,9 @@
 }
 
 #site-header {
-    padding: 1em 0;
+    .container {
+        padding: 1em; // up from default `0 1em`
+    }
 }
 
 #site-subheader,


### PR DESCRIPTION
Borsetshire `#site-header` is a bit funky because it has an extra "fake" menu on desktop on all pages except `.mappage`.

Adding padding to `#site-header .container` is a much simpler way to vertically centre the logo and the fake menu on desktop, and the logo and mobile header controls on narrow screens, without _also_ messing up the `.mappage` header height calculations.

I also took the opportunity to replace a few magic numbers in the borsetshire `layout.scss` with numbers calculated from `$mappage-header-height`.