### PR TITLE
Allow $ENV overrides for hostname/port

### DIFF
--- a/perllib/Catalyst/Engine.pm
+++ b/perllib/Catalyst/Engine.pm
@@ -418,9 +418,9 @@ sub prepare_path {
 
     my $env = $ctx->request->env;
 
-    my $scheme    = $ctx->request->secure ? 'https' : 'http';
-    my $host      = $env->{HTTP_HOST} || $env->{SERVER_NAME};
-    my $port      = $env->{SERVER_PORT} || 80;
+    my $scheme    = $ENV{DEBUG_HTTP_SCHEME} || ( $ctx->request->secure ? 'https' : 'http' );
+    my $host      = $ENV{DEBUG_HTTP_HOST} || $env->{HTTP_HOST} || $env->{SERVER_NAME};
+    my $port      = $ENV{DEBUG_HTTP_PORT} || $env->{SERVER_PORT} || 80;
     my $base_path = $env->{SCRIPT_NAME} || "/";
 
     # set the request URI


### PR DESCRIPTION
Accessing the dev server via a service such as ngrok/vagrant share is made
difficult because some redirects (e.g. to /auth) and form POSTS (e.g. front
page) include the absolute URL including the BASE_URL hostname and port.
This commit allows 3 environment variables to be set which will be used in
absolute URL redirects.