### PR TITLE
fix imbalanced paragraph tags in glossary

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -532,7 +532,6 @@ technical information, see
     with an appropriate translation in a different language. This presupposes
     the text has been translated &mdash; the alternative translations are 
     storied in <code>.po</code> files.
-    </p>
     <div class="more-info">
       <p>More information:</p>
       <ul>
@@ -933,6 +932,7 @@ technical information, see
       example, with caching disabled, and debugging switched off. Make sure you set
       <code><a href="{{site.baseurl}}customising/config/#staging_site">STAGING_SITE</a></code>
       to <code>0</code>.
+    </p>
     <p>
       If you have a staging server, the system environment of your staging and
       production servers should be identical.


### PR DESCRIPTION
Spotted a rude `</dl>` showing up at the end of [the glossary](http://fixmystreet.org/glossary/) (and there was a `</p>` higher up too, which turned out to be the real culprit) — I believe* this fixes it.

![fms-glossary-fail](https://user-images.githubusercontent.com/111320/27679243-ff32d094-5caf-11e7-9b3d-02d782a754d3.png)

 * Locally, Jekyll rendered the offending page cleanly, so I didn't manage to reproduce the error locally before modifying the markdown.