### PR TITLE
Add scripts to rule them all.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,6 @@ install:
   - .travis/install
 before_script:
   - commonlib/bin/gettext-makemo FixMyStreet
-script: "bin/run-tests --jobs 3 t"
+script: "script/test --jobs 3 t"
 after_success:
   - .travis/after_script

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+cd "$(dirname "$0")/.."
+
+git submodule --quiet update --init --recursive --rebase
+bin/install_perl_modules

--- a/script/console
+++ b/script/console
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
+
+eval `"$DIR"/setenv.pl`

--- a/script/server
+++ b/script/server
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+cd "$(dirname "$0")/.."
+
+script/fixmystreet_app_server.pl $@

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+cd "$(dirname "$0")/.."
+
+# Same as update for now
+script/update

--- a/script/test
+++ b/script/test
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+cd "$(dirname "$0")/.."
+
+bin/run-tests $@

--- a/script/update
+++ b/script/update
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+cd "$(dirname "$0")/.."
+
+script/bootstrap
+bin/update-schema --commit
+bin/make_css
+commonlib/bin/gettext-makemo


### PR DESCRIPTION
This adds the following scripts that do the following:

`bootstrap`: updates submodules, installs Perl modules.
`console`: Turns on virtualenv (this needs to be run as `. script/console`)
`server`: Starts app server.
`setup`: Runs `update`.
`test`: Runs test suite.
`update`: Runs `bootstrap`, updates DB schema, compiles CSS, compiles `.mo` files.