### PR TITLE
[Oxfordshire] Separate defect creation from state.

### DIFF
--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -72,6 +72,17 @@
             <label for="state">[% loc('State') %]</label>
             [% INCLUDE 'report/inspect/state_groups_select.html' %]
           </p>
+        [% IF permissions.report_instruct AND NOT problem.get_extra_metadata('inspected') %]
+          <div id="js-inspect-action-scheduled" class="[% "hidden" UNLESS problem.state == 'action scheduled' %]">
+            <p>[% loc('Do you want to automatically raise a defect?') %]</p>
+            <p class="segmented-control segmented-control--radio">
+                <input type="radio" name="raise_defect" id="raise_defect_yes" value="1">
+                <label class="btn" for="raise_defect_yes">[% loc('Yes') %]</label>
+                <input type="radio" name="raise_defect" id="raise_defect_no" value="0">
+                <label class="btn" for="raise_defect_no">[% loc('No') %]</label>
+            </p>
+          </div>
+        [% END %]
           <div id="js-duplicate-reports" class="[% "hidden" UNLESS problem.duplicate_of %]">
             <input type="hidden" name="duplicate_of" value="[% problem.duplicate_of.id %]">
             <p class="[% "hidden" UNLESS problem.duplicate_of %]"><strong>[% loc('Duplicate of') %]</strong></p>

--- a/templates/web/oxfordshire/report/inspect/state_groups_select.html
+++ b/templates/web/oxfordshire/report/inspect/state_groups_select.html
@@ -2,13 +2,10 @@
 
 SET state_groups = [
     [ loc('New'), [ 'confirmed', 'investigating' ] ],
+    [ loc('Scheduled'), [ 'action scheduled' ] ],
     [ loc('Fixed'), [ 'fixed - council' ] ],
     [ loc('Closed'), [ 'not responsible', 'duplicate', 'unable to fix' ] ]
 ];
-
-IF c.user_exists AND c.user.has_body_permission_to('report_instruct');
-    CALL state_groups.splice(1, 0, [ [ loc('Scheduled'), [ 'action scheduled' ] ] ]);
-END
 
 %]
 [% DEFAULT current_state = problem.state %]

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -80,6 +80,18 @@ $.extend(fixmystreet.set_up, {
       $("#js-change-duplicate-report").click(refresh_duplicate_list);
   },
 
+  action_scheduled_raise_defect: function() {
+    $("#report_inspect_form").find('[name=state]').on('change', function() {
+        if ($(this).val() !== "action scheduled") {
+            $("#js-inspect-action-scheduled").addClass("hidden");
+            $('#raise_defect_yes').prop('required', false);
+        } else {
+            $("#js-inspect-action-scheduled").removeClass("hidden");
+            $('#raise_defect_yes').prop('required', true);
+        }
+    });
+  },
+
   list_item_actions: function() {
     $('.item-list--reports').on('click', ':submit', function(e) {
       e.preventDefault();

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2253,7 +2253,7 @@ table.nicetable {
 .segmented-control--radio {
   input {
     position: absolute;
-    left: -999px;
+    opacity: 0;
   }
 
   input:checked + label {


### PR DESCRIPTION
Revert the behaviour from 36baff2d, so that everyone can use the 'action scheduled' state, and instead if someone with report_instruct permission has the state set to 'action scheduled', add an extra mandatory question asking whether they want to raise a defect or not.
