### PR TITLE
Allow static home page template override.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -110,7 +110,7 @@ requires 'Algorithm::Diff';
 # Modules used by CSS & watcher
 requires 'CSS::Sass';
 requires 'File::ChangeNotify';
-requires 'Path::Tiny';
+requires 'Path::Tiny', '0.104';
 requires 'File::Find::Rule';
 
 # Modules used by the test suite

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -4581,28 +4581,30 @@ DISTRIBUTIONS
       overload 0
       strict 0
       warnings 0
-  Path-Tiny-0.028
-    pathname: D/DA/DAGOLDEN/Path-Tiny-0.028.tar.gz
+  Path-Tiny-0.104
+    pathname: D/DA/DAGOLDEN/Path-Tiny-0.104.tar.gz
     provides:
-      Path::Tiny 0.028
+      Path::Tiny 0.104
+      Path::Tiny::Error 0.104
     requirements:
       Carp 0
       Cwd 0
       Digest 1.03
       Digest::SHA 5.45
       Exporter 5.57
-      ExtUtils::MakeMaker 6.30
+      ExtUtils::MakeMaker 6.17
       Fcntl 0
       File::Copy 0
+      File::Glob 0
       File::Path 2.07
-      File::Spec 3.40
-      File::Temp 0.18
+      File::Spec 0.86
+      File::Temp 0.19
       File::stat 0
-      autodie::exception 2.14
       constant 0
+      if 0
       overload 0
+      perl 5.008001
       strict 0
-      threads 0
       warnings 0
   PathTools-3.40
     pathname: S/SM/SMUELLER/PathTools-3.40.tar.gz

--- a/perllib/FixMyStreet/App.pm
+++ b/perllib/FixMyStreet/App.pm
@@ -200,6 +200,10 @@ sub setup_request {
 
     $c->stash->{site_name} = Utils::trim_text($c->render_fragment('site-name.html'));
 
+    if (my $template = $c->forward('/about/find_template', [ 'homepage' ])) {
+        $c->stash->{homepage_template} = $template;
+    }
+
     $c->model('DB::Problem')->set_restriction( $cobrand->site_key() );
 
     Memcached::set_namespace( FixMyStreet->config('FMS_DB_NAME') . ":" );

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -28,14 +28,11 @@ Redirect to homepage unless C<id> parameter in query, in which case redirect to
 sub index : Path('') : Args(0) {
     my ( $self, $c ) = @_;
 
-    my $id = $c->get_param('id');
-
-    my $uri =
-        $id
-      ? $c->uri_for( '/report', $id )
-      : $c->uri_for('/');
-
-    $c->res->redirect($uri);
+    if ($c->stash->{homepage_template}) {
+        $c->stash->{template} = 'index.html';
+    } else {
+        $c->res->redirect('/');
+    }
 }
 
 =head2 report_display

--- a/perllib/FixMyStreet/App/Controller/Root.pm
+++ b/perllib/FixMyStreet/App/Controller/Root.pm
@@ -58,6 +58,11 @@ sub index : Path : Args(0) {
         return;
     }
 
+    if ($c->stash->{homepage_template}) {
+        $c->stash->{template} = $c->stash->{homepage_template};
+        $c->detach;
+    }
+
     $c->forward('/auth/get_csrf_token');
 }
 

--- a/t/app/controller/about.t
+++ b/t/app/controller/about.t
@@ -1,3 +1,9 @@
+package FixMyStreet::Cobrand::Tester;
+use parent 'FixMyStreet::Cobrand::Default';
+sub path_to_web_templates { [ FixMyStreet->path_to( 't', 'app', 'controller', 'templates') ] }
+
+package main;
+
 use FixMyStreet::TestMech;
 
 ok( my $mech = FixMyStreet::TestMech->new, 'Created mech object' );
@@ -23,6 +29,24 @@ FixMyStreet::override_config {
     $mech->get_ok('/faq');
     $mech->content_like(qr{Ofte spurte spørsmål ::});
     $mech->content_contains('html class="no-js" lang="nb"');
+};
+
+$mech->get_ok('/');
+$mech->content_contains('Report a problem');
+$mech->content_lacks('STATIC FRONT PAGE');
+$mech->get('/report');
+is $mech->res->code, 200, "got 200";
+is $mech->res->previous->code, 302, "got 302 for redirect";
+is $mech->uri->path, '/', 'redirected to front page';
+
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => [ 'tester' ],
+}, sub {
+    $mech->get_ok('/');
+    $mech->content_contains('STATIC FRONT PAGE');
+    $mech->get_ok('/report');
+    is $mech->res->previous, undef, 'No redirect';
+    $mech->content_contains('Report a problem');
 };
 
 done_testing();

--- a/t/app/controller/report_display.t
+++ b/t/app/controller/report_display.t
@@ -35,11 +35,6 @@ subtest "check that no id redirects to homepage" => sub {
     is $mech->uri->path, '/', "at home page";
 };
 
-subtest "test id=NNN redirects to /NNN" => sub {
-    $mech->get_ok("/report?id=$report_id");
-    is $mech->uri->path, "/report/$report_id", "at /report/$report_id";
-};
-
 subtest "test bad council email clients web links" => sub {
     $mech->get_ok("/report/3D$report_id");
     is $mech->uri->path, "/report/$report_id", "at /report/$report_id";

--- a/t/app/controller/templates/about/homepage.html
+++ b/t/app/controller/templates/about/homepage.html
@@ -1,0 +1,3 @@
+<p>
+    THIS IS A STATIC FRONT PAGE.
+</p>

--- a/templates/web/base/main_nav_items.html
+++ b/templates/web/base/main_nav_items.html
@@ -1,4 +1,4 @@
-[%~ INCLUDE navitem uri='/' label=loc('Report a problem') attrs='class="report-a-problem-btn"' ~%]
+[%~ INCLUDE navitem uri=(homepage_template ? '/report' : '/') label=loc('Report a problem') attrs='class="report-a-problem-btn"' ~%]
 
 [%~ IF c.user_exists ~%]
     [%~ INCLUDE navitem uri='/my' label=loc('Your account') ~%]


### PR DESCRIPTION
If you have a templates/web/COBRAND/about/homepage.html file, then that page will be used as the front page of your site, and the normal front page will instead be available at `/report`. Fixes #1745 

- [x] Tests