### PR TITLE
Form on FMS Pro page for requesting access to demo

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Contact.pm
+++ b/perllib/FixMyStreet/App/Controller/Contact.pm
@@ -54,7 +54,8 @@ sub submit : Path('submit') : Args(0) {
           && $c->forward('determine_contact_type')
           && $c->forward('validate')
           && $c->forward('prepare_params_for_email')
-          && $c->forward('send_email');
+          && $c->forward('send_email')
+          && $c->forward('redirect_on_success');
 }
 
 =head2 determine_contact_type
@@ -99,7 +100,7 @@ sub determine_contact_type : Private {
 
 =head2 validate
 
-Validate the form submission parameters. Sets error messages and redirect 
+Validate the form submission parameters. Sets error messages and redirect
 to index page if errors.
 
 =cut
@@ -258,6 +259,23 @@ sub send_email : Private {
     }
 
     $c->stash->{success} = $c->send_email('contact.txt', $params);
+
+    return 1;
+}
+
+=head2 redirect_on_success
+
+Redirect to a custom URL if one was provided
+
+=cut
+
+sub redirect_on_success : Private {
+    my ( $self, $c ) = @_;
+
+    if (my $success_url = $c->get_param('success_url')) {
+        $c->res->redirect($success_url);
+        $c->detach;
+    }
 
     return 1;
 }

--- a/t/app/controller/contact.t
+++ b/t/app/controller/contact.t
@@ -380,6 +380,41 @@ for my $test (
     };
 }
 
+for my $test (
+    {
+        fields => {
+            em          => 'test@example.com',
+            name        => 'A name',
+            subject     => 'A subject',
+            message     => 'A message',
+            dest        => 'from_council',
+            success_url => '/faq',
+        },
+        url_should_be => 'http://localhost/faq',
+    },
+    {
+        fields => {
+            em          => 'test@example.com',
+            name        => 'A name',
+            subject     => 'A subject',
+            message     => 'A message',
+            dest        => 'from_council',
+            success_url => 'http://www.example.com',
+        },
+        url_should_be => 'http://www.example.com',
+    },
+  )
+{
+    subtest 'check user can be redirected to a custom URL after contact form is submitted' => sub {
+        FixMyStreet::override_config {
+            ALLOWED_COBRANDS => [ 'fixmystreet' ],
+        }, sub {
+            $mech->post('/contact/submit', $test->{fields});
+            is $mech->uri->as_string, $test->{url_should_be};
+        }
+    };
+}
+
 $problem_main->delete;
 
 done_testing();

--- a/templates/web/fixmystreet.com/about/council.html
+++ b/templates/web/fixmystreet.com/about/council.html
@@ -25,7 +25,7 @@
     </div>
     <div class="councils-hero__demo-access">
       <h2>Try FixMyStreet Professional right now, on our demo site</h2>
-      <form class="councils-hero__demo-access__form js-fms-pro-demo-form">
+      <form action="/contact/submit" method="post" class="councils-hero__demo-access__form js-fms-pro-demo-form">
         <div class="form-group">
           <label for="demo-name">Name</label>
           <span class="required">required</span>
@@ -43,9 +43,15 @@
         </div>
         <div class="form-group">
           <label for="demo-job">Job title</label>
-          <input type="text" name="job" id="demo-job">
+          <input type="text" name="extra.job_title" id="demo-job">
         </div>
         <div class="form-group submit-group">
+          <input type="hidden" name="extra.referer" value="[% c.req.headers.referer | html %]">
+          <input type="hidden" name="subject" value="Demo site request">
+          <input type="hidden" name="message" value="This visitor was sent a link to demo.fixmystreet.com">
+          <input type="hidden" name="recipient" value="enquiries">
+          <input type="hidden" name="dest" value="from_council">
+          <input type="hidden" name="success_url" value="https://demo.fixmystreet.com">
           <input type="submit" value="Let me in" class="btn">
         </div>
       </form>

--- a/templates/web/fixmystreet.com/about/council.html
+++ b/templates/web/fixmystreet.com/about/council.html
@@ -23,7 +23,33 @@
       <p class="councils-hero__subtitle__secondary">Residents, staff and contractors love FixMyStreet for its easy-use interfaces.
         If you’re the budget-holder, you’ll love its sensible pricing, too.</p>
     </div>
-
+    <div class="councils-hero__demo-access">
+      <h2>Try FixMyStreet Professional right now, on our demo site</h2>
+      <form class="councils-hero__demo-access__form js-fms-pro-demo-form">
+        <div class="form-group">
+          <label for="demo-name">Name</label>
+          <span class="required">required</span>
+          <input type="text" name="name" id="demo-name" required>
+        </div>
+        <div class="form-group">
+          <label for="demo-email">Contact email</label>
+          <span class="required">required</span>
+          <input type="email" name="em" id="demo-email" required>
+          <p class="form-note">Ending in .gov.uk</p>
+        </div>
+        <div class="form-group">
+          <label for="demo-phone">Contact phone number</label>
+          <input type="text" name="extra.phone" id="demo-phone">
+        </div>
+        <div class="form-group">
+          <label for="demo-job">Job title</label>
+          <input type="text" name="job" id="demo-job">
+        </div>
+        <div class="form-group submit-group">
+          <input type="submit" value="Let me in" class="btn">
+        </div>
+      </form>
+    </form>
   </div>
   <div class="councils-sales councils-sales--benefits">
     <div class="councils-content-wrapper">

--- a/web/cobrands/fixmystreet.com/fmsforcouncils.scss
+++ b/web/cobrands/fixmystreet.com/fmsforcouncils.scss
@@ -142,8 +142,71 @@ $fms-pink: #E65376;
     color: #777;
   }
 
+  .councils-hero__demo-access {
+    background-color: $fms-pink;
+    border-radius: 3px;
+    color: #fff;
+    padding: 2em;
+    margin: 4em auto -4em auto;
+    max-width: 26em;
+    position: relative;
+    z-index: 1;
+
+    @media (min-width: 44em) {
+      padding: 3em;
+    }
+
+    h2 {
+      text-align: center;
+      margin: 0 0 1em 0;
+    }
+
+    .form-group {
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    label {
+      font-weight: normal;
+    }
+
+    // Avoid border collapse jump on jQuery.slideDown()
+    .form-group:first-child label {
+      margin-top: 0;
+    }
+
+    input[type="text"],
+    input[type="email"] {
+      border: 1px solid desaturate(darken($fms-pink, 10%), 20%);
+      width: 100%;
+      padding: 0.5em;
+      border-radius: 3px;
+      font-size: 1em;
+      box-sizing: border-box;
+    }
+
+    .btn {
+      display: block;
+      margin: 0 auto;
+      background-image: none;
+      background-color: desaturate(darken($fms-pink, 10%), 20%);
+      border: none;
+
+      &:hover,
+      &:active,
+      &:focus {
+        background-color: desaturate(darken($fms-pink, 20%), 20%);
+      }
+    }
+
+    .required,
+    .form-note {
+      color: mix($fms-pink, #fff, 30%);
+    }
+  }
+
   .councils-sales {
-    padding: 3em 0 5em;
+    padding: 2em 0 5em;
     .councils-content-wrapper {
       max-width: 58em;
     }
@@ -188,7 +251,8 @@ $fms-pink: #E65376;
   .councils-sales--benefits {
     background-color: #F7F6F5;
     border-bottom: 1px solid #e9e9e9;
-    padding-top: 1em;
+    padding-top: 5em;
+
     h2 {
       font-size: 2.5em;
       text-align: center;

--- a/web/cobrands/fixmystreet.com/js.js
+++ b/web/cobrands/fixmystreet.com/js.js
@@ -65,4 +65,16 @@ $(function(){
             });
         }
     });
+
+    // Hide the demo access form behind a button, to save space on initial page load
+    $('.js-fms-pro-demo-form').each(function(){
+        var $form = $(this);
+        var $revealBtn = $('<button>').addClass('btn').text('Request access').on('click', function(){
+            $form.slideDown(250, function(){
+                $form.find('input[type="text"], input[type="text"]').eq(0).focus();
+            });
+            $(this).remove();
+        }).insertAfter($form);
+        $form.hide();
+    });
 });


### PR DESCRIPTION
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/857

* Form is shown by default.
* If JavaScript is available, form is hidden behind another button, to save space.
* Submitting the form sends contact details to the enquiries email address, and automatically forwards the user on to the Demo site.

![form](https://user-images.githubusercontent.com/739624/28322456-0b5e35ac-6bce-11e7-80ba-df3003280f4d.gif)
