### PR TITLE
[DOCS] Expanded documentation for multi language support.

### DIFF
--- a/customising/boundaries.md
+++ b/customising/boundaries.md
@@ -244,7 +244,7 @@ It's possible that the admin boundaries of local government in your area are
 already available in the OpenStreetMap project. If this is the case,
 FixMyStreet can automatically use them. **This is the easiest solution if the
 data you need is there** because we already run two servers 
-([UK MapIt](http://mapit.mysociety.org) and 
+([UK MapIt](https://mapit.mysociety.org) and 
 [global MapIt](http://global.mapit.mysociety.org))
 that make this data available.
 
@@ -261,7 +261,7 @@ Use this type of boundary if:
       Start by finding the <a href="{{ "/glossary/#latlong" | relative_url }}"
       class="glossary__link">lat-long</a> of some of the places you want to cover,
       and look them up on <a href="http://global.mapit.mysociety.org">global
-      MapIt</a> (or maybe the <a href="http://mapit.mysociety.org">UK one</a>).
+      MapIt</a> (or maybe the <a href="https://mapit.mysociety.org">UK one</a>).
       If you see the "Areas covering this point" include the admin
       boundaries you need, you're good to go! For example, here's
       the <a
@@ -329,7 +329,7 @@ Use this type of boundary if:
   <dd>
     <p>
       We run two public MapIt services: <a
-      href="http://mapit.mysociety.org">mapit.mysociety.org</a> covers the UK
+      href="https://mapit.mysociety.org">mapit.mysociety.org</a> covers the UK
       (because that's where we're based, and it serves our own 
       <a href="www.fixmystreet.com">UK FixMySteet</a> site), and 
       <a href="http://global.mapit.mysociety.org">global.mapit.mysociety.org</a>,
@@ -360,7 +360,7 @@ Use this type of boundary if:
     <p>
       Find the areas you need by looking on the
       <a href="http://global.mapit.mysociety.org">global MapIt website</a> or the
-      <a href="http://mapit.mysociety.org">UK one</a>. You must also nominate
+      <a href="https://mapit.mysociety.org">UK one</a>. You must also nominate
       the types of area these are (effectively the <em>level</em> of admin
       boundary it is), and the generation. On global, the area types look
       something like <code>[ 'O05', 'O06' ]</code>. (Note those contain capital

--- a/customising/config.md
+++ b/customising/config.md
@@ -446,7 +446,7 @@ LANGUAGES:
         <li>
           In the UK, you probably want, to cover all councils:
           <p><code>
-            MAPIT_URL: 'http://mapit.mysociety.org/'<br>
+            MAPIT_URL: 'https://mapit.mysociety.org/'<br>
             MAPIT_TYPES: [ 'DIS', 'LBO', 'MTD', 'UTA', 'CTY', 'COI', 'LGD' ]
           </code></p>
           <p>

--- a/customising/language/index.md
+++ b/customising/language/index.md
@@ -77,6 +77,35 @@ site. For example, a basic two language switcher:
         <li><a href="https://fr.[% c.cobrand.base_host %][% c.req.uri.path_query %]">Français</a></li>
     [% END %]
 
+## Ensuring links in emails default to the right language
+
+With the default configuration links in emails will use the `BASE_URL`
+and hence clicking on them means the user will see the browser
+negotiated language. This behaviour can be changed using the
+`base_url_with_lang` function in your Cobrand module which is used
+when generating URLs for emails.
+
+A basic version of this that supports two languages would look like
+like this:
+
+    sub base_url_with_lang {
+        my $self = shift;
+        my $base = $self->base_url;
+        my $lang = $mySociety::Locale::lang;
+        if ($lang eq 'fr') {
+            $base =~ s{https?://}{$&fr.};
+        } else {
+            $base =~ s{https?://}{$&en.};
+        }
+        return $base;
+    }
+
+The current language is stored when a report is made and this is used
+when sending out emails related to the report. When the email is sent
+this means that `$mySociety::Local::lang` returns the language used at
+the time the report was submitted, hence the function above will return
+URLs for the correct language.
+
 ## Contributing a translation
 
 If we don't already have a translation for the language you want, please do

--- a/customising/language/index.md
+++ b/customising/language/index.md
@@ -47,6 +47,36 @@ upon the browser. If you have used the install script on a clean server, or the
 AMI, you should be able to visit your domain with a language code at the start
 by default.
 
+Using the example above `http://fr.fixmystreet.com/` would display the
+French translation and `http://de.fixmystreet.com/` would display the
+German translation. If no language is specified in the URL, or an
+unsupported code is used then it will fall back to the language
+negotiated by the browser. If that language is not available,
+the first language listed in the `LANGUAGES` configuration option
+will be displayed.
+
+Note that this method only supports two letter language codes. This
+means you cannot use `sv-se` format strings to distingish regional
+variants in the hostname. However, the first part of the language string
+does not need to be an official language code so you can use it to allow
+regional variants, e.g:
+
+    LANGUAGES:
+        - 'sv,Svenska,sv_SE'
+        - 'sf,Svenska,sv_FI'
+
+`http://sv.fixmystreet.com` would dsplay `sv_SE` and
+`http://sf.fixmystreet.com` would display `sv_FI`.
+
+These language links can be used for adding a language switcher to the
+site. For example, a basic two language switcher:
+
+    [% IF lang_code == 'fr' %]
+        <li><a href="https://en.[% c.cobrand.base_host %][% c.req.uri.path_query %]">English</a></li>
+    [% ELSE %]
+        <li><a href="https://fr.[% c.cobrand.base_host %][% c.req.uri.path_query %]">Français</a></li>
+    [% END %]
+
 ## Contributing a translation
 
 If we don't already have a translation for the language you want, please do

--- a/customising/language/index.md
+++ b/customising/language/index.md
@@ -89,3 +89,14 @@ The templates use the `loc` function to pass strings to gettext for
 translation. If you create or update a `.po` file, you will need to run the
 `commonlib/bin/gettext-makemo` script to compile these files into the machine
 readable format used by the site.
+
+## Translating the FAQ
+
+The FAQ pages do not use gettext so need to be translated separately by
+creating a new template under your co-brand, e.g for a German
+translation:
+
+  templates/web/<co-brand>/about/faq-de.html
+
+For other languages the file should be `faq-<lang>.html`. If there is
+not a translated template it will fall back to `faq.html`.

--- a/glossary.md
+++ b/glossary.md
@@ -760,7 +760,7 @@ technical information, see
           is the global MapIt service
         </li>
         <li>
-          <a href="http://mapit.mysociety.org/">mapit.mysociety.org</a> is the
+          <a href="https://mapit.mysociety.org/">mapit.mysociety.org</a> is the
           UK MapIt service
         </li>
         <li>

--- a/updating/ami.md
+++ b/updating/ami.md
@@ -45,6 +45,11 @@ to take a backup of your database first.
     fms@ip-10-58-191-98:~/fixmystreet$ bin/make_css
     fms@ip-10-58-191-98:~/fixmystreet$ commonlib/bin/gettext-makemo
 
+If you are updating to version 2.1 or greater then there is a single script
+that will run all the commands required for an update.
+
+    fms@ip-10-58-191-98:~/fixmystreet$ script/update
+
 If you have made changes to the schema yourself, this may not work,
 please feel free to [contact us](/community/) to discuss it first.
 

--- a/updating/ami.md
+++ b/updating/ami.md
@@ -42,7 +42,7 @@ to take a backup of your database first.
     fms@ip-10-58-191-98:~/fixmystreet$ git submodule update
     fms@ip-10-58-191-98:~/fixmystreet$ bin/install_perl_modules
     fms@ip-10-58-191-98:~/fixmystreet$ bin/update-schema --commit
-    fms@ip-10-58-191-98:~/fixmystreet$ bin/make-css
+    fms@ip-10-58-191-98:~/fixmystreet$ bin/make_css
     fms@ip-10-58-191-98:~/fixmystreet$ commonlib/bin/gettext-makemo
 
 If you have made changes to the schema yourself, this may not work,

--- a/updating/index.md
+++ b/updating/index.md
@@ -58,6 +58,13 @@ bin/make_css
 commonlib/bin/gettext-makemo
 {% endhighlight %}
 
+If you are updating to version 2.1 or greater then there is a single script
+that will run all the commands required for an update.
+
+{% highlight bash %}
+    script/update
+{% endhighlight %}
+
 Of course, if you have made changes to the database schema yourself, this may
 not work, please feel free to [contact us](/community/) to discuss it first.
 


### PR DESCRIPTION
Adds expanded documentation for using http://$lang.fixmystreet.com/ style URLs as well as basic details of adding a language switcher.

Also documents `base_url_with_lang` for adding language specific URLs to emails.

Fixes #1571.
Fixes #1619.