### PR TITLE
do not replace deleted text with [...] when moderating

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Moderate.pm
+++ b/perllib/FixMyStreet/App/Controller/Moderate.pm
@@ -146,7 +146,7 @@ sub report_moderate_title : Private {
 
     my $title = $c->get_param('problem_revert_title') ?
         $original_title
-        : $self->diff($original_title, $c->get_param('problem_title'));
+        : $c->get_param('problem_title');
 
     if ($title ne $old_title) {
         $original->insert unless $original->in_storage;
@@ -167,7 +167,7 @@ sub report_moderate_detail : Private {
     my $original_detail = $original->detail;
     my $detail = $c->get_param('problem_revert_detail') ?
         $original_detail
-        : $self->diff($original_detail, $c->get_param('problem_detail'));
+        : $c->get_param('problem_detail');
 
     if ($detail ne $old_detail) {
         $original->insert unless $original->in_storage;
@@ -285,7 +285,7 @@ sub update_moderate_detail : Private {
     my $original_detail = $original->detail;
     my $detail = $c->get_param('update_revert_detail') ?
         $original_detail
-        : $self->diff($original_detail, $c->get_param('update_detail'));
+        : $c->get_param('update_detail');
 
     if ($detail ne $old_detail) {
         $original->insert unless $original->in_storage;
@@ -339,29 +339,6 @@ sub return_text : Private {
     $c->res->content_type('text/plain; charset=utf-8');
     $c->res->body( $text // '' );
 }
-
-sub diff {
-    my ($self, $old, $new) = @_;
-
-    $new =~s/\[\.{3}\]//g;
-
-    my $diff = Algorithm::Diff->new( [ split //, $old ], [ split //, $new ] );
-    my $string;
-    while ($diff->Next) {
-        my $d = $diff->Diff;
-        if ($d & 1) {
-            my $deleted = join '', $diff->Items(1);
-            unless ($deleted =~/^\s*$/) {
-                $string .= ' ' if $deleted =~/^ /;
-                $string .= '[...]';
-                $string .= ' ' if $deleted =~/ $/;
-            }
-        }
-        $string .= join '', $diff->Items(2);
-    }
-    return $string;
-}
-
 
 __PACKAGE__->meta->make_immutable;
 

--- a/t/app/controller/moderate.t
+++ b/t/app/controller/moderate.t
@@ -96,8 +96,8 @@ subtest 'Problem moderation' => sub {
         $mech->content_like(qr/Moderated by Bromley Council/);
 
         $report->discard_changes;
-        is $report->title, 'Good [...] good';
-        is $report->detail, 'Good [...] good [...]improved';
+        is $report->title, 'Good good';
+        is $report->detail, 'Good good improved';
     };
 
     subtest 'Revert title and text' => sub {
@@ -191,8 +191,8 @@ subtest 'Problem 2' => sub {
     $mech->base_like( qr{\Q$REPORT2_URL\E} );
 
     $report2->discard_changes;
-    is $report2->title, 'Good [...] good';
-    is $report2->detail, 'Good [...] good [...]improved';
+    is $report2->title, 'Good good';
+    is $report2->detail, 'Good good improved';
 
     $mech->submit_form_ok({ with_fields => {
         %problem_prepopulated,
@@ -236,7 +236,7 @@ subtest 'updates' => sub {
         $mech->base_like( qr{\Q$REPORT_URL\E} );
 
         $update->discard_changes;
-        is $update->text, 'update good good [...] good',
+        is $update->text, 'update good good good',
     };
 
     subtest 'Revert text' => sub {
@@ -320,7 +320,7 @@ subtest 'Update 2' => sub {
     }}) or die $mech->content;
 
     $update2->discard_changes;
-    is $update2->text, 'update good good [...] good',
+    is $update2->text, 'update good good good',
 };
 
 subtest 'Now stop being a staff user' => sub {


### PR DESCRIPTION
Replacing deleted text with [...] when moderating reports and comments
leads to very odd looking reports when correcting minor typos so just
leave the text as deleted.

Fixes #1774