### PR TITLE
Make map image in HTML emails clickable

### DIFF
--- a/templates/email/default/_email_sidebar.html
+++ b/templates/email/default/_email_sidebar.html
@@ -1,6 +1,19 @@
-[% DEFAULT report = object ~%]
+[%
+
+# There are cases (eg: when sending email about an update on a problem)
+# where `object` might not be a report. So in those cases, you can pass
+# in a `report` argument, which should be the report the email is about.
+# Otherwise, we assume the `object` you passed is a report.
+DEFAULT report = object;
+
+# There are cases (eg: when confirming a not-yet-published report) where
+# you will want the map image to link to somewhere other than the report
+# page. So in those cases, you can pass in a custom `url` argument.
+DEFAULT url = cobrand.base_url_for_report(report) _ report.url
+
+~%]
 <th style="[% td_style %][% secondary_column_style %]" id="secondary_column">
-  <img style="[% map_image_style %]" src="[% inline_image(report.static_map, 'map.jpeg') %]" width="310" height="200" alt="">
+  <a href="[% url %]"><img style="[% map_image_style %]" src="[% inline_image(report.static_map, 'map.jpeg') %]" width="310" height="200" alt=""></a>
   [% start_padded_box %]
     [%~ IF object.photo %]
       <img style="[% preview_photo_style %]" src="[% inline_image(object.get_first_image_fp) %]" alt="" align="right">

--- a/templates/email/default/problem-confirm-not-sending.html
+++ b/templates/email/default/problem-confirm-not-sending.html
@@ -22,7 +22,7 @@ council.</p>
   <p style="[% p_style %]">If you no longer wish to publish this report, please take no further action.</p>
   [% end_padded_box %]
 </th>
-[% WRAPPER '_email_sidebar.html' object = report %]
+[% WRAPPER '_email_sidebar.html' object = report, url = token_url %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
     <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
 [% END %]

--- a/templates/email/default/problem-confirm.html
+++ b/templates/email/default/problem-confirm.html
@@ -25,7 +25,7 @@ of problem, so it will instead be sent to [% report.body %].
   <p style="[% p_style %]">If you no longer wish to send this report, please take no further action.</p>
   [% end_padded_box %]
 </th>
-[% WRAPPER '_email_sidebar.html' object = report %]
+[% WRAPPER '_email_sidebar.html' object = report, url = token_url %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
     <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
 [% END %]

--- a/templates/email/default/questionnaire.html
+++ b/templates/email/default/questionnaire.html
@@ -22,7 +22,7 @@ INCLUDE '_email_top.html';
   <p style="[% p_style %]">Thank you! Your feedback is really valuable.</p>
   [% end_padded_box %]
 </th>
-[% WRAPPER '_email_sidebar.html' object = report %]
+[% WRAPPER '_email_sidebar.html' object = report, url = url %]
     <h2 style="[% h2_style %]">[% title %]</h2>
     <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
 [% END %]

--- a/templates/email/fixamingata/problem-confirm-not-sending.html
+++ b/templates/email/fixamingata/problem-confirm-not-sending.html
@@ -22,7 +22,7 @@ skickas till kommunen.</p>
   <p style="[% p_style %]">Om du inte vill skicka din rapport så behöver du inte göra något.</p>
   [% end_padded_box %]
 </th>
-[% WRAPPER '_email_sidebar.html' object = report %]
+[% WRAPPER '_email_sidebar.html' object = report, url = token_url %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
     <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
 [% END %]

--- a/templates/email/fixamingata/problem-confirm.html
+++ b/templates/email/fixamingata/problem-confirm.html
@@ -21,7 +21,7 @@ måste du klicka på nedanstående knapp.</p>
   <p style="[% p_style %]">Om du inte vill skicka din rapport så behöver du inte göra något.</p>
   [% end_padded_box %]
 </th>
-[% WRAPPER '_email_sidebar.html' object = report %]
+[% WRAPPER '_email_sidebar.html' object = report, url = token_url %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
     <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
 [% END %]

--- a/templates/email/fixamingata/questionnaire.html
+++ b/templates/email/fixamingata/questionnaire.html
@@ -22,7 +22,7 @@ INCLUDE '_email_top.html';
   <p style="[% p_style %]">Tack! Din feedback är värdefull.</p>
   [% end_padded_box %]
 </th>
-[% WRAPPER '_email_sidebar.html' object = report %]
+[% WRAPPER '_email_sidebar.html' object = report, url = url %]
     <h2 style="[% h2_style %]">[% title %]</h2>
     <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
 [% END %]


### PR DESCRIPTION
Emails that contain a report’s title, description, and location in the ”sidebar” will now have a map that takes you to the report’s web page when clicked.

Fixes #1596. Thanks to @MyfanwyNixon for the suggestion!