### PR TITLE
[Oxfordshire] Open311 update, no open state switch

### DIFF
--- a/perllib/Open311/GetServiceRequestUpdates.pm
+++ b/perllib/Open311/GetServiceRequestUpdates.pm
@@ -143,6 +143,9 @@ sub update_comments {
                     # don't update state unless it's an allowed state and it's
                     # actually changing the state of the problem
                     if ( FixMyStreet::DB::Result::Problem->council_states()->{$state} && $p->state ne $state &&
+                        # For Oxfordshire, don't allow changes back to Open from other open states
+                        !( $body->areas->{$AREA_ID_OXFORDSHIRE} && $state eq 'confirmed' && $p->is_open ) &&
+                        # Don't let it change between the (same in the front end) fixed states
                         !( $p->is_fixed && FixMyStreet::DB::Result::Problem->fixed_states()->{$state} ) ) {
                         if ($p->is_visible) {
                             $p->state($state);


### PR DESCRIPTION
As we only get `open`/`closed` back from Oxfordshire, don't switch back to 'open' if we receive an open and we're already in an open state.