### PR TITLE
Always show pagination figures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Releases
 
 * Unreleased
+    - Front end improvements:
+        - Always show pagination figures even if only one page.
     - Bugfixes:
         - Set up action scheduled field when report loaded. #1789
         - Stop errors from JS validator due to form in form.

--- a/templates/web/base/pagination.html
+++ b/templates/web/base/pagination.html
@@ -1,4 +1,4 @@
-[% IF pager.last_page > 1 %]
+[% IF pager.total_entries > 1 %]
     <p class="pagination">
         [% IF pager.previous_page %]
             <a class="prev" href="[% c.uri_with({ $param => pager.previous_page, ajax => undefined }) %][% '#' _ hash IF hash %]">[% loc('Previous') %]</a>


### PR DESCRIPTION
Even if no next/previous page, the number of items can be useful.

Fixes https://github.com/mysociety/fixmystreetforcouncils/issues/202