### PR TITLE
Variety of brokenness to quickly fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     - Bugfixes:
         - Set up action scheduled field when report loaded. #1789
         - Stop errors from JS validator due to form in form.
+        - Stop update form toggle causing report submission.
 
 * v2.1.1 (3rd August 2017)
     - Email improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Unreleased
     - Bugfixes:
         - Set up action scheduled field when report loaded. #1789
+        - Stop errors from JS validator due to form in form.
 
 * v2.1.1 (3rd August 2017)
     - Email improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - Set up action scheduled field when report loaded. #1789
         - Stop errors from JS validator due to form in form.
         - Stop update form toggle causing report submission.
+        - Update map size if an extra column has appeared.
 
 * v2.1.1 (3rd August 2017)
     - Email improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Releases
 
 * Unreleased
+    - Bugfixes:
+        - Set up action scheduled field when report loaded. #1789
 
 * v2.1.1 (3rd August 2017)
     - Email improvements:

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -452,10 +452,10 @@ sub inspect : Private {
             if ($c->user->has_body_permission_to('planned_reports')) {
                 my $categories = join(',', @{ $c->user->categories });
                 my $params = {
-                    filter_category => $categories,
                     lat => $problem->latitude,
                     lon => $problem->longitude,
                 };
+                $params->{filter_category} = $categories if $categories;
                 $redirect_uri = $c->uri_for( "/around", $params );
             }
 

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -6,7 +6,7 @@
 
     [% INCLUDE 'errors.html' %]
 
-    <form id="report_inspect_form" method="post" action="[% c.uri_for( '/report', problem.id ) %]">
+    <form id="report_inspect_form" method="post" action="[% c.uri_for( '/report', problem.id ) %]" class="validate">
 
       <div class="inspect-section">
         <p>

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1053,7 +1053,7 @@ fixmystreet.display = {
             fixmystreet.page = 'report';
 
             fixmystreet.mobile_reporting.remove_ui();
-            if ($('html').hasClass('mobile') && fixmystreet.map.updateSize) {
+            if (fixmystreet.map.updateSize && ($twoColReport.length || $('html').hasClass('mobile'))) {
                 fixmystreet.map.updateSize();
             }
 

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1042,6 +1042,7 @@ fixmystreet.display = {
                 $('body').addClass('with-actions');
                 fixmystreet.run(fixmystreet.set_up.report_page_inspect);
                 fixmystreet.run(fixmystreet.set_up.manage_duplicates);
+                fixmystreet.run(fixmystreet.set_up.action_scheduled_raise_defect);
             } else {
                 $sideReport.appendTo('#map_sidebar');
             }

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -312,7 +312,8 @@ $.extend(fixmystreet.set_up, {
     $updateFormH2.hide().nextAll().hide();
     $updateFormBtn.addClass('btn btn--provide-update');
     $updateFormBtn.text( $updateFormH2.text() );
-    $updateFormBtn.on('click', function(){
+    $updateFormBtn.on('click', function(e) {
+        e.preventDefault();
         $updateFormH2.nextAll().toggle();
     });
   },


### PR DESCRIPTION
A variety of issues caused mostly when a report is pulled in via JavaScript (still?!):
* Action scheduled behaviour not correct. Fixes https://github.com/mysociety/fixmystreetforcouncils/issues/195
* Errors in console from JS validator
* Update form toggle broken
* Map size incorrect (so e.g. panTo centring not centre).