### PR TITLE
[WIP] Simplified email & RSS alert signup

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Alert.pm
+++ b/perllib/FixMyStreet/App/Controller/Alert.pm
@@ -464,8 +464,6 @@ sub setup_request : Private {
         $c->stash->{rznvy} ||= $c->user->email;
     }
 
-    $c->stash->{template} = 'alert/list-ajax.html' if $c->get_param('ajax');
-
     return 1;
 }
 

--- a/t/app/controller/alert.t
+++ b/t/app/controller/alert.t
@@ -7,8 +7,8 @@ use t::Mock::Nominatim;
 
 # check that we can get the page
 $mech->get_ok('/alert');
-$mech->title_like(qr/^Local RSS feeds and email alerts/);
-$mech->content_contains('Local RSS feeds and email alerts');
+$mech->title_like(qr/^Email alerts & RSS/);
+$mech->content_contains('Subscribe to email alerts for problems in the area you care about');
 $mech->content_contains('html class="no-js" lang="en-gb"');
 
 # check that we can get list page
@@ -18,25 +18,34 @@ FixMyStreet::override_config {
     GEOCODER => '',
 }, sub {
     $mech->get_ok('/alert/list');
-    $mech->title_like(qr/^Local RSS feeds and email alerts/);
-    $mech->content_contains('Local RSS feeds and email alerts');
+    $mech->title_like(qr/^Email alerts & RSS/);
+    # No postcode provided, so we get redirected back to /alert/index.html
+    $mech->content_contains('Subscribe to email alerts for problems in the area you care about');
     $mech->content_contains('html class="no-js" lang="en-gb"');
 
-    $mech->get_ok('/alert/list?pc=EH1 1BB');
-    $mech->title_like(qr/^Local RSS feeds and email alerts/);
-    $mech->content_contains('Here are the types of local problem alerts for &lsquo;EH1&nbsp;1BB&rsquo;');
+    $mech->get_ok('/alert/list?pc=EH1+1BB');
+    $mech->title_like(qr/^Email alerts & RSS/);
+    # Got a postcode this time, so we are asked for alert config options
+    $mech->content_contains('Which problems do you want alerts about?');
     $mech->content_contains('html class="no-js" lang="en-gb"');
-    $mech->content_contains('Problems within 10.0km');
-    $mech->content_contains('rss/pc/EH11BB/2');
-    $mech->content_contains('rss/pc/EH11BB/5');
-    $mech->content_contains('rss/pc/EH11BB/10');
-    $mech->content_contains('rss/pc/EH11BB/20');
+    $mech->content_like(qr/Problems within [0-9.]+km of EH1 1BB/);
     $mech->content_contains('Problems within Edinburgh City');
     $mech->content_contains('Problems within City Centre ward');
-    $mech->content_contains('/rss/reports/Edinburgh');
-    $mech->content_contains('/rss/reports/Edinburgh/City+Centre');
     $mech->content_contains('council:2651:Edinburgh');
     $mech->content_contains('ward:2651:20728:Edinburgh:City_Centre');
+    $mech->content_contains('And where should your alerts be delivered?');
+    $mech->content_contains('Subscribe by email');
+
+    $mech->get_ok('/alert/list?pc=EH1+1BB&delivery=rss');
+    $mech->title_like(qr/^Email alerts & RSS/);
+    $mech->content_contains('Which problems do you want alerts about?');
+    $mech->content_like(qr/Problems within [0-9.]+km of EH1 1BB/);
+    $mech->content_contains('Problems within Edinburgh City');
+    $mech->content_contains('Problems within City Centre ward');
+    # Asked for RSS feeds this time!
+    $mech->content_lacks('And where should your alerts be delivered?');
+    $mech->content_contains('Grab your RSS feed');
+    $mech->content_contains('js-alerts-rss-live-preview');
 
     subtest "Test Nominatim lookup" => sub {
         LWP::Protocol::PSGI->register(t::Mock::Nominatim->run_if_script, host => 'nominatim.openstreetmap.org');
@@ -45,31 +54,40 @@ FixMyStreet::override_config {
     };
 
     $mech->get_ok('/alert/list?pc=');
-    $mech->content_contains('To find out what local alerts we have for you');
+    $mech->title_like(qr/^Email alerts & RSS/);
+    $mech->content_contains('Subscribe to email alerts for problems in the area you care about');
 
     $mech->get_ok('/alert/list?pc=GL502PR');
+    $mech->content_contains('Reports near GL50 2PR are sent to different councils');
     $mech->content_contains('Problems within the boundary of');
+    $mech->content_contains('area:2326:Cheltenham');
+    $mech->content_contains('area:2226:Gloucestershire');
+    $mech->content_contains('Or problems reported to');
+    $mech->content_contains('council:2326:Cheltenham');
+    $mech->content_contains('council:2226:Gloucestershire');
+    $mech->content_contains('And where should your alerts be delivered?');
+    $mech->content_contains('Subscribe by email');
 
-    $mech->get_ok('/alert/subscribe?rss=1&type=local&pc=ky16+8yg&rss=Give+me+an+RSS+feed&rznvy=' );
+    $mech->get_ok('/alert/subscribe?type=local&pc=ky16+8yg&rss=Give+me+an+RSS+feed&rznvy=' );
     $mech->content_contains('Please select the feed you want');
 
-    $mech->get_ok('/alert/subscribe?rss=1&feed=invalid:1000:A_Locationtype=local&pc=ky16+8yg&rss=Give+me+an+RSS+feed&rznvy=');
+    $mech->get_ok('/alert/subscribe?feed=invalid:1000:A_Location&type=local&pc=ky16+8yg&rss=Give+me+an+RSS+feed&rznvy=');
     $mech->content_contains('Illegal feed selection');
 
     $mech->create_body_ok(2504, 'Birmingham City Council');
     $mech->create_body_ok(2226, 'Gloucestershire County Council');
     $mech->create_body_ok(2326, 'Cheltenham Borough Council');
 
-    $mech->get_ok('/alert/subscribe?rss=1&feed=area:1000:Birmingham');
+    $mech->get_ok('/alert/subscribe?rss=Give+me+an+RSS+feed&feed=area:1000:Birmingham');
     is $mech->uri->path, '/rss/reports/Birmingham';
 
-    $mech->get_ok('/alert/subscribe?rss=1&feed=area:1000:1001:Cheltenham:Lansdown');
+    $mech->get_ok('/alert/subscribe?rss=Give+me+an+RSS+feed&feed=area:1000:1001:Cheltenham:Lansdown');
     is $mech->uri->path, '/rss/area/Cheltenham/Lansdown';
 
-    $mech->get_ok('/alert/subscribe?rss=1&feed=council:1000:Gloucestershire');
+    $mech->get_ok('/alert/subscribe?rss=Give+me+an+RSS+feed&feed=council:1000:Gloucestershire');
     is $mech->uri->path, '/rss/reports/Gloucestershire';
 
-    $mech->get_ok('/alert/subscribe?rss=1&feed=ward:1000:1001:Cheltenham:Lansdown');
+    $mech->get_ok('/alert/subscribe?rss=Give+me+an+RSS+feed&feed=ward:1000:1001:Cheltenham:Lansdown');
     is $mech->uri->path, '/rss/reports/Cheltenham/Lansdown';
 };
 

--- a/t/app/controller/alert_new.t
+++ b/t/app/controller/alert_new.t
@@ -311,7 +311,7 @@ subtest "Test two-tier council alerts" => sub {
             ALLOWED_COBRANDS => [ { 'fixmystreet' => '.' } ],
             MAPIT_URL => 'http://mapit.uk/',
         }, sub {
-            $mech->get_ok( '/alert/list?pc=GL502PR' );
+            $mech->get_ok( '/alert/list?pc=GL502PR&delivery=rss' );
             $mech->submit_form_ok( {
                 button => 'rss',
                 with_fields => {

--- a/templates/web/base/alert/_list.html
+++ b/templates/web/base/alert/_list.html
@@ -3,92 +3,63 @@
   <input type="hidden" name="pc" value="[% pc | html %]">
   <input type="hidden" name="latitude" value="[% latitude | html %]">
   <input type="hidden" name="longitude" value="[% longitude | html %]">
+  <input type="hidden" name="delivery" value="[% delivery | html %]">
 
-  <p>
-  [% IF pretty_pc %]
-    [% tprintf( loc('Here are the types of local problem alerts for &lsquo;%s&rsquo;.'), pretty_pc ) %]
-  [% END %]
-  [% loc('Select which type of alert you’d like and click the button for an RSS feed, or enter your email address to subscribe to an email alert.') %]
+[% INCLUDE 'errors.html' %]
+
+  <h2>[% loc('Which problems do you want alerts about?') %]</h2>
+
+[% SET name_of_location = pretty_pc || loc('this location') %]
+
+[% IF reported_to_options %]
+  <div class="alerts-two-tier-explanation">
+      <p>
+          [% tprintf(loc('Reports near %s are sent to different councils,
+          depending on the type of problem.'), name_of_location) %]
+      </p>
+      <p>
+          [% loc('You can choose to subscribe to all problems reported in an
+          area, or reports based on their destination.') %]
+      </p>
+  </div>
+[% END %]
+
+  <p class="multiple-choice">
+      <input type="radio" name="feed" id="[% rss_feed_id %]" value="[% rss_feed_id %]"[% IF rss_feed_id == selected_feed || selected_feed == '' %] checked[% END %]>
+      <label class="inline" for="[% rss_feed_id %]">[% tprintf( loc('Problems within %dkm of %s'), population_radius, name_of_location ) %]</label>
   </p>
 
-  [% INCLUDE 'errors.html' %]
+[% IF reported_to_options %]
+  <h3>[% loc('Problems within the boundary of:') %]</h3>
+[% END %]
 
-  <p>
-  [% loc('The simplest alert is our geographic one:') %]
+[% FOREACH option IN options %]
+  <p class="multiple-choice">
+      <input type="radio" name="feed" id="[% option.id %]" value="[% option.id %]"[% IF option.id == selected_feed %] checked[% END %]>
+      <label class="inline" for="[% option.id %]">[% option.text %]</label>
   </p>
+[% END %]
 
-  <p id="rss_local">
-    <input type="radio" name="feed" id="[% rss_feed_id %]" value="[% rss_feed_id %]"[% IF rss_feed_id == selected_feed || selected_feed == '' %] checked[% END %]>
-    <label class="inline" for="[% rss_feed_id %]">[% tprintf( loc('Problems within %.1fkm of this location'), population_radius ) %]</label>
-    <a href="[% rss_feed_uri %]"><img src='/i/feed.png' width='16' height='16' title='[% loc('RSS feed of nearby problems') %]' alt='[% loc('RSS feed') %]' border='0'></a>
-    <br />
-    [% loc('(a default distance which covers roughly 200,000 people)') %]
+[% IF reported_to_options %]
+  <h3>[% loc('Or problems reported to:') %]</h3>
+[% FOREACH option IN reported_to_options %]
+  <p class="multiple-choice">
+      <input type="radio" name="feed" id="[% option.id %]" value="[% option.id %]"[% IF option.id == selected_feed %] checked[% END %]>
+      <label class="inline" for="[% option.id %]">[% option.text %]</label>
   </p>
+[% END %]
+[% END %]
 
-  <p id="rss_local_alt">
-  [% SET distance_options = '<a href="' _ rss_feed_2k _ ' ">2km</a> / <a href="' _ rss_feed_5k _ ' ">5km</a> / <a href="' _ rss_feed_10k _ '">10km</a> / <a href="' _ rss_feed_20k _ '">20km</a>' %]
-  [% tprintf(loc('(alternatively the RSS feed can be customised, within %s)', "%s is a list of distance links, e.g. [2km] / [5km] / [10km] / [20km]"), distance_options) %]
-  </p>
-
-  <p>
-  [% IF c.cobrand.is_council %]
-  Or you can subscribe to an alert for all council problems or one based upon what ward you&rsquo;re in:
-  [% ELSE %]
-  [% loc("Or you can subscribe to an alert based upon what ward or council you&rsquo;re in:") %]
-  [% END %]
-  </p>
-
-    [% IF reported_to_options %]
-        <p><strong>
-          [% loc('Problems within the boundary of:') %]
-        </strong></p>
-        <ul class="plain-list">
-    [% ELSE %]
-      <ul id="rss_feed" class="plain-list">
-    [% END %]
-
-  [% FOREACH option IN options %]
-  <li[% IF ! (loop.count % 2) %] class="a"[% END %]>
-    <input type="radio" name="feed" id="[% option.id %]" value="[% option.id %]"[% IF option.id == selected_feed %] checked[% END %]>
-    <a href="[% option.uri %]"><img src="/i/feed.png" width="16" height="16"
-title="[% option.rss_text %]" alt="RSS feed" border="0"></a>
-    <label class="inline" for="[% option.id %]">[% option.text %]</label>
-  </li>
-  [% END %]
-</ul>
-    [% IF reported_to_options %]
-        <p><strong>
-          [% loc('Or problems reported to:') %]
-        </strong></p>
-        <ul class="plain-list">
-      [% FOREACH option IN reported_to_options %]
-      <li[% IF ! (loop.count % 2) %] class="a"[% END %]>
-        <input type="radio" name="feed" id="[% option.id %]" value="[% option.id %]"[% IF option.id == selected_feed %] checked[% END %]>
-        <a href="[% option.uri %]"><img src="/i/feed.png" width="16" height="16"
-    title="[% option.rss_text %]" alt="RSS feed" border="0"></a>
-        <label class="inline" for="[% option.id %]">[% option.text %]</label>
-      </li>
-      [% END %]
-    </ul>
-    <p><small>
-      [% tprintf(loc('%s sends different categories of problem
-to the appropriate council, so problems within the boundary of a particular council
-might not match the problems sent to that council. For example, a graffiti report
-will be sent to the district council, so will appear in both of the district
-council&rsquo;s alerts, but will only appear in the "Within the boundary" alert
-for the county council.', "%s is the site name"), site_name) %]
-    </small></p>
-    [% END %]
-
-  <input id="alert_rss_button" class="green-btn" type="submit" name="rss" value="[% loc('Give me an RSS feed') %]">
-
-  <p id="alert_or">
-    [% loc('or') %]
-  </p>
-
+[% IF delivery == 'rss' %]
+  <h2>[% loc('Grab your RSS feed:') %]</h2>
+  <input id="alert_rss_button" class="btn-primary" type="submit" name="rss" value="[% loc('Give me an RSS feed') %]">
+[% ELSE %]
   [% UNLESS c.user_exists %]
-    <label for="rznvy">[% loc('Your email') %]</label>
-    <input class="form-control" type="text" id="rznvy" name="rznvy" value="[% rznvy | html %]">
+    <h2>[% loc('And where should your alerts be delivered?') %]</h2>
+    <p>
+        <label for="rznvy">[% loc('Email address') %]</label>
+        <input class="form-control" type="text" id="rznvy" name="rznvy" value="[% rznvy | html %]">
+    </p>
   [% END %]
-    <input id="alert_email_button" style="margin-top:1em;" class="green-btn" type="submit" name="alert" value="[% loc('Subscribe me to an email alert') %]">
-
+  <input id="alert_email_button" class="btn-primary" type="submit" name="alert" value="[% loc('Subscribe by email') %]">
+[% END %]

--- a/templates/web/base/alert/_list.html
+++ b/templates/web/base/alert/_list.html
@@ -51,11 +51,11 @@
 [% END %]
 
 [% IF delivery == 'rss' %]
-  <h2>[% loc('Grab your RSS feed:') %]</h2>
-  <input id="alert_rss_button" class="btn-primary" type="submit" name="rss" value="[% loc('Give me an RSS feed') %]">
+  <h2 class="alerts-final-question">[% loc('Grab your RSS feed:') %]</h2>
+  <input id="alert_rss_button" class="btn-primary js-alerts-rss-live-preview" type="submit" name="rss" value="[% loc('Give me an RSS feed') %]">
 [% ELSE %]
   [% UNLESS c.user_exists %]
-    <h2>[% loc('And where should your alerts be delivered?') %]</h2>
+    <h2 class="alerts-final-question">[% loc('And where should your alerts be delivered?') %]</h2>
     <p>
         <label for="rznvy">[% loc('Email address') %]</label>
         <input class="form-control" type="text" id="rznvy" name="rznvy" value="[% rznvy | html %]">

--- a/templates/web/base/alert/choose.html
+++ b/templates/web/base/alert/choose.html
@@ -1,6 +1,8 @@
-[% INCLUDE 'header.html', title =>  loc('Local RSS feeds and email alerts') %]
+[% SET title = loc('Email alerts & RSS') %]
 
-<h1>[% loc('Local RSS feeds and email alerts') %]</h1>
+[% INCLUDE 'header.html', title = title %]
+
+<h1>[% title | html %]</h1>
 
 [% IF possible_location_matches %]
     <p>[% loc('We found more than one match for that location. We show up to ten matches, please try a different search if yours is not here.') %]</p>

--- a/templates/web/base/alert/index.html
+++ b/templates/web/base/alert/index.html
@@ -1,51 +1,36 @@
-[% INCLUDE 'header.html', title = loc('Local RSS feeds and email alerts'), bodyclass = 'fullwidthpage' %]
+[% SET title = loc('Email alerts & RSS') %]
 
-<h1>[% loc('Local RSS feeds and email alerts') %]</h1>
+[% INCLUDE 'header.html', title = title, bodyclass = 'fullwidthpage' %]
 
-<p>
-[% IF c.cobrand.is_council %]
-[% tprintf(loc('%s has a variety of RSS feeds and email alerts for local
-problems, including alerts for all problems within a particular ward, or all
-problems within a certain distance of a particular location.', "%s is the site name"), site_name) %]
-[% ELSE %]
-[% tprintf(loc('%s has a variety of RSS feeds and email alerts for local problems, including
-alerts for all problems within a particular ward or council, or all problems
-within a certain distance of a particular location.', "%s is the site name"), site_name) %]
-[% END %]
-</p>
-
-[% IF location_error %]
-  <div class="error">[% location_error %]</div>
-[% ELSE %]
-  [% INCLUDE 'errors.html' %]
-[% END %]
-
-<p>
-[% IF c.cobrand.is_council %]
-[% tprintf(loc('To find out what local alerts we have for you, please enter your %s postcode or street name and area:'), c.cobrand.council_area) %]
-[% ELSE %]
-[% loc('To find out what local alerts we have for you, please enter your postcode or street name and area' ) %]
-[% END %]
-</p>
-<form method="get" action="/alert/list" class="form-box js-geolocate">
-  <fieldset>
-    <div class="form-txt-submit-box">
-      <input class="form-control" type="text" name="pc" value="[% pc | html %]" placeholder="[% tprintf(loc('e.g. ‘%s’ or ‘%s’'), c.cobrand.example_places) %]">
-      <input class="green-btn" type="submit" value="[% loc('Go') %]">
+<div class="content-row content-row--first">
+    <div class="content-col alerts-header">
+        <h1>[% title | html %]</h1>
     </div>
-  </fieldset>
-</form>
-
-[% IF photos.size %]
-<h2>[% loc('Some photos of recent reports') %]</h2>
-<div class="alerts__nearby-activity__photos">
-  [% FOREACH p IN photos %]
-    <a href="/report/[% p.id %]">
-        <img border="0" height="100" src="[% p.photos.first.url_tn %]"
-        alt="[% p.title | html %]" title="[% p.title | html %]">
-    </a>
-  [% END %]
 </div>
-[% END %]
+
+<div class="content-row">
+    <div class="content-col alerts-page">
+
+        <h2>[% loc('Subscribe to email alerts for problems in the area you care about') %]</h2>
+
+      [% IF location_error %]
+        <div class="error">[% location_error %]</div>
+      [% ELSE %]
+        [% INCLUDE 'errors.html' %]
+      [% END %]
+
+        <form method="get" action="/alert/list">
+            <p>
+                <label for="pc">[% loc('Postcode or address') %]</label>
+                <input class="form-control" type="text" name="pc" id="pc" value="[% pc | html %]" placeholder="[% tprintf(loc('e.g. ‘%s’ or ‘%s’'), c.cobrand.example_places) %]">
+            </p>
+            <p class="alerts-submit-buttons">
+                <button type="submit" name="delivery" value="email" class="btn-primary">[% loc('Subscribe by email') %]</button>
+                <button type="submit" name="delivery" value="rss" class="btn">[% loc('Subscribe by RSS') %]</button>
+            </p>
+        </form>
+
+    </div>
+</div>
 
 [% INCLUDE 'footer.html' %]

--- a/templates/web/base/alert/list-ajax.html
+++ b/templates/web/base/alert/list-ajax.html
@@ -1,9 +1,0 @@
-[% IF pretty_pc %]
-    [%
-        pretty_pc = pretty_pc | html | replace(' ', '&nbsp;');
-    %]
-[% END %]
-
-<div id="alerts">
-  [% INCLUDE 'alert/_list.html' %]
-</div>

--- a/templates/web/base/alert/list.html
+++ b/templates/web/base/alert/list.html
@@ -1,41 +1,21 @@
-[%
-    IF pretty_pc;
-        title = tprintf( loc("Local RSS feeds and email alerts for ‘%s’"), pretty_pc );
-    ELSE;
-        title = loc('Local RSS feeds and email alerts');
-    END;
-%]
+[% SET title = loc('Email alerts & RSS') %]
 
 [% INCLUDE 'header.html', title = title, bodyclass = 'fullwidthpage' %]
 
-[% IF pretty_pc %]
-    [%
-        pretty_pc = pretty_pc | html | replace(' ', '&nbsp;');
-        title = tprintf( loc("Local RSS feeds and email alerts for ‘%s’"), pretty_pc );
-    %]
-[% END %]
-
-
-<h1>[% title %]</h1>
-
-[% IF photos.size %]
-<div class="alerts__nearby-activity">
-    <h2>[% loc('Photos of recent nearby reports') %]</h2>
-    <div class="alerts__nearby-activity__photos">
-      [% FOREACH p IN photos %]
-        <a href="/report/[% p.id %]">
-            <img border="0" height="100" src="[% p.photos.first.url_tn %]"
-            alt="[% p.title | html %]" title="[% p.title | html %]">
-        </a>
-      [% END %]
+<div class="content-row content-row--first">
+    <div class="content-col alerts-header">
+        <h1>[% title | html %]</h1>
     </div>
 </div>
-[% END %]
 
-<form id="alerts" name="alerts" method="post" action="/alert/subscribe">
+<div class="content-row">
+    <div class="content-col alerts-page">
 
-  [% INCLUDE 'alert/_list.html' %]
+        <form method="post" action="/alert/subscribe">
+            [% INCLUDE 'alert/_list.html' %]
+        </form>
 
-</form>
+    </div>
+</div>
 
 [% INCLUDE 'footer.html' %]

--- a/templates/web/base/alert/updates.html
+++ b/templates/web/base/alert/updates.html
@@ -1,4 +1,4 @@
-[% title = loc('Local RSS feeds and email alerts') %]
+[% title = loc('Email alerts &nbsp; RSS') %]
 
 [% INCLUDE 'header.html', title => title %]
 

--- a/templates/web/base/around/_updates.html
+++ b/templates/web/base/around/_updates.html
@@ -1,5 +1,5 @@
 <div class="shadow-wrap">
     <ul id="key-tools" class="singleton">
-        <li><a class="feed" id="key-tool-around-updates" href="[% email_url | html %]">[% loc("Get updates") %]</a></li>
+        <li><a class="feed" href="[% alert_subscribe_url | html %]">[% loc("Get updates") %]</a></li>
     </ul>
 </div>

--- a/templates/web/base/around/display_location.html
+++ b/templates/web/base/around/display_location.html
@@ -8,7 +8,7 @@
         ? c.uri_for( "/rss/pc", pc )
         : c.uri_for( "/rss/l/$latitude,$longitude" );
 
-    email_url = c.uri_for(
+    alert_subscribe_url = c.uri_for(
         '/alert/list',
         {
             lat  => latitude,

--- a/templates/web/base/js/translation_strings.html
+++ b/templates/web/base/js/translation_strings.html
@@ -61,6 +61,8 @@
 
         login_with_email: '[% loc('Log in with email') | replace("'", "\\'") %]',
 
+        loading: '[% loc('Loading&hellip;') | replace("'", "\\'") %]',
+
         offline: {
             your_reports: '[% loc('Your offline reports') | replace("'", "\\'") %]',
             update_saved: '[% loc('Your update has been saved offline for submission when back online.') | replace("'", "\\'") %]',

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -711,7 +711,6 @@ $.extend(fixmystreet.set_up, {
         });
     } else {
         $('#key-tool-wards').drawer('council_wards', false);
-        $('#key-tool-around-updates').drawer('updates_ajax', true);
     }
     $('#key-tool-report-updates').small_drawer('report-updates-data');
     $('#key-tool-report-share').small_drawer('report-share');
@@ -756,27 +755,6 @@ $.extend(fixmystreet.set_up, {
             $('.form-focus-hidden').fadeIn(500);
         });
     }
-  },
-
-  alert_page_buttons: function() {
-    // Go directly to RSS feed if RSS button clicked on alert page
-    // (due to not wanting around form to submit, though good thing anyway)
-    $('body').on('click', '#alert_rss_button', function(e) {
-        e.preventDefault();
-        var feed = $('input[name=feed][type=radio]:checked').nextAll('a').attr('href');
-        window.location.href = feed;
-    });
-    $('body').on('click', '#alert_email_button', function(e) {
-        e.preventDefault();
-        var form = $('<form/>').attr({ method:'post', action:"/alert/subscribe" });
-        form.append($('<input name="alert" value="Subscribe me to an email alert" type="hidden" />'));
-        $('#alerts input[type=text], #alerts input[type=hidden], #alerts input[type=radio]:checked').each(function() {
-            var $v = $(this);
-            $('<input/>').attr({ name:$v.attr('name'), value:$v.val(), type:'hidden' }).appendTo(form);
-        });
-        $('body').append(form);
-        form.submit();
-    });
   },
 
   promo_elements: function() {

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -777,6 +777,55 @@ $.extend(fixmystreet.set_up, {
     });
   },
 
+  alerts_live_rss_preview: function() {
+      $('.js-alerts-rss-live-preview').each(function() {
+          var $button = $(this);
+          var $form = $button.parents('form');
+          var $preview = $('<a>');
+
+          $preview.addClass('alerts-rss-live-preview');
+          $preview.attr('target', '_blank');
+          $preview.insertBefore($button);
+
+          var reset = function reset() {
+              $preview.remove();
+              $form.off('.rss-live-preview');
+          };
+
+          $form.on('change.rss-live-preview', function() {
+              $preview.removeAttr('href');
+              $preview.html(translation_strings.loading);
+              $preview.addClass('loading');
+
+              var dataObj = $form.serializeArray();
+              dataObj.push({ name: 'ajax', value: 1 });
+
+              $.ajax({
+                  url: $form.attr('action'),
+                  type: $form.attr('method'),
+                  data: $.param(dataObj),
+                  dataType: 'json'
+
+              }).always(function() {
+                  $preview.removeClass('loading');
+
+              }).done(function(data) {
+                  if (data.status == 'success') {
+                      $preview.attr('href', data.url);
+                      $preview.text(data.url);
+                  } else {
+                      reset();
+                  }
+
+              }).fail(function(jqXHR, textStatus, errorThrown) {
+                  reset();
+              });
+          });
+
+          $form.trigger('change');
+      });
+  },
+
   ajax_history: function() {
     $('#map_sidebar').on('click', '.item-list--reports a', function(e) {
         if (e.metaKey || e.ctrlKey) {

--- a/web/cobrands/sass/_alerts.scss
+++ b/web/cobrands/sass/_alerts.scss
@@ -14,6 +14,11 @@
         font-weight: bold;
         margin-top: 0;
     }
+
+    // Special case for second h2 at end of form
+    .alerts-final-question {
+        margin-top: 2em;
+    }
 }
 
 .alerts-submit-buttons {
@@ -30,5 +35,48 @@
         font-size: 1.125em; // 18px
         color: #777;
         margin-bottom: 0.5em;
+    }
+}
+
+.alerts-rss-live-preview {
+    display: block;
+    font-size: 1.125em; // 18px
+    line-height: 1em;
+    border: 2px solid $form-control-border-color;
+    padding: 1em;
+    border-radius: 4px;
+
+    @media (min-width: 48em) {
+        padding: 1.5em;
+    }
+
+    &:before {
+        content: "";
+        display: inline-block;
+        width: 16px;
+        height: 16px;
+        background: transparent url(/i/feed.png) 0 0 no-repeat;
+        margin-#{$right}: 0.75em;
+        vertical-align: middle;
+    }
+
+    &:hover,
+    &:focus {
+        background-color: mix(#0BA7D1, #fff, 10%); // lighter version of `a` color
+        border-color: #0D7CCE; // match a:hover color
+    }
+
+    &.loading {
+        border-color: #ddd;
+        color: #666;
+
+        &:before {
+            content: none;
+        }
+    }
+
+    & + input {
+        position: absolute;
+        left: -9999px;
     }
 }

--- a/web/cobrands/sass/_alerts.scss
+++ b/web/cobrands/sass/_alerts.scss
@@ -1,0 +1,34 @@
+.alerts-header {
+    background-color: $primary;
+
+    h1 {
+        font-family: inherit;
+        font-weight: bold;
+        margin: 0;
+    }
+}
+
+.alerts-page {
+    h2 {
+        font-family: inherit;
+        font-weight: bold;
+        margin-top: 0;
+    }
+}
+
+.alerts-submit-buttons {
+    margin: 0.5em -0.5em;
+
+    .btn,
+    .btn-primary {
+        margin: 0.5em;
+    }
+}
+
+.alerts-two-tier-explanation {
+    p {
+        font-size: 1.125em; // 18px
+        color: #777;
+        margin-bottom: 0.5em;
+    }
+}

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2118,42 +2118,6 @@ table.nicetable {
     }
 }
 
-#alerts {
-    ul {
-        margin-bottom: 1em;
-    }
-    li {
-        padding: 0em;
-        margin-bottom: 0.5em;
-    }
-    .a {
-        background: #f6f6f6;
-    }
-    img[width="16"] {
-        float: $right;
-    }
-}
-
-.alerts__nearby-activity {
-    background-color: #f6f6f6;
-    margin: 1em -1em;
-    padding: 1em;
-
-    & > :first-child {
-        margin-top: 0;
-    }
-}
-
-.alerts__nearby-activity__photos {
-    white-space: nowrap;
-    overflow: hidden;
-
-    a {
-        margin-right: 0.5em;
-        text-decoration: none; // avoid underline showing between images
-    }
-}
-
 .confirmation-header {
   padding: 140px 0 2em;
   text-align: center;
@@ -2446,4 +2410,7 @@ table.nicetable {
 @import "_dropzone";
 @import "_multiselect";
 @import "_autocomplete";
+@import "_content-grid";
+@import "_multiple-choice";
 @import "_dashboard";
+@import "_alerts";

--- a/web/cobrands/sass/_content-grid.scss
+++ b/web/cobrands/sass/_content-grid.scss
@@ -1,0 +1,38 @@
+// A simple little grid system, built to work within
+// the existing, padded FixMyStreet .content element
+
+.content-row {
+    @include clearfix();
+    margin: 0 -1em; // cover horizontal padding on .container (mobile) or .content (desktop)
+}
+
+@media (min-width: 48em) {
+    .content-row--first {
+        margin-top: -1em; // cover vertical padding on .content (desktop)
+    }
+}
+
+.content-col {
+    @include box-sizing(border-box);
+    width: 100%;
+    padding: 1em; // reinstate padding
+}
+
+@media (min-width: 48em) {
+    .content-col {
+        float: left;
+        padding: 2em; // more spacious padding on wide screens
+    }
+
+    .content-col--6 {
+        width: 50%;
+    }
+
+    .content-col--4 {
+        width: 33.33%;
+    }
+
+    .content-col--3 {
+        width: 25%;
+    }
+}

--- a/web/cobrands/sass/_dashboard.scss
+++ b/web/cobrands/sass/_dashboard.scss
@@ -1,3 +1,7 @@
+// TODO: Update web/base/reports/index.html to use the grid
+// classes from _content-grid.scss, and remove the grid stuff
+// from these .dashboard-* rulesets.
+
 .dashboard-header {
     background-color: $primary;
     margin: 0 -1em;

--- a/web/cobrands/sass/_multiple-choice.scss
+++ b/web/cobrands/sass/_multiple-choice.scss
@@ -1,0 +1,112 @@
+// Creates nice, chunky radio buttons and checkboxes.
+// Inspired by the GOV.UK elements library:
+// https://github.com/alphagov/govuk_elements
+
+.multiple-choice {
+    $input-size: 38px;
+
+    display: block;
+    position: relative; // for positioning of fake checkbox/radio
+    padding-#{$left}: $input-size;
+    margin: 1em 0;
+
+    // Make checkbox/radio invisible and stretch it over
+    // the fake checkbox/radio, to intercept clicks.
+    input {
+        position: absolute;
+        z-index: 1; // stack above label:before/label:after
+        top: 0;
+        left: 0;
+        width: $input-size;
+        height: $input-size;
+        opacity: 0;
+        cursor: pointer; // make fake checkbox/radio look clickable
+
+        // IE8 and below don't support pseudo-elements,
+        // so reveal the real checkbox/radio.
+        .lt-ie9 & {
+            opacity: 1;
+        }
+    }
+
+    label {
+        display: block;
+        cursor: pointer;
+        padding: 0;
+        padding-top: ($input-size - 24px) / 2;
+        padding-bottom: ($input-size - 24px) / 2;
+        padding-#{$left}: 0.75em;
+        margin: 0;
+
+        @media (min-width: 48em) {
+            font-size: 1.125em; // 18px
+        }
+
+        &:before,
+        &:after {
+            content: "";
+            display: block;
+            position: absolute;
+            @include box-sizing(border-box);
+        }
+
+        // The checkbox/radio outline
+        &:before {
+            width: $input-size;
+            height: $input-size;
+            top: 0;
+            left: 0;
+            border: 1px solid $form-control-border-color;
+            box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.2);
+        }
+
+        // The checkbox/radio filling
+        &:after {
+            opacity: 0; // hide until input is checked
+        }
+    }
+
+    [type="radio"] + label {
+        &:before {
+            border-radius: 50%;
+        }
+
+        &:after {
+            border-radius: 50%;
+            border: 10px solid;
+            top: ($input-size / 2) - 10px;
+            left: ($input-size / 2) - 10px;
+        }
+    }
+
+    [type="checkbox"] + label {
+        &:before {
+            border-radius: 4px;
+        }
+
+        &:after {
+            border: solid;
+            border-width: 0 0 5px 5px;
+            background: transparent;
+            border-top-color: transparent;
+            height: 11px;
+            width: 22px;
+            top: ($input-size / 2) - 8px;
+            left: ($input-size / 2) - 11px;
+            @include experimental(transform, rotate(-45deg));
+        }
+    }
+
+    input:checked + label {
+        &:after {
+            opacity: 1;
+        }
+    }
+
+    input:focus + label {
+        &:before {
+            border-color: #0D7CCE; // match a:hover color
+            box-shadow: inset 0 1px 3px rgba(0,0,0,0.2), 0 0 5px 1px #0BA7D1;
+        }
+    }
+}


### PR DESCRIPTION
Partway through implementing the new signup flow in mysociety/fixmystreet-commercial#866.

To do:

- [x] Remove photos of recent reports
- [x] Two submit buttons on first page
   - Work out what to do about geolocation link (if the delivery method is decided by which submit button the user uses, we can’t just forward them to the list page when they click the geolocation link).
- [x] Remove RSS links from list page
- [x] Remove special cases around “Get updates” slide-in drawer on /around pages
- [x] If RSS feed requested, redirect to that when list page is submitted
   - Because `alert_page_buttons` no longer intercepts the form submission, the user is given "ugly" latlng-based feed URLs, rather than postcode-based URLs. Can we do anything about this?
- [x] Progressively enhance results page to ajax submit for real-time RSS feed URL preview
- [ ] Tabs on list page, when in two-tier area
- [ ] Live map preview on list page
- [ ] Customisable radius as `<input type="text">` in first option (RSS feeds only)
- [ ] Google Analytics tracking for location search, list page submission, and RSS feed URL preview mousedowns
- [x] Fix tests
- [ ] Changelog entry
