### PR TITLE
Clearer styling for chosen report, when closing report as duplicate

### DIFF
--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -98,7 +98,7 @@
             <input type="hidden" name="duplicate_of" value="[% problem.duplicate_of.id %]">
             <p class="[% "hidden" UNLESS problem.duplicate_of %]"><strong>[% loc('Duplicate of') %]</strong></p>
             <p class="[% "hidden" IF problem.duplicate_of %]">[% loc('Which report is it a duplicate of?') %]</p>
-            <ul class="item-list">
+            <ul class="item-list item-list--inspect-duplicates">
               [% IF problem.duplicate_of %]
                 [% INCLUDE 'report/_item.html' item_extra_class = 'item-list--reports__item--selected' problem = problem.duplicate_of %]
                 <li class="item-list__item"><a class="btn" href="#" id="js-change-duplicate-report">[% loc('Choose another') %]</a></li>
@@ -107,7 +107,7 @@
           </div>
           [% IF problem.duplicates.size %]
             <p><strong>[% loc('Duplicates') %]</strong></p>
-            <ul class="item-list">
+            <ul class="item-list item-list--inspect-duplicates">
               [% FOR duplicate IN problem.duplicates %]
                 [% INCLUDE 'report/_item.html' problem = duplicate %]
               [% END %]

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -9,7 +9,7 @@ $.extend(fixmystreet.set_up, {
               latitude: $('input[name="latitude"]').val(),
               longitude: $('input[name="longitude"]').val()
           };
-          $("#js-duplicate-reports ul").html("<li>Loading...</li>");
+          $("#js-duplicate-reports ul").html('<li class="item-list__item">Loading...</li>');
           var nearby_url = '/report/'+report_id+'/nearby.json';
           $.getJSON(nearby_url, args, function(data) {
               var duplicate_of = $("#report_inspect_form [name=duplicate_of]").val();

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1187,6 +1187,21 @@ input.final-submit {
   }
 }
 
+// List of potential duplicate reports (or a single confirmed duplicate)
+// that appears in Inspector form, when closing a report as a duplicate.
+.item-list--inspect-duplicates {
+    border-bottom: none;
+
+    .item-list__item {
+        background-color: rgba(255, 255, 255, 0.5);
+    }
+
+    .item-list--reports__item--selected {
+        border: 0.25em solid $primary;
+        background-color: #fff;
+    }
+}
+
 .item-list__heading {
   font-size: 1em;
   font-weight: normal;


### PR DESCRIPTION
The chosen "original" report is now much more visually distinct from the other options, with a white background and a thick border in the site’s primary colour. Here’s how it looks in the Oxfordshire cobrand:

![screen shot 2017-08-14 at 12 29 46](https://user-images.githubusercontent.com/739624/29270086-f0a1de92-80ec-11e7-9925-b0a9dc1bb681.png)

Looks the same on mobile too.

Fixes mysociety/fixmystreetforcouncils#211