### PR TITLE
Improve new translation lookup performance

### DIFF
--- a/locale/nb_NO.UTF-8/LC_MESSAGES/FixMyStreet.po
+++ b/locale/nb_NO.UTF-8/LC_MESSAGES/FixMyStreet.po
@@ -4230,7 +4230,7 @@ msgstr "Oppdateringer av {{title}}"
 #: templates/web/base/report/display.html:0
 #: templates/web/base/report/display.html:9
 msgid "Updates to this problem, %s"
-msgstr "Oppdateringer til dette problemet, FiksGataMi"
+msgstr "Oppdateringer til dette problemet, %s"
 
 #: templates/web/base/admin/contact-form.html:41
 #: templates/web/base/admin/contact-form.html:42

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -1941,7 +1941,7 @@ sub check_page_allowed : Private {
 sub fetch_all_bodies : Private {
     my ($self, $c ) = @_;
 
-    my @bodies = $c->model('DB::Body')->all;
+    my @bodies = $c->model('DB::Body')->all_translated;
     if ( $c->cobrand->moniker eq 'zurich' ) {
         @bodies = $c->cobrand->admin_fetch_all_bodies( @bodies );
     } else {

--- a/perllib/FixMyStreet/App/Controller/Location.pm
+++ b/perllib/FixMyStreet/App/Controller/Location.pm
@@ -31,8 +31,6 @@ sub determine_location_from_coords : Private {
 
     my $latitude = $c->get_param('latitude') || $c->get_param('lat');
     my $longitude = $c->get_param('longitude') || $c->get_param('lon');
-    $c->log->debug($longitude);
-    $c->log->debug($latitude);
 
     if ( defined $latitude && defined $longitude ) {
         ($c->stash->{latitude}, $c->stash->{longitude}) =

--- a/perllib/FixMyStreet/DB/Result/Body.pm
+++ b/perllib/FixMyStreet/DB/Result/Body.pm
@@ -132,6 +132,21 @@ sub url {
     return $c->uri_for( '/reports/' . $c->cobrand->short_name( $self ), $args || {} );
 }
 
+__PACKAGE__->might_have(
+  "translations",
+  "FixMyStreet::DB::Result::Translation",
+  sub {
+    my $args = shift;
+    return {
+        "$args->{foreign_alias}.object_id" => { -ident => "$args->{self_alias}.id" },
+        "$args->{foreign_alias}.tbl" => { '=' => \"?" },
+        "$args->{foreign_alias}.col" => { '=' => \"?" },
+        "$args->{foreign_alias}.lang" => { '=' => \"?" },
+    };
+  },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
 around name => \&translate_around;
 
 sub areas {

--- a/perllib/FixMyStreet/DB/ResultSet/Body.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Body.pm
@@ -14,4 +14,15 @@ sub for_areas {
     return $result;
 }
 
+sub all_translated {
+    my $rs = shift;
+    my $schema = $rs->result_source->schema;
+    my @bodies = $rs->search(undef, {
+        '+columns' => { 'msgstr' => 'translations.msgstr' },
+        join => 'translations',
+        bind => [ 'name', $schema->lang, 'body' ],
+    })->all;
+    return @bodies;
+}
+
 1;

--- a/perllib/FixMyStreet/Roles/Translatable.pm
+++ b/perllib/FixMyStreet/Roles/Translatable.pm
@@ -1,6 +1,7 @@
 package FixMyStreet::Roles::Translatable;
 
 use Moo::Role;
+use FixMyStreet;
 
 has _translated  => (is => 'rw');
 
@@ -24,6 +25,9 @@ sub translate_column {
 
 sub _translate {
     my ($self, $col, $fallback) = @_;
+
+    my $langs = FixMyStreet->config('LANGUAGES');
+    return $fallback if @$langs < 2;
 
     my %cols = $self->get_columns;
     return $cols{msgstr} if $cols{msgstr};

--- a/perllib/FixMyStreet/Roles/Translatable.pm
+++ b/perllib/FixMyStreet/Roles/Translatable.pm
@@ -25,6 +25,9 @@ sub translate_column {
 sub _translate {
     my ($self, $col, $fallback) = @_;
 
+    my %cols = $self->get_columns;
+    return $cols{msgstr} if $cols{msgstr};
+
     my $schema = $self->result_source->schema;
     my $table = lc $self->result_source->source_name;
     my $id = $self->id;

--- a/t/roles/translatable.t
+++ b/t/roles/translatable.t
@@ -41,31 +41,37 @@ is $body->name, "Dunkirk";
 is $contact->category_display, "Potholes";
 is $problem->category_display, "Potholes";
 
-FixMyStreet::DB->schema->lang("fr");
-is $body->name, "Dunkerque";
-is $contact->category_display, "Potholes";
-is $problem->category_display, "Potholes";
+# Multiple LANGUAGES so translation code is called
+FixMyStreet::override_config {
+    LANGUAGES => [ 'en-gb,English,en_GB', 'de,German,de_DE' ]
+}, sub {
+    FixMyStreet::DB->schema->lang("fr");
+    is $body->name, "Dunkerque";
+    is $contact->category_display, "Potholes";
+    is $problem->category_display, "Potholes";
 
-FixMyStreet::DB->schema->lang("de");
-is $body->name, "Dunkirk";
-is $contact->category_display, "Schlaglöcher";
-is $problem->category_display, "Schlaglöcher";
+    FixMyStreet::DB->schema->lang("de");
+    is $body->name, "Dunkirk";
+    is $contact->category_display, "Schlaglöcher";
+    is $problem->category_display, "Schlaglöcher";
 
-is $contact->translation_for('category', 'de')->msgstr, "Schlaglöcher";
-is $body->translation_for('name', 'fr')->msgstr, "Dunkerque";
+    is $contact->translation_for('category', 'de')->msgstr, "Schlaglöcher";
+    is $body->translation_for('name', 'fr')->msgstr, "Dunkerque";
 
-ok $body->add_translation_for('name', 'es', 'Dunkerque');
+    ok $body->add_translation_for('name', 'es', 'Dunkerque');
 
-FixMyStreet::DB->schema->lang("es");
-is $body->name, "Dunkerque";
+    FixMyStreet::DB->schema->lang("es");
+    is $body->name, "Dunkerque";
 
-is $body->translation_for('name')->count, 2;
+    is $body->translation_for('name')->count, 2;
+};
 
 FixMyStreet::override_config {
+    LANGUAGES => [ 'en-gb,English,en_GB', 'nb,Norwegian,nb_NO' ],
     ALLOWED_COBRANDS => [ 'fiksgatami' ],
 }, sub {
     $mech->get_ok($problem->url);
-	$mech->content_contains('Hull i veien');
+    $mech->content_contains('Hull i veien');
 };
 
 done_testing;


### PR DESCRIPTION
This should remember a translation looked up for the remainder of the request, plus add a way to look up all translations when fetching all bodies at once.