### PR TITLE
Store duplicate reverse lookups upon dupe setting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
         - Stop errors from JS validator due to form in form.
         - Stop update form toggle causing report submission.
         - Update map size if an extra column has appeared.
+        - Improve performance of duplicate display.
     - Development improvements:
         - `switch-site` script to automate switching config.yml files. #1741
 

--- a/bin/one-off-update-duplicates
+++ b/bin/one-off-update-duplicates
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../setenv.pl";
+}
+
+use FixMyStreet::DB;
+
+my $rs = FixMyStreet::DB->resultset("Problem")->search({ extra => => { like => "%duplicate_of%" } });
+while (my $row = $rs->next) {
+    my $duplicate_of = $row->get_extra_metadata('duplicate_of');
+    next unless $duplicate_of;
+    $row->set_duplicate_of($duplicate_of);
+}

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -325,7 +325,7 @@ sub inspect : Private {
         my %update_params = ();
 
         if ($permissions->{report_inspect}) {
-            foreach (qw/detailed_information traffic_information duplicate_of/) {
+            foreach (qw/detailed_information traffic_information/) {
                 $problem->set_extra_metadata( $_ => $c->get_param($_) );
             }
 
@@ -360,7 +360,10 @@ sub inspect : Private {
             }
             if ( $problem->state ne 'duplicate' ) {
                 $problem->unset_extra_metadata('duplicate_of');
+            } elsif (my $duplicate_of = $c->get_param('duplicate_of')) {
+                $problem->set_duplicate_of($duplicate_of);
             }
+
             if ( $problem->state ne $old_state ) {
                 $c->forward( '/admin/log_edit', [ $problem->id, 'problem', 'state_change' ] );
 

--- a/t/app/model/problem.t
+++ b/t/app/model/problem.t
@@ -776,6 +776,8 @@ subtest 'check duplicate reports' => sub {
     $problem1->set_extra_metadata(duplicate_of => $problem2->id);
     $problem1->state('duplicate');
     $problem1->update;
+    $problem2->set_extra_metadata(duplicates => [ $problem1->id ]);
+    $problem2->update;
 
     is $problem1->duplicate_of->title, $problem2->title, 'problem1 returns correct problem from duplicate_of';
     is scalar @{ $problem2->duplicates }, 1, 'problem2 has correct number of duplicates';


### PR DESCRIPTION
This avoids the need to search the whole table to find a report's
duplicates. And is easier than constructing an index or upgrading
PostgreSQL.