### PR TITLE
show all report updates, even if no public text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
         - Extra fields can be added to report form site-wide. #1743
     - Front end improvements:
         - Always show pagination figures even if only one page.
+        - Report pages list every update to a report. #1806
     - Admin improvements:
         - Highlight current shortlisted user in list tooltip.
         - Extra fields on contacts can be edited. #1743


### PR DESCRIPTION
Create a comment entry for all updates to reports regardless of whether
there is any text part. Also adds an entry to extra if a defect was
raised and includes that in the update.