### PR TITLE
[fixmystreet.com] Encode ampersands in link hrefs

### DIFF
--- a/templates/web/fixmystreet.com/about/faq-en-gb.html
+++ b/templates/web/fixmystreet.com/about/faq-en-gb.html
@@ -318,7 +318,7 @@ correspondence to you – or if you only have an auto-response, you may be able
 to find further contact details there.
 <p>If you still have no joy, we suggest starting a new FixMyStreet report. You
 may also like to use another useful mySociety website, <a
-href="https://www.writetothem.com/?utm_source=fixmystreet.com&utm_campaign=static_links&utm_medium=link&utm_content=help+what_now">WriteToThem</a>,
+href="https://www.writetothem.com/?utm_source=fixmystreet.com&amp;utm_campaign=static_links&amp;utm_medium=link&amp;utm_content=help+what_now">WriteToThem</a>,
 to contact your local councillors and ask them to help.
 </dd>
 

--- a/templates/web/fixmystreet.com/contact/who.html
+++ b/templates/web/fixmystreet.com/contact/who.html
@@ -44,7 +44,7 @@
     <p>
     <strong>If you're not having any luck getting your community problems fixed</strong>,
     you could try contacting your local councillor, using another useful mySociety site:
-    <a href="https://www.writetothem.com/?utm_source=fixmystreet.com&utm_campaign=contact_workflow_links&utm_medium=link&utm_content=contact+not_fixed">WriteToThem</a>.
+    <a href="https://www.writetothem.com/?utm_source=fixmystreet.com&amp;utm_campaign=contact_workflow_links&amp;utm_medium=link&amp;utm_content=contact+not_fixed">WriteToThem</a>.
     </p>
 
     [% END %]

--- a/templates/web/fixmystreet.com/footer_extra.html
+++ b/templates/web/fixmystreet.com/footer_extra.html
@@ -47,7 +47,7 @@
             <div class="col-sm-3">
                 <div class="mysoc-footer__donate">
                     <p>Your donations keep this site and others like it running</p>
-                    <a href="https://www.mysociety.org/donate?utm_source=fixmystreet.com&utm_content=footer+donate+now&utm_medium=link&utm_campaign=mysoc_footer" class="mysoc-footer__donate__button">Donate now</a>
+                    <a href="https://www.mysociety.org/donate?utm_source=fixmystreet.com&amp;utm_content=footer+donate+now&amp;utm_medium=link&amp;utm_campaign=mysoc_footer" class="mysoc-footer__donate__button">Donate now</a>
                 </div>
             </div>
 
@@ -59,7 +59,7 @@
                 <div class="mysoc-footer__orgs">
                     <p class="mysoc-footer__org">
                         Built by
-                        <a href="https://www.mysociety.org?utm_source=fixmystreet.com&utm_content=footer+logo&utm_medium=link&utm_campaign=mysoc_footer" class="mysoc-footer__org__logo mysoc-footer__org__logo--mysociety">mySociety</a>
+                        <a href="https://www.mysociety.org?utm_source=fixmystreet.com&amp;utm_content=footer+logo&amp;utm_medium=link&amp;utm_campaign=mysoc_footer" class="mysoc-footer__org__logo mysoc-footer__org__logo--mysociety">mySociety</a>
                     </p>
                     <p class="mysoc-footer__org">
                         Powered by
@@ -70,7 +70,7 @@
 
             <div class="col-sm-4">
                 <div class="mysoc-footer__legal">
-                    <p>mySociety Limited is a project of UK Citizens Online Democracy, a registered charity in England and Wales. For full details visit <a href="https://www.mysociety.org?utm_source=fixmystreet.com&utm_content=footer+full+legal+details&utm_medium=link&utm_campaign=mysoc_footer">mysociety.org</a>.</p>
+                    <p>mySociety Limited is a project of UK Citizens Online Democracy, a registered charity in England and Wales. For full details visit <a href="https://www.mysociety.org?utm_source=fixmystreet.com&amp;utm_content=footer+full+legal+details&amp;utm_medium=link&amp;utm_campaign=mysoc_footer">mysociety.org</a>.</p>
                 </div>
             </div>
 

--- a/templates/web/fixmystreet.com/next_steps.html
+++ b/templates/web/fixmystreet.com/next_steps.html
@@ -21,7 +21,7 @@
       <h2>[% loc('Help support FixMyStreet') %]</h2>
       <p>[% loc('Even a small donation of £5 today will help mySociety run sites like FixMyStreet.') %]</p>
     <p class="next-steps__step__cta">
-      <a href="https://www.mysociety.org/donate?utm_source=fixmystreet.com&utm_content=[% utm_content | uri %]&utm_medium=link&utm_campaign=fms_thankyou_pages"><img src="/cobrands/fixmystreet.com/images/next-step-donate.png" alt="Donate now" width="138" height="37"></a>
+      <a href="https://www.mysociety.org/donate?utm_source=fixmystreet.com&amp;utm_content=[% utm_content | uri %]&amp;utm_medium=link&amp;utm_campaign=fms_thankyou_pages"><img src="/cobrands/fixmystreet.com/images/next-step-donate.png" alt="Donate now" width="138" height="37"></a>
     </p>
   </div>
   <div class="next-steps__step next-steps__step--goodies">

--- a/templates/web/fixmystreet.com/questionnaire/completed-open.html
+++ b/templates/web/fixmystreet.com/questionnaire/completed-open.html
@@ -13,7 +13,7 @@
     </p>
 
     <p>
-    You can do this on <a href="https://www.writetothem.com/?utm_source=fixmystreet.com&utm_campaign=workflow_links&utm_medium=link&utm_content=completed+unfixed">WriteToThem</a>, another
+    You can do this on <a href="https://www.writetothem.com/?utm_source=fixmystreet.com&amp;utm_campaign=workflow_links&amp;utm_medium=link&amp;utm_content=completed+unfixed">WriteToThem</a>, another
     useful mySociety website.
     </p>
 [% END %]

--- a/templates/web/fixmystreet.com/static/unresponsive.html
+++ b/templates/web/fixmystreet.com/static/unresponsive.html
@@ -26,7 +26,7 @@
 
   <h2>If you’d prefer to use FixMyStreet next time:</h2>
 
-  <a href="https://www.writetothem.com/?utm_source=fixmystreet.com&utm_campaign=workflow_links&utm_medium=link&utm_content=unresponsive_council+cta" class="unresponsive-council-cta">
+  <a href="https://www.writetothem.com/?utm_source=fixmystreet.com&amp;utm_campaign=workflow_links&amp;utm_medium=link&amp;utm_content=unresponsive_council+cta" class="unresponsive-council-cta">
     <strong>Write to your MP or local councillors</strong> to let them know this isn’t okay
   </a>
 


### PR DESCRIPTION
@dracos correctly noted that some unencoded ampersands slipped into #1810 because I just copied the `utm` link template from the footer donation link, which didn’t have encoded ampersands either.

So, this fixes all of the unencoded ampersands in `href` attributes everywhere in the `.html` templates (which turns out to only be in the `fixmystreet.com` cobrand).

[skip changelog]