### PR TITLE
Improve /report loading time for inspectors

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -404,6 +404,14 @@ sub load_and_group_problems : Private {
     my $page = $c->get_param('p') || 1;
     my $category = [ $c->get_param_list('filter_category', 1) ];
 
+    if ($c->user_exists) {
+        my @shortlist_ids = $c->user->active_planned_reports->search( undef, {
+            columns => [ 'id' ]
+        })->all;
+        my %shortlist_ids = map { $_->id => 1 } @shortlist_ids;
+        $c->stash->{user_shortlist_ids} = \%shortlist_ids;
+    }
+
     my $states = $c->stash->{filter_problem_states};
     my $where = {
         non_public => 0,

--- a/templates/web/base/report/_item.html
+++ b/templates/web/base/report/_item.html
@@ -8,7 +8,8 @@
       <input type="submit" value="1"
         data-label-remove="[% loc('Remove from shortlist') %]"
         data-label-add="[% loc('Add to shortlist') %]"
-      [% IF c.user.is_planned_report(problem) ~%]
+      [% problem_id = problem.id ~%]
+      [% IF user_shortlist_ids.$problem_id ~%]
         name="shortlist-remove" title="[% loc('Remove from shortlist') %]" class="item-list__item__shortlist-remove"
       [%~ ELSE ~%]
         name="shortlist-add" title="[% IF problem.shortlisted_user %]


### PR DESCRIPTION
On `/report` pages several queries were missing a `JOIN`, meaning hundreds of excess queries and a very slow page load time when logged in as an inspector.

This PR improves the queries by adding the `JOIN` which makes things nice and snappy again.

[skip changelog]