### PR TITLE
[Travis] Run code coverage on 5.24.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,11 +37,11 @@ addons:
 
 install:
   - .travis/install
-  - 'if [ "$TRAVIS_PERL_VERSION" = "5.14" ]; then cpanm --quiet --notest Devel::Cover::Report::Codecov; fi'
+  - 'if [ "$TRAVIS_PERL_VERSION" = "5.24" ]; then cpanm --quiet --notest Devel::Cover::Report::Codecov; fi'
 before_script:
   - commonlib/bin/gettext-makemo FixMyStreet
-  - 'if [ "$TRAVIS_PERL_VERSION" = "5.14" ]; then export HARNESS_PERL_SWITCHES="-MDevel::Cover=+ignore,local/lib/perl5,commonlib,perllib/Catalyst,perllib/DBIx,perllib/Email,perllib/Template,^t"; fi'
+  - 'if [ "$TRAVIS_PERL_VERSION" = "5.24" ]; then export HARNESS_PERL_SWITCHES="-MDevel::Cover=+ignore,local/lib/perl5,commonlib,perllib/Catalyst,perllib/DBIx,perllib/Email,perllib/Template,^t"; fi'
 script: "script/test --jobs 3 t"
 after_success:
   - .travis/after_script
-  - 'if [ "$TRAVIS_PERL_VERSION" = "5.14" ]; then cover --report codecov; fi'
+  - 'if [ "$TRAVIS_PERL_VERSION" = "5.24" ]; then cover --report codecov; fi'


### PR DESCRIPTION
Older perl versions can leak the locale decimal point character, leading to invalid JSON being written by Devel::Cover.

The changes to coverage can be seen at: https://codecov.io/gh/mysociety/fixmystreet/compare/6e22df6dd8fbf1504bcedd6a3e77201cf438525d...f0f863865a270d9a508e8c3c273a31764555e60f/changes
The main desired change due to this is the questionnaire controller (which finished with a Norway test), which rises 50% in coverage to 87%.

[skip changelog]