### PR TITLE
Fix redisplay of uploaded photo thumbnails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
         - Include MapIt API key on admin config page. #1778
     - Bugfixes:
         - Set up action scheduled field when report loaded. #1789
+        - Fix display of thumbnail images on page reload. #1815
         - Fix sidebar hover behaviour being lost. #1808
         - Stop errors from JS validator due to form in form.
         - Stop update form toggle causing report submission.

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -579,9 +579,13 @@ $.extend(fixmystreet.set_up, {
         if (!f) {
             return;
         }
-        var mockFile = { name: f, server_id: f };
+        var mockFile = { name: f, server_id: f, dataURL: '/photo/temp.' + f };
         photodrop.emit("addedfile", mockFile);
-        photodrop.createThumbnailFromUrl(mockFile, '/photo/temp.' + f);
+        photodrop.createThumbnailFromUrl(mockFile,
+            photodrop.options.thumbnailWidth, photodrop.options.thumbnailHeight,
+            photodrop.options.thumbnailMethod, true, function(thumbnail) {
+                photodrop.emit('thumbnail', mockFile, thumbnail);
+            });
         photodrop.emit("complete", mockFile);
         photodrop.options.maxFiles -= 1;
       });


### PR DESCRIPTION
Dropzone version 5 changed how createThumbnailFromUrl was called,
so the upgrade in 30dd9d8 broke this.