### PR TITLE
Fix a crash if changing report category without state field present

### DIFF
--- a/perllib/FixMyStreet/App.pm
+++ b/perllib/FixMyStreet/App.pm
@@ -173,6 +173,7 @@ sub setup_request {
     $c->setup_dev_overrides();
 
     my $cobrand = $c->cobrand;
+    FixMyStreet::DB->schema->cobrand($cobrand);
 
     $cobrand->call_hook('add_response_headers');
 

--- a/perllib/FixMyStreet/App/Model/DB.pm
+++ b/perllib/FixMyStreet/App/Model/DB.pm
@@ -21,6 +21,7 @@ __PACKAGE__->config(
 
 sub build_per_context_instance {
     my ( $self, $c ) = @_;
+    # $self->schema->cobrand($c->cobrand);
     $self->schema->cache({});
     return $self;
 }

--- a/perllib/FixMyStreet/DB/Schema.pm
+++ b/perllib/FixMyStreet/DB/Schema.pm
@@ -25,6 +25,8 @@ __PACKAGE__->connection(FixMyStreet->dbic_connect_info);
 
 has lang => ( is => 'rw' );
 
+has cobrand => ( is => 'rw' );
+
 has cache => ( is => 'rw', lazy => 1, default => sub { {} } );
 
 1;

--- a/t/app/sendreport/inspection_required.t
+++ b/t/app/sendreport/inspection_required.t
@@ -5,6 +5,9 @@ use FixMyStreet::SendReport::Email;
 
 ok( my $mech = FixMyStreet::TestMech->new, 'Created mech object' );
 
+use_ok 'FixMyStreet::Cobrand';
+FixMyStreet::DB->schema->cobrand(FixMyStreet::Cobrand::FixMyStreet->new());
+
 my $user = $mech->create_user_ok( 'user@example.com' );
 
 my $body = $mech->create_body_ok( 2237, 'Oxfordshire County Council');


### PR DESCRIPTION
Spotted on the Ground Control cobrand, where the inspector form only shows the category field and not the state field.

(NB: it looks like this functionality is [tested in `report_inspect.t`](https://github.com/mysociety/fixmystreet/blob/0c4b5041d807899ab708db4c5dd15203d23df257/t/app/controller/report_inspect.t#L231) so I'm not sure why this wasn't noticed sooner, unless I'm reading the test wrong.)

[skip changelog]