### PR TITLE
Extra fields for Council dashboard CSV export

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Dashboard.pm
+++ b/perllib/FixMyStreet/App/Controller/Dashboard.pm
@@ -212,6 +212,7 @@ sub export_as_csv {
             'Status',
             'Latitude', 'Longitude',
             'Nearest Postcode',
+            'Ward',
             'Report URL',
             );
     my @body = ($csv->string);
@@ -243,6 +244,11 @@ sub export_as_csv {
             }
         }
 
+        my $wards = join ', ',
+          map { $c->stash->{children}->{$_}->{name} }
+          grep {$c->stash->{children}->{$_} }
+          split ',', $hashref->{areas};
+
         $csv->combine(
             @{$hashref}{
                 'id',
@@ -259,6 +265,7 @@ sub export_as_csv {
                 'latitude', 'longitude',
                 'postcode',
                 },
+            $wards,
             (join '', $c->cobrand->base_url_for_report($report), $report->url),
         );
 

--- a/perllib/FixMyStreet/App/Controller/Dashboard.pm
+++ b/perllib/FixMyStreet/App/Controller/Dashboard.pm
@@ -213,6 +213,8 @@ sub export_as_csv {
             'Latitude', 'Longitude',
             'Nearest Postcode',
             'Ward',
+            'Easting',
+            'Northing',
             'Report URL',
             );
     my @body = ($csv->string);
@@ -249,6 +251,8 @@ sub export_as_csv {
           grep {$c->stash->{children}->{$_} }
           split ',', $hashref->{areas};
 
+        my @local_coords = $report->local_coords;
+
         $csv->combine(
             @{$hashref}{
                 'id',
@@ -266,6 +270,8 @@ sub export_as_csv {
                 'postcode',
                 },
             $wards,
+            $local_coords[0],
+            $local_coords[1],
             (join '', $c->cobrand->base_url_for_report($report), $report->url),
         );
 

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -861,6 +861,7 @@ sub as_hashref {
         latitude  => $self->latitude,
         longitude => $self->longitude,
         postcode  => $self->postcode,
+        areas     => $self->areas,
         state     => $self->state,
         state_t   => _( $self->state ),
         used_map  => $self->used_map,

--- a/t/app/controller/dashboard.t
+++ b/t/app/controller/dashboard.t
@@ -604,7 +604,7 @@ FixMyStreet::override_config {
         }
         is scalar @rows, 6, '1 (header) + 5 (reports) = 6 lines';
 
-        is scalar @{$rows[0]}, 16, '16 columns present';
+        is scalar @{$rows[0]}, 18, '18 columns present';
 
         is_deeply $rows[0],
             [
@@ -623,11 +623,16 @@ FixMyStreet::override_config {
                 'Longitude',
                 'Nearest Postcode',
                 'Ward',
+                'Easting',
+                'Northing',
                 'Report URL',
             ],
             'Column headers look correct';
 
         is $rows[5]->[14], 'Bradford-on-Avon', 'Ward column is name not ID';
+
+        is $rows[5]->[15], '610591', 'Correct Easting conversion';
+        is $rows[5]->[16], '126573', 'Correct Northing conversion';
     };
 };
 restore_time;

--- a/t/app/controller/dashboard.t
+++ b/t/app/controller/dashboard.t
@@ -593,6 +593,7 @@ FixMyStreet::override_config {
             detail => "this report\nis split across\nseveral lines",
             state => "confirmed",
             conf_dt => DateTime->now(),
+            areas => 62883,
         } );
         $mech->get_ok('/dashboard?export=1');
         open my $data_handle, '<', \$mech->content;
@@ -602,6 +603,31 @@ FixMyStreet::override_config {
             push @rows, $row;
         }
         is scalar @rows, 6, '1 (header) + 5 (reports) = 6 lines';
+
+        is scalar @{$rows[0]}, 16, '16 columns present';
+
+        is_deeply $rows[0],
+            [
+                'Report ID',
+                'Title',
+                'Detail',
+                'User Name',
+                'Category',
+                'Created',
+                'Confirmed',
+                'Acknowledged',
+                'Fixed',
+                'Closed',
+                'Status',
+                'Latitude',
+                'Longitude',
+                'Nearest Postcode',
+                'Ward',
+                'Report URL',
+            ],
+            'Column headers look correct';
+
+        is $rows[5]->[14], 'Bradford-on-Avon', 'Ward column is name not ID';
     };
 };
 restore_time;


### PR DESCRIPTION
This adds a Ward, Easting and Northing columns to the CSV export from the council dashboard.

Fixes mysociety/fixmystreetforcouncils#220.
Fixes mysociety/fixmystreetforcouncils#221.