### PR TITLE
[Oxfordshire] Log when problems are sent in RDI

### DIFF
--- a/bin/oxfordshire/send-rdi-emails
+++ b/bin/oxfordshire/send-rdi-emails
@@ -38,6 +38,7 @@ foreach my $inspector (@inspectors) {
         end_date => $end_date,
         inspection_date => $inspection_date,
         user => $inspector,
+        mark_as_processed => 1,
     };
     my $rdi = FixMyStreet::Integrations::ExorRDI->new($params);
     try {

--- a/perllib/FixMyStreet/App/Controller/Admin/ExorDefects.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/ExorDefects.pm
@@ -59,6 +59,7 @@ sub download : Path('download') : Args(0) {
         inspection_date => $start_date,
         end_date => $end_date + $one_day,
         user => $c->get_param('user_id'),
+        mark_as_processed => 0,
     };
     my $rdi = FixMyStreet::Integrations::ExorRDI->new($params);
 

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -171,6 +171,7 @@
           [% ELSE %]
             <p>[% loc("<strong>Note:</strong> This report hasn't yet been sent onwards for action. Any changes made may not be passed on.") %]</p>
           [% END %]
+          [% TRY %][% INCLUDE 'report/_inspect_extra_info.html' %][% CATCH file %][% END %]
         [% END %]
 
         <p>

--- a/templates/web/oxfordshire/report/_inspect_extra_info.html
+++ b/templates/web/oxfordshire/report/_inspect_extra_info.html
@@ -1,0 +1,8 @@
+<p><small>
+RDI sent:
+[% IF problem.get_extra_metadata('rdi_processed') %]
+    [% problem.get_extra_metadata('rdi_processed') %]
+[% ELSE %]
+    <strong>not yet sent</strong>
+[% END %]
+</small></p>


### PR DESCRIPTION
The timestamp of when a problem was included in an RDI is shown on the problem’s
report_edit page in the Oxfordshire cobrand admin.

If a report hasn't been inspected yet:
<img width="766" alt="screen shot 2017-09-05 at 12 00 53" src="https://user-images.githubusercontent.com/4776/30058717-16b6818e-9234-11e7-94d2-3a6cacaa9765.png">

If it's been inspected and instructed but not yet sent:
<img width="760" alt="screen shot 2017-09-05 at 12 00 45" src="https://user-images.githubusercontent.com/4776/30058713-0fe3833e-9234-11e7-872a-7d61a64221ca.png">

And once it's been sent in an RDI:
<img width="831" alt="screen shot 2017-09-05 at 09 41 15" src="https://user-images.githubusercontent.com/4776/30058730-245ad6f0-9234-11e7-9b06-cfe6f06cdccb.png">


Fixes mysociety/fixmystreetforcouncils#223.

[skip changelog]