### PR TITLE
sort body dashboard CSV export by report confirmed time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
         - Body users can filter reports by all states. #1790
         - `LOGIN_REQUIRED` config key to limit site access to logged-in users.
         - `SIGNUPS_DISABLED` config key to prevent new user registrations.
+        - Body dashboard CSV export includes Northing, Easting and Ward.
+          It also now orders fields by report confirmed time. #1832 #1835
     - Front end improvements:
         - Always show pagination figures even if only one page. #1787
         - Report pages list every update to a report. #1806

--- a/perllib/FixMyStreet/App/Controller/Dashboard.pm
+++ b/perllib/FixMyStreet/App/Controller/Dashboard.pm
@@ -181,7 +181,7 @@ sub export_as_csv {
     my ($self, $c, $problems_rs, $body) = @_;
     require Text::CSV;
     my $problems = $problems_rs->search(
-        {}, { prefetch => 'comments' });
+        {}, { prefetch => 'comments', order_by => 'me.confirmed' });
 
     my $filename = do {
         my %where = (

--- a/t/app/controller/dashboard.t
+++ b/t/app/controller/dashboard.t
@@ -531,12 +531,12 @@ FixMyStreet::override_config {
             desc => 'Selecting no state does nothing',
             p1 => {
                     state   => 'fixed - user',
-                    conf_dt => DateTime->now(),
+                    conf_dt => DateTime->now()->subtract( minutes => 1 ),
                     category => 'Potholes',
             },
             p2 => {
                     state   => 'confirmed',
-                    conf_dt => DateTime->now(),
+                    conf_dt => DateTime->now()->subtract( minutes => 1 ),
                     category => 'Litter',
             },
             state => '',
@@ -553,12 +553,12 @@ FixMyStreet::override_config {
             desc => 'All fixed states count as fixed',
             p1 => {
                     state   => 'fixed - council',
-                    conf_dt => DateTime->now(),
+                    conf_dt => DateTime->now()->subtract( minutes => 1 ),
                     category => 'Potholes',
             },
             p2 => {
                     state   => 'fixed',
-                    conf_dt => DateTime->now(),
+                    conf_dt => DateTime->now()->subtract( minutes => 1 ),
                     category => 'Potholes',
             },
             state => 'fixed',


### PR DESCRIPTION
And update the tests to avoid a random failure caused by inconsistent
ordering.