### PR TITLE
Fix issue editing category with '/' in it.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -27,7 +27,7 @@ Admin pages
 
 =cut
 
-sub begin : Private {
+sub auto : Private {
     my ( $self, $c ) = @_;
 
     $c->uri_disposition('relative');
@@ -44,10 +44,6 @@ sub begin : Private {
     if ( $c->cobrand->moniker eq 'zurich' ) {
         $c->cobrand->admin_type();
     }
-}
-
-sub auto : Private {
-    my ( $self, $c ) = @_;
 
     $c->forward('check_page_allowed');
 }

--- a/perllib/FixMyStreet/App/Controller/Admin/DefectTypes.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/DefectTypes.pm
@@ -6,12 +6,6 @@ use mySociety::ArrayUtils;
 BEGIN { extends 'Catalyst::Controller'; }
 
 
-sub begin : Private {
-    my ( $self, $c ) = @_;
-
-    $c->forward('/admin/begin');
-}
-
 sub index : Path : Args(0) {
     my ( $self, $c ) = @_;
 

--- a/perllib/FixMyStreet/App/Controller/Admin/ExorDefects.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/ExorDefects.pm
@@ -9,12 +9,6 @@ use FixMyStreet::Integrations::ExorRDI;
 BEGIN { extends 'Catalyst::Controller'; }
 
 
-sub begin : Private {
-    my ( $self, $c ) = @_;
-
-    $c->forward('/admin/begin');
-}
-
 sub index : Path : Args(0) {
     my ( $self, $c ) = @_;
 

--- a/perllib/FixMyStreet/App/Controller/Admin/ReportExtraFields.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/ReportExtraFields.pm
@@ -6,12 +6,6 @@ use List::MoreUtils qw(uniq);
 BEGIN { extends 'Catalyst::Controller'; }
 
 
-sub begin : Private {
-    my ( $self, $c ) = @_;
-
-    $c->forward('/admin/begin');
-}
-
 sub index : Path : Args(0) {
     my ( $self, $c ) = @_;
 

--- a/perllib/FixMyStreet/App/Controller/Admin/ResponsePriorities.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/ResponsePriorities.pm
@@ -5,12 +5,6 @@ use namespace::autoclean;
 BEGIN { extends 'Catalyst::Controller'; }
 
 
-sub begin : Private {
-    my ( $self, $c ) = @_;
-
-    $c->forward('/admin/begin');
-}
-
 sub index : Path : Args(0) {
     my ( $self, $c ) = @_;
 

--- a/perllib/FixMyStreet/App/Controller/Admin/States.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/States.pm
@@ -4,12 +4,6 @@ use namespace::autoclean;
 
 BEGIN { extends 'Catalyst::Controller'; }
 
-sub begin : Private {
-    my ( $self, $c ) = @_;
-
-    $c->forward('/admin/begin');
-}
-
 sub index : Path : Args(0) {
     my ( $self, $c ) = @_;
 

--- a/perllib/FixMyStreet/App/Controller/My.pm
+++ b/perllib/FixMyStreet/App/Controller/My.pm
@@ -19,9 +19,10 @@ Catalyst Controller.
 
 =cut
 
-sub begin : Private {
+sub auto : Private {
     my ($self, $c) = @_;
     $c->detach( '/auth/redirect' ) unless $c->user;
+    return 1;
 }
 
 =head2 index

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -695,6 +695,7 @@ subtest "only superuser can edit bodies" => sub {
     $user = $mech->log_in_ok( 'dm1@example.org' );
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => [ 'zurich' ],
+        MAPIT_URL => 'http://mapit.zurich/',
     }, sub {
         $mech->get( '/admin/body/' . $zurich->id );
     };


### PR DESCRIPTION
Simplify chaining of body/category admin URLs so that all categories are treated the same, with `/` or without, and the template will then always have its CSRF token. Fixes #1836

(Also fixes awkward bug I stumbled across when the first page after restart is admin as it was when testing above fix.)

[skip changelog] - main bug introduced by body/category translation, stumbled bug introduced by superuser fix (nothing on user model used schema before).