### PR TITLE
Disable email field for logged in people using JS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
         - Improve performance of various pages. #1799
         - Duplicate list not loading when phone number present. #1803
         - Don't list multiple fixed states all as Fixed in dropdown. #1824
+        - Disable email field for logged in people. #1840
     - Development improvements:
         - Debug toolbar added. #1823
         - `switch-site` script to automate switching config.yml files. #1741

--- a/templates/web/base/report/new/form_user_loggedin.html
+++ b/templates/web/base/report/new/form_user_loggedin.html
@@ -30,10 +30,8 @@
 [% END %]
 
     <label for="form_email">[% loc('Email address') %]</label>
-    <input class="form-control" id="form_email"
-    [%- IF js OR can_contribute_as_another_user OR can_contribute_as_body -%]
-    name="email"
-    [%- ELSE -%]
+    <input class="form-control" id="form_email" name="email"
+    [%- IF NOT can_contribute_as_another_user -%]
     disabled
     [%- END -%]
     type="text" value="[% c.user.email | html %]">


### PR DESCRIPTION
They're logged in, it's only showing them as a confirmatory check, so it
should not be editable. I'm afraid I don't understand my commit that did
this last year, so there may be some edge case I've now forgotten :-/