### PR TITLE
improve report status filter default message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
         - Only create one update when staff user updating category #1857
         - Do not include blank updates in email alerts #1857
         - Redirect inspectors correctly on creation in two-tier.
+        - Report status filter All option works for body users #1845
     - Admin improvements:
       - Character length limit can be placed on report detailed information #1848
       - Inspector panel shows nearest address if available #1850

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -539,16 +539,19 @@ sub stash_report_filter_status : Private {
         my $s = FixMyStreet::DB::Result::Problem->open_states();
         %filter_problem_states = (%filter_problem_states, %$s);
         $filter_status{open} = 1;
+        $filter_status{$_} = 1 for keys %$s;
     }
     if ($status{closed}) {
         my $s = FixMyStreet::DB::Result::Problem->closed_states();
         %filter_problem_states = (%filter_problem_states, %$s);
         $filter_status{closed} = 1;
+        $filter_status{$_} = 1 for keys %$s;
     }
     if ($status{fixed}) {
         my $s = FixMyStreet::DB::Result::Problem->fixed_states();
         %filter_problem_states = (%filter_problem_states, %$s);
         $filter_status{fixed} = 1;
+        $filter_status{$_} = 1 for keys %$s;
     }
 
     if ($status{all}) {

--- a/templates/web/base/reports/_list-filters.html
+++ b/templates/web/base/reports/_list-filters.html
@@ -1,10 +1,18 @@
 [% select_status = BLOCK %]
     <select class="form-control js-multiple" name="status" id="statuses" multiple
-      data-all="[% loc('All') %]" data-all-options='["open","closed","fixed"]'
-    [%~ IF c.cobrand.on_map_default_status == 'open' %]
-      data-none="[% loc('Unfixed reports') %]"
+    data-all="[% loc('All') %]"
+    [% IF c.user_exists AND c.user.is_superuser OR c.user.belongs_to_body(body.id) %]
+    [% options = []; FOR group IN filter_states; FOR state IN group.1; NEXT IF state == 'hidden'; options.push(state); END; END %]
+    data-all-options='["[% options.join('", "') %]"]'
+    [%~ ELSE ~%]
+      [%~ IF has_fixed_state ~%]
+        data-all-options='["open","closed","fixed"]'
+      [%~ ELSE ~%]
+        data-all-options='["open","closed"]'
+      [%~ END ~%]
     [%~ END ~%]
-      >
+    [% INCLUDE 'reports/_status_filter_options.html' %]
+    >
       [% IF c.user_exists AND c.user.has_body_permission_to('planned_reports') AND !shortlist %]
         <option value="shortlisted"[% ' selected' IF filter_status.shortlisted %]>[% loc('Shortlisted') %]</option>
         <option value="unshortlisted"[% ' selected' IF filter_status.unshortlisted %]>[% loc('Unshortlisted') %]</option>

--- a/templates/web/base/reports/_status_filter_options.html
+++ b/templates/web/base/reports/_status_filter_options.html
@@ -1,0 +1,3 @@
+    [%~ IF c.cobrand.on_map_default_status == 'open' %]
+      data-none="[% prettify_state('confirmed') %]"
+    [%~ END ~%]

--- a/templates/web/oxfordshire/reports/_status_filter_options.html
+++ b/templates/web/oxfordshire/reports/_status_filter_options.html
@@ -1,0 +1,7 @@
+    [% IF c.user_exists AND c.user.is_superuser OR c.user.belongs_to_body(body.id) %]
+      data-none="All unresolved"
+      data-extra="All unresolved"
+      data-extra-options='["confirmed","investigating","action scheduled"]'
+    [% ELSE %]
+      data-none="Open"
+    [%~ END ~%]

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -113,15 +113,25 @@ function isR2L() {
 
     make_multi: function() {
         var $this = $(this),
-            all = $this.data('all');
+            all = $this.data('all'),
+            none = $this.data('none') || all,
+            allOpts = $this.data('all-options') || [],
+            extra = $this.data('extra'),
+            extraOpts = $this.data('extra-options') || [];
+
+            var presets = [{
+                name: all,
+                options: allOpts
+            }];
+
+            if (extra) {
+                presets.push({name: extra, options: extraOpts});
+            }
         $this.multiSelect({
             allText: all,
-            noneText: all,
+            noneText: none,
             positionMenuWithin: $('#side'),
-            presets: [{
-                name: all,
-                options: []
-            }]
+            presets: presets
         });
     }
 


### PR DESCRIPTION
Partly to restore a more meaningful default message to the Oxfordshire cobrand for the default status of the report status filter, also to make the all option work better for body users.

https://github.com/mysociety/fixmystreetforcouncils/issues/227