### PR TITLE
Maximum length for inspector detailed information 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
         - Area summary statistics page in admin #1834
     - Bugfixes
         - Shortlist menu item always remains a link #1855
+    - Admin improvements:
+      - Character length limit can be placed on report detailed information #1848
 
 * v2.2 (13th September 2017)
     - New features:

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -326,6 +326,8 @@ sub inspect : Private {
         $c->stash->{has_default_priority} = scalar( grep { $_->is_default } $problem->response_priorities );
     }
 
+    $c->stash->{max_detailed_info_length} = $c->cobrand->max_detailed_info_length;
+
     if ( $c->get_param('save') ) {
         $c->forward('/auth/check_csrf_token');
 
@@ -339,7 +341,9 @@ sub inspect : Private {
 
             if ( my $info = $c->get_param('detailed_information') ) {
                 $problem->set_extra_metadata( detailed_information => $info );
-                if (length($info) > 172) {
+                if ($c->cobrand->max_detailed_info_length &&
+                    length($info) > $c->cobrand->max_detailed_info_length
+                ) {
                     $valid = 0;
                     push @{ $c->stash->{errors} },
                         sprintf(

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -335,8 +335,18 @@ sub inspect : Private {
         my %update_params = ();
 
         if ($permissions->{report_inspect}) {
-            foreach (qw/detailed_information traffic_information/) {
-                $problem->set_extra_metadata( $_ => $c->get_param($_) );
+            $problem->set_extra_metadata( traffic_information => $c->get_param('traffic_information') );
+
+            if ( my $info = $c->get_param('detailed_information') ) {
+                $problem->set_extra_metadata( detailed_information => $info );
+                if (length($info) > 172) {
+                    $valid = 0;
+                    push @{ $c->stash->{errors} },
+                        sprintf(
+                            _('Detailed information is limited to %d characters.'),
+                            $c->cobrand->max_detailed_info_length
+                        );
+                }
             }
 
             if ( $c->get_param('defect_type') ) {

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -1090,6 +1090,8 @@ sub state_groups_inspect {
     ]
 }
 
+sub max_detailed_info_length { 0 }
+
 =head2 never_confirm_updates
 
 If true then we never send an email to confirm an update

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -217,6 +217,8 @@ sub user_extra_fields {
 
 sub display_days_ago_threshold { 28 }
 
+sub max_detailed_info_length { 172 }
+
 sub defect_type_extra_fields {
     return [
         'activity_code',

--- a/t/app/controller/report_inspect.t
+++ b/t/app/controller/report_inspect.t
@@ -261,38 +261,58 @@ FixMyStreet::override_config {
             });
         };
     }
-
-    subtest "detailed_information has max length" => sub {
-        $user->user_body_permissions->delete;
-        $user->user_body_permissions->create({ body => $oxon, permission_type => 'report_inspect' });
-        $mech->get_ok("/report/$report_id");
-        $mech->submit_form_ok({
-            button => 'save',
-            with_fields => {
-                include_update => 0,
-                detailed_information => 'XXX172XXX' . 'x' x 163,
-            }
-        });
-
-        $report->discard_changes;
-        like $report->get_extra_metadata('detailed_information'), qr/XXX172XXX/, 'detailed information saved';
-        $mech->content_lacks('limited to 172 characters', "172 charcters of detailed information ok");
-        $mech->content_contains('XXX172XXX', "Detailed information field contains submitted text");
-
-        $mech->submit_form_ok({
-            button => 'save',
-            with_fields => {
-                include_update => 0,
-                detailed_information => 'XXX173XXX' . 'x' x 164,
-            }
-        });
-        $mech->content_contains('limited to 172 characters', "173 charcters of detailed information not ok");
-        $mech->content_contains('XXX173XXX', "Detailed information field contains submitted text");
-
-        $report->discard_changes;
-        like $report->get_extra_metadata('detailed_information'), qr/XXX172XXX/, 'detailed information not saved';
-    };
 };
+
+foreach my $test (
+    { cobrand => 'fixmystreet', limited => 0, desc => 'detailed_information has no max length' },
+    { cobrand => 'oxfordshire', limited => 1, desc => 'detailed_information has max length'  },
+) {
+
+    FixMyStreet::override_config {
+      ALLOWED_COBRANDS => $test->{cobrand},
+    }, sub {
+        subtest $test->{desc} => sub {
+            $user->user_body_permissions->delete;
+            $user->user_body_permissions->create({ body => $oxon, permission_type => 'report_inspect' });
+            $mech->get_ok("/report/$report_id");
+            $mech->submit_form_ok({
+                button => 'save',
+                with_fields => {
+                    include_update => 0,
+                    detailed_information => 'XXX172XXX' . 'x' x 163,
+                }
+            });
+
+            $report->discard_changes;
+            like $report->get_extra_metadata('detailed_information'), qr/XXX172XXX/, 'detailed information saved';
+            $mech->content_lacks('limited to 172 characters', "172 charcters of detailed information ok");
+            $mech->content_contains('XXX172XXX', "Detailed information field contains submitted text");
+
+            $mech->submit_form_ok({
+                button => 'save',
+                with_fields => {
+                    include_update => 0,
+                    detailed_information => 'XXX173XXX' . 'x' x 164,
+                }
+            });
+            if ($test->{limited}) {
+                $mech->content_contains('172 characters maximum');
+                $mech->content_contains('limited to 172 characters', "173 charcters of detailed information not ok");
+                $mech->content_contains('XXX173XXX', "Detailed information field contains submitted text");
+
+                $report->discard_changes;
+                like $report->get_extra_metadata('detailed_information'), qr/XXX172XXX/, 'detailed information not saved';
+            } else {
+                $mech->content_lacks(' characters maximum');
+                $mech->content_lacks('limited to 172 characters', "173 charcters of detailed information ok");
+                $mech->content_contains('XXX173XXX', "Detailed information field contains submitted text");
+
+                $report->discard_changes;
+                like $report->get_extra_metadata('detailed_information'), qr/XXX173XXX/, 'detailed information saved';
+            }
+        };
+    };
+}
 
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => 'oxfordshire',

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -141,9 +141,9 @@
           </select>
         </p>
         <p>
-          <label for="detailed_information">[% loc('Extra details') %]</label>
+          <label for="detailed_information">[% loc('Extra details') %]</label> <span id="detailed_information_length"></span>
           <textarea rows="2" name="detailed_information" id="detailed_information" class="form-control"
-            [% IF max_detailed_info_length %]placeholder="[% tprintf(loc('%d characters maximum'), max_detailed_info_length) %]"[% END %]>[% problem.get_extra_metadata('detailed_information') | html %]</textarea>
+            [% IF max_detailed_info_length %]data-max-length="[% max_detailed_info_length %]" placeholder="[% tprintf(loc('%d characters maximum'), max_detailed_info_length) %]"[% END %]>[% problem.get_extra_metadata('detailed_information') | html %]</textarea>
         </p>
         [% END %]
 

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -142,7 +142,8 @@
         </p>
         <p>
           <label for="detailed_information">[% loc('Extra details') %]</label>
-          <textarea rows="2" name="detailed_information" id="detailed_information" class="form-control">[% problem.get_extra_metadata('detailed_information') | html %]</textarea>
+          <textarea rows="2" name="detailed_information" id="detailed_information" class="form-control"
+            [% IF max_detailed_info_length %]placeholder="[% tprintf(loc('%d characters maximum'), max_detailed_info_length) %]"[% END %]>[% problem.get_extra_metadata('detailed_information') | html %]</textarea>
         </p>
         [% END %]
 

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -299,6 +299,20 @@ $.extend(fixmystreet.set_up, {
         toggle_public_update();
     });
 
+    if ($('#detailed_information').data('max-length')) {
+        $('#detailed_information').on('keyup', function() {
+            var $this = $(this),
+            counter = $('#detailed_information_length');
+            var chars_left = $this.data('max-length') - $this.val().length;
+            counter.html(chars_left);
+            if (chars_left < 0) {
+                counter.addClass('error');
+            } else {
+                counter.removeClass('error');
+            }
+        });
+    }
+
     if (geo_position_js.init()) {
         fixmystreet.geolocate.setup(function(pos) {
             var latlon = new OpenLayers.LonLat(pos.coords.longitude, pos.coords.latitude);

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1863,6 +1863,13 @@ label .muted {
   padding: 1em;
   margin: 0 -1em;
   background-color: #E9F2FF;
+
+  #detailed_information_length {
+    float: right;
+    &.error {
+      color: red;
+    }
+  }
 }
 
 .inspect-form-heading {


### PR DESCRIPTION
Add an optional maximum length, configured in the cobrand, for the detailed information field in the inspector panel.

Fixes mysociety/fixmystreetforcouncils#228