### PR TITLE
show nearest address for report in inspector panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
         - Shortlist menu item always remains a link #1855
     - Admin improvements:
       - Character length limit can be placed on report detailed information #1848
+      - Inspector panel shows nearest address if available #1850
 
 * v2.2 (13th September 2017)
     - New features:

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -618,6 +618,15 @@ sub meta_line {
     return $meta;
 }
 
+sub nearest_address {
+    my $self = shift;
+
+    return '' unless $self->geocode;
+
+    my $address = $self->geocode->{resourceSets}[0]{resources}[0];
+    return $address->{name};
+}
+
 sub body {
     my ( $problem, $c ) = @_;
     my $body;

--- a/t/app/controller/report_inspect.t
+++ b/t/app/controller/report_inspect.t
@@ -261,6 +261,43 @@ FixMyStreet::override_config {
             });
         };
     }
+
+    subtest "check nearest address display" => sub {
+        $mech->get_ok("/report/$report_id");
+        $mech->content_lacks('Nearest calculated address', 'No address displayed');
+
+        my $data = {
+            resourceSets => [ {
+                resources => [ {
+                    address => {
+                        addressLine => 'Constitution Hill',
+                        locality => 'London',
+                    }
+                } ],
+            } ],
+        };
+        $report->geocode($data);
+        $report->update;
+        $mech->get_ok("/report/$report_id");
+        $mech->content_lacks('Nearest calculated address', 'No address displayed');
+
+        $data = {
+            resourceSets => [ {
+                resources => [ {
+                    name => 'Constitution Hill, London, SW1A',
+                    address => {
+                        addressLine => 'Constitution Hill',
+                        locality => 'London',
+                    }
+                } ],
+            } ],
+        };
+        $report->geocode($data);
+        $report->update;
+        $mech->get_ok("/report/$report_id");
+        $mech->content_contains('Nearest calculated address', 'Address displayed');
+        $mech->content_contains('Constitution Hill, London, SW1A', 'Correct address displayed');
+    }
 };
 
 foreach my $test (

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -34,6 +34,12 @@
           <input type="hidden" name="longitude" value="[% problem.longitude %]">
           <input type="hidden" name="latitude" value="[% problem.latitude %]">
         </p>
+        [% IF problem.nearest_address() %]
+        <p>
+            <strong>[% loc('Nearest calculated address:') %]</strong>
+            [% problem.nearest_address() %]
+        </p>
+        [% END %]
         <p>
           <a target="_blank" href="https://www.google.com/maps/dir/Current+Location/[% problem.latitude %],[% problem.longitude %]" class="btn btn--block btn--navigate">[% loc('Navigate to this problem') %]</a>
         </p>


### PR DESCRIPTION
If we've stored the nearest address then display that at the top of the
inspector panel.

Fixes mysociety/fixmystreetforcouncils#230