### PR TITLE
move area stats page problems by status calc into database

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/AreaStats.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/AreaStats.pm
@@ -207,7 +207,12 @@ sub stats : Private {
             join     => 'problem'
         }
     )->first;
-    $c->stash->{average} = int( ($comments->get_column('time')||0)/ 60 / 60 / 24 + 0.5 );
+    my $raw_average = $comments->get_column('time');
+    if (defined $raw_average) {
+        $c->stash->{average} = int( $raw_average / 60 / 60 / 24 + 0.5 );
+    } else {
+        $c->stash->{average} = -1;
+    }
 }
 
 sub load_user_body : Private {

--- a/t/app/controller/area_stats.t
+++ b/t/app/controller/area_stats.t
@@ -98,6 +98,8 @@ FixMyStreet::override_config {
 
         $mech->text_contains('Potholes6');
         $mech->text_contains('Traffic lights13');
+
+        $mech->text_contains('average time between issue being opened and set to another status was 0 days');
     };
 
     subtest 'shows correct stats to area user' => sub {
@@ -212,6 +214,16 @@ FixMyStreet::override_config {
         $mech->get_ok("/admin/areastats/$body_id?area=20720");
         $mech->text_contains('average time between issue being opened and set to another status was 4 days');
     };
+
+    subtest 'shows no problems changed state if no average' => sub {
+        for my $p (@scheduled_problems, @fixed_problems, @closed_problems) {
+            $p->comments->delete;
+        }
+
+        $mech->get_ok("/admin/areastats/$body_id?area=20720");
+        $mech->text_contains('17 opened, 0 scheduled, 0 closed, 0 fixed');
+        $mech->text_contains('no problems changed state');
+    }
 };
 
 END {

--- a/t/app/controller/area_stats.t
+++ b/t/app/controller/area_stats.t
@@ -183,6 +183,17 @@ FixMyStreet::override_config {
         $mech->text_contains('Traffic lights3730');
     };
 
+    subtest 'ignores second state change if first was last month' => sub {
+        my $comment = $scheduled_problems[0]->comments->search({}, { order_by => { '-asc' => 'id' } } )->first;
+        $comment->update({ confirmed => DateTime->now->subtract(days => 40) });
+        $mech->get_ok("/admin/areastats/$body_id?area=20720");
+
+        $mech->content_contains('15 opened, 6 scheduled, 3 closed, 4 fixed');
+        $mech->text_contains('Potholes2004');
+        $mech->text_contains('Traffic lights3730');
+        $comment->update({ confirmed => DateTime->now });
+    };
+
     subtest 'average is only to first state change' => sub {
         for my $i (0..4) {
             $scheduled_problems[$i]->comments->first->update({ confirmed => $scheduled_problems[$i]->confirmed });

--- a/templates/web/base/admin/areastats/area.html
+++ b/templates/web/base/admin/areastats/area.html
@@ -47,7 +47,7 @@
   [% END %]
 </table>
 
-[% IF average > 0 %]
+[% IF average >= 0 %]
 <p>[% tprintf(loc('In the last month – average time between issue being opened and set to another status was %s days'), average) %]</p>
 [% ELSE %]
 <p>[% loc('In the last month no problems changed state') %]</p>


### PR DESCRIPTION
Doing this calculation in code turns out to be much too slow.

As part of this also fix an issue where if a report changed state last
month but had a further comment this month that was counted as being
a state change this month.

Also tweak the 'last month' start date to be midnight so the stats don't
change throughout the day.

[skip changelog]