### PR TITLE
make sure shortlist menu item is link on report pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Unreleased
     - New features:
         - Area summary statistics page in admin #1834
+    - Bugfixes
+        - Shortlist menu item always remains a link #1855
 
 * v2.2 (13th September 2017)
     - New features:

--- a/templates/web/base/main_nav.html
+++ b/templates/web/base/main_nav.html
@@ -8,7 +8,7 @@
 %]
 [% BLOCK navitem ~%]
     <li [% liattrs %]>
-      [%~ IF c.req.uri.path == uri ~%]
+      [%~ IF c.req.uri.path == uri AND NOT always_url ~%]
           <span [% attrs %]>[% label %]</span>
       [%~ ELSE ~%]
           <a href="[% base %][% uri %][% suffix IF suffix %]" [% attrs %]>[% label %]</a>

--- a/templates/web/base/main_nav_items.html
+++ b/templates/web/base/main_nav_items.html
@@ -7,7 +7,7 @@
 [%~ END ~%]
 
 [%~ IF c.user_exists AND c.user.has_body_permission_to('planned_reports') ~%]
-    [%~ INCLUDE navitem uri='/my/planned' label=loc('Shortlist') ~%]
+    [%~ INCLUDE navitem always_url=1 uri='/my/planned' label=loc('Shortlist') ~%]
 [%~ END ~%]
 
 


### PR DESCRIPTION
Because we move to report pages using ajax and pushstate rather than links the shortlist menu item remains inactive because the page doesn't reload. Fix this by making the Shortlist menu item a link all the time.

Fixes mysociety/fixmystreetforcouncils#233