### PR TITLE
Fix category updating issues with inspect form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
     - Bugfixes
         - Shortlist menu item always remains a link #1855
         - Fix encoded entities in RSS output. #1859
+        - Only save category changes if staff user update valid #1857
+        - Only create one update when staff user updating category #1857
     - Admin improvements:
       - Character length limit can be placed on report detailed information #1848
       - Inspector panel shows nearest address if available #1850

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -950,7 +950,7 @@ Handles changing a problem's category and the complexity that comes with it.
 =cut
 
 sub report_edit_category : Private {
-    my ($self, $c, $problem) = @_;
+    my ($self, $c, $problem, $no_comment) = @_;
 
     if ((my $category = $c->get_param('category')) ne $problem->category) {
         my $category_old = $problem->category;
@@ -978,16 +978,21 @@ sub report_edit_category : Private {
         }
 
         $problem->bodies_str(join( ',', @new_body_ids ));
-        $problem->add_to_comments({
-            text => '*' . sprintf(_('Category changed from ‘%s’ to ‘%s’'), $category_old, $category) . '*',
-            created => \'current_timestamp',
-            confirmed => \'current_timestamp',
-            user_id => $c->user->id,
-            name => $c->user->from_body ? $c->user->from_body->name : $c->user->name,
-            state => 'confirmed',
-            mark_fixed => 0,
-            anonymous => 0,
-        });
+        my $update_text = '*' . sprintf(_('Category changed from ‘%s’ to ‘%s’'), $category_old, $category) . '*';
+        if ($no_comment) {
+            $c->stash->{update_text} = $update_text;
+        } else {
+            $problem->add_to_comments({
+                text => $update_text,
+                created => \'current_timestamp',
+                confirmed => \'current_timestamp',
+                user_id => $c->user->id,
+                name => $c->user->from_body ? $c->user->from_body->name : $c->user->name,
+                state => 'confirmed',
+                mark_fixed => 0,
+                anonymous => 0,
+            });
+        }
     }
 }
 

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -424,7 +424,11 @@ sub inspect : Private {
         }
 
         if ($permissions->{report_inspect} || $permissions->{report_edit_category}) {
-            $c->forward( '/admin/report_edit_category', [ $problem ] );
+            $c->forward( '/admin/report_edit_category', [ $problem, 1 ] );
+
+            if ($c->stash->{update_text}) {
+                $update_text .= "\n\n" . $c->stash->{update_text};
+            }
 
             # The new category might require extra metadata (e.g. pothole size), so
             # we need to update the problem with the new values.

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -6,7 +6,7 @@
 
     [% INCLUDE 'errors.html' %]
 
-    <form id="report_inspect_form" method="post" action="[% c.uri_for( '/report', problem.id ) %]" class="validate">
+    <form name="report_inspect_form" id="report_inspect_form" method="post" action="[% c.uri_for( '/report', problem.id ) %]" class="validate">
       <input type="hidden" name="js" value="">
 
       <div class="inspect-section">


### PR DESCRIPTION
This changes the admin code that updates problem categories to do two things:
 * Only update the problem category if the updates are valid
 * Only create a single comment for the changes rather than one for the category change and another for other changes.

For #1857 