### PR TITLE
In RSS, only escape the necessary five/ctrl chars.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
         - Area summary statistics page in admin #1834
     - Bugfixes
         - Shortlist menu item always remains a link #1855
+        - Fix encoded entities in RSS output. #1859
     - Admin improvements:
       - Character length limit can be placed on report detailed information #1848
       - Inspector panel shows nearest address if available #1850

--- a/perllib/FixMyStreet/App/Controller/Rss.pm
+++ b/perllib/FixMyStreet/App/Controller/Rss.pm
@@ -3,7 +3,7 @@ package FixMyStreet::App::Controller::Rss;
 use Moose;
 use namespace::autoclean;
 use POSIX qw(strftime);
-use HTML::Entities;
+use HTML::Entities qw();
 use URI::Escape;
 use XML::RSS;
 
@@ -27,6 +27,10 @@ Catalyst Controller.
 =head1 METHODS
 
 =cut
+
+sub encode_entities {
+    HTML::Entities::encode_entities($_[0], '\x00-\x1f\x7f<>&"\'');
+}
 
 sub updates : LocalRegex('^(\d+)$') {
     my ( $self, $c ) = @_;

--- a/perllib/FixMyStreet/SendReport/EastHants.pm
+++ b/perllib/FixMyStreet/SendReport/EastHants.pm
@@ -6,7 +6,11 @@ BEGIN { extends 'FixMyStreet::SendReport'; }
 
 use Try::Tiny;
 use Encode;
-use HTML::Entities;
+use HTML::Entities qw();
+
+sub encode_entities {
+    HTML::Entities::encode_entities($_[0], '\x00-\x1f\x7f<>&"\'');
+}
 
 sub construct_message {
     my %h = @_;

--- a/t/app/controller/rss.t
+++ b/t/app/controller/rss.t
@@ -1,3 +1,4 @@
+use open ':std', ':locale';
 use FixMyStreet::TestMech;
 use FixMyStreet::App;
 
@@ -18,7 +19,7 @@ my $report = FixMyStreet::App->model('DB::Problem')->find_or_create( {
     bodies_str         => '2651',
     areas              => ',11808,135007,14419,134935,2651,20728,',
     category           => 'Street lighting',
-    title              => 'Testing',
+    title              => '&Test’i<n>g \'☃"',
     detail             => 'Testing Detail',
     used_map           => 1,
     name               => $user1->name,
@@ -44,7 +45,7 @@ FixMyStreet::override_config {
 }, sub {
     $mech->get_ok("/rss/pc/EH11BB/2");
 };
-$mech->content_contains( "Testing, 10th October" );
+$mech->content_contains( "&amp;Test’i&lt;n&gt;g &#39;☃&quot;, 10th October" );
 $mech->content_lacks( 'Nearest road to the pin' );
 is $mech->response->header('Access-Control-Allow-Origin'), '*';
 
@@ -118,7 +119,7 @@ FixMyStreet::override_config {
 }, sub {
     $mech->get_ok("/rss/pc/EH11BB/2");
 };
-$mech->content_contains( "Testing, 10th October" );
+$mech->content_contains( "&amp;Test’i&lt;n&gt;g &#39;☃&quot;, 10th October" );
 $mech->content_contains( '18 North Bridge, Edinburgh' );
 
 $report->delete();


### PR DESCRIPTION
By default encode_entities uses named entities, which don't exist
by default in XML. It seemed nicer to switch to only escaping the
minimum rather than switching to numeric entities.

Fixes #1859