### PR TITLE
Avoid blank updates in alert emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
         - Fix encoded entities in RSS output. #1859
         - Only save category changes if staff user update valid #1857
         - Only create one update when staff user updating category #1857
+        - Do not include blank updates in email alerts #1857
     - Admin improvements:
       - Character length limit can be placed on report detailed information #1848
       - Inspector panel shows nearest address if available #1850

--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -274,14 +274,9 @@ sub problem_state_display {
         return FixMyStreet::DB->resultset("State")->display('confirmed', 1);
     } elsif ($self->problem_state) {
         my $state = $self->problem_state;
-        if ($state eq 'not responsible') {
-            $update_state = _( "not the council's responsibility" );
-            if ($cobrand eq 'bromley' || $self->problem->to_body_named('Bromley')) {
-                $update_state = 'third party responsibility';
-            }
-        } else {
-            $update_state = FixMyStreet::DB->resultset("State")->display($state, 1);
-        }
+        my $cobrand_name = $cobrand;
+        $cobrand_name = 'bromley' if $self->problem->to_body_named('Bromley');
+        $update_state = FixMyStreet::DB->resultset("State")->display($state, 1, $cobrand_name);
     }
 
     return $update_state;

--- a/perllib/FixMyStreet/DB/ResultSet/State.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/State.pm
@@ -58,7 +58,7 @@ sub fixed { [ $_[0]->_filter(sub { $_->type eq 'fixed' }) ] }
 # This function can be used to return that label's display name.
 
 sub display {
-    my ($rs, $label, $single_fixed) = @_;
+    my ($rs, $label, $single_fixed, $cobrand) = @_;
     my $unchanging = {
         unconfirmed => _("Unconfirmed"),
         hidden => _("Hidden"),
@@ -72,6 +72,10 @@ sub display {
     };
     $label = 'fixed' if $single_fixed && $label =~ /^fixed - (council|user)$/;
     return $unchanging->{$label} if $unchanging->{$label};
+    if ($cobrand && $label eq 'not responsible') {
+        return 'third party responsibility' if $cobrand eq 'bromley';
+        return _("not the council's responsibility");
+    }
     my ($state) = $rs->_filter(sub { $_->label eq $label });
     return $label unless $state;
     $state->name($translate_now->{$label}) if $translate_now->{$label};

--- a/perllib/FixMyStreet/Script/Alerts.pm
+++ b/perllib/FixMyStreet/Script/Alerts.pm
@@ -103,6 +103,7 @@ sub send() {
             my $url = $cobrand->base_url_for_report($row);
             # this is currently only for new_updates
             if (defined($row->{item_text})) {
+                next unless $row->{item_text};
                 if ( $cobrand->moniker ne 'zurich' && $row->{alert_user_id} == $row->{user_id} ) {
                     # This is an alert to the same user who made the report - make this a login link
                     # Don't bother with Zurich which has no accounts

--- a/t/app/controller/alert_new.t
+++ b/t/app/controller/alert_new.t
@@ -475,7 +475,7 @@ subtest "Test normal alert signups and that alerts are sent" => sub {
     $mech->delete_user($user2);
 };
 
-subtest "Test alerts are correct for no-text updates" => sub {
+subtest "Test alerts are not sent for no-text updates" => sub {
     $mech->delete_user( 'reporter@example.com' );
     $mech->delete_user( 'alerts@example.com' );
 
@@ -540,14 +540,7 @@ subtest "Test alerts are correct for no-text updates" => sub {
         FixMyStreet::Script::Alerts::send();
     };
 
-    $mech->email_count_is(1);
-    my $email = $mech->get_email;
-    my $body = $mech->get_text_body_from_email($email);
-    like $body, qr/The following updates have been left on this report:/, 'email is about updates to existing report';
-    like $body, qr/Staff User/, 'Update comes from correct user';
-
-    my @urls = $mech->get_link_from_email($email, 1);
-    is $urls[0], "http://www.example.org/report/" . $report_id, "Correct report URL in email";
+    $mech->email_count_is(0);
 
     $mech->delete_user($user1);
     $mech->delete_user($user2);


### PR DESCRIPTION
This both ignores blank updates for email alerts and also includes useful text in the update if the status of the problem was changed.

For #1857