### PR TITLE
Allow ward page to show multiple wards.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
           using confirmation by phone text.
         - Improved email/phone management in your profile.
         - Area summary statistics page in admin #1834
+        - Allow multiple wards to be shown on reports page
     - Bugfixes
         - Shortlist menu item always remains a link #1855
         - Fix encoded entities in RSS output. #1859

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -81,10 +81,6 @@ sub dispatch_request {
             $self->output({2226 => {parent_area => undef, id => 2226, name => "Gloucestershire County Council", type => "CTY"}});
         } elsif ($areas eq 'Cheltenham') {
             $self->output({2326 => {parent_area => undef, id => 2326, name => "Cheltenham Borough Council", type => "DIS"}});
-        } elsif ($areas eq 'Lansdown and Park') {
-            $self->output({22261 => {parent_area => 2226, id => 22261, name => "Lansdown and Park", type => "CED"}});
-        } elsif ($areas eq 'Lansdown') {
-            $self->output({23261 => {parent_area => 2326, id => 23261, name => "Lansdown", type => "DIW"}});
         } elsif ($areas eq 'UTA') {
             $self->output({2650 => {parent_area => undef, id => 2650, name => "Aberdeen Council", type => "UTA"}});
         }
@@ -104,6 +100,18 @@ sub dispatch_request {
 
     sub (GET + /area/*/children) {
         my ($self, $area) = @_;
+        if ($area eq '2514') {
+            return $self->output({
+                8794 => {parent_area => 2514, id => 8794, name => "Aston", type => "MTW"},
+                8773 => {parent_area => 2514, id => 8773, name => "Bournville", type => "MTW"},
+            });
+        }
+        if ($area eq '2326') {
+            return $self->output({23261 => {parent_area => 2326, id => 23261, name => "Lansdown", type => "DIW"}});
+        }
+        if ($area eq '2226') {
+            return $self->output({22261 => {parent_area => 2226, id => 22261, name => "Lansdown and Park", type => "CED"}});
+        }
         my $response = {
             "60705" => { "parent_area" => 2245, "generation_high" => 25, "all_names" => { }, "id" => 60705, "codes" => { "ons" => "00HY226", "gss" => "E04011842", "unit_id" => "17101" }, "name" => "Trowbridge", "country" => "E", "type_name" => "Civil parish/community", "generation_low" => 12, "country_name" => "England", "type" => "CPC" },
             "62883" => { "parent_area" => 2245, "generation_high" => 25, "all_names" => { }, "id" => 62883, "codes" => { "ons" => "00HY026", "gss" => "E04011642", "unit_id" => "17205" }, "name" => "Bradford-on-Avon", "country" => "E", "type_name" => "Civil parish/community", "generation_low" => 12, "country_name" => "England", "type" => "CPC" },

--- a/t/app/controller/reports.t
+++ b/t/app/controller/reports.t
@@ -114,6 +114,18 @@ FixMyStreet::override_config {
     MAPIT_URL => 'http://mapit.uk/',
 }, sub {
     $mech->submit_form_ok( { with_fields => { body => $body_edin_id } }, 'Submitted dropdown okay' );
+    is $mech->uri->path, '/reports/City+of+Edinburgh+Council';
+
+    subtest "test ward pages" => sub {
+        $mech->get_ok('/reports/Birmingham/Bad-Ward');
+        is $mech->uri->path, '/reports/Birmingham+City+Council';
+        $mech->get_ok('/reports/Birmingham/Aston');
+        is $mech->uri->path, '/reports/Birmingham+City+Council/Aston';
+        $mech->get_ok('/reports/Birmingham/Aston|Bournville');
+        is $mech->uri->path, '/reports/Birmingham+City+Council/Aston%7CBournville';
+        $mech->content_contains('Aston, Bournville');
+    };
+
     $mech->get_ok('/reports/Westminster');
 };
 

--- a/templates/web/base/reports/body.html
+++ b/templates/web/base/reports/body.html
@@ -42,7 +42,12 @@
         [% ward.name %]
     </h1>
     <a href="[% body_url %]">[% body.name %]</a>
-    [% ELSE %]
+  [% ELSIF wards %]
+    <h1 id="reports_heading">
+    [% FOREACH w IN wards %][% w.name %][% IF NOT loop.last %], [% END %][% END %]
+    </h1>
+    <a href="[% body_url %]">[% body.name %]</a>
+  [% ELSE %]
     <h1 id="reports_heading">
         [% body.name %]
     </h1>


### PR DESCRIPTION
URLs have to be manually constructed, but specifying multiple ward names
separated by "|" will show all those wards and their reports on the map.

![image](https://user-images.githubusercontent.com/154364/31278031-57a38eba-aa9b-11e7-86b9-e55779c9cdf6.png)


Fixes https://github.com/mysociety/fixmystreetforcouncils/issues/231