### PR TITLE
make sure duplicate id provided when marking as duplicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
       - Inspector panel shows nearest address if available #1850
       - Return a 200 rather than 404 for ref ID lookup.
       - Public report page shows state changes made in admin interface #1846
+      - Marking an item as a duplicate enforces providing duplicate id or
+        a public update #1873
 
 * v2.2 (13th September 2017)
     - New features:

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -377,15 +377,15 @@ sub inspect : Private {
             if ( $problem->state eq 'hidden' ) {
                 $problem->get_photoset->delete_cached;
             }
-            if ( $problem->state eq 'duplicate' && $old_state ne 'duplicate' ) {
-                # If the report is being closed as duplicate, make sure the
-                # update records this.
-                $update_params{problem_state} = "duplicate";
-            }
-            if ( $problem->state ne 'duplicate' ) {
+            if ( $problem->state eq 'duplicate') {
+                if (my $duplicate_of = $c->get_param('duplicate_of')) {
+                    $problem->set_duplicate_of($duplicate_of);
+                } elsif (not $c->get_param('public_update')) {
+                    $valid = 0;
+                    push @{ $c->stash->{errors} }, _('Please provide a duplicate ID or public update for this report.');
+                }
+            } else {
                 $problem->unset_extra_metadata('duplicate_of');
-            } elsif (my $duplicate_of = $c->get_param('duplicate_of')) {
-                $problem->set_duplicate_of($duplicate_of);
             }
 
             if ( $problem->state ne $old_state ) {


### PR DESCRIPTION
It was possible to mark a report as a duplicate in the inspector panel
without providing an id of the duplicate. This prevents that.

Fixes mysociety/fixmystreetforcouncils#236