### PR TITLE
Add expand map toggle to more mobile maps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
         - Area summary statistics page in admin #1834
         - Allow multiple wards to be shown on reports page
         - Don't cover whole map with pin loading indicator.
+        - Add Expand map toggle to more mobile maps.
     - Bugfixes
         - Shortlist menu item always remains a link #1855
         - Fix encoded entities in RSS output. #1859

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -659,7 +659,7 @@ $.extend(fixmystreet.set_up, {
         }
         $('#key-tools li:empty').remove();
         $('#report-updates-data').insertAfter($('#map_box'));
-        if (fixmystreet.page === 'report' || fixmystreet.page === 'reports') {
+        if (fixmystreet.page !== 'around') {
             $('#sub_map_links').append('<a href="#" id="toggle-fullscreen" class="expand" data-expand-text="'+ translation_strings.expand_map +'" data-compress-text="'+ translation_strings.collapse_map +'" >'+ translation_strings.expand_map +'</span>');
         }
     }


### PR DESCRIPTION
Any map bar the already-full-screen /around map could benefit from
the expand map option, especially the list of your reports.