### PR TITLE
Redirect inspectors correctly on creation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
         - Only save category changes if staff user update valid #1857
         - Only create one update when staff user updating category #1857
         - Do not include blank updates in email alerts #1857
+        - Redirect inspectors correctly on creation in two-tier.
     - Admin improvements:
       - Character length limit can be placed on report detailed information #1848
       - Inspector panel shows nearest address if available #1850

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1362,9 +1362,13 @@ sub redirect_or_confirm_creation : Private {
                 to => [ [ $report->user->email, $report->name ] ],
             } );
         }
-        if ($c->user_exists && $c->user->has_body_permission_to('planned_reports')) {
+        # If the user has shortlist permission, and either we're not on a
+        # council cobrand or the just-created problem is owned by the cobrand
+        # (so we'll stay on-cobrand), redirect to the problem.
+        if ($c->user_exists && $c->user->has_body_permission_to('planned_reports') &&
+            (!$c->cobrand->is_council || $c->cobrand->owns_problem($report))) {
             $c->log->info($report->user->id . ' is an inspector - redirecting straight to report page for ' . $report->id);
-            $c->res->redirect( '/report/'. $report->id );
+            $c->res->redirect( $report->url );
         } else {
             $c->log->info($report->user->id . ' was logged in, showing confirmation page for ' . $report->id);
             $c->stash->{created_report} = 'loggedin';


### PR DESCRIPTION
Do not try and redirect to a report that won't be viewable on the cobrand being used.