### PR TITLE
Add per-body reports summary pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
         - Allow multiple wards to be shown on reports page
         - Don't cover whole map with pin loading indicator.
         - Add Expand map toggle to more mobile maps.
+        - Add functionality to have per-body /reports page.
     - Bugfixes
         - Shortlist menu item always remains a link #1855
         - Fix encoded entities in RSS output. #1859

--- a/bin/update-all-reports
+++ b/bin/update-all-reports
@@ -16,16 +16,18 @@ BEGIN {
     require "$d/../setenv.pl";
 }
 
+use FixMyStreet::DB;
 use FixMyStreet::Script::UpdateAllReports;
-use File::Path ();
-use File::Slurp;
+use Path::Tiny;
 use Getopt::Long::Descriptive;
 use JSON::MaybeXS;
 
 my ($opt, $usage) = describe_options(
     '%c %o',
     [ 'table', "Output JSON for old table-style page." ],
-    [ 'areas', "Include area IDs in output JSON." ],
+    [ 'body=i', "Restrict results to a particular body (dashboard-style)." ],
+    [ 'all-bodies', "Generate set of results for all bodies." ],
+    [ 'areas', "Include area IDs in output JSON (table-style)." ],
     [ 'help', "print usage message and exit", { shortcircuit => 1 } ],
 );
 print($usage->text), exit if $opt->help;
@@ -33,12 +35,26 @@ print($usage->text), exit if $opt->help;
 my ($data, $filename);
 if ($opt->table) {
     $data = FixMyStreet::Script::UpdateAllReports::generate($opt->areas);
-    $filename = 'all-reports.json';
+    output('all-reports', $data);
+} elsif ($opt->all_bodies) {
+    my $bodies = FixMyStreet::DB->resultset("Body")->search({ deleted => 0 });
+    while (my $body = $bodies->next) {
+        my $data = FixMyStreet::Script::UpdateAllReports::generate_dashboard($body->id);
+        output("all-reports-dashboard-" . $body->id, $data);
+    }
+} elsif (my $body_id = $opt->body) {
+    my $body = FixMyStreet::DB->resultset("Body")->find({ id => $body_id });
+    die "Could not find body $body_id" unless $body;
+    $data = FixMyStreet::Script::UpdateAllReports::generate_dashboard($body);
+    output("all-reports-dashboard-$body_id", $data);
 } else {
     $data = FixMyStreet::Script::UpdateAllReports::generate_dashboard();
-    $filename = 'all-reports-dashboard.json';
+    output("all-reports-dashboard", $data);
 }
 
-my $json = encode_json($data);
-File::Path::mkpath(FixMyStreet->path_to('../data/')->stringify);
-File::Slurp::write_file(FixMyStreet->path_to("../data/$filename")->stringify, \$json);
+sub output {
+    my ($filename, $data) = @_;
+    my $json = encode_json($data);
+    path(FixMyStreet->path_to('../data/'))->mkpath;
+    path(FixMyStreet->path_to("../data/$filename.json"))->spew_utf8($json);
+}

--- a/bin/update-all-reports
+++ b/bin/update-all-reports
@@ -17,7 +17,10 @@ BEGIN {
 }
 
 use FixMyStreet::Script::UpdateAllReports;
+use File::Path ();
+use File::Slurp;
 use Getopt::Long::Descriptive;
+use JSON::MaybeXS;
 
 my ($opt, $usage) = describe_options(
     '%c %o',
@@ -27,8 +30,15 @@ my ($opt, $usage) = describe_options(
 );
 print($usage->text), exit if $opt->help;
 
+my ($data, $filename);
 if ($opt->table) {
-    FixMyStreet::Script::UpdateAllReports::generate($opt->areas);
+    $data = FixMyStreet::Script::UpdateAllReports::generate($opt->areas);
+    $filename = 'all-reports.json';
 } else {
-    FixMyStreet::Script::UpdateAllReports::generate_dashboard();
+    $data = FixMyStreet::Script::UpdateAllReports::generate_dashboard();
+    $filename = 'all-reports-dashboard.json';
 }
+
+my $json = encode_json($data);
+File::Path::mkpath(FixMyStreet->path_to('../data/')->stringify);
+File::Slurp::write_file(FixMyStreet->path_to("../data/$filename")->stringify, \$json);

--- a/perllib/FixMyStreet/App/Controller/About.pm
+++ b/perllib/FixMyStreet/App/Controller/About.pm
@@ -23,6 +23,7 @@ sub page : Path("/about") : Args(1) {
     my $template = $c->forward('find_template');
     $c->detach('/page_error_404_not_found', []) unless $template;
     $c->stash->{template} = $template;
+    $c->cobrand->call_hook('about_hook');
 }
 
 sub index : Path("/about") : Args(0) {

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -2,9 +2,9 @@ package FixMyStreet::App::Controller::Reports;
 use Moose;
 use namespace::autoclean;
 
-use File::Slurp;
 use JSON::MaybeXS;
 use List::MoreUtils qw(any);
+use Path::Tiny;
 use POSIX qw(strcoll);
 use RABX;
 use mySociety::MaPit;
@@ -83,16 +83,15 @@ sub index : Path : Args(0) {
     $c->stash->{any_empty_bodies} = any { $_->get_column('area_count') == 0 } @bodies;
 
     my $dashboard = eval {
-        my $data = File::Slurp::read_file(
-            FixMyStreet->path_to( '../data/all-reports-dashboard.json' )->stringify
-        );
-        $c->stash(decode_json($data));
+        my $data = FixMyStreet->config('TEST_DASHBOARD_DATA');
+        unless ($data) {
+            $data = decode_json(path(FixMyStreet->path_to('../data/all-reports-dashboard.json'))->slurp_utf8);
+        }
+        $c->stash($data);
         return 1;
     };
     my $table = eval {
-        my $data = File::Slurp::read_file(
-            FixMyStreet->path_to( '../data/all-reports.json' )->stringify
-        );
+        my $data = path(FixMyStreet->path_to('../data/all-reports.json'))->slurp_utf8;
         $c->stash(decode_json($data));
         return 1;
     };

--- a/perllib/FixMyStreet/DB/Result/Body.pm
+++ b/perllib/FixMyStreet/DB/Result/Body.pm
@@ -156,12 +156,13 @@ sub areas {
 }
 
 sub first_area_children {
-    my ( $self, $c ) = @_;
+    my ( $self ) = @_;
 
     my $area_id = $self->body_areas->first->area_id;
 
+    my $cobrand = $self->result_source->schema->cobrand;
     my $children = mySociety::MaPit::call('area/children', $area_id,
-        type => $c->cobrand->area_types_children,
+        type => $cobrand->area_types_children,
     );
 
     return $children;

--- a/perllib/FixMyStreet/Script/UpdateAllReports.pm
+++ b/perllib/FixMyStreet/Script/UpdateAllReports.pm
@@ -6,9 +6,6 @@ use warnings;
 use FixMyStreet;
 use FixMyStreet::DB;
 
-use File::Path ();
-use File::Slurp;
-use JSON::MaybeXS;
 use List::MoreUtils qw(zip);
 use List::Util qw(sum);
 
@@ -81,13 +78,10 @@ sub generate {
         }
     }
 
-    my $body = encode_json( {
+    return {
         fixed => \%fixed,
         open  => \%open,
-    } );
-
-    File::Path::mkpath( FixMyStreet->path_to( '../data/' )->stringify );
-    File::Slurp::write_file( FixMyStreet->path_to( '../data/all-reports.json' )->stringify, \$body );
+    };
 }
 
 sub end_period {
@@ -247,9 +241,7 @@ sub generate_dashboard {
     }
     $data{other_categories} = $last_seven_days;
 
-    my $body = encode_json( \%data );
-    File::Path::mkpath( FixMyStreet->path_to( '../data/' )->stringify );
-    File::Slurp::write_file( FixMyStreet->path_to( '../data/all-reports-dashboard.json' )->stringify, \$body );
+    return \%data;
 }
 
 sub stuff_by_day_or_year {

--- a/perllib/FixMyStreet/Script/UpdateAllReports.pm
+++ b/perllib/FixMyStreet/Script/UpdateAllReports.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use FixMyStreet;
+use FixMyStreet::Cobrand;
 use FixMyStreet::DB;
 
 use List::MoreUtils qw(zip);
@@ -17,6 +18,11 @@ my $age_column = 'confirmed';
 if ( FixMyStreet->config('BASE_URL') =~ /zurich|zueri/ ) {
     $age_column = 'created';
 }
+
+my $dtf = FixMyStreet::DB->schema->storage->datetime_parser;
+
+my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker('default')->new;
+FixMyStreet::DB->schema->cobrand($cobrand);
 
 sub generate {
     my $include_areas = shift;
@@ -101,10 +107,18 @@ sub loop_period {
 }
 
 sub generate_dashboard {
+    my $body = shift;
+
     my %data;
 
+    my $rs = FixMyStreet::DB->resultset('Problem');
+    $rs = $rs->to_body($body) if $body;
+
+    my $rs_c = FixMyStreet::DB->resultset('Comment');
+    $rs_c = $rs_c->to_body($body) if $body;
+
     my $end_today = end_period('day');
-    my $min_confirmed = FixMyStreet::DB->resultset('Problem')->search({
+    my $min_confirmed = $rs->search({
         state => [ FixMyStreet::DB::Result::Problem->visible_states() ],
     }, {
         select => [ { min => 'confirmed' } ],
@@ -128,11 +142,11 @@ sub generate_dashboard {
     my @problem_periods = loop_period($min_confirmed, $group_by, $extra);
 
     my %problems_reported_by_period = stuff_by_day_or_year(
-        $group_by, 'Problem',
+        $group_by, $rs,
         state => [ FixMyStreet::DB::Result::Problem->visible_states() ],
     );
     my %problems_fixed_by_period = stuff_by_day_or_year(
-        $group_by, 'Problem',
+        $group_by, $rs,
         state => [ FixMyStreet::DB::Result::Problem->fixed_states() ],
     );
 
@@ -152,24 +166,23 @@ sub generate_dashboard {
     );
     $data{last_seven_days} = \%last_seven_days;
 
-    my $dtf = FixMyStreet::DB->schema->storage->datetime_parser;
     my $eight_ago = $dtf->format_datetime(DateTime->now->subtract(days => 8));
     %problems_reported_by_period = stuff_by_day_or_year('day',
-        'Problem',
+        $rs,
         state => [ FixMyStreet::DB::Result::Problem->visible_states() ],
-        confirmed => { '>=', $eight_ago },
+        'me.confirmed' => { '>=', $eight_ago },
     );
     %problems_fixed_by_period = stuff_by_day_or_year('day',
-        'Comment',
-        confirmed => { '>=', $eight_ago },
+        $rs_c,
+        'me.confirmed' => { '>=', $eight_ago },
         -or => [
             problem_state => [ FixMyStreet::DB::Result::Problem->fixed_states() ],
             mark_fixed => 1,
         ],
     );
     my %problems_updated_by_period = stuff_by_day_or_year('day',
-        'Comment',
-        confirmed => { '>=', $eight_ago },
+        $rs_c,
+        'me.confirmed' => { '>=', $eight_ago },
     );
 
     my $date = DateTime->today->subtract(days => 7);
@@ -183,13 +196,65 @@ sub generate_dashboard {
     $last_seven_days{fixed_total} = sum @{$last_seven_days{fixed}};
     $last_seven_days{updated_total} = sum @{$last_seven_days{updated}};
 
+    if ($body) {
+        calculate_top_five_wards(\%data, $rs, $body);
+    } else {
+        calculate_top_five_bodies(\%data, $rs_c);
+    }
+
+    my $week_ago = $dtf->format_datetime(DateTime->now->subtract(days => 7));
+    my $last_seven_days = $rs->search({
+        confirmed => { '>=', $week_ago },
+    })->count;
+    my @top_five_categories = $rs->search({
+        confirmed => { '>=', $week_ago },
+        category => { '!=', 'Other' },
+    }, {
+        select => [ 'category', { count => 'id' } ],
+        as => [ 'category', 'count' ],
+        group_by => 'category',
+        rows => 5,
+        order_by => { -desc => 'count' },
+    });
+    $data{top_five_categories} = [ map {
+        { category => $_->category, count => $_->get_column('count') }
+        } @top_five_categories ];
+    foreach (@top_five_categories) {
+        $last_seven_days -= $_->get_column('count');
+    }
+    $data{other_categories} = $last_seven_days;
+
+    return \%data;
+}
+
+sub stuff_by_day_or_year {
+    my $period = shift;
+    my $rs = shift;
+    my %params = @_;
+    my $results = $rs->search({
+        %params
+    }, {
+        select => [ { extract => \"$period from me.confirmed", -as => $period }, { count => 'me.id' } ],
+        as => [ $period, 'count' ],
+        group_by => [ $period ],
+    });
+    my %out;
+    while (my $row = $results->next) {
+        my $p = $row->get_column($period);
+        $out{$p} = $row->get_column('count');
+    }
+    return %out;
+}
+
+sub calculate_top_five_bodies {
+    my ($data, $rs_c) = @_;
+
     my(@top_five_bodies);
-    $data{top_five_bodies} = \@top_five_bodies;
 
     my $bodies = FixMyStreet::DB->resultset('Body')->search;
     my $substmt = "select min(id) from comment where me.problem_id=comment.problem_id and (problem_state in ('fixed', 'fixed - council', 'fixed - user') or mark_fixed)";
     while (my $body = $bodies->next) {
-        my $subquery = FixMyStreet::DB->resultset('Comment')->to_body($body)->search({
+        my $subquery = $rs_c->to_body($body)->search({
             -or => [
                 problem_state => [ FixMyStreet::DB::Result::Problem->fixed_states() ],
                 mark_fixed => 1,
@@ -214,53 +279,33 @@ sub generate_dashboard {
             if defined $avg;
     }
     @top_five_bodies = sort { $a->{days} <=> $b->{days} } @top_five_bodies;
-    $data{average} = @top_five_bodies
+    $data->{average} = @top_five_bodies
         ? int((sum map { $_->{days} } @top_five_bodies) / @top_five_bodies + 0.5) : undef;
 
     @top_five_bodies = @top_five_bodies[0..4] if @top_five_bodies > 5;
-
-    my $week_ago = $dtf->format_datetime(DateTime->now->subtract(days => 7));
-    my $last_seven_days = FixMyStreet::DB->resultset("Problem")->search({
-        confirmed => { '>=', $week_ago },
-    })->count;
-    my @top_five_categories = FixMyStreet::DB->resultset("Problem")->search({
-        confirmed => { '>=', $week_ago },
-        category => { '!=', 'Other' },
-    }, {
-        select => [ 'category', { count => 'id' } ],
-        as => [ 'category', 'count' ],
-        group_by => 'category',
-        rows => 5,
-        order_by => { -desc => 'count' },
-    });
-    $data{top_five_categories} = [ map {
-        { category => $_->category, count => $_->get_column('count') }
-        } @top_five_categories ];
-    foreach (@top_five_categories) {
-        $last_seven_days -= $_->get_column('count');
-    }
-    $data{other_categories} = $last_seven_days;
-
-    return \%data;
+    $data->{top_five_bodies} = \@top_five_bodies;
 }
 
-sub stuff_by_day_or_year {
-    my $period = shift;
-    my $table = shift;
-    my %params = @_;
-    my $results = FixMyStreet::DB->resultset($table)->search({
-        %params
-    }, {
-        select => [ { extract => \"$period from confirmed", -as => $period }, { count => 'id' } ],
-        as => [ $period, 'count' ],
-        group_by => [ $period ],
-    });
-    my %out;
-    while (my $row = $results->next) {
-        my $p = $row->get_column($period);
-        $out{$p} = $row->get_column('count');
+sub calculate_top_five_wards {
+    my ($data, $rs, $body) = @_;
+
+    my $children = $body->first_area_children;
+    die $children->{error} if $children->{error};
+
+    my $week_ago = $dtf->format_datetime(DateTime->now->subtract(days => 7));
+    my $last_seven_days = $rs->search({ confirmed => { '>=', $week_ago } });
+    my $last_seven_days_count = $last_seven_days->count;
+    $last_seven_days = $last_seven_days->search(undef, { select => 'areas' });
+
+    while (my $row = $last_seven_days->next) {
+        $children->{$_}{reports}++ foreach grep { $children->{$_} } split /,/, $row->areas;
     }
-    return %out;
+    my @wards = sort { $b->{reports} <=> $a->{reports} } grep { $_->{reports} } values %$children;
+    @wards = @wards[0..4] if @wards > 5;
+
+    my $sum_five = (sum map { $_->{reports} } @wards) || 0;
+    $data->{other_wards} = $last_seven_days_count - $sum_five;
+    $data->{wards} = \@wards;
 }
 
 1;

--- a/t/cobrand/fixmystreet.t
+++ b/t/cobrand/fixmystreet.t
@@ -1,0 +1,47 @@
+use FixMyStreet::Script::UpdateAllReports;
+
+use FixMyStreet::TestMech;
+my $mech = FixMyStreet::TestMech->new;
+
+my $body = $mech->create_body_ok( 2514, 'Birmingham' );
+
+my $data;
+FixMyStreet::override_config {
+    MAPIT_URL => 'http://mapit.uk/',
+}, sub {
+    $data = FixMyStreet::Script::UpdateAllReports::generate_dashboard($body);
+};
+
+FixMyStreet::override_config {
+    MAPIT_URL => 'http://mapit.uk/',
+    TEST_DASHBOARD_DATA => $data,
+    ALLOWED_COBRANDS => 'fixmystreet',
+}, sub {
+    # Not logged in, redirected
+    $mech->get_ok('/reports/Birmingham/summary');
+    is $mech->uri->path, '/about/council-dashboard';
+
+    $mech->submit_form_ok({ with_fields => { username => 'someone@somewhere.example.org' }});
+    $mech->content_contains('We will be in touch');
+    # XXX Check email arrives
+
+    $mech->log_in_ok('someone@somewhere.example.org');
+    $mech->get_ok('/reports/Birmingham/summary');
+    is $mech->uri->path, '/about/council-dashboard';
+    $mech->content_contains('Ending in .gov.uk');
+
+    $mech->submit_form_ok({ with_fields => { name => 'Someone', username => 'someone@birmingham.gov.uk' }});
+    $mech->content_contains('Now check your email');
+    # XXX Check email arrives, click link
+
+    $mech->log_in_ok('someone@birmingham.gov.uk');
+    # Logged in, redirects
+    $mech->get_ok('/about/council-dashboard');
+    is $mech->uri->path, '/reports/Birmingham/summary';
+    $mech->content_contains('Top 5 wards');
+
+};
+
+END {
+    done_testing();
+}

--- a/templates/web/base/reports/index.html
+++ b/templates/web/base/reports/index.html
@@ -15,7 +15,9 @@
 [% INCLUDE 'header.html', title = loc('Dashboard'), bodyclass => 'dashboard fullwidthpage' %]
 
 <div class="dashboard-header">
-    <h1>[% loc('Dashboard') %]</h1>
+    <h1>[% loc('Dashboard') %]
+    [% IF body %] – [% body.name %] [% END %]
+    </h1>
 </div>
 
 <div class="dashboard-row">
@@ -58,19 +60,31 @@
         </div>
     </div>
     <div class="dashboard-item dashboard-item--6">
-        <form class="dashboard-search" action="/reports">
+        <form class="dashboard-search">
             <h2>[% loc('Show reports in your area') %]</h2>
+          [% IF body %]
+            <label for="ward">[% loc('Pick your ward') %]</label>
+            <div class="dashboard-search__input">
+                <select id="ward" name="ward" class="js-autocomplete">
+                    <option value="">[% loc('Pick your ward') %]</option>
+                  [% FOR child IN children.values.sort('name') %]
+                    <option>[% child.name | html ~%]</option>
+                  [% END %]
+                </select>
+            </div>
+          [% ELSE %]
             <label for="body">[% loc('Pick your council') %]</label>
             <div class="dashboard-search__input">
                 <select id="body" name="body" class="js-autocomplete">
                     <option value="">[% loc('Pick your council') %]</option>
-                  [% FOR body IN bodies %]
-                    <option value="[% body.id %]">[% body.name | html ~%]
-                        [% IF NOT body.get_column("area_count") %] [% loc('(no longer exists)') %][% END ~%]
+                  [% FOR b IN bodies # Not body as 'body' may be on stash %]
+                    <option value="[% b.id %]">[% b.name | html ~%]
+                        [% IF NOT b.get_column("area_count") %] [% loc('(no longer exists)') %][% END ~%]
                     </option>
                   [% END %]
                 </select>
             </div>
+          [% END %]
             <div class="dashboard-search__submit">
                 <input type="submit" value="[% loc('Go') %]">
             </div>
@@ -80,6 +94,20 @@
 
 <div class="dashboard-row">
     <div class="dashboard-item dashboard-item--6">
+      [% IF body %]
+        <h2 class="dashboard-subheading">[% loc('Top 5 wards') %]</h2>
+        <p>[% loc('Number of problems reported in each ward, in the last 7 days.') %]</p>
+        <table class="dashboard-ranking-table">
+            <tbody>
+              [% FOR line IN wards %]
+                <tr><td>[% line.name %]</td><td>[% tprintf(nget("%s report", "%s reports", line.reports), line.reports) %]</td></tr>
+              [% END %]
+            </tbody>
+            <tfoot>
+                <tr><td>[% loc('Other wards') %]</td><td>[% tprintf(nget("%s report", "%s reports", other_wards), other_wards) %]</td></tr>
+            </tfoot>
+        </table>
+      [% ELSE %]
         <h2 class="dashboard-subheading">[% loc('Top 5 responsive councils') %]</h2>
         <p>[% loc('Average time between a problem being reported and being fixed, last 100 reports.') %]</p>
         <table class="dashboard-ranking-table">
@@ -92,6 +120,7 @@
                 <tr><td>[% loc('Overall average') %]</td><td>[% tprintf(nget("%s day", "%s days", average), average) %]</td></tr>
             </tfoot>
         </table>
+      [% END %]
     </div>
     <div class="dashboard-item dashboard-item--6">
         <h2 class="dashboard-subheading">[% loc('Top 5 most used categories') %]</h2>

--- a/templates/web/fixmystreet.com/about/council-dashboard.html
+++ b/templates/web/fixmystreet.com/about/council-dashboard.html
@@ -1,0 +1,60 @@
+[% extra_css = BLOCK %]
+    <link rel="stylesheet" href="[% version('/cobrands/fixmystreet.com/fmsforcouncils.css') %]">
+    <link href="https://fonts.googleapis.com/css?family=Rubik:400,500" rel="stylesheet">
+[% END %]
+
+[% IF no_body_found %]
+
+[% INCLUDE header.html
+    title = 'FixMyStreet Professional', bodyclass = 'fullwidthpage'
+%]
+
+<div class="confirmation-header confirmation-header--inbox">
+    <h1>Thanks!</h1>
+    <p>We will be in touch with a confirmation link soon.</p>
+</div>
+
+[% ELSE %]
+
+[% INCLUDE header.html
+    title = 'FixMyStreet Professional', bodyclass = 'fms-for-councils fullwidthpage'
+%]
+
+<div class="fixed-container">
+  <div class="council-header">
+    <h1 class="councils-logo">FixMyStreet Professional</h1>
+  </div>
+  <div class="councils-hero">
+    <div class="councils-hero__demo-access">
+      <p>To access a council-specific version of our main dashboard page,
+      please provide your name and email below and we'll send you a link.</p>
+      <form method="post" class="councils-hero__demo-access__form">
+        <div class="form-group">
+          <label for="demo-name">Name</label>
+          <span class="required">required</span>
+          <input type="text" name="name" id="demo-name" required value="[% form_name | html %]">
+        </div>
+        <div class="form-group">
+          <label for="demo-email">Contact email</label>
+          <span class="required">required</span>
+          <input type="email" name="username" id="demo-email" required value="[% email | html %]">
+          <p class="form-note">Ending in .gov.uk, or other official council domain</p>
+        </div>
+        <div class="form-group submit-group">
+          <input type="hidden" name="r" value="about/council-dashboard">
+          <input type="hidden" name="extra.referer" value="[% c.req.headers.referer | html %]">
+          <input type="hidden" name="subject" value="Council dashboard request">
+          <input type="hidden" name="message" value="Filled in the council dashboard form">
+          <input type="hidden" name="recipient" value="bettercities">
+          <input type="hidden" name="dest" value="from_council">
+          <input type="submit" value="Let me in" class="btn">
+        </div>
+      </form>
+    </div>
+  </div>
+
+</div>
+
+[% END %]
+
+[% INCLUDE footer.html %]

--- a/web/cobrands/fixmystreet.com/fmsforcouncils.scss
+++ b/web/cobrands/fixmystreet.com/fmsforcouncils.scss
@@ -147,7 +147,7 @@ $fms-pink: #E65376;
     border-radius: 3px;
     color: #fff;
     padding: 2em;
-    margin: 4em auto -4em auto;
+    margin: 4em auto 4em auto;
     max-width: 26em;
     position: relative;
     z-index: 1;


### PR DESCRIPTION
Firstly this updates `update-all-reports` to allow it to output the same data used for `/reports` restricted to a particular body, or output for each body. Then it updates the front end to display this data (with ward selection rather than body selection; whoops, guess it shouldn't show it if the area has no children). Then lastly, for .com it restricts those pages to logged in users whose domain matches a council one, and provides a customised login page at `/about/council-dashboard` which if an email is entered for a relevant body, acts like normal and sends confirmation email, or if not, sends us an email for manual checking (probably by adding the domain if possible and sending them a confirmation email? Perhaps list shouldn't be in version control.)

This final form could be duplicated on `/pro` somewhere and post directly to here, to allow easier updating of any text around it etc.

I thought adding a hook to about pages was a nice way of doing this for a particular cobrand for a quasi-static page, but other opinions welcome. It needs some tests.