### PR TITLE
cobrand option to control prefilling of report fields for inspectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
       - Remove hidden from default staff state dropdown. #1878
       - Marking an item as a duplicate enforces providing duplicate id or
         a public update #1873
+      - Report field pre-filling for inspectors configurable #1854
 
 * v2.2 (13th September 2017)
     - New features:

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -1073,6 +1073,8 @@ sub state_groups_inspect {
 
 sub max_detailed_info_length { 0 }
 
+sub prefill_report_fields_for_inspector { 0 }
+
 =head2 never_confirm_updates
 
 If true then we never send an email to confirm an update

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -220,4 +220,6 @@ sub available_permissions {
     return $perms;
 }
 
+sub prefill_report_fields_for_inspector { 1 }
+
 1;

--- a/templates/web/base/report/new/category.html
+++ b/templates/web/base/report/new/category.html
@@ -5,7 +5,11 @@
     <label for='form_category' id="form_category_label">
         [%~ loc('Category') ~%]
     </label>[% =%]
-    <select class="form-control" name='category' id='form_category' data-role='[% c.user.has_body_permission_to('planned_reports') ? 'inspector' : 'user'  %]' data-body='[% c.user.from_body.name %]'>
+    <select class="form-control" name="category" id="form_category"
+    [%~ IF c.user.from_body =%]
+      data-role="[% c.user.has_body_permission_to('planned_reports') ? 'inspector' : 'user'  %]" data-body="[% c.user.from_body.name %]" data-prefill="[% c.cobrand.prefill_report_fields_for_inspector %]"
+    [%~ END ~%]
+    >
         [%~ FOREACH cat_op IN category_options ~%]
         [% cat_op_lc = cat_op.name | lower =%]
         <option value='[% cat_op.name | html %]'[% ' selected' IF report.category == cat_op.name || category_lc == cat_op_lc || (category_options.size == 2 AND loop.last) ~%]

--- a/templates/web/base/report/new/category_wrapper.html
+++ b/templates/web/base/report/new/category_wrapper.html
@@ -1,7 +1,11 @@
 <div id="form_category_row">
 [% IF js %]
     <label for="form_category">[% loc('Category') %]</label>
-    <select class="form-control" name="category" id="form_category" data-role="[% c.user.has_body_permission_to('planned_reports') ? 'inspector' : 'user'  %]" data-body="[% c.user.from_body.name %]" required><option>[% loc('Loading...') %]</option></select>
+    <select class="form-control" name="category" id="form_category"
+    [%~ IF c.user.from_body =%]
+      data-role="[% c.user.has_body_permission_to('planned_reports') ? 'inspector' : 'user'  %]" data-body="[% c.user.from_body.name %]" data-prefill="[% c.cobrand.prefill_report_fields_for_inspector %]"
+    [%~ END =%]
+    required><option>[% loc('Loading...') %]</option></select>
 [% ELSE %]
     [% IF category_options.size %]
         [% IF field_errors.category %]

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -436,11 +436,10 @@ $.extend(fixmystreet.set_up, {
     // Delegation is necessary because #form_category may be replaced during the lifetime of the page
     $("#problem_form").on("change.category", "select#form_category", function(){
         var args = {
-            category: $(this).val()
+            category: $(this).val(),
+            latitude: $('input[name="latitude"]').val(),
+            longitude: $('input[name="longitude"]').val()
         };
-
-        args.latitude = $('input[name="latitude"]').val();
-        args.longitude = $('input[name="longitude"]').val();
 
         $.getJSON('/report/new/category_extras', args, function(data) {
             var $category_meta = $('#category_meta');
@@ -458,7 +457,11 @@ $.extend(fixmystreet.set_up, {
         });
 
         if (fixmystreet.hooks.update_problem_fields) {
-            fixmystreet.hooks.update_problem_fields($(this).data('role'), $(this).data('body'), args);
+            args.prefill_reports = $(this).data('prefill');
+            args.role = $(this).data('role');
+            args.body = $(this).data('body');
+
+            fixmystreet.hooks.update_problem_fields(args);
         }
     });
   },

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -429,10 +429,10 @@ $.extend(fixmystreet.set_up, {
 });
 
 $.extend(fixmystreet.hooks, {
-    update_problem_fields: function(role, body, args) {
-        if (role == 'inspector') {
+    update_problem_fields: function(args) {
+        if (args.prefill_reports && args.role == 'inspector') {
             var title = args.category + ' problem has been scheduled for fixing';
-            var description = args.category + ' problem found - scheduled for fixing by ' + body;
+            var description = args.category + ' problem found - scheduled for fixing by ' + args.body;
 
             var $title_field = $('#form_title');
             var $description_field = $('#form_detail');


### PR DESCRIPTION
Add a `prefill_report_fields_for_inspectors` config to cobrands,
defaulted to 0, to control the automatic pre-population of report
fields.

Also add default of 1 for UKCouncil cobrand.

Fixed #1854