### PR TITLE
Remove shortlist form from inspect duplicate list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
         - Redirect inspectors correctly on creation in two-tier.
         - Report status filter All option works for body users #1845
         - Always allow reports to be removed from shortlist #1882
+        - Remove shortlist form from inspect duplicate list.
     - Admin improvements:
       - Character length limit can be placed on report detailed information #1848
       - Inspector panel shows nearest address if available #1850

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -520,6 +520,9 @@ sub nearby_json : Private {
     my $p = $c->stash->{problem};
     my $dist = 1;
 
+    # This is for the list template, this is a list on that page.
+    $c->stash->{page} = 'report';
+
     my $nearby = $c->model('DB::Nearby')->nearby(
         $c, $dist, [ $p->id ], 5, $p->latitude, $p->longitude, undef, [ $p->category ], undef
     );

--- a/templates/web/base/report/_item.html
+++ b/templates/web/base/report/_item.html
@@ -121,13 +121,18 @@
 
 
 </a>
-[% IF item_action AND page != 'around' %]
+[% IF item_action ~%]
+  [% IF page == 'report' ~%]
+    [%# We don't want to output shortlist on report page (in duplicate list) %]
+  [% ELSIF page == 'around' ~%]
+    [%# The around page list is already contained within the new report form %]
+    [% item_action.replace('("shortlist-[^"]*)', '$1-' _ problem.id) %]
+  [% ELSE ~%]
     <form method="post" action="/my/planned/change">
         <input type="hidden" name="id" value="[% problem.id %]">
         <input type="hidden" name="token" value="[% csrf_token %]">
         [% item_action %]
     </form>
-[% ELSIF item_action ~%]
-    [% item_action.replace('("shortlist-[^"]*)', '$1-' _ problem.id) %]
-[% END ~%]
+  [% END ~%]
+[% END %]
 </li>


### PR DESCRIPTION
This functionality isn't needed here, and causes an issue with the main form submitting due to a form inside a form.

Fixes https://github.com/mysociety/fixmystreetforcouncils/issues/248