### PR TITLE
[fixmystreet.com] Disable social login on council cobrands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
         - Add functionality to have per-body /reports page.
     - Front end improvements:
         - Remove unneeded 2x PNG fallback images.
+        - Individual cobrands can disable social login #1890
     - Bugfixes
         - Shortlist menu item always remains a link #1855
         - Fix encoded entities in RSS output. #1859

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -1244,6 +1244,10 @@ admin.
 
 sub allow_report_extra_fields { 0 }
 
-
+sub social_auth_enabled {
+    my $self = shift;
+    my $key_present = FixMyStreet->config('FACEBOOK_APP_ID') or FixMyStreet->config('TWITTER_KEY');
+    return $key_present && !$self->call_hook("social_auth_disabled");
+}
 
 1;

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -222,4 +222,6 @@ sub available_permissions {
 
 sub prefill_report_fields_for_inspector { 1 }
 
+sub social_auth_disabled { 1 }
+
 1;

--- a/t/cobrand/councils.t
+++ b/t/cobrand/councils.t
@@ -1,6 +1,15 @@
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;
 
+my $oxon = $mech->create_body_ok(2237, 'Oxfordshire County Council' );
+my $contact = $mech->create_contact_ok( body_id => $oxon->id, category => 'Cows', email => 'cows@example.net' );
+
+my ($report) = $mech->create_problems_for_body(1, $oxon->id, 'Test', {
+    category => 'Cows', cobrand => 'fixmystreet',
+});
+my $report_id = $report->id;
+
+
 foreach my $council (qw/oxfordshire bromley/) {
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => [ $council ],
@@ -10,5 +19,32 @@ foreach my $council (qw/oxfordshire bromley/) {
         $mech->content_like( qr/\u$council/ );
     };
 }
+
+
+foreach my $test (
+    { cobrand => 'fixmystreet', social => 1 },
+    { cobrand => 'bromley', social => 0 },
+) {
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ $test->{cobrand} ],
+        FACEBOOK_APP_ID => 'facebook-app-id',
+        TWITTER_KEY => 'twitter-key',
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $mech->get_ok('/auth');
+        $mech->contains_or_lacks($test->{social}, "Log in with Facebook");
+        $mech->contains_or_lacks($test->{social}, "Log in with Twitter");
+
+        $mech->get_ok("/report/new?lat=51.754926&lon=-1.256179");
+        $mech->contains_or_lacks($test->{social}, "Log in with Facebook");
+        $mech->contains_or_lacks($test->{social}, "Log in with Twitter");
+
+        $mech->get_ok("/report/$report_id");
+        $mech->contains_or_lacks($test->{social}, "Log in with Facebook");
+        $mech->contains_or_lacks($test->{social}, "Log in with Twitter");
+    };
+};
+
 
 done_testing();

--- a/templates/web/base/auth/general.html
+++ b/templates/web/base/auth/general.html
@@ -16,7 +16,7 @@
 
         <input type="hidden" name="r" value="[% c.req.params.r | html %]">
 
-[% IF NOT oauth_need_email AND (c.config.FACEBOOK_APP_ID OR c.config.TWITTER_KEY) %]
+[% IF NOT oauth_need_email AND c.cobrand.social_auth_enabled %]
     [% IF c.config.FACEBOOK_APP_ID %]
       <div class="form-box">
         <button name="facebook_sign_in" id="facebook_sign_in" value="facebook_sign_in" class="btn btn--block btn--social btn--facebook">
@@ -64,7 +64,7 @@
           [% END %]
         </div>
 
-[% IF NOT oauth_need_email AND (c.config.FACEBOOK_APP_ID OR c.config.TWITTER_KEY) %]
+[% IF NOT oauth_need_email AND c.cobrand.social_auth_enabled %]
       </div>
 [% END %]
 

--- a/templates/web/base/report/new/form_user_loggedout.html
+++ b/templates/web/base/report/new/form_user_loggedout.html
@@ -1,4 +1,4 @@
-[% IF c.config.FACEBOOK_APP_ID OR c.config.TWITTER_KEY %]
+[% IF c.cobrand.social_auth_enabled %]
   [% IF c.config.FACEBOOK_APP_ID %]
     <div class="form-box">
     <button name="facebook_sign_in" id="facebook_sign_in" value="facebook_sign_in" class="btn btn--block btn--social btn--facebook">
@@ -27,6 +27,6 @@
     [% PROCESS 'report/new/form_user_loggedout_by_email.html' %]
 </div>
 
-[% IF c.config.FACEBOOK_APP_ID OR c.config.TWITTER_KEY %]
+[% IF c.cobrand.social_auth_enabled %]
     </div>
 [% END %]

--- a/templates/web/base/report/update/form_user_loggedout.html
+++ b/templates/web/base/report/update/form_user_loggedout.html
@@ -1,4 +1,4 @@
-[% IF c.config.FACEBOOK_APP_ID OR c.config.TWITTER_KEY %]
+[% IF c.cobrand.social_auth_enabled %]
     <h3>[% loc("Now to submit your update&hellip;") %]</h3>
   [% IF c.config.FACEBOOK_APP_ID %]
     <div class="form-box">
@@ -29,6 +29,6 @@
     [% INCLUDE 'report/update/form_user_loggedout_by_email.html' %]
 </div>
 
-[% IF c.config.FACEBOOK_APP_ID OR c.config.TWITTER_KEY %]
+[% IF c.cobrand.social_auth_enabled %]
     </div>
 [% END %]


### PR DESCRIPTION
We want to enable FB login on fixmystreet.com, but not the various UK council cobrands also active on that instance. This PR allows individual cobrands to opt-out of social login, and does so for our council cobrands.

For #1890.