### PR TITLE
do not override template when displaying body contacts as text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
         - Always allow reports to be removed from shortlist #1882
         - Remove shortlist form from inspect duplicate list.
         - Fix pin size when JavaScript unavailable.
+        - Fix display of text only body contacts #1895
     - Admin improvements:
       - Character length limit can be placed on report detailed information #1848
       - Inspector panel shows nearest address if available #1850

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -608,9 +608,12 @@ sub edit_body : Chained('body') : PathPart('') : Args(0) {
     $c->set_param('posted', '');
 
     $c->forward('fetch_translations');
+
+    # don't set this last as fetch_contacts might over-ride it
+    # to display email addresses as text
+    $c->stash->{template} = 'admin/body.html';
     $c->forward('fetch_contacts');
 
-    $c->stash->{template} = 'admin/body.html';
     return 1;
 }
 

--- a/t/app/controller/admin.t
+++ b/t/app/controller/admin.t
@@ -289,6 +289,7 @@ subtest 'check text output' => sub {
     $mech->get_ok('/admin/body/' . $body->id . '?text=1');
     is $mech->content_type, 'text/plain';
     $mech->content_contains('test category');
+    $mech->content_lacks('<body');
 };
 
 


### PR DESCRIPTION
move setting the body template to before `fetch_contacts` so it doesn't
override setting the text only email address template.

Fixes #1895