### PR TITLE
Prevent homepage stats text overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
         - Always allow reports to be removed from shortlist #1882
         - Remove shortlist form from inspect duplicate list.
         - Fix pin size when JavaScript unavailable.
+        - Prevent text overflow bug on homepage stats #1722
     - Admin improvements:
       - Character length limit can be placed on report detailed information #1848
       - Inspector panel shows nearest address if available #1850

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2036,11 +2036,11 @@ table.nicetable {
         size:0.8125em;
         weight:bold;
       }
-      big {
-        display:block;
-        margin-bottom:0.5em;
-        font-size:1.5385em;
-      }
+    }
+    big {
+      display:block;
+      margin-bottom:0.5em;
+      font-size:1.5385em;
     }
   }
 }

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -931,10 +931,16 @@ textarea.form-error {
     color: #222;
     border-top:0.25em solid $primary;
     padding-top:1em;
-    div {
-      big {
-        color: $layout_front_stats_color;
-        font-size: 3.2308em;
+    big {
+      color: $layout_front_stats_color;
+      font-size: 2em;
+      @media (min-width: 54em) {
+        // 54em roughly halfway between 48em and 62em
+        font-size: 2.5em;
+      }
+      @media (min-width: 62em) {
+        // container max-width 60em + 2em side padding
+        font-size: 3em;
       }
     }
   }


### PR DESCRIPTION
Prevent long numbers on homepage from overflowing their container and looking messy. Fixes #1722.

Updating the size in three media queries is a bit fragile. But it’s much simpler than any other more "automatic" alternative I could think of (eg: flexbox). Looks good with the huge numbers on the UK site, and still looks ok on sites with fewer reports.

I also took the opportunity to simplify the overpowered `…#front_stats div big` selector down one notch, to `…#front_stats big`, while I was in the area.

# window 768–863px wide
![screen shot 2017-11-07 at 12 39 55](https://user-images.githubusercontent.com/739624/32494302-f757e722-c3b8-11e7-8332-16f703cebbc3.png)

# window 864–991px wide
![screen shot 2017-11-07 at 12 40 26](https://user-images.githubusercontent.com/739624/32494303-f9842204-c3b8-11e7-8942-4b380316ad8b.png)

# window 992px+ wide
![screen shot 2017-11-07 at 12 40 54](https://user-images.githubusercontent.com/739624/32494305-fad1181a-c3b8-11e7-85ff-77e0754b4328.png)
