### PR TITLE
Fix geocoder encoding issue

### DIFF
--- a/perllib/FixMyStreet/Geocode.pm
+++ b/perllib/FixMyStreet/Geocode.pm
@@ -79,8 +79,12 @@ sub cache {
         $url .= '&' . $args if $args;
         $ua->timeout(15);
         $js = LWP::Simple::get($url);
-        $cache_dir->mkpath;
+        # The returned data is not correctly decoded if the content type is
+        # e.g. application/json. Which all of our geocoders return.
+        # uncoverable branch false
+        $js = decode_utf8($js) if !utf8::is_utf8($js);
         if ($js && (!$re || $js !~ $re) && !FixMyStreet->config('STAGING_SITE')) {
+            $cache_dir->mkpath; # uncoverable statement
             # uncoverable statement
             $cache_file->spew_utf8($js);
         }

--- a/perllib/FixMyStreet/Geocode/OSM.pm
+++ b/perllib/FixMyStreet/Geocode/OSM.pm
@@ -41,7 +41,7 @@ sub string {
         if $params->{bounds};
     $query_params{countrycodes} = $params->{country}
         if $params->{country};
-    $url .= join('&', map { "$_=$query_params{$_}" } keys %query_params);
+    $url .= join('&', map { "$_=$query_params{$_}" } sort keys %query_params);
 
     my $js = FixMyStreet::Geocode::cache('osm', $url);
     if (!$js) {

--- a/t/Mock/Nominatim.pm
+++ b/t/Mock/Nominatim.pm
@@ -6,7 +6,7 @@ use Web::Simple;
 has json => (
     is => 'lazy',
     default => sub {
-        JSON->new->pretty->allow_blessed->convert_blessed;
+        JSON->new->utf8->pretty->allow_blessed->convert_blessed;
     },
 );
 
@@ -30,7 +30,7 @@ sub query {
     my ($self, $q) = @_;
     if ($q eq 'high street') {
         return [
-            {"osm_type"=>"way","osm_id"=>"4684282","lat"=>"55.9504009","lon"=>"-3.1858425","display_name"=>"High Street, Old Town, City of Edinburgh, Scotland, EH1 1SP, United Kingdom","class"=>"highway","type"=>"tertiary","importance"=>0.55892577838734},
+            {"osm_type"=>"way","osm_id"=>"4684282","lat"=>"55.9504009","lon"=>"-3.1858425","display_name"=>"High Street, Old Town, City of Ed\x{ed}nburgh, Scotland, EH1 1SP, United Kingdom","class"=>"highway","type"=>"tertiary","importance"=>0.55892577838734},
             {"osm_type"=>"node","osm_id"=>"27424410","lat"=>"55.8596449","lon"=>"-4.240377","display_name"=>"High Street, Collegelands, Merchant City, Glasgow, Glasgow City, Scotland, G, United Kingdom","class"=>"railway","type"=>"station","importance"=>0.53074299592768}
         ];
     }

--- a/t/cobrand/fixamingata.t
+++ b/t/cobrand/fixamingata.t
@@ -102,7 +102,7 @@ subtest "Test ajax decimal points" => sub {
         $mech->content_contains('51.5');
 
         $mech->get_ok('/ajax/lookup_location?term=high+street');
-        $mech->content_contains('Edinburgh');
+        $mech->content_contains("Ed\xc3\xadnburgh");
     };
 };
 


### PR DESCRIPTION
It turns out that HTTP::Message (as used by LWP::Simple::get) only decodes text/* and 'XML', not application/json, as used by all the geocoders. Work around this, hopefully in a future-proof way.
Fixes #1905.
[skip changelog] (as was introduced as an aside recently)