### PR TITLE
Prevent multiple 'Expand map' links appearing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
         - Fix display of text only body contacts #1895
         - Prevent text overflow bug on homepage stats #1722
         - Stop page jumping too far down on inspect form. #1863
+        - Prevent multiple 'Expand map' links appearing. #1909
     - Admin improvements:
       - Character length limit can be placed on report detailed information #1848
       - Inspector panel shows nearest address if available #1850

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -605,7 +605,7 @@ $.extend(fixmystreet.set_up, {
         }
         $('#key-tools li:empty').remove();
         $('#report-updates-data').insertAfter($('#map_box'));
-        if (fixmystreet.page !== 'around') {
+        if (fixmystreet.page !== 'around' && !$('#toggle-fullscreen').length) {
             $('#sub_map_links').append('<a href="#" id="toggle-fullscreen" class="expand" data-expand-text="'+ translation_strings.expand_map +'" data-compress-text="'+ translation_strings.collapse_map +'" >'+ translation_strings.expand_map +'</span>');
         }
     }
@@ -636,7 +636,7 @@ $.extend(fixmystreet.set_up, {
             .prependTo('#sub_map_links');
     }
 
-    $('#toggle-fullscreen').click(function() {
+    $('#toggle-fullscreen').off('click').on('click', function() {
       var btnClass = $('html').hasClass('map-fullscreen') ? 'expand' : 'compress';
       var text = $(this).data(btnClass + '-text');
 


### PR DESCRIPTION
On mobile, if you e.g. selected one report and then another, you'd get
another "Expand map" appearing. Check that one is needed before adding
it, and also make sure the handler is only attached once to prevent it
conflicting with itself (and so cancelling itself out).