### PR TITLE
display council contacts on council dashboard

### DIFF
--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -80,6 +80,9 @@ sub council_dashboard_hook {
         $c->detach;
     }
 
+    $c->forward('/admin/fetch_contacts');
+    $c->stash->{display_contacts} = 1;
+
     return if $c->user->is_superuser;
 
     my $body = $c->user->from_body || _user_to_body($c);

--- a/templates/web/base/reports/index.html
+++ b/templates/web/base/reports/index.html
@@ -139,4 +139,58 @@
     </div>
 </div>
 
+[% IF display_contacts %]
+<div class="dashboard-row">
+    <div class="dashboard-item dashboard-item--12">
+        <h2 class="dashboard-subheading">[% tprintf( loc('Where we send %s reports'), body.name ) %]</h2>
+        [% IF body.send_method == 'Refused' %]
+          <p>
+            [% tprintf( loc('%s currently does not accept reports from FixMyStreet.'), body.name) %]
+          </p>
+
+          <p>
+            [% loc('If you&rsquo;d like to discuss this then <a href="/contact">get in touch</a>.') %]
+          </p>
+        [% ELSIF body.send_method == 'Noop' %]
+          <p>
+            [% tprintf( loc('Reports are currently not being sent to %s.'), body.name ) %]
+          </p>
+        [% ELSIF body.send_method != 'Email' AND body.send_method != ''  %]
+          <p>
+              [% tprintf( loc('Reports to %s are currently sent directly into backend services.'), body.name) %]
+          </p>
+        [% ELSE %]
+        <p>
+          [% loc('We currently send all reports to the email addresses below.') %]
+        </p>
+
+        <p>
+          [% loc('Did you know that if you used the approved open standard Open311 you could send reports directly into your own backend services &ndash; and get much more control over what additional information you request?') %]
+        </p>
+
+        <p>
+          [% loc('If that&rsquo;s new to you, <a href="https://www.mysociety.org/2013/01/10/open311-introduced/">take a look at our simple Open311 primer</a> to see what you need to do to get up and running in a few days.') %]
+        </p>
+
+        <p>
+          [% loc('If you would like to change either the categories or the contact emails below then <a href="/contact">get in touch</a>.') %]
+        <p>
+        <table class="dashboard-contacts-table">
+          <tr>
+            <th>[% loc('Category') %]</th>
+            <th>[% loc('Contact') %]</th>
+          </tr>
+          [% WHILE ( cat = live_contacts.next ) %]
+            <tr>
+              <td class="contact-category"><a href="[% c.uri_for( 'body', body_id, cat.category ) %]">[% cat.category_display | html %]</a>
+              </td>
+              <td>[% cat.email | html %]</td>
+            </tr>
+          [% END %]
+        </table>
+        [% END %]
+    </div>
+</div>
+[% END %]
+
 [% INCLUDE 'footer.html' pagefooter = 'yes' %]

--- a/web/cobrands/sass/_dashboard.scss
+++ b/web/cobrands/sass/_dashboard.scss
@@ -184,15 +184,12 @@
     }
 }
 
-.dashboard-ranking-table {
+.dashboard-ranking-table,
+.dashboard-contacts-table {
     width: 100%;
 
     td {
         padding: 0.4em 0.8em;
-
-        &:last-child {
-            text-align: $right;
-        }
     }
 
     tbody tr:nth-child(odd) {
@@ -203,5 +200,20 @@
 
     tfoot td {
         font-weight: bold;
+    }
+}
+
+.dashboard-ranking-table {
+    td {
+        &:last-child {
+            text-align: $right;
+        }
+    }
+}
+
+.dashboard-contacts-table {
+    th {
+        text-align: $left;
+        padding: 0.4em 0.8em;
     }
 }


### PR DESCRIPTION
Display a list of the email addresses used to contact the council on the
council dashboard. Does not display emails if the council has an
integration, rejects FMS reports or is currently turned off.

Fixes mysociety/fixmystreet-commercial#941

[skip changelog]
