### PR TITLE
Fix UI bug stopping superusers making reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
         - Prevent text overflow bug on homepage stats #1722
         - Stop page jumping too far down on inspect form. #1863
         - Prevent multiple 'Expand map' links appearing. #1909
+        - Superusers without a from_body can make reports again. #1913
     - Admin improvements:
         - Character length limit can be placed on report detailed information #1848
         - Inspector panel shows nearest address if available #1850

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -48,9 +48,12 @@ STAGING_SITE: 1
 #   this to 1 if you want a staging site to route reports as normal.
 # - skip_checks: Manual testing of multiple cobrands can be made easier by
 #   skipping some checks they have in them, if this variable is set.
+# - enable_appcache: Whether the appcache should be active. NB: Only affects
+#     superuser sessions.
 STAGING_FLAGS:
   send_reports: 0
   skip_checks: 0
+  enable_appcache: 0
 
 # What to use as front page/alert example places placeholder
 # Defaults to High Street, Main Street

--- a/perllib/FixMyStreet/App/Controller/Offline.pm
+++ b/perllib/FixMyStreet/App/Controller/Offline.pm
@@ -18,7 +18,8 @@ Offline pages Catalyst Controller.
 
 sub have_appcache : Private {
     my ($self, $c) = @_;
-    return $c->user_exists && $c->user->has_body_permission_to('planned_reports');
+    return $c->user_exists && $c->user->has_body_permission_to('planned_reports')
+        && !($c->user->is_superuser && FixMyStreet->staging_flag('enable_appcache', 0));
 }
 
 sub manifest : Path("/offline/appcache.manifest") {

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -867,6 +867,7 @@ fixmystreet.update_pin = function(lonlat, savePushState) {
             if (!data.contribute_as.body) {
                 $select.find('option[value=body]').remove();
             }
+            $select.change();
             $('#js-contribute-as-wrapper').show();
         } else {
             $('#js-contribute-as-wrapper').hide();


### PR DESCRIPTION
This checks that the user has a from_body *and* the planned_reports
permission when considering whether to default to 'yourself' or the
council in the 'report as' field.

Fixes #1913.