### PR TITLE
Hide geolocation link if not on HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
         - Remove unneeded 2x PNG fallback images.
         - Individual cobrands can disable social login #1890
         - Improve performance of various pages, especially front. #1903
+        - Don't show geolocation link on non-HTTPS pages.
     - Bugfixes
         - Shortlist menu item always remains a link #1855
         - Fix encoded entities in RSS output. #1859

--- a/web/js/geolocation.js
+++ b/web/js/geolocation.js
@@ -29,7 +29,8 @@ fixmystreet.geolocate = function(element, success_callback) {
 (function(){
     var link = document.getElementById('geolocate_link');
     if (!link) { return; }
-    if ('geolocation' in navigator) {
+    var https = window.location.protocol.toLowerCase() === 'https:';
+    if ('geolocation' in navigator && https) {
         fixmystreet.geolocate(link, function(pos) {
             var latitude = pos.coords.latitude.toFixed(6);
             var longitude = pos.coords.longitude.toFixed(6);


### PR DESCRIPTION
Modern browsers disable geolocation on non-HTTPS pages, but
sadly still report it as available with the `navigator.geolocation`
object. This commit adds a check for HTTPS and hides the link
if it won’t work.