### PR TITLE
Ensure calculated lat/lon are sent to DB in correct format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
         - Stop page jumping too far down on inspect form. #1863
         - Prevent multiple 'Expand map' links appearing. #1909
         - Superusers without a from_body can make reports again. #1913
+        - Fix crash when viewing /around in certain locales. #1916
     - Admin improvements:
         - Character length limit can be placed on report detailed information #1848
         - Inspector panel shows nearest address if available #1850

--- a/perllib/FixMyStreet/Map.pm
+++ b/perllib/FixMyStreet/Map.pm
@@ -83,13 +83,13 @@ sub map_features {
         # use deltas that are roughly 500m in the UK - so we get a 1 sq km search box
         my $lat_delta = 0.00438;
         my $lon_delta = 0.00736;
-        $p{min_lon} = $p{longitude} - $lon_delta;
-        $p{min_lat} = $p{latitude} - $lat_delta;
-        $p{max_lon} = $p{longitude} + $lon_delta;
-        $p{max_lat} = $p{latitude} + $lat_delta;
+        $p{min_lon} = Utils::truncate_coordinate($p{longitude} - $lon_delta);
+        $p{min_lat} = Utils::truncate_coordinate($p{latitude} - $lat_delta);
+        $p{max_lon} = Utils::truncate_coordinate($p{longitude} + $lon_delta);
+        $p{max_lat} = Utils::truncate_coordinate($p{latitude} + $lat_delta);
     } else {
-        $p{longitude} = ($p{max_lon} + $p{min_lon} ) / 2;
-        $p{latitude} = ($p{max_lat} + $p{min_lat} ) / 2;
+        $p{longitude} = Utils::truncate_coordinate(($p{max_lon} + $p{min_lon} ) / 2);
+        $p{latitude} = Utils::truncate_coordinate(($p{max_lat} + $p{min_lat} ) / 2);
     }
 
     $p{page} = $c->get_param('p') || 1;

--- a/web/js/front.js
+++ b/web/js/front.js
@@ -10,4 +10,9 @@ document.getElementById('pc').focus();
         el.value = 1;
         form.insertBefore(el, form.firstChild);
     }
+    var around_links = document.querySelectorAll('a[href*="around"]');
+    for (i=0; i<around_links.length; i++) {
+        var link = around_links[i];
+        link.href = link.href + (link.href.indexOf('?') > -1 ? '&js=1' : '?js=1');
+    }
 })();


### PR DESCRIPTION
When viewing /around without the `js=1` parameter in a Spanish locale
the incorrect decimal separator was being passed to the DB query,
causing a crash.

Fixes mysociety/fixmystreet-commercial#942