### PR TITLE
Remove intro text when showing location disambiguations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
         - Improve performance of various pages, especially front. #1903
         - Don't show geolocation link on non-HTTPS pages.
         - More prominent "Hide pins" link on map pages, to aid reporting in busy areas. #525
+        - Improve location disambiguation page on small screens. #1918
     - Bugfixes
         - Shortlist menu item always remains a link #1855
         - Fix encoded entities in RSS output. #1859

--- a/templates/web/base/around/_error_multiple.html
+++ b/templates/web/base/around/_error_multiple.html
@@ -3,12 +3,13 @@
 [% END %]
 
 [% IF possible_location_matches %]
-    <p>[% loc('We found more than one match for that location. We show up to ten matches, please try a different search if yours is not here.') %]</p>
+    <p>[% loc('We found more than one match for that location.') %]</p>
     <ul class="pc_alternatives">
         [% FOREACH match IN possible_location_matches %]
         <li><a href="/around?latitude=[% match.latitude | uri %];longitude=[% match.longitude | uri %]">[% match.address | html %]</a></li>
         [% END %]
     </ul>
+    <p>[% loc('We show up to ten matches, please try a different search if yours is not here.') %]</p>
 [% END %]
 
 [% IF partial_token %]

--- a/templates/web/base/around/postcode_form.html
+++ b/templates/web/base/around/postcode_form.html
@@ -1,6 +1,8 @@
 <div id="front-main">
     <div id="front-main-container">
-        [% INCLUDE 'around/intro.html' %]
+        [% UNLESS possible_location_matches %]
+            [% INCLUDE 'around/intro.html' %]
+        [% END %]
 
         [%
             question = c.cobrand.enter_postcode_text || loc('Enter a nearby street name and area');


### PR DESCRIPTION
The intro header takes up a lot of vertical screen space, which on small devices means that the suggestion links end up beneath the fold. This can make it seem as though nothing has happened at all when you enter a search term on the front page, e.g.:

iOS | Android
----|--------
![iphone_suggestions](https://user-images.githubusercontent.com/4776/33265244-c39db21c-d368-11e7-938a-3733f2c8bf73.gif) |  ![android_suggestions](https://user-images.githubusercontent.com/4776/33265321-19c0d61a-d369-11e7-854a-1bf53636b7af.gif)


This PR improves things by removing the intro header if there are location suggestions, and also shifts the second sentence of the help text to the bottom of the list where it's more likely to be read:

![iphone_improved](https://user-images.githubusercontent.com/4776/33265357-483d9d7a-d369-11e7-9f52-ff996ee30d6f.gif)

The same change applies to larger screens too:
![fixmystreet dev_3000_around_js 1 pc bromley](https://user-images.githubusercontent.com/4776/33265400-77371e80-d369-11e7-9cbb-e7201f0d34b6.png)


I'm opening this PR for discussion. Is this change a good idea? Can the problem be solved better? What's the next steps?