### PR TITLE
Fix back bug, from report after using list filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
         - Prevent multiple 'Expand map' links appearing. #1909
         - Superusers without a from_body can make reports again. #1913
         - Fix crash when viewing /around in certain locales. #1916
+        - Fix back bug, from report after using list filters. #1920
     - Admin improvements:
         - Character length limit can be placed on report detailed information #1848
         - Inspector panel shows nearest address if available #1850

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1073,8 +1073,12 @@ fixmystreet.display = {
   reports_list: function(reportListUrl, callback) {
     // If the report list is already in the DOM,
     // just reveal it, rather than loading new page.
-    if ($('#side').length) {
-        $('#side').show();
+    var side = document.getElementById('side');
+    if (side) {
+        if (side.style.display !== 'none') {
+            return;
+        }
+        side.style.display = '';
         $('#side-form').hide();
         // Report page may have been one or two columns, remove either
         $('#side-report').remove();
@@ -1178,6 +1182,7 @@ $(function() {
                     $('#sort').val(e.state.filter_change.sort);
                     $('#filter_categories').add('#statuses')
                         .trigger('change.filters').trigger('change.multiselect');
+                    fixmystreet.display.reports_list(location.href);
                 } else if ('hashchange' in e.state) {
                     // This popstate was just here because the hash changed.
                     // (eg: mobile nav click.) We want to ignore it.


### PR DESCRIPTION
The popstate event for a filter change assumed that the list was already
being displayed, but it was not if you were going back from a report.

The reports_list function to display the list page is idempotent (though
this commit makes it more so), so can happily be called whether the list
page is currently displayed or not.

Fixes #1920