### PR TITLE
Open311 category group support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
         - Add Expand map toggle to more mobile maps.
         - Add functionality to have per-body /reports page.
         - Cobrands can disable sending of moderation emails. #1910
+        - Open311 category group support. #1923
     - Front end improvements:
         - SVG assets for core elements like button icons and map controls #1888
         - Remove unneeded 2x PNG fallback images.

--- a/perllib/Open311/PopulateServiceList.pm
+++ b/perllib/Open311/PopulateServiceList.pm
@@ -156,7 +156,13 @@ sub _handle_existing_contact {
     if ( $contact and lc($metadata) eq 'true' ) {
         $self->_add_meta_to_contact( $contact );
     } elsif ( $contact and $contact->extra and lc($metadata) eq 'false' ) {
-        $contact->update( { extra => undef } );
+        $contact->set_extra_fields();
+        $contact->update;
+    }
+
+    if (my $group = $self->_current_service->{group}) {
+        $contact->set_extra_metadata(group => $group);
+        $contact->update;
     }
 
     push @{ $self->found_contacts }, $self->_current_service->{service_code};
@@ -181,6 +187,12 @@ sub _create_contact {
             }
         );
     };
+
+    if (my $group = $self->_current_service->{group}) {
+        $contact->set_extra_metadata(group => $group);
+        $contact->update;
+    }
+
 
     if ( $@ ) {
         warn "Failed to create contact for service code " . $self->_current_service->{service_code} . " for body @{[$self->_current_body->id]}: $@\n"

--- a/t/open311/populate-service-list.t
+++ b/t/open311/populate-service-list.t
@@ -39,6 +39,15 @@ subtest 'check basic functionality' => sub {
 
     my $contact_count = FixMyStreet::DB->resultset('Contact')->search( { body_id => 1 } )->count();
     is $contact_count, 3, 'correct number of contacts';
+
+    for my $test (
+        { code => "001", group => "sanitation" },
+        { code => "002", group => "street" },
+        { code => "003", group => "street" },
+    ) {
+        my $contact = FixMyStreet::DB->resultset('Contact')->search( { body_id => 1, email => $test->{code} } )->first;
+        is $contact->get_extra->{group}, $test->{group}, "Group set correctly";
+    }
 };
 
 subtest 'check non open311 contacts marked as deleted' => sub {

--- a/templates/web/base/report/new/category.html
+++ b/templates/web/base/report/new/category.html
@@ -1,4 +1,10 @@
-[% IF category_options.size ~%]
+[% IF category_options.size OR category_groups.size ~%]
+    [%~ BLOCK category_option ~%]
+    [% cat_op_lc = cat_op.name | lower =%]
+    <option value='[% cat_op.name | html %]'[% ' selected' IF report.category == cat_op.name || category_lc == cat_op_lc || (category_options.size == 2 AND loop.last) ~%]
+    >[% IF loop.first %][% cat_op.value %][% ELSE %][% cat_op.value | html %][% END %]</option>
+    [%~ END ~%]
+
     [% IF category;
         category_lc = category | lower;
        END; ~%]
@@ -10,10 +16,18 @@
       data-role="[% c.user.has_body_permission_to('planned_reports') ? 'inspector' : 'user'  %]" data-body="[% c.user.from_body.name %]" data-prefill="[% c.cobrand.prefill_report_fields_for_inspector %]"
     [%~ END ~%]
     >
-        [%~ FOREACH cat_op IN category_options ~%]
-        [% cat_op_lc = cat_op.name | lower =%]
-        <option value='[% cat_op.name | html %]'[% ' selected' IF report.category == cat_op.name || category_lc == cat_op_lc || (category_options.size == 2 AND loop.last) ~%]
-        >[% IF loop.first %][% cat_op.value %][% ELSE %][% cat_op.value | html %][% END %]</option>
-        [%~ END =%]
+        [%~ IF category_groups.size ~%]
+            [%~ FOREACH group IN category_groups ~%]
+                [% IF group.name %]<optgroup label="[% group.name %]">[% END %]
+                [%~ FOREACH cat_op IN group.categories ~%]
+                    [% INCLUDE category_option %]
+                [%~ END ~%]
+                [% IF group.name %]</optgroup>[% END %]
+            [%~ END =%]
+        [%~ ELSE ~%]
+            [%~ FOREACH cat_op IN category_options ~%]
+                [% INCLUDE category_option %]
+            [%~ END =%]
+        [%~ END ~%]
     </select>
 [%~ END ~%]

--- a/templates/web/base/report/new/category.html
+++ b/templates/web/base/report/new/category.html
@@ -11,7 +11,7 @@
     <label for='form_category' id="form_category_label">
         [%~ loc('Category') ~%]
     </label>[% =%]
-    <select class="form-control" name="category" id="form_category"
+    <select class="form-control[% IF category_groups.size %] js-grouped-select[% END %]" name="category" id="form_category"
     [%~ IF c.user.from_body =%]
       data-role="[% c.user.has_body_permission_to('planned_reports') ? 'inspector' : 'user'  %]" data-body="[% c.user.from_body.name %]" data-prefill="[% c.cobrand.prefill_report_fields_for_inspector %]"
     [%~ END ~%]
@@ -30,4 +30,9 @@
             [%~ END =%]
         [%~ END ~%]
     </select>
+    [%~ IF category_groups.size ~%]
+          <label id="form_subcategory_label" class="hidden">
+            [%~ loc('Subcategory') ~%]
+        </label>
+    [%~ END ~%]
 [%~ END ~%]


### PR DESCRIPTION
This PR adds support for the Open311 `group` field for services. Practically this means:

 - The `group` field is populated on `Contact`s by `PopulateServiceList`
 - New UI for categories/subcategories based on group when making reports
 - Cobrand hook (`use_category_groups`) to enable UI 

![subcategories](https://user-images.githubusercontent.com/4776/32497726-7146768c-c3c5-11e7-9174-8cd99b3cbf12.gif)


For mysociety/fixmystreetforcouncils#40