### PR TITLE
Use auto-response ResponseTemplates for text when fetching Open311 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@
         - More JavaScript-enhanced `<select multiple>` elements #1589
         - Council dashboard CSV export now has token based authentication #1911
         - Consolidate various admin summary statistics page. #1919.
+        - 'Auto-response' flag on response templates is honoured for fetched
+          Open311 updates. #1924
     - UK:
         - Use SVG logo, inlined on front page. #1887
         - Inline critical CSS on front page.

--- a/perllib/FixMyStreet/TestMech.pm
+++ b/perllib/FixMyStreet/TestMech.pm
@@ -630,6 +630,14 @@ sub delete_defect_type {
     $defect_type->delete;
 }
 
+sub delete_response_template {
+    my $mech = shift;
+    my $response_template = shift;
+
+    $response_template->contact_response_templates->delete_all;
+    $response_template->delete;
+}
+
 sub create_contact_ok {
     my $self = shift;
     my %contact_params = (

--- a/templates/web/base/admin/template_edit.html
+++ b/templates/web/base/admin/template_edit.html
@@ -9,19 +9,24 @@
     accept-charset="utf-8"
     class="validate">
 
+    <div class="admin-hint">
+      <p>
+        [% loc('This is a <strong>private</strong> name for this template so you can identify it when updating reports or editing in the admin.') %]
+      </p>
+    </div>
     <p>
         <strong>[% loc('Title:') %] </strong>
         <input type="text" name="title" class="required form-control" size="30" value="[% rt.title| html %]">
     </p>
+
+    <div class="admin-hint">
+      <p>
+        [% loc('This is the <strong>public</strong> text that will be shown on the site.') %]
+      </p>
+    </div>
     <p>
         <strong>[% loc('Text:') %] </strong>
         <textarea class="form-control" name="text" class="required">[% rt.text |html %]</textarea>
-    </p>
-    <p>
-      <label>
-        <strong>[% loc('Auto-response:') %]</strong>
-        <input type="checkbox" name="auto_response" [% 'checked' IF rt.auto_response %] />
-      </label>
     </p>
 
     <div class="admin-hint">
@@ -41,13 +46,25 @@
       [% INCLUDE 'admin/state_groups_select.html' current_state=rt.state include_empty=1 %]
     </p>
 
+    <div class="admin-hint">
+      <p>
+        [% loc('If ticked, this template will be used for Open311 updates that put problems in this state.') %]
+      </p>
+    </div>
+    <p>
+      <label>
+        <strong>[% loc('Auto-response:') %]</strong>
+        <input type="checkbox" name="auto_response" [% 'checked' IF rt.auto_response %] />
+      </label>
+    </p>
+
     <p>
       <input type="hidden" name="token" value="[% csrf_token %]" >
       <input type="submit" class="btn" name="Edit templates" value="[% rt.id ? loc('Save changes') : loc('Create template') %]" >
     </p>
     [% IF rt.id %]
         <p>
-            <input class="delete btn-danger" type="submit" name="delete_template" value="[% loc('Delete template') %]">
+            <input class="delete btn-danger" type="submit" name="delete_template" value="[% loc('Delete template') %]" data-confirm="[% loc('Are you sure?') %]">
         </p>
     [% END %]
 </form>

--- a/templates/web/base/admin/template_edit.html
+++ b/templates/web/base/admin/template_edit.html
@@ -9,6 +9,11 @@
     accept-charset="utf-8"
     class="validate">
 
+    [% IF errors %]
+        <p class="error">[% loc('Please correct the errors below') %]</p>
+    [% END %]
+
+
     <div class="admin-hint">
       <p>
         [% loc('This is a <strong>private</strong> name for this template so you can identify it when updating reports or editing in the admin.') %]
@@ -46,6 +51,9 @@
       [% INCLUDE 'admin/state_groups_select.html' current_state=rt.state include_empty=1 %]
     </p>
 
+    [% IF errors.auto_response %]
+        <div class="form-error">[% errors.auto_response %]</div>
+    [% END %]
     <div class="admin-hint">
       <p>
         [% loc('If ticked, this template will be used for Open311 updates that put problems in this state.') %]

--- a/templates/web/base/admin/templates.html
+++ b/templates/web/base/admin/templates.html
@@ -1,24 +1,30 @@
 [% INCLUDE 'admin/header.html' title=tprintf(loc('Response Templates for %s'), body.name) -%]
 
-[% IF c.cobrand.moniker == 'zurich' %]
-  <h2> [% tprintf(loc('Response Templates for %s'), body.name) %] </h2>
-[% END %]
-
 <table>
     <thead>
     <tr>
         <th>  [% loc('Title') %] </th>
-        <th>  [% loc('Text') %] </th>
-        <th>  [% loc('Created') %] </th>
+        <th>  [% loc('Categories') %] </th>
+        <th>  [% loc('State') %] </th>
+        <th>  [% loc('Auto Response') %] </th>
         <th>  &nbsp; </th>
     </tr>
     </thead>
     <tbody>
 [% FOR t IN response_templates %]
     <tr>
-        <td>  [% t.title %] </td>
-        <td> [% t.text %] </td>
-        <td> [% t.created %] </td>
+        <td> [% t.title | html %] </td>
+        <td>
+            [% UNLESS t.contacts.size %]
+                <em>[% loc('All categories') %]</em>
+            [% ELSE %]
+                [% FOR contact IN t.contacts %]
+                [% contact.category_display %][% ',' UNLESS loop.last %]
+                [% END %]
+            [% END %]
+        </td>
+        <td> [% t.state | html %] </td>
+        <td> [% IF t.auto_response %]X[% END %] </td>
         <td> <a href="[% c.uri_for('templates', body.id, t.id) %]" class="btn">[% loc('Edit') %]</a> </td>
     </tr>
 [% END %]

--- a/templates/web/zurich/admin/templates.html
+++ b/templates/web/zurich/admin/templates.html
@@ -1,0 +1,28 @@
+[% INCLUDE 'admin/header.html' title=tprintf(loc('Response Templates for %s'), body.name) -%]
+
+<h2> [% tprintf(loc('Response Templates for %s'), body.name) %] </h2>
+
+<table>
+    <thead>
+    <tr>
+        <th>  [% loc('Title') %] </th>
+        <th>  [% loc('Text') %] </th>
+        <th>  [% loc('Created') %] </th>
+        <th>  &nbsp; </th>
+    </tr>
+    </thead>
+    <tbody>
+[% FOR t IN response_templates %]
+    <tr>
+        <td>  [% t.title %] </td>
+        <td> [% t.text %] </td>
+        <td> [% t.created %] </td>
+        <td> <a href="[% c.uri_for('templates', body.id, t.id) %]" class="btn">[% loc('Edit') %]</a> </td>
+    </tr>
+[% END %]
+    </tbody>
+</table>
+
+<a href="[% c.uri_for('templates', body.id, 'new') %]" class="btn">[% loc('New template') %]</a>
+
+[% INCLUDE 'admin/footer.html' %]


### PR DESCRIPTION
If an Open311 service request update with an empty description field is received and there is a matching ResponseTemplate for the problem's category & state (and it's marked as auto-response) then the text from that ResponseTemplate will be used for the created update.

This PR adds that functionality, as well as improving the admin UI for managing response templates and marking them as auto-responses.

Fixes mysociety/fixmystreetforcouncils#263