### PR TITLE
Ensure Mock::Nominatim JSON is encoded in en-gb locale

### DIFF
--- a/t/Mock/Nominatim.pm
+++ b/t/Mock/Nominatim.pm
@@ -21,7 +21,9 @@ sub dispatch_request {
     sub (GET + /search + ?q=) {
         my ($self, $q) = @_;
         my $response = $self->query($q);
-        my $json = $self->json->encode($response);
+        my $json = mySociety::Locale::in_gb_locale {
+            $self->json->encode($response);
+        };
         return [ 200, [ 'Content-Type' => 'application/json' ], [ $json ] ];
     },
 }


### PR DESCRIPTION
This was causing an error in "Test ajax decimal points" in fixamingata.t
due to "importance" being encoded with a comma decimal separator.

[skip changelog]