### PR TITLE
Small send method fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
         - Consolidate various admin summary statistics page. #1919.
         - 'Auto-response' flag on response templates is honoured for fetched
           Open311 updates. #1924
+        - Store all successful send methods. #1933
     - UK:
         - Use SVG logo, inlined on front page. #1887
         - Inline critical CSS on front page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
         - Superusers without a from_body can make reports again. #1913
         - Fix crash when viewing /around in certain locales. #1916
         - Fix back bug, from report after using list filters. #1920
+        - Fix issues with send method category change. #1933
     - Admin improvements:
         - Character length limit can be placed on report detailed information #1848
         - Inspector panel shows nearest address if available #1850

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -867,6 +867,17 @@ sub update_send_failed {
     } );
 }
 
+sub add_send_method {
+    my $self = shift;
+    my $sender = shift;
+    ($sender = ref $sender) =~ s/^.*:://;
+    if (my $send_method = $self->send_method_used) {
+        $self->send_method_used("$send_method,$sender");
+    } else {
+        $self->send_method_used($sender);
+    }
+}
+
 sub as_hashref {
     my $self = shift;
     my $c    = shift;

--- a/perllib/FixMyStreet/Script/Reports.pm
+++ b/perllib/FixMyStreet/Script/Reports.pm
@@ -222,7 +222,9 @@ sub send(;$) {
         for my $sender ( keys %reporters ) {
             debug_print("sending using " . $sender, $row->id) if $debug_mode;
             $sender = $reporters{$sender};
-            $result *= $sender->send( $row, \%h );
+            my $res = $sender->send( $row, \%h );
+            $result *= $res;
+            $row->add_send_method($sender) if !$res;
             if ( $sender->unconfirmed_counts) {
                 foreach my $e (keys %{ $sender->unconfirmed_counts } ) {
                     foreach my $c (keys %{ $sender->unconfirmed_counts->{$e} }) {

--- a/perllib/FixMyStreet/SendReport/Angus.pm
+++ b/perllib/FixMyStreet/SendReport/Angus.pm
@@ -154,7 +154,6 @@ sub send {
         my $external_id = $self->get_external_id( $result );
         if ( $external_id ) {
             $row->external_id( $external_id );
-            $row->send_method_used('Angus');
             $return = 0;
         }
     } catch {

--- a/perllib/FixMyStreet/SendReport/Open311.pm
+++ b/perllib/FixMyStreet/SendReport/Open311.pm
@@ -84,7 +84,6 @@ sub send {
 
         if ( $resp ) {
             $row->external_id( $resp );
-            $row->send_method_used('Open311');
             $result *= 0;
             $self->success( 1 );
         } else {

--- a/templates/web/fixmystreet.com/report/updates-sidebar-notes.html
+++ b/templates/web/fixmystreet.com/report/updates-sidebar-notes.html
@@ -1,5 +1,5 @@
 <p>
-  [% IF problem.send_method_used != 'Open311' OR NOT problem.to_body_named('Bromley|Stevenage') %]
+  [% IF NOT problem.send_method_used.match('Open311') OR NOT problem.to_body_named('Bromley|Stevenage') %]
     [% loc( 'Please note that updates are not sent to the council.' ) %]
   [% END %]
     [% loc( 'Your information will only be used in accordance with our <a href="/privacy">privacy policy</a>' ) %]


### PR DESCRIPTION
This fixes an issue whereby if you changed a problem from a category that was send method A at the time the problem was made but is now send method B, to send method B, it wasn't being resent. It also stores all send methods used rather than just a couple, and adds a script to spot reports not sent via RDI.