### PR TITLE
[UK] Make sure jQuery is loaded where it is needed

### DIFF
--- a/perllib/FixMyStreet/Map/Bristol.pm
+++ b/perllib/FixMyStreet/Map/Bristol.pm
@@ -63,6 +63,8 @@ sub map_javascript { [
     '/js/map-OpenLayers.js',
     '/js/map-wmts-base.js',
     '/js/map-wmts-bristol.js',
+    '/cobrands/fixmystreet/assets.js',
+    '/cobrands/bristol/js.js',
 ] }
 
 # Reproject a WGS84 lat/lon into BNG easting/northing

--- a/t/map/tests.t
+++ b/t/map/tests.t
@@ -4,7 +4,7 @@ use Test::More;
 my $requires = {
     'Angus' => 'angus/js.js',
     'Bing' => 'map-bing-ol.js',
-    'Bristol' => 'map-wmts-bristol.js',
+    'Bristol' => 'bristol/js.js',
     'Bromley' => 'bromley/map.js',
     'FMS' => 'map-fms.js',
     'Google' => 'map-google.js',

--- a/templates/web/base/common_footer_tags.html
+++ b/templates/web/base/common_footer_tags.html
@@ -5,8 +5,13 @@
 <!--[if lte IE 9]>
   <script src="[% version('/vendor/history.polyfill.min.js') %]"></script>
 <![endif]-->
-[% FOR script IN scripts ~%]
-    [% script = script.0 ? script : [ script ] ~%]
+[%
+scripts_seen = {};
+FOR script IN scripts;
+    script = script.0 ? script : [ script ];
+    NEXT IF scripts_seen.${script.0};
+    scripts_seen.${script.0} = 1;
+    ~%]
     <script src="[% script.0 %]"
         [%~ FOR attr IN script.1 %] [% attr.key %]="[% attr.value %]"[% END ~%]
         ></script>

--- a/templates/web/base/common_scripts.html
+++ b/templates/web/base/common_scripts.html
@@ -9,21 +9,16 @@ scripts.push(
     start _ "/js/translation_strings." _ lang_code _ ".js?" _ Math.int( date.now / 3600 ),
 );
 
-SET jquery_loaded = 0;
-SET geolocation_loaded = 0;
 IF bodyclass.match('frontpage');
-    SET geolocation_loaded = 1;
     scripts.push(
         version('/js/front.js'),
         version('/js/geolocation.js'),
     );
 ELSIF bodyclass.match('alertpage');
-    SET geolocation_loaded = 1;
     scripts.push(
         version('/js/geolocation.js'),
     );
 ELSE;
-    SET jquery_loaded = 1;
     scripts.push(
         version('/js/validation_rules.js'),
         version('/jslib/jquery-1.7.2.min.js'),
@@ -38,17 +33,9 @@ FOR script IN extra_js;
 END;
 
 IF c.user_exists AND (c.user.from_body OR c.user.is_superuser);
-    IF NOT geolocation_loaded;
-        scripts.push(
-            version('/js/geolocation.js'),
-        );
-    END;
-    IF NOT jquery_loaded;
-        scripts.push(
-            version('/jslib/jquery-1.7.2.min.js'),
-        );
-    END;
     scripts.push(
+        version('/js/geolocation.js'),
+        version('/jslib/jquery-1.7.2.min.js'),
         version('/cobrands/fixmystreet/staff.js')
     );
     IF c.user.has_body_permission_to('planned_reports');

--- a/templates/web/bristol/footer_extra_js.html
+++ b/templates/web/bristol/footer_extra_js.html
@@ -1,6 +1,4 @@
 [% scripts.push(
     version('/vendor/OpenLayers.Projection.OrdnanceSurvey.js')
     version('/cobrands/fixmystreet-uk-councils/js.js'),
-    version('/cobrands/fixmystreet/assets.js'),
-    version('/cobrands/bristol/js.js'),
 ) %]

--- a/templates/web/bromley/footer_extra_js.html
+++ b/templates/web/bromley/footer_extra_js.html
@@ -1,3 +1,4 @@
 [% scripts.push(
+    version('/jslib/jquery-1.7.2.min.js'),
     version('/cobrands/bromley/a-z-nav.js'),
 ) %]

--- a/templates/web/zurich/footer.html
+++ b/templates/web/zurich/footer.html
@@ -34,10 +34,7 @@
     </div>
     </div>
 
-    <script src="[% version('/cobrands/zurich/validation_rules.js') %]"></script>
     [% INCLUDE 'common_footer_tags.html' %]
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/jquery-ui.min.js" charset="utf-8"></script>
-    <script src="[% version('/cobrands/zurich/js.js') %]"></script>
 
 </body>
 </html>

--- a/templates/web/zurich/footer_extra_js.html
+++ b/templates/web/zurich/footer_extra_js.html
@@ -1,0 +1,6 @@
+[% scripts.push(
+    version('/jslib/jquery-1.7.2.min.js'),
+    version('/cobrands/zurich/validation_rules.js'),
+    '//ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/jquery-ui.min.js',
+    version('/cobrands/zurich/js.js'),
+) %]

--- a/web/cobrands/borsetshire/js.js
+++ b/web/cobrands/borsetshire/js.js
@@ -1,5 +1,9 @@
 (function(){
 
+    if (typeof jQuery === 'undefined') {
+        return;
+    }
+
     function set_redirect(form) {
         var e = form.username.value;
         if (e == 'inspector@example.org') {

--- a/web/cobrands/fixmystreet-uk-councils/js.js
+++ b/web/cobrands/fixmystreet-uk-councils/js.js
@@ -1,5 +1,5 @@
 (function(){
-    if (!jQuery.validator) {
+    if (typeof jQuery === 'undefined' || !jQuery.validator) {
         return;
     }
     var validNamePat = /\ba\s*n+on+((y|o)mo?u?s)?(ly)?\b/i;

--- a/web/cobrands/oxfordshire/js.js
+++ b/web/cobrands/oxfordshire/js.js
@@ -1,7 +1,5 @@
 fixmystreet.utils = fixmystreet.utils || {};
 
-$.extend(fixmystreet.utils, {
-    defect_type_format: function(data) {
-        return data.extra.defect_code + ' - ' + data.extra.activity_code + ' (' + data.name + ')';
-    }
-});
+fixmystreet.utils.defect_type_format = function(data) {
+    return data.extra.defect_code + ' - ' + data.extra.activity_code + ' (' + data.name + ')';
+};


### PR DESCRIPTION
A few front pages giving a jQuery missing error because they're either loading JS they don't need to or not loading jQuery when they do need to:
* Bromley uses jQuery for its A-Z on all pages;
* only load Bristol map JavaScript on map pages (same as Angus);
* fix Zurich load order; and
* improve jQuery check in other JavaScript.
[skip changelog]