### PR TITLE
Force dashboard filters onto a single line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Releases
 
 * Unreleased
+    - Bugfixes:
+        - Make sure dashboard filters all fit onto one line.
 
 * v2.3 (18th December 2017)
     - New features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Unreleased
     - Bugfixes:
         - Make sure dashboard filters all fit onto one line.
+        - Fix issue with red bars on bar graph of many categories.
 
 * v2.3 (18th December 2017)
     - New features:

--- a/web/cobrands/sass/_dashboard.scss
+++ b/web/cobrands/sass/_dashboard.scss
@@ -220,6 +220,11 @@
     border-top: $primary solid 0.75em;
     padding: 0 1em;
 
+    // Force field elements onto a single line.
+    @media (min-width: 48em) {
+        @include flex-container();
+    }
+
     // No border-top when visually preceded by .dashboard-header
     .dashboard-header + * & {
         border-top: none;

--- a/web/js/dashboard.js
+++ b/web/js/dashboard.js
@@ -179,8 +179,8 @@ $(function(){
             rowValues.push( parseInt($(this).find('td').text(), 10) );
         });
 
-        for (var i=colours.length; i<rowLabels.length; i++) {
-            colours[i] = colours[i % colours.length];
+        for (var l=colours.length, i=l; i<rowLabels.length; i++) {
+            colours[i] = colours[i % l];
         }
 
         var barChart = new Chart($canvas, {


### PR DESCRIPTION
Fixes part of mysociety/fixmystreet-commercial#965.

Previously, filter items were capped at 25% of the parent width. If you had more than 4 of items, there was a chance enough would extend to the 25% maximum that you’d get items wrapping onto multiple lines:

![screen shot 2017-12-19 at 16 30 07](https://user-images.githubusercontent.com/739624/34167550-f82ac222-e4d9-11e7-8ae5-51ea9120c998.png)

This pull request fixes that for modern browsers, using flexbox. Items take up a maximum of 25% width, as before, except now, if the total of all items exceeds 100% of the parent, the width of each item is reduced until they all fit. Flexbox does it all automatically for us:

![screen shot 2017-12-19 at 16 30 32](https://user-images.githubusercontent.com/739624/34167562-fc3337a0-e4d9-11e7-8886-ab8406793208.png)

We’ll need to be careful that we don’t abuse this by cramming too many items into these filter forms. But for now, this is the most sensible fix.