### PR TITLE
Update Ordnance Survey phone number

### DIFF
--- a/templates/web/fixmystreet.com/about/faq-en-gb.html
+++ b/templates/web/fixmystreet.com/about/faq-en-gb.html
@@ -216,7 +216,7 @@ bet is to describe the problem location in as much detail as possible, as well
 as using the map to pinpoint it.
 <p>Ordnance Survey will accept requests for amendments to their maps: contact
 them on customerservices@ordnancesurvey.co.uk or via the post to Ordnance
-Survey, Adanac Drive, Southampton, SO16 0AS or telephone 08456 05 05 05.
+Survey, Adanac Drive, Southampton, SO16 0AS or telephone 03456 05 05 05.
 </dd>
 
 <dt>There are too many pins on the map; I can't make a report</dt>


### PR DESCRIPTION
They've changed from using an 0845 number to 0345, which is a Good Thing as it will cost people less to call.
[skip changelog]