### PR TITLE
Include "SameSite=Lax" with all set cookies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Releases
 
 * Unreleased
+    - Front end improvements:
+        - Include "SameSite=Lax" with all cookies.
     - Bugfixes:
         - Make sure dashboard filters all fit onto one line.
         - Fix issue with red bars on bar graph of many categories.

--- a/cpanfile
+++ b/cpanfile
@@ -13,6 +13,7 @@ requires 'PadWalker', '2.2';
 requires 'aliased', '0.34';
 requires 'Net::SSLeay', '1.81';
 requires 'Module::ScanDeps', '1.24';
+requires 'CGI', '4.38';
 
 # Catalyst itself, and modules/plugins used
 requires 'Catalyst', '5.80031';
@@ -32,7 +33,6 @@ requires 'Catalyst::View::TT';
 requires 'Authen::SASL';
 requires 'Cache::Memcached';
 requires 'Carp';
-requires 'CGI';
 requires 'Crypt::Eksblowfish::Bcrypt';
 requires 'DateTime';
 requires 'DateTime::Format::HTTP';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -75,19 +75,19 @@ DISTRIBUTIONS
       perl 5.008001
       strict 0
       warnings 0
-  CGI-4.28
-    pathname: L/LE/LEEJO/CGI-4.28.tar.gz
+  CGI-4.38
+    pathname: L/LE/LEEJO/CGI-4.38.tar.gz
     provides:
-      CGI 4.28
-      CGI::Carp 4.28
-      CGI::Cookie 4.28
-      CGI::File::Temp 4.28
+      CGI 4.38
+      CGI::Carp 4.38
+      CGI::Cookie 4.38
+      CGI::File::Temp 4.38
       CGI::HTML::Functions undef
-      CGI::Pretty 4.28
-      CGI::Push 4.28
-      CGI::Util 4.28
-      Fh 4.28
-      MultipartBuffer 4.28
+      CGI::MultipartBuffer 4.38
+      CGI::Pretty 4.38
+      CGI::Push 4.38
+      CGI::Util 4.38
+      Fh 4.38
     requirements:
       Carp 0
       Config 0
@@ -95,7 +95,7 @@ DISTRIBUTIONS
       Exporter 0
       ExtUtils::MakeMaker 0
       File::Spec 0.82
-      File::Temp 0
+      File::Temp 0.17
       HTML::Entities 3.69
       base 0
       if 0

--- a/perllib/FixMyStreet/App.pm
+++ b/perllib/FixMyStreet/App.pm
@@ -98,6 +98,7 @@ __PACKAGE__->config(
 );
 
 __PACKAGE__->response_class('FixMyStreet::App::Response');
+__PACKAGE__->engine_class('FixMyStreet::App::Engine');
 
 # Start the application
 __PACKAGE__->setup();

--- a/perllib/FixMyStreet/App/Engine.pm
+++ b/perllib/FixMyStreet/App/Engine.pm
@@ -1,0 +1,68 @@
+package FixMyStreet::App::Engine;
+
+use Moose;
+extends 'Catalyst::Engine';
+
+use CGI::Cookie;
+use utf8;
+
+use namespace::clean -except => 'meta';
+
+=head1 NAME
+
+FixMyStreet::App::Engine - Catalyst Engine wrapper
+
+=head1 SYNOPSIS
+
+See L<Catalyst::Engine>.
+
+=head1 METHODS
+
+=head2 $self->finalize_cookies($c)
+
+Create CGI::Cookie objects from C<< $c->res->cookies >>, and set them as
+response headers. Adds a C<samesite=lax> part.
+
+=cut
+
+sub finalize_cookies {
+    my ( $self, $c ) = @_;
+
+    my @cookies;
+    my $response = $c->response;
+
+    foreach my $name (keys %{ $response->cookies }) {
+
+        my $val = $response->cookies->{$name};
+
+        my $cookie = (
+            blessed($val)
+            ? $val
+            : CGI::Cookie->new(
+                -name    => $name,
+                -value   => $val->{value},
+                -expires => $val->{expires},
+                -domain  => $val->{domain},
+                -path    => $val->{path},
+                -secure  => $val->{secure} || 0,
+                -httponly => $val->{httponly} || 0,
+                -samesite => 'Lax',
+            )
+        );
+        if (!defined $cookie) {
+            $c->log->warn("undef passed in '$name' cookie value - not setting cookie")
+                if $c->debug;
+            next;
+        }
+
+        push @cookies, $cookie->as_string;
+    }
+
+    for my $cookie (@cookies) {
+        $response->headers->push_header( 'Set-Cookie' => $cookie );
+    }
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/perllib/FixMyStreet/App/Response.pm
+++ b/perllib/FixMyStreet/App/Response.pm
@@ -13,7 +13,7 @@ around 'redirect' => sub {
     return $self->$orig() unless @_;  # getter
 
     my $agent = $self->_context->request->user_agent;
-    return $self->$orig(@_) unless $agent =~ /Edge\/14/;  # Only care about Edge
+    return $self->$orig(@_) unless $agent && $agent =~ /Edge\/14/;  # Only care about Edge
 
     # Instead of a redirect, output HTML that redirects
     $self->body(<<END

--- a/t/app/engine.t
+++ b/t/app/engine.t
@@ -1,0 +1,9 @@
+use FixMyStreet::Test;
+
+use Catalyst::Test 'FixMyStreet::App';
+
+my $res = request("/?_override_foo=bar");
+
+like $res->headers->header('Set-Cookie'), qr/SameSite=Lax/;
+
+done_testing;


### PR DESCRIPTION
This prevents FixMyStreet cookies from being sent from third-party `<img>`s and the like, in supporting browsers.