### PR TITLE
Fix two around filter issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Unreleased
     - Bugfixes:
+        - Fix bug specifying category in URL on /around. #1950
         - Make sure dashboard filters all fit onto one line.
         - Fix issue with red bars on bar graph of many categories.
         - Prefetch translations in /reports list of bodies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Unreleased
     - Bugfixes:
         - Fix bug specifying category in URL on /around. #1950
+        - Fix bug with multiple select-multiples on a page. #1951
         - Make sure dashboard filters all fit onto one line.
         - Fix issue with red bars on bar graph of many categories.
         - Prefetch translations in /reports list of bodies.

--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -240,7 +240,7 @@ sub check_and_stash_category : Private {
     )->all;
     my @categories = map { { name => $_->category, value => $_->category_display } } @contacts;
     $c->stash->{filter_categories} = \@categories;
-    my %categories_mapped = map { $_ => 1 } @categories;
+    my %categories_mapped = map { $_->{name} => 1 } @categories;
 
     my $categories = [ $c->get_param_list('filter_category', 1) ];
     my %valid_categories = map { $_ => 1 } grep { $_ && $categories_mapped{$_} } @$categories;

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -112,8 +112,9 @@ function isR2L() {
     },
 
     make_multi: function() {
-        // A convenience wrapper around $.multiSelect() that translates HTML
-        // data-* attributes into settings for the multiSelect constructor.
+      // A convenience wrapper around $.multiSelect() that translates HTML
+      // data-* attributes into settings for the multiSelect constructor.
+      return this.each(function() {
         var $select = $(this);
         var settings = {};
 
@@ -144,6 +145,7 @@ function isR2L() {
         }
 
         $select.multiSelect(settings);
+      });
     }
 
   });


### PR DESCRIPTION
One server-side (not selecting the category correctly when provided in URL), one client-side (all select multiples using the same settings, that of the first on the page).
Fixes #1950. Fixes #1951.