### PR TITLE
Zoom out as much as necessary, even on mobile.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Unreleased
     - Front end improvements:
         - Include "SameSite=Lax" with all cookies.
+	- Zoom out as much as necessary on body map page, even on mobile. #1958
     - Bugfixes:
         - Fix bug specifying category in URL on /around. #1950
         - Fix bug with multiple select-multiples on a page. #1951

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -240,9 +240,6 @@ $.extend(fixmystreet.utils, {
         strategy.deactivate();
         var center = bounds.getCenterLonLat();
         var z = fixmystreet.map.getZoomForExtent(bounds);
-        if ( z < 13 && $('html').hasClass('mobile') ) {
-            z = 13;
-        }
         fixmystreet.map.setCenter(center, z);
         // Reactivate the strategy and make it think it's done an update
         strategy.activate();


### PR DESCRIPTION
This also fixes an inconsistency between what you can see on the map and the
list of reports underneath.
Fixes #1958