### PR TITLE
Never skip sending reports with --debug flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
     - Development improvements:
         - Add hook for pre-wrapper content.
         - Include JSON representation of extra fields in category_extras output
+        - send-reports will never skip failed reports when using --debug
     - UK:
         - Use SVG logo, inlined on front page. #1887
         - Inline critical CSS on front page. #1893

--- a/perllib/FixMyStreet/Script/Reports.pm
+++ b/perllib/FixMyStreet/Script/Reports.pm
@@ -159,7 +159,7 @@ sub send(;$) {
                 }
             }
 
-            if ( $reporters{ $sender }->should_skip( $row ) ) {
+            if ( $reporters{ $sender }->should_skip( $row, $debug_mode ) ) {
                 $skip = 1;
                 debug_print("skipped by sender " . $sender_info->{method} . " (might be due to previous failed attempts?)", $row->id) if $debug_mode;
             } else {

--- a/perllib/FixMyStreet/SendReport.pm
+++ b/perllib/FixMyStreet/SendReport.pm
@@ -19,10 +19,12 @@ has 'unconfirmed_notes' => ( 'is' => 'rw', isa => HashRef, default => sub { {} }
 
 
 sub should_skip {
-    my $self = shift;
-    my $row  = shift;
+    my $self  = shift;
+    my $row   = shift;
+    my $debug = shift;
 
     return 0 unless $row->send_fail_count;
+    return 0 if $debug;
 
     my $now = DateTime->now( time_zone => FixMyStreet->local_time_zone );
     my $diff = $now - $row->send_fail_timestamp;


### PR DESCRIPTION
It’s a little annoying to have to fiddle with the database between runs
of send-reports when debugging a stuck/failing report or working on a
new Open311 integration. This commit disables skipping of reports when
the --debug flag is used.