### PR TITLE
Show loading message on /around page load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 * Unreleased
     - Front end improvements:
-	- Zoom out as much as necessary on body map page, even on mobile. #1958
+        - Zoom out as much as necessary on body map page, even on mobile. #1958
+        - Show loading message on initial /around map load #1976
     - Bugfixes:
         - Fix bug specifying category in URL on /around. #1950
         - Fix bug with multiple select-multiples on a page. #1951

--- a/templates/web/base/around/on_map_list_items.html
+++ b/templates/web/base/around/on_map_list_items.html
@@ -14,7 +14,11 @@
     </li>
 [% ELSE %]
     <li class="item-list__item item-list__item--empty">
-        <p>[% loc('There are no reports to show.') %]</p>
+        [% IF c.get_param('js') %]
+            <p>[% loc('Loading reports…') %]</p>
+        [% ELSE %]
+            <p>[% loc('There are no reports to show.') %]</p>
+        [% END %]
     </li>
 [% END %]
 </ul>


### PR DESCRIPTION
The map and sidebar are empty on /around when the page loads, and JS is used
to pull in the relevant reports and populate the page. The previous message
indicated that there were no reports at all, but in fact they were being loaded
asynchronously. This commit shows a more helpful message whilst the pins are
being loaded.
