### PR TITLE
prevent timezone related util test failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
         - Change text on /reports to match lower down (fix translation).
         - Ensure all reports graph can't dip downward. #1956
         - Fix error sending `requires_inspection` reports. #1961
+        - Fix timezone related test failure. #1984
     - Admin improvements:
         - Admin can anonymize/hide all a user's reports. #1942 #1943
         - Admin can log a user out. #1975

--- a/t/utils.t
+++ b/t/utils.t
@@ -67,7 +67,9 @@ is Utils::cleanup_text( "This has new\n\n\nlines in it", { allow_multiline => 1 
 
 
 is Utils::prettify_dt(), "[unknown time]";
-my $dt = DateTime->now;
+# Make sure we create the date using the FMS timezone that prettify_dt uses
+# otherwise this can fail if the local timezone is not the same as the FMS one
+my $dt = DateTime->now( time_zone =>  FixMyStreet->time_zone || FixMyStreet->local_time_zone );
 is Utils::prettify_dt($dt), $dt->strftime("%H:%M today");
 
 # Same week test


### PR DESCRIPTION
Make sure that the prettify_dt tests use the same timezone as FMS
otherwise the test can fail if now in the local timezone is actually
yesterday/tomorrow in the FMS timezone.

Fixes #1984

This does point to underlying issues with `prettify_dt` but given that FMS doesn't really handle multiple timezones I suspect that `prettify_dt` getting passed a date in a different timezone is probably a sign of something else wrong.