### PR TITLE
Make asset layers more awesome

### DIFF
--- a/web/cobrands/angus/js.js
+++ b/web/cobrands/angus/js.js
@@ -4,7 +4,7 @@ if (!fixmystreet.maps) {
     return;
 }
 
-$(fixmystreet.add_assets({
+fixmystreet.assets.add({
     wfs_url: "https://data.angus.gov.uk/geoserver/services/wfs",
     wfs_feature: "lighting_column_v",
     wfs_fault_feature: "lighting_faults_v",
@@ -18,6 +18,6 @@ $(fixmystreet.add_assets({
         column_id: 'n'
     },
     geometryName: 'g'
-}));
+});
 
 })();

--- a/web/cobrands/bristol/js.js
+++ b/web/cobrands/bristol/js.js
@@ -19,32 +19,32 @@ var options = {
     geometryName: 'SHAPE'
 };
 
-$(fixmystreet.add_assets($.extend({}, options, {
+fixmystreet.assets.add($.extend({}, options, {
     wfs_feature: "COD_ASSETS_AREA",
     asset_type: 'area',
     asset_category: "Bridges/Subways",
     asset_item: 'bridge/subway'
-})));
+}));
 
-$(fixmystreet.add_assets($.extend({}, options, {
+fixmystreet.assets.add($.extend({}, options, {
     asset_category: "Gully/Drainage",
     asset_item: 'gully',
     filter_key: 'COD_ASSET_TYPE',
     filter_value: 'GULLY'
-})));
+}));
 
-$(fixmystreet.add_assets($.extend({}, options, {
+fixmystreet.assets.add($.extend({}, options, {
     asset_category: "Grit Bins",
     asset_item: 'grit bin',
     filter_key: 'COD_ASSET_TYPE',
     filter_value: 'GRITBIN'
-})));
+}));
 
-$(fixmystreet.add_assets($.extend({}, options, {
+fixmystreet.assets.add($.extend({}, options, {
     asset_category: "Street Lighting",
     asset_item: 'street light',
     filter_key: 'COD_ASSET_TYPE',
     filter_value: 'SL'
-})));
+}));
 
 })();

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -113,7 +113,7 @@ function check_zoom_message_visibility() {
 
 function layer_visibilitychanged() {
     check_zoom_message_visibility.call(this);
-    var layers = fixmystreet.map.getLayersByName('WFS');
+    var layers = fixmystreet.map.getLayersBy('assets', true);
     var visible = 0;
     for (var i = 0; i<layers.length; i++) {
         if (layers[i].getVisibility()) {
@@ -304,7 +304,8 @@ fixmystreet.add_assets = function(options) {
             visibility: false,
             maxResolution: options.max_resolution,
             minResolution: options.min_resolution,
-            styleMap: options.stylemap || get_asset_stylemap()
+            styleMap: options.stylemap || get_asset_stylemap(),
+            assets: true
         };
         if (options.srsName !== undefined) {
             layer_options.projection = new OpenLayers.Projection(options.srsName);
@@ -319,7 +320,7 @@ fixmystreet.add_assets = function(options) {
                 value: options.filter_value
             });
         }
-        asset_layer = new OpenLayers.Layer.Vector("WFS", layer_options);
+        asset_layer = new OpenLayers.Layer.Vector(options.name || "WFS", layer_options);
 
         // A non-interactive layer to display existing street light faults
         if (options.wfs_fault_feature) {
@@ -331,7 +332,8 @@ fixmystreet.add_assets = function(options) {
             var lo = {
                 strategies: [new OpenLayers.Strategy.BBOX()],
                 protocol: fault_protocol,
-                styleMap: get_fault_stylemap()
+                styleMap: get_fault_stylemap(),
+                assets: true
             };
             OpenLayers.Util.applyDefaults(lo, layer_options);
             asset_fault_layer = new OpenLayers.Layer.Vector("WFS", lo);

--- a/web/vendor/OpenLayers.Projection.OrdnanceSurvey.js
+++ b/web/vendor/OpenLayers.Projection.OrdnanceSurvey.js
@@ -107,11 +107,19 @@ OpenLayers.Projection.OS = {
     },
   
     goog2osgb: function(point) {
-        return OpenLayers.Projection.OS.projectForwardBritish(OpenLayers.Layer.SphericalMercator.projectInverse(point));
+        var p1 = OpenLayers.Layer.SphericalMercator.inverseMercator(point.x, point.y);
+        var p2 = OpenLayers.Projection.OS.projectForwardBritish({x: p1.lon, y: p1.lat});
+        point.x = p2.x;
+        point.y = p2.y;
+        return point;
     },
   
     osgb2goog: function(point) {
-        return OpenLayers.Layer.SphericalMercator.projectForward(OpenLayers.Projection.OS.projectInverseBritish(point));
+        var p1 = OpenLayers.Projection.OS.projectInverseBritish(point);
+        var p2 = OpenLayers.Layer.SphericalMercator.forwardMercator(p1.x, p1.y);
+        point.x = p2.lon;
+        point.y = p2.lat;
+        return point;
     },
     
     /*****


### PR DESCRIPTION
This PR makes the asset layers code easier to work with if you want to load features from a quirky WFS endpoint, or show a layer independent of the category field, or provide your own styles for features.