### PR TITLE
More asset/inspector form improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - Improve questionnaire process. #1939 #1998
     - Bugfixes:
         - Stop asset layers obscuring marker layer. #1999
+        - Don't delete hidden field values when inspecting reports. #1999
     - Admin improvements:
         - Inspectors can set non_public status of reports. #1992
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Unreleased
     - Front end improvements:
         - Improve questionnaire process. #1939 #1998
+    - Bugfixes:
+        - Stop asset layers obscuring marker layer. #1999
     - Admin improvements:
         - Inspectors can set non_public status of reports. #1992
 

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -68,9 +68,9 @@
                data-defect-types='[% category_defect_types.$cat_name %]'
                data-templates='[% templates_by_category.$cat_name %]'>
               [% IF cat_name == problem.category %]
-                  [% INCLUDE 'report/new/category_extras_fields.html' metas=category_extras.$cat_name hide_notices=1 %]
+                  [% INCLUDE 'report/new/category_extras_fields.html' metas=category_extras.$cat_name hide_notices=1 show_hidden=1 %]
               [% ELSE %]
-                  [% INCLUDE 'report/new/category_extras_fields.html' report_meta='' metas=category_extras.$cat_name hide_notices=1 %]
+                  [% INCLUDE 'report/new/category_extras_fields.html' report_meta='' metas=category_extras.$cat_name hide_notices=1 show_hidden=1 %]
               [% END %]
             </p>
         [% END %]

--- a/templates/web/base/report/new/category_extras_fields.html
+++ b/templates/web/base/report/new/category_extras_fields.html
@@ -1,7 +1,7 @@
 [%- FOR meta IN metas %]
   [%- meta_name = meta.code -%]
 
-  [% IF c.cobrand.category_extra_hidden(meta_name) %]
+  [% IF c.cobrand.category_extra_hidden(meta_name) AND NOT show_hidden %]
 
       <input type="hidden" value="[% report_meta.$meta_name.value | html %]" name="[% cat_prefix %][% meta_name %]" id="[% cat_prefix %]form_[% meta_name %]">
 

--- a/templates/web/base/report/new/category_extras_fields.html
+++ b/templates/web/base/report/new/category_extras_fields.html
@@ -3,7 +3,7 @@
 
   [% IF c.cobrand.category_extra_hidden(meta_name) %]
 
-      <input type="hidden" value="" name="[% cat_prefix %][% meta_name %]" id="[% cat_prefix %]form_[% meta_name %]">
+      <input type="hidden" value="[% report_meta.$meta_name.value | html %]" name="[% cat_prefix %][% meta_name %]" id="[% cat_prefix %]form_[% meta_name %]">
 
   [% ELSIF meta.variable != 'false' || NOT hide_notices %]
 

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -523,4 +523,25 @@ OpenLayers.Layer.Vector.prototype.getNearestFeature = function(point, threshold)
     return nearest_feature;
 };
 
+
+/*
+ * MapServer 6 (the version available on Debian Wheezy) outputs incorrect
+ * GML for MultiCurve geometries - see https://github.com/mapserver/mapserver/issues/4924
+ * The end result is that features with 'curveMembers' elements in their
+ * geometries will be missing from the map as the default GML parser doesn't
+ * know how to handle these elements.
+ * This subclass works around the problem by parsing 'curveMembers' elements.
+ */
+OpenLayers.Format.GML.v3.MultiCurveFix = OpenLayers.Class(OpenLayers.Format.GML.v3, {
+    readers: $.extend(true, {}, OpenLayers.Format.GML.v3.prototype.readers, {
+        "gml": {
+            "curveMembers": function(node, obj) {
+                this.readChildNodes(node, obj);
+            }
+        }
+    }),
+
+    CLASS_NAME: "OpenLayers.Format.GML.v3.MultiCurveFix"
+});
+
 })();

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -370,19 +370,11 @@ fixmystreet.assets = {
         if (options.always_visible) {
             asset_layer.setVisibility(true);
         }
-        if (asset_fault_layer) {
-            fixmystreet.assets.layers.push(asset_fault_layer);
-        }
         if (hover_feature_control) {
             fixmystreet.assets.controls.push(hover_feature_control);
         }
         if (select_feature_control) {
             fixmystreet.assets.controls.push(select_feature_control);
-        }
-
-        // Make sure the fault markers always appear beneath the linked assets
-        if (asset_fault_layer) {
-            asset_fault_layer.setZIndex(asset_layer.getZIndex()-1);
         }
 
         if (!asset_layer.fixmystreet.always_visible) {
@@ -391,14 +383,14 @@ fixmystreet.assets = {
                 var category = $(this).val();
                 if (category == options.asset_category) {
                     asset_layer.setVisibility(true);
-                    if (asset_fault_layer) {
-                        asset_fault_layer.setVisibility(true);
+                    if (asset_layer.fixmystreet.fault_layer) {
+                        asset_layer.fixmystreet.fault_layer.setVisibility(true);
                     }
                     zoom_to_assets(asset_layer);
                 } else {
                     asset_layer.setVisibility(false);
-                    if (asset_fault_layer) {
-                        asset_fault_layer.setVisibility(false);
+                    if (asset_layer.fixmystreet.fault_layer) {
+                        asset_layer.fixmystreet.fault_layer.setVisibility(false);
                     }
                 }
             });
@@ -426,12 +418,25 @@ fixmystreet.assets = {
             return hide_assets;
         })(fixmystreet.maps.display_around);
 
+        var pins_layer = fixmystreet.map.getLayersByName("Pins")[0];
         for (var i = 0; i < fixmystreet.assets.layers.length; i++) {
             var layer = fixmystreet.assets.layers[i];
             fixmystreet.map.addLayer(layer);
             if (layer.fixmystreet.asset_category) {
                 fixmystreet.map.events.register( 'zoomend', layer, check_zoom_message_visibility);
             }
+
+            // Don't cover the existing pins layer
+            if (pins_layer) {
+                layer.setZIndex(pins_layer.getZIndex()-1);
+            }
+
+            // Make sure the fault markers always appear beneath the linked assets
+            if (layer.fixmystreet.fault_layer) {
+                fixmystreet.map.addLayer(layer.fixmystreet.fault_layer);
+                layer.fixmystreet.fault_layer.setZIndex(layer.getZIndex()-1);
+            }
+
         }
 
         for (i = 0; i < fixmystreet.assets.controls.length; i++) {

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -417,6 +417,9 @@ $.extend(fixmystreet.set_up, {
             } else {
                 $category_meta.empty();
             }
+            if (fixmystreet.assets) {
+                fixmystreet.assets.update_usrn_field();
+            }
         });
 
         if (fixmystreet.hooks.update_problem_fields) {

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -459,6 +459,9 @@ $.extend(fixmystreet.set_up, {
 
     var add_option = function(el) {
         $group_select.append($(el).clone());
+        if (el.selected) {
+            $group_select.val(el.value);
+        }
     };
 
     var add_optgroup = function(el) {
@@ -478,11 +481,11 @@ $.extend(fixmystreet.set_up, {
             $sub_select.attr("id", subcategory_id);
             $sub_select.append($empty_option.clone());
             $options.each(function() {
-                var $newopt = $(this).clone();
-                $sub_select.append($newopt);
+                $sub_select.append($(this).clone());
                 // Make sure any preselected value is preserved in the new UI:
-                if ($newopt.attr('selected')) {
+                if (this.selected) {
                     $group_select.val(label);
+                    $sub_select.val(this.value);
                 }
             });
             $sub_select.hide().insertAfter($subcategory_label).change(subcategory_change);

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -40,19 +40,32 @@ $.extend(fixmystreet.utils, {
     };
 
     $.extend(fixmystreet.maps, {
-      // This function might be passed either an OpenLayers.LonLat (so has
-      // lon and lat), or an OpenLayers.Geometry.Point (so has x and y).
       update_pin: function(lonlat) {
+        // This function might be passed either an OpenLayers.LonLat (so has
+        // lon and lat), or an OpenLayers.Geometry.Point (so has x and y).
+        if (lonlat.x !== undefined && lonlat.y !== undefined) {
+            // It's a Point, convert to a LatLon
+            lonlat = new OpenLayers.LonLat(lonlat.x, lonlat.y);
+        }
+
         var transformedLonlat = lonlat.clone().transform(
             fixmystreet.map.getProjectionObject(),
             new OpenLayers.Projection("EPSG:4326")
         );
 
-        var lat = transformedLonlat.lat || transformedLonlat.y;
-        var lon = transformedLonlat.lon || transformedLonlat.x;
+        var lat = transformedLonlat.lat;
+        var lon = transformedLonlat.lon;
 
         document.getElementById('fixmystreet.latitude').value = lat;
         document.getElementById('fixmystreet.longitude').value = lon;
+
+        // This tight coupling isn't ideal. A better solution would be for the
+        // asset code to register an event handler somewhere, but the correct
+        // place isn't apparent.
+        if (fixmystreet.assets) {
+            fixmystreet.assets.select_usrn(lonlat);
+        }
+
         return {
             'url': { 'lon': lon, 'lat': lat },
             'state': { 'lon': lonlat.lon, 'lat': lonlat.lat }


### PR DESCRIPTION
 - Display asset layers beneath existing markers on the map
 - Fill report `usrn` field from highways asset layer independently of e.g. street lights/grit bins
 - Fix bug that would delete values of hidden report extra fields when inspector form saved
 - Show hidden report extra fields on inspector form