### PR TITLE
[Bristol] Always include an email address for Open311 reports

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bristol.pm
+++ b/perllib/FixMyStreet/Cobrand/Bristol.pm
@@ -71,4 +71,10 @@ sub categories_restriction {
     return $rs->search( { 'me.send_method' => undef } );
 }
 
+sub open311_config {
+    my ($self, $row, $h, $params) = @_;
+
+    $params->{always_send_email} = 1;
+}
+
 1;

--- a/perllib/Open311.pm
+++ b/perllib/Open311.pm
@@ -31,6 +31,7 @@ has extended_description => ( is => 'ro', isa => Str, default => 1 );
 has use_service_as_deviceid => ( is => 'ro', isa => Bool, default => 0 );
 has use_extended_updates => ( is => 'ro', isa => Bool, default => 0 );
 has extended_statuses => ( is => 'ro', isa => Bool, default => 0 );
+has always_send_email => ( is => 'ro', isa => Bool, default => 0 );
 
 before [
     qw/get_service_list get_service_meta_info get_service_requests get_service_request_updates
@@ -135,6 +136,12 @@ sub _populate_service_request_params {
 
     $params->{phone} = $problem->user->phone if $problem->user->phone;
     $params->{email} = $problem->user->email if $problem->user->email;
+
+    # Some endpoints don't follow the Open311 spec correctly and require an
+    # email address for service requests.
+    if ($self->always_send_email && !$params->{email}) {
+        $params->{email} = FixMyStreet->config('DO_NOT_REPLY_EMAIL');
+    }
 
     # if you click nearby reports > skip map then it's possible
     # to end up with used_map = f and nothing in postcode


### PR DESCRIPTION
Bristol's Open311 endpoint isn't fully compliant with [the spec](http://wiki.open311.org/GeoReport_v2/#post-service-request) as it rejects service requests that have no email parameter. This is causing stuck reports since [email addresses aren't always required on fixmystreet.com](https://github.com/mysociety/fixmystreet/pull/1978) any more.

[skip changelog]