### PR TITLE
[UK] Track clicks on ".big-green-button"

### DIFF
--- a/web/cobrands/fixmystreet.com/js.js
+++ b/web/cobrands/fixmystreet.com/js.js
@@ -10,4 +10,10 @@
     }
     jQuery.validator.addMethod('validName', valid_name_factory(0), translation_strings.name.required);
     jQuery.validator.addMethod('validNameU', valid_name_factory(1), translation_strings.name.required);
+
+    jQuery('.big-green-banner').on('click', function(){
+        if (typeof ga !== 'undefined') {
+            ga('send', 'event', 'big-green-banner', 'click');
+        }
+    });
 })();


### PR DESCRIPTION
We’re interested in seeing whether people are mistakenly clicking the (inert) "Click map to report a problem" banner on the `/around` page. This will record a Google Analytics event if and when they do.

I’ve included tracking in the code for both fixmystreet.com and all UK councils … but, on second thoughts, I’m wondering whether we _even need it_ in the UK council cobrands, because they won’t be set up to send Google Analytics events anywhere we can see them. Thoughts, @dracos?

Fixes mysociety/fixmystreet-commercial#963.