### PR TITLE
Increase size of sub map links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Unreleased
     - Front end improvements:
         - Improve questionnaire process. #1939 #1998
+        - Increase size of "sub map links" (hide pins, permalink, etc) #2003
     - Bugfixes:
         - Stop asset layers obscuring marker layer. #1999
         - Don't delete hidden field values when inspecting reports. #1999

--- a/web/cobrands/oxfordshire/base.scss
+++ b/web/cobrands/oxfordshire/base.scss
@@ -34,11 +34,6 @@ dd, p {
   line-height: 1.4em;
 }
 
-// TODO: Should this be applied to the base base stylesheet, to prevent possible similar issues in other cobrands?
-#sub_map_links {
-  line-height: 1em;
-}
-
 .council_info_box {
   border-top: 1px solid #ccc;
   padding: 1em;

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1474,12 +1474,14 @@ html.js #map .noscript {
   background: #333;
   background: rgba(0, 0, 0, 0.7);
   margin: 0;
+  font-size: 1em;
+  line-height: 1em;
 
   a {
     display: inline-block;
-    font-size: 0.6875em;
+    font-size: 0.8em;
     color: #fff;
-    padding: 0.6em 1em 0.5em 1em;
+    padding: 0.7em 1em;
 
     &:hover {
       background-color: #000;
@@ -1523,6 +1525,7 @@ html.js #map .noscript {
   }
 }
 
+// The "Try again / OK" buttons in mobile reporting UI
 #mob_sub_map_links {
   position: absolute;
   bottom:0;

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -671,11 +671,13 @@ body.authpage {
 
   &:after {
     content: "";
-    display: inline-block;
-    vertical-align: middle;
+    display: block;
+    position: absolute;
     width: 6px;
     height: 12px;
-    margin-#{$left}: ((16px - 6px) / 2); // horizontally centre in 16px wide parent
+    top: 50%;
+    margin-top: -6px;
+    #{$left}: ((16px - 6px) / 2); // horizontally centre in 16px wide parent
     background-size: 96px 12px;
     @include svg-background-image('/cobrands/fixmystreet/images/map-tools');
   }


### PR DESCRIPTION
The tiny buttons could prove hard to trigger, especially on touchscreen devices, and with large screens now more commonplace, there’s no reason not to give them a few more pixels.

One of a number of enhancements suggested in #1462.

# Mobile: Before / After

![mobile-before](https://user-images.githubusercontent.com/739624/36602759-bd024458-18b0-11e8-8b4d-6c48acf4a5eb.png) ![mobile-after](https://user-images.githubusercontent.com/739624/36602774-c5c18540-18b0-11e8-9fb1-6e8075ddb3db.png)

# Desktop: Before / After

![desktop-before](https://user-images.githubusercontent.com/739624/36602764-c0b47f26-18b0-11e8-9c73-5d601bd32ec4.png) ![desktop-after](https://user-images.githubusercontent.com/739624/36602778-c7534ab0-18b0-11e8-94ac-26559040c55f.png)
