### PR TITLE
[Zurich] Do not reopen closed reports by mistake.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -639,7 +639,7 @@ sub admin_report_edit {
         my $closure_states = $self->zurich_closed_states;
         delete $closure_states->{'fixed - council'}; # may not be needed?
 
-        my $old_closure_state = $problem->get_extra_metadata('closure_status');
+        my $old_closure_state = $problem->get_extra_metadata('closure_status') || '';
 
         # update the public update from DM
         if (my $update = $c->get_param('status_update')) {
@@ -661,9 +661,8 @@ sub admin_report_edit {
             $internal_note_text = "Weitergeleitet von $old_cat an $new_cat";
             $self->update_admin_log($c, $problem, "Changed category from $old_cat to $new_cat");
             $redirect = 1 if $cat->body_id ne $body->id;
-        } elsif ( $closure_states->{$state} and
-                    ( $oldstate ne 'planned' )
-                    || (($old_closure_state ||'') ne $state))
+        } elsif ( $oldstate ne $state and $closure_states->{$state} and
+                  $oldstate ne 'planned' || $old_closure_state ne $state)
         {
             # for these states
             #  - closed (Extern)

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -289,6 +289,9 @@ subtest "report_edit" => sub {
         is ( $report->state, 'hidden', 'Closing as hidden sets state to hidden');
         is ( $report->get_extra_metadata('closure_status'), undef, 'Closing as hidden unsets closure_status');
 
+        $mech->submit_form_ok( { with_fields => { new_internal_note => 'Initial internal note.' } } );
+        $report->discard_changes;
+        is ( $report->state, 'hidden', 'Another internal note does not reopen');
 
         reset_report_state($report);
         is ( $report->get_extra_metadata('moderated_overdue'), undef, 'Sanity check' );


### PR DESCRIPTION
The code for moving a report to the intermediary state was running
even if the report was in a closed state and had not been changed.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/974. [skip changelog]