### PR TITLE
Fix check for visible sub map links.

### DIFF
--- a/.cypress/cypress/integration/regressions.js
+++ b/.cypress/cypress/integration/regressions.js
@@ -1,0 +1,9 @@
+describe('Regression tests', function() {
+    it('Shows the sub-map links after clicking Try again', function() {
+        cy.viewport(480, 800);
+        cy.visit('/around?pc=BS10+5EE&js=1');
+        cy.get('#map_box').click(200, 200);
+        cy.get('#try_again').click();
+        cy.get('#sub_map_links').should('be.visible');
+    });
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
         - Fix text layout issues in /reports/…/summary dashboard charts.
         - Fix post-edit issues on admin report edit page.
         - Truncate dates in Open311 output to the second. #2023
+        - Fix check for visible sub map links after 'Try again'.
     - Admin improvements:
         - Inspectors can set non_public status of reports. #1992
         - Default start date is shown on the dashboard.

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -16,6 +16,7 @@ BEGIN {
 }
 
 use List::Util qw(shuffle);
+use Path::Tiny;
 use FixMyStreet;
 use FixMyStreet::Cobrand;
 use FixMyStreet::DB::Factories;

--- a/templates/web/base/around/_updates.html
+++ b/templates/web/base/around/_updates.html
@@ -1,5 +1,5 @@
 <div class="shadow-wrap">
     <ul id="key-tools">
-        <li><a class="feed" id="key-tool-around-updates" href="[% email_url | html %]">[% loc("Get updates") %]</a></li>
+        <li><a class="feed js-feed" id="key-tool-around-updates" href="[% email_url | html %]">[% loc("Get updates") %]</a></li>
     </ul>
 </div>

--- a/templates/web/base/report/display_tools.html
+++ b/templates/web/base/report/display_tools.html
@@ -11,7 +11,7 @@
         %]</a></li>
         [% END %]
         [% IF c.cobrand.moniker != 'zurich' %]
-        <li><a rel="nofollow" id="key-tool-report-updates" class="feed" href="[% c.uri_for( '/alert/subscribe', { id => problem.id } ) %]">[% loc('Get updates' ) %]</a></li>
+        <li><a rel="nofollow" id="key-tool-report-updates" class="feed js-feed" href="[% c.uri_for( '/alert/subscribe', { id => problem.id } ) %]">[% loc('Get updates' ) %]</a></li>
         [% END %]
         [% IF c.cobrand.moniker == 'fixmystreet' %]
         <li><a rel="nofollow" id="key-tool-report-share" class="share" href="#report-share">[% loc('Share') %]</a></li>

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -682,11 +682,11 @@ $.extend(fixmystreet.set_up, {
     }
 
     if ($('.mobile').length) {
-        $('#map_permalink').hide();
+        $('#map_permalink').addClass('hidden');
         // Make sure we end up with one Get updates link
-        if ($('#key-tools a.feed').length) {
-            $('#sub_map_links a.feed').remove();
-            $('#key-tools a.feed').appendTo('#sub_map_links');
+        if ($('#key-tools a.js-feed').length) {
+            $('#sub_map_links a.js-feed').remove();
+            $('#key-tools a.js-feed').appendTo('#sub_map_links');
         }
         $('#key-tools li:empty').remove();
         $('#report-updates-data').insertAfter($('#map_box'));
@@ -696,7 +696,7 @@ $.extend(fixmystreet.set_up, {
     }
 
     // Show/hide depending on whether it has any children to show
-    if ($('#sub_map_links a:visible').length) {
+    if ($('#sub_map_links a').not('.hidden').length) {
         $('#sub_map_links').show();
     } else {
         $('#sub_map_links').hide();


### PR DESCRIPTION
I don't think this check could ever have worked, because items are invisible
if their parent is set to `display: none`, so it would hide the links bar if
it was already hidden, and show it if it was already shown.

Use a js- class for the movement of the feed item into the sub map links.