### PR TITLE
Store contributed-as data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
         - Inspectors can set non_public status of reports. #1992
         - Default start date is shown on the dashboard.
         - Users with 'user_edit' permission can search for users/reports. #2027
+        - Don't send sent-report emails to as-body/as-anonymous reports.
     - Development improvements:
         - Add HTML email previewer.
 

--- a/perllib/FixMyStreet/App/Controller/Report/Update.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/Update.pm
@@ -444,9 +444,17 @@ sub save_update : Private {
     if ( $c->cobrand->never_confirm_updates ) {
         $update->user->update_or_insert;
         $update->confirm();
-    } elsif ( $c->forward('/report/new/created_as_someone_else', [ $update->problem->bodies_str ]) ) {
-        # If created on behalf of someone else, we automatically confirm it,
-        # but we don't want to update the user account
+    # If created on behalf of someone else, we automatically confirm it,
+    # but we don't want to update the user account
+    } elsif ($c->stash->{contributing_as_another_user}) {
+        $update->set_extra_metadata( contributed_as => 'another_user');
+        $update->set_extra_metadata( contributed_by => $c->user->id );
+        $update->confirm();
+    } elsif ($c->stash->{contributing_as_body}) {
+        $update->set_extra_metadata( contributed_as => 'body' );
+        $update->confirm();
+    } elsif ($c->stash->{contributing_as_anonymous_user}) {
+        $update->set_extra_metadata( contributed_as => 'anonymous_user' );
         $update->confirm();
     } elsif ( !$update->user->in_storage ) {
         # User does not exist.

--- a/perllib/FixMyStreet/Script/Reports.pm
+++ b/perllib/FixMyStreet/Script/Reports.pm
@@ -294,6 +294,9 @@ sub _send_report_sent_email {
     # Don't send 'report sent' text
     return unless $row->user->email_verified;
 
+    my $contributed_as = $row->get_extra_metadata('contributed_as') || '';
+    return if $contributed_as eq 'body' || $contributed_as eq 'anonymous_user';
+
     FixMyStreet::Email::send_cron(
         $row->result_source->schema,
         'confirm_report_sent.txt',


### PR DESCRIPTION
Store if the report/update was created by someone using the contributed-as
dropdown, and use that information to perhaps not send report-sent emails.