### PR TITLE
optionally convert incoming open311 problem locations from EPSG:27700

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
         - Fetch/store external status code with Open311 updates. #2048
         - Response templates can be triggered by external status code. #2048
         - Cobrand hook for adding extra areas to MAPIT_WHITELIST/_TYPES. #2049
+        - Enable conversion from EPSG:27700 when fetching over Open311 #2028
     - Front end improvements:
         - Improve questionnaire process. #1939 #1998
         - Increase size of "sub map links" (hide pins, permalink, etc) #2003

--- a/bin/update-schema
+++ b/bin/update-schema
@@ -212,6 +212,7 @@ else {
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
     return 'EMPTY' if ! table_exists('problem');
+    return '0060' if column_exists('body', 'convert_latlong');
     return '0059' if column_exists('response_templates', 'external_status_code');
     return '0058' if column_exists('body', 'blank_updates_permitted');
     return '0057' if column_exists('body', 'fetch_problems');

--- a/db/downgrade_0059---0058.sql
+++ b/db/downgrade_0059---0058.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE body DROP convert_latlong;
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -56,6 +56,7 @@ create table body (
     send_extended_statuses boolean not null default 'f',
     fetch_problems boolean not null default 'f',
     blank_updates_permitted boolean not null default 'f',
+    convert_latlong boolean not null default 'f',
     deleted boolean not null default 'f'
 );
 

--- a/db/schema_0059-add-convert_latlong.sql
+++ b/db/schema_0059-add-convert_latlong.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE body ADD convert_latlong boolean default 'f' not null;
+
+COMMIT;

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -452,6 +452,7 @@ sub body_params : Private {
     %defaults = ( %defaults,
         send_comments => 0,
         fetch_problems => 0,
+        convert_latlong => 0,
         blank_updates_permitted => 0,
         suppress_alerts => 0,
         comment_user_id => undef,

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -475,7 +475,13 @@ sub inspect : Private {
             if ($update_text || %update_params) {
                 my $timestamp = \'current_timestamp';
                 if (my $saved_at = $c->get_param('saved_at')) {
-                    $timestamp = DateTime->from_epoch( epoch => $saved_at );
+                    # this comes in as a UTC epoch but the database expects everything
+                    # to have the FMS timezone so we need to add the timezone otherwise
+                    # dates come back out the database at time +/- timezone offset.
+                    $timestamp = DateTime->from_epoch(
+                        time_zone =>  FixMyStreet->time_zone || FixMyStreet->local_time_zone,
+                        epoch => $saved_at
+                    );
                 }
                 my $name = $c->user->from_body ? $c->user->from_body->name : $c->user->name;
                 $problem->add_to_comments( {

--- a/perllib/FixMyStreet/DB/Result/Body.pm
+++ b/perllib/FixMyStreet/DB/Result/Body.pm
@@ -47,6 +47,8 @@ __PACKAGE__->add_columns(
   "fetch_problems",
   { data_type => "boolean", default_value => \"false", is_nullable => 0 },
   "blank_updates_permitted",
+  { data_type => "boolean", default_value => \"false", is_nullable => 1 },
+  "convert_latlong",
   { data_type => "boolean", default_value => \"false", is_nullable => 0 },
 );
 __PACKAGE__->set_primary_key("id");
@@ -122,8 +124,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2018-03-01 12:27:28
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:dzqgZI1wkGDPS2PfJgDEIg
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2018-03-15 12:38:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:rturOWpYmPRO0yE9yWHXjA
 
 use Moo;
 use namespace::clean;

--- a/perllib/Open311/GetServiceRequests.pm
+++ b/perllib/Open311/GetServiceRequests.pm
@@ -34,6 +34,7 @@ sub fetch {
         );
 
         $self->system_user( $body->comment_user );
+        $self->convert_latlong( $body->convert_latlong );
         $self->create_problems( $o, $body );
     }
 }

--- a/perllib/Open311/GetServiceRequests.pm
+++ b/perllib/Open311/GetServiceRequests.pm
@@ -11,6 +11,7 @@ has start_date => ( is => 'ro', default => sub { undef } );
 has end_date => ( is => 'ro', default => sub { undef } );
 has verbose => ( is => 'ro', default => 0 );
 has schema => ( is =>'ro', lazy => 1, default => sub { FixMyStreet::DB->schema->connect } );
+has convert_latlong => ( is => 'rw', default => 0 );
 
 sub fetch {
     my $self = shift;
@@ -76,6 +77,10 @@ sub create_problems {
             if mySociety::Config::get('MAPIT_GENERATION');
 
         my ($latitude, $longitude) = ( $request->{lat}, $request->{long} );
+
+        ($latitude, $longitude) = Utils::convert_en_to_latlon_truncated( $longitude, $latitude )
+            if $self->convert_latlong;
+
         my $all_areas =
           mySociety::MaPit::call( 'point',
             "4326/$longitude,$latitude", %params );
@@ -146,8 +151,8 @@ sub create_problems {
                     state => $state,
                     postcode => '',
                     used_map => 1,
-                    latitude => $request->{lat},
-                    longitude => $request->{long},
+                    latitude => $latitude,
+                    longitude => $longitude,
                     areas => ',' . $body->id . ',',
                     bodies_str => $body->id,
                     send_method_used => 'Open311',

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -30,6 +30,7 @@ my @PLACES = (
     [ '?', 51.754926, -1.256179, 2237, 'Oxfordshire County Council', 'CTY', 2421, 'Oxford City Council', 'DIS' ],
     [ 'OX20 1SZ', 51.754926, -1.256179, 2237, 'Oxfordshire County Council', 'CTY', 2421, 'Oxford City Council', 'DIS' ],
     [ 'BR1 3UH', 51.4021, 0.01578, 2482, 'Bromley Council', 'LBO' ],
+    [ 'BR1 3UH', 51.402096, 0.015784, 2482, 'Bromley Council', 'LBO' ],
     [ '?', 50.78301, -0.646929 ],
     [ 'GU51 4AE', 51.279456, -0.846216, 2333, 'Hart District Council', 'DIS', 2227, 'Hampshire County Council', 'CTY' ],
     [ 'WS1 4NH', 52.563074, -1.991032, 2535, 'Sandwell Borough Council', 'MTD' ],

--- a/t/app/controller/report_inspect.t
+++ b/t/app/controller/report_inspect.t
@@ -613,7 +613,11 @@ FixMyStreet::override_config {
     subtest "test saved-at setting" => sub {
         $report->comments->delete;
         $mech->get_ok("/report/$report_id");
-        my $now = DateTime->now->subtract(days => 1);
+        # set the timezone on this so the date comparison below doesn't fail due to mismatched
+        # timezones
+        my $now = DateTime->now(
+            time_zone =>  FixMyStreet->time_zone || FixMyStreet->local_time_zone
+        )->subtract(days => 1);
         $mech->submit_form(button => 'save', form_id => 'report_inspect_form',
             fields => { include_update => 1, public_update => 'An update', saved_at => $now->epoch });
         $report->discard_changes;

--- a/t/open311/getservicerequests.t
+++ b/t/open311/getservicerequests.t
@@ -151,7 +151,6 @@ for my $test (
         };
         my $after_count = FixMyStreet::DB->resultset('Problem')->count;
 
-        warn $count;
         is $count, $after_count, "problems not created";
 
         my $with_text = FixMyStreet::DB->resultset('Problem')->search( {
@@ -255,6 +254,45 @@ for my $test (
         my $after = FixMyStreet::DB->resultset('Problem')->count;
 
         is $count, $after, 'problem not added';
+    };
+}
+
+for my $test (
+  {
+      desc => 'convert easting/northing to lat/long',
+      subs => { lat => 168935, long => 540315 },
+      expected => { lat => 51.402096, long => 0.015784 },
+  },
+) {
+    subtest $test->{desc} => sub {
+        my $xml = prepare_xml( $test->{subs} );
+        my $o = Open311->new(
+            jurisdiction => 'mysociety',
+            endpoint => 'http://example.com',
+            test_mode => 1,
+            test_get_returns => { 'requests.xml' => $xml}
+        );
+
+        my $update = Open311::GetServiceRequests->new(
+            system_user => $user,
+            convert_latlong => 1,
+        );
+
+        FixMyStreet::override_config {
+            MAPIT_URL => 'http://mapit.uk/',
+        }, sub {
+            $update->create_problems( $o, $body );
+        };
+
+        my $p = FixMyStreet::DB->resultset('Problem')->search(
+            { external_id => 123456 }
+        )->first;
+
+        ok $p, 'problem created';
+        is $p->latitude, $test->{expected}->{lat}, 'correct latitude';
+        is $p->longitude, $test->{expected}->{long}, 'correct longitude';
+
+        $p->delete;
     };
 }
 

--- a/templates/web/base/admin/open311-form-fields.html
+++ b/templates/web/base/admin/open311-form-fields.html
@@ -134,5 +134,18 @@
         <input type="checkbox" id="send_extended_statuses" name="send_extended_statuses"[% ' checked' IF object.send_extended_statuses %]>
         <label for="send_extended_statuses" class="inline">[% loc('Send extended Open311 statuses with service request updates') %]</label>
     </p>
+
+    <div class="admin-hint">
+      <p>
+        [% loc(
+            "Enable <strong>Convert location from Easting/Northing</strong> if you've enabled Open311 problem-fetching above
+            and problems fetching from the endpoint have the location in Easting/Northings and not Latitude/Longitude."
+        ) %]
+      </p>
+    </div>
+    <p>
+        <input type="checkbox" id="convert_latlong" name="convert_latlong"[% ' checked' IF object.convert_latlong %]>
+        <label for="convert_latlong" class="inline">[% loc('Convert location from Easting/Northing') %]</label>
+    </p>
   [% END %]
 </div>


### PR DESCRIPTION
If the backend we are pulling reports from cannot provide Lat/Long then accept Easting and Northing and convert to Lat/Long in FixMyStreet.

This is here to avoid it being in the Open311 adapter and leave that to be as much of a pass through system as possible.

Fixes #2028