### PR TITLE
Clicking "big green banner" on /around begins a report

### DIFF
--- a/.cypress/cypress/integration/simple_spec.js
+++ b/.cypress/cypress/integration/simple_spec.js
@@ -14,3 +14,17 @@ describe('My First Test', function() {
         cy.get('form').submit();
     });
 });
+
+describe('Clicking the "big green banner" on a map page', function() {
+    before(function() {
+        cy.visit('/');
+        cy.get('[name=pc]').type('BS10 5EE');
+        cy.get('#postcodeForm').submit();
+        cy.get('.big-green-banner').click();
+    });
+
+    it('begins a new report', function() {
+        cy.url().should('include', '/report/new');
+        cy.get('#form_title').should('be.visible');
+    });
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
         - Increase size of "sub map links" (hide pins, permalink, etc) #2003
         - Edge-to-edge email layout on narrow screens #2010
         - Add default placeholder to report extra fields. #2027
+        - Clicking the "Click map" instruction banner now begins a new report #2033
     - Bugfixes:
         - Stop asset layers obscuring marker layer. #1999
         - Don't delete hidden field values when inspecting reports. #1999

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -669,6 +669,14 @@ $.extend(fixmystreet.set_up, {
     });
   },
 
+  clicking_banner_begins_report: function() {
+    $('.big-green-banner').on('click', function(){
+      if (fixmystreet.map.getCenter) {
+        fixmystreet.display.begin_report( fixmystreet.map.getCenter() );
+      }
+    });
+  },
+
   map_controls: function() {
     //add permalink on desktop, force hide on mobile
     //add links container (if its not there)


### PR DESCRIPTION
Data collected by #2001 has shown that some people are clicking the big green "Click map to report a problem" banner on fixmystreet.com/around. We assume the same is true for other cobrands.

As suggested in #2016, this commit adds a click handler to that banner element, which will begin a new report at the centre of the screen. It might not be the exact right location, but the pin can be repositioned from the `/report/new` form, and beginning a report is better than just soaking up the click and doing nothing.