### PR TITLE
send easting/northing over open311 if send_notpinpointed and no map/postcode

### DIFF
--- a/perllib/FixMyStreet/SendReport/Open311.pm
+++ b/perllib/FixMyStreet/SendReport/Open311.pm
@@ -54,7 +54,9 @@ sub send {
                 # send_notpinpointed=0 then this line will need changing to
                 # consider the send_notpinpointed check, as per the
                 # '#NOTPINPOINTED#' code in perllib/Open311.pm.
-                if ( $row->used_map || $open311_params{always_send_latlong} ) {
+                if ( $row->used_map || $open311_params{always_send_latlong} || (
+                    !$row->used_map && !$row->postcode && $open311_params{send_notpinpointed}
+                ) ) {
                     push @$extra, { name => $_->{code}, value => $h->{$_->{code}} };
                 }
             }


### PR DESCRIPTION
If the map was not clicked and we don't have a postcode we should still
send the easting and northing extra attributes if send_notpinpointed is
set.