### PR TITLE
Fix issues with new report pin, improve cursor.

### DIFF
--- a/.cypress/cypress/integration/regressions.js
+++ b/.cypress/cypress/integration/regressions.js
@@ -1,3 +1,10 @@
+// See https://github.com/cypress-io/cypress/issues/761 - Cypress dies if we
+// go straight to the next test with an XHR in progress. So visit a 404 page
+// to cancel anything in progress.
+Cypress.Commands.add('cleanUpXHR', function() {
+    cy.visit('/404', { failOnStatusCode: false });
+});
+
 describe('Regression tests', function() {
     it('Shows the sub-map links after clicking Try again', function() {
         cy.viewport(480, 800);
@@ -5,5 +12,12 @@ describe('Regression tests', function() {
         cy.get('#map_box').click(200, 200);
         cy.get('#try_again').click();
         cy.get('#sub_map_links').should('be.visible');
+        cy.cleanUpXHR();
+    });
+    it('Does not hide the new report pin even if you click really quick', function() {
+        cy.visit('/around?pc=BS10+5EE&js=1');
+        cy.get('#map_box').click(200, 200);
+        cy.get('#loading-indicator').should('be.hidden');
+        cy.get('#map_box image').should('be.visible');
     });
 });

--- a/.cypress/cypress/integration/regressions.js
+++ b/.cypress/cypress/integration/regressions.js
@@ -14,6 +14,11 @@ describe('Regression tests', function() {
         cy.get('#sub_map_links').should('be.visible');
         cy.cleanUpXHR();
     });
+    it('Does not fade on new pin hover', function() {
+        cy.visit('/around?pc=BS10+5EE&js=1');
+        cy.get('#map_box').click(200, 200);
+        cy.get('#map_box image').last().trigger('mousemove').should('have.css', 'opacity', '1');
+    });
     it('Does not hide the new report pin even if you click really quick', function() {
         cy.visit('/around?pc=BS10+5EE&js=1');
         cy.get('#map_box').click(200, 200);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
         - Fix post-edit issues on admin report edit page.
         - Truncate dates in Open311 output to the second. #2023
         - Fix check for visible sub map links after 'Try again'.
+        - Stop race condition when making a new report quickly.
     - Admin improvements:
         - Inspectors can set non_public status of reports. #1992
         - Default start date is shown on the dashboard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
         - Add default placeholder to report extra fields. #2027
         - Clicking the "Click map" instruction banner now begins a new report #2033
         - Homepage postcode input is now marked up as a required input #2037
+        - Improved cursor/display of the new report pin. #2038
     - Bugfixes:
         - Stop asset layers obscuring marker layer. #1999
         - Don't delete hidden field values when inspecting reports. #1999

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1649,6 +1649,16 @@ html.js #map .noscript {
     bottom: 3px !important;
     #{$right}: 3px;
 }
+.olControlDragFeatureFMSOver {
+    cursor: move;
+    cursor: -webkit-grab;
+    cursor: grab;
+}
+.olControlDragFeatureFMSActive.olControlDragFeatureFMSOver.olDragDown {
+    cursor: move;
+    cursor: -webkit-grabbing;
+    cursor: grabbing;
+}
 
 /* Drag is only present in noscript form. XXX Copy from core. */
 #drag {

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -96,6 +96,7 @@ $.extend(fixmystreet.utils, {
             fixmystreet.markers.features[0].move(lonlat);
         } else {
             var markers = fixmystreet.maps.markers_list( [ [ lonlat.lat, lonlat.lon, fixmystreet.pin_new_report_colour ] ], false );
+            fixmystreet.bbox_strategy.layer.protocol.abort(fixmystreet.bbox_strategy.response);
             fixmystreet.bbox_strategy.deactivate();
             fixmystreet.markers.removeAllFeatures();
             fixmystreet.markers.addFeatures( markers );
@@ -578,6 +579,9 @@ $.extend(fixmystreet.utils, {
         });
         fixmystreet.markers.events.register( 'loadstart', null, fixmystreet.maps.loading_spinner.show);
         fixmystreet.markers.events.register( 'loadend', null, fixmystreet.maps.loading_spinner.hide);
+        OpenLayers.Request.XMLHttpRequest.onabort = function() {
+            fixmystreet.markers.events.triggerEvent("loadend", {response: null});
+        };
 
         var markers = fixmystreet.maps.markers_list( fixmystreet.pins, true );
         fixmystreet.markers.addFeatures( markers );

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -126,7 +126,7 @@ $.extend(fixmystreet.utils, {
                     fixmystreet.map.getProjectionObject()
                 );
             }
-            var id = +pin[3];
+            var id = pin[3] === undefined ? pin[3] : +pin[3];
             var marker_size = (id === window.selected_problem_id) ? selected_size : size;
             var marker = new OpenLayers.Feature.Vector(loc, {
                 colour: pin[2],


### PR DESCRIPTION
Fix race condition making a new report: If you started a new report by clicking the map before the server had responded with the map list pins, when they did arrive they would replace the new report pin. Fixes #1434 (better way this time too, I think).

The "coerce pin ID to integer" behaviour to fix a previous issue was coercing undefined to NaN, which then caused other problems with the new report pin, such as fading out when hovered, and being the wrong size (well, it used to be bigger and now it is again, though dunno if people are now used to smaller). Fixes #2038.

Also improve the cursor handling, showing the grab/ grabbing cursors where available.