### PR TITLE
Set database session timezone on connection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
         - Truncate dates in Open311 output to the second. #2023
         - Fix check for visible sub map links after 'Try again'.
         - Stop race condition when making a new report quickly.
+        - Set a session timezone in case database server is set differently.
     - Admin improvements:
         - Inspectors can set non_public status of reports. #1992
         - Default start date is shown on the dashboard.

--- a/perllib/FixMyStreet.pm
+++ b/perllib/FixMyStreet.pm
@@ -154,7 +154,12 @@ sub dbic_connect_info {
         AutoCommit     => 1,
         pg_enable_utf8 => 1,
     };
-    my $dbic_args = {};
+    my $local_time_zone = local_time_zone();
+    my $dbic_args = {
+        on_connect_do => [
+            "SET TIME ZONE '" . $local_time_zone->name . "'",
+        ],
+    };
 
     return ( $dsn, $user, $password, $dbi_args, $dbic_args );
 }


### PR DESCRIPTION
fixmystreet.com went down early Sunday morning because the database server had
been upgraded in the past year and was now set to UTC and not local time. This
confused the codebase when it encountered timestamps that could not exist, all
between 1-2am UTC.

Ideally, timestamps in the database should be 'with time zone' or be stored in
UTC, but for now let us set the time zone to the local one upon connection.