### PR TITLE
[Bromley] Asset layers and related

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
         - Response template containing double quote now works.
         - A few small display issues with RTL text display.
         - Improve handling of loading spinner display. #2059
+        - Ignore non-interactive layers for asset message.
     - Admin improvements:
         - Inspectors can set non_public status of reports. #1992
         - Default start date is shown on the dashboard.

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -402,7 +402,7 @@ sub inspect : Private {
             if ( $problem->state eq 'duplicate') {
                 if (my $duplicate_of = $c->get_param('duplicate_of')) {
                     $problem->set_duplicate_of($duplicate_of);
-                } elsif (not $c->get_param('public_update')) {
+                } elsif (not $c->get_param('include_update')) {
                     $valid = 0;
                     push @{ $c->stash->{errors} }, _('Please provide a duplicate ID or public update for this report.');
                 }

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -112,11 +112,19 @@ sub open311_config {
     my ($self, $row, $h, $params) = @_;
 
     my $extra = $row->get_extra_fields;
+    my $title = $row->title;
+
+    foreach (@$extra) {
+        $title .= ' | ID: ' . $_->{value} if $_->{name} eq 'feature_id';
+        $title .= ' | PROW ID: ' . $_->{value} if $_->{name} eq 'prow_reference';
+    }
+    @$extra = grep { $_->{name} !~ /feature_id|prow_reference/ } @$extra;
+
     push @$extra,
         { name => 'report_url',
           value => $h->{url} },
         { name => 'report_title',
-          value => $row->title },
+          value => $title },
         { name => 'public_anonymity_required',
           value => $row->anonymous ? 'TRUE' : 'FALSE' },
         { name => 'email_alerts_requested',

--- a/perllib/FixMyStreet/Map/Bromley.pm
+++ b/perllib/FixMyStreet/Map/Bromley.pm
@@ -10,10 +10,11 @@ use base 'FixMyStreet::Map::FMS';
 use strict;
 
 sub map_javascript { [
-    '/vendor/OpenLayers/OpenLayers.fixmystreet.js',
+    '/vendor/OpenLayers/OpenLayers.buckinghamshire.js',
     '/js/map-OpenLayers.js',
     '/js/map-bing-ol.js',
     '/js/map-fms.js',
+    '/cobrands/fixmystreet/assets.js',
     '/cobrands/bromley/map.js',
 ] }
 

--- a/perllib/Open311/PopulateServiceList.pm
+++ b/perllib/Open311/PopulateServiceList.pm
@@ -248,6 +248,25 @@ sub _add_meta_to_contact_cobrand_overrides {
 
     if ($self->_current_body->name eq 'Bromley Council') {
         $contact->set_extra_metadata( id_field => 'service_request_id_ext');
+        # Lights we want to store feature ID, PROW on all categories.
+        push @$meta, {
+            code => 'prow_reference',
+            datatype => 'string',
+            description => 'Right of way reference',
+            order => 101,
+            required => 'false',
+            variable => 'true',
+            automated => 'hidden_field',
+        };
+        push @$meta, {
+            code => 'feature_id',
+            datatype => 'string',
+            description => 'Feature ID',
+            order => 100,
+            required => 'false',
+            variable => 'true',
+            automated => 'hidden_field',
+        } if $self->_current_service->{service_code} eq 'LIGHTS';
     } elsif ($self->_current_body->name eq 'Warwickshire County Council') {
         $contact->set_extra_metadata( id_field => 'external_id');
     }

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -54,6 +54,7 @@ for my $test (
           'attribute[easting]' => 529025,
           'attribute[northing]' => 179716,
           'attribute[service_request_id_ext]' => $report->id,
+          'attribute[report_title]' => 'Test Test 1 for ' . $body->id,
           'jurisdiction_id' => 'FMS',
           address_id => undef,
         },
@@ -72,11 +73,20 @@ for my $test (
           'address_id' => '#NOTPINPOINTED#',
         },
     },
+    {
+        desc => 'asset ID',
+        feature_id => '1234',
+        expected => {
+          'attribute[service_request_id_ext]' => $report->id,
+          'attribute[report_title]' => 'Test Test 1 for ' . $body->id . ' | ID: 1234',
+        },
+    },
 ) {
     subtest $test->{desc}, sub {
-        $report->set_extra_fields();
         $report->$_($test->{updates}->{$_}) for keys %{$test->{updates}};
         $report->$_(undef) for qw/ whensent send_method_used external_id /;
+        $report->set_extra_fields({ name => 'feature_id', value => $test->{feature_id} })
+            if $test->{feature_id};
         $report->update;
         $body->update( { send_method => 'Open311', endpoint => 'http://bromley.endpoint.example.com', jurisdiction => 'FMS', api_key => 'test', send_comments => 1 } );
         my $test_data;

--- a/web/cobrands/bromley/map.js
+++ b/web/cobrands/bromley/map.js
@@ -77,7 +77,32 @@ fixmystreet.assets.add($.extend(true, {}, defaults, {
     stylemap: highways_stylemap,
     always_visible: true,
     asset_category: ["Blocked drains", "Faulty street light", 'Faulty street sign', 'Floral displays', 'Grass needs cutting', 'Obstructions (skips, A boards)', 'Overhanging vegetation from private land', 'Pavement defect', 'Public Tree related issue', "Road defect"],
-    non_interactive: true
+    non_interactive: true,
+    road: true,
+    actions: {
+        found: function(layer) {
+            if (fixmystreet.assets.selectedFeature()) {
+                $('#road-warning').remove();
+                return;
+            }
+            var msg = 'The location selected is a Transport for London Red Route. TfL are responsible for the reported category and can be alerted to issues via: <a href="https://tfl.gov.uk/help-and-contact/contact-us-about-streets-and-other-road-issues">Street issues</a>';
+            if ( $('#road-warning').length ) {
+                $('#road-warning').html(msg);
+            } else {
+                $('.change_location').after('<div class="box-warning" id="road-warning">' + msg + '</div>');
+            }
+            $('#single_body_only').val(layer.fixmystreet.body_found);
+        },
+
+        not_found: function(layer) {
+            if ( $('#road-warning').length ) {
+                $('#road-warning').remove();
+            }
+            $('#single_body_only').val(layer.fixmystreet.body_council);
+        }
+    },
+    body_found: 'TfL',
+    body_council: 'Bromley Council'
 }));
 
 var prow_stylemap = new OpenLayers.StyleMap({

--- a/web/cobrands/bromley/map.js
+++ b/web/cobrands/bromley/map.js
@@ -1,1 +1,104 @@
 fixmystreet.maps.tile_base = [ [ "", "a-" ], "https://{S}fix.bromley.gov.uk/tilma" ];
+
+(function(){
+
+if (!fixmystreet.maps) {
+    return;
+}
+
+var defaults = {
+    http_options: {
+        url: "https://tilma.staging.mysociety.org/mapserver/bromley_wfs",
+        params: {
+            SERVICE: "WFS",
+            VERSION: "1.1.0",
+            REQUEST: "GetFeature",
+            SRSNAME: "urn:ogc:def:crs:EPSG::3857"
+        }
+    },
+    format_class: OpenLayers.Format.GML.v3.MultiCurveFix,
+    asset_type: 'spot',
+    max_resolution: 2.388657133579254,
+    min_resolution: 0.5971642833948135,
+    asset_id_field: 'CENTRAL_AS',
+    geometryName: 'msGeometry',
+    srsName: "EPSG:3857",
+    strategy_class: OpenLayers.Strategy.FixMyStreet
+};
+
+fixmystreet.assets.add($.extend(true, {}, defaults, {
+    http_options: {
+        params: {
+            TYPENAME: "Streetlights"
+        }
+    },
+    asset_id_field: 'FEATURE_ID',
+    attributes: {
+        feature_id: 'FEATURE_ID'
+    },
+    asset_category: ["Faulty street light"],
+    asset_item: 'street light'
+}));
+
+fixmystreet.assets.add($.extend(true, {}, defaults, {
+    http_options: {
+        params: {
+            TYPENAME: "Bins"
+        }
+    },
+    asset_category: ["Overflowing litter bin"],
+    asset_item: 'park bin',
+    asset_item_message: 'For our parks, pick a <b class="asset-spot">bin</b> from the map &raquo;'
+}));
+
+fixmystreet.assets.add($.extend(true, {}, defaults, {
+    http_options: {
+        params: {
+            TYPENAME: "Street_Trees"
+        }
+    },
+    asset_category: ["Public Tree related issue"],
+    asset_item: 'tree'
+}));
+
+var highways_stylemap = new OpenLayers.StyleMap({
+    'default': new OpenLayers.Style({
+        fill: false,
+        stroke: false
+    })
+});
+
+fixmystreet.assets.add($.extend(true, {}, defaults, {
+    http_options: {
+        params: {
+            TYPENAME: "TFL_Red_Route"
+        }
+    },
+    stylemap: highways_stylemap,
+    always_visible: true,
+    asset_category: ["Blocked drains", "Faulty street light", 'Faulty street sign', 'Floral displays', 'Grass needs cutting', 'Obstructions (skips, A boards)', 'Overhanging vegetation from private land', 'Pavement defect', 'Public Tree related issue', "Road defect"],
+    non_interactive: true
+}));
+
+var prow_stylemap = new OpenLayers.StyleMap({
+    'default': new OpenLayers.Style({
+        fill: false,
+        fillOpacity: 0,
+        strokeColor: "#660099",
+        strokeOpacity: 0.5,
+        strokeWidth: 6
+    })
+});
+
+fixmystreet.assets.add($.extend(true, {}, defaults, {
+    http_options: {
+        params: {
+            TYPENAME: "PROW"
+        }
+    },
+    stylemap: prow_stylemap,
+    always_visible: true,
+    non_interactive: true
+}));
+
+})();

--- a/web/cobrands/bromley/map.js
+++ b/web/cobrands/bromley/map.js
@@ -123,7 +123,17 @@ fixmystreet.assets.add($.extend(true, {}, defaults, {
     },
     stylemap: prow_stylemap,
     always_visible: true,
-    non_interactive: true
+    non_interactive: true,
+    road: true,
+    all_categories: true,
+    actions: {
+        found: function(layer, feature) {
+            $('#form_prow_reference').val(feature.attributes.PROW_REFER);
+        },
+        not_found: function(layer) {
+            $('#form_prow_reference').val('');
+        }
+    }
 }));
 
 })();

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -301,6 +301,9 @@ function find_matching_feature(feature, layer, asset_id_field) {
 }
 
 function check_zoom_message_visibility() {
+    if (this.fixmystreet.non_interactive) {
+        return;
+    }
     var category = $("#problem_form select#form_category").val(),
         prefix = category.replace(/[^a-z]/gi, ''),
         id = "category_meta_message_" + prefix,

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -238,6 +238,12 @@ function asset_selected(e) {
         return;
     }
 
+    var layer = e.feature.layer;
+    var feature = e.feature;
+
+    // Keep track of selection in case layer is reloaded or hidden etc.
+    selected_feature = feature.clone();
+
     // Pick up the USRN for the location of this asset. NB we do this *before*
     // handling the attributes on the selected feature in case the feature has
     // its own USRN which should take precedence.
@@ -264,13 +270,8 @@ function asset_selected(e) {
     fixmystreet.maps.update_pin(lonlat);
 
     // Make sure the marker that was clicked is drawn on top of its neighbours
-    var layer = e.feature.layer;
-    var feature = e.feature;
     layer.eraseFeatures([feature]);
     layer.drawFeature(feature);
-
-    // Keep track of selection in case layer is reloaded or hidden etc.
-    selected_feature = feature.clone();
 }
 
 function asset_unselected(e) {
@@ -461,6 +462,10 @@ function get_fault_stylemap() {
 fixmystreet.assets = {
     layers: [],
     controls: [],
+
+    selectedFeature: function() {
+        return selected_feature;
+    },
 
     add: function(options) {
         var asset_fault_layer = null;

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -312,9 +312,13 @@ function check_zoom_message_visibility() {
         }
 
         if (this.getVisibility() && this.inRange) {
-            $p.html('Or pick a <b class="asset-' + this.fixmystreet.asset_type + '">' + this.fixmystreet.asset_item + '</b> from the map &raquo;');
+            if (this.fixmystreet.asset_item_message) {
+                $p.html(this.fixmystreet.asset_item_message);
+            } else {
+                $p.html('You can pick a <b class="asset-' + this.fixmystreet.asset_type + '">' + this.fixmystreet.asset_item + '</b> from the map &raquo;');
+            }
         } else {
-            $p.html('Or zoom in and pick a ' + this.fixmystreet.asset_item + ' from the map');
+            $p.html('Zoom in to pick a ' + this.fixmystreet.asset_item + ' from the map');
         }
 
     } else {


### PR DESCRIPTION
This PR does asset-related things for Bromley Council, see https://github.com/mysociety/fixmystreet-commercial/issues/1005

It adds bins, street lights, trees, TfL red routes, and rights of way layers. The first three are point layers that can be selected, the red routes are used in certain categories to explain/divert to TfL (unless asset selected), and rights of way are displayed and ID taken through. In order to have multiple 'road' type layers, the USRN/road code is refactored into its own Layer class, which shouldn't affect anything but needs some testing.