### PR TITLE
Gitignore cypress.env.json

### DIFF
--- a/.cypress/.gitignore
+++ b/.cypress/.gitignore
@@ -1,2 +1,3 @@
 /cypress/videos
 /cypress/screenshots
+/cypress.env.json


### PR DESCRIPTION
The Cypress docs suggest putting machine-specific config into a
`cypress.env.json` file at the same location as `cypress.json`.
(For example, if you want to disable video recording of test sessions
on your machine, but not everyone else’s.) Since this file will be
machine-specific, we don’t want it tracked in Git.

[skip changelog]