### PR TITLE
Allow response templates to be triggered by Confirm status code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
           attributes #1986
         - Optionally supress blank Open311 update errors #1986
         - Fetch/store external status code with Open311 updates. #2048
+        - Response templates can be triggered by external status code. #2048
     - Front end improvements:
         - Improve questionnaire process. #1939 #1998
         - Increase size of "sub map links" (hide pins, permalink, etc) #2003

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
         - Allow Open311 service definitions to include automated
           attributes #1986
         - Optionally supress blank Open311 update errors #1986
+        - Fetch/store external status code with Open311 updates. #2048
     - Front end improvements:
         - Improve questionnaire process. #1939 #1998
         - Increase size of "sub map links" (hide pins, permalink, etc) #2003

--- a/bin/update-schema
+++ b/bin/update-schema
@@ -212,6 +212,7 @@ else {
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
     return 'EMPTY' if ! table_exists('problem');
+    return '0059' if column_exists('response_templates', 'external_status_code');
     return '0058' if column_exists('body', 'blank_updates_permitted');
     return '0057' if column_exists('body', 'fetch_problems');
     return '0056' if column_exists('users', 'email_verified');

--- a/db/downgrade_0058---0058.sql
+++ b/db/downgrade_0058---0058.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE response_templates DROP external_status_code;
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -472,6 +472,7 @@ create table response_templates (
     created timestamp not null default current_timestamp,
     auto_response boolean NOT NULL DEFAULT 'f',
     state text,
+    external_status_code text,
     unique(body_id, title)
 );
 

--- a/db/schema_0059-response-templates-external_status_code.sql
+++ b/db/schema_0059-response-templates-external_status_code.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE response_templates ADD external_status_code text;
+
+COMMIT;

--- a/perllib/FixMyStreet/DB/Result/ResponseTemplate.pm
+++ b/perllib/FixMyStreet/DB/Result/ResponseTemplate.pm
@@ -35,6 +35,8 @@ __PACKAGE__->add_columns(
   { data_type => "boolean", default_value => \"false", is_nullable => 0 },
   "state",
   { data_type => "text", is_nullable => 1 },
+  "external_status_code",
+  { data_type => "text", is_nullable => 1 },
 );
 __PACKAGE__->set_primary_key("id");
 __PACKAGE__->add_unique_constraint("response_templates_body_id_title_key", ["body_id", "title"]);
@@ -52,8 +54,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2016-12-01 15:10:52
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ySPzQpFwJNki8XBjCNiqZQ
+# Created by DBIx::Class::Schema::Loader v0.07048 @ 2018-03-22 11:18:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:p0+/jFma6H9eZ3MZAJQRaQ
 
 __PACKAGE__->many_to_many( contacts => 'contact_response_templates', 'contact' );
 

--- a/perllib/Open311/GetServiceRequestUpdates.pm
+++ b/perllib/Open311/GetServiceRequestUpdates.pm
@@ -110,6 +110,7 @@ sub update_comments {
 
             if ( !$c->first ) {
                 my $state = $open311->map_state( $request->{status} );
+                my $external_status_code = $request->{external_status_code};
                 my $comment = $self->schema->resultset('Comment')->new(
                     {
                         problem => $p,
@@ -125,6 +126,14 @@ sub update_comments {
                         state => 'confirmed',
                     }
                 );
+
+                # Some Open311 services, e.g. Confirm via open311-adapter, provide
+                # a more fine-grained status code that we use within FMS for
+                # response templates.
+                if ( $external_status_code ) {
+                    $comment->set_extra_metadata(external_status_code =>$external_status_code);
+                    $p->set_extra_metadata(external_status_code =>$external_status_code);
+                }
 
                 $open311->add_media($request->{media_url}, $comment)
                     if $request->{media_url};

--- a/perllib/Open311/GetServiceRequestUpdates.pm
+++ b/perllib/Open311/GetServiceRequestUpdates.pm
@@ -116,7 +116,7 @@ sub update_comments {
                         problem => $p,
                         user => $self->system_user,
                         external_id => $request->{update_id},
-                        text => $self->comment_text_for_request($request, $p, $state),
+                        text => $self->comment_text_for_request($request, $p, $state, $external_status_code),
                         mark_fixed => 0,
                         mark_open => 0,
                         anonymous => 0,
@@ -183,13 +183,20 @@ sub update_comments {
 }
 
 sub comment_text_for_request {
-    my ($self, $request, $problem, $state) = @_;
+    my ($self, $request, $problem, $state, $external_status_code) = @_;
 
     return $request->{description} if $request->{description};
 
+    my $state_params = {
+        'me.state' => $state
+    };
+    if ($external_status_code) {
+        $state_params->{'me.external_status_code'} = $external_status_code;
+    };
+
     if (my $template = $problem->response_templates->search({
         auto_response => 1,
-        'me.state' => $state
+        -or => $state_params,
     })->first) {
         return $template->text;
     }

--- a/templates/web/base/admin/report_edit.html
+++ b/templates/web/base/admin/report_edit.html
@@ -101,6 +101,12 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
 <li><label for="external_team">[% loc('External team') %]:</label>
     <input type="text" class="form-control" name="external_team" team="external_team" value="[% problem.external_team | html %]">
 
+[% IF problem.get_extra_metadata('external_status_code') %]
+<li>
+    <label for="external_status_code">[% loc('External status code') %]:</label>
+    <span>[% problem.get_extra_metadata('external_status_code') %]</span>
+</li>
+[% END %]
 </ul>
 </div>
 

--- a/templates/web/base/admin/template_edit.html
+++ b/templates/web/base/admin/template_edit.html
@@ -21,7 +21,7 @@
     </div>
     <p>
         <strong>[% loc('Title:') %] </strong>
-        <input type="text" name="title" class="required form-control" size="30" value="[% rt.title| html %]">
+        <input type="text" name="title" class="required form-control" size="30" value="[% rt.title | html %]">
     </p>
 
     <div class="admin-hint">
@@ -31,7 +31,7 @@
     </div>
     <p>
         <strong>[% loc('Text:') %] </strong>
-        <textarea class="form-control" name="text" class="required">[% rt.text |html %]</textarea>
+        <textarea class="form-control" name="text" class="required">[% rt.text | html %]</textarea>
     </p>
 
     <div class="admin-hint">
@@ -41,6 +41,9 @@
     </div>
     [% INCLUDE 'admin/category-checkboxes.html' %]
 
+    [% IF errors.state %]
+        <div class="form-error">[% errors.state %]</div>
+    [% END %]
     <div class="admin-hint">
       <p>
         [% loc('If you want to use this template to prefill the update field when changing a report&rsquo;s state, select the state here.') %]
@@ -49,6 +52,19 @@
     <p>
       <label for="state">[% loc('State') %]</label>
       [% INCLUDE 'admin/state_groups_select.html' current_state=rt.state include_empty=1 %]
+    </p>
+
+    [% IF errors.external_status_code %]
+        <div class="form-error">[% errors.external_status_code %]</div>
+    [% END %]
+    <div class="admin-hint">
+      <p>
+        [% loc('If you want to use this template to prefill the update field when a report&rsquo;s <strong>external</strong> (e.g. Confirm) status code changes, enter the status code here.') %]
+      </p>
+    </div>
+    <p>
+      <label for="external_status_code">[% loc('External status code') %]</label>
+      <input type="text" name="external_status_code" class="form-control" size="30" value="[% rt.external_status_code | html %]">
     </p>
 
     [% IF errors.auto_response %]

--- a/templates/web/base/admin/templates.html
+++ b/templates/web/base/admin/templates.html
@@ -23,7 +23,10 @@
                 [% END %]
             [% END %]
         </td>
-        <td> [% t.state | html %] </td>
+        <td>
+            [% IF t.state %][% t.state | html %][% END %]
+            [% IF t.external_status_code %][% t.external_status_code | html %] (external)[% END %]
+        </td>
         <td> [% IF t.auto_response %]X[% END %] </td>
         <td> <a href="[% c.uri_for('templates', body.id, t.id) %]" class="btn">[% loc('Edit') %]</a> </td>
     </tr>

--- a/templates/web/base/admin/update_edit.html
+++ b/templates/web/base/admin/update_edit.html
@@ -53,6 +53,9 @@
 <li>[% loc('Cobrand:') %] [% update.cobrand %]</li>
 <li>[% loc('Cobrand data:') %] [% update.cobrand_data %]</li>
 <li>[% loc('Created:') %] [% PROCESS format_time time=update.created %]</li>
+[% IF update.get_extra_metadata('external_status_code') %]
+<li>[% loc('External status code:') %] [% update.get_extra_metadata('external_status_code') | html %]</li>
+[% END %]
 
 [% IF update.photo %]
 <li>


### PR DESCRIPTION
Fixes mysociety/fixmystreetforcouncils#297. As mentioned in that ticket, Confirm has a more fine-grained status code system than FMS which we want to use to trigger response templates/emails to users.

This PR:

 - Fetches the `external_status_code` attribute from Open311 service request updates
 - Allows response templates to be associated with an external status code instead of an FMS state
 - Triggers response templates by `external_status_code` when fetching updates.