### PR TITLE
fix timezone problems with offline inspector comments

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -475,7 +475,13 @@ sub inspect : Private {
             if ($update_text || %update_params) {
                 my $timestamp = \'current_timestamp';
                 if (my $saved_at = $c->get_param('saved_at')) {
-                    $timestamp = DateTime->from_epoch( epoch => $saved_at );
+                    # this comes in as a UTC epoch but the database expects everything
+                    # to have the FMS timezone so we need to add the timezone otherwise
+                    # dates come back out the database at time +/- timezone offset.
+                    $timestamp = DateTime->from_epoch(
+                        time_zone =>  FixMyStreet->time_zone || FixMyStreet->local_time_zone,
+                        epoch => $saved_at
+                    );
                 }
                 my $name = $c->user->from_body ? $c->user->from_body->name : $c->user->name;
                 $problem->add_to_comments( {

--- a/t/app/controller/report_inspect.t
+++ b/t/app/controller/report_inspect.t
@@ -613,7 +613,11 @@ FixMyStreet::override_config {
     subtest "test saved-at setting" => sub {
         $report->comments->delete;
         $mech->get_ok("/report/$report_id");
-        my $now = DateTime->now->subtract(days => 1);
+        # set the timezone on this so the date comparison below doesn't fail due to mismatched
+        # timezones
+        my $now = DateTime->now(
+            time_zone =>  FixMyStreet->time_zone || FixMyStreet->local_time_zone
+        )->subtract(days => 1);
         $mech->submit_form(button => 'save', form_id => 'report_inspect_form',
             fields => { include_update => 1, public_update => 'An update', saved_at => $now->epoch });
         $report->discard_changes;


### PR DESCRIPTION
Comments added offline by an inspector set the time in JavaScript using
a UTC epoch. We need to add the FMS timezone to this so it's in the
timezone the database expects for timestamps otherwise it's incorrect
when we fetch it back out
[skip changelog]