### PR TITLE
Issues/2005 ie chart fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
         - Stop race condition when making a new report quickly.
         - Set a session timezone in case database server is set differently.
         - Fix SQL error on update edit admin page in cobrands. #2049
+        - Improve chart display in old IE versions. #2005
     - Admin improvements:
         - Inspectors can set non_public status of reports. #1992
         - Default start date is shown on the dashboard.

--- a/web/cobrands/sass/_dashboard.scss
+++ b/web/cobrands/sass/_dashboard.scss
@@ -98,6 +98,8 @@
         position: absolute;
         margin-top: -1em;
         margin-#{$right}: 0;
+        right: 0;
+        width: 18%; // 20% padding from .labelled-line-chart, 2% gutter
     }
 }
 

--- a/web/cobrands/sass/_dashboard.scss
+++ b/web/cobrands/sass/_dashboard.scss
@@ -63,7 +63,6 @@
 
     canvas {
         width: 100% !important;
-        height: auto !important;
     }
 }
 

--- a/web/cobrands/sass/_dashboard.scss
+++ b/web/cobrands/sass/_dashboard.scss
@@ -329,3 +329,23 @@
         margin-top: -1px;
     }
 }
+
+.ie9 {
+    .labelled-line-chart,
+    .labelled-sparkline,
+    .responsive-bar-chart {
+        canvas {
+            height: 0 !important;
+            width: 0 !important;
+            display: none !important;
+        }
+       
+    }
+    .labelled-line-chart .label {
+        @media (min-width: 48em) {
+            position: static !important;
+            margin-top: inherit !important;
+            margin-#{$right}: 1.5em !important;
+        }
+    }
+}

--- a/web/cobrands/sass/_dashboard.scss
+++ b/web/cobrands/sass/_dashboard.scss
@@ -205,7 +205,7 @@
     }
 
     th {
-        text-align: inherit;
+        text-align: left;
     }
 
     tbody tr:nth-child(odd) > * {

--- a/web/js/dashboard.js
+++ b/web/js/dashboard.js
@@ -27,7 +27,6 @@ $(function(){
 
     var setUpLabelsForChart = function(chart){
         var $parent = $(chart.chart.canvas).parent();
-        var xGutterInPixels = 30;
 
         var lasty = 0;
         $.each(chart.config.data.datasets, function(datasetIndex, dataset){
@@ -38,8 +37,7 @@ $(function(){
                 y = lasty;
             }
             $label.css({
-                top: y,
-                left: latestPoint._model.x + xGutterInPixels
+                top: y
             });
             lasty = y + $label.height() + 8;
         });

--- a/web/js/dashboard.js
+++ b/web/js/dashboard.js
@@ -1,4 +1,7 @@
 $(function(){
+    if ($('html').is('.ie9')) {
+        return;
+    }
 
     Chart.defaults.global.defaultFontSize = 16;
     // Chart.defaults.global.defaultFontFamily = $('body').css('font-family');


### PR DESCRIPTION
Fixes #2005 

All charts render in IE10+ and look fine, IE9 and below get the same content just not presented in quite the same way, but it doesn't look broken