### PR TITLE
asset layer map attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
         - Improved cursor/display of the new report pin. #2038
         - Asset layers can be attached to more than one category each. #2049
         - Cobrands hook to remove phone number field. #2049
+        - Asset layer attribution automatically shown. #2061
     - Bugfixes:
         - Stop asset layers obscuring marker layer. #1999
         - Don't delete hidden field values when inspecting reports. #1999

--- a/templates/web/base/maps/osm.html
+++ b/templates/web/base/maps/osm.html
@@ -1,3 +1,4 @@
 [%
+map.copyright = ''; # This is handled with OpenLayers.Control.Attribution
 map_html = INCLUDE maps/openlayers.html
 %]

--- a/web/cobrands/bathnes/js.js
+++ b/web/cobrands/bathnes/js.js
@@ -187,7 +187,8 @@ fixmystreet.assets.add($.extend(true, {}, fixmystreet.maps.banes_defaults, {
         attribute: 'usrn',
         field: 'site_code'
     },
-    name: "Adopted Highways"
+    name: "Adopted Highways",
+    attribution: " © Crown Copyright. All rights reserved. 1000233344"
 }));
 
 

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -475,6 +475,9 @@ fixmystreet.assets = {
             styleMap: options.stylemap || get_asset_stylemap(),
             assets: true
         };
+        if (options.attribution !== undefined) {
+            layer_options.attribution = options.attribution;
+        }
         if (options.srsName !== undefined) {
             layer_options.projection = new OpenLayers.Projection(options.srsName);
         } else if (fixmystreet.wmts_config) {

--- a/web/js/map-OpenStreetMap.js
+++ b/web/js/map-OpenStreetMap.js
@@ -4,6 +4,7 @@ fixmystreet.maps.config = function() {
         permalink_id = 'map_permalink';
     }
     fixmystreet.controls = [
+        new OpenLayers.Control.Attribution(),
         new OpenLayers.Control.ArgParser(),
         //new OpenLayers.Control.LayerSwitcher(),
         new OpenLayers.Control.Navigation(),


### PR DESCRIPTION
Allow asset layers to add their own attribution string to the map.

Fixes mysociety/fixmystreetforcouncils#304