### PR TITLE
Prevent green banner (#2032) appearing over mobile map

### DIFF
--- a/templates/web/fixmystreet.com/header_extra.html
+++ b/templates/web/fixmystreet.com/header_extra.html
@@ -14,6 +14,7 @@
     html .banner-position-variant-1 { display: none !important; }
     html.banner-position-variant-1 .banner-position-variant-0 { display: none !important; }
     html.banner-position-variant-1 .banner-position-variant-1 { display: block !important; }
+    html.map-fullscreen .banner-position-variant-1 { display: none !important; }
     html.banner-position-variant-1 #side .big-green-banner ~ section.full-width { margin-top: -1em; }
 </style>
 [% END %]


### PR DESCRIPTION
#2032 introduced a bug on FMS.com only, where, if you were chosen to be in the "button over map" experiment group, the button would be incorrectly shown _even_ on mobile, because of a CSS selector specificity issue.

Fixes #2060.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/739624/38319848-c9e5e80c-382a-11e8-8103-7583fc232b4c.png">
</td>
<td>
<img src="https://user-images.githubusercontent.com/739624/38319863-d45f3162-382a-11e8-9df5-819928da1715.png"></td>
</tr>
</table>