### PR TITLE
Open311 fetch all reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Unreleased
     - New features
-        - Fetch problems over Open311 #1986
+        - Fetch problems over Open311 #1986 #2067
         - Option to send multiple photos over Open311 #1986
         - Allow Open311 service definitions to include automated
           attributes #1986

--- a/bin/update-schema
+++ b/bin/update-schema
@@ -212,6 +212,7 @@ else {
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
     return 'EMPTY' if ! table_exists('problem');
+    return '0061' if column_exists('body', 'extra');
     return '0060' if column_exists('body', 'convert_latlong');
     return '0059' if column_exists('response_templates', 'external_status_code');
     return '0058' if column_exists('body', 'blank_updates_permitted');

--- a/db/downgrade_0061---0060.sql
+++ b/db/downgrade_0061---0060.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE body DROP extra;
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -57,7 +57,8 @@ create table body (
     fetch_problems boolean not null default 'f',
     blank_updates_permitted boolean not null default 'f',
     convert_latlong boolean not null default 'f',
-    deleted boolean not null default 'f'
+    deleted boolean not null default 'f',
+    extra           text
 );
 
 create table body_areas (

--- a/db/schema_0061-add-extra-body.sql
+++ b/db/schema_0061-add-extra-body.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE body ADD extra text;
+
+COMMIT;

--- a/perllib/FixMyStreet/DB/Result/Body.pm
+++ b/perllib/FixMyStreet/DB/Result/Body.pm
@@ -50,6 +50,8 @@ __PACKAGE__->add_columns(
   { data_type => "boolean", default_value => \"false", is_nullable => 1 },
   "convert_latlong",
   { data_type => "boolean", default_value => \"false", is_nullable => 0 },
+  "extra",
+  { data_type => "text", is_nullable => 1 },
 );
 __PACKAGE__->set_primary_key("id");
 __PACKAGE__->has_many(
@@ -124,13 +126,17 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2018-03-15 12:38:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:rturOWpYmPRO0yE9yWHXjA
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2018-04-05 14:29:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:HV8IM2C1ErrpvXoRTZ1B1Q
+
+__PACKAGE__->load_components("+FixMyStreet::DB::RABXColumn");
+__PACKAGE__->rabx_column('extra');
 
 use Moo;
 use namespace::clean;
 
-with 'FixMyStreet::Roles::Translatable';
+with 'FixMyStreet::Roles::Translatable',
+     'FixMyStreet::Roles::Extra';
 
 sub url {
     my ( $self, $c, $args ) = @_;

--- a/t/app/controller/admin/bodies.t
+++ b/t/app/controller/admin/bodies.t
@@ -150,6 +150,45 @@ subtest 'check open311 configuring' => sub {
     is $conf->endpoint, 'http://example.org/open311', 'endpoint updated';
     is $conf->api_key, 'new api key', 'api key updated';
     is $conf->jurisdiction, 'open311', 'jurisdiction configures';
+    ok !$conf->get_extra_metadata('fetch_all_problems'), 'fetch all problems unset';
+
+    $mech->form_number(3);
+    $mech->submit_form_ok(
+        {
+            with_fields => {
+                api_key      => 'new api key',
+                endpoint     => 'http://example.org/open311',
+                jurisdiction => 'open311',
+                send_comments => 0,
+                send_method  => 'Open311',
+                fetch_all_problems => 1,
+            }
+        }
+    );
+
+    $mech->content_contains('Values updated');
+
+    $conf = FixMyStreet::App->model('DB::Body')->find( $body->id );
+    ok $conf->get_extra_metadata('fetch_all_problems'), 'fetch all problems set';
+
+    $mech->form_number(3);
+    $mech->submit_form_ok(
+        {
+            with_fields => {
+                api_key      => 'new api key',
+                endpoint     => 'http://example.org/open311',
+                jurisdiction => 'open311',
+                send_comments => 0,
+                send_method  => 'Open311',
+                fetch_all_problems => 0,
+            }
+        }
+    );
+
+    $mech->content_contains('Values updated');
+
+    $conf = FixMyStreet::App->model('DB::Body')->find( $body->id );
+    ok !$conf->get_extra_metadata('fetch_all_problems'), 'fetch all problems unset';
 };
 
 subtest 'check text output' => sub {

--- a/templates/web/base/admin/open311-form-fields.html
+++ b/templates/web/base/admin/open311-form-fields.html
@@ -76,6 +76,52 @@
         <label for="send_comments" class="inline">[% loc('Use Open311 update-sending extension') %]</label>
     </p>
 
+    <div class="admin-open311-section">
+        <div class="admin-hint">
+          <p>
+            [% loc(
+              "If you've enabled Open311 update-sending above, you must identify which 
+              FixMyStreet <strong>user</strong> will be attributed as the creator of those updates
+              when they are shown on the site. Enter the ID (number) of that user."
+            ) %]
+          </p>
+        </div>
+        <p>
+            <label for"comment_user_id">[% loc('User ID to attribute fetched comments to') %]</label>
+            <input type="text" class="form-control" name="comment_user_id" value="[% object.comment_user_id %]">
+            [% IF object.comment_user_id %]
+            <a href="[% c.uri_for('user_edit', object.comment_user_id) %]">[% loc('edit user') %]</a>
+            [% END %]
+        </p>
+
+        <div class="admin-hint">
+          <p>
+            [% loc(
+              "If you've enabled Open311 update-sending above, enable <strong>suppression of alerts</strong> 
+              if you do <strong>not</strong> want that user to be notified whenever these updates are created."
+            ) %]
+          </p>
+        </div>
+        <p>
+            <input type="checkbox" id="suppress_alerts" name="suppress_alerts"[% ' checked' IF object.suppress_alerts %]>
+            <label for="suppress_alerts" class="inline">[% loc('Do not send email alerts on fetched comments to problem creator') %]</label>
+        </p>
+
+        <div class="admin-hint">
+          <p>
+            [% loc(
+              "If you've enabled Open311 update-sending above, Open311 usually only accepts OPEN or CLOSED status in 
+              its updates. Enable <strong>extended Open311 stauses</strong> if you want to allow extra states to be passed.
+              Check that your cobrand supports this feature before switching it on."
+            ) %]
+          </p>
+        </div>
+        <p>
+            <input type="checkbox" id="send_extended_statuses" name="send_extended_statuses"[% ' checked' IF object.send_extended_statuses %]>
+            <label for="send_extended_statuses" class="inline">[% loc('Send extended Open311 statuses with service request updates') %]</label>
+        </p>
+    </div>
+
     <div class="admin-hint">
       <p>
         [% loc(
@@ -91,61 +137,19 @@
         <label for="fetch_problems" class="inline">[% loc('Use Open311 problem fetching') %]</label>
     </p>
 
-    <div class="admin-hint">
-      <p>
-        [% loc(
-          "If you've enabled Open311 update-sending above, you must identify which 
-          FixMyStreet <strong>user</strong> will be attributed as the creator of those updates
-          when they are shown on the site. Enter the ID (number) of that user."
-        ) %]
-      </p>
+    <div class="admin-open311-section">
+        <div class="admin-hint">
+          <p>
+            [% loc(
+                "Enable <strong>Convert location from Easting/Northing</strong> if you've enabled Open311 problem-fetching above
+                and problems fetching from the endpoint have the location in Easting/Northings and not Latitude/Longitude."
+            ) %]
+          </p>
+        </div>
+        <p>
+            <input type="checkbox" id="convert_latlong" name="convert_latlong"[% ' checked' IF object.convert_latlong %]>
+            <label for="convert_latlong" class="inline">[% loc('Convert location from Easting/Northing') %]</label>
+        </p>
     </div>
-    <p>
-        <label for"comment_user_id">[% loc('User ID to attribute fetched comments to') %]</label>
-        <input type="text" class="form-control" name="comment_user_id" value="[% object.comment_user_id %]">
-        [% IF object.comment_user_id %]
-        <a href="[% c.uri_for('user_edit', object.comment_user_id) %]">[% loc('edit user') %]</a>
-        [% END %]
-    </p>
-
-    <div class="admin-hint">
-      <p>
-        [% loc(
-          "If you've enabled Open311 update-sending above, enable <strong>suppression of alerts</strong> 
-          if you do <strong>not</strong> want that user to be notified whenever these updates are created."
-        ) %]
-      </p>
-    </div>
-    <p>
-        <input type="checkbox" id="suppress_alerts" name="suppress_alerts"[% ' checked' IF object.suppress_alerts %]>
-        <label for="suppress_alerts" class="inline">[% loc('Do not send email alerts on fetched comments to problem creator') %]</label>
-    </p>
-
-    <div class="admin-hint">
-      <p>
-        [% loc(
-          "If you've enabled Open311 update-sending above, Open311 usually only accepts OPEN or CLOSED status in 
-          its updates. Enable <strong>extended Open311 stauses</strong> if you want to allow extra states to be passed.
-          Check that your cobrand supports this feature before switching it on."
-        ) %]
-      </p>
-    </div>
-    <p>
-        <input type="checkbox" id="send_extended_statuses" name="send_extended_statuses"[% ' checked' IF object.send_extended_statuses %]>
-        <label for="send_extended_statuses" class="inline">[% loc('Send extended Open311 statuses with service request updates') %]</label>
-    </p>
-
-    <div class="admin-hint">
-      <p>
-        [% loc(
-            "Enable <strong>Convert location from Easting/Northing</strong> if you've enabled Open311 problem-fetching above
-            and problems fetching from the endpoint have the location in Easting/Northings and not Latitude/Longitude."
-        ) %]
-      </p>
-    </div>
-    <p>
-        <input type="checkbox" id="convert_latlong" name="convert_latlong"[% ' checked' IF object.convert_latlong %]>
-        <label for="convert_latlong" class="inline">[% loc('Convert location from Easting/Northing') %]</label>
-    </p>
   [% END %]
 </div>

--- a/templates/web/base/admin/open311-form-fields.html
+++ b/templates/web/base/admin/open311-form-fields.html
@@ -150,6 +150,20 @@
             <input type="checkbox" id="convert_latlong" name="convert_latlong"[% ' checked' IF object.convert_latlong %]>
             <label for="convert_latlong" class="inline">[% loc('Convert location from Easting/Northing') %]</label>
         </p>
+
+        <div class="admin-hint">
+          <p>
+            [% loc(
+                "Enable <strong>Always fetch all problems</strong> if you've enabled Open311 problem-fetching above
+                and the endpoint always returns a list of all problems. This will suppress error messages about
+                bad dates in the problems fetched."
+            ) %]
+          </p>
+        </div>
+        <p>
+            <input type="checkbox" id="fetch_all_problems" name="fetch_all_problems"[% ' checked' IF object.get_extra_metadata('fetch_all_problems') %]>
+            <label for="fetch_all_problems" class="inline">[% loc('Always fetch all problems') %]</label>
+        </p>
     </div>
   [% END %]
 </div>

--- a/web/cobrands/sass/_admin.scss
+++ b/web/cobrands/sass/_admin.scss
@@ -111,6 +111,11 @@ $button_bg_col: #a1a1a1;  // also search bar (tables)
     margin: 1em 0;
 }
 
+.admin-open311-section {
+    padding-left: 1em;
+    border-left: 1px solid #ccc;
+}
+
 .admin-hint {
     font-size: 80%; // little question marks are small
     cursor: pointer;


### PR DESCRIPTION
This adds an option to not set start and end dates when fetching problems over Open311. This is either if you always want to fetch all of them or if the API doesn't have a date options and you want to suppress the warnings about problems outside the default date range.