### PR TITLE
[Open311] Generally store update state.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
         - Set a session timezone in case database server is set differently.
         - Fix SQL error on update edit admin page in cobrands. #2049
         - Improve chart display in old IE versions. #2005
+        - Improve handling of Open311 state changes. #2069
     - Admin improvements:
         - Inspectors can set non_public status of reports. #1992
         - Default start date is shown on the dashboard.

--- a/perllib/Open311/GetServiceRequestUpdates.pm
+++ b/perllib/Open311/GetServiceRequestUpdates.pm
@@ -138,22 +138,22 @@ sub update_comments {
                 $open311->add_media($request->{media_url}, $comment)
                     if $request->{media_url};
 
-                # if the comment is older than the last update
-                # do not change the status of the problem as it's
-                # tricky to determine the right thing to do.
-                # Allow the same time in case report/update created at same time (in external system)
-                if ( $comment->created >= $p->lastupdate ) {
-                    # don't update state unless it's an allowed state and it's
-                    # actually changing the state of the problem
-                    if ( FixMyStreet::DB::Result::Problem->visible_states()->{$state} && $p->state ne $state &&
-                        # For Oxfordshire, don't allow changes back to Open from other open states
-                        !( $body->areas->{$AREA_ID_OXFORDSHIRE} && $state eq 'confirmed' && $p->is_open ) &&
-                        # Don't let it change between the (same in the front end) fixed states
-                        !( $p->is_fixed && FixMyStreet::DB::Result::Problem->fixed_states()->{$state} ) ) {
-                        if ($p->is_visible) {
-                            $p->state($state);
-                        }
-                        $comment->problem_state($state);
+                # don't update state unless it's an allowed state
+                if ( FixMyStreet::DB::Result::Problem->visible_states()->{$state} &&
+                    # For Oxfordshire, don't allow changes back to Open from other open states
+                    !( $body->areas->{$AREA_ID_OXFORDSHIRE} && $state eq 'confirmed' && $p->is_open ) &&
+                    # Don't let it change between the (same in the front end) fixed states
+                    !( $p->is_fixed && FixMyStreet::DB::Result::Problem->fixed_states()->{$state} ) ) {
+
+                    $comment->problem_state($state);
+
+                    # if the comment is older than the last update do not
+                    # change the status of the problem as it's tricky to
+                    # determine the right thing to do. Allow the same time in
+                    # case report/update created at same time (in external
+                    # system). Only do this if the report is currently visible.
+                    if ( $comment->created >= $p->lastupdate && $p->state ne $state && $p->is_visible ) {
+                        $p->state($state);
                     }
                 }
 

--- a/t/open311/getservicerequestupdates.t
+++ b/t/open311/getservicerequestupdates.t
@@ -150,7 +150,7 @@ for my $test (
         comment_status => 'OPEN',
         mark_fixed=> 0,
         mark_open => 0,
-        problem_state => undef,
+        problem_state => 'confirmed',
         end_state => 'confirmed',
     },
     {


### PR DESCRIPTION
Previously, an update's problem_state was set via an Open311 update if:
* the update timestamp was equal or greater to the report's last update;
* the new state was visible, and not equal to the report's current state;
* the update wouldn't change the report from a fixed state to another fixed state;
* (Oxfordshire) the update wouldn't change the report from any open state to Open.

It would also set the report's state to match if the report was currently visible.

This mostly worked, but could lead to issues if e.g. the report started life in
a non-confirmed state (e.g. we pulled it in already fixed from an external
source), as then the update did not record its state and the update display got
confused as to the state history. However it did mean there wasn't confusion if
a later update than the Open311 update was made on the site itself.

This new code will set an update's problem_state if:
* the new state is visible;
* the update wouldn't change the report from a fixed state to another fixed state;
* (Oxfordshire) the update wouldn't change the report from any open state to Open.

It will also set the report's state to match if the report is currently
visible, changing state, and the update timestamp is equal or greater to the
report's last update.

So when the report state changes is unchanged, all the conditions still apply,
but the update's problem_state is set more often (it will be set regardless of
whether the timestamps align, or whether the state matches the report's current
state).

This could theoretically lead to issues elsewhere, e.g. if an update is left on
a report on FixMyStreet and then an Open311 update is pulled in later (but with
an earlier timestamp) that changes the state, the report state will not be
updated due to the later update being made, though the Open311 update will list
the state change, and then the later update might say it changed it back (if it
recorded the current state in its problem_state), even though it technically
did not. I think this issue is less worrying than the current situation, which
can state that a random update has fixed a report when it was the previous
update that did, and there will always be such issues with multiple sources of
truth for a report status. An alternative would be to allow the Open311 update
to override.