### PR TITLE
Add link to edit current report in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
         - Don't send sent-report emails to as-body/as-anonymous reports.
         - Show Open311 service code as tooltip on admin category checkboxes. #2049
         - Bulk user import admin page. #2057
+        - Add link to admin edit page for reports. #2071
     - Development improvements:
         - Add HTML email previewer.
         - Add CORS header to Open311 output. #2022

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -16,6 +16,9 @@
         <p>
           <strong>[% loc('Report ID:') %]</strong>
           <span class="js-report-id">[% problem.id %]</span>
+          [% IF c.user_exists AND c.cobrand.admin_allow_user(c.user) AND c.user.has_permission_to('report_edit', problem.bodies_str_ids) %]
+            (<a href="[% c.uri_for_action( "admin/report_edit", problem.id ) %]">[% loc('admin') %]</a>)
+          [% END %]
         </p>
         [% IF permissions.report_inspect AND problem.user.phone %]
           <p>


### PR DESCRIPTION
I find myself wanting to view the current report in the admin all the time -
this PR adds a link to the top of the inspector column that goes right there.
Only visible for superusers and staff users with permission to actually view the
admin.

<img width="977" alt="screen shot 2018-04-11 at 09 58 30" src="https://user-images.githubusercontent.com/4776/38606810-f8949cd6-3d6e-11e8-9c9f-6d06b2018cc5.png">
