### PR TITLE
Add info on anonymisation feature

### DIFF
--- a/templates/web/fixmystreet.com/about/faq-en-gb.html
+++ b/templates/web/fixmystreet.com/about/faq-en-gb.html
@@ -127,6 +127,9 @@ tone of their correspondence tends to be more constructive and less abusive.
 anonymously – just uncheck the 'show my name publicly' box on submission. This
 will mean that your name is not displayed on the FixMyStreet website, although
 it is still sent to the council.
+<p>If you want to anonymise a report you made in the past, sign in to your
+account (see below for how to register) and you'll see a 'Hide your name?'
+option on the report.
 </dd>
 
 </dl>
@@ -261,7 +264,8 @@ misrouted. Please include the URL (web address) of your FixMyStreet report.
 <p>If you've already submitted your report, but now you need to send further
 information to your council, you should wait until they reply to you, and then
 respond to their communication directly.
-<p>You can also leave an update on your FixMyStreet report page, but note that
+
+  <p>You can also leave an update on your FixMyStreet report page, but note that
 updates are not forwarded to the council. They are intended as a place for
 residents to discuss local problems and offer advice or support.
 <p>With this in mind, you may wish to both update your report on the site, and


### PR DESCRIPTION
Since https://github.com/mysociety/fixmystreet/pull/1554 it has been possible for a user to hide their name on their reports and updates, rather than having to contact support. This PR updates the FAQ to mention that.
[skip changelog]