### PR TITLE
Always set memcached namespace.

### DIFF
--- a/perllib/FixMyStreet/App.pm
+++ b/perllib/FixMyStreet/App.pm
@@ -232,8 +232,6 @@ sub setup_request {
 
     $c->model('DB::Problem')->set_restriction( $cobrand->site_key() );
 
-    Memcached::set_namespace( FixMyStreet->config('FMS_DB_NAME') . ":" );
-
     FixMyStreet::Map::set_map_class( $cobrand->map_type || $c->get_param('map_override') );
     # All pages need this, either loading it or prefetching it
     $c->stash->{map_js} = FixMyStreet::Map::map_javascript();

--- a/perllib/Memcached.pm
+++ b/perllib/Memcached.pm
@@ -1,21 +1,15 @@
-#
 # Memcached.pm:
-# Trying out memcached on FixMyStreet
-#
-# Copyright (c) 2008 UK Citizens Online Democracy. All rights reserved.
-# Email: matthew@mysociety.org; WWW: http://www.mysociety.org/
+# Tiny FixMyStreet memcached wrapper
 
 package Memcached;
 
 use strict;
 use warnings;
 use Cache::Memcached;
+use FixMyStreet;
 
-my ($memcache, $namespace);
-
-sub set_namespace {
-    $namespace = shift;
-}
+my $memcache;
+my $namespace = FixMyStreet->config('FMS_DB_NAME') . ":";
 
 sub instance {
     return $memcache //= Cache::Memcached->new({


### PR DESCRIPTION
The namespace was only being set in the web loop, so cron scripts
were accessing different memcached keys. In particular, the state
list would be shared between instances on the same host.