### PR TITLE
Collideoscope refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ gh_fixmycommunity
 # Commercial
 /fixmystreet-commercial
 *[Gg]round[Cc]ontrol*
+[Ss]midsy*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
         - Add HTML email previewer.
         - Add CORS header to Open311 output. #2022
         - Add some Cypress browser-based testing.
+        - Add validation to cobrand-specific custom reporting fields.
 
 * v2.3.1 (12th February 2018)
     - Front end improvements:

--- a/perllib/CronFns.pm
+++ b/perllib/CronFns.pm
@@ -27,6 +27,7 @@ sub site {
     my $base_url = shift;
     my $site = 'fixmystreet';
     $site = 'zurich' if $base_url =~ /zurich|zueri/;
+    $site = 'smidsy' if $base_url =~ /smidsy|collideosco/;
     return $site;
 }
 

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -1042,7 +1042,7 @@ sub report_edit_location : Private {
         $c->forward('/council/load_and_check_areas', []);
         $c->forward('/report/new/setup_categories_and_bodies');
         my %allowed_bodies = map { $_ => 1 } @{$problem->bodies_str_ids};
-        my @new_bodies = @{$c->stash->{bodies_to_list}};
+        my @new_bodies = keys %{$c->stash->{bodies_to_list}};
         my $bodies_match = grep { exists( $allowed_bodies{$_} ) } @new_bodies;
         $c->stash($safe_stash);
         return unless $bodies_match;

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -966,6 +966,14 @@ sub process_report : Private {
         my $value = $c->get_param($form_name) || '';
         $c->stash->{field_errors}->{$form_name} = _('This information is required')
             if $field->{required} && !$value;
+        if ($field->{validator}) {
+            eval {
+                $value = $field->{validator}->($value);
+            };
+            if ($@) {
+                $c->stash->{field_errors}->{$form_name} = $@;
+            }
+        }
         $report->set_extra_metadata( $form_name => $value );
     }
 

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -695,9 +695,7 @@ sub setup_categories_and_bodies : Private {
     # put results onto stash for display
     $c->stash->{bodies} = \%bodies;
     $c->stash->{contacts} = \@contacts;
-    $c->stash->{bodies_to_list} = [ keys %bodies_to_list ];
-    $c->stash->{bodies_to_list_names} = [ map { $_->name } values %bodies_to_list ];
-    $c->stash->{bodies_to_list_urls} = [ map { $_->external_url } values %bodies_to_list ];
+    $c->stash->{bodies_to_list} = \%bodies_to_list;
     $c->stash->{category_options} = \@category_options;
     $c->stash->{category_extras}  = \%category_extras;
     $c->stash->{category_extras_hidden}  = \%category_extras_hidden;
@@ -948,7 +946,7 @@ sub process_report : Private {
         if ( $c->stash->{non_public_categories}->{ $report->category } ) {
             $report->non_public( 1 );
         }
-    } elsif ( @{ $c->stash->{bodies_to_list} } ) {
+    } elsif ( %{ $c->stash->{bodies_to_list} } ) {
 
         # There was an area with categories, but we've not been given one. Bail.
         $c->stash->{field_errors}->{category} = _('Please choose a category');

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -918,6 +918,7 @@ sub process_report : Private {
 
     # set these straight from the params
     $report->category( _ $params{category} ) if $params{category};
+    $c->cobrand->call_hook(report_new_munge_category => $report);
     $report->subcategory( $params{subcategory} );
 
     my $areas = $c->stash->{all_areas_mapit};
@@ -1350,6 +1351,8 @@ sub save_user_and_report : Private {
         $report->user->discard_changes();
         $c->log->info($report->user->id . ' exists, but is not logged in for this report');
     }
+
+    $c->cobrand->call_hook(report_new_munge_before_insert => $report);
 
     $report->update_or_insert;
 

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -93,6 +93,7 @@ sub index : Path : Args(0) {
         }
     } else {
         my @bodies = $c->model('DB::Body')->active->translated->with_area_count->all_sorted;
+        @bodies = @{$c->cobrand->call_hook('reports_hook_restrict_bodies_list', \@bodies) || \@bodies };
         $c->stash->{bodies} = \@bodies;
     }
 

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -23,6 +23,7 @@ sub output {
 }
 
 my @PLACES = (
+    [ '?', 53.387402, -2.943997, 2527, 'Liverpool City Council', 'MTD' ],
     [ 'EH1 1BB', 55.952055, -3.189579, 2651, 'Edinburgh City Council', 'UTA', 20728, 'City Centre', 'UTE' ],
     [ 'BS10 5EE', 51.494885, -2.602237, 2561, 'Bristol City Council', 'UTA', 148646, 'Bedminster', 'UTW' ],
     [ 'SW1A 1AA', 51.501009, -0.141588, 2504, 'Westminster City Council', 'LBO' ],

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -1169,6 +1169,7 @@ FixMyStreet::override_config {
     $extra_details = $mech->get_ok_json( '/report/new/ajax?latitude=' . $saved_lat . '&longitude=' . $saved_lon );
 };
 $mech->content_contains( "Pothol\xc3\xa9s" );
+like $extra_details->{councils_text}, qr/<strong>Cheltenham/;
 ok !$extra_details->{titles_list}, 'Non Bromley does not send back list of titles';
 
 FixMyStreet::override_config {

--- a/t/app/controller/reports.t
+++ b/t/app/controller/reports.t
@@ -95,6 +95,9 @@ $fife_problems[10]->update( {
     state => 'hidden',
 });
 
+# Run the cron script old-data (for the table no longer used by default)
+FixMyStreet::Script::UpdateAllReports::generate(1);
+
 # Run the cron script that makes the data for /reports so we don't get an error.
 my $data = FixMyStreet::Script::UpdateAllReports::generate_dashboard();
 

--- a/templates/web/base/around/index.html
+++ b/templates/web/base/around/index.html
@@ -1,5 +1,5 @@
 [% pre_container_extra = INCLUDE 'around/postcode_form.html' %]
-[% SET bodyclass = 'frontpage fullwidthpage' ~%]
+[% SET bodyclass = 'frontpage fullwidthpage aroundpage' ~%]
 [% INCLUDE 'header.html', title = loc('Reporting a problem') %]
 
 [%

--- a/templates/web/base/report/new/category_extras.html
+++ b/templates/web/base/report/new/category_extras.html
@@ -1,4 +1,5 @@
-[% DEFAULT list_of_names = bodies_to_list_names %]
+[% SET default_list = [] %][% FOR b IN bodies_to_list.values %][% default_list.push(b.name) %][% END %]
+[% DEFAULT list_of_names = default_list %]
 
 <div id="category_meta">
   [%- IF unresponsive.$category %]

--- a/templates/web/base/report/new/councils_text_all.html
+++ b/templates/web/base/report/new/councils_text_all.html
@@ -1,4 +1,5 @@
-[% DEFAULT list_of_names = bodies_to_list_names %]
+[% SET default_list = [] %][% FOR b IN bodies_to_list.values %][% default_list.push(b.name) %][% END %]
+[% DEFAULT list_of_names = default_list %]
 
 <p>
 [%

--- a/templates/web/base/report/new/form_report.html
+++ b/templates/web/base/report/new/form_report.html
@@ -17,13 +17,7 @@
       [% END %]
     </div>
 
-    [% DEFAULT form_title = loc('Summarise the problem') %]
-    <label for="form_title">[% form_title %]</label>
-[% IF field_errors.title %]
-    <p class='form-error'>[% field_errors.title %]</p>
-[% END %]
-    [% DEFAULT form_title_placeholder = loc('10 inch pothole on Example St, near post box') %]
-    <input class="form-control" type="text" value="[% report.title | html %]" name="title" id="form_title" placeholder="[% form_title_placeholder %]" required>
+    [% INCLUDE 'report/new/form_title.html' %]
 
 [% TRY %][% PROCESS 'report/new/after_title.html' %][% CATCH file %][% END %]
 
@@ -54,7 +48,8 @@
 
 [% TRY %][% PROCESS 'report/new/after_photo.html' %][% CATCH file %][% END %]
 
-    <label for="form_detail">[% loc('Explain what’s wrong') %]</label>
+    [% DEFAULT form_detail_label = loc('Explain what’s wrong') %]
+    <label for="form_detail">[% form_detail_label %]</label>
 [% IF field_errors.detail %]
     <p class='form-error'>[% field_errors.detail %]</p>
 [% END %]

--- a/templates/web/base/report/new/form_title.html
+++ b/templates/web/base/report/new/form_title.html
@@ -1,0 +1,7 @@
+[% DEFAULT form_title = loc('Summarise the problem') %]
+<label for="form_title">[% form_title %]</label>
+[% IF field_errors.title %]
+    <p class='form-error'>[% field_errors.title %]</p>
+[% END %]
+[% DEFAULT form_title_placeholder = loc('10 inch pothole on Example St, near post box') %]
+<input class="form-control" type="text" value="[% report.title | html %]" name="title" id="form_title" placeholder="[% form_title_placeholder %]" required>

--- a/templates/web/base/report/update/form_state_checkbox.html
+++ b/templates/web/base/report/update/form_state_checkbox.html
@@ -1,0 +1,17 @@
+[% IF (problem.is_fixed OR problem.is_closed) AND ((c.user_exists AND c.user.id == problem.user_id) OR alert_to_reporter) %]
+
+    <input type="checkbox" name="reopen" id="form_reopen" value="1"[% ' checked' IF (update.mark_open || c.req.params.reopen) %]>
+    [% IF problem.is_closed %]
+      <label class="inline" for="form_reopen">[% loc('This problem is still ongoing') %]</label>
+    [% ELSE %]
+      <label class="inline" for="form_reopen">[% loc('This problem has not been fixed') %]</label>
+    [% END %]
+
+[% ELSIF !problem.is_fixed AND has_fixed_state %]
+
+    <div class="checkbox-group">
+        <input type="checkbox" name="fixed" id="form_fixed" value="1"[% ' checked' IF update.mark_fixed %]>
+        <label class="inline" for="form_fixed">[% loc('This problem has been fixed') %]</label>
+    </div>
+
+[% END %]

--- a/templates/web/base/report/update/form_update.html
+++ b/templates/web/base/report/update/form_update.html
@@ -39,21 +39,5 @@
     <label for="state">[% loc( 'State' ) %]</label>
     [% INCLUDE 'report/inspect/state_groups_select.html' %]
 [% ELSE %]
-  [% IF (problem.is_fixed OR problem.is_closed) AND ((c.user_exists AND c.user.id == problem.user_id) OR alert_to_reporter) %]
-
-    <input type="checkbox" name="reopen" id="form_reopen" value="1"[% ' checked' IF (update.mark_open || c.req.params.reopen) %]>
-    [% IF problem.is_closed %]
-      <label class="inline" for="form_reopen">[% loc('This problem is still ongoing') %]</label>
-    [% ELSE %]
-      <label class="inline" for="form_reopen">[% loc('This problem has not been fixed') %]</label>
-    [% END %]
-
-  [% ELSIF !problem.is_fixed AND has_fixed_state %]
-
-    <div class="checkbox-group">
-        <input type="checkbox" name="fixed" id="form_fixed" value="1"[% ' checked' IF update.mark_fixed %]>
-        <label class="inline" for="form_fixed">[% loc('This problem has been fixed') %]</label>
-    </div>
-
-  [% END %]
+  [% INCLUDE report/update/form_state_checkbox.html %]
 [% END %]

--- a/templates/web/fixamingata/report/new/top_message_none.html
+++ b/templates/web/fixamingata/report/new/top_message_none.html
@@ -1,15 +1,15 @@
 <p>
-[% IF bodies_to_list_names.size == 1 %]
+[% IF bodies_to_list.size == 1 %]
 [%
     tprintf(
         "%s har valt att inte ta emot rapporter från FixaMinGata, utan hänvisar fel- &amp; synpunktsrapportering till <a href='%s'>kommunens egen webbplats</a>.",
-        bodies_to_list_names.first, bodies_to_list_urls.first);
+        bodies_to_list.values.first.name, bodies_to_list.values.first.external_url);
 %]
 [% END %]
 [%
     loc("If you submit a problem here the problem will <strong>not</strong> be reported to the council.");
 %]
-[% IF bodies_to_list_names.size != 1 %]
+[% IF bodies_to_list.size != 1 %]
 [%
     tprintf(
         loc("You can help us by finding a contact email address for local problems for %s and emailing it to us at <a href='mailto:%s'>%s</a>."),


### PR DESCRIPTION
These are the hooks needed for the refactor of the `smidsy-candidate` branch (still there if that's useful) on to current master:
* table dashboard - to have its own columns on `/reports`
* bodies list - to filter the list of bodies on `/reports`
* new reports - to change the title/category before submission based on extra data submitted
* `aroundpage` class
* One new template
* Adding 'validation' of report_form_extras

I didn't need the contact changes (master now handles extra values), email changes (master is fine) will do batched reporting in the cobrand, and various other bits are now done differently.

The cobrand specific files are not in core any longer, but at https://github.com/mysociety/collideoscope/pull/4

Will probably need looking at https://github.com/mysociety/fixmystreet/pull/1183 after.