### PR TITLE
cobrand hook to deny access to pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Releases
 
 * Unreleased
+    - New features
+        - Cobrand hook to allow extra login conditions #2092
     - Front end improvements:
         - Simplify footer CSS. #2107
     - Bugfixes:

--- a/perllib/FixMyStreet/App/Controller/Root.pm
+++ b/perllib/FixMyStreet/App/Controller/Root.pm
@@ -39,6 +39,7 @@ sub auto : Private {
 
     # decide which cobrand this request should use
     $c->setup_request();
+    $c->detach('/auth/redirect') if $c->cobrand->call_hook('check_login_disallowed');
 
     return 1;
 }

--- a/t/app/controller/root.t
+++ b/t/app/controller/root.t
@@ -1,4 +1,5 @@
 use FixMyStreet::TestMech;
+use Test::MockModule;
 
 ok( my $mech = FixMyStreet::TestMech->new, 'Created mech object' );
 
@@ -71,6 +72,20 @@ FixMyStreet::override_config {
             is $mech->res->code, 404, "got 404";
         }
     };
+};
+
+subtest "check_login_disallowed cobrand hook" => sub {
+    warn '#' x 50 . "\n";
+    my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Default');
+    $cobrand->mock('check_login_disallowed', sub {
+            my $self = shift;
+            return 0 if $self->{c}->req->path eq 'auth';
+            return 1;
+        }
+    );
+
+    $mech->get_ok('/');
+    is $mech->uri->path_query, '/auth?r=', 'redirects to auth page';
 };
 
 done_testing();


### PR DESCRIPTION
Add a check in the root controller `auto` to a cobrand hook that denies
access if it returns true. This goes here so that cobrands and users are
set up, which is not the case for `check_login_required`. Used to do
things like deny site access unless the user is a superuser.