### PR TITLE
Update Vagrantfile to use Xenial.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
         - Add HTML email previewer.
         - Add CORS header to Open311 output. #2022
         - Add some Cypress browser-based testing.
+        - Upgrade Vagrantfile to use Ubuntu Xenial. #2093
 
 * v2.3.1 (12th February 2018)
     - Front end improvements:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-BOX_NAME = ENV['BOX_NAME'] || "precise64"
-BOX_URI = ENV['BOX_URI'] || "http://files.vagrantup.com/precise64.box"
-
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
@@ -13,11 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = BOX_NAME
-
-  # The url from where the 'config.vm.box' box will be fetched if it
-  # doesn't already exist on the user's system.
-  config.vm.box_url = BOX_URI
+  config.vm.box = "ubuntu/xenial64"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,


### PR DESCRIPTION
The precise box's default libssl cannot connect to github; yes, you can update/upgrade first off to get it usable, but precise is in extended-support anyway now, and bionic is out soon, so I think moving to xenial for vagrant makes sense. FMS should already be supporting xenial, so this should be fine (just running it from scratch now).