### PR TITLE
WIP [UK] update uk site privacy policy with GDPR changes

### DIFF
--- a/templates/web/fixmystreet.com/about/privacy.html
+++ b/templates/web/fixmystreet.com/about/privacy.html
@@ -6,46 +6,384 @@
 
 <h1>Privacy, cookies, and third party services</h1>
 
-<p><strong>Our use of your data, cookies, and external services: what you
-should know, and how to opt out if you want to.</strong></p>
+<h2>Privacy Policy</h2>
 
-<p>Summary: We care a lot about our users’ privacy. We provide details below,
-and we try our hardest to look after the private data that we hold. Like many
-other websites, we sometimes use cookies and Google Analytics to help us make
-our websites better. These tools are very common and used by many other sites,
-but they do have privacy implications, and as a charity concerned with socially
-positive uses of the internet, we think it’s important to explain them in full.
-If you don’t want to share your browsing activities on mySociety’s sites with
-other companies, you can adjust your usage or install opt-out browser plugins.
+<p>
+    FixMyStreet is run by the charity <a href="https://www.mysociety.org/">mySociety</a>.
+</p>
 
-<h2>Privacy</h2>
+<p>
+    Working in the fields of transparency and accountability, mySociety thinks hard and
+    cares very much about the privacy and security of our users: the length of this
+    privacy policy is one result of that. We know no-one goes through Privacy Policies for
+    fun though, so we’ve tried to keep it a clear and reasonably quick read.
+</p>
 
-    <dl>
-        <dt>Who gets to see my email address?</dt>
-        <dd>If you submit a problem, we pass on your details, and details of
-the problem, to the council contact or contacts responsible for the area where
-you located the problem, or other relevant body. Other than the council, who obviously get
-your email address, only people we authorise to view the FixMyStreet
-administration interface will be able to see your email address and they will
-never use it for anything other than to help administer FixMyStreet. Similarly
-with email addresses from updates. We will never give or sell your email
-address to anyone else, unless we are obliged to by law. Your name, given in
-the name field, will not be published anywhere unless you let us (if you give
-your name elsewhere, e.g. in the public details section, it will be publicly
-available).</dd>
-        <dt>Will you send nasty, brutish spam to my email address?</dt>
-        <dd>Never. We will email you if someone leaves an update on a
-problem you&rsquo;ve reported, and send you a questionnaire email four weeks
-after you submit a problem, asking for a status update; we&rsquo;ll only ever
-send you emails in relation to your problem.</dd>
+<p>
+    We hope it covers everything you need to know, but if you still have any questions
+    please feel free to <a href="/contact">contact us</a>.
+</p>
 
-        <dt>How do I stop receiving emails from you?</dt>
-        <dd>Every alert email we send contains an unsubscribe link at the
-bottom for you to stop receiving that alert. After the first questionnaire
-email on a report, mentioned above, you have to opt in to receive any further
-questionnaire on that report.</dd>
+<h2>What information we collect and how we use it</h2>
 
-    </dl>
+<p>
+    When you submit a report, <b>we pass on your details, and details of the issue, to the
+    council contact</b> or contacts responsible for the area where you located the issue, or
+    other relevant body such as TfL.
+</p>
+
+<h3>
+When you make a report
+</h3>
+
+<p>
+    When you use FixMyStreet to send a report, you provide us with personal information
+    including:
+</p>
+
+<ul>
+    <li>Your name</li>
+    <li>Contact details</li>
+</ul>
+
+<p>
+    We <b>send this information to the body responsible for fixing your issue</b>, as per your
+    choice of category and location.
+</p>
+
+<p>
+    At the same time, <b>your report appears on the FixMyStreet website</b>. Your email address
+    and phone number are not published, and your name is only published if you have opted
+    to do so.
+</p>
+
+<p>
+    Some councils use FixMyStreet on their own websites. If you make a report within the
+    boundaries of one of these councils (either through FixMyStreet.com or via the council
+    website), it will be published on both sites.
+</p>
+
+<p>
+    FixMyStreet provides RSS/JSON feeds which allow anyone to publish reports on their own
+    website or page. Typically these feeds consist of reports made within a specific local
+    area, and are published on community or local interest sites.
+</p>
+
+<p>
+    Note that anything you include in the body of your report will be published in one or
+    all of the places listed above, so please take care to keep personal information such
+    as your contact details to the correct fields.
+</p>
+
+<p>
+    We <b>store your personal details</b>, along with your password where used (passwords are
+    stored in a format that is unreadable to anyone — including us —  known as a hash) and
+    any reports or updates you make, in our own database.
+</p>
+
+<p>
+    These are accessible only to FixMyStreet administrators who adhere to strict internal
+    data-handling policies, and, where a council is a <a href="https://www.fixmystreet.com/pro/">FixMyStreet Pro</a> client, to council
+    staff, whose own data-handling and security policies will apply .
+</p>
+
+<h3>
+    When you add an update or respond to our ‘has your problem been fixed?’ survey
+</h3>
+
+<p>
+    When you add an update to a report, or click through from our ‘has your problem been
+    fixed?’ survey, we record this along with the initial report and your user data.
+</p>
+
+<p>
+    <b>Updates are published on the website</b> but not routinely sent to the council except in
+    cases where a council has opted for full integration. You may opt to include your
+    name; your email address is not published.
+</p>
+
+<h3>
+    When you subscribe to an alert by email
+</h3>
+
+<p>
+    We collect your email address, which we store with the details of whichever alert/s
+    you have subscribed to.
+</p>
+
+<h3>
+    When you contact the support team
+</h3>
+
+<p>
+    Your message will be accessible to our small team of support staff, who adhere to
+    strict internal data-handling policies.
+</p>
+
+<p>
+    <b>Your personal information is never shared, or used for purposes other than those
+    listed above, unless we are obliged to by law.</b>
+</p>
+
+<h2>
+    Research
+</h2>
+
+<p>
+    We sometimes use data from FixMyStreet, or share it with trusted third parties, for
+    research. This data is completely anonymised and contains no identifying details such
+    as names, email addresses or the content of reports. Our Research Data Release policy
+    may be seen on request.
+</p>
+
+<h2>
+    FixMyStreet Pro
+</h2>
+
+<h3>
+    When you make an enquiry
+</h3>
+
+<p>
+    We collect the names, phone numbers and email addresses of council employees who make
+    an enquiry about FixMyStreet Pro, request a callback or join one of our webinars.
+</p>
+
+<p>
+    These details are stored in our internal CRM. In accordance with your request, you
+    will hear from us via the channel which you have selected (email, phone or by mail).
+</p>
+
+<h3>
+    When you subscribe to our newsletter
+</h3>
+
+<p>
+    We add your name and email address to mySociety’s newsletter mailing list, which is
+    managed via <a href="https://mailchimp.com/">Mailchimp</a>. Note that Mailchimp may
+    transfer personal data outside the EU.  Please
+    <a href="https://mailchimp.com/contact">contact Mailchimp</a> with questions or
+    concerns about this.
+</p>
+
+<p>
+    You will receive one general mySociety newsletter monthly; if you have selected to
+    receive one or more of our special interest newsletters, you’ll receive an extra
+    monthly bulletin for each.
+</p>
+
+<h2>
+    What happens when you use FixMyStreet
+</h2>
+
+<h2>
+    Making a report
+</h2>
+
+<ul>
+    <li>
+        When your council responds to your report, if you have provided us with an email
+        address, in most cases <b>their reply will go directly to your email inbox</b>. This
+        response, and any subsequent correspondence, happens outside the FixMyStreet
+        system, except in the case of some councils which have integrated with FixMyStreet
+        so that their responses and auto-updates are published on the report page. If you
+        have submitted via phone verification, you may not receive any response from the
+        council, depending on how their systems are set up.
+    </li>
+    <li>
+        We <b>email you if someone leaves an update</b> on a report you’ve made.
+    </li>
+    <li>
+        We <b>send you a questionnaire email</b> four weeks after you submit a problem, asking
+        for a status update. You can then opt in or out of subsequent status update
+        questionnaires.
+    </li>
+    <li>
+        If your report is particularly interesting, our Communications Manager may get in
+        touch, as we like to feature notable requests on the
+        <a href="https://www.mysociety.org/blog/">mySociety blog</a> (or just
+        <a href="mailto:press@mysociety.org">let us know</a> directly!).
+    </li>
+    <li>
+        We only ever send you emails in relation to your reports or use of the site.
+    </li>
+</ul>
+
+<h3>
+    Subscribing to alerts
+</h3>
+
+<p>
+    We’ll send you an automated email every time someone makes a report within the area
+    you specify, or when updates are made to a report you’ve opted to follow. The
+    frequency of these emails will depend on how large your chosen area is and how many
+    reports are made within it, but you won’t get more than one an hour.
+</p>
+
+<h2>
+    Unsubscribing
+</h2>
+
+<h3>
+    How do I stop receiving emails from you?
+</h3>
+
+<p>
+    Every alert email we send contains an unsubscribe link at the bottom for you to stop
+    receiving that alert. After the first questionnaire email on a report, mentioned
+    above, you have to opt in to receive any further questionnaire on that report.
+</p>
+
+<h3>
+    Unsubscribing from the newsletter
+</h3>
+
+<p>
+    Every newsletter contains a quick and easy unsubscribe link in its footer.
+</p>
+
+<p>
+    When you unsubscribe from a newsletter managed via Mailchimp, your details remain on
+    the list of past recipients. This is a measure to prevent circumstances such as a
+    member of staff accidentally manually re-adding you. Mailchimp states: “As a
+    compliance measure, subscribers who unsubscribe themselves can't be deleted from your
+    list.”
+</p>
+
+<p>
+    However, provided you are still a subscriber at the point when you contact us, on
+    request your details can be permanently removed from the list -
+    <a href="mailto:enquiries@mysociety.org">please get in touch</a> if you would like
+    this to happen.
+</p>
+
+<h3>
+    Unsubscribing from FixMyStreet Pro marketing activity
+</h3>
+
+<p>
+    All contact will give you the option to opt out of future emails or calls. You may
+    also <a href="mailto:enquiries@mysociety.org">contact us</a> at any time to ask that
+    we remove your details from our CRM. Note that opting out may be a better solution
+    than having your details removed, as it allows us to keep a record that you do not
+    wish to be contacted, and prevents the accidental re-addition of your details.
+</p>
+
+<h2>
+    Legal basis for processing
+</h2>
+
+<p>
+    In using FixMyStreet for any of the functions listed above (sending a report, leaving
+    an update, email alerts, site registration or newsletters), we are processing your data
+    under the legal basis 6(1)(f) – legitimate interests.
+</p>
+
+<h2>
+    Retention periods and your right to removal
+</h2>
+
+<h3>
+    Reports and updates
+</h3>
+
+<p>
+    Except in exceptional circumstances, we do not delete reports or updates made through
+    FixMyStreet. Historic FixMyStreet reports provide an invaluable resource for
+    researchers into the quantity and type of street problems made across the UK during
+    the years the site has been running. This research can help inform civic planners,
+    developers, coders, historians and social scientists, among others.
+</p>
+
+<p>
+    Therefore, <b>if you ask for a report to be removed, in most cases we will instead invite
+    you to anonymise it</b>, so that there is no public connection between the content and
+    your name. You can anonymise reports singly, or in bulk, by logging in to your account
+    and clicking on the ‘“Hide your name” link beside the time and date of your report.
+    From here you may anonymise this report or all reports you have made.
+</p>
+
+<h3>
+    Your personal information
+</h3>
+
+<p>
+    As well as your report or update appearing on the FixMyStreet website, your details,
+    including name and email address, are stored in our admin system.
+</p>
+
+<p>
+    If you submit a report but do not click on the confirmation email, your report will
+    not be sent to the council; however, the report and your details remain in our system
+    and are accessible to site administrators.
+</p>
+
+<p>
+    Please <a href="/contact">contact us</a> if you would like your details to be removed from our admin
+    database.
+</p>
+
+<h3>
+    Support mail
+</h3>
+
+<p>
+    If you contact FixMyStreet via our support email address we keep your message for two
+    years at which point they will be automatically deleted.. This is to aid continuity
+    and so that we can view any historic context which may have bearing on subsequent
+    support mail, even if members of the support staff change. Support staff adhere to
+    internal privacy policies which may be viewed on request.
+</p>
+
+<h3>
+    FixMyStreet Pro
+</h3>
+
+<p>
+    If contact has not been made for a period of 18 months, we will mark your record as
+    inactive, and will not contact you for sales purposes unless you re-establish contact.
+</p>
+
+<h2>
+    Your right to access
+</h2>
+
+<p>
+    You may <a href="/contact">contact us</a> at any time to ask to see what personal data we hold about you.
+</p>
+
+<h2>
+    Your right to complain
+</h2>
+
+<p>
+    If you believe that we have mishandled your data, you have the right to lodge a
+    complaint with the Information Commissioner’s Office.
+    <a href="https://ico.org.uk/concerns/handling/">You can report a concern here</a>
+    (but do contact us first, so that we can try and help).
+</p>
+
+<h3>
+    Who we are
+</h3>
+
+<p>
+    FixMyStreet is run by mySociety, a UK not-for-profit social enterprise. Our registered
+    address is:
+</p>
+
+<p>
+mySociety<br>
+483 Green Lanes<br>
+London<br>
+N13 4BS<br>
+United Kingdom<br>
+</p>
+
+<p>
+    …and we can also be <a href="/contact">contacted here</a>.
+</p>
+
 
 <h2>Cookies</h2>
 
@@ -73,9 +411,9 @@ the cookies and services that this site can use.
 
 <h3>Measuring website usage (Google Analytics)</h3>
 
-<p>We use Google Analytics to collect information about how people use this
-site. We do this to make sure it’s meeting its users’ needs and to understand
-how we could do it better.
+<p>We use Google Analytics software to collect information about how you use
+this site. We do this to help make sure the site is meeting the needs of its
+users and to help us make improvements.
 
 <p>Google Analytics stores information such as what
 pages you visit, how long you are on the site, how you got here, what you click
@@ -85,50 +423,9 @@ do not allow Google to use or share our analytics data for any purpose besides
 providing us with analytics information, and we recommend that any user of
 Google Analytics does the same.
 
-<p>We have also enabled the Advertising Features of Google
-Analytics. In particular, we use <b>Demographics and Interest
-reporting</b> to identify trends in the types of users visiting our
-site, which may be used for internal reporting and improvement of
-the site content.
-
-<p>In technical speak, this allows Google to collect data about your
-traffic via Google
-<a href="https://www.google.com/policies/technologies/types/">advertising
-cookies</a> and
-<a href="https://www.google.com/policies/privacy/key-terms/#toc-terms-identifier">anonymous
-identifiers</a>, in addition to data collected through a standard
-Google Analytics implementation. Regardless of the source of the
-data, we strictly adhere to
-<a href="https://support.google.com/analytics/answer/2700409">Google&rsquo;s
-policy requirements</a> in our treatment of your data. We do not
-facilitate the merging of personally-identifiable information with
-non-personally identifiable information collected through any Google
-advertising product or feature.
-
-<h4>Google’s Official Statement about Analytics Data</h4>
-
-<p>“This website uses Google Analytics, a web analytics service provided by
-Google, Inc. (“Google”). Google Analytics uses “cookies”, which are text files
-placed on your computer, to help the website analyze how users use the site.
-The information generated by the cookie about your use of the website
-(including your IP address) will be transmitted to and stored by Google on
-servers in the United States . Google will use this information for the purpose
-of evaluating your use of the website, compiling reports on website activity
-for website operators and providing other services relating to website activity
-and internet usage. Google may also transfer this information to third parties
-where required to do so by law, or where such third parties process the
-information on Google’s behalf. Google will not associate your IP address with
-any other data held by Google. You may refuse the use of cookies by selecting
-the appropriate settings on your browser, however please note that if you do
-this you may not be able to use the full functionality of this website. By
-using this website, you consent to the processing of data about you by Google
-in the manner and for the purposes set out above.”</p>
-
 <h3>Opting out</h3>
-<p>If you’re unhappy with the idea of sharing the fact you
-visited our site (and any other sites) with Google, you can
-<a href="https://tools.google.com/dlpage/gaoptout/">install the
-official browser plugin for blocking Google Analytics</a>.
+<p>You can <a href="https://tools.google.com/dlpage/gaoptout">opt out of Google
+Analytics cookies</a>.
 
 <p>If you want to disable advertising-based tracking, you can
 <a href="https://www.google.com/settings/ads">adjust your Google Ads


### PR DESCRIPTION
This updates the privacy policy with the changes required to comply with
GDPR.

Fixes #1900 
[skip changelog]

TO DO

- [x] Update lawful basis to refer to legitimate interests, not consent
- [x] Remove section on Google advertising features