### PR TITLE
display the contents of report's extra field in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
         - Add link to admin edit page for reports. #2071
         - Nicer Open311 errors. #2078
         - Deleted body categories now hidden by default #1962
+        - Display contents of report's extra field #1809
     - Development improvements:
         - Add HTML email previewer.
         - Add CORS header to Open311 output. #2022

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -843,6 +843,27 @@ sub report_edit : Path('report_edit') : Args(1) {
     }
 
     $c->stash->{problem} = $problem;
+    if ( $problem->extra ) {
+        my @fields;
+        if ( my $fields = $problem->get_extra_fields ) {
+            for my $field ( @{$fields} ) {
+                my $name = $field->{description} ?
+                    "$field->{description} ($field->{name})" :
+                    "$field->{name}";
+                push @fields, { name => $name, val => $field->{value} };
+            }
+        }
+        my $extra = $problem->get_extra_metadata;
+        if ( $extra->{duplicates} ) {
+            push @fields, { name => 'Duplicates', val => join( ',', @{ $problem->get_extra_metadata('duplicates') } ) };
+            delete $extra->{duplicates};
+        }
+        for my $key ( keys %$extra ) {
+            push @fields, { name => $key, val => $extra->{$key} };
+        }
+
+        $c->stash->{extra_fields} = \@fields;
+    }
 
     $c->forward('/auth/get_csrf_token');
 

--- a/templates/web/base/admin/report_edit.html
+++ b/templates/web/base/admin/report_edit.html
@@ -92,7 +92,6 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
 <li>[% loc('Cobrand:') %] [% problem.cobrand %]
 <br><small>[% loc('Cobrand data:') %] [% cobrand_data OR '<em>' _ loc('None') _ '</em>' %]</small>
 </li>
-<li>[% loc('Extra data:') %] [% problem.extra ? 'Yes' : 'No' %]</li>
 <li>[% loc('Going to send questionnaire?') %] [% IF problem.send_questionnaire %][% loc('Yes') %][% ELSE %][% loc('No') %][% END %]</li>
 
 <li><label for="external_id">[% loc('External ID') %]:</label>
@@ -126,6 +125,7 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
 <li><label class="inline-text" for="category">[% loc('Category:') %]</label>
     [% INCLUDE 'admin/report-category.html' %]
 </li>
+<li>[% loc('Extra data:') %] [% IF extra_fields.size %]<ul>[% FOREACH field IN extra_fields %]<li><strong>[% field.name %]</strong>: [% field.val %]</li>[% END %]</ul>[% ELSE %]No[% END %]</li>
 <li><label class="inline-text" for="anonymous">[% loc('Anonymous:') %]</label>
 <select class="form-control" name="anonymous"  id="anonymous">
 <option [% 'selected ' IF problem.anonymous %]value="1">[% loc('Yes') %]</option>


### PR DESCRIPTION
Instead of just a Yes/No display a formatted list of values in extra.
Has special handling for known fields otherwise just prints them out
dumbly.

Fixes #1809