### PR TITLE
hide deleted contacts by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
         - Bulk user import admin page. #2057
         - Add link to admin edit page for reports. #2071
         - Nicer Open311 errors. #2078
+        - Deleted body categories now hidden by default #1962
     - Development improvements:
         - Add HTML email previewer.
         - Add CORS header to Open311 output. #2022

--- a/web/cobrands/fixmystreet/admin.js
+++ b/web/cobrands/fixmystreet/admin.js
@@ -51,7 +51,7 @@ $(function(){
     // on a body's page, hide/show deleted contact categories
     var $table_with_deleted_contacts = $('table tr.is-deleted td.contact-category').closest('table');
     if ($table_with_deleted_contacts.length == 1) {
-        var $toggle_deleted_btn = $("<input type='submit' class='btn' value='Hide deleted contacts' id='toggle-deleted-contacts-btn' style='margin:1em 0;'/>");
+        var $toggle_deleted_btn = $("<input type='submit' class='btn' value='Show deleted contacts' id='toggle-deleted-contacts-btn' style='margin:1em 0;'/>");
         $table_with_deleted_contacts.before($toggle_deleted_btn);
         $toggle_deleted_btn.on('click', function(e){
             e.preventDefault();

--- a/web/cobrands/sass/_admin.scss
+++ b/web/cobrands/sass/_admin.scss
@@ -69,6 +69,10 @@ $button_bg_col: #a1a1a1;  // also search bar (tables)
     }
 }
 
+.js tr.is-deleted {
+  display: none;
+}
+
 .admin-box { // for delimiting forms, etc
     border:1px solid #999;
     padding:0.5em 1em;


### PR DESCRIPTION
If JavaScript is enabled hide the deleted contacts from the list on the
body page. Display as normal if no JavaScript.

Fixes #1962