### PR TITLE
Don’t trigger response templates unless problem state changes

### DIFF
--- a/t/open311/getservicerequestupdates.t
+++ b/t/open311/getservicerequestupdates.t
@@ -358,6 +358,18 @@ for my $test (
         end_state => 'investigating',
     },
     {
+        desc => 'unchanging state does not trigger auto-response template',
+        description => '',
+        xml_description => '',
+        external_id => 638344,
+        start_state => 'investigating',
+        comment_status => 'INVESTIGATING',
+        mark_fixed => 0,
+        mark_open => 0,
+        problem_state => 'investigating',
+        end_state => 'investigating',
+    },
+    {
         desc => 'open status does not re-open hidden report',
         description => 'This is a note',
         external_id => 638344,


### PR DESCRIPTION
Response templates won't be triggered unless the problem state or
external status code is changed.

Fixes #2075 
[skip changelog]