### PR TITLE
[Open311] warn about send-comments errors if verbose flag set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
         - Response templates can be triggered by external status code. #2048
         - Cobrand hook for adding extra areas to MAPIT_WHITELIST/_TYPES. #2049
         - Enable conversion from EPSG:27700 when fetching over Open311 #2028
+        - send-comments warns about errors when called with --verbose #2091
     - Front end improvements:
         - Improve questionnaire process. #1939 #1998
         - Increase size of "sub map links" (hide pins, permalink, etc) #2003 #2056

--- a/bin/send-comments
+++ b/bin/send-comments
@@ -153,8 +153,12 @@ while ( my $body = $bodies->next ) {
             $comment->update( {
                 send_fail_count => $comment->send_fail_count + 1,
                 send_fail_timestamp => \'current_timestamp',
-                send_fail_reason => 'Failed to post over Open311',
+                send_fail_reason => "Failed to post over Open311\n\n" . $o->error,
             } );
+
+            if ( $verbose && $o->error ) {
+                warn $o->error;
+            }
         }
     }
 }


### PR DESCRIPTION
Previously send-comments errors would only be printed the first time
they occurred so there was no visibility of ongoing errors. This brings
send-comments in line with send-reports by emitting errors if the script
is called with --verbose.

Fixes #2091