### PR TITLE
Don’t strip whitespace from user passwords during registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
         - Fix SQL error on update edit admin page in cobrands. #2049
         - Improve chart display in old IE versions. #2005
         - Improve handling of Open311 state changes. #2069
+        - Don't strip whitespace from user passwords. #2111
     - Admin improvements:
         - Inspectors can set non_public status of reports. #1992
         - Default start date is shown on the dashboard.

--- a/perllib/FixMyStreet/App/Controller/Alert.pm
+++ b/perllib/FixMyStreet/App/Controller/Alert.pm
@@ -369,7 +369,7 @@ sub process_user : Private {
 #        return 1;
 #    }
 #
-#    $alert_user->password( Utils::trim_text( $params{password_register} ) );
+#    $alert_user->password( $params{password_register} );
 }
 
 =head2 setup_coordinate_rss_feeds

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -829,7 +829,7 @@ sub process_user : Private {
     $c->forward('update_user', [ \%params ]);
     if ($params{password_register}) {
         $c->forward('/auth/test_password', [ $params{password_register} ]);
-        $report->user->password(Utils::trim_text($params{password_register}));
+        $report->user->password($params{password_register});
     }
 
     return 1;

--- a/perllib/FixMyStreet/App/Controller/Report/Update.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/Update.pm
@@ -156,7 +156,7 @@ sub process_user : Private {
 
     if ($params{password_register}) {
         $c->forward('/auth/test_password', [ $params{password_register} ]);
-        $update->user->password(Utils::trim_text($params{password_register}));
+        $update->user->password($params{password_register});
     }
 
     return 1;


### PR DESCRIPTION
If a new user registers during the report/update process
and their password starts or ends with whitespace or has
consecutive whitespace chars then those would be stripped
and the entered password wouldn’t work for subsequent logins.
