### PR TITLE
Allow cobrands to supply arbitrary extra query params for map pins

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -257,12 +257,16 @@ sub map_features : Private {
 
     return if $c->get_param('js'); # JS will request the same (or more) data client side
 
+    # Allow the cobrand to add in any additional query parameters
+    my $extra_params = $c->cobrand->call_hook('display_location_extra_params');
+
     my ( $on_map, $nearby, $distance ) =
       FixMyStreet::Map::map_features(
         $c, %$extra,
         categories => [ keys %{$c->stash->{filter_category}} ],
         states => $c->stash->{filter_problem_states},
         order => $c->stash->{sort_order},
+        extra => $extra_params,
       );
 
     my @pins;

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -553,8 +553,10 @@ sub nearby_json : Private {
     # This is for the list template, this is a list on that page.
     $c->stash->{page} = 'report';
 
+    my $extra_params = $c->cobrand->call_hook('display_location_extra_params');
+
     my $nearby = $c->model('DB::Nearby')->nearby(
-        $c, $dist, [ $p->id ], 5, $p->latitude, $p->longitude, [ $p->category ], undef
+        $c, $dist, [ $p->id ], 5, $p->latitude, $p->longitude, [ $p->category ], undef, $extra_params
     );
     # Want to treat these as if they were on map
     $nearby = [ map { $_->problem } @$nearby ];

--- a/perllib/FixMyStreet/DB/ResultSet/Nearby.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Nearby.pm
@@ -10,7 +10,7 @@ sub to_body {
 }
 
 sub nearby {
-    my ( $rs, $c, $dist, $ids, $limit, $mid_lat, $mid_lon, $categories, $states ) = @_;
+    my ( $rs, $c, $dist, $ids, $limit, $mid_lat, $mid_lon, $categories, $states, $extra_params ) = @_;
 
     unless ( $states ) {
         $states = FixMyStreet::DB::Result::Problem->visible_states();
@@ -26,6 +26,9 @@ sub nearby {
     FixMyStreet::DB::ResultSet::Problem->non_public_if_possible($params, $c);
 
     $rs = $c->cobrand->problems_restriction($rs);
+
+    # Add in any optional extra query parameters
+    $params = { %$params, %$extra_params } if $extra_params;
 
     my $attrs = {
         prefetch => 'problem',

--- a/perllib/FixMyStreet/DB/ResultSet/Problem.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Problem.pm
@@ -176,6 +176,9 @@ sub around_map {
 
     $rs->non_public_if_possible($q, $c);
 
+    # Add in any optional extra query parameters
+    $q = { %$q, %{$p{extra}} } if $p{extra};
+
     my $problems = mySociety::Locale::in_gb_locale {
         $rs->search( $q, $attr )->include_comment_counts->page($p{page});
     };

--- a/perllib/FixMyStreet/Map.pm
+++ b/perllib/FixMyStreet/Map.pm
@@ -104,7 +104,7 @@ sub map_features {
         my $limit = 20;
         my @ids = map { $_->id } @$on_map;
         $nearby = $c->model('DB::Nearby')->nearby(
-            $c, $dist, \@ids, $limit, @p{"latitude", "longitude", "categories", "states"}
+            $c, $dist, \@ids, $limit, @p{"latitude", "longitude", "categories", "states", "extra"}
         );
     }
 

--- a/t/app/controller/around.t
+++ b/t/app/controller/around.t
@@ -137,7 +137,7 @@ subtest 'check non public reports are not displayed on around page' => sub {
 };
 
 
-subtest 'check category and status filtering works on /around' => sub {
+subtest 'check category, status and extra filtering works on /around' => sub {
     my $body = $mech->create_body_ok(2237, "Oxfordshire");
 
     my $categories = [ 'Pothole', 'Vegetation', 'Flytipping' ];
@@ -157,6 +157,7 @@ subtest 'check category and status filtering works on /around' => sub {
                 %$params,
                 category => $category,
                 state => $state,
+                external_body => "$category-$state",
             );
             $mech->create_problems_for_body( 1, $body->id, 'Around page', \%report_params );
         }
@@ -185,6 +186,13 @@ subtest 'check category and status filtering works on /around' => sub {
     $json = $mech->get_ok_json( '/around?ajax=1&status=fixed&filter_category=Vegetation&bbox=' . $bbox );
     $pins = $json->{pins};
     is scalar @$pins, 1, 'correct number of fixed Vegetation reports';
+
+    my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Default');
+    $cobrand->mock('display_location_extra_params', sub { { external_body => "Pothole-fixed" } });
+
+    $json = $mech->get_ok_json( '/around?ajax=1&bbox=' . $bbox );
+    $pins = $json->{pins};
+    is scalar @$pins, 1, 'correct number of external_body reports';
 };
 
 subtest 'check skip_around skips around page' => sub {


### PR DESCRIPTION
So that you can build functionality to add extra limitations on to the map pins displayed. Useful for Collideoscope initially to filter out (or in) reports from the Department of Transport's Stats19 Data.
[skip changelog]