### PR TITLE
[Open311] Hide fetched update if no data to show.

### DIFF
--- a/perllib/Open311/GetServiceRequestUpdates.pm
+++ b/perllib/Open311/GetServiceRequestUpdates.pm
@@ -136,8 +136,8 @@ sub update_comments {
                 # a more fine-grained status code that we use within FMS for
                 # response templates.
                 if ( $external_status_code ) {
-                    $comment->set_extra_metadata(external_status_code =>$external_status_code);
-                    $p->set_extra_metadata(external_status_code =>$external_status_code);
+                    $comment->set_extra_metadata(external_status_code => $external_status_code);
+                    $p->set_extra_metadata(external_status_code => $external_status_code);
                 }
 
                 $open311->add_media($request->{media_url}, $comment)
@@ -161,6 +161,10 @@ sub update_comments {
                         $p->state($state);
                     }
                 }
+
+                # If nothing to show (no text, photo, or state change), don't show this update
+                $comment->state('hidden') unless $comment->text || $comment->photo
+                    || ($comment->problem_state && $state ne $old_state);
 
                 $p->lastupdate( $comment->created );
                 $p->update;

--- a/t/open311/getservicerequestupdates.t
+++ b/t/open311/getservicerequestupdates.t
@@ -368,6 +368,7 @@ for my $test (
         mark_open => 0,
         problem_state => 'investigating',
         end_state => 'investigating',
+        comment_state => 'hidden',
     },
     {
         desc => 'open status does not re-open hidden report',
@@ -401,6 +402,7 @@ for my $test (
         is $c->mark_fixed, $test->{mark_fixed}, 'mark_closed correct';
         is $c->problem_state, $test->{problem_state}, 'problem_state correct';
         is $c->mark_open, $test->{mark_open}, 'mark_open correct';
+        is $c->state, $test->{comment_state} || 'confirmed', 'comment state correct';
         is $problem->state, $test->{end_state}, 'correct problem state';
         $problem->comments->delete;
     };


### PR DESCRIPTION
If no text, photo, or state change, hide the update from display.

Question: hide, or not insert them? Not inserting means it'll process them again next time, but presumably with same outcome? So might be better.
Todo: test.
[skip changelog]