### PR TITLE
Extra help text for categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
         - Upgrade Vagrantfile to use Ubuntu Xenial. #2093
         - Add validation to cobrand-specific custom reporting fields.
         - Drop support for IE7, improve IE8 support. #2114
+        - Add ability to have category extra help text.
 
 * v2.3.1 (12th February 2018)
     - Front end improvements:

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -1088,7 +1088,7 @@ sub categories_for_point : Private {
     # Remove the "Pick a category" option
     shift @{$c->stash->{category_options}} if @{$c->stash->{category_options}};
 
-    $c->stash->{categories_hash} = { map { $_->{name} => 1 } @{$c->stash->{category_options}} };
+    $c->stash->{categories_hash} = { map { $_->category => 1 } @{$c->stash->{category_options}} };
 }
 
 sub templates : Path('templates') : Args(0) {

--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -233,7 +233,7 @@ sub check_and_stash_category : Private {
             body_id => [ keys %bodies ],
         },
         {
-            columns => [ 'category' ],
+            columns => [ 'category', 'extra' ],
             order_by => [ 'category' ],
             distinct => 1
         }

--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -228,7 +228,7 @@ sub check_and_stash_category : Private {
     my @bodies = $c->model('DB::Body')->active->for_areas(keys %$all_areas)->all;
     my %bodies = map { $_->id => $_ } @bodies;
 
-    my @contacts = $c->model('DB::Contact')->not_deleted->search(
+    my @categories = $c->model('DB::Contact')->not_deleted->search(
         {
             body_id => [ keys %bodies ],
         },
@@ -238,9 +238,8 @@ sub check_and_stash_category : Private {
             distinct => 1
         }
     )->all;
-    my @categories = map { { name => $_->category, value => $_->category_display } } @contacts;
     $c->stash->{filter_categories} = \@categories;
-    my %categories_mapped = map { $_->{name} => 1 } @categories;
+    my %categories_mapped = map { $_->category => 1 } @categories;
 
     my $categories = [ $c->get_param_list('filter_category', 1) ];
     my %valid_categories = map { $_ => 1 } grep { $_ && $categories_mapped{$_} } @$categories;

--- a/perllib/FixMyStreet/App/Controller/My.pm
+++ b/perllib/FixMyStreet/App/Controller/My.pm
@@ -159,7 +159,7 @@ sub setup_page_data : Private {
     my @categories = $c->stash->{problems_rs}->search({
         state => [ FixMyStreet::DB::Result::Problem->visible_states() ],
     }, {
-        columns => [ 'category' ],
+        columns => [ 'category', 'extra' ],
         distinct => 1,
         order_by => [ 'category' ],
     } )->all;

--- a/perllib/FixMyStreet/App/Controller/My.pm
+++ b/perllib/FixMyStreet/App/Controller/My.pm
@@ -163,7 +163,6 @@ sub setup_page_data : Private {
         distinct => 1,
         order_by => [ 'category' ],
     } )->all;
-    @categories = map { { name => $_->category, value => $_->category_display } } @categories;
     $c->stash->{filter_categories} = \@categories;
 
     $c->stash->{page} = 'my';

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -156,7 +156,7 @@ sub ward : Path : Args(2) {
     $c->stash->{stats} = $c->cobrand->get_report_stats();
 
     my @categories = $c->stash->{body}->contacts->not_deleted->search( undef, {
-        columns => [ 'category' ],
+        columns => [ 'category', 'extra' ],
         distinct => 1,
         order_by => [ 'category' ],
     } )->all;

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -160,7 +160,6 @@ sub ward : Path : Args(2) {
         distinct => 1,
         order_by => [ 'category' ],
     } )->all;
-    @categories = map { { name => $_->category, value => $_->category_display } } @categories;
     $c->stash->{filter_categories} = \@categories;
     $c->stash->{filter_category} = { map { $_ => 1 } $c->get_param_list('filter_category', 1) };
 

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -499,7 +499,7 @@ sub category_options {
     my ($self, $c) = @_;
     my @categories = $c->model('DB::Contact')->not_deleted->all;
     $c->stash->{category_options} = [ map { {
-        name => $_->category, value => $_->category,
+        category => $_->category, category_display => $_->category,
         abbreviation => $_->get_extra_metadata('abbreviation'),
     } } @categories ];
 }

--- a/t/app/controller/admin/report_edit.t
+++ b/t/app/controller/admin/report_edit.t
@@ -558,7 +558,6 @@ subtest "Test setting a report from unconfirmed to something else doesn't cause 
 };
 
 subtest "Test display of report extra data" => sub {
-    $report->unset_extra_metadata;
     $mech->get_ok("/admin/report_edit/$report_id");
     $mech->content_contains('Extra data: No');
     $report->set_extra_metadata('extra_field', 'this is extra data');

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -1,3 +1,4 @@
+use Test::MockModule;
 use FixMyStreet::TestMech;
 use FixMyStreet::App;
 use Web::Scraper;
@@ -1084,6 +1085,21 @@ subtest "Test inactive categories" => sub {
         $mech->content_contains('Trees');
         # Change back
         $contact2->update( { state => 'confirmed' } );
+    };
+};
+
+subtest "category groups" => sub {
+    my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::FixMyStreet');
+    $cobrand->mock('enable_category_groups', sub { 1 });
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'fixmystreet',
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $contact2->update( { extra => { group => 'Roads' } } );
+        $contact9->update( { extra => { group => 'Roads' } } );
+        $contact10->update( { extra => { group => 'Roads' } } );
+        $mech->get_ok("/report/new?lat=$saved_lat&lon=$saved_lon");
+        $mech->content_like(qr{<optgroup label="Roads">\s*<option value='Potholes'>Potholes</option>\s*<option value='Street lighting'>Street lighting</option></optgroup>});
     };
 };
 

--- a/templates/web/base/admin/report-category.html
+++ b/templates/web/base/admin/report-category.html
@@ -7,7 +7,7 @@
   [% IF category_options.size %]
     <optgroup label="[% loc('Available categories') %]">
       [% FOREACH cat IN category_options %]
-        <option value="[% cat.name | html %]"[% ' selected' IF problem.category == cat.name %]>[% cat.value | html %]</option>
+        <option value="[% cat.category | html %]"[% ' selected' IF problem.category == cat.category %]>[% cat.category_display | html %]</option>
       [% END %]
     </optgroup>
   [% END %]

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -67,7 +67,7 @@
         </p>
 
         [% FOREACH category IN category_options %]
-          [% cat_name = category.name;
+          [% cat_name = category.category;
              cat_prefix = cat_name | lower | replace('[^a-z]', '');
              cat_prefix = "category_" _ cat_prefix _ "_" %]
             <p data-category="[% cat_name | html %]"

--- a/templates/web/base/report/new/category.html
+++ b/templates/web/base/report/new/category.html
@@ -2,7 +2,9 @@
     [%~ BLOCK category_option ~%]
     [% cat_op_lc = cat_op.category | lower =%]
     <option value='[% cat_op.category | html %]'[% ' selected' IF report.category == cat_op.category || category_lc == cat_op_lc || (category_options.size == 2 AND loop.last) ~%]
-    >[% IF loop.first %][% cat_op.category_display %][% ELSE %][% cat_op.category_display | html %][% END %]</option>
+    >[% IF loop.first %][% cat_op.category_display %][% ELSE %][% cat_op.category_display | html %][% END %]
+    [%~ IF cat_op.get_extra_metadata('help_text') %] ([% cat_op.get_extra_metadata('help_text') %])[% END ~%]
+    </option>
     [%~ END ~%]
 
     [% IF category;

--- a/templates/web/base/report/new/category.html
+++ b/templates/web/base/report/new/category.html
@@ -1,8 +1,8 @@
 [% IF category_options.size OR category_groups.size ~%]
     [%~ BLOCK category_option ~%]
-    [% cat_op_lc = cat_op.name | lower =%]
-    <option value='[% cat_op.name | html %]'[% ' selected' IF report.category == cat_op.name || category_lc == cat_op_lc || (category_options.size == 2 AND loop.last) ~%]
-    >[% IF loop.first %][% cat_op.value %][% ELSE %][% cat_op.value | html %][% END %]</option>
+    [% cat_op_lc = cat_op.category | lower =%]
+    <option value='[% cat_op.category | html %]'[% ' selected' IF report.category == cat_op.category || category_lc == cat_op_lc || (category_options.size == 2 AND loop.last) ~%]
+    >[% IF loop.first %][% cat_op.category_display %][% ELSE %][% cat_op.category_display | html %][% END %]</option>
     [%~ END ~%]
 
     [% IF category;

--- a/templates/web/base/reports/_list-filters.html
+++ b/templates/web/base/reports/_list-filters.html
@@ -40,6 +40,7 @@
         [% FOR cat IN filter_categories %]
             <option value="[% cat.category | html %]"[% ' selected' IF filter_category.${cat.category} %]>
                 [% cat.category_display | html %]
+                [%~ IF cat.get_extra_metadata('help_text') %] ([% cat.get_extra_metadata('help_text') %])[% END ~%]
             </option>
         [% END %]
     </select>

--- a/templates/web/base/reports/_list-filters.html
+++ b/templates/web/base/reports/_list-filters.html
@@ -38,8 +38,8 @@
   [% IF filter_categories.size %]
     <select class="form-control js-multiple" name="filter_category" id="filter_categories" multiple data-all="[% loc('Everything') %]">
         [% FOR cat IN filter_categories %]
-            <option value="[% cat.name | html %]"[% ' selected' IF filter_category.${cat.name} %]>
-                [% cat.value | html %]
+            <option value="[% cat.category | html %]"[% ' selected' IF filter_category.${cat.category} %]>
+                [% cat.category_display | html %]
             </option>
         [% END %]
     </select>

--- a/templates/web/zurich/admin/report_edit.html
+++ b/templates/web/zurich/admin/report_edit.html
@@ -171,7 +171,7 @@
             <select class="form-control" name="category" id="category">
                 <option value="">--</option>
               [% FOREACH cat IN category_options %]
-                <option value="[% cat.name %]">[% cat.value ~%]
+                <option value="[% cat.category %]">[% cat.category_display ~%]
                     [% ' (' _ cat.abbreviation _ ')' IF cat.abbreviation %]</option>
               [% END %]
             </select>

--- a/templates/web/zurich/admin/stats/index.html
+++ b/templates/web/zurich/admin/stats/index.html
@@ -27,7 +27,7 @@
   <select class="form-control" name="category" id="category">
     <option value="">--</option>
   [% FOREACH cat IN category_options %]
-    <option value="[% cat.name %]"[% ' selected' IF cat.name == category %]>[% cat.value ~%]
+    <option value="[% cat.category %]"[% ' selected' IF cat.category == category %]>[% cat.category_display ~%]
         [% ' (' _ cat.abbreviation _ ')' IF cat.abbreviation %]</option>
   [% END %]
   </select>


### PR DESCRIPTION
This displays a category's extra `help_text` if present in list filters and when reporting.
It also takes the opportunity to just pass around Contact objects rather than map them to smaller hashes.