### PR TITLE
[Bromley] fix inability to click hide update checkbox

### DIFF
--- a/templates/web/base/report/update.html
+++ b/templates/web/base/report/update.html
@@ -4,6 +4,7 @@
     <ul class="item-list item-list--updates">
 [% END %]
         <li class="item-list__item item-list__item--updates">
+            <a name="update_[% update.id %]" class="internal-link-fixed-header"></a>
           [% IF permissions.moderate; original_update = update.moderation_original_data %]
             <form method="post" action="/moderate/report/[% problem.id %]/update/[% update.id %]">
                 <input type="hidden" name="token" value="[% csrf_token %]">
@@ -25,7 +26,6 @@
                     <p class="meta-2">[% INCLUDE meta_line %]</p>
                 </div>
             [% ELSE %]
-                <a name="update_[% update.id %]" class="internal-link-fixed-header"></a>
                 [% INCLUDE 'report/photo.html' object=update %]
                 <div class="item-list__update-text">
                     <div class="moderate-display">

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -13,13 +13,8 @@ $header-top-border: $header-top-border-width solid $primary !default;
 
 .internal-link-fixed-header {
     display: block;
-    @if unit($mappage-header-height) == 'em' {
-        padding-top: $mappage-header-height + 1em;
-        margin-top: -($mappage-header-height + 1em);
-    } @else {
-        padding-top: $mappage-header-height + 16px;
-        margin-top: -($mappage-header-height + 16px);
-    }
+    position: relative;
+    top: -2em;
 }
 
 //hacks for desk/mob only stuff


### PR DESCRIPTION
The internal link for updates to enable #update_n anchor links to work
has some padding/margin CSS to make sure the place scrolled to doesn't
obscure any of the update. This is partly based on the page header and
does not interact well with the header for the Bromley cobrand
preventing the user from clicking on the update moderation checkboxes.
By overriding the margin/padding for Bromley the anchor link still works
and the checkboxes also work

Fixes mysociety/fixmystreet-commercial#1027

[skip changelog]