### PR TITLE
Avoid empty space either side of "key tools" drawer when open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
         - Make OpenGraph description translatable.
         - Stop double-escaping title in alert-update email.
         - Use inspection states in response template admin.
+        - Fixed CSS padding/overflow bug during sidebar "drawer" animations. #2132
     - Admin improvements:
         - Inspectors can set non_public status of reports. #1992
         - Default start date is shown on the dashboard.

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -699,6 +699,7 @@ body.authpage {
 
   &.static {
     padding: 0 0 1em;
+    margin: 0 -1em; // overlap parent side padding
     position: static;
     width: auto; // avoid horizontal scrollbar as drawer opens (on devices with permanent scroll bars)
   }


### PR DESCRIPTION
Fixes #2124.

# Before

![screen shot 2018-05-18 at 16 00 15](https://user-images.githubusercontent.com/739624/40242134-b1ea69ce-5ab4-11e8-9322-4f22606b6452.png)

# After

![screen shot 2018-05-18 at 16 00 44](https://user-images.githubusercontent.com/739624/40242142-b53e419a-5ab4-11e8-818a-c64fd5e65572.png)
