### PR TITLE
Escape data attributes in template.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
         - Stop double-escaping title in alert-update email.
         - Use inspection states in response template admin.
         - Fixed CSS padding/overflow bug during sidebar "drawer" animations. #2132
+        - Response template containing double quote now works.
     - Admin improvements:
         - Inspectors can set non_public status of reports. #1992
         - Default start date is shown on the dashboard.

--- a/perllib/FixMyStreet/DB/ResultSet/DefectType.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/DefectType.pm
@@ -4,7 +4,6 @@ use base 'DBIx::Class::ResultSet';
 use strict;
 use warnings;
 use Moo;
-use HTML::Entities;
 
 with('FixMyStreet::Roles::ContactExtra');
 
@@ -16,10 +15,10 @@ sub map_extras {
     my ($rs, @ts) = @_;
     return map {
         my $meta = $_->get_extra_metadata();
-        my %extra = map { $_ => encode_entities($meta->{$_}) } keys %$meta;
+        my %extra = map { $_ => $meta->{$_} } keys %$meta;
         {
             id => $_->id,
-            name => encode_entities($_->name),
+            name => $_->name,
             extra => \%extra
         }
     } @ts;

--- a/perllib/FixMyStreet/DB/ResultSet/ResponsePriority.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/ResponsePriority.pm
@@ -4,7 +4,6 @@ use base 'DBIx::Class::ResultSet';
 use strict;
 use warnings;
 use Moo;
-use HTML::Entities;
 
 with('FixMyStreet::Roles::ContactExtra');
 
@@ -14,7 +13,7 @@ sub join_table {
 
 sub map_extras {
     my ($rs, @ts) = @_;
-    return map { { id => $_->id, name => encode_entities($_->name) } } @ts;
+    return map { { id => $_->id, name => $_->name } } @ts;
 }
 
 1;

--- a/perllib/FixMyStreet/DB/ResultSet/ResponseTemplate.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/ResponseTemplate.pm
@@ -2,7 +2,6 @@ package FixMyStreet::DB::ResultSet::ResponseTemplate;
 use base 'DBIx::Class::ResultSet';
 
 use Moo;
-use HTML::Entities;
 
 with('FixMyStreet::Roles::ContactExtra');
 
@@ -17,8 +16,8 @@ sub name_column {
 sub map_extras {
     my ($rs, @ts) = @_;
     return map {
-        my $out = { id => encode_entities($_->text), name => encode_entities($_->title) };
-        $out->{state} = encode_entities($_->state) if $_->state;
+        my $out = { id => $_->text, name => $_->title };
+        $out->{state} = $_->state if $_->state;
         $out;
     } @ts;
 }

--- a/t/app/model/defecttype.t
+++ b/t/app/model/defecttype.t
@@ -99,27 +99,6 @@ subtest 'by_categories returns defect types for an area with multiple bodies' =>
     is scalar @$pavements, 3, 'Pavements have 3 defect types';
 };
 
-subtest 'by_categories encodes HTML entities' => sub {
-    my $apostrophe_defect_type = FixMyStreet::App->model('DB::DefectType')->find_or_create(
-        {
-            body_id => $oxfordshire->id,
-            name => 'This defect type\'s name has an apostrophe',
-            description => 'This defect type is for all categories'
-        }
-    );
-    $apostrophe_defect_type->set_extra_metadata('defect_code' => 'Here\'s an apostrophe');
-    $apostrophe_defect_type->update();
-
-    my @contacts = FixMyStreet::DB->resultset('Contact')->not_deleted->search( { body_id => [ $oxfordshire->id ] } )->all;
-    my $defect_types = FixMyStreet::App->model('DB::DefectType')->by_categories($area_id, @contacts);
-    my $traffic_lights = decode_json($defect_types->{'Traffic lights'});
-    my $defect_type = @$traffic_lights[2];
-    is $defect_type->{name}, 'This defect type&#39;s name has an apostrophe';
-    is $defect_type->{extra}->{defect_code}, 'Here&#39;s an apostrophe';
-
-};
-
-
 END {
     done_testing();
 }

--- a/t/app/model/responsepriority.t
+++ b/t/app/model/responsepriority.t
@@ -78,24 +78,6 @@ subtest 'by_categories returns all response priorities for an area with multiple
     is scalar @$traffic_lights, 2, 'Traffic lights have 2 defect types';
 };
 
-subtest 'by_categories encodes HTML entities' => sub {
-    FixMyStreet::App->model('DB::ResponsePriority')->find_or_create(
-        {
-            body_id => $other_body->id,
-            name => 'This priority\'s name has an apostrophe',
-            description => 'This priority is for all categories'
-        }
-    );
-
-    my @contacts = FixMyStreet::DB->resultset('Contact')->not_deleted->search( { body_id => [ $oxfordshire->id ] } )->all;
-    my $priorities = FixMyStreet::App->model('DB::ResponsePriority')->by_categories($area_id, @contacts);
-
-    my $traffic_lights = decode_json($priorities->{'Traffic lights'});
-    use Data::Dumper;
-    my $priority = @$traffic_lights[2];
-    is $priority->{name}, 'This priority&#39;s name has an apostrophe';
-};
-
 END {
     $mech->delete_body( $other_body );
     $mech->delete_body( $oxfordshire );

--- a/t/app/model/responsetemplate.t
+++ b/t/app/model/responsetemplate.t
@@ -1,0 +1,28 @@
+use FixMyStreet::TestMech;
+use JSON::MaybeXS;
+
+my $mech = FixMyStreet::TestMech->new;
+my $area_id = 2651;
+
+my $body = $mech->create_body_ok($area_id, 'Edinburgh Council');
+my $c1 = $mech->create_contact_ok(category => 'Potholes', body_id => $body->id, email => 'p');
+my $c2 = $mech->create_contact_ok(category => 'Graffiti', body_id => $body->id, email => 'g');
+my $t1 = FixMyStreet::DB->resultset('ResponseTemplate')->create({ body_id => $body->id, title => "Title 1", text => "Text 1" });
+my $t2 = FixMyStreet::DB->resultset('ResponseTemplate')->create({ body_id => $body->id, title => "Title 2", text => "Text 2", state => 'investigating' });
+my $t3 = FixMyStreet::DB->resultset('ResponseTemplate')->create({ body_id => $body->id, title => "Title 3", text => "Text 3" });
+$t1->add_to_contacts($c1);
+$t2->add_to_contacts($c2);
+
+my @contacts = FixMyStreet::DB->resultset('Contact')->not_deleted->search( { body_id => [ $body->id ] } )->all;
+
+subtest 'by_categories returns allresponse templates grouped by category' => sub {
+    my $templates = FixMyStreet::App->model('DB::ResponseTemplate')->by_categories($area_id, @contacts);
+    my $potholes = decode_json($templates->{Potholes});
+    my $graffiti = decode_json($templates->{Graffiti});
+
+    is scalar @$potholes, 2, 'Potholes have 2 templates';
+    is scalar @$graffiti, 2, 'Graffiti has 2 templates';
+    is $graffiti->[0]->{state}, 'investigating', 'Graffiti first template has right state';
+};
+
+done_testing;

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -72,9 +72,9 @@
              cat_prefix = "category_" _ cat_prefix _ "_" %]
             <p data-category="[% cat_name | html %]"
                [%~ IF cat_name != problem.category %] class="hidden"[% END %]
-               data-priorities='[% priorities_by_category.$cat_name %]'
-               data-defect-types='[% category_defect_types.$cat_name %]'
-               data-templates='[% templates_by_category.$cat_name %]'>
+               data-priorities='[% priorities_by_category.$cat_name | html %]'
+               data-defect-types='[% category_defect_types.$cat_name | html %]'
+               data-templates='[% templates_by_category.$cat_name | html %]'>
               [% IF cat_name == problem.category %]
                   [% INCLUDE 'report/new/category_extras_fields.html' metas=category_extras.$cat_name hide_notices=1 show_hidden=1 %]
               [% ELSE %]

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -232,6 +232,9 @@ $.extend(fixmystreet.set_up, {
         opts.state = opts.state || $inspect_form.find('[name=state]').val();
         var selector = "[data-category='" + opts.category + "']";
         var data = $inspect_form.find(selector).data('templates') || [];
+        if (data.constructor !== Array) {
+          return;
+        }
         data = $.grep(data, function(d, i) {
             if (!d.state || d.state == opts.state) {
                 return true;
@@ -243,6 +246,9 @@ $.extend(fixmystreet.set_up, {
 
     function populateSelect($select, data, label_formatter) {
       $select.find('option:gt(0)').remove();
+      if (data.constructor !== Array) {
+        return;
+      }
       $.each(data, function(k,v) {
         var label = window.fixmystreet.utils[label_formatter](v);
         var $opt = $('<option></option>').attr('value', v.id).text(label);


### PR DESCRIPTION
This fixes a bug whereby a double quote in an item would not be JSON-escaped
due to being HTML-escaped first, meaning it would not parse as JSON on the
client.