### PR TITLE
Fix CSS specificity bug with new nicetable hover styles

### DIFF
--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2433,7 +2433,7 @@ $nicetable-hover-background: rgba($primary, 0.15) !default;
             background: $nicetable-hover-background;
         }
 
-        thead tr {
+        thead tr:hover {
             background: transparent;
         }
     }


### PR DESCRIPTION
There was a CSS specificity bug in #2137 that meant table heads would change colour on hover, which wasn’t intended. This fixes that!

[skip changelog]