### PR TITLE
add reminder to include link to report on contact form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Releases
 
 * Unreleased
+    - Front end improvements:
+      - Extra help text on contact form #2149
 
 * v2.3.2 (31st May 2018)
     - Front end improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Unreleased
     - Front end improvements:
       - Extra help text on contact form #2149
+    - Bugfixes:
+      - Prevent contact form leaking information about updates #2149
 
 * v2.3.2 (31st May 2018)
     - Front end improvements:

--- a/perllib/FixMyStreet/App/Controller/Contact.pm
+++ b/perllib/FixMyStreet/App/Controller/Contact.pm
@@ -87,9 +87,17 @@ sub determine_contact_type : Private {
     } elsif ($id) {
         $c->forward( '/report/load_problem_or_display_error', [ $id ] );
         if ($update_id) {
-            my $update = $c->model('DB::Comment')->find(
-                { id => $update_id }
-            );
+            my $update = $c->model('DB::Comment')->search(
+                {
+                    id => $update_id,
+                    problem_id => $id,
+                    state => 'confirmed',
+                }
+            )->first;
+
+            unless ($update) {
+                $c->detach( '/page_error_404_not_found', [ _('Unknown update ID') ] );
+            }
 
             $c->stash->{update} = $update;
         }

--- a/templates/web/base/contact/index.html
+++ b/templates/web/base/contact/index.html
@@ -103,6 +103,10 @@
         [% END %]
         <textarea class="form-control required" name="message" id="form_message" rows="7" cols="50">[% message | html %]</textarea>
 
+        [% IF NOT problem AND NOT update %]
+        <p>[% loc('If you are contacting us about a specific report or update please include a link to the report in the message.') %]</p>
+        [% END %]
+
 
         <input class="final-submit green-btn" type="submit" value="[% loc('Send') %]">
 


### PR DESCRIPTION
We get quite a few emails to support that are about a specific problem
but fail to include a link to that problem. This adds some text to the
contact form to ask people to do so.