### PR TITLE
Fix pointer event issue selecting pin on map.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Unreleased
     - Bugfixes:
         - Fix pointer event issue selecting pin on map. #2130
+        - Fix admin navigation links in multi-language installs.
 
 * v2.3.2 (31st May 2018)
     - Front end improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Releases
 
 * Unreleased
+    - Bugfixes:
+        - Fix pointer event issue selecting pin on map. #2130
 
 * v2.3.2 (31st May 2018)
     - Front end improvements:

--- a/templates/web/base/main_nav.html
+++ b/templates/web/base/main_nav.html
@@ -1,7 +1,4 @@
 [%
-    SET base = "";
-    SET base = c.cobrand.base_url IF admin;
-
     # DEFAULT would make sense here, except it treats the empty string as falsy
     # and some cobrands want to set ul_class to an empty string.
     SET ul_class="nav-menu nav-menu--main" UNLESS ul_class.defined;
@@ -11,7 +8,7 @@
       [%~ IF c.req.uri.path == uri AND NOT always_url ~%]
           <span [% attrs %]>[% label %]</span>
       [%~ ELSE ~%]
-          <a href="[% base %][% uri %][% suffix IF suffix %]" [% attrs %]>[% label %]</a>
+          <a href="[% uri %][% suffix IF suffix %]" [% attrs %]>[% label %]</a>
       [%~ END ~%]
     </li>
 [%~ END %]

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1145,6 +1145,9 @@ fixmystreet.display = {
                 fixmystreet.maps.markers_resize(); // force a redraw so the selected marker gets bigger
             }
 
+            // We disabled this upon first touch to prevent it taking effect, re-enable now
+            fixmystreet.maps.click_control.activate();
+
             if (typeof callback === 'function') {
                 callback();
             }

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -311,6 +311,9 @@ $.extend(fixmystreet.utils, {
             return;
         }
 
+        // clickFeature operates on touchstart, we do not want the map click taking place on touchend!
+        fixmystreet.maps.click_control.deactivate();
+
         // All of this, just so that ctrl/cmd-click on a pin works?!
         var event;
         if (typeof window.MouseEvent === 'function') {
@@ -720,7 +723,7 @@ $.extend(fixmystreet.utils, {
         }
 
         if (document.getElementById('mapForm')) {
-            var click = new OpenLayers.Control.Click();
+            var click = fixmystreet.maps.click_control = new OpenLayers.Control.Click();
             fixmystreet.map.addControl(click);
             click.activate();
         }


### PR DESCRIPTION
On a mobile device that implements pointer events, there are two events that
can happen on an /around page – touching the map starts a new report (or goes
back to the map if already on a report page); touching a pin pulls in that
report’s page. The map touch, which uses an OpenLayers.Handler.Click, operates
by default on click, whereas the pin touch, which uses an
OpenLayers.Handler.Feature, operates on touchstart. You end up either starting
a new report, and then it tries to pull in an undefined pin ID report and
errors, or the pin report loads and then you instantly go back to the map page.

The first touchstart event disables click events on the handlers, which fixes
this issue (and hence why the problem does not arise if you drag the map
first). So we disable the click handlers as soon as the map touch control is
activated.

fixes #2130