### PR TITLE
[Oxfordshire] convert UTC string to local time

### DIFF
--- a/perllib/Open311/GetServiceRequestUpdates.pm
+++ b/perllib/Open311/GetServiceRequestUpdates.pm
@@ -69,6 +69,8 @@ sub update_comments {
     # default to asking for last 2 hours worth if not Bromley
     } elsif ( ! $body->areas->{$AREA_ID_BROMLEY} ) {
         my $end_dt = DateTime->now();
+        # Oxfordshire uses local time and not UTC for dates
+        FixMyStreet->set_time_zone($end_dt) if ( $body->areas->{$AREA_ID_OXFORDSHIRE} );
         my $start_dt = $end_dt->clone;
         $start_dt->add( hours => -2 );
 

--- a/t/open311/oxfordshire/open311_services.t
+++ b/t/open311/oxfordshire/open311_services.t
@@ -1,0 +1,37 @@
+use FixMyStreet::Test;
+use POSIX qw(tzset);
+
+my $d;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    $d = dirname(File::Spec->rel2abs(__FILE__));
+}
+
+use lib "$d/../../../bin/oxfordshire";
+
+use_ok 'open311_services';
+
+my $old_tz = $ENV{TZ};
+$ENV{TZ} = 'Europe/London';
+tzset;
+
+is get_utc_iso8601_string('2018-06-01 13:37:42'), '2018-06-01T12:37:42Z', 'convert local to iso UTC';
+
+is get_date_or_nothing('2018-06-01T12:37:42Z'), '2018-06-01 12:37:42', 'convert date format';
+is get_date_or_nothing('2018-06-01T12:37Z'), '2018-06-01 12:37:00', 'convert date format add seconds';
+is get_date_or_nothing('2018-06-01T12:37:42Z', 1), '2018-06-01', 'convert date format and ignore time';
+is get_date_or_nothing('2018/06/01 12:37:42'), '', 'convert date returns nothing if no match';
+
+is get_date_or_nothing('2018-06-07T12:35:08+01:00'), '2018-06-07 12:35:08', 'convert date format with TZ';
+
+$ENV{TZ} = 'Europe/Rome';
+tzset;
+
+is get_utc_iso8601_string('2018-06-01 14:37:42'), '2018-06-01T12:37:42Z', 'convert local to iso UTC alt TZ';
+
+$ENV{TZ} = $old_tz;
+tzset;
+
+done_testing();


### PR DESCRIPTION
Times in the Oxfordshire DB use local time so we need to convert our UTC
strings before using them in queries.

Fixes mysociety/fixmystreet-commercial#1062

[skip changelog]