### PR TITLE
include automated field when editing contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Releases
 
 * Unreleased
+    - Bugfixes:
+      - Don't remove automated fields when editing contacts #2163
 
 * v2.3.4 (7th June 2018)
     - Bugfixes:

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -2145,6 +2145,8 @@ sub update_extra_fields : Private {
         $meta->{variable} = $notice ? 'false' : 'true';
         $meta->{description} = $c->get_param("metadata[$i].description");
         $meta->{datatype_description} = $c->get_param("metadata[$i].datatype_description");
+        $meta->{automated} = $c->get_param("metadata[$i].automated")
+            if $c->get_param("metadata[$i].automated");
 
         if ( $meta->{datatype} eq "singlevaluelist" ) {
             $meta->{values} = [];

--- a/perllib/FixMyStreet/DB/Result/Contact.pm
+++ b/perllib/FixMyStreet/DB/Result/Contact.pm
@@ -94,14 +94,12 @@ sub category_display {
     $self->translate_column('category');
 }
 
-sub get_metadata_for_input {
+sub get_metadata_for_editing {
     my $self = shift;
     my $id_field = $self->id_field;
     my @metadata = @{$self->get_extra_fields};
     # First, ones we always want to ignore (hard-coded, old system)
     @metadata = grep { $_->{code} !~ /^(easting|northing|closest_address|$id_field)$/ } @metadata;
-    # Also ignore any we have with a 'server_set' automated attribute
-    @metadata = grep { !$_->{automated} || $_->{automated} ne 'server_set' } @metadata;
 
     # Just in case the extra data is in an old parsed format
     foreach (@metadata) {
@@ -109,6 +107,16 @@ sub get_metadata_for_input {
             $_->{values} = [ map { { name => $_->{name}[0], key => $_->{key}[0] } } @{$_->{values}->{value}} ];
         }
     }
+    return \@metadata;
+}
+
+sub get_metadata_for_input {
+    my $self = shift;
+    my $metadata = $self->get_metadata_for_editing;
+
+    # Also ignore any we have with a 'server_set' automated attribute
+    my @metadata = grep { !$_->{automated} || $_->{automated} ne 'server_set' } @$metadata;
+
     return \@metadata;
 }
 

--- a/templates/web/base/admin/contact-form.html
+++ b/templates/web/base/admin/contact-form.html
@@ -144,5 +144,5 @@ as well.") %]
         <dt>[% pair.key %]</dt> <dd>[% pair.value %]</dd>
       [% END %]
     </dl>
-    [% INCLUDE 'admin/extra-metadata-form.html' metas=(contact.get_metadata_for_input OR []) %]
+    [% INCLUDE 'admin/extra-metadata-form.html' metas=(contact.get_metadata_for_editing OR []) %]
 </form>

--- a/templates/web/base/admin/extra-metadata-form.html
+++ b/templates/web/base/admin/extra-metadata-form.html
@@ -6,7 +6,17 @@
         <div class="admin-hint"><p>[% loc('The ordering of this field on the report page. Fields are shown in ascending order according to this value.') %]</p></div>
         <label>
             [% loc('Order') %]
-            <input name="metadata[[% loop.index %]].order" data-field-name="order" type=text value="[% meta.order | html %]">
+            <input name="metadata[[% loop.index %]].order" data-field-name="order" type=text value="[% meta.order OR 0 | html %]">
+        </label>
+
+        <div class="admin-hint"><p>[% loc('Whether the field is displayed to the user, included as a hidden field and automatically populated, or set by the server upon Open311 submission. This field is usually set automatically.') %]</p></div>
+        <label>
+            [% loc('Automated') %]
+            <select name="metadata[[% loop.index %]].automated" data-field-name="automated" class="js-metadata-item-type">
+                <option value="" [% meta.automated == '' ? 'selected' : '' %]></option>
+                <option value="server_set" [% meta.automated == 'server_set' ? 'selected' : '' %]>[% loc('Server Set') %]</option>
+                <option value="hidden_field" [% meta.automated == 'hidden_field' ? 'selected' : '' %]>[% loc('Hidden Field') %]</option>
+            </select>
         </label>
 
         <div class="admin-hint"><p>[% loc('The code used to store this field value in the database. e.g. <code>address</code> would be available as <code>problem.extra.address</code> in the templates.') %]</p></div>


### PR DESCRIPTION
Display fields that are automatically filled in the contact editing form
otherwise the data is lost. Also include the automated field in the
form.

Fixes #2136