### PR TITLE
Hide old reports by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
         - Simplify footer CSS. #2107
         - Keep commas in geocode lookups.
         - Show message on reports closed to updates.
+        - Only display last 6 months of reports on around page by default #2098
     - Admin improvements:
         - Category group can be edited.
     - Bugfixes:

--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -253,6 +253,7 @@ sub map_features : Private {
 
     $c->forward( '/reports/stash_report_filter_status' );
     $c->forward( '/reports/stash_report_sort', [ 'created-desc' ]);
+    $c->stash->{show_old_reports} = $c->get_param('show_old_reports');
 
     return if $c->get_param('js'); # JS will request the same (or more) data client side
 

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -758,10 +758,13 @@ sub stash_report_sort : Private {
 
     $sort =~ /^(updated|created|comments)-(desc|asc)$/;
     my $order_by = $types{$1} || $1;
+    # field to use for report age cutoff
+    $c->stash->{report_age_field} = $order_by eq 'comment_count' ? 'lastupdate' : $order_by;
     my $dir = $2;
     $order_by = { -desc => $order_by } if $dir eq 'desc';
 
     $c->stash->{sort_order} = $order_by;
+
     return 1;
 }
 

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -445,6 +445,10 @@ sub reports_per_page {
     return FixMyStreet->config('ALL_REPORTS_PER_PAGE') || 100;
 }
 
+sub report_age {
+    return '6 months';
+}
+
 =item reports_ordering
 
 The order_by clause to use for reports on all reports page

--- a/perllib/FixMyStreet/DB/ResultSet/Nearby.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Nearby.pm
@@ -10,7 +10,7 @@ sub to_body {
 }
 
 sub nearby {
-    my ( $rs, $c, $dist, $ids, $limit, $mid_lat, $mid_lon, $categories, $states, $extra_params ) = @_;
+    my ( $rs, $c, $dist, $ids, $limit, $mid_lat, $mid_lon, $categories, $states, $extra_params, $report_age ) = @_;
 
     unless ( $states ) {
         $states = FixMyStreet::DB::Result::Problem->visible_states();
@@ -22,6 +22,9 @@ sub nearby {
     $params->{id} = { -not_in => $ids }
         if $ids;
     $params->{category} = $categories if $categories && @$categories;
+
+    $params->{$c->stash->{report_age_field}} = { '>=', \"current_timestamp-'$report_age'::interval" }
+        if $report_age;
 
     FixMyStreet::DB::ResultSet::Problem->non_public_if_possible($params, $c);
 

--- a/perllib/FixMyStreet/DB/ResultSet/Problem.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Problem.pm
@@ -172,6 +172,9 @@ sub around_map {
             latitude => { '>=', $p{min_lat}, '<', $p{max_lat} },
             longitude => { '>=', $p{min_lon}, '<', $p{max_lon} },
     };
+
+    $q->{$c->stash->{report_age_field}} = { '>=', \"current_timestamp-'$p{report_age}'::interval" } if
+        $p{report_age};
     $q->{category} = $p{categories} if $p{categories} && @{$p{categories}};
 
     $rs->non_public_if_possible($q, $c);

--- a/t/map/tilma/original.t
+++ b/t/map/tilma/original.t
@@ -91,6 +91,7 @@ for my $test (
     subtest "pin colour for state $test->{state}" => sub {
         $report->state($test->{state});
         $report->update;
+        $c->stash->{report_age_field} = 'lastupdate';
 
         my ( $on_map, $nearby, $dist ) =
             FixMyStreet::Map::map_features($c, bbox => "0,0,0,0");

--- a/templates/web/base/around/on_map_list_items.html
+++ b/templates/web/base/around/on_map_list_items.html
@@ -1,4 +1,4 @@
-<ul class="item-list item-list--reports">
+<ul class="item-list item-list--reports"[%' data-show-old-reports="1"' IF num_old_reports > 0 %]>
 [% IF on_map.size %]
     [% FOREACH problem IN on_map %]
         [% INCLUDE 'reports/_list-entry.html' %]

--- a/templates/web/base/pagination.html
+++ b/templates/web/base/pagination.html
@@ -8,6 +8,8 @@
 
         [% IF pager.next_page %]
             <a class="next" href="[% c.uri_with({ $param => pager.next_page, ajax => undefined }) %][% '#' _ hash IF hash %]">[% loc('Next') %]</a>
+        [% ELSIF num_old_reports > 0 AND NOT show_old_reports AND page == 'around' %]
+            <a class="next show_old" href="[% c.uri_with({ $param => pager.current_page, show_old_reports = 1, ajax => undefined }) %][% '#' _ hash IF hash %]">[% loc('Show older') %]</a>
         [% END %]
     </p>
 [% END %]

--- a/templates/web/base/reports/_list-filters.html
+++ b/templates/web/base/reports/_list-filters.html
@@ -80,6 +80,13 @@
             </select>
             <input type="submit" name="filter_update" value="[% loc('Go') %]">
         </p>
+        [% IF page == 'around' %]
+        <p id="show_old_reports_wrapper" class="report-list-filters[% ' hidden' UNLESS num_old_reports > 0 %]">
+            <label for="show_old_reports">[% loc('Show older reports') %]</label>
+            <input type="checkbox" name="show_old_reports" id="show_old_reports" value="1"[% ' checked' IF show_old_reports %]>
+            <input type="submit" name="filter_update" value="[% loc('Go') %]">
+        </p>
+        [% END %]
 
 [% IF use_form_wrapper %]
     </form>

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1291,6 +1291,9 @@ $(function() {
                 } else if ('page_change' in e.state) {
                     $('.pagination').data('page', e.state.page_change.page)
                         .trigger('change.filters');
+                    if ( fixmystreet.page != 'reports' ) {
+                        fixmystreet.display.reports_list(location.href);
+                    }
                 } else if ('filter_change' in e.state) {
                     $('#filter_categories').val(e.state.filter_change.filter_categories);
                     $('#statuses').val(e.state.filter_change.statuses);

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1280,7 +1280,7 @@ $(function() {
                     if (fixmystreet.utils && fixmystreet.utils.parse_query_string) {
                         var qs = fixmystreet.utils.parse_query_string();
                         var page = qs.p || 1;
-                        $('.pagination').data('page', page)
+                        $('.pagination:first').data('page', page)
                             .trigger('change.filters');
                     }
                     fixmystreet.display.reports_list(location.href);
@@ -1289,7 +1289,8 @@ $(function() {
                 } else if ('newReportAtLonlat' in e.state) {
                     fixmystreet.display.begin_report(e.state.newReportAtLonlat, false);
                 } else if ('page_change' in e.state) {
-                    $('.pagination').data('page', e.state.page_change.page)
+                    fixmystreet.markers.protocol.use_page = true;
+                    $('.pagination:first').data('page', e.state.page_change.page) //;
                         .trigger('change.filters');
                     if ( fixmystreet.page != 'reports' ) {
                         fixmystreet.display.reports_list(location.href);

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1280,6 +1280,7 @@ $(function() {
                     if (fixmystreet.utils && fixmystreet.utils.parse_query_string) {
                         var qs = fixmystreet.utils.parse_query_string();
                         var page = qs.p || 1;
+                        $('#show_old_reports').prop('checked', qs.show_old_reports || '');
                         $('.pagination:first').data('page', page)
                             .trigger('change.filters');
                     }
@@ -1290,6 +1291,7 @@ $(function() {
                     fixmystreet.display.begin_report(e.state.newReportAtLonlat, false);
                 } else if ('page_change' in e.state) {
                     fixmystreet.markers.protocol.use_page = true;
+                    $('#show_old_reports').prop('checked', e.state.page_change.show_old_reports);
                     $('.pagination:first').data('page', e.state.page_change.page) //;
                         .trigger('change.filters');
                     if ( fixmystreet.page != 'reports' ) {
@@ -1299,6 +1301,7 @@ $(function() {
                     $('#filter_categories').val(e.state.filter_change.filter_categories);
                     $('#statuses').val(e.state.filter_change.statuses);
                     $('#sort').val(e.state.filter_change.sort);
+                    $('#show_old_reports').prop('checked', e.state.filter_change.show_old_reports);
                     $('#filter_categories').add('#statuses')
                         .trigger('change.filters').trigger('change.multiselect');
                     fixmystreet.display.reports_list(location.href);

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -387,7 +387,7 @@ $.extend(fixmystreet.utils, {
         }
         var qs = fixmystreet.utils.parse_query_string();
 
-        var page = $('.pagination').data('page');
+        var page = $('.pagination:first').data('page');
         if (page > 1) {
             qs.p = page;
         } else {
@@ -643,11 +643,11 @@ $.extend(fixmystreet.utils, {
             $('.js-pagination').on('change.filters', categories_or_status_changed);
             $('.js-pagination').on('click', 'a', function(e) {
                 e.preventDefault();
-                var page = $('.pagination').data('page');
+                var page = $('.pagination:first').data('page');
                 if ($(this).hasClass('next')) {
-                    $('.pagination').data('page', page + 1);
+                    $('.pagination:first').data('page', page + 1);
                 } else {
-                    $('.pagination').data('page', page - 1);
+                    $('.pagination:first').data('page', page - 1);
                 }
                 fixmystreet.markers.protocol.use_page = true;
                 $(this).trigger('change');
@@ -916,7 +916,7 @@ OpenLayers.Protocol.FixMyStreet = OpenLayers.Class(OpenLayers.Protocol.HTTP, {
         });
         var page;
         if (this.use_page) {
-            page = $('.pagination').data('page');
+            page = $('.pagination:first').data('page');
             this.use_page = false;
         } else if (this.initial_page) {
             page = 1;

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -361,8 +361,14 @@ $.extend(fixmystreet.utils, {
 
     function replace_query_parameter(qs, id, key) {
         var value = $('#' + id).val();
+        if ( $('#' + id).prop('type') == 'checkbox' ) {
+            value = $('#' + id).prop('checked') ? '1' : '';
+        } else if (value) {
+            value = (typeof value === 'string') ? value : fixmystreet.utils.array_to_csv_line(value);
+        }
+
         if (value) {
-            qs[key] = (typeof value === 'string') ? value : fixmystreet.utils.array_to_csv_line(value);
+            qs[key] = value;
         } else {
             delete qs[key];
         }
@@ -387,15 +393,17 @@ $.extend(fixmystreet.utils, {
         }
         var qs = fixmystreet.utils.parse_query_string();
 
+        var show_old_reports = '';
         var page = $('.pagination:first').data('page');
         if (page > 1) {
+            show_old_reports = replace_query_parameter(qs, 'show_old_reports', 'show_old_reports');
             qs.p = page;
         } else {
             delete qs.p;
         }
         var new_url = update_url(qs);
         history.pushState({
-            page_change: { 'page': page }
+            page_change: { 'page': page, 'show_old_reports': show_old_reports }
         }, null, new_url);
     }
 
@@ -407,10 +415,11 @@ $.extend(fixmystreet.utils, {
         var filter_categories = replace_query_parameter(qs, 'filter_categories', 'filter_category');
         var filter_statuses = replace_query_parameter(qs, 'statuses', 'status');
         var sort_key = replace_query_parameter(qs, 'sort', 'sort');
+        var show_old_reports = replace_query_parameter(qs, 'show_old_reports', 'show_old_reports');
         delete qs.p;
         var new_url = update_url(qs);
         history.pushState({
-            filter_change: { 'filter_categories': filter_categories, 'statuses': filter_statuses, 'sort': sort_key }
+            filter_change: { 'filter_categories': filter_categories, 'statuses': filter_statuses, 'sort': sort_key, 'show_old_reports': show_old_reports }
         }, null, new_url);
     }
 
@@ -640,11 +649,14 @@ $.extend(fixmystreet.utils, {
             $("#filter_categories").on("change.filters", categories_or_status_changed);
             $("#statuses").on("change.filters", categories_or_status_changed);
             $("#sort").on("change.filters", categories_or_status_changed);
+            $("#show_old_reports").on("change.filters", categories_or_status_changed);
             $('.js-pagination').on('change.filters', categories_or_status_changed);
             $('.js-pagination').on('click', 'a', function(e) {
                 e.preventDefault();
                 var page = $('.pagination:first').data('page');
-                if ($(this).hasClass('next')) {
+                if ($(this).hasClass('show_old')) {
+                    $("#show_old_reports").prop('checked', true);
+                } else if ($(this).hasClass('next')) {
                     $('.pagination:first').data('page', page + 1);
                 } else {
                     $('.pagination:first').data('page', page - 1);
@@ -655,6 +667,7 @@ $.extend(fixmystreet.utils, {
             $("#filter_categories").on("change.user", categories_or_status_changed_history);
             $("#statuses").on("change.user", categories_or_status_changed_history);
             $("#sort").on("change.user", categories_or_status_changed_history);
+            $("#show_old_reports").on("change.user", categories_or_status_changed_history);
             $('.js-pagination').on('click', 'a', page_changed_history);
         } else if (fixmystreet.page == 'new') {
             drag.activate();
@@ -914,6 +927,9 @@ OpenLayers.Protocol.FixMyStreet = OpenLayers.Class(OpenLayers.Protocol.HTTP, {
                 options.params[key] = val.join ? fixmystreet.utils.array_to_csv_line(val) : val;
             }
         });
+        if ( $('#show_old_reports').is(':checked') ) {
+            options.params.show_old_reports = 1;
+        }
         var page;
         if (this.use_page) {
             page = $('.pagination:first').data('page');
@@ -942,6 +958,11 @@ OpenLayers.Format.FixMyStreet = OpenLayers.Class(OpenLayers.Format.JSON, {
         var reports_list;
         if (typeof(obj.reports_list) != 'undefined' && (reports_list = document.getElementById('js-reports-list'))) {
             reports_list.innerHTML = obj.reports_list;
+            if ( $('.item-list--reports').data('show-old-reports') ) {
+                $('#show_old_reports_wrapper').removeClass('hidden');
+            } else {
+                $('#show_old_reports_wrapper').addClass('hidden');
+            }
         }
         if (typeof(obj.pagination) != 'undefined') {
             $('.js-pagination').html(obj.pagination);


### PR DESCRIPTION
Hides reports older than 6 months on the around page by default.

Fixes #2098