### PR TITLE
Reduce complexity of footer CSS a bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Releases
 
 * Unreleased
+    - Front end improvements:
+        - Simplify footer CSS. #2107
     - Bugfixes:
         - Don't remove automated fields when editing contacts #2163
         - Remove small border to left of Fixed banner. #2156

--- a/templates/web/fixmystreet.com/about/faq-en-gb.html
+++ b/templates/web/fixmystreet.com/about/faq-en-gb.html
@@ -48,7 +48,6 @@ FAQs answer your question first, because that saves your time and ours.
 <a href="https://itunes.apple.com/gb/app/fixmystreet/id297456545">app for iOS</a>
 and an
 <a href="https://play.google.com/store/apps/details?id=org.mysociety.FixMyStreet">Android app</a>.
-A volunteer has also written an <a href="http://store.ovi.com/content/107557">Nokia Ovi app</a>.
 <p>If your phone isn't supported, try accessing FixMyStreet via your mobile
 browser – it should work well.
 </dd>

--- a/templates/web/greenwich/about/faq-en-gb.html
+++ b/templates/web/greenwich/about/faq-en-gb.html
@@ -64,8 +64,6 @@ by a user of the site.</dd>
 			<a href="https://itunes.apple.com/gb/app/fixmystreet/id297456545">FixMyStreet app for iPhone</a>		
 	    <li>
 			<a href="https://play.google.com/store/apps/details?id=org.mysociety.FixMyStreet">FixMyStreet app for Android</a>
-	    <li><em>Nokia:</em> A volunteer, Thomas Forth, has written an app available from the
-			<a href="http://store.ovi.com/content/107557">Ovi Store</a>.
 	</ul>
     </dd>
 

--- a/templates/web/hart/about/faq-en-gb.html
+++ b/templates/web/hart/about/faq-en-gb.html
@@ -62,8 +62,6 @@ by a user of the site.</dd>
 			<a href="https://itunes.apple.com/gb/app/fixmystreet/id297456545">FixMyStreet app for iPhone</a>		
 	    <li>
 			<a href="https://play.google.com/store/apps/details?id=org.mysociety.FixMyStreet">FixMyStreet app for Android</a>
-	    <li><em>Nokia:</em> A volunteer, Thomas Forth, has written an app available from the
-			<a href="http://store.ovi.com/content/107557">Ovi Store</a>.
 	</ul>
     </dd>
 

--- a/templates/web/stevenage/about/faq-en-gb.html
+++ b/templates/web/stevenage/about/faq-en-gb.html
@@ -56,8 +56,6 @@ by a user of the site.</dd>
             <a href="https://itunes.apple.com/gb/app/fixmystreet/id297456545">FixMyStreet app for iPhone</a>
         <li>
             <a href="https://play.google.com/store/apps/details?id=org.mysociety.FixMyStreet">FixMyStreet app for Android</a>
-        <li><em>Nokia:</em> A volunteer, Thomas Forth, has written an app available from the
-            <a href="http://store.ovi.com/content/107557">Ovi Store</a>.
     </ul>
     </dd>
 

--- a/templates/web/stevenage/footer.html
+++ b/templates/web/stevenage/footer.html
@@ -1,30 +1,6 @@
                     [% IF pagefooter %]
                     <footer role="contentinfo">
-                        <div class="tablewrapper bordered">
-                            <div id="footer-mobileapps">
-                                <h4>Mobile apps</h4>
-
-                                <ul>
-                                    <li><a class="m-app-iphone" href="http://itunes.apple.com/gb/app/fixmystreet/id297456545">iPhone</a></li>
-                                    <li><a class="m-app-droid" href="https://market.android.com/details?id=com.android.fixmystreet">Android</a></li>
-                                    <li><a class="m-app-nokia" href="http://store.ovi.com/content/107557">Nokia</a></li>
-                                </ul>
-                            </div>
-
-                            <div id="footer-help">
-                                <ul>
-                                    <li>
-                                        <h4>[% loc('Are you a developer?') %]</h4>
-                                        <p>[% loc('Would you like to contribute to FixMyStreet? Our code is open source and <a href="http://github.com/mysociety/fixmystreet">available on GitHub</a>.') %]</p>
-                                    </li>
-                                    <li>
-                                        <h4>[% loc('Are you from a council?') %]</h4>
-                                        <p>[% loc('Would you like better integration with FixMyStreet? <a href="https://www.fixmystreet.com/pro/">Find out about FixMyStreet Pro</a>.') %]</p>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                        <p><a href="/privacy">Privacy and cookies</a></p>
+                        [% INCLUDE 'front/footer-marketing.html' %]
                     </footer>
                     [% END %]
                 </div><!-- .content role=main -->

--- a/templates/web/stevenage/front/footer-marketing.html
+++ b/templates/web/stevenage/front/footer-marketing.html
@@ -1,0 +1,25 @@
+<div class="tablewrapper bordered">
+    <div id="footer-mobileapps">
+        <h4>Mobile apps</h4>
+
+        <ul>
+            <li><a class="m-app-iphone" href="http://itunes.apple.com/gb/app/fixmystreet/id297456545">iPhone</a></li>
+            <li><a class="m-app-droid" href="https://market.android.com/details?id=com.android.fixmystreet">Android</a></li>
+            <li><a class="m-app-nokia" href="http://store.ovi.com/content/107557">Nokia</a></li>
+        </ul>
+    </div>
+
+    <div id="footer-help">
+        <ul>
+            <li>
+                <h4>[% loc('Are you a developer?') %]</h4>
+                <p>[% loc('Would you like to contribute to FixMyStreet? Our code is open source and <a href="http://github.com/mysociety/fixmystreet">available on GitHub</a>.') %]</p>
+            </li>
+            <li>
+                <h4>[% loc('Are you from a council?') %]</h4>
+                <p>[% loc('Would you like better integration with FixMyStreet? <a href="https://www.fixmystreet.com/pro/">Find out about FixMyStreet Pro</a>.') %]</p>
+            </li>
+        </ul>
+    </div>
+</div>
+<p><a href="/privacy">Privacy and cookies</a></p>

--- a/templates/web/stevenage/front/footer-marketing.html
+++ b/templates/web/stevenage/front/footer-marketing.html
@@ -5,7 +5,6 @@
         <ul>
             <li><a class="m-app-iphone" href="http://itunes.apple.com/gb/app/fixmystreet/id297456545">iPhone</a></li>
             <li><a class="m-app-droid" href="https://market.android.com/details?id=com.android.fixmystreet">Android</a></li>
-            <li><a class="m-app-nokia" href="http://store.ovi.com/content/107557">Nokia</a></li>
         </ul>
     </div>
 

--- a/web/cobrands/bromley/layout.scss
+++ b/web/cobrands/bromley/layout.scss
@@ -66,8 +66,7 @@ h1.main {
 
 // Because we've changed the page background, the footer looks a bit rubbish
 footer,
-body.twothirdswidthpage .container .content footer .tablewrapper,
-body.fullwidthpage .container .content footer .tablewrapper {
+.content footer .tablewrapper {
   background-color: $bromley_blue;
 }
 

--- a/web/cobrands/fixamingata/layout.scss
+++ b/web/cobrands/fixamingata/layout.scss
@@ -119,4 +119,4 @@ body.mappage {
 
 #postcodeForm { margin-left: -1em !important; margin-right: -1em !important; }
 
-body.fullwidthpage .container .content footer .tablewrapper { background: #fff; }
+.content footer .tablewrapper { background: #fff; }

--- a/web/cobrands/greenwich/layout.scss
+++ b/web/cobrands/greenwich/layout.scss
@@ -198,64 +198,62 @@ body.twothirdswidthpage .content .sticky-sidebar {
     }
 }
 
-body.fullwidthpage, body.twothirdswidthpage {
-    .container .content footer {
-        a.platform-logo {
-            background-color: $greenwich_dark_grey;
-            background-position: center center;
-            background-size: 13em 1.5em;
-            width: 14em;
-            height: 3em;
-            border-radius: 1.5em;
-        }
+.content footer {
+    a.platform-logo {
+        background-color: $greenwich_dark_grey;
+        background-position: center center;
+        background-size: 13em 1.5em;
+        width: 14em;
+        height: 3em;
+        border-radius: 1.5em;
+    }
 
-        .tablewrapper {
-            padding: 0;
-            margin: 1em 0;
+    .tablewrapper {
+        padding: 0;
+        margin: 1em 0;
 
-            div {
-                text-align: center;
+        div {
+            text-align: center;
 
-                p {
-                    margin: 0;
-                    padding: 0;
-                    line-height: 3em;
-                }
-            }
-        }
-
-        .footer-nav {
-            padding: 0;
-            margin: 1em 0;
-
-            ul {
+            p {
                 margin: 0;
                 padding: 0;
-                text-align: center;
+                line-height: 3em;
+            }
+        }
+    }
 
-                li {
-                    display: inline;
-                    padding: 0 4px 0 7px;
-                    font-size: 0.8em;
-                    border-left: solid 1px $greenwich_dark_grey;
+    .footer-nav {
+        padding: 0;
+        margin: 1em 0;
 
-                    &:first-child {
-                        border-left: none;
-                    }
+        ul {
+            margin: 0;
+            padding: 0;
+            text-align: center;
 
-                    a, a:link, a:visited {
-                        color: $primary_text;
-                    }
+            li {
+                display: inline;
+                padding: 0 4px 0 7px;
+                font-size: 0.8em;
+                border-left: solid 1px $greenwich_dark_grey;
+
+                &:first-child {
+                    border-left: none;
+                }
+
+                a, a:link, a:visited {
+                    color: $primary_text;
                 }
             }
         }
+    }
 
-        hr {
-            padding: 0;
-            margin: 0 -24px;
-            border-bottom: solid 8px $greenwich_red;
-            border-top: solid 48px $greenwich_dark_grey;
-            height: 0;
-        }
+    hr {
+        padding: 0;
+        margin: 0 -24px;
+        border-bottom: solid 8px $greenwich_red;
+        border-top: solid 48px $greenwich_dark_grey;
+        height: 0;
     }
 }

--- a/web/cobrands/rutland/layout.scss
+++ b/web/cobrands/rutland/layout.scss
@@ -15,10 +15,6 @@ body.frontpage #site-logo {
 }
 
 
-body.fullwidthpage, body.twothirdswidthpage {
-    .container .content footer {
-        a.platform-logo {
-            background-image: url(/cobrands/fixmystreet/images/fms-platform-logo-dark.svg);
-        }
-    }
+a.platform-logo {
+    background-image: url(/cobrands/fixmystreet/images/fms-platform-logo-dark.svg);
 }

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -379,60 +379,47 @@ body.mappage.admin {
   }
 }
 
-body.twothirdswidthpage,
-body.fullwidthpage {
-    .container {
-        .content {
-            footer {
-                margin-top: 0em;
-                margin-bottom: -1em;
-                .tablewrapper {
-                    padding-top: 2em;
-                    padding-bottom: 3em;
-                    background: $base_bg;
-                    color: $base_fg;
-                    a:link,
-                    a:visited {
-                        color: $primary;
-                    }
-                    #footer-mobileapps {
-                        a {
-                            padding-#{$left}: 0.5em;
-                        }
-                    }
-                    h4 {
-                        font-weight: normal;
-                        padding-bottom: 0.5em;
-                    }
-                }
-
-                a.platform-logo {
-                    vertical-align: baseline;
-                    display: inline-block;
-                    background-position: top left;
-                    background-repeat: no-repeat;
-                    background-size: auto 1.5em;
-                    background-image: url(/cobrands/fixmystreet/images/fms-platform-logo.svg);
-                    text-indent: -1000%;
-                    height: 1.7em;
-                    width: 16em;
-                    padding-#{$right}: 0.25em;
-                }
+// Only want to capture footers that are inside .content
+// (like the one in base)
+.content {
+    footer {
+        margin-top: 0em;
+        margin-bottom: -1em;
+        .tablewrapper {
+            padding-top: 2em;
+            padding-bottom: 3em;
+            background: $base_bg;
+            color: $base_fg;
+            a:link,
+            a:visited {
+                color: $primary;
+            }
+            h4 {
+                font-weight: normal;
+                padding-bottom: 0.5em;
             }
         }
     }
-
 }
-.ie8 {
-  body.twothirdswidthpage,
-  body.fullwidthpage {
-    .container .content footer a.platform-logo {
-      color: #ffffff;
-      background: none;
-      text-indent: 0px;
-      height: auto;
+
+a.platform-logo {
+    vertical-align: baseline;
+    display: inline-block;
+    background-position: top left;
+    background-repeat: no-repeat;
+    background-size: auto 1.5em;
+    background-image: url(/cobrands/fixmystreet/images/fms-platform-logo.svg);
+    text-indent: -1000%;
+    height: 1.7em;
+    width: 16em;
+    padding-#{$right}: 0.25em;
+
+    .ie8 & {
+        color: #ffffff;
+        background: none;
+        text-indent: 0px;
+        height: auto;
     }
-  }
 }
 
 // two thirds width page, also has option for a sidebar which can be sticky or not
@@ -535,7 +522,10 @@ body.authpage {
     margin-top:0;
   }
   p {
-	  border-bottom:none;
+    border-bottom:none;
+  }
+  a {
+    padding-#{$left}: 0.5em;
   }
 }
 


### PR DESCRIPTION
Fixes #2107. The offending CSS from the issue is now the much more obvious `#footer-mobileapps a`, and the worst bit in the section is now `.content footer .tablewrapper h4` which is fair enough as it is because `.tablewrapper` and `footer` are both used elsewhere, and I didn't want this to be a big hunt of fixing the classes at the mo!