### PR TITLE
send unresponsive details back with category extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
         - Don't remove automated fields when editing contacts #2163
         - Remove small border to left of Fixed banner. #2156
         - Fix issue displaying admin timeline. #2159
+        - Send details of unresponsive bodies to mobile app #2164
 
 * v2.3.4 (7th June 2018)
     - Bugfixes:

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -227,6 +227,7 @@ sub report_form_ajax : Path('ajax') : Args(0) {
             titles_list     => $extra_titles_list,
             %$contribute_as ? (contribute_as => $contribute_as) : (),
             $top_message ? (top_message => $top_message) : (),
+            unresponsive => $c->stash->{unresponsive}->{ALL} || '',
         }
     );
 
@@ -259,6 +260,7 @@ sub category_extras_ajax : Path('category_extras') : Args(0) {
     my $category_extra = '';
     my $category_extra_json = [];
     my $generate;
+    my $unresponsive = '';
     if ( $c->stash->{category_extras}->{$category} && @{ $c->stash->{category_extras}->{$category} } >= 1 ) {
         $c->stash->{category_extras} = { $category => $c->stash->{category_extras}->{$category} };
         $generate = 1;
@@ -277,11 +279,13 @@ sub category_extras_ajax : Path('category_extras') : Args(0) {
     my $councils_text = $c->render_fragment( 'report/new/councils_text.html', $vars);
     my $councils_text_private = $c->render_fragment( 'report/new/councils_text_private.html');
 
+    $unresponsive = $c->stash->{unresponsive}->{$category} || $c->stash->{unresponsive}->{ALL} || '';
     my $body = encode_json({
         category_extra => $category_extra,
         councils_text => $councils_text,
         councils_text_private => $councils_text_private,
         category_extra_json => $category_extra_json,
+        unresponsive => $unresponsive,
     });
 
     $c->res->content_type('application/json; charset=utf-8');

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -1640,6 +1640,10 @@ subtest "unresponsive body handling works" => sub {
         $mech->get_ok('/report/new/ajax?latitude=55.952055&longitude=-3.189579'); # Edinburgh
         my $body_id = $contact1->body->id;
         ok $mech->content_like( qr{Edinburgh.*accept reports.*/unresponsive\?body=$body_id} );
+        my $extra_details = $mech->get_ok_json('/report/new/ajax?latitude=55.952055&longitude=-3.189579');
+        is $extra_details->{unresponsive}, $body_id, "unresponsive json set";
+        $extra_details = $mech->get_ok_json('/report/new/category_extras?category=Street%20lighting&latitude=55.952055&longitude=-3.189579');
+        is $extra_details->{unresponsive}, $body_id, "unresponsive json set";
 
         my $test_email = 'test-2@example.com';
         $mech->log_out_ok;
@@ -1715,6 +1719,8 @@ subtest "unresponsive body handling works" => sub {
         $contact3->update( { email => 'REFUSED' } );
         $mech->get_ok('/report/new/category_extras?category=Trees&latitude=51.896268&longitude=-2.093063');
         ok $mech->content_like( qr/Cheltenham.*Trees.*unresponsive.*category=Trees/ );
+        $extra_details = $mech->get_ok_json('/report/new/category_extras?category=Trees&latitude=51.896268&longitude=-2.093063');
+        is $extra_details->{unresponsive}, $contact3->body->id, "unresponsive json set";
 
         $mech->get_ok('/around');
         $mech->submit_form_ok( { with_fields => { pc => 'GL50 2PR', } }, "submit location" );


### PR DESCRIPTION
This allows the mobile app to explicitly detect when a body is
unresponsive and display the category_extra text.

For mysociety/fixmystreet-mobile#266