### PR TITLE
Map Open311 CLOSED status to closed state if extended statuses enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
         - Remove small border to left of Fixed banner. #2156
         - Fix issue displaying admin timeline. #2159
         - Send details of unresponsive bodies to mobile app #2164
+    - Open311 improvements:
+        - CLOSED status maps to 'closed' state if extended statuses are enabled.
 
 * v2.3.4 (7th June 2018)
     - Bugfixes:

--- a/perllib/Open311.pm
+++ b/perllib/Open311.pm
@@ -327,7 +327,7 @@ sub map_state {
         'not councils responsibility' => 'not responsible',
         'no further action'           => 'unable to fix',
         open                          => 'confirmed',
-        closed                        => 'fixed - council',
+        closed                        => $self->extended_statuses ? 'closed' : 'fixed - council',
     );
 
     return $state_map{$incoming_state} || $incoming_state;

--- a/t/open311/getservicerequestupdates.t
+++ b/t/open311/getservicerequestupdates.t
@@ -258,6 +258,18 @@ for my $test (
         end_state => 'fixed - council',
     },
     {
+        desc => 'status of CLOSED marks report as closed when using extended statuses',
+        description => 'This is a note',
+        external_id => 638344,
+        start_state => 'confirmed',
+        comment_status => 'CLOSED',
+        mark_fixed=> 0,
+        mark_open => 0,
+        problem_state => 'closed',
+        end_state => 'closed',
+        extended_statuses => 1,
+    },
+    {
         desc => 'status of OPEN re-opens fixed report',
         description => 'This is a note',
         external_id => 638344,
@@ -384,7 +396,7 @@ for my $test (
 ) {
     subtest $test->{desc} => sub {
         my $local_requests_xml = setup_xml($problem->external_id, $problem->id, $test->{comment_status}, $test->{xml_description});
-        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $local_requests_xml } );
+        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', extended_statuses => $test->{extended_statuses}, test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $local_requests_xml } );
 
         $problem->lastupdate( DateTime->now()->subtract( days => 1 ) );
         $problem->state( $test->{start_state} );


### PR DESCRIPTION
The Open311 specification has two values for a report's status:

 - open: it has been reported.
 - closed: it has been resolved.

FixMyStreet previously mapped 'closed' to 'fixed - council', but this
has been causing issues with Open311 endpoints that want to mark a FMS
report as closed but not fixed. The mySociety Open311 additions
introduce extended statuses, some of which represent a 'closed' state
e.g. duplicate, no_further_action, but there are times when a report
should simply be closed without any indication why - for example, if
open311-adapter is being used to integrate with a council system which
has a closed state not represented by the extended statuses. Marking a
report as 'closed' on a council system and displaying that as 'fixed'
on the FixMyStreet front end is not an ideal situation.

This commit changes the mapping of the Open311 'closed' status to the
'closed' FMS state when extended_statuses is enabled.