### PR TITLE
Body specific asset layers

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -9,6 +9,7 @@ use Encode;
 use JSON::MaybeXS;
 use Utils;
 use Try::Tiny;
+use Text::CSV;
 
 =head1 NAME
 
@@ -230,6 +231,10 @@ sub check_and_stash_category : Private {
     my $all_areas = $c->stash->{all_areas};
     my @bodies = $c->model('DB::Body')->active->for_areas(keys %$all_areas)->all;
     my %bodies = map { $_->id => $_ } @bodies;
+    my @list_of_names = map { $_->name } values %bodies;
+    my $csv = Text::CSV->new();
+    $csv->combine(@list_of_names);
+    $c->{stash}->{list_of_names_as_string} = $csv->string;
 
     my @categories = $c->model('DB::Contact')->not_deleted->search(
         {

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -208,6 +208,7 @@ sub report_form_ajax : Path('ajax') : Args(0) {
 
     my $extra_titles_list = $c->cobrand->title_list($c->stash->{all_areas});
 
+    my @list_of_names = map { $_->name } values %{$c->stash->{bodies}};
     my $contribute_as = {};
     if ($c->user_exists) {
         my @bodies = keys %{$c->stash->{bodies}};
@@ -221,6 +222,7 @@ sub report_form_ajax : Path('ajax') : Args(0) {
 
     my $body = encode_json(
         {
+            bodies          => \@list_of_names,
             councils_text   => $councils_text,
             councils_text_private => $councils_text_private,
             category        => $category,
@@ -254,8 +256,9 @@ sub category_extras_ajax : Path('category_extras') : Args(0) {
     $category = '' if $category eq _('-- Pick a category --');
 
     my $bodies = $c->forward('contacts_to_bodies', [ $category ]);
+    my $list_of_names = [ map { $_->name } @$bodies ];
     my $vars = {
-        $category ? (list_of_names => [ map { $_->name } @$bodies ]) : (),
+        $category ? (list_of_names => $list_of_names) : (),
     };
 
     my $category_extra = '';
@@ -281,12 +284,14 @@ sub category_extras_ajax : Path('category_extras') : Args(0) {
     my $councils_text_private = $c->render_fragment( 'report/new/councils_text_private.html');
 
     $unresponsive = $c->stash->{unresponsive}->{$category} || $c->stash->{unresponsive}->{ALL} || '';
+
     my $body = encode_json({
         category_extra => $category_extra,
         councils_text => $councils_text,
         councils_text_private => $councils_text_private,
         category_extra_json => $category_extra_json,
         unresponsive => $unresponsive,
+        bodies => $list_of_names,
     });
 
     $c->res->content_type('application/json; charset=utf-8');
@@ -706,6 +711,12 @@ sub setup_categories_and_bodies : Private {
     $c->stash->{category_extras_hidden}  = \%category_extras_hidden;
     $c->stash->{non_public_categories}  = \%non_public_categories;
     $c->stash->{extra_name_info} = $first_area->{id} == COUNCIL_ID_BROMLEY ? 1 : 0;
+
+    # escape these so we can then split on , cleanly in the template.
+    my @list_of_names = map { $_->name } values %bodies_to_list;
+    my $csv = Text::CSV->new();
+    $csv->combine(@list_of_names);
+    $c->stash->{list_of_names_as_string} = $csv->string;
 
     my @missing_details_bodies = grep { !$bodies_to_list{$_->id} } values %bodies;
     my @missing_details_body_names = map { $_->name } @missing_details_bodies;

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -40,6 +40,7 @@ for my $body (
     { area_id => 2482, name => 'Bromley Council' },
     { area_id => 2227, name => 'Hampshire County Council' },
     { area_id => 2333, name => 'Hart Council' },
+    { area_id => 2535, name => 'Sandwell Borough Council' },
 ) {
     my $body_obj = $mech->create_body_ok($body->{area_id}, $body->{name});
     push @bodies, $body_obj;
@@ -1177,24 +1178,48 @@ subtest "test report creation for a category that is non public" => sub {
 $contact2->category( "Pothol\xc3\xa9s" );
 $contact2->update;
 
-my $extra_details;
-FixMyStreet::override_config {
-    ALLOWED_COBRANDS => [ { fixmystreet => '.' } ],
-    MAPIT_URL => 'http://mapit.uk/',
-}, sub {
-    $extra_details = $mech->get_ok_json( '/report/new/ajax?latitude=' . $saved_lat . '&longitude=' . $saved_lon );
-};
-$mech->content_contains( "Pothol\xc3\xa9s" );
-like $extra_details->{councils_text}, qr/<strong>Cheltenham/;
-ok !$extra_details->{titles_list}, 'Non Bromley does not send back list of titles';
+subtest "check map click ajax response" => sub {
+    my $extra_details;
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'fixmystreet',
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $extra_details = $mech->get_ok_json( '/report/new/ajax?latitude=' . $saved_lat . '&longitude=' . $saved_lon );
+    };
+    # this order seems to be random so check individually/sort
+    like $extra_details->{councils_text}, qr/Cheltenham Borough Council/, 'correct council text for two tier';
+    like $extra_details->{councils_text}, qr/Gloucestershire County Council/, 'correct council text for two tier';
+    like $extra_details->{category}, qr/Pothol\x{00E9}s.*Street lighting/, 'category looks correct for two tier council';
+    my @sorted_bodies = sort @{ $extra_details->{bodies} };
+    is_deeply \@sorted_bodies, [ $body_ids{2226}, $body_ids{2326} ], 'correct bodies for two tier';
+    ok !$extra_details->{titles_list}, 'Non Bromley does not send back list of titles';
 
-FixMyStreet::override_config {
-    ALLOWED_COBRANDS => [ { fixmystreet => '.' } ],
-    MAPIT_URL => 'http://mapit.uk/',
-}, sub {
-    $extra_details = $mech->get_ok_json( '/report/new/ajax?latitude=51.4021&longitude=0.01578');
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'fixmystreet',
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $extra_details = $mech->get_ok_json( '/report/new/ajax?latitude=51.4021&longitude=0.01578');
+    };
+    ok $extra_details->{titles_list}, 'Bromley sends back list of titles';
+    like $extra_details->{councils_text}, qr/Bromley Council/, 'correct council text';
+    like $extra_details->{councils_text_private}, qr/^These will be sent to the council, but will never be shown online/, 'correct private council text';
+    like $extra_details->{category}, qr/Trees/, 'category looks correct';
+    is_deeply $extra_details->{bodies}, [ $body_ids{2482} ], 'correct bodies';
+    ok !$extra_details->{contribute_as}, 'no contribute as section';
+    ok !$extra_details->{top_message}, 'no top message';
+    ok $extra_details->{extra_name_info}, 'extra name info';
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'fixmystreet',
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $extra_details = $mech->get_ok_json( '/report/new/ajax?latitude=52.563074&longitude=-1.991032' );
+    };
+    like $extra_details->{councils_text}, qr/^These will be published online for others to see/, 'correct council text for council with no contacts';
+    is $extra_details->{category}, '', 'category is empty for council with no contacts';
+    is_deeply $extra_details->{bodies}, [ $body_ids{2535} ], 'correct bodies for council with no contacts';
+    ok !$extra_details->{extra_name_info}, 'no extra name info';
 };
-ok $extra_details->{titles_list}, 'Bromley sends back list of titles';
 
 #### test uploading an image
 
@@ -1885,6 +1910,7 @@ subtest "extra google analytics code displayed on email confirmation problem cre
     };
 };
 
+my $inspector = $mech->create_user_ok('inspector@example.org', name => 'inspector', from_body => $bodies[0]);
 foreach my $test (
   { non_public => 0 },
   { non_public => 1 },
@@ -1897,12 +1923,11 @@ foreach my $test (
     }, sub {
         $mech->log_out_ok;
 
-        my $user = $mech->create_user_ok('inspector@example.org', name => 'inspector', from_body => $bodies[0]);
-        $user->user_body_permissions->find_or_create({
+        $inspector->user_body_permissions->find_or_create({
             body => $bodies[0],
             permission_type => 'planned_reports',
         });
-        $user->user_body_permissions->find_or_create({
+        $inspector->user_body_permissions->find_or_create({
             body => $bodies[0],
             permission_type => 'report_inspect',
         });
@@ -1935,6 +1960,90 @@ foreach my $test (
         like $mech->uri->path, qr/\/report\/[0-9]+/, 'Redirects directly to report';
     }
   };
+}
+
+subtest "check map click ajax response for inspector" => sub {
+    $mech->log_out_ok;
+
+    my $extra_details;
+    $inspector->user_body_permissions->find_or_create({
+        body => $bodies[0],
+        permission_type => 'planned_reports',
+    });
+    $inspector->user_body_permissions->find_or_create({
+        body => $bodies[0],
+        permission_type => 'report_inspect',
+    });
+
+    $mech->log_in_ok('inspector@example.org');
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ { fixmystreet => '.' } ],
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $extra_details = $mech->get_ok_json( '/report/new/ajax?latitude=55.952055&longitude=-3.189579' );
+    };
+    like $extra_details->{category}, qr/data-role="inspector/, 'category has correct data-role';
+    ok !$extra_details->{contribute_as}, 'no contribute as section';
+};
+
+for my $test (
+    {
+        desc => 'map click ajax for contribute_as_another_user',
+        permissions => {
+            contribute_as_another_user => 1,
+            contribute_as_anonymous_user => undef,
+            contribute_as_body => undef,
+        }
+    },
+    {
+        desc => 'map click ajax for contribute_as_anonymous_user',
+        permissions => {
+            contribute_as_another_user => undef,
+            contribute_as_anonymous_user => 1,
+            contribute_as_body => undef,
+        }
+    },
+    {
+        desc => 'map click ajax for contribute_as_body',
+        permissions => {
+            contribute_as_another_user => undef,
+            contribute_as_anonymous_user => undef,
+            contribute_as_body => 1,
+        }
+    },
+) {
+    subtest $test->{desc} => sub {
+        $mech->log_out_ok;
+        my $extra_details;
+        (my $name = $test->{desc}) =~ s/.*(contri.*)/$1/;
+        my $user = $mech->create_user_ok("$name\@example.org", name => 'test user', from_body => $bodies[0]);
+        for my $p ( keys %{$test->{permissions}} ) {
+            next unless $test->{permissions}->{$p};
+            $user->user_body_permissions->find_or_create({
+                body => $bodies[0],
+                permission_type => $p,
+            });
+        }
+        $mech->log_in_ok("$name\@example.org");
+        FixMyStreet::override_config {
+            ALLOWED_COBRANDS => [ { fixmystreet => '.' } ],
+            MAPIT_URL => 'http://mapit.uk/',
+        }, sub {
+            $extra_details = $mech->get_ok_json( '/report/new/ajax?latitude=55.952055&longitude=-3.189579' );
+        };
+        for my $p ( keys %{$test->{permissions}} ) {
+            (my $key = $p) =~ s/contribute_as_//;
+            is $extra_details->{contribute_as}->{$key}, $test->{permissions}->{$p}, "$key correctly set";
+        }
+
+        FixMyStreet::override_config {
+            ALLOWED_COBRANDS => [ { fixmystreet => '.' } ],
+            MAPIT_URL => 'http://mapit.uk/',
+        }, sub {
+            $extra_details = $mech->get_ok_json( '/report/new/ajax?latitude=51.754926&longitude=-1.256179' );
+        };
+        ok !$extra_details->{contribute_as}, 'no contribute as section for other council';
+    };
 }
 
 done_testing();

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -1191,7 +1191,7 @@ subtest "check map click ajax response" => sub {
     like $extra_details->{councils_text}, qr/Gloucestershire County Council/, 'correct council text for two tier';
     like $extra_details->{category}, qr/Pothol\x{00E9}s.*Street lighting/, 'category looks correct for two tier council';
     my @sorted_bodies = sort @{ $extra_details->{bodies} };
-    is_deeply \@sorted_bodies, [ $body_ids{2226}, $body_ids{2326} ], 'correct bodies for two tier';
+    is_deeply \@sorted_bodies, [ "Cheltenham Borough Council", "Gloucestershire County Council" ], 'correct bodies for two tier';
     ok !$extra_details->{titles_list}, 'Non Bromley does not send back list of titles';
 
     FixMyStreet::override_config {
@@ -1204,7 +1204,7 @@ subtest "check map click ajax response" => sub {
     like $extra_details->{councils_text}, qr/Bromley Council/, 'correct council text';
     like $extra_details->{councils_text_private}, qr/^These will be sent to the council, but will never be shown online/, 'correct private council text';
     like $extra_details->{category}, qr/Trees/, 'category looks correct';
-    is_deeply $extra_details->{bodies}, [ $body_ids{2482} ], 'correct bodies';
+    is_deeply $extra_details->{bodies}, [ "Bromley Council" ], 'correct bodies';
     ok !$extra_details->{contribute_as}, 'no contribute as section';
     ok !$extra_details->{top_message}, 'no top message';
     ok $extra_details->{extra_name_info}, 'extra name info';
@@ -1217,7 +1217,7 @@ subtest "check map click ajax response" => sub {
     };
     like $extra_details->{councils_text}, qr/^These will be published online for others to see/, 'correct council text for council with no contacts';
     is $extra_details->{category}, '', 'category is empty for council with no contacts';
-    is_deeply $extra_details->{bodies}, [ $body_ids{2535} ], 'correct bodies for council with no contacts';
+    is_deeply $extra_details->{bodies}, [ "Sandwell Borough Council" ], 'correct bodies for council with no contacts';
     ok !$extra_details->{extra_name_info}, 'no extra name info';
 };
 

--- a/templates/web/base/maps/openlayers.html
+++ b/templates/web/base/maps/openlayers.html
@@ -25,6 +25,9 @@
 [% IF include_key -%]
     data-key='[% c.config.BING_MAPS_API_KEY %]'
 [%- END -%]
+[% IF list_of_names_as_string -%]
+    data-bodies='[% list_of_names_as_string | html %]'
+[%- END -%]
 >
 </div>
 <div id="map_box" aria-hidden="true">

--- a/web/cobrands/bathnes/js.js
+++ b/web/cobrands/bathnes/js.js
@@ -114,14 +114,14 @@ function include_feature(f) {
     return f &&
            f.attributes &&
            f.attributes.ownername &&
-           exclude_ownernames.indexOf(f.attributes.ownername) == -1;
+           OpenLayers.Util.indexOf(exclude_ownernames, f.attributes.ownername) == -1;
 }
 
 function banes_owns_feature(f) {
     return f &&
            f.attributes &&
            f.attributes.ownername &&
-           banes_ownernames.indexOf(f.attributes.ownername) > -1 &&
+           OpenLayers.Util.indexOf(banes_ownernames, f.attributes.ownername) > -1 &&
            include_feature(f);
 }
 

--- a/web/cobrands/buckinghamshire/js.js
+++ b/web/cobrands/buckinghamshire/js.js
@@ -103,7 +103,7 @@ function bucks_owns_feature(f) {
     return f &&
            f.attributes &&
            f.attributes.feature_ty &&
-           bucks_types.indexOf(f.attributes.feature_ty) > -1;
+           OpenLayers.Util.indexOf(bucks_types, f.attributes.feature_ty) > -1;
 }
 
 function bucks_does_not_own_feature(f) {
@@ -167,7 +167,7 @@ fixmystreet.assets.add($.extend(true, {}, defaults, {
             if (fixmystreet.assets.selectedFeature()) {
                 hide_responsibility_errors();
                 enable_report_form();
-            } else if (bucks_types.indexOf(feature.attributes.feature_ty) != -1) {
+            } else if (OpenLayers.Util.indexOf(bucks_types, feature.attributes.feature_ty) != -1) {
                 hide_responsibility_errors();
                 enable_report_form();
             } else {

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -284,7 +284,7 @@ function check_zoom_message_visibility() {
         }
 
     } else {
-        this.fixmystreet.asset_category.forEach( function(c) {
+        $.each(this.fixmystreet.asset_category, function(i, c) {
             var prefix = c.replace(/[^a-z]/gi, ''),
             id = "category_meta_message_" + prefix,
             $p = $('#' + id);
@@ -490,7 +490,7 @@ fixmystreet.assets = {
                 layer_options.filter = new OpenLayers.Filter.FeatureId({
                     type: OpenLayers.Filter.Function,
                     evaluate: function(f) {
-                        return options.filter_value.indexOf(f.attributes[options.filter_key]) != -1;
+                        return OpenLayers.Util.indexOf(options.filter_value, f.attributes[options.filter_key]) != -1;
                     }
                 });
                 layer_options.strategies.push(new OpenLayers.Strategy.Filter({filter: layer_options.filter}));

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -409,6 +409,7 @@ $.extend(fixmystreet.set_up, {
             } else {
                 $category_meta.empty();
             }
+            fixmystreet.bodies = data.bodies || [];
             $(fixmystreet).trigger('report_new:category_change:extras_received');
         });
 
@@ -939,6 +940,8 @@ fixmystreet.update_pin = function(lonlat, savePushState) {
             if ( lb.length === 0 ) { lb = $('#form_name').prev(); }
             lb.before(data.extra_name_info);
         }
+
+        fixmystreet.bodies = data.bodies || [];
 
         // If the category filter appears on the map and the user has selected
         // something from it, then pre-fill the category field in the report,

--- a/web/cobrands/fixmystreet/map.js
+++ b/web/cobrands/fixmystreet/map.js
@@ -3,7 +3,7 @@ var fixmystreet = fixmystreet || {};
 (function(){
 
     var map_data = document.getElementById('js-map-data'),
-        map_keys = [ 'area', 'latitude', 'longitude', 'zoomToBounds', 'zoom', 'pin_prefix', 'pin_new_report_colour', 'numZoomLevels', 'zoomOffset', 'map_type', 'key' ],
+        map_keys = [ 'area', 'latitude', 'longitude', 'zoomToBounds', 'zoom', 'pin_prefix', 'pin_new_report_colour', 'numZoomLevels', 'zoomOffset', 'map_type', 'key', 'bodies' ],
         numeric = { zoom: 1, numZoomLevels: 1, zoomOffset: 1, id: 1 },
         pin_keys = [ 'lat', 'lon', 'colour', 'id', 'title', 'type' ];
 
@@ -17,6 +17,9 @@ var fixmystreet = fixmystreet || {};
             fixmystreet[key] = +fixmystreet[key];
         }
     });
+
+
+    fixmystreet.bodies = fixmystreet.bodies ? fixmystreet.utils.csv_to_array(fixmystreet.bodies)[0] : [];
 
     fixmystreet.area = fixmystreet.area ? fixmystreet.area.split(',') : [];
     if (fixmystreet.map_type) {

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -27,6 +27,48 @@ $.extend(fixmystreet.utils, {
         return out.join(',');
     },
 
+    // https://stackoverflow.com/questions/1293147/javascript-code-to-parse-csv-data/1293163#1293163
+    csv_to_array: function( strData, strDelimiter ) {
+        strDelimiter = (strDelimiter || ",");
+
+        var objPattern = new RegExp(
+            (
+                "(\\" + strDelimiter + "|\\r?\\n|\\r|^)" +
+                "(?:\"([^\"]*(?:\"\"[^\"]*)*)\"|" +
+                "([^\"\\" + strDelimiter + "\\r\\n]*))"
+            ),
+            "gi"
+            );
+
+        var arrData = [[]];
+
+        var arrMatches = objPattern.exec( strData );
+        while (arrMatches) {
+
+            var strMatchedDelimiter = arrMatches[ 1 ];
+
+            if ( strMatchedDelimiter.length &&
+                strMatchedDelimiter !== strDelimiter) {
+                arrData.push( [] );
+            }
+
+            var strMatchedValue;
+            if (arrMatches[ 2 ]) {
+                strMatchedValue = arrMatches[ 2 ].replace(
+                    new RegExp( "\"\"", "g" ),
+                    "\""
+                );
+            } else {
+                strMatchedValue = arrMatches[ 3 ];
+            }
+
+            arrData[ arrData.length - 1 ].push( strMatchedValue );
+            arrMatches = objPattern.exec( strData );
+        }
+
+        return( arrData );
+    },
+
     parse_query_string: function() {
         var qs = {};
         if (!location.search) {


### PR DESCRIPTION
Associate layers with a body and only show them if the body covers the area displayed on the map. This is to allow us to use asset layers on the national site and only display the appropriate layers for an area.

This adds a body property to layers which specifies the body associated with the layer, a bodies property to the fixmystreet object to specify which bodies are associated with the area shown on the map, and the associated code to only display that layer if the two match.

Connects https://github.com/mysociety/fixmystreet-commercial/issues/1086
[skip changelog]