### PR TITLE
Allow questionnaire pages to be revisited within 2 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
         - Allow any user who can see private checkbox to use it.
         - Prevent dupliate category listing on /my.
         - Hide password help field along with other similar. #2185
+        - Allow questionnaire link to be revisited in quick succession. #2123
     - Open311 improvements:
         - CLOSED status maps to 'closed' state if extended statuses are enabled.
     - Development improvements:

--- a/perllib/FixMyStreet/App/Controller/Questionnaire.pm
+++ b/perllib/FixMyStreet/App/Controller/Questionnaire.pm
@@ -33,7 +33,8 @@ sub check_questionnaire : Private {
 
     my $problem = $questionnaire->problem;
 
-    if ( $unanswered && $questionnaire->whenanswered ) {
+    my $cutoff = DateTime->now()->subtract( minutes => 2 );
+    if ( $unanswered && $questionnaire->whenanswered && $questionnaire->whenanswered < $cutoff) {
         my $problem_url = $c->cobrand->base_url_for_report( $problem ) . $problem->url;
         my $contact_url = $c->uri_for( "/contact" );
         my $message = sprintf(_("You have already answered this questionnaire. If you have a question, please <a href='%s'>get in touch</a>, or <a href='%s'>view your problem</a>.\n"), $contact_url, $problem_url);

--- a/t/app/controller/questionnaire.t
+++ b/t/app/controller/questionnaire.t
@@ -85,9 +85,15 @@ foreach my $test (
     },
     {
         desc => 'User goes to questionnaire URL for an already answered questionnaire',
-        answered => \'current_timestamp',
+        answered => \"current_timestamp - '10 minutes'::interval",
         content => 'already answered this questionnaire',
         code => 400,
+    },
+    {
+        desc => 'User goes to questionnaire URL for a very recently answered questionnaire',
+        answered => \"current_timestamp - '10 seconds'::interval",
+        content_lacks => 'already answered this questionnaire',
+        code => 200,
     },
 ) {
     subtest $test->{desc} => sub {
@@ -99,7 +105,8 @@ foreach my $test (
         $token .= $test->{token_extra} if $test->{token_extra};
         $mech->get("/Q/$token");
         is $mech->res->code, $test->{code}, "Right status received";
-        $mech->content_contains( $test->{content} );
+        $mech->content_contains( $test->{content} ) if $test->{content};
+        $mech->content_lacks( $test->{content_lacks} ) if $test->{content_lacks};
         # Reset, no matter what test did
         $report->state( 'confirmed' );
         $report->update;


### PR DESCRIPTION
Users who double click links were seeing an error when visiting the
questionnaire page. This change gives a grace period of two minutes
for revisiting the questionnaire page.

Fixes #2123.