### PR TITLE
Make non-pro dashboard CSV download limit clearer

### DIFF
--- a/templates/web/fixmystreet.com/reports/summary.html
+++ b/templates/web/fixmystreet.com/reports/summary.html
@@ -131,7 +131,7 @@
                 <li>[% INCLUDE gb new_gb='category' text='category' %]</li>
                 <li>[% INCLUDE gb new_gb='device' text='device' %]</li>
                 <li>[% INCLUDE gb new_gb='state' text='state' %]</li>
-                <li class="pull-right"><a href="[% c.uri_with({ csv => 1 }) %]">[% loc('Export as CSV') %]</a></li>
+                <li class="pull-right"><a href="[% c.uri_with({ csv => 1 }) %]">[% loc('Export CSV preview (100 rows)') %]</a></li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
<img width="941" alt="screen shot 2018-07-12 at 12 49 37" src="https://user-images.githubusercontent.com/739624/42631419-13563f74-85d2-11e8-9b39-2f537ef8043e.png">
[skip changelog]
Fixes mysociety/fixmystreet-commercial#1087. I think it also fixes #2103?

