### PR TITLE
"New report near here" button in nav bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
         - Only display last 6 months of reports on around page by default #2098
         - Always show all reports by default on /my.
         - Much less reliance on input placeholders, for better accessibility #2180
+        - Button in nav bar now makes it easier to report again in the same location #2195
     - Admin improvements:
         - Mandatory defect type selection if defect raised.
         - Send login email button on user edit page #2041

--- a/templates/web/base/js/translation_strings.html
+++ b/templates/web/base/js/translation_strings.html
@@ -71,6 +71,12 @@ fixmystreet.password_minimum_length = [% c.cobrand.password_minimum_length %];
         login_with_email: '[% loc('Log in with email') | replace("'", "\\'") %]',
         [% END ~%]
 
+        report_a_problem_btn: {
+            default: '[% loc('Report a problem') | replace("'", "\\'") %]',
+            here: '[% loc('Report a problem here') | replace("'", "\\'") %]',
+            another: '[% loc('Report another problem here') | replace("'", "\\'") %]'
+        },
+
         offline: {
             your_reports: '[% loc('Your offline reports') | replace("'", "\\'") %]',
             update_saved: '[% loc('Your update has been saved offline for submission when back online.') | replace("'", "\\'") %]',

--- a/templates/web/base/main_nav_items.html
+++ b/templates/web/base/main_nav_items.html
@@ -1,4 +1,12 @@
-[%~ INCLUDE navitem uri=(homepage_template ? '/report' : '/') label=loc('Report a problem') attrs='class="report-a-problem-btn"' ~%]
+[%~ IF problem ~%]
+    [%~ INCLUDE navitem uri='/report/new?longitude=' _ problem.longitude _ '&amp;latitude=' _ problem.latitude label=loc('Report another problem here') attrs='class="report-a-problem-btn"' ~%]
+[%~ ELSIF latitude AND longitude ~%]
+    [%~ INCLUDE navitem uri='/report/new?longitude=' _ longitude _ '&amp;latitude=' _ latitude label=loc('Report a problem here') attrs='class="report-a-problem-btn"' ~%]
+[%~ ELSIF homepage_template ~%]
+    [%~ INCLUDE navitem uri='/report' label=loc('Report a problem') attrs='class="report-a-problem-btn"' ~%]
+[%~ ELSE ~%]
+    [%~ INCLUDE navitem uri='/' label=loc('Report a problem') attrs='class="report-a-problem-btn"' ~%]
+[%~ END ~%]
 
 [%~ IF c.user_exists ~%]
     [%~ INCLUDE navitem uri='/my' label=loc('Your account') ~%]

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -671,6 +671,27 @@ $.extend(fixmystreet.set_up, {
     });
   },
 
+  report_a_problem_btn: function() {
+    $(fixmystreet).on('maps:update_view', fixmystreet.update_report_a_problem_btn);
+
+    // Hide button on new report page.
+    if ( fixmystreet.page === 'new' ) {
+      $('.report-a-problem-btn').hide();
+    }
+
+    $('.report-a-problem-btn').on('click', function(e){
+      var url = this.href;
+      if ( url.indexOf('report/new') > -1 ) {
+        try {
+          e.preventDefault();
+          fixmystreet.display.begin_report( fixmystreet.map.getCenter() );
+        } catch (error) {
+          window.location = url;
+        }
+      }
+    });
+  },
+
   map_controls: function() {
     //add permalink on desktop, force hide on mobile
     //add links container (if its not there)
@@ -891,6 +912,34 @@ $.extend(fixmystreet.set_up, {
 
 });
 
+fixmystreet.update_report_a_problem_btn = function() {
+    var zoom = fixmystreet.map.getZoom();
+    var center = fixmystreet.map.getCenterWGS84();
+    var new_report_url = '/report/new?longitude=' + center.lon.toFixed(6) + '&latitude=' + center.lat.toFixed(6);
+
+    var href = '/';
+    var visible = true;
+    var text = translation_strings.report_a_problem_btn.default;
+
+    if (fixmystreet.page === 'new') {
+        visible = false;
+
+    } else if (fixmystreet.page === 'report') {
+        text = translation_strings.report_a_problem_btn.another;
+        href = new_report_url;
+
+    } else if (fixmystreet.page === 'around' && zoom > 1) {
+        text = translation_strings.report_a_problem_btn.here;
+        href = new_report_url;
+
+    } else if (fixmystreet.page === 'reports' && zoom > 12) {
+        text = translation_strings.report_a_problem_btn.here;
+        href = new_report_url;
+    }
+
+    $('.report-a-problem-btn').attr('href', href).text(text).toggle(visible);
+};
+
 fixmystreet.update_councils_text = function(data) {
     $('#js-councils_text').html(data.councils_text);
     $('#js-councils_text_private').html(data.councils_text_private);
@@ -1084,6 +1133,8 @@ fixmystreet.display = {
     }
 
     fixmystreet.page = 'new';
+
+    fixmystreet.update_report_a_problem_btn();
   },
 
   report: function(reportPageUrl, reportId, callback) {
@@ -1152,6 +1203,8 @@ fixmystreet.display = {
             fixmystreet.run(fixmystreet.set_up.moderation);
             fixmystreet.run(fixmystreet.set_up.response_templates);
 
+            fixmystreet.update_report_a_problem_btn();
+
             window.selected_problem_id = reportId;
             var marker = fixmystreet.maps.get_marker_by_id(reportId);
             if (fixmystreet.map.panTo && ($('html').hasClass('mobile') || !marker.onScreen())) {
@@ -1213,6 +1266,8 @@ fixmystreet.display = {
         }
         $('.big-hide-pins-link').show();
         fixmystreet.set_up.map_controls();
+
+        fixmystreet.update_report_a_problem_btn();
 
         window.selected_problem_id = undefined;
 

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -117,7 +117,7 @@ h1 {
   a.report-a-problem-btn {
     color: $primary_text;
     background-color: $primary;
-    padding:0.25em;
+    padding:0.25em 0.5em;
     margin:0.5em;
     @include border-radius(0.25em);
     &:hover {

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -791,6 +791,16 @@ $.extend(fixmystreet.utils, {
             fixmystreet.map.setCenter(centre, fixmystreet.zoom || 3);
         }
 
+        // map.getCenter() returns a position in "map units", but sometimes you
+        // want the center in GPS-style latitude/longitude coordinates (WGS84)
+        // for example, to pass as GET params to fixmystreet.com/report/new.
+        fixmystreet.map.getCenterWGS84 = function() {
+            return fixmystreet.map.getCenter().transform(
+                fixmystreet.map.getProjectionObject(),
+                new OpenLayers.Projection("EPSG:4326")
+            );
+        };
+
         if (document.getElementById('mapForm')) {
             var click = fixmystreet.maps.click_control = new OpenLayers.Control.Click();
             fixmystreet.map.addControl(click);
@@ -803,6 +813,12 @@ $.extend(fixmystreet.utils, {
         } else {
             onload();
         }
+
+        // Allow external scripts to react to pans/zooms on the map,
+        // by subscribing to $(fixmystreet).on('maps:update_view')
+        fixmystreet.map.events.register('moveend', null, function(){
+            $(fixmystreet).trigger('maps:update_view');
+        });
 
         (function() {
             var timeout;


### PR DESCRIPTION
Fixes #2016 and is a partway solution to #2012.

Rather than always saying "Report a problem" and always just linking back to the homepage postcode search form, the `.report-a-problem-btn` in the nav bar now behaves differently, based on what else is on the page.

The general idea is that, if you’re looking at an individual problem already, then the button will say "Report _another_ problem here" and will automatically begin creating a new report at the same coordinates. Otherwise, if you’re zoomed a sensible distance into a map, then the button will say "Report a problem _here_" and will begin a report at the centre of the visible map. And finally, if neither of those cases are true, it’ll just do what it always did, and take you to the homepage.

When clicking the button, if it’s possible for the current page to be seamlessly transformed into the reporting form, then we do that. Otherwise, we fall back to a server-side page load.

# /around page, zoomed far out

![screenshot_2018-08-02 viewing a location](https://user-images.githubusercontent.com/739624/43585262-999f0364-965c-11e8-8295-42f2284c84e7.png)

# /around page, zoomed closer

![screenshot_2018-08-02 viewing a location 1](https://user-images.githubusercontent.com/739624/43585274-a1973dac-965c-11e8-8663-04b94d196ea0.png)

# /report/<id> page

![screenshot_2018-08-02 full litter bins - viewing a problem](https://user-images.githubusercontent.com/739624/43585297-ad4f26e6-965c-11e8-89f5-ae2752e813d2.png)

# /reports/<area> page, zoomed fairly close

![screenshot_2018-08-02 borsetshire county council - summary reports](https://user-images.githubusercontent.com/739624/43585308-b5763f1c-965c-11e8-8132-1f961fa4ff19.png)
