### PR TITLE
"Report another problem here" button on confirmation page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
         - Only display last 6 months of reports on around page by default #2098
         - Always show all reports by default on /my.
         - Much less reliance on input placeholders, for better accessibility #2180
+        - “Report another problem here” button on report confirmation page #2198
     - Admin improvements:
         - Mandatory defect type selection if defect raised.
         - Send login email button on user edit page #2041

--- a/templates/web/base/tokens/confirm_problem.html
+++ b/templates/web/base/tokens/confirm_problem.html
@@ -31,6 +31,12 @@
 
 [% TRY %][% INCLUDE 'tokens/_extras_confirm.html' %][% CATCH file %][% END %]
 
+  <p class="confirmation-again">
+    <a href="/report/new?latitude=[% report.latitude %]&amp;longitude=[% report.longitude %]" class="btn btn-primary">
+      [% loc('Report another problem here') %]
+    </a>
+  </p>
+
 </div>
 
 [% INCLUDE

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2160,6 +2160,12 @@ a#geolocate_link.loading, .btn--geolocate.loading {
   }
 }
 
+.confirmation-again {
+  margin-top: 2em;
+  color: inherit;
+  font-size: 1em;
+}
+
 /* Questionnaire page */
 
 .questionnaire-report-header {


### PR DESCRIPTION
Part of #2012.

Should make it much quicker to report multiple problems in the same location, one after the other.

![screenshot_2018-08-02 confirmation](https://user-images.githubusercontent.com/739624/43587081-46e07a40-9661-11e8-9de8-f844332ec57d.png)

Uses the same new `loc('Report another problem here')` string that was introduced in #2195.