### PR TITLE
[Open311] No update text on fixed state move.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
         - Update Google Maps directions link.
     - Open311 improvements:
         - CLOSED status maps to 'closed' state if extended statuses are enabled.
+        - Don't generate template comment text on move between fixed states.
     - Development improvements:
         - Cobrand hook for presenting custom search results. #2183
         - Cobrand hook to allow extra login conditions #2092

--- a/perllib/Open311/GetServiceRequestUpdates.pm
+++ b/perllib/Open311/GetServiceRequestUpdates.pm
@@ -201,8 +201,10 @@ sub comment_text_for_request {
 
     return $request->{description} if $request->{description};
 
-    # Response templates are only triggered if the state/external status has changed
-    my $state_changed = $state ne $old_state;
+    # Response templates are only triggered if the state/external status has changed.
+    # And treat any fixed state as fixed.
+    my $state_changed = $state ne $old_state
+        && !( $problem->is_fixed && FixMyStreet::DB::Result::Problem->fixed_states()->{$state} );
     my $ext_code_changed = $ext_code ne $old_ext_code;
     if ($state_changed || $ext_code_changed) {
         my $state_params = {

--- a/t/open311/getservicerequestupdates.t
+++ b/t/open311/getservicerequestupdates.t
@@ -32,6 +32,12 @@ my $response_template = $bodies{2482}->response_templates->create({
     auto_response => 1,
     state => "investigating"
 });
+my $response_template_fixed = $bodies{2482}->response_templates->create({
+    title => "fixed template",
+    text => "We have fixed this report.",
+    auto_response => 1,
+    state => "fixed - council"
+});
 
 my $requests_xml = qq{<?xml version="1.0" encoding="utf-8"?>
 <service_requests_updates>
@@ -368,6 +374,19 @@ for my $test (
         mark_open => 0,
         problem_state => 'investigating',
         end_state => 'investigating',
+    },
+    {
+        desc => 'change in fixed state does not trigger auto-response template',
+        description => '',
+        xml_description => '',
+        external_id => 638344,
+        start_state => 'fixed - user',
+        comment_status => 'FIXED',
+        mark_fixed => 0,
+        mark_open => 0,
+        problem_state => undef,
+        end_state => 'fixed - user',
+        comment_state => 'hidden',
     },
     {
         desc => 'unchanging state does not trigger auto-response template',
@@ -898,6 +917,7 @@ foreach my $test ( {
     }
 }
 
+$response_template_fixed->delete;
 foreach my $test ( {
         desc => 'normally blank text produces a warning',
         num_alerts => 1,


### PR DESCRIPTION
A move between fixed states (presumably fixed-user to fixed-council) should
not count as a state change for the purposes of generating comment text from
templates.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1123