### PR TITLE
[Buckinghamshire] Update flytipping handling.

### DIFF
--- a/perllib/FixMyStreet/SendReport/Email.pm
+++ b/perllib/FixMyStreet/SendReport/Email.pm
@@ -57,7 +57,7 @@ sub send {
     my $self = shift;
     my ( $row, $h ) = @_;
 
-    my $recips = $self->build_recipient_list( $row, $h );
+    my $recips = @{$self->to} ? 1 : $self->build_recipient_list( $row, $h );
 
     # on a staging server send emails to ourselves rather than the bodies
     if (FixMyStreet->staging_flag('send_reports', 0) && !FixMyStreet->test_mode) {

--- a/perllib/FixMyStreet/SendReport/Open311.pm
+++ b/perllib/FixMyStreet/SendReport/Open311.pm
@@ -94,6 +94,8 @@ sub send {
             $self->error( "Failed to send over Open311\n" ) unless $self->error;
             $self->error( $self->error . "\n" . $open311->error );
         }
+
+        $cobrand->call_hook(open311_post_send => $row, $h);
     }
 
 

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -26,6 +26,7 @@ my @PLACES = (
     [ '?', 53.387402, -2.943997, 2527, 'Liverpool City Council', 'MTD' ],
     [ 'EH1 1BB', 55.952055, -3.189579, 2651, 'Edinburgh City Council', 'UTA', 20728, 'City Centre', 'UTE' ],
     [ 'BS10 5EE', 51.494885, -2.602237, 2561, 'Bristol City Council', 'UTA', 148646, 'Bedminster', 'UTW' ],
+    [ 'SL9 0NX', 51.615559, -0.556903, 2217, 'Buckinghamshire County Council', 'CTY', 2257, 'Chiltern District Council', 'DIS' ],
     [ 'SW1A 1AA', 51.501009, -0.141588, 2504, 'Westminster City Council', 'LBO' ],
     [ 'GL50 2PR', 51.896268, -2.093063, 2226, 'Gloucestershire County Council', 'CTY', 2326, 'Cheltenham Borough Council', 'DIS', 4544, 'Lansdown', 'DIW', 143641, 'Lansdown and Park', 'CED' ],
     [ '?', 51.754926, -1.256179, 2237, 'Oxfordshire County Council', 'CTY', 2421, 'Oxford City Council', 'DIS' ],

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -4,8 +4,15 @@ use FixMyStreet::Script::Reports;
 
 my $mech = FixMyStreet::TestMech->new;
 
-my $body = $mech->create_body_ok(2217, 'Buckinghamshire');
-$mech->create_contact_ok(body_id => $body->id, category => 'Flytipping', email => "flytipping\@example.org");
+my $body = $mech->create_body_ok(2217, 'Buckinghamshire', {
+    send_method => 'Open311', api_key => 'key', endpoint => 'endpoint', jurisdiction => 'fms' });
+
+$mech->create_contact_ok(body_id => $body->id, category => 'Flytipping', email => "FLY");
+$mech->create_contact_ok(body_id => $body->id, category => 'Potholes', email => "POT");
+
+my $district = $mech->create_body_ok(2257, 'Chiltern');
+$mech->create_contact_ok(body_id => $district->id, category => 'Flytipping', email => "flytipping\@chiltern");
+$mech->create_contact_ok(body_id => $district->id, category => 'Graffiti', email => "graffiti\@chiltern");
 
 my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Buckinghamshire');
 $cobrand->mock('lookup_site_code', sub {
@@ -16,6 +23,7 @@ $cobrand->mock('lookup_site_code', sub {
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'buckinghamshire', 'fixmystreet' ],
     MAPIT_URL => 'http://mapit.uk/',
+    STAGING_FLAGS => { send_reports => 1, skip_checks => 0 },
 }, sub {
 
 subtest 'cobrand displays council name' => sub {
@@ -24,7 +32,16 @@ subtest 'cobrand displays council name' => sub {
     $mech->content_contains('Buckinghamshire');
 };
 
-$mech->create_problems_for_body(1, $body->id, 'On Road', {
+subtest 'cobrand displays correct categories' => sub {
+    my $json = $mech->get_ok_json('/report/new/ajax?latitude=51.615559&longitude=-0.556903');
+    is @{$json->{bodies}}, 2, 'Both Chiltern and Bucks returned';
+    like $json->{category}, qr/Flytipping/, 'Flytipping displayed';
+    unlike $json->{category}, qr/Graffiti/, 'Graffiti not displayed';
+    $json = $mech->get_ok_json('/report/new/category_extras?latitude=51.615559&longitude=-0.556903');
+    is @{$json->{bodies}}, 2, 'Still both Chiltern and Bucks returned';
+};
+
+my ($report) = $mech->create_problems_for_body(1, $body->id, 'On Road', {
     category => 'Flytipping', cobrand => 'fixmystreet',
     latitude => 51.812244, longitude => -0.827363,
 });
@@ -32,19 +49,35 @@ $mech->create_problems_for_body(1, $body->id, 'On Road', {
 subtest 'flytipping on road sent to extra email' => sub {
     FixMyStreet::Script::Reports::send();
     my $email = $mech->get_email;
-    my $tfb = join('', 'crmbusinesssupport', '@', 'buckscc.gov.uk');
-    is $email->header('To'), '"Buckinghamshire" <flytipping@example.org>, "TfB" <' . $tfb . '>';
+    my $tfb = join('', 'illegaldumpingcosts', '@', 'buckscc.gov.uk');
+    is $email->header('To'), '"TfB" <' . $tfb . '>';
+    $report->discard_changes;
+    is $report->external_id, 248, 'Report has right external ID';
 };
 
-$mech->create_problems_for_body(1, $body->id, 'Off Road', {
+($report) = $mech->create_problems_for_body(1, $body->id, 'On Road', {
+    category => 'Potholes', cobrand => 'fixmystreet',
+    latitude => 51.812244, longitude => -0.827363,
+});
+
+subtest 'pothole on road not sent to extra email' => sub {
+    $mech->clear_emails_ok;
+    FixMyStreet::Script::Reports::send();
+    $mech->email_count_is(0);
+    $report->discard_changes;
+    is $report->external_id, 248, 'Report has right external ID';
+};
+
+($report) = $mech->create_problems_for_body(1, $district->id, 'Off Road', {
     category => 'Flytipping', cobrand => 'fixmystreet',
     latitude => 51.813173, longitude => -0.826741,
 });
-subtest 'flytipping on road sent to extra email' => sub {
-    $mech->clear_emails_ok;
+subtest 'flytipping off road sent to extra email' => sub {
     FixMyStreet::Script::Reports::send();
     my $email = $mech->get_email;
-    is $email->header('To'), '"Buckinghamshire" <flytipping@example.org>';
+    is $email->header('To'), '"Chiltern" <flytipping@chiltern>';
+    $report->discard_changes;
+    is $report->external_id, undef, 'Report has right external ID';
 };
 
 };

--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -173,10 +173,15 @@ fixmystreet.assets.add($.extend(true, {}, defaults, {
     actions: {
         found: function(layer, feature) {
             fixmystreet.body_overrides.allow_send(layer.fixmystreet.body);
+            fixmystreet.body_overrides.remove_only_send();
             if (fixmystreet.assets.selectedFeature()) {
                 hide_responsibility_errors();
                 enable_report_form();
             } else if (OpenLayers.Util.indexOf(bucks_types, feature.attributes.feature_ty) != -1) {
+                var cat = $('select#form_category').val();
+                if (cat === 'Flytipping') {
+                    fixmystreet.body_overrides.only_send(layer.fixmystreet.body);
+                }
                 hide_responsibility_errors();
                 enable_report_form();
             } else if (is_only_body(layer.fixmystreet.body)) {
@@ -192,6 +197,7 @@ fixmystreet.assets.add($.extend(true, {}, defaults, {
             // probably a field or something. Show an error to that effect,
             // unless an asset is selected.
             fixmystreet.body_overrides.do_not_send(layer.fixmystreet.body);
+            fixmystreet.body_overrides.remove_only_send();
             if (fixmystreet.assets.selectedFeature()) {
                 fixmystreet.body_overrides.allow_send(layer.fixmystreet.body);
                 hide_responsibility_errors();


### PR DESCRIPTION
Allow flytipping reporting on cobrand and .com, with road reports going to Bucks Confirm and email, and non-road reports going to district and Bucks emails. [skip changelog]

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1118
