### PR TITLE
Fix Bristol assets on .com, and show assets more zoomed out

### DIFF
--- a/web/cobrands/bathnes/assets.js
+++ b/web/cobrands/bathnes/assets.js
@@ -23,7 +23,7 @@ fixmystreet.maps.banes_defaults = {
     asset_category: "",
     asset_item: "asset",
     asset_type: 'spot',
-    max_resolution: 2.388657133579254,
+    max_resolution: 4.777314267158508,
     min_resolution: 0.5971642833948135,
     asset_id_field: 'feature_no',
     attributes: null,

--- a/web/cobrands/bristol/assets.js
+++ b/web/cobrands/bristol/assets.js
@@ -7,7 +7,10 @@ if (!fixmystreet.maps) {
 var options = {
     wfs_url: "https://maps.bristol.gov.uk/arcgis/services/ext/FixMyStreetSupportData/MapServer/WFSServer",
     wfs_feature: "COD_ASSETS_POINT",
-    max_resolution: 0.33072982812632296,
+    max_resolution: {
+        'bristol': 0.33072982812632296,
+        'fixmystreet': 4.777314267158508
+    },
     min_resolution: 0.00001,
     asset_id_field: 'COD_ASSET_ID',
     asset_type: 'spot',
@@ -17,6 +20,7 @@ var options = {
         usrn: 'COD_USRN'
     },
     body: "Bristol City Council",
+    srsName: "EPSG:27700",
     geometryName: 'SHAPE'
 };
 

--- a/web/cobrands/bromley/assets.js
+++ b/web/cobrands/bromley/assets.js
@@ -16,7 +16,7 @@ var defaults = {
     },
     format_class: OpenLayers.Format.GML.v3.MultiCurveFix,
     asset_type: 'spot',
-    max_resolution: 2.388657133579254,
+    max_resolution: 4.777314267158508,
     min_resolution: 0.5971642833948135,
     asset_id_field: 'CENTRAL_AS',
     geometryName: 'msGeometry',

--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -16,7 +16,7 @@ var defaults = {
     },
     format_class: OpenLayers.Format.GML.v3.MultiCurveFix,
     asset_type: 'spot',
-    max_resolution: 2.388657133579254,
+    max_resolution: 4.777314267158508,
     min_resolution: 0.5971642833948135,
     asset_id_field: 'central_as',
     attributes: {

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -491,12 +491,17 @@ fixmystreet.assets = {
             options.asset_category = [ options.asset_category ];
         }
 
+        var max_resolution = options.max_resolution;
+        if (typeof max_resolution === 'object') {
+            max_resolution = max_resolution[fixmystreet.cobrand];
+        }
+
         var layer_options = {
             fixmystreet: options,
             strategies: [new StrategyClass()],
             protocol: protocol,
             visibility: false,
-            maxResolution: options.max_resolution,
+            maxResolution: max_resolution,
             minResolution: options.min_resolution,
             styleMap: options.stylemap || get_asset_stylemap(),
             assets: true


### PR DESCRIPTION
Bristol - different maps on Bristol/.com, different resolutions. Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1126

Showing the assets more zoomed out - there is the possibility of e.g. going to a Bucks location on .com, clicking map on-road at zoomed out level (say most zoomed in 1:25k), selecting category and it saying you're not on a road and not letting you. Easiest solution is showing them at zoom level 2 also (was previously 3), but perhaps need to show some at all zoom levels? Probably quite an edge case.

[skip changelog]