### PR TITLE
Few small breakages to fix

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -834,6 +834,7 @@ sub report_edit_display : Private {
             longitude => $problem->longitude,
             colour    => $c->cobrand->pin_colour($problem, 'admin'),
             type      => 'big',
+            draggable => 1,
           } ]
         : [],
         print_report => 1,

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -251,7 +251,7 @@ sub generate_map_tags : Private {
         latitude  => $problem->latitude,
         longitude => $problem->longitude,
         pins      => $problem->used_map
-            ? [ $problem->pin_data($c, 'report', type => 'big') ]
+            ? [ $problem->pin_data($c, 'report', type => 'big', draggable => 1) ]
             : [],
     );
 

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1430,6 +1430,7 @@ sub generate_map : Private {
             pins      => [ {
                 latitude  => $latitude,
                 longitude => $longitude,
+                draggable => 1,
                 colour    => 'green', # 'yellow',
             } ],
         );

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -783,7 +783,8 @@ sub ajax : Private {
 
     my @pins = map {
         my $p = $_;
-        [ $p->{latitude}, $p->{longitude}, $p->{colour}, $p->{id}, $p->{title} ]
+        # lat, lon, 'colour', ID, title, type/size, draggable
+        [ $p->{latitude}, $p->{longitude}, $p->{colour}, $p->{id}, $p->{title}, '', JSON->false ]
     } @{$c->stash->{pins}};
 
     my $list_html = $c->render_fragment($template);

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -1017,6 +1017,7 @@ sub pin_data {
         id => $self->id,
         title => $title,
         problem => $self,
+        draggable => $opts{draggable},
         type => $opts{type},
     }
 };

--- a/perllib/FixMyStreet/Map/FMS.pm
+++ b/perllib/FixMyStreet/Map/FMS.pm
@@ -37,7 +37,7 @@ sub map_tiles {
     } else {
         my $key = FixMyStreet->config('BING_MAPS_API_KEY');
         my $url = "g=6570";
-        $url .= "&productSet=mmOS&key=$key" if $z > 10 && !$ni;
+        $url .= "&productSet=mmOS&key=$key" if $z > 11 && !$ni;
         return [
             "//ecn.t0.tiles.virtualearth.net/tiles/r" . $self->get_quadkey($x-1, $y-1, $z) . ".png?$url",
             "//ecn.t1.tiles.virtualearth.net/tiles/r" . $self->get_quadkey($x,   $y-1, $z) . ".png?$url",

--- a/templates/web/base/maps/pin.html
+++ b/templates/web/base/maps/pin.html
@@ -7,6 +7,7 @@
     class="pin js-pin" data-lat="[% pin.latitude %]" data-lon="[% pin.longitude %]"
     data-colour="[% pin.colour %]" data-id="[% pin.id %]"
     data-title="[% pin.title | html %]" data-type="[% pin.type %]"
+    data-draggable="[% pin.draggable %]"
 [% ELSE -%]
     class="pin"
 [% END -%]

--- a/templates/web/oxfordshire/footer_extra_js.html
+++ b/templates/web/oxfordshire/footer_extra_js.html
@@ -1,3 +1,4 @@
 [% scripts.push(
+    version('/vendor/OpenLayers.Projection.OrdnanceSurvey.js'),
     version('/cobrands/oxfordshire/js.js'),
 ) %]

--- a/web/cobrands/fixmystreet/map.js
+++ b/web/cobrands/fixmystreet/map.js
@@ -5,7 +5,8 @@ var fixmystreet = fixmystreet || {};
     var map_data = document.getElementById('js-map-data'),
         map_keys = [ 'area', 'latitude', 'longitude', 'zoomToBounds', 'zoom', 'pin_prefix', 'pin_new_report_colour', 'numZoomLevels', 'zoomOffset', 'map_type', 'key', 'bodies' ],
         numeric = { zoom: 1, numZoomLevels: 1, zoomOffset: 1, id: 1 },
-        pin_keys = [ 'lat', 'lon', 'colour', 'id', 'title', 'type' ];
+        bool = { draggable: 1 },
+        pin_keys = [ 'lat', 'lon', 'colour', 'id', 'title', 'type', 'draggable' ];
 
     if (!map_data) {
         return;
@@ -38,6 +39,9 @@ var fixmystreet = fixmystreet || {};
             var val = pin.getAttribute('data-' + key);
             if (numeric[key]) {
                 val = +val;
+            }
+            if (bool[key]) {
+                val = !!val;
             }
             arr.push(val);
         });

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -198,13 +198,14 @@ $.extend(fixmystreet.utils, {
             }
             var id = pin[3] === undefined ? pin[3] : +pin[3];
             var marker_size = (id === window.selected_problem_id) ? selected_size : size;
+            var draggable = (id === window.selected_problem_id) ? true : (pin[6] === false ? false : true);
             var marker = new OpenLayers.Feature.Vector(loc, {
                 colour: pin[2],
                 size: pin[5] || marker_size,
                 faded: 0,
                 id: id,
                 title: pin[4] || '',
-                draggable: pin[6] === false ? false : true
+                draggable: draggable
             });
             markers.push( marker );
         }
@@ -215,10 +216,13 @@ $.extend(fixmystreet.utils, {
         var size = fixmystreet.maps.marker_size();
         var selected_size = fixmystreet.maps.selected_marker_size();
         for (var i = 0; i < fixmystreet.markers.features.length; i++) {
-            if (fixmystreet.markers.features[i].attributes.id == window.selected_problem_id) {
-                fixmystreet.markers.features[i].attributes.size = selected_size;
+            var attr = fixmystreet.markers.features[i].attributes;
+            if (attr.id == window.selected_problem_id) {
+                attr.size = selected_size;
+                attr.draggable = true;
             } else {
-                fixmystreet.markers.features[i].attributes.size = size;
+                attr.size = size;
+                attr.draggable = false;
             }
         }
         fixmystreet.markers.redraw();
@@ -277,6 +281,8 @@ $.extend(fixmystreet.utils, {
                   }
               }
           } );
+          // Allow handled feature click propagation to other click handlers
+          drag.handlers.feature.stopClick = false;
           fixmystreet.map.addControl( drag );
           drag.activate();
       },

--- a/web/js/map-fms.js
+++ b/web/js/map-fms.js
@@ -57,7 +57,7 @@ OpenLayers.Layer.BingUK = OpenLayers.Class(OpenLayers.Layer.Bing, {
             }
         } else {
             var type = '';
-            if (z > 10 && in_uk) {
+            if (z > 11 && in_uk) {
                 type = '&productSet=mmOS&key=' + fixmystreet.key;
             }
             urls = [


### PR DESCRIPTION
* New OS map doesn't work at zoom level 11 any more.
* 27700 library not loaded for Oxfordshire, so inspectors not getting easting/northing when pin dragged.
* Set up fully whether pins are draggable or not, which should fix inspector issue dragging/unable to click pins that shouldn't be draggable. Theoetically this means the DragFeatureFMS control could be loaded at all times, and it shouldn't affect any non-draggable pins, but I have not done that here.

[skip changelog]