### PR TITLE
New House Rule forbidding impersonation

### DIFF
--- a/templates/web/fixmystreet.com/about/house-rules.html
+++ b/templates/web/fixmystreet.com/about/house-rules.html
@@ -33,6 +33,10 @@ directly to the police.</li>
 defamatory, abusive, threatening, harmful, obscene, profane, sexually oriented,
 homophobic or racially offensive.</li>
 
+<li><strong>Do not impersonate other people.</strong> Reports or comments
+deliberately intended to look as though they are coming from someone else may
+leave you liable to defamation law.</li>
+
 <li><strong>Do not use the website as a place to air personal
 grievances</strong> about other people or organisations.</li>
 


### PR DESCRIPTION
We’ve recently come across a case of a FixMyStreet user making reports and comments under the name of other nearby residents, often then going on to fabricate potentially defamatory conversations between these sockpuppet accounts.

This is clearly not how we expect people to use FixMyStreet, and it brings no benefit to the community, or the councils receiving the reports. If users feel the need to contribute without disclosing their name, they can do so anonymously.

![screen shot 2018-08-10 at 14 10 53](https://user-images.githubusercontent.com/739624/43959584-3d13fb12-9ca7-11e8-9970-bcc8618c8f25.png)

[skip changelog]