### PR TITLE
Make it easier to prevent a form_detail_placeholder being printed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
         - Cobrand hook for presenting custom search results. #2183
         - Cobrand hook to allow extra login conditions #2092
         - Add ability for client to set bodies not to be sent to.
+        - Make it easier to prevent a form_detail_placeholder being printed.
 
 
 * v2.3.4 (7th June 2018)

--- a/templates/web/base/report/new/form_report.html
+++ b/templates/web/base/report/new/form_report.html
@@ -49,13 +49,22 @@
 [% TRY %][% PROCESS 'report/new/after_photo.html' %][% CATCH file %][% END %]
 
     [% DEFAULT form_detail_label = loc('Explain what’s wrong') %]
-    [% DEFAULT form_detail_placeholder = loc('e.g. ‘This pothole has been here for two months and…’') %]
     <label for="form_detail">[% form_detail_label %]</label>
+
+[%# You can prevent a hint being printed by setting form_detail_placeholder to a Falsey value %]
+[% IF NOT form_detail_placeholder.defined %]
+    [% SET form_detail_placeholder = loc('e.g. ‘This pothole has been here for two months and…’') %]
+[% END %]
+
+[% IF form_detail_placeholder %]
     <p class="form-hint" id="detail-hint">[% form_detail_placeholder %]</p>
+[% END %]
+
 [% IF field_errors.detail %]
     <p class='form-error'>[% field_errors.detail %]</p>
 [% END %]
-    <textarea class="form-control" rows="7" cols="26" name="detail" id="form_detail" aria-describedby="detail-hint" required>[% report.detail | html %]</textarea>
+
+    <textarea class="form-control" rows="7" cols="26" name="detail" id="form_detail" [% IF form_detail_placeholder %]aria-describedby="detail-hint"[% END %] required>[% report.detail | html %]</textarea>
 
 [% TRY %][% PROCESS 'report/new/inline-tips.html' %][% CATCH file %][% END %]
 


### PR DESCRIPTION
Previously, if you didn’t want a hint to appear under the main "details" textarea on the new report form, you had to override the entire `form_report.html` template, or leave the hint element in the markup but hide it with CSS.

Now, you can set `form_detail_placeholder` to a falsey value, and the template won’t output the hint element at all. It also amends the `aria-describedby` attribute on the textarea so it doesn’t end up referencing a hint element that doesn’t exist.

I needed this for https://github.com/mysociety/collideoscope/pull/28, because the existing `[% DEFAULT form_detail_placeholder = … %]` block gave me no easy way to prevent the hint being shown.

# How it looks:

When no custom `form_detail_placeholder` is defined in the cobrand, eg:

```
# /templates/web/<cobrand>/report/new/_form_labels.html
[% form_detail_label = loc('Can you describe what happened?') %]
```

![undefined](https://user-images.githubusercontent.com/739624/44271853-2609ac00-a233-11e8-92ca-7b932f4219e8.png)

When a custom `form_detail_placeholder` is defined in the cobrand, eg:

```
# /templates/web/<cobrand>/report/new/_form_labels.html
[% form_detail_placeholder = "Helpful cobrand-specific hint here" %]
[% form_detail_label = loc('Can you describe what happened?') %]
```

![truthy](https://user-images.githubusercontent.com/739624/44271958-66692a00-a233-11e8-91db-41f506492375.png)

**NEW:** When `form_detail_placeholder` is set to a falsey value, eg:

```
# /templates/web/<cobrand>/report/new/_form_labels.html
[% form_detail_placeholder = 0 %]
[% form_detail_label = loc('Can you describe what happened?') %]
```

![falsey](https://user-images.githubusercontent.com/739624/44272011-87ca1600-a233-11e8-8099-c1c836a0b023.png)
