### PR TITLE
Remove need for category_extras ajax call.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
         - “Report another problem here” button on report confirmation page #2198
         - Button in nav bar now makes it easier to report again in the same location #2195
         - Shrink OpenLayers library a bit. #2217
+        - Remove need for separate per-category ajax call. #1201
     - Admin improvements:
         - Mandatory defect type selection if defect raised.
         - Send login email button on user edit page #2041

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -1669,10 +1669,9 @@ subtest "unresponsive body handling works" => sub {
         # Test body-level send method
         my $old_send = $contact1->body->send_method;
         $contact1->body->update( { send_method => 'Refused' } );
-        $mech->get_ok('/report/new/ajax?latitude=55.952055&longitude=-3.189579'); # Edinburgh
         my $body_id = $contact1->body->id;
-        ok $mech->content_like( qr{Edinburgh.*accept reports.*/unresponsive\?body=$body_id} );
         my $extra_details = $mech->get_ok_json('/report/new/ajax?latitude=55.952055&longitude=-3.189579');
+        like $extra_details->{top_message}, qr{Edinburgh.*accept reports.*/unresponsive\?body=$body_id};
         is $extra_details->{unresponsive}, $body_id, "unresponsive json set";
         $extra_details = $mech->get_ok_json('/report/new/category_extras?category=Street%20lighting&latitude=55.952055&longitude=-3.189579');
         is $extra_details->{unresponsive}, $body_id, "unresponsive json set";
@@ -1749,8 +1748,8 @@ subtest "unresponsive body handling works" => sub {
         # And test per-category refusing
         my $old_email = $contact3->email;
         $contact3->update( { email => 'REFUSED' } );
-        $mech->get_ok('/report/new/category_extras?category=Trees&latitude=51.896268&longitude=-2.093063');
-        ok $mech->content_like( qr/Cheltenham.*Trees.*unresponsive.*category=Trees/ );
+        $extra_details = $mech->get_ok_json('/report/new/ajax?latitude=51.896268&longitude=-2.093063');
+        like $extra_details->{by_category}{$contact3->category}{category_extra}, qr/Cheltenham.*Trees.*unresponsive.*category=Trees/s;
         $extra_details = $mech->get_ok_json('/report/new/category_extras?category=Trees&latitude=51.896268&longitude=-2.093063');
         is $extra_details->{unresponsive}, $contact3->body->id, "unresponsive json set";
 

--- a/t/app/controller/report_new_open311.t
+++ b/t/app/controller/report_new_open311.t
@@ -249,13 +249,18 @@ subtest "Category extras omits description label when all fields are hidden" => 
         ALLOWED_COBRANDS => [ { fixmystreet => '.' } ],
         MAPIT_URL => 'http://mapit.uk/',
     }, sub {
-        my $json = $mech->get_ok_json('/report/new/category_extras?category=Pothole&latitude=55.952055&longitude=-3.189579');
-        my $category_extra = $json->{category_extra};
-        contains_string($category_extra, "usrn");
-        contains_string($category_extra, "central_asset_id");
-        lacks_string($category_extra, "USRN", "Lacks 'USRN' label");
-        lacks_string($category_extra, "Asset ID", "Lacks 'Asset ID' label");
-        lacks_string($category_extra, "resolve your problem quicker, by providing some extra detail", "Lacks description text");
+        for (
+          { url => '/report/new/ajax?' },
+          { url => '/report/new/category_extras?category=Pothole' },
+        ) {
+            my $json = $mech->get_ok_json($_->{url} . '&latitude=55.952055&longitude=-3.189579');
+            my $category_extra = $json->{by_category} ? $json->{by_category}{Pothole}{category_extra} : $json->{category_extra};
+            contains_string($category_extra, "usrn");
+            contains_string($category_extra, "central_asset_id");
+            lacks_string($category_extra, "USRN", "Lacks 'USRN' label");
+            lacks_string($category_extra, "Asset ID", "Lacks 'Asset ID' label");
+            lacks_string($category_extra, "resolve your problem quicker, by providing some extra detail", "Lacks description text");
+        }
     };
 };
 
@@ -266,15 +271,19 @@ subtest "Category extras includes description label for user" => sub {
     }, sub {
         $contact4->push_extra_fields({ description => 'Size?', code => 'size', required => 'true', automated => '', variable => 'true', order => '3' });
         $contact4->update;
-
-        my $json = $mech->get_ok_json('/report/new/category_extras?category=Pothole&latitude=55.952055&longitude=-3.189579');
-        my $category_extra = $json->{category_extra};
-        contains_string($category_extra, "usrn");
-        contains_string($category_extra, "central_asset_id");
-        lacks_string($category_extra, "USRN", "Lacks 'USRN' label");
-        lacks_string($category_extra, "Asset ID", "Lacks 'Asset ID' label");
-        contains_string($category_extra, "Size?");
-        contains_string($category_extra, "resolve your problem quicker, by providing some extra detail", "Contains description text");
+        for (
+          { url => '/report/new/ajax?' },
+          { url => '/report/new/category_extras?category=Pothole' },
+        ) {
+            my $json = $mech->get_ok_json($_->{url} . '&latitude=55.952055&longitude=-3.189579');
+            my $category_extra = $json->{by_category} ? $json->{by_category}{Pothole}{category_extra} : $json->{category_extra};
+            contains_string($category_extra, "usrn");
+            contains_string($category_extra, "central_asset_id");
+            lacks_string($category_extra, "USRN", "Lacks 'USRN' label");
+            lacks_string($category_extra, "Asset ID", "Lacks 'Asset ID' label");
+            contains_string($category_extra, "Size?");
+            contains_string($category_extra, "resolve your problem quicker, by providing some extra detail", "Contains description text");
+        }
     };
 };
 

--- a/templates/web/base/js/translation_strings.html
+++ b/templates/web/base/js/translation_strings.html
@@ -38,6 +38,8 @@ fixmystreet.password_minimum_length = [% c.cobrand.password_minimum_length %];
         how_to_send: '[% loc('How to send successful reports') | replace("'", "\\'") %]',
         more_details: '[% loc('Details') | replace("'", "\\'") %]',
 
+        or: '[% loc(' or ') | replace("'", "\\'") %]',
+
         geolocation_declined: '[% loc('You declined; please fill in the box above') | replace("'", "\\'") %]',
         geolocation_no_position: '[% loc('Could not look up location') | replace("'", "\\'") %]',
         geolocation_no_result: '[% loc('No result returned') | replace("'", "\\'") %]',


### PR DESCRIPTION
Add `by_category` output to the `/report/new/ajax` call, containing all the data (or at least, the needed subset, e.g. not returning `councils_text` if same as general one) that `/report/new/category_extras` returns for one category. Then alter the JS to use that data immediately when needed. Fixes #1201.

The `/category_extras` is kept (mobile app currently using it) but no longer outputs councils_text (unused), or category_extra/json if no output (code copes fine); it still has to output `unresponsive` as app code specifically checks for empty string.

One issue I came across was when switching from Flytipping to Graffiti in Bucks, it not switching off the single_body_only for Bucks. This was because in old-way, `road_found` fired for Graffiti (thus removing single_body_only) at the `category_changed` event, then layer was removed when category_extras returned (in the `extras_received` event), whereas in the new-way, the layer is removed immediately and isn't there to then fire anything at all on the road layer. So I added the change to `layer_visibilitychanged` to call road_not_found if a road layer becomes invisible, which seems to work here okay.

I think `fixmystreet.bodies` can probably then be removed/refactored/changed a bit, but this seemed enough to begin with. 