### PR TITLE
Make sure Home clickable with Try again overlay.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
         - Allow questionnaire link to be revisited in quick succession. #2123
         - Update Google Maps directions link.
         - Fix inspector pin dragging. #2073.
+        - Make sure Home clickable with Try again overlay.
     - Open311 improvements:
         - CLOSED status maps to 'closed' state if extended statuses are enabled.
         - Don't generate template comment text on move between fixed states.

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1531,7 +1531,7 @@ html.js #map .noscript {
     display: block;
 
     // "Fade out" the map.
-    height: 100%;
+    top: 30px;
     background-color: rgba(#000, 0.3);
 
     #try_again,


### PR DESCRIPTION
Fixes https://github.com/mysociety/collideoscope/issues/44

# Before

(Note the "HOME" button and "RIGHT PLACE?" title stacked _behind_ the black overlay)

![screen shot 2018-09-04 at 16 13 10](https://user-images.githubusercontent.com/739624/45040504-0dd0c400-b05e-11e8-885f-948f101738b8.png)

# After

("HOME" button is no longer obscured by the black overlay, so can be pressed)

![screen shot 2018-09-04 at 16 16 46](https://user-images.githubusercontent.com/739624/45040513-12957800-b05e-11e8-9fa6-2499fda3e513.png)
