### PR TITLE
allow web based use of report import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Releases
 
 * Unreleased
+    - Front end improvements:
+        - Import end point can optionally return a web page #2225
     - Bugfixes:
         - Fix display of area/pins on body page when using Bing or TonerLite map.
         - Do not scan through all problems to show /_dev pages.

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -418,6 +418,12 @@ sub report_import : Path('/import') {
 
     $c->send_email( 'partial.txt', { to => $report->user->email, } );
 
+    if ( $c->get_param('web') ) {
+        $c->res->content_type('text/html; charset=utf-8');
+        $c->stash->{template}   = 'email_sent.html';
+        $c->stash->{email_type} = 'problem';
+        return 1;
+    }
     $c->res->body('SUCCESS');
     return 1;
 }

--- a/t/app/controller/report_import.t
+++ b/t/app/controller/report_import.t
@@ -89,6 +89,15 @@ subtest "Test creating bad partial entries" => sub {
 
 };
 
+for my $test (
+    {
+        desc => 'Submit a correct entry',
+    },
+    {
+        desc => 'Submit a correct web entry',
+        web  => 1,
+    }
+) {
 subtest "Submit a correct entry" => sub {
     $mech->get_ok('/import');
 
@@ -101,13 +110,18 @@ subtest "Submit a correct entry" => sub {
                 subject => 'Test report',
                 detail  => 'This is a test report',
                 photo   => $sample_file,
+                web     => $test->{web},
             }
         },
         "fill in form"
     );
 
     is_deeply( $mech->import_errors, [], "got no errors" );
-    is $mech->content, 'SUCCESS', "Got success response";
+    if ( $test->{web} ) {
+        $mech->content_contains('Nearly done! Now check', "Got email confirmation page");
+    } else {
+        is $mech->content, 'SUCCESS', "Got success response";
+    }
 
     # check that we have received the email
     my $token_url = $mech->get_link_from_email;
@@ -223,6 +237,7 @@ subtest "Submit a correct entry" => sub {
 
     $mech->delete_user($user);
 };
+}
 
 subtest "Submit a correct entry (with location)" => sub {
 

--- a/templates/web/base/report/new/report_import.html
+++ b/templates/web/base/report/new/report_import.html
@@ -85,6 +85,7 @@ line each starting with <samp>ERROR:</samp>.
     </dd>
 </dl>
 
+<input type="hidden" name="web" value="0">
 <input type="submit" />
 
 </form>


### PR DESCRIPTION
if a web parameter is passed to /import then display the email
confirmation sent page rather than a SUCCESS message. Enables this page
to be used for creating partial reports from a web page.

For mysociety/collideoscope#17