### PR TITLE
Issues/collideoscope/42 report button mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Unreleased
     - Front end improvements:
         - Import end point can optionally return a web page #2225
+        - Clicking the "Report" header links on the homepage now focusses
+          the #pc search input #2237
     - Bugfixes:
         - Fix display of area/pins on body page when using Bing or TonerLite map.
         - Do not scan through all problems to show /_dev pages.

--- a/web/js/front.js
+++ b/web/js/front.js
@@ -17,7 +17,7 @@ document.getElementById('pc').focus();
     }
 
     var lk = document.querySelector('span.report-a-problem-btn');
-    if (lk.addEventListener) {
+    if (lk && lk.addEventListener) {
         lk.addEventListener('click', function(){
             scrollTo(0,0);
         });

--- a/web/js/front.js
+++ b/web/js/front.js
@@ -10,6 +10,7 @@ document.getElementById('pc').focus();
         el.value = 1;
         form.insertBefore(el, form.firstChild);
     }
+
     var around_links = document.querySelectorAll('a[href*="around"]');
     for (i=0; i<around_links.length; i++) {
         var link = around_links[i];
@@ -18,8 +19,19 @@ document.getElementById('pc').focus();
 
     var lk = document.querySelector('span.report-a-problem-btn');
     if (lk && lk.addEventListener) {
-        lk.addEventListener('click', function(){
+        lk.addEventListener('click', function(e){
+            e.preventDefault();
             scrollTo(0,0);
+            document.getElementById('pc').focus();
+        });
+    }
+
+    var cta = document.getElementById('report-cta');
+    if (cta && cta.addEventListener) {
+        cta.addEventListener('click', function(e) {
+            e.preventDefault();
+            scrollTo(0,0);
+            document.getElementById('pc').focus();
         });
     }
 })();


### PR DESCRIPTION
Fixes mysociety/collideoscope/issues/42.

On the homepage:

* Pressing "Report a problem" (in the nav menu on wide screens, or at the bottom of the page on small screens) now scrolls you to the search input and focusses it, so you can begin typing.
* Pressing the "Report" convenience button in the header on narrow screens does the same as above.

~~I also tried to refactor code in `front.js` a bit, since I’m guessing we want this file to be as short as possible, given it’s on the homepage, and we want that to get delivered as quickly as possible? (Hence why, for example, we don’t load jQuery on the homepage?)~~