### PR TITLE
Don't lose from_body if edited by non-superuser.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
         - Fix display of area/pins on body page when using Bing or TonerLite map.
         - Do not scan through all problems to show /_dev pages.
         - Say “Set password”, not Change, if no password set.
+        - Do not lose from_body field when edited by non-superuser admin.
     - Development improvements:
         - Cobrand hook for disabling updates on individual problems.
         - Cobrand hook for disallowing title moderation. #2228

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -1591,11 +1591,12 @@ sub user_edit : Path('user_edit') : Args(1) {
         # set from_body to the same value as their own from_body.
         if ( $c->user->is_superuser || $c->cobrand->moniker eq 'zurich' ) {
             $user->from_body( $c->get_param('body') || undef );
-        } elsif ( $c->user->has_body_permission_to('user_assign_body') &&
-                  $c->get_param('body') && $c->get_param('body') eq $c->user->from_body->id ) {
-            $user->from_body( $c->user->from_body );
-        } else {
-            $user->from_body( undef );
+        } elsif ( $c->user->has_body_permission_to('user_assign_body') ) {
+            if ($c->get_param('body') && $c->get_param('body') eq $c->user->from_body->id ) {
+                $user->from_body( $c->user->from_body );
+            } else {
+                $user->from_body( undef );
+            }
         }
 
         $c->forward('user_cobrand_extra_fields');

--- a/t/app/controller/admin/permissions.t
+++ b/t/app/controller/admin/permissions.t
@@ -100,6 +100,16 @@ FixMyStreet::override_config {
         }
     }
 
+    subtest "Users can't edit users of their own council without permission" => sub {
+        $mech->get_ok("/admin/user_edit/$user2_id");
+        $mech->submit_form_ok( { with_fields => {
+            email => $user2->email,
+        } } );
+        $user2->discard_changes;
+        # Make sure we haven't lost the from_body info
+        is $user2->from_body->id, $oxfordshire->id;
+    };
+
     $oxfordshireuser->user_body_permissions->create({
         body => $oxfordshire,
         permission_type => 'user_assign_body',


### PR DESCRIPTION
If an admin with the user_edit permission but not user_assign_body
edited a user with from_body set, the from_body field was lost.