### PR TITLE
Add configuration option for memcached host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
         - Cobrand hook for disabling updates on individual problems.
         - Cobrand hook for disallowing title moderation. #2228
         - Cobrand hook for per-questionnaire sending. #2231
+        - Add option for configuring memcache server.
 
 * v2.4 (6th September 2018)
     - Security

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -197,6 +197,10 @@ SMTP_PASSWORD: ''
 # this as is.
 GAZE_URL: 'https://gaze.mysociety.org/gaze'
 
+# Memcached host
+# This can be safely left out and will default to '127.0.0.1' even if not present.
+MEMCACHED_HOST: '127.0.0.1'
+
 # Should problem reports link to the council summary pages?
 AREA_LINKS_FROM_PROBLEMS: '0'
 

--- a/perllib/Memcached.pm
+++ b/perllib/Memcached.pm
@@ -10,10 +10,11 @@ use FixMyStreet;
 
 my $memcache;
 my $namespace = FixMyStreet->config('FMS_DB_NAME') . ":";
+my $server    = FixMyStreet->config('MEMCACHED_HOST') || '127.0.0.1';
 
 sub instance {
     return $memcache //= Cache::Memcached->new({
-        'servers' => [ '127.0.0.1:11211' ],
+        'servers' => [ "${server}:11211" ],
         'namespace' => $namespace,
         'debug' => 0,
         'compress_threshold' => 10_000,


### PR DESCRIPTION
Previously we assumed that any memcache instance would be running on the local loopback interface. This commit makes this configurable with a `FMS_MEMCACHED_HOST` option. If left unset, this will default to `127.0.0.1`.