### PR TITLE
Switch to direct app server, not FastCGI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
         - Add Blackhole send method. #2246
         - Add script to list/diff template changes in core that
           might need applying to a cobrand.
+        - Move away from FastCGI in sample conf/sysvinit config.
 
 * v2.4 (6th September 2018)
     - Security

--- a/conf/nginx.conf.example
+++ b/conf/nginx.conf.example
@@ -63,9 +63,10 @@ server {
     }
 
     location @catalyst {
-        include /etc/nginx/fastcgi_params;
-        fastcgi_param PATH_INFO $fastcgi_script_name;
-        fastcgi_param SCRIPT_NAME '';
-        fastcgi_pass 127.0.0.1:9000;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_redirect off;
+        proxy_pass http://127.0.0.1:9000;
     }
 }

--- a/conf/sysvinit.example
+++ b/conf/sysvinit.example
@@ -5,8 +5,8 @@
 # Required-Stop:     $local_fs $network
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: Starts the FastCGI app server for the "FixMyStreet" site
-# Description:       The FastCGI application server for the "FixMyStreet" site
+# Short-Description: Starts the app server for the "FixMyStreet" site
+# Description:       The application server for the "FixMyStreet" site
 ### END INIT INFO
 
 # This example sysvinit script is based on the helpful example here:
@@ -17,6 +17,8 @@ SITE_HOME=/var/www/fixmystreet
 NAME=fixmystreet
 DESC="FixMyStreet app server"
 USER=fms
+PIDFILE=${SITE_HOME}/${NAME}.pid
+LOGDIR=${SITE_HOME}/logs
 
 echo $DAEMON
 test -f $DAEMON || exit 0
@@ -24,30 +26,30 @@ test -f $DAEMON || exit 0
 set -e
 
 start_daemon() {
-  su -l -c "cd $SITE_HOME/fixmystreet && web/fixmystreet_app_fastcgi.cgi -d -l :9000 -n 2" $USER
+  su -l -c "cd $SITE_HOME/fixmystreet && script/server --port 9000 --env deployment --daemonize --pid $PIDFILE --access-log $LOGDIR/$NAME.access.log --error-log $LOGDIR/$NAME.error.log" $USER
 }
 
 stop_daemon() {
-  pkill -f perl-fcgi -u $USER || true
+  kill -TERM `cat $PIDFILE`
 }
 
 case "$1" in
- start)
- start_daemon
- ;;
- stop)
- stop_daemon
- ;;
- reload|restart|force-reload)
- stop_daemon
- sleep 5
- start_daemon
- ;;
- *)
- N=/etc/init.d/$NAME
- echo "Usage: $N {start|stop|reload|restart|force-reload}" >&2
- exit 1
- ;;
+  start)
+    start_daemon
+    ;;
+  stop)
+    stop_daemon
+    ;;
+  reload|restart|force-reload)
+    stop_daemon
+    sleep 5
+    start_daemon
+    ;;
+  *)
+    N=/etc/init.d/$NAME
+    echo "Usage: $N {start|stop|reload|restart|force-reload}" >&2
+    exit 1
+    ;;
 esac
 
 exit 0

--- a/script/server
+++ b/script/server
@@ -1,7 +1,15 @@
-#!/bin/sh
+#!/bin/bash
+#
+# By default, if no arguments given, runs a server on port 3000 with
+# auto-reloading, and debug switched on. Run with FIXMYSTREET_APP_DEBUG=0 to
+# override debug, or provide arguments to override everything.
 
 set -e
 cd "$(dirname "$0")/.."
 
-export FIXMYSTREET_APP_DEBUG=${FIXMYSTREET_APP_DEBUG=1}
-bin/cron-wrapper local/bin/plackup -s Starman --listen :3000 --Reload perllib,conf
+if [ -z "$1" ]; then
+    export FIXMYSTREET_APP_DEBUG=${FIXMYSTREET_APP_DEBUG=1}
+    set -- --listen :3000 --Reload perllib,conf
+fi
+
+bin/cron-wrapper local/bin/plackup -s Starman $@


### PR DESCRIPTION
This allows `script/server` to take arguments, switches the example sysvinit script to use it rather than the FastCGI daemon, and the example nginx config to proxy rather than use FastCGI.