### PR TITLE
Speed up fetching lists of bodies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
         - Clicking the "Report" header links on the homepage now focusses
           the #pc search input #2237
         - Clearer relocation options while you’re reporting a problem #2238
+        - Speed up fetching lists of bodies. #2248
     - Bugfixes:
         - Fix display of area/pins on body page when using Bing or TonerLite map.
         - Do not scan through all problems to show /_dev pages.

--- a/perllib/FixMyStreet/App/Controller/Admin/DefectTypes.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/DefectTypes.pm
@@ -12,6 +12,7 @@ sub index : Path : Args(0) {
     my $user = $c->user;
 
     if ($user->is_superuser) {
+        $c->stash->{with_defect_type_count} = 1;
         $c->forward('/admin/fetch_all_bodies');
     } elsif ( $user->from_body ) {
         $c->forward('load_user_body', [ $user->from_body->id ]);

--- a/perllib/FixMyStreet/App/Controller/Dashboard.pm
+++ b/perllib/FixMyStreet/App/Controller/Dashboard.pm
@@ -99,7 +99,9 @@ sub index : Path : Args(0) {
             $c->stash->{body_name} = join "", map { $children->{$_}->{name} } grep { $children->{$_} } $c->user->area_id;
         }
     } else {
-        my @bodies = $c->model('DB::Body')->active->translated->with_area_count->all_sorted;
+        my @bodies = $c->model('DB::Body')->search(undef, {
+            columns => [ "id", "name" ],
+        })->active->translated->with_area_count->all_sorted;
         $c->stash->{bodies} = \@bodies;
     }
 

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -66,7 +66,9 @@ sub index : Path : Args(0) {
             $c->stash->{children} = $children;
         }
     } else {
-        my @bodies = $c->model('DB::Body')->active->translated->with_area_count->all_sorted;
+        my @bodies = $c->model('DB::Body')->search(undef, {
+            columns => [ "id", "name" ],
+        })->active->translated->with_area_count->all_sorted;
         @bodies = @{$c->cobrand->call_hook('reports_hook_restrict_bodies_list', \@bodies) || \@bodies };
         $c->stash->{bodies} = \@bodies;
     }

--- a/t/app/controller/admin/defecttypes.t
+++ b/t/app/controller/admin/defecttypes.t
@@ -28,6 +28,20 @@ FixMyStreet::override_config { ALLOWED_COBRANDS => ['oxfordshire'], }, sub {
 
     my $body = $mech->create_body_ok( 2237, 'Oxfordshire County Council' );
 
+    subtest 'check defect types menu available to superusers' => sub {
+        my $user = $mech->create_user_ok(
+            'superuser@example.com',
+            name => 'Test Superuser',
+            is_superuser => 1
+        );
+
+        $mech->log_in_ok( $user->email );
+        $mech->get_ok('/admin');
+        $mech->content_contains('Defect Types');
+        $mech->get_ok('/admin/defecttypes');
+        $mech->log_out_ok();
+    };
+
     my $user = $mech->create_user_ok(
         'oxford@example.com',
         name => 'Test User',

--- a/templates/web/base/admin/bodies.html
+++ b/templates/web/base/admin/bodies.html
@@ -32,12 +32,12 @@
       </tr>
   [%- FOREACH body IN bodies %]
       [%- SET id = body.id %]
-      [% NEXT IF c.cobrand.moniker == 'zurich' AND admin_type == 'dm' AND (body.parent OR body.bodies) %]
+      [% NEXT IF c.cobrand.moniker == 'zurich' AND admin_type == 'dm' AND (body.parent OR body.children_count) %]
       <tr[% IF body.deleted %] class="adminhidden"[% END %]
         [% IF NOT counts.$id OR counts.$id.deleted == counts.$id.c %] class="is-deleted"[% END %]>
           <td>
             [% IF c.cobrand.moniker == 'zurich' %]
-              [% FILTER repeat(4*body.api_key) %]&nbsp;[% END %]
+              [% FILTER repeat(4*body.indent_level) %]&nbsp;[% END %]
               [% IF admin_type == 'super' %]
                 <a href="[% c.uri_for( 'body', id ) %]">[% body.name | html %]</a>
               [% ELSE %]

--- a/templates/web/base/admin/defecttypes/index.html
+++ b/templates/web/base/admin/defecttypes/index.html
@@ -4,8 +4,7 @@
     [% FOR body IN bodies %]
         <li>
             <a href="[% c.uri_for('',  body.id) %]">[% body.name %]</a>
-            [% defect_types_count = body.defect_types.count %]
-            [% IF defect_types_count %]([% defect_types_count %])[% END %]
+            [% IF body.defect_type_count %]([% body.defect_type_count %])[% END %]
         </li>
     [% END %]
 </ul>

--- a/templates/web/base/dashboard/index.html
+++ b/templates/web/base/dashboard/index.html
@@ -50,7 +50,7 @@
         <label for="ward">[% loc('Council:') %]</label>
         <select class="form-control" name="body" id="body"><option value=''>[% loc('All') %]</option>
             [% FOR b IN bodies %]
-                [% NEXT IF NOT b.get_column("area_count") %]
+                [% NEXT IF NOT b.area_count %]
                 <option value="[% b.id %]">[% b.name %]</option>
             [% END %]
         </select>

--- a/templates/web/base/reports/index.html
+++ b/templates/web/base/reports/index.html
@@ -79,7 +79,7 @@
                     <option value="">[% loc('Pick your council') %]</option>
                   [% FOR b IN bodies # Not body as 'body' may be on stash %]
                     <option value="[% b.id %]">[% b.name | html ~%]
-                        [% IF NOT b.get_column("area_count") %] [% loc('(no longer exists)') %][% END ~%]
+                        [% IF NOT b.area_count %] [% loc('(no longer exists)') %][% END ~%]
                     </option>
                   [% END %]
                 </select>


### PR DESCRIPTION
Use a HashRefInflator wherever `all_sorted` is used, with consequential changes to deal with it now not being an object (e.g. add some `with_*` functions for manual fetching of extra data).