### PR TITLE
Pre OCC WDM go live

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -234,6 +234,13 @@ sub available_permissions {
     my $perms = $self->next::method();
     $perms->{Bodies}->{defect_type_edit} = "Add/edit defect types";
 
+    delete $perms->{Problems}->{report_edit};
+    delete $perms->{Problems}->{report_edit_category};
+    delete $perms->{Problems}->{report_edit_priority};
+    delete $perms->{Problems}->{report_inspect};
+    delete $perms->{Problems}->{report_instruct};
+    delete $perms->{Problems}->{planned_reports};
+
     return $perms;
 }
 

--- a/t/app/controller/admin/defecttypes.t
+++ b/t/app/controller/admin/defecttypes.t
@@ -1,4 +1,5 @@
 use FixMyStreet::TestMech;
+use Test::MockModule;
 
 my $mech = FixMyStreet::TestMech->new;
 
@@ -25,6 +26,16 @@ FixMyStreet::override_config { ALLOWED_COBRANDS => ['bromley'], }, sub {
 };
 
 FixMyStreet::override_config { ALLOWED_COBRANDS => ['oxfordshire'], }, sub {
+
+    my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Oxfordshire');
+    $cobrand->mock('available_permissions', sub {
+        my $self = shift;
+
+        my $perms = FixMyStreet::Cobrand::Default->available_permissions;
+        $perms->{Bodies}->{defect_type_edit} = "Add/edit defect types";
+
+        return $perms;
+    });
 
     my $body = $mech->create_body_ok( 2237, 'Oxfordshire County Council' );
 

--- a/t/app/controller/admin/permissions.t
+++ b/t/app/controller/admin/permissions.t
@@ -1,4 +1,5 @@
 use FixMyStreet::TestMech;
+use Test::MockModule;
 
 my $mech = FixMyStreet::TestMech->new;
 
@@ -27,6 +28,13 @@ my $report_id = $report->id;
 ok $report, "created test report - $report_id";
 
 $mech->log_in_ok( $oxfordshireuser->email );
+
+my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Oxfordshire');
+$cobrand->mock('available_permissions', sub {
+    my $self = shift;
+
+    return FixMyStreet::Cobrand::Default->available_permissions;
+});
 
 subtest "Users can't edit report without report_edit permission" => sub {
     FixMyStreet::override_config {

--- a/t/app/controller/my_planned.t
+++ b/t/app/controller/my_planned.t
@@ -1,4 +1,5 @@
 use FixMyStreet::TestMech;
+use Test::MockModule;
 my $mech = FixMyStreet::TestMech->new;
 
 $mech->get_ok('/my/planned');
@@ -187,6 +188,13 @@ FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'oxfordshire' ],
     BASE_URL => 'http://oxfordshire.fixmystreet.site',
 }, sub {
+    my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Oxfordshire');
+    $cobrand->mock('available_permissions', sub {
+        my $self = shift;
+
+        return FixMyStreet::Cobrand::Default->available_permissions;
+    });
+
     subtest "can remove problems not displayed in cobrand from shortlist" => sub {
         $user->user_planned_reports->remove();
         my ($problem1) = $mech->create_problems_for_body(2, $body->id, 'New Problem');


### PR DESCRIPTION
Adds a message about the system being off line and also turns off the inspector tool.

[skip changelog]