### PR TITLE
Vagrant: Use the mysociety/fixmystreet box by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
         - Add script to list/diff template changes in core that
           might need applying to a cobrand.
         - Move away from FastCGI in sample conf/sysvinit config.
+        - Customised Vagrant box available, with an override option.
 
 * v2.4 (6th September 2018)
     - Security


### PR DESCRIPTION
This sets the default box to be `mysociety/fixmystreet` and provides
an optional argument, `--base-box`, that can be used to override this.

When using the `mysociety/fixmystreet` box, the Perl modules are
prebuilt in `/usr/share/fixmystreet/local` and are bind-mounted into
`/home/vagrant/fixmystreet/local`. This ensures that these are
compatible with the guest machine and speeds up an initial launch.

The `mysociety/fixmystreet` box is also based on Debian Stretch so is
a closer match to our current production environment.