### PR TITLE
[Dependencies] Add libxml2-dev to packages files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN /install-site.sh --docker fixmystreet fms 127.0.0.1.xip.io \
         libexpat1-dev \
         libssl-dev \
         zlib1g-dev \
+        libxml2-dev \
         postgresql-server-dev-all \
         exim4-daemon-light \
       && apt-get -y clean \

--- a/conf/packages
+++ b/conf/packages
@@ -18,3 +18,4 @@ ttf-bitstream-vera
 libexpat1-dev
 libssl-dev
 zlib1g-dev
+libxml2-dev

--- a/conf/packages.docker
+++ b/conf/packages.docker
@@ -13,3 +13,4 @@ ttf-bitstream-vera
 libexpat1-dev
 libssl-dev
 zlib1g-dev
+libxml2-dev

--- a/conf/packages.generic
+++ b/conf/packages.generic
@@ -14,3 +14,4 @@ ttf-bitstream-vera
 libexpat1-dev
 libssl-dev
 zlib1g-dev
+libxml2-dev


### PR DESCRIPTION
This is required to build `XML::LibXML`, a dependency of `Net::Amazon::S3`. Without this, the Docker and Vagrant builds fail.