### PR TITLE
[Docker] Copy the preinit file from the local working copy at build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,7 @@ RUN /install-site.sh --docker fixmystreet fms 127.0.0.1.xip.io \
       && rm -fr /var/lib/apt/lists/* \
       && rm -fr /home/fms/.cpanm/*
 
-RUN cd /var/www/fixmystreet/fixmystreet \
-      && git show master:bin/docker.preinit > /usr/local/preinit/99-fixmystreet \
+RUN cp /var/www/fixmystreet/fixmystreet/bin/docker.preinit /usr/local/preinit/99-fixmystreet \
       && chmod +x /usr/local/preinit/99-fixmystreet
 
 EXPOSE 9000


### PR DESCRIPTION
Rather than pulling across the preinit file from master, use the
version in the copy of FixMyStreet on the image - this will then
match the release actually being built.
