### PR TITLE
HTML template for the "partial" report confirmation email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
         - Speed up fetching lists of bodies. #2248
         - Improve vertical alignment of navigation menu in Internet Explorer 9–11.
         - Mobile menu button no longer uses -9999px text-indent hack.
+        - HTML email template for confirming "partial" reports #2263
     - Bugfixes:
         - Fix display of area/pins on body page when using Bing or TonerLite map.
         - Do not scan through all problems to show /_dev pages.

--- a/templates/email/default/partial.html
+++ b/templates/email/default/partial.html
@@ -1,0 +1,22 @@
+[%
+
+email_summary = "Confirm your report on " _ site_name;
+email_columns = 1;
+
+PROCESS '_email_settings.html';
+
+INCLUDE '_email_top.html';
+
+%]
+
+<th style="[% td_style %][% only_column_style %]">
+  <h1 style="[% h1_style %]">Confirm your report</h1>
+  <p style="[% p_style %]">Hello [% report.name || report.email %],</p>
+  <p style="[% p_style %]">Please click on the link below, to confirm the report you have uploaded to [% site_name %] via [% report.service %], and to check or add any details:</p>
+  <p style="margin: 20px auto; text-align: center">
+    <a style="[% button_style %]" href="[% token_url %]">Check &amp; confirm report</a>
+  </p>
+</th>
+
+[% INCLUDE '_email_bottom.html' %]
+


### PR DESCRIPTION
Fixes #2263.

Here’s what it should look like:

![screenshot_2018-10-01 screenshot](https://user-images.githubusercontent.com/739624/46298052-12719500-c596-11e8-9f57-26164f1b72d4.png)

@dracos Do I need to add a test somewhere that checks the "partial" email is now multipart text+html? Or is that generic enough that it’s covered by other tests like `send_email.t`?