### PR TITLE
Add check for PIDFILE to init script stop action

### DIFF
--- a/conf/sysvinit.example
+++ b/conf/sysvinit.example
@@ -30,7 +30,11 @@ start_daemon() {
 }
 
 stop_daemon() {
-  kill -TERM `cat $PIDFILE`
+  if [ -e "$PIDFILE" ]; then
+    kill -TERM `cat $PIDFILE`
+  else
+    echo "No $PIDFILE found, skipping KILL."
+  fi
 }
 
 case "$1" in


### PR DESCRIPTION
The install script calls a service restart at build, this failed if the stop action in the init script doesn't check for the existence of the `PIDFILE` first, so check.

Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
