### PR TITLE
[Vagrant] Ensure `local` directory is present

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,6 +27,7 @@ $setup = <<-EOS
     cd fixmystreet
     git submodule --quiet update --init --recursive --rebase
     if [ "$BASEBOX" = "mysociety/fixmystreet" ]; then
+        [ ! -e /home/vagrant/fixmystreet/local ] && mkdir /home/vagrant/fixmystreet/local
         mount -o bind /usr/share/fixmystreet/local /home/vagrant/fixmystreet/local
         chown -R vagrant:vagrant /home/vagrant/fixmystreet/local
     fi


### PR DESCRIPTION
When using the mySociety Vagrant box, ensure that the `local/` directory is present before attempting to bind mount the pre-built Perl modules.

Without this directory present the bind mount will fail and the Perl modules will all be built again unnecessarily.

Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
