### PR TITLE
[UK] Fix ward pages containing ampersands.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -392,10 +392,11 @@ sub ward_check : Private {
     my $qw = mySociety::MaPit::call('area/children', [ $parent_id ],
         type => $c->cobrand->area_types_children,
     );
-    my %names = map { $_ => 1 } @wards;
+    my %names = map { $c->cobrand->short_name({ name => $_ }) => 1 } @wards;
     my @areas;
     foreach my $area (sort { $a->{name} cmp $b->{name} } values %$qw) {
-        push @areas, $area if $names{$area->{name}};
+        my $name = $c->cobrand->short_name($area);
+        push @areas, $area if $names{$name};
     }
     if (@areas) {
         $c->stash->{ward} = $areas[0] if @areas == 1;

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -107,9 +107,6 @@ sub short_name {
     return 'Durham+County' if $name eq 'Durham County Council';
     return 'Durham+City' if $name eq 'Durham City Council';
 
-    # special case Horncastle and the Keals as MapIt has the &
-    return 'Horncastle+&amp;+the+Keals' if $name eq 'Horncastle & the Keals';
-
     $name =~ s/ (Borough|City|District|County) Council$//;
     $name =~ s/ Council$//;
     $name =~ s/ & / and /;

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -113,8 +113,8 @@ sub dispatch_request {
         my ($self, $area) = @_;
         if ($area eq '2514') {
             return $self->output({
-                8794 => {parent_area => 2514, id => 8794, name => "Aston", type => "MTW"},
-                8773 => {parent_area => 2514, id => 8773, name => "Bournville", type => "MTW"},
+                151907 => {parent_area => 2514, id => 151907, name => "Bordesley & Highgate", type => "MTW"},
+                151942 => {parent_area => 2514, id => 151942, name => "Birchfield", type => "MTW"},
             });
         }
         if ($area eq '2326') {

--- a/t/app/controller/reports.t
+++ b/t/app/controller/reports.t
@@ -115,19 +115,20 @@ $mech->content_contains('5,9,10,22');
 $mech->content_contains('2,3,4,4');
 
 FixMyStreet::override_config {
+    ALLOWED_COBRANDS => 'fixmystreet',
     MAPIT_URL => 'http://mapit.uk/',
 }, sub {
     $mech->submit_form_ok( { with_fields => { body => $body_edin_id } }, 'Submitted dropdown okay' );
-    is $mech->uri->path, '/reports/City+of+Edinburgh+Council';
+    is $mech->uri->path, '/reports/City+of+Edinburgh';
 
     subtest "test ward pages" => sub {
         $mech->get_ok('/reports/Birmingham/Bad-Ward');
-        is $mech->uri->path, '/reports/Birmingham+City+Council';
-        $mech->get_ok('/reports/Birmingham/Aston');
-        is $mech->uri->path, '/reports/Birmingham+City+Council/Aston';
-        $mech->get_ok('/reports/Birmingham/Aston|Bournville');
-        is $mech->uri->path, '/reports/Birmingham+City+Council/Aston%7CBournville';
-        $mech->content_contains('Aston, Bournville');
+        is $mech->uri->path, '/reports/Birmingham';
+        $mech->get_ok('/reports/Birmingham/Bordesley+and+Highgate');
+        is $mech->uri->path, '/reports/Birmingham/Bordesley+and+Highgate';
+        $mech->get_ok('/reports/Birmingham/Bordesley+and+Highgate|Birchfield');
+        is $mech->uri->path, '/reports/Birmingham/Bordesley+and+Highgate%7CBirchfield';
+        $mech->content_contains('Birchfield, Bordesley & Highgate');
     };
 
     $mech->get_ok('/reports/Westminster');


### PR DESCRIPTION
Map ward names on their short names, so any processing applies equally to URL and names returned by MapIt.

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [ ] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]