### PR TITLE
OCC reference search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Unreleased
     - New features:
         - Dashboard now has update CSV export. #2249
+        - Allow cobrands to override searching by reference #2271
     - Front end improvements:
         - Clearer relocation options while you’re reporting a problem #2238
     - Bugfixes:

--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -399,10 +399,13 @@ sub _geocode : Private {
 sub lookup_by_ref : Private {
     my ( $self, $c, $ref ) = @_;
 
-    my $problems = $c->cobrand->problems->search([
-        id => $ref,
-        external_id => $ref
-    ]);
+    my $criteria = $c->cobrand->call_hook("lookup_by_ref", $ref) ||
+        [
+            id => $ref,
+            external_id => $ref
+        ];
+
+    my $problems = $c->cobrand->problems->search( $criteria );
 
     my $count = try {
         $problems->count;

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -53,6 +53,22 @@ sub users_can_hide { return 1; }
 
 sub default_show_name { 0 }
 
+sub lookup_by_ref_regex {
+    return qr/^\s*((?:ENQ)?\d+)\s*$/;
+}
+
+sub lookup_by_ref {
+    my ($self, $ref) = @_;
+
+    if ( $ref =~ /^ENQ/ ) {
+        my $len = length($ref);
+        my $filter = "%T18:customer_reference,T$len:$ref,%";
+        return { 'extra' => { -like => $filter } };
+    }
+
+    return 0;
+}
+
 =head2 problem_response_days
 
 Returns the number of working days that are expected to elapse

--- a/t/cobrand/oxfordshire.t
+++ b/t/cobrand/oxfordshire.t
@@ -186,6 +186,20 @@ subtest 'Reports are marked as inspected correctly' => sub {
     };
 };
 
+subtest 'can use customer reference to search for reports' => sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'oxfordshire' ],
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        my $problem = $problems[0];
+        $problem->set_extra_metadata( customer_reference => 'ENQ12456' );
+        $problem->update;
+
+        $mech->get_ok('/around?pc=ENQ12456');
+        is $mech->uri->path, '/report/' . $problem->id, 'redirects to report';
+    };
+};
+
 END {
     done_testing();
 }


### PR DESCRIPTION
Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Are the changes tested for accessibility?
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

Allow cobrands to do their own search from the front page if the string matches `lookup_by_ref_regexp'.
Add in a custom search for OCC if the search matches a customer_reference.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1200