### PR TITLE
Deal with a variety of low-level test warnings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## Releases
 
 * Unreleased
+    - Front end improvements:
         - Clearer relocation options while you’re reporting a problem #2238
+    - Bugfixes:
+        - Add perl 5.26/5.28 support.
 
 * v2.4.1 (2nd October 2018)
     - New features:

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -1,12 +1,16 @@
 #!/usr/bin/env perl
 use strict; use warnings;
 
+my $d;
 BEGIN {
     use File::Basename qw(dirname);
     use File::Spec;
-    my $d = dirname(File::Spec->rel2abs($0));
+    $d = dirname(File::Spec->rel2abs($0));
     require "$d/../setenv.pl";
 }
+
+# So the t::Mock:: modules can be found
+$ENV{PERL5LIB} = "$d/..:$ENV{PERL5LIB}";
 
 use FixMyStreet::TestAppProve;
 

--- a/cpanfile
+++ b/cpanfile
@@ -14,6 +14,8 @@ requires 'aliased', '0.34';
 requires 'Net::SSLeay', '1.81';
 requires 'Module::ScanDeps', '1.24';
 requires 'CGI', '4.38';
+requires 'Lingua::EN::Tagger', '0.27';
+requires 'Params::Classify', '0.014';
 
 # Catalyst itself, and modules/plugins used
 requires 'Catalyst', '5.80031';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -3852,10 +3852,10 @@ DISTRIBUTIONS
       Try::Tiny 0
       strict 0
       warnings 0
-  Lingua-EN-Tagger-0.23
-    pathname: A/AC/ACOBURN/Lingua-EN-Tagger-0.23.tar.gz
+  Lingua-EN-Tagger-0.30
+    pathname: A/AC/ACOBURN/Lingua-EN-Tagger-0.30.tar.gz
     provides:
-      Lingua::EN::Tagger 0.23
+      Lingua::EN::Tagger 0.30
     requirements:
       ExtUtils::MakeMaker 0
       File::Spec 0.84
@@ -5463,13 +5463,12 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.008001
-  Params-Classify-0.013
-    pathname: Z/ZE/ZEFRAM/Params-Classify-0.013.tar.gz
+  Params-Classify-0.015
+    pathname: Z/ZE/ZEFRAM/Params-Classify-0.015.tar.gz
     provides:
-      Params::Classify 0.013
+      Params::Classify 0.015
     requirements:
       Exporter 0
-      ExtUtils::ParseXS 2.2006
       Module::Build 0
       Scalar::Util 1.01
       Test::More 0

--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -258,6 +258,7 @@ sub map_features : Private {
     my ($self, $c, $extra) = @_;
 
     $c->stash->{page} = 'around'; # Needed by _item.html / so the map knows to make clickable pins, update on pan
+    $c->stash->{num_old_reports} = 0;
 
     $c->forward( '/reports/stash_report_filter_status' );
     $c->forward( '/reports/stash_report_sort', [ 'created-desc' ]);

--- a/perllib/FixMyStreet/App/Controller/Photo.pm
+++ b/perllib/FixMyStreet/App/Controller/Photo.pm
@@ -47,6 +47,9 @@ sub index :LocalRegex('^(c/)?([1-9]\d*)(?:\.(\d+))?(?:\.(full|tn|fp))?\.(?:jpeg|
     my ( $self, $c ) = @_;
     my ( $is_update, $id, $photo_number, $size ) = @{ $c->req->captures };
 
+    $photo_number ||= 0;
+    $size ||= '';
+
     my $item;
     if ( $is_update ) {
         ($item) = $c->model('DB::Comment')->search( {

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -258,7 +258,7 @@ sub by_category_ajax_data : Private {
     my ($self, $c, $type, $category) = @_;
 
     my $generate;
-    if (($c->stash->{category_extras}->{$category} && @{ $c->stash->{category_extras}->{$category} } >= 1) or \
+    if (($c->stash->{category_extras}->{$category} && @{ $c->stash->{category_extras}->{$category} } >= 1) or
             $c->stash->{unresponsive}->{$category} or $c->stash->{report_extra_fields}) {
         $generate = 1;
     }

--- a/t/app/controller/develop.t
+++ b/t/app/controller/develop.t
@@ -1,5 +1,8 @@
 use FixMyStreet::TestMech;
 
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
 ok( my $mech = FixMyStreet::TestMech->new, 'Created mech object' );
 
 my ($problem) = $mech->create_problems_for_body(1, 2504, 'title');

--- a/t/app/controller/root.t
+++ b/t/app/controller/root.t
@@ -75,7 +75,6 @@ FixMyStreet::override_config {
 };
 
 subtest "check_login_disallowed cobrand hook" => sub {
-    warn '#' x 50 . "\n";
     my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Default');
     $cobrand->mock('check_login_disallowed', sub {
             my $self = shift;

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -959,7 +959,6 @@ subtest "test stats" => sub {
 };
 
 subtest "test admin_log" => sub {
-    diag $report->id;
     my @entries = FixMyStreet::DB->resultset('AdminLog')->search({
         object_type => 'problem',
         object_id   => $report->id,

--- a/t/i18n.t
+++ b/t/i18n.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use utf8;
 
 use Test::More;
 

--- a/t/open311/getservicerequestupdates.t
+++ b/t/open311/getservicerequestupdates.t
@@ -421,7 +421,10 @@ for my $test (
         $problem->state( $test->{start_state} );
         $problem->update;
 
-        my $update = Open311::GetServiceRequestUpdates->new( system_user => $user );
+        my $update = Open311::GetServiceRequestUpdates->new(
+            system_user => $user,
+            blank_updates_permitted => 1,
+        );
         $update->update_comments( $o, $bodies{2482} );
 
         is $problem->comments->count, 1, 'comment count';

--- a/t/photostorage/s3.t
+++ b/t/photostorage/s3.t
@@ -2,6 +2,7 @@
 use FixMyStreet::Test;
 
 use Test::MockModule;
+use Test::Warn;
 use Path::Tiny 'path';
 use Net::Amazon::S3::Client::Bucket;
 
@@ -112,7 +113,9 @@ FixMyStreet::override_config {
             $create_bucket_called = 1;
         });
 
-        ok !$s3->init(), "PhotoStorage::S3::init failed";
+        warning_like {
+            $s3->init();
+        } qr/S3 bucket 'fms-test-photos' doesn't exist and CREATE_BUCKET is not set./, 'PhotoStorage::S3::init failed';
         ok $buckets_called, "Client::buckets called";
         ok !$create_bucket_called, "Client::create_bucket not called";
     };

--- a/templates/web/base/pagination.html
+++ b/templates/web/base/pagination.html
@@ -8,7 +8,7 @@
 
         [% IF pager.next_page %]
             <a class="next" href="[% c.uri_with({ $param => pager.next_page, ajax => undefined }) %][% '#' _ hash IF hash %]">[% loc('Next') %]</a>
-        [% ELSIF num_old_reports > 0 AND NOT show_old_reports AND page == 'around' %]
+        [% ELSIF page == 'around' AND num_old_reports > 0 AND NOT show_old_reports %]
             <a class="next show_old" href="[% c.uri_with({ $param => pager.current_page, show_old_reports = 1, ajax => undefined }) %][% '#' _ hash IF hash %]">[% loc('Show older') %]</a>
         [% END %]
     </p>


### PR DESCRIPTION
* Stop red warning being output by S3 bucket creation failure test
* Make sure 'num_old_reports' is always a number on /around pages
* Stop 'category_extra' being generated when unnecessary
* Prevent warning printed in getservicerequestupdates.t
* Prevent info lines from being output in develop.t

[skip changelog]
