### PR TITLE
update Params::Classify to avoid build problems on later Perls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Unreleased
         - Clearer relocation options while you’re reporting a problem #2238
+        - Update Params::Classify to avoid build problems on later Perls
 
 * v2.4.1 (2nd October 2018)
     - New features:

--- a/cpanfile
+++ b/cpanfile
@@ -35,6 +35,7 @@ requires 'Auth::GoogleAuth';
 requires 'Authen::SASL';
 requires 'Cache::Memcached';
 requires 'Carp';
+requires 'Params::Classify', '0.015'; # Blowfish needs this and earlier versions don't work on later Perls
 requires 'Crypt::Eksblowfish::Bcrypt';
 requires 'Data::Password::Common';
 requires 'DateTime';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -5463,10 +5463,10 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.008001
-  Params-Classify-0.013
-    pathname: Z/ZE/ZEFRAM/Params-Classify-0.013.tar.gz
+  Params-Classify-0.015
+    pathname: Z/ZE/ZEFRAM/Params-Classify-0.015.tar.gz
     provides:
-      Params::Classify 0.013
+      Params::Classify 0.015
     requirements:
       Exporter 0
       ExtUtils::ParseXS 2.2006


### PR DESCRIPTION
e.g. module installation fails on perl 5.28 due to changes to
op codes.

Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Are the changes tested for accessibility?
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog