### PR TITLE
[Oxfordshire] add customer reference to old issues when sending comments

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -179,6 +179,19 @@ sub open311_config_updates {
 sub should_skip_sending_update {
     my ($self, $update ) = @_;
 
+    my $p = $update->problem;
+
+    # Reports that were synced with Exor stored the external id
+    # in external_id so do not have a customer_reference. We need
+    # to copy the exor id across to customer_reference in order to
+    # send them
+    if (
+        $p->id != $p->external_id &&
+        !$p->get_extra_metadata('customer_reference')
+    ) {
+        $p->set_extra_metadata( customer_reference => $p->external_id );
+        $p->update;
+    }
     # Oxfordshire stores the external id of the problem as a customer reference
     # in metadata
     return 1 if !$update->problem->get_extra_metadata('customer_reference');

--- a/t/open311/post-service-request-updates.t
+++ b/t/open311/post-service-request-updates.t
@@ -111,6 +111,7 @@ subtest 'Oxfordshire adds customer reference' => sub {
     ALLOWED_COBRANDS => ['fixmystreet', 'bromley', 'buckinghamshire', 'lewisham', 'oxfordshire'],
   }, sub {
       $p2->unset_extra_metadata('customer_reference');
+      # now set external id to a different value as if it had been sent to Exor
       $p2->external_id('654321');
       $p2->update;
       $c2->send_fail_count(0);


### PR DESCRIPTION
OCC issues need a customer_reference in extra to send but old issues
that were sent to Exor do not have this. If a problem is an old
issue then turn the external_id into the customer_reference.

Old issues are ones where the problem id and external_id do not match.

Fixes mysociety/fixmystreet-commercial#1214

Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
