### PR TITLE
Have body.url work in hashref lookup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     - Bugfixes:
         - Add perl 5.26/5.28 support.
         - Fix subcategory issues when visiting /report/new directly #2276
+        - Have body.url work in hashref lookup. #2284
     - Internal things:
         - Move send-comments code to package for testing.
 

--- a/perllib/FixMyStreet/DB/Result/Body.pm
+++ b/perllib/FixMyStreet/DB/Result/Body.pm
@@ -138,10 +138,17 @@ use namespace::clean;
 with 'FixMyStreet::Roles::Translatable',
      'FixMyStreet::Roles::Extra';
 
+sub _url {
+    my ( $obj, $cobrand, $args ) = @_;
+    my $uri = URI->new('/reports/' . $cobrand->short_name($obj));
+    $uri->query_form($args) if $args;
+    return $uri;
+}
+
 sub url {
     my ( $self, $c, $args ) = @_;
-    # XXX $areas_info was used here for Norway parent - needs body parents, I guess
-    return $c->uri_for( '/reports/' . $c->cobrand->short_name( $self ), $args || {} );
+    my $cobrand = $self->result_source->schema->cobrand;
+    return _url($self, $cobrand, $args);
 }
 
 __PACKAGE__->might_have(

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -663,7 +663,7 @@ sub body {
         my @body_names = sort map {
             my $name = $_->name;
             if ($c and FixMyStreet->config('AREA_LINKS_FROM_PROBLEMS')) {
-                '<a href="' . $_->url($c) . '">' . $name . '</a>';
+                '<a href="' . $_->url . '">' . $name . '</a>';
             } else {
                 $name;
             }

--- a/perllib/FixMyStreet/DB/ResultSet/Body.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Body.pm
@@ -149,8 +149,16 @@ sub all_sorted {
     })->all;
     @bodies = sort { strcoll($a->{msgstr} || $a->{name}, $b->{msgstr} || $b->{name}) } @bodies;
 
+    my $cobrand = $rs->result_source->schema->cobrand;
+
     foreach my $body (@bodies) {
         $body->{parent} = { id => $body->{parent}, name => $body->{parent_name} } if $body->{parent};
+
+        # DEPRECATED: url(c, query_params) -> url
+        $body->{url} = sub {
+            my ($c, $args) = @_;
+            return FixMyStreet::DB::Result::Body::_url($body, $cobrand, $args);
+        };
 
         # DEPRECATED: get_column('area_count') -> area_count
         next unless defined $body->{area_count};

--- a/t/app/controller/report_display.t
+++ b/t/app/controller/report_display.t
@@ -151,7 +151,7 @@ subtest "test duration string" => sub {
         AREA_LINKS_FROM_PROBLEMS => 1,
     }, sub {
         $mech->get_ok("/report/$report_id");
-        $mech->content_contains('Sent to <a href="http://localhost/reports/Westminster+City+Council">Westminster');
+        $mech->content_contains('Sent to <a href="/reports/Westminster+City+Council">Westminster');
     };
 };
 

--- a/t/app/controller/report_display.t
+++ b/t/app/controller/report_display.t
@@ -129,6 +129,7 @@ subtest "test a good report" => sub {
       'Reported by Test User at 15:47, Sat 16 April 2011',
       'correct problem meta information';
     $mech->content_contains('Test 2 Detail');
+    $mech->content_lacks('Sent to');
 
     my $update_form = $mech->form_name('updateForm');
 
@@ -140,6 +141,18 @@ subtest "test a good report" => sub {
         fixed     => undef
     );
     is $update_form->value($_), $fields{$_}, "$_ value" for keys %fields;
+};
+
+subtest "test duration string" => sub {
+    $report->update({ whensent => \'current_timestamp' });
+    $mech->get_ok("/report/$report_id");
+    $mech->content_contains('Sent to Westminster');
+    FixMyStreet::override_config {
+        AREA_LINKS_FROM_PROBLEMS => 1,
+    }, sub {
+        $mech->get_ok("/report/$report_id");
+        $mech->content_contains('Sent to <a href="http://localhost/reports/Westminster+City+Council">Westminster');
+    };
 };
 
 foreach my $meta (

--- a/t/app/controller/reports.t
+++ b/t/app/controller/reports.t
@@ -1,7 +1,7 @@
 use Test::MockTime qw(:all);
 use FixMyStreet::TestMech;
 use mySociety::MaPit;
-use FixMyStreet::App;
+use FixMyStreet::DB;
 use FixMyStreet::Script::UpdateAllReports;
 use DateTime;
 
@@ -254,7 +254,7 @@ subtest "it lists shortlisted reports" => sub {
     FixMyStreet::override_config {
         MAPIT_URL => 'http://mapit.uk/'
     }, sub {
-        my $body = FixMyStreet::App->model('DB::Body')->find( $body_edin_id );
+        my $body = FixMyStreet::DB->resultset('Body')->find( $body_edin_id );
         my $user = $mech->log_in_ok( 'test@example.com' );
         $user->update({ from_body => $body });
         $user->user_body_permissions->find_or_create({
@@ -304,7 +304,7 @@ subtest "it allows body users to filter by subtypes" => sub {
     FixMyStreet::override_config {
         MAPIT_URL => 'http://mapit.uk/'
     }, sub {
-        my $body = FixMyStreet::App->model('DB::Body')->find( $body_edin_id );
+        my $body = FixMyStreet::DB->resultset('Body')->find( $body_edin_id );
         my $user = $mech->log_in_ok( 'test@example.com' );
         $user->update({ from_body => $body });
 
@@ -363,7 +363,7 @@ subtest "it does not allow body users to filter subcategories for other bodies" 
     FixMyStreet::override_config {
         MAPIT_URL => 'http://mapit.uk/'
     }, sub {
-        my $body = FixMyStreet::App->model('DB::Body')->find( $body_west_id );
+        my $body = FixMyStreet::DB->resultset('Body')->find( $body_west_id );
         my $user = $mech->log_in_ok( 'test@example.com' );
         $user->update({ from_body => $body });
 

--- a/templates/web/base/admin/body.html
+++ b/templates/web/base/admin/body.html
@@ -28,7 +28,7 @@
       [% END %]
     [% END %]
 <br>
-    <a href="[% c.uri_for_email(body.url(c)) %]" class="admin-offsite-link">[% loc('List all reported problems' ) %]</a> |
+    <a href="[% c.uri_for_email(body.url) %]" class="admin-offsite-link">[% loc('List all reported problems' ) %]</a> |
     <a href="[% c.uri_for( 'body', body_id, { text => 1 } ) %]">[% loc('Text only version') %]</a>
 </p>
 


### PR DESCRIPTION
`body.url` could still be in use by old-school `/reports` table index pages (though they were dropped in 2.1, so a cobrand would have to have overridden it since then) and the update to speed up body lists in #2248 broke it. This puts it back in minimal form.

I've removed the Norwegian note as they must have something different, the current code wouldn't be working for them either.

- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog