### PR TITLE
Add cobrand hook for dashboard viewing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@
     - Bugfixes:
         - Add perl 5.26/5.28 support.
         - Fix subcategory issues when visiting /report/new directly #2276
+    - Development improvements:
+        - Add cobrand hook for dashboard viewing permission. #2285
     - Internal things:
-        - Move send-comments code to package for testing.
+        - Move send-comments code to package for testing. #2109 #2170
 
 * v2.4.1 (2nd October 2018)
     - New features:

--- a/t/app/controller/dashboard.t
+++ b/t/app/controller/dashboard.t
@@ -236,15 +236,12 @@ FixMyStreet::override_config {
 sub test_table {
     my ($content, @expected) = @_;
     my $res = $categories->scrape( $mech->content );
-    my $i = 0;
+    my @actual;
     foreach my $row ( @{ $res->{rows} }[1 .. 11] ) {
-        foreach my $col ( @{ $row->{cols} } ) {
-            is $col, $expected[$i++];
-        }
+        push @actual, @{$row->{cols}} if $row->{cols};
     }
+    is_deeply \@actual, \@expected;
 }
 
-END {
-    restore_time;
-    done_testing();
-}
+restore_time;
+done_testing();


### PR DESCRIPTION
This allows a cobrand to e.g., as the test does, allow public access to dashboard CSV export for a body, but not otherwise.

- [ ] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
