### PR TITLE
do not reuse original open311 object in fetch comments loop

### DIFF
--- a/perllib/Open311/GetServiceRequestUpdates.pm
+++ b/perllib/Open311/GetServiceRequestUpdates.pm
@@ -42,12 +42,12 @@ sub fetch {
         $cobrand->call_hook(open311_config_updates => \%open311_conf)
             if $cobrand;
 
-        $open311 //= Open311->new(%open311_conf);
+        my $o = $open311 || Open311->new(%open311_conf);
 
         $self->suppress_alerts( $body->suppress_alerts );
         $self->blank_updates_permitted( $body->blank_updates_permitted );
         $self->system_user( $body->comment_user );
-        $self->update_comments( $open311, $body );
+        $self->update_comments( $o, $body );
     }
 }
 


### PR DESCRIPTION
The //= meant that once `$open311` was populated we reused it each time
which mean we were passing the original config in to each body.

Please check the following:
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
