### PR TITLE
allow map zoom constants to be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     - Development improvements:
         - Add cobrand hook for dashboard viewing permission. #2285
         - Have body.url work in hashref lookup. #2284
+        - OSM based map types can now override zoom levels #2288
     - Internal things:
         - Move send-comments code to package for testing. #2109 #2170
 

--- a/perllib/FixMyStreet/Map/OSM.pm
+++ b/perllib/FixMyStreet/Map/OSM.pm
@@ -69,8 +69,8 @@ sub display_map {
 sub generate_map_data {
     my ($self, $data, %params) = @_;
 
-    my $numZoomLevels = ZOOM_LEVELS;
-    my $zoomOffset = MIN_ZOOM_LEVEL;
+    my $numZoomLevels = $self->ZOOM_LEVELS;
+    my $zoomOffset = $self->MIN_ZOOM_LEVEL;
     if ($params{any_zoom}) {
         $numZoomLevels = 19;
         $zoomOffset = 0;

--- a/t/app/controller/around.t
+++ b/t/app/controller/around.t
@@ -1,3 +1,13 @@
+package FixMyStreet::Map::Tester;
+use base 'FixMyStreet::Map::FMS';
+
+use constant ZOOM_LEVELS    => 99;
+use constant MIN_ZOOM_LEVEL => 88;
+
+1;
+
+package main;
+
 use Test::MockModule;
 
 use FixMyStreet::TestMech;
@@ -276,6 +286,27 @@ subtest 'check skip_around skips around page' => sub {
         $mech->get('/around?latitude=51.754926&longitude=-1.256179');
         is $mech->res->code, 302, "around page is a redirect";
         is $mech->uri->path, '/report/new', "and redirects to /report/new";
+    };
+};
+
+subtest 'check map zoom level customisation' => sub {
+    FixMyStreet::override_config {
+        MAPIT_URL => 'http://mapit.uk/',
+        MAP_TYPE => 'OSM',
+    }, sub {
+        $mech->get('/around?latitude=51.754926&longitude=-1.256179');
+        $mech->content_contains('data-numZoomLevels=6');
+        $mech->content_contains('data-zoomOffset=13');
+    };
+
+
+    FixMyStreet::override_config {
+        MAPIT_URL => 'http://mapit.uk/',
+        MAP_TYPE => 'Tester',
+    }, sub {
+        $mech->get('/around?latitude=51.754926&longitude=-1.256179');
+        $mech->content_contains('data-numZoomLevels=99');
+        $mech->content_contains('data-zoomOffset=88');
     };
 };
 


### PR DESCRIPTION
call ZOOM_LEVELS and MIN_ZOOM_LEVELS using self so that we can override
them in a subclass.

Please check the following:

- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog