### PR TITLE
Bathnes roadworks

### DIFF
--- a/perllib/FixMyStreet/Map/BathNES.pm
+++ b/perllib/FixMyStreet/Map/BathNES.pm
@@ -11,7 +11,9 @@ sub map_javascript { [
     '/vendor/OpenLayers.Projection.OrdnanceSurvey.js',
     '/js/map-OpenLayers.js',
     '/js/map-OpenStreetMap.js',
+    '/cobrands/fixmystreet-uk-councils/roadworks.js',
     '/cobrands/fixmystreet/assets.js',
+    '/cobrands/bathnes/js.js',
     '/cobrands/bathnes/assets.js',
 ] }
 

--- a/web/cobrands/bathnes/base.scss
+++ b/web/cobrands/bathnes/base.scss
@@ -76,3 +76,18 @@ a:active, a:hover { color: $link-hover-colour; }
         color: #fff;
     }
 }
+
+.js-roadworks-message {
+  margin: 1em -1em;
+  padding: 1em;
+  background-color: #00aeef;
+  color: #fff;
+  dt {
+    float: left;
+    margin-right: 0.25em;
+  }
+
+  p:last-child {
+    font-weight: bold;
+  }
+}

--- a/web/cobrands/bathnes/js.js
+++ b/web/cobrands/bathnes/js.js
@@ -37,6 +37,20 @@ fixmystreet.roadworks.display_message = function(feature) {
         $('.change_location').after($msg);
 };
 
+fixmystreet.roadworks.filter = function() {
+  var category = $('select#form_category').val(),
+      categories = ['Damage to pavement', 'Damage to road', 'Faded road markings', 'Damaged Railing, manhole, or drain cover'];
+    return OpenLayers.Util.indexOf(categories, category) != -1;
+};
+
+fixmystreet.roadworks.category_change = function() {
+    if (fixmystreet.map) {
+        fixmystreet.roadworks.show_nearby(null, fixmystreet.map.getCenter());
+    }
+};
+
+$(fixmystreet).on('report_new:category_change', fixmystreet.roadworks.category_change);
+
 var org_id = '114';
 var body = "Bath and North East Somerset Council";
 fixmystreet.assets.add($.extend(true, {}, fixmystreet.roadworks.layer_future, {

--- a/web/cobrands/bathnes/js.js
+++ b/web/cobrands/bathnes/js.js
@@ -37,10 +37,17 @@ fixmystreet.roadworks.display_message = function(feature) {
         $('.change_location').after($msg);
 };
 
-fixmystreet.roadworks.filter = function() {
+fixmystreet.roadworks.filter = function(feature) {
   var category = $('select#form_category').val(),
+      parts = feature.attributes.symbol.split(''),
+      valid_types = ['h', 'n', 'l', 'w'],
+      valid_subtypes = ['15', '25'],
+      type = parts[2],
+      sub_type = parts[4] + parts[5],
       categories = ['Damage to pavement', 'Damage to road', 'Faded road markings', 'Damaged Railing, manhole, or drain cover'];
-    return OpenLayers.Util.indexOf(categories, category) != -1;
+    return OpenLayers.Util.indexOf(categories, category) != -1 &&
+    ( OpenLayers.Util.indexOf(valid_types, type) != -1 ||
+      ( type === 'o' && OpenLayers.Util.indexOf(valid_subtypes, sub_type) != -1 ) );
 };
 
 fixmystreet.roadworks.category_change = function() {

--- a/web/cobrands/bathnes/js.js
+++ b/web/cobrands/bathnes/js.js
@@ -1,0 +1,51 @@
+(function(){
+
+if (!fixmystreet.maps) {
+    return;
+}
+
+fixmystreet.roadworks.display_message = function(feature) {
+    var attr = feature.attributes,
+        start = new Date(attr.start.replace(/{ts '([^ ]*).*/, '$1')).toDateString(),
+        end = new Date(attr.end.replace(/{ts '([^ ]*).*/, '$1')).toDateString(),
+        tooltip = attr.tooltip.replace(/\\n/g, '\n'),
+        desc = attr.works_desc.replace(/\\n/g, '\n');
+
+        var $msg = $('<div class="js-roadworks-message box-warning"><h3>Roadworks are scheduled near this location, so you may not need to report your issue.</h3></div>');
+        var $dl = $("<dl></dl>").appendTo($msg);
+        $dl.append("<dt>Dates:</dt>");
+        $dl.append($("<dd></dd>").text(start + " until " + end));
+        $dl.append("<dt>Summary:</dt>");
+        var $summary = $("<dd></dd>").appendTo($dl);
+        tooltip.split("\n").forEach(function(para) {
+            if (para.match(/^(\d{2}\s+\w{3}\s+(\d{2}:\d{2}\s+)?\d{4}( - )?){2}/)) {
+                // skip showing the date again
+                return;
+            }
+            if (para.match(/^delays/)) {
+                // skip showing traffic delay information
+                return;
+            }
+            $summary.append(para).append("<br />");
+        });
+        if (desc) {
+            $dl.append("<dt>Description:</dt>");
+            $dl.append($("<dd></dd>").text(desc));
+        }
+        $dl.append($("<p>If you think this issue needs immediate attention you can continue your report below</p>"));
+
+        $('.change_location').after($msg);
+};
+
+var org_id = '114';
+var body = "Bath and North East Somerset Council";
+fixmystreet.assets.add($.extend(true, {}, fixmystreet.roadworks.layer_future, {
+    http_options: { params: { organisation_id: org_id } },
+    body: body
+}));
+fixmystreet.assets.add($.extend(true, {}, fixmystreet.roadworks.layer_planned, {
+    http_options: { params: { organisation_id: org_id } },
+    body: body
+}));
+
+})();

--- a/web/cobrands/fixmystreet-uk-councils/roadworks.js
+++ b/web/cobrands/fixmystreet-uk-councils/roadworks.js
@@ -169,11 +169,15 @@ fixmystreet.roadworks.show_nearby = function(evt, lonlat) {
             // The click wasn't directly over a road, try and find one nearby
             feature = layer.getNearestFeature(point, 100);
         }
-        if (feature !== null) {
+        if (feature !== null && fixmystreet.roadworks.filter(feature)) {
             fixmystreet.roadworks.display_message(feature);
             return true;
         }
     }
+};
+
+fixmystreet.roadworks.filter = function() {
+    return 1;
 };
 
 fixmystreet.roadworks.display_message = function(feature) {


### PR DESCRIPTION
Add roadworks.org layer to Bathnes cobrand.

Also introduces ability to filter on which roadworks messages are shown.

Fixes mysociety/fixmystreet-freshdesk#17

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [ ] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [ ] Are the changes tested for accessibility?
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]