### PR TITLE
[Bromley] disable contact form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     - New features:
         - Dashboard now has update CSV export. #2249
         - Allow cobrands to override searching by reference #2271
+        - Allow cobrands to limit contact form to abuse reports only
     - Front end improvements:
         - Clearer relocation options while you’re reporting a problem #2238
     - Admin improvements

--- a/docs/customising/cobrand-module.md
+++ b/docs/customising/cobrand-module.md
@@ -101,5 +101,10 @@ name.
     <a href="{{ "/glossary/#state" | relative_url }}" class="glossary__link">state</a>
     of the report. Return 0 to disable this feature so that surveys are never
     sent.
-    
+
+* abuse_reports_only
+
+    Limit the contact page to only accepting abuse reports for comments
+    and updates. This can be useful if you have another contact form and
+    want to prevent people using this.
 

--- a/perllib/FixMyStreet/App/Controller/Contact.pm
+++ b/perllib/FixMyStreet/App/Controller/Contact.pm
@@ -100,6 +100,8 @@ sub determine_contact_type : Private {
         if ( $c->get_param("reject") && $c->user->has_permission_to(report_reject => $c->stash->{problem}->bodies_str_ids) ) {
             $c->stash->{rejecting_report} = 1;
         }
+    } elsif ( $c->cobrand->abuse_reports_only ) {
+        $c->detach( '/page_error_404_not_found' );
     }
 
     return 1;

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -106,6 +106,8 @@ sub contact_email {
 }
 sub contact_name { 'Bromley Council (do not reply)'; }
 
+sub abuse_reports_only { 1; }
+
 sub reports_per_page { return 20; }
 
 sub tweak_all_reports_map {

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -765,6 +765,14 @@ used in emails).
 sub contact_name  { FixMyStreet->config('CONTACT_NAME') }
 sub contact_email { FixMyStreet->config('CONTACT_EMAIL') }
 
+=item abuse_reports_only
+
+Return true if only abuse reports should be allowed from the contact form.
+
+=cut
+
+sub abuse_reports_only { 0; }
+
 =item email_host
 
 Return if we are the virtual host that sends email for this cobrand

--- a/templates/web/bromley/footer_extra.html
+++ b/templates/web/bromley/footer_extra.html
@@ -4,19 +4,18 @@
             <div class="additional-links footer-list1">
                 <h5>Get in touch</h5>
                 <ul>
-                    <li class="border first-child"><a href="http://www.bromley.gov.uk/contact">Contact Us</a></li>
-                    <li class="border"><a href="http://www.bromley.gov.uk/feedback">Feedback</a></li>
+                    <li class="border first-child"><a href="https://www.bromley.gov.uk/contact">Contact Us</a></li>
+                    <li class="border"><a href="https://www.bromley.gov.uk/feedback">Feedback</a></li>
                 </ul>
             </div><!--additional-links-->
             <div class="additional-links footer-list2">
                 <h5>Our website</h5>
                 <ul>
-                    <li class="first-child"><a href="http://www.bromley.gov.uk/accessibility">Accessibility</a></li>
+                    <li class="first-child"><a href="https://www.bromley.gov.uk/accessibility">Accessibility</a></li>
                     <li><a href="javascript:void(0);" onclick="window.print()" rel="nofollow">Print</a></li>
-                    <li><a href="javascript:bookmark('http://www.bromley.gov.uk', 'London Borough of Bromley')">Bookmark this page</a></li>
-                    <li><a href="http://www.bromley.gov.uk/privacy">Privacy and cookies</a></li>
-                    <li><a href="http://www.bromley.gov.uk/terms">Disclaimer</a></li>
-                    <li><a href="http://www.bromley.gov.uk/press/article/977/community_library_management_proposals_invited#mast">To the top</a></li>
+                    <li><a href="javascript:bookmark('https://www.bromley.gov.uk', 'London Borough of Bromley')">Bookmark this page</a></li>
+                    <li><a href="https://www.bromley.gov.uk/privacy">Privacy and cookies</a></li>
+                    <li><a href="https://www.bromley.gov.uk/terms">Disclaimer</a></li>
                 </ul>
             </div><!--additional-links-->
             <div class="additional-links">
@@ -24,10 +23,10 @@
                 <div class="social">
                     <ul class="inline-list small-size width">
                         <li class="first-child"><a href="http://www.facebook.com/LBBromley" title="Facebook"><img src="/cobrands/bromley/facebook.png" alt="Facebook"></a></li>
-                        <li><a href="http://twitter.com/LBofBromley" title="Twitter"><img src="/cobrands/bromley/twitter.png" alt="twitter"></a></li>
-                        <li><a href="http://www.youtube.com/LBBromley" title="Youtube"><img src="/cobrands/bromley/youtube.png" alt="youtube"></a></li>
-                        <li><a href="http://www.flickr.com/photos/lbofbromley/" title="flickr"><img src="/cobrands/bromley/flickr.png" alt="flickr"></a></li>
-                        <li><a href="http://www.bromley.gov.uk/rss/press" title="RSS"><img src="/cobrands/bromley/rss.png" alt="RSS"></a></li>
+                        <li><a href="https://twitter.com/LBofBromley" title="Twitter"><img src="/cobrands/bromley/twitter.png" alt="twitter"></a></li>
+                        <li><a href="https://www.youtube.com/LBBromley" title="Youtube"><img src="/cobrands/bromley/youtube.png" alt="youtube"></a></li>
+                        <li><a href="https://www.flickr.com/photos/lbofbromley/" title="flickr"><img src="/cobrands/bromley/flickr.png" alt="flickr"></a></li>
+                        <li><a href="https://www.bromley.gov.uk/rss/press" title="RSS"><img src="/cobrands/bromley/rss.png" alt="RSS"></a></li>
                     </ul>
                 </div><!--social-->
             </div><!--additional-links-->

--- a/templates/web/bromley/footer_extra.html
+++ b/templates/web/bromley/footer_extra.html
@@ -4,7 +4,7 @@
             <div class="additional-links footer-list1">
                 <h5>Get in touch</h5>
                 <ul>
-                    <li class="border first-child"><a href="/contact">Contact Us</a></li>
+                    <li class="border first-child"><a href="http://www.bromley.gov.uk/contact">Contact Us</a></li>
                     <li class="border"><a href="http://www.bromley.gov.uk/feedback">Feedback</a></li>
                 </ul>
             </div><!--additional-links-->


### PR DESCRIPTION
Remove links to the contact form for Bromley cobrand.

Also add a cobrand option to limit the contact form to abuse reports only and turn that on for Bromley.

Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

Fixes mysociety/fixmystreet-commercial#1198