### PR TITLE
list user's alerts on user edit page in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
         - Clearer relocation options while you’re reporting a problem #2238
     - Admin improvements
         - List number of alerts on report page #669
+        - viewing and managing of user alerts in admin #676
     - Bugfixes:
         - Add perl 5.26/5.28 support.
         - Fix subcategory issues when visiting /report/new directly #2276

--- a/templates/web/base/admin/user-alerts.html
+++ b/templates/web/base/admin/user-alerts.html
@@ -1,0 +1,49 @@
+[% IF alerts.size %]
+<h3>[% loc("User's alerts") %]</h3>
+<table>
+<tr>
+    <th>[% loc('ID') %]</th>
+    <th>[% loc('Type') %]</th>
+    <th>[% loc('Confirmed') %]</th>
+    <th>[% loc('State') %]</th>
+    <th>[% loc('Details') %]</th>
+</tr>
+[% FOREACH alert IN alerts %]
+<tr>
+    <td>[% alert.id %]</td>
+    <td>[% alert.alert_type.ref %]</td>
+    <td>[% IF alert.confirmed %][% loc('Yes') %][% ELSE %][% loc('No') %][% END %]</td>
+    <td>[% loc('Subscribed:') %] [% alert.whensubscribed %]
+        <br>[% loc('Disabled:') %] [% alert.whendisabled %]
+    </td>
+    <td>
+    [% SWITCH alert.alert_type.ref %]
+        [% CASE 'new_updates' %]
+            [% tprintf( loc('New updates on report <a href="%s">%s</a>'), c.uri_for( '/report', alert.parameter ), alert.parameter ) %]
+        [% CASE 'local_problems' %]
+            [% tprintf( loc('New problems near <a href="%s">%s,%s</a>'), c.uri_for( '/around', { lon => alert.parameter, lat => alert.parameter2 } ), alert.parameter, alert.parameter2 ) %]
+        [% CASE 'ward_problems' %]
+            [% body = alert.parameter %]
+            [% ward = alert.parameter2 %]
+            [% IF alert_areas.$ward AND body_names.$body %]
+                [% tprintf( loc('New problems for <a href="%s">%s</a> ward in <a href="%s">%s</a>'), c.uri_for('/reports', body_names.$body, alert_areas.$ward.name), alert_areas.$ward.name, c.uri_for('/reports', body_names.$body), body_names.$body ) %]
+            [% ELSE %]
+                [% tprintf( loc('New problems for ward id %s in body id %s'), alert.parameter2, body ) %]
+            [% END %]
+        [% CASE 'council_problems' %]
+            [% body = alert.parameter %]
+            [% IF body_names.$body %]
+                [% tprintf( loc('New problems for <a href="%s">%s</a>'), c.uri_for('/reports', body_names.$body) body_names.$body ) %]
+            [% ELSE %]
+                [% tprintf( loc('New problems for %s'), body ) %]
+            [% END %]
+        [% CASE 'area_problems' %]
+            [% tprintf( loc('New problems for area id <a href="%s">%s</a>'), c.config.MAPIT_URL _ 'area/' _ alert.parameter _ '.html', alert.parameter ) %]
+        [% CASE %]
+            [% alert.parameter %] [% alert.parameter2 %]
+    [% END %]
+    </td>
+</tr>
+[% END %]
+</table>
+[% END %]

--- a/templates/web/base/admin/user-alerts.html
+++ b/templates/web/base/admin/user-alerts.html
@@ -1,5 +1,8 @@
 [% IF alerts.size %]
 <h3>[% loc("User's alerts") %]</h3>
+<form method="POST">
+<input type="hidden" name="token" value="[% csrf_token %]" >
+<input type="hidden" name="update_alerts" value="1" >
 <table>
 <tr>
     <th>[% loc('ID') %]</th>
@@ -7,6 +10,9 @@
     <th>[% loc('Confirmed') %]</th>
     <th>[% loc('State') %]</th>
     <th>[% loc('Details') %]</th>
+    <th>[% loc('Enable') %]</th>
+    <th>[% loc('Disable') %]</th>
+    <th>[% loc('Delete') %]</th>
 </tr>
 [% FOREACH alert IN alerts %]
 <tr>
@@ -43,7 +49,12 @@
             [% alert.parameter %] [% alert.parameter2 %]
     [% END %]
     </td>
+    <td><input type="radio" name="edit_alert[[% alert.id %]]" value="enable"[% ' disabled' UNLESS alert.whendisabled %]></td>
+    <td><input type="radio" name="edit_alert[[% alert.id %]]" value="disable"[% ' disabled' IF alert.whendisabled %]></td>
+    <td><input type="radio" name="edit_alert[[% alert.id %]]" value="delete"></td>
 </tr>
 [% END %]
 </table>
+<input type="submit" value="[% loc('Update') %]">
+</form>
 [% END %]

--- a/templates/web/base/admin/user_edit.html
+++ b/templates/web/base/admin/user_edit.html
@@ -10,4 +10,6 @@
 
 [% INCLUDE 'admin/user-form.html' %]
 
+[% INCLUDE 'admin/user-alerts.html' %]
+
 [% INCLUDE 'admin/footer.html' %]


### PR DESCRIPTION
Include a list of alerts the user is subscribed to at the bottom of the
user_edit page in the admin. Also allows disabling, enabling and deleting of alerts.

Fixes #676 

Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Are the changes tested for accessibility?
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
