### PR TITLE
display alert count on admin report page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
         - Allow cobrands to override searching by reference #2271
     - Front end improvements:
         - Clearer relocation options while you’re reporting a problem #2238
+    - Admin improvements
+        - List number of alerts on report page #669
     - Bugfixes:
         - Add perl 5.26/5.28 support.
         - Fix subcategory issues when visiting /report/new directly #2276

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -883,6 +883,8 @@ sub report_edit : Path('report_edit') : Args(1) {
 
     $c->forward('categories_for_point');
 
+    $c->forward('alerts_for_report');
+
     $c->forward('check_username_for_abuse', [ $problem->user ] );
 
     $c->stash->{updates} =
@@ -1109,6 +1111,17 @@ sub categories_for_point : Private {
     shift @{$c->stash->{category_options}} if @{$c->stash->{category_options}};
 
     $c->stash->{categories_hash} = { map { $_->category => 1 } @{$c->stash->{category_options}} };
+}
+
+sub alerts_for_report : Private {
+    my ($self, $c) = @_;
+
+    $c->stash->{alert_count} = $c->model('DB::Alert')->search({
+        alert_type => 'new_updates',
+        parameter => $c->stash->{report}->id,
+        confirmed => 1,
+        whendisabled => undef,
+    })->count();
 }
 
 sub templates : Path('templates') : Args(0) {

--- a/t/app/controller/admin/report_edit.t
+++ b/t/app/controller/admin/report_edit.t
@@ -608,6 +608,32 @@ subtest "Test display of report extra data" => sub {
     $mech->content_contains('extra_field</strong>: this is extra data');
 };
 
+subtest "Test alert count display" => sub {
+    $mech->get_ok("/admin/report_edit/$report_id");
+    $mech->content_contains('Alerts: 0');
+
+    my $alert = FixMyStreet::App->model('DB::Alert')->find_or_create(
+        {
+            alert_type => 'new_updates',
+            parameter => $report_id,
+            user => $user,
+        }
+    );
+
+    $mech->get_ok("/admin/report_edit/$report_id");
+    $mech->content_contains('Alerts: 0', 'does not include unconfirmed reports');
+
+    $alert->update( { confirmed => 1 } );
+    $mech->get_ok("/admin/report_edit/$report_id");
+    $mech->content_contains('Alerts: 1');
+
+    $alert->update( { whendisabled => \"now()" } );
+    $mech->get_ok("/admin/report_edit/$report_id");
+    $mech->content_contains('Alerts: 0');
+
+    $alert->delete;
+};
+
 my $report2 = FixMyStreet::App->model('DB::Problem')->find_or_create(
     {
         postcode           => 'SW1A 1AA',

--- a/templates/web/base/admin/report_edit.html
+++ b/templates/web/base/admin/report_edit.html
@@ -88,6 +88,7 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
   [% END %]
 </li>
 <li class="sm">[% loc('Last update:') %] [% PROCESS format_time time=problem.lastupdate %]</li>
+<li>[% loc('Alerts:') %] [% alert_count %]</li>
 <li>[% loc('Service:') %] [% problem.service OR '<em>' _ loc('None') _ '</em>' %]</li>
 <li>[% loc('Cobrand:') %] [% problem.cobrand %]
 <br><small>[% loc('Cobrand data:') %] [% cobrand_data OR '<em>' _ loc('None') _ '</em>' %]</small>


### PR DESCRIPTION
Add a count of currently active alerts on new updates for a report to
the admin page.

Fixes #669

Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog