### PR TITLE
Update areas when moving report pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
         - Add perl 5.26/5.28 support.
         - Fix subcategory issues when visiting /report/new directly #2276
         - Give superusers access to update staff dropdowns. #2286
+        - Update report areas when moving its location. #2181
     - Development improvements:
         - Add cobrand hook for dashboard viewing permission. #2285
         - Have body.url work in hashref lookup. #2284

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -1082,6 +1082,7 @@ sub report_edit_location : Private {
         # this lookup is bad. So let's save the stash and restore it after the
         # comparison.
         my $safe_stash = { %{$c->stash} };
+        $c->stash->{fetch_all_areas} = 1;
         $c->forward('/council/load_and_check_areas', []);
         $c->forward('/report/new/setup_categories_and_bodies');
         my %allowed_bodies = map { $_ => 1 } @{$problem->bodies_str_ids};
@@ -1091,6 +1092,8 @@ sub report_edit_location : Private {
         return unless $bodies_match;
         $problem->latitude($c->stash->{latitude});
         $problem->longitude($c->stash->{longitude});
+        my $areas = $c->stash->{all_areas_mapit};
+        $problem->areas( ',' . join( ',', sort keys %$areas ) . ',' );
     }
     return 1;
 }

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -32,6 +32,7 @@ my @PLACES = (
     [ 'GL50 2PR', 51.896268, -2.093063, 2226, 'Gloucestershire County Council', 'CTY', 2326, 'Cheltenham Borough Council', 'DIS', 4544, 'Lansdown', 'DIW', 143641, 'Lansdown and Park', 'CED' ],
     [ '?', 51.754926, -1.256179, 2237, 'Oxfordshire County Council', 'CTY', 2421, 'Oxford City Council', 'DIS' ],
     [ 'OX20 1SZ', 51.754926, -1.256179, 2237, 'Oxfordshire County Council', 'CTY', 2421, 'Oxford City Council', 'DIS' ],
+    [ 'OX16 9UP', 52.038712, -1.346397, 2237, 'Oxfordshire County Council', 'CTY', 2419, 'Cherwell District Council', 'DIS', 151767, "Banbury, Calthorpe & Easington", "DIW" ],
     [ 'BR1 3UH', 51.4021, 0.01578, 2482, 'Bromley Council', 'LBO' ],
     [ 'BR1 3UH', 51.402096, 0.015784, 2482, 'Bromley Council', 'LBO' ],
     [ '?', 50.78301, -0.646929 ],


### PR DESCRIPTION
The change in report_inspect.t from WODC to Oxford City was necessary
because moving reports to a location not in Mock::MapIt was resulting in
an empties bodies_str in the "test category/body changes" test.

Fixes #2181.

Please check the following:

- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

