### PR TITLE
WIP cobrand validation 

### DIFF
--- a/templates/web/buckinghamshire/footer_extra_js.html
+++ b/templates/web/buckinghamshire/footer_extra_js.html
@@ -1,0 +1,3 @@
+[% scripts.push(
+    version('/cobrands/buckinghamshire/validation_rules.js'),
+) %]

--- a/templates/web/lincolnshire/footer_extra_js.html
+++ b/templates/web/lincolnshire/footer_extra_js.html
@@ -1,0 +1,3 @@
+[% scripts.push(
+    version('/cobrands/lincolnshire/validation_rules.js'),
+) %]

--- a/templates/web/rutland/footer_extra_js.html
+++ b/templates/web/rutland/footer_extra_js.html
@@ -1,0 +1,3 @@
+[% scripts.push(
+    version('/cobrands/rutland/validation_rules.js'),
+) %]

--- a/web/cobrands/buckinghamshire/validation_rules.js
+++ b/web/cobrands/buckinghamshire/validation_rules.js
@@ -1,0 +1,4 @@
+validation_rules.name = {
+  required: true,
+  maxlength: 50
+};

--- a/web/cobrands/lincolnshire/validation_rules.js
+++ b/web/cobrands/lincolnshire/validation_rules.js
@@ -1,0 +1,3 @@
+validation_rules.phone = {
+  maxlength: 20
+};

--- a/web/cobrands/rutland/validation_rules.js
+++ b/web/cobrands/rutland/validation_rules.js
@@ -1,0 +1,4 @@
+validation_rules.name = {
+  required: true,
+  maxlength: 40
+};


### PR DESCRIPTION
Add some validation restrictions for specific cobrands

Fixes mysociety/fixmystreet-commercial#1144

Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [ ] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [ ] Are the changes tested for accessibility?
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]