### PR TITLE
Restore zoom level when navigating back to /around from /report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
         - Sort user updates in reverse date order.
         - Improve update display on admin report edit page.
         - Keep all moderation history, and show in report/update admin. #2329
+    - Bugfixes:
+        - Restore map zoom out when navigating to /around from /report. #1649
     - Open311 improvements:
         - Fix bug in contact group handling. #2323
         - Improve validation of fetched reports timestamps. #2327

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -340,6 +340,22 @@ $.extend(fixmystreet.utils, {
                   $('#loading-indicator').attr('aria-hidden', true);
               }
           }
+      },
+
+      get_map_state: function() {
+          var centre = fixmystreet.map.getCenter();
+          return {
+              zoom: fixmystreet.map.getZoom(),
+              lat: centre.lat,
+              lon: centre.lon,
+          };
+      },
+
+      set_map_state: function(state) {
+          fixmystreet.map.setCenter(
+              new OpenLayers.LonLat( state.lon, state.lat ),
+              state.zoom
+          );
       }
     });
 


### PR DESCRIPTION
Clicking a pin twice on /around zooms in, and this PR ensures the back button and 'back to all reports' link zooms the map back to where you were initially.

Fixes #1649.