### PR TITLE
Fix "two taps to show report" behaviour on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
         - Fix subcategory issues when visiting /report/new directly #2276
         - Give superusers access to update staff dropdowns. #2286
         - Update report areas when moving its location. #2181
+        - Don't require two taps on reports in list on iOS. #2294
     - Development improvements:
         - Add cobrand hook for dashboard viewing permission. #2285
         - Have body.url work in hashref lookup. #2284

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1201,6 +1201,9 @@ fixmystreet.display = {
                 $sideReport.appendTo('#map_sidebar');
             }
             $('#map_sidebar').scrollTop(0);
+            if ($("html").hasClass("mobile")) {
+                $(document).scrollTop(0);
+            }
 
             var found = html.match(/<title>([\s\S]*?)<\/title>/);
             var page_title = found[1];

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -180,7 +180,6 @@ a {
     color: #0BA7D1;
   }
 
-  &:hover,
   &:active {
     text-decoration: underline;
     color: #0D7CCE;
@@ -461,9 +460,6 @@ p.form-error {
     color: white;
     text-decoration: underline;
   }
-  a:hover {
-    text-decoration: none;
-  }
 }
 
 input.form-error,
@@ -552,7 +548,7 @@ ul.error {
   padding: 0.4em;
   border-radius: 0.3em;
 
-  &:hover, &:focus {
+  &:focus {
     text-decoration: none;
     background-color: $nav_fg_hover;
   }
@@ -577,21 +573,11 @@ ul.error {
   a:visited {
     color: #333;
   }
-  a:hover {
-    background-color: #333;
-    color: #fff;
-    text-decoration: none;
-  }
   span {
     background-color: #ccc;
   }
   span.report-a-problem-btn {
     cursor: pointer;
-  }
-  span.report-a-problem-btn:hover {
-    background-color: #333;
-    color: #fff;
-    text-decoration: none;
   }
 }
 
@@ -635,7 +621,7 @@ ul.error {
     white-space: normal;
     border-radius: 0;
 
-    &:hover, &.hover {
+    &.hover {
       text-decoration:none;
       background-color:#333;
       color: #fff !important;
@@ -952,7 +938,7 @@ input.final-submit {
     display: block;
     padding: 0.5em 1em;
   }
-  a:hover, a:focus, &.hovered a {
+  a:focus, &.hovered a {
     background-color: $itemlist_item_background_hover;
     text-decoration: none;
   }
@@ -1034,11 +1020,6 @@ input.final-submit {
     padding-#{$left}: 2.5em; // make space for background image
     border-#{$left}: solid 1em transparent; // inset background image 1em from the left
     background: transparent;
-  }
-
-  // Trigger hover style even when hovering over sibling item-action-button
-  &:hover a {
-    background-color: $itemlist_item_background_hover;
   }
 
   h3 {
@@ -1283,10 +1264,6 @@ input.final-submit {
       background-size: 16px 16px;
       @include svg-background-image('/cobrands/fixmystreet/images/magnify');
     }
-
-    &:hover span {
-      opacity: 1;
-    }
   }
 }
 
@@ -1298,7 +1275,7 @@ input.final-submit {
   padding-bottom: 0.8em;
   border-bottom: 1px solid #eee;
 
-  &:link, &:visited, &:hover {
+  &:link, &:visited, {
     color: #666;
   }
 
@@ -1498,7 +1475,6 @@ html.js #map .noscript {
         font-size: 1em;
         text-align: center;
 
-        &:hover,
         &:focus {
             background-color: #000;
             text-decoration: none;
@@ -1900,7 +1876,7 @@ label .muted {
   background:#ff0000;
   padding:1em;
   color:#fff;
-  a, a:hover {
+  a {
     color:$primary;
   }
 }
@@ -1924,10 +1900,6 @@ label .muted {
     background: $primary;
     padding-#{$left}: 0.5em;
     padding-#{$right}: 0.5em;
-    &:hover {
-      text-decoration:none;
-      background:$primary/1.1;
-    }
   }
 }
 
@@ -2001,9 +1973,6 @@ label .muted {
         color:#fff;
         text-transform:uppercase;
         @include border-radius(0);
-        &:hover {
-          background:#333;
-        }
       }
     }
   }
@@ -2018,10 +1987,6 @@ label .muted {
       size:0.8125em;
     }
     @include border-radius(0 0 0.25em 0.25em);
-    &:hover {
-      text-decoration:none;
-      background:#2a2a2a;
-    }
   }
   a#geolocate_link.loading {
       background: #1a1a1a url("/cobrands/fixmystreet/images/spinner-black.gif") flip(100%,0) 50% no-repeat;
@@ -2160,7 +2125,6 @@ a#geolocate_link.loading, .btn--geolocate.loading {
       text-decoration: underline;
       color: inherit;
 
-      &:hover,
       &:focus {
         text-decoration: none;
         color: #0BA7D1; // default link colour
@@ -2464,14 +2428,6 @@ $nicetable-hover-background: rgba($primary, 0.15) !default;
     &.hover {
         td, th {
             padding: $nicetable-cell-padding;
-        }
-
-        tr:hover {
-            background: $nicetable-hover-background;
-        }
-
-        thead tr:hover {
-            background: transparent;
         }
     }
 

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -11,6 +11,112 @@ $mappage-actions-width--medium: 20em;
 $header-top-border-width: 0.25em !default;
 $header-top-border: $header-top-border-width solid $primary !default;
 
+// hover styles migrated from _base.scss, included at the top here so hover
+// styles further down take precedence
+$itemlist_item_background_hover: #e6e6e6 !default; // duplicated from _base.scss :(
+
+a:hover {
+  text-decoration: underline;
+  color: #0D7CCE;
+}
+
+div.form-error,
+p.form-error {
+  a:hover {
+    text-decoration: none;
+  }
+}
+
+#report-cta:hover {
+  text-decoration: none;
+  background-color: $nav_fg_hover;
+}
+
+.nav-menu {
+  a:hover {
+    background-color: #333;
+    color: #fff;
+    text-decoration: none;
+  }
+  span.report-a-problem-btn:hover {
+    background-color: #333;
+    color: #fff;
+    text-decoration: none;
+  }
+}
+
+#key-tools {
+  a, button {
+    &:hover, &.hover {
+      text-decoration:none;
+      background-color:#333;
+      color: #fff !important;
+    }
+  }
+}
+
+.item-list--wards__item, .item-list--reports__item {
+  a:hover, a:focus, &.hovered a {
+    background-color: $itemlist_item_background_hover;
+    text-decoration: none;
+  }
+}
+
+// Trigger hover style even when hovering over sibling item-action-button
+.item-list__item--indented:hover a {
+  background-color: $itemlist_item_background_hover;
+}
+
+.update-img a:hover span {
+  opacity: 1;
+}
+
+.problem-back:hover {
+  color: #666;
+}
+
+.sub-map-links a:hover {
+  background-color: #000;
+  text-decoration: none;
+}
+
+.alert a:hover {
+  color:$primary;
+}
+
+.pagination a:hover {
+  text-decoration:none;
+  background:$primary/1.1;
+}
+
+#front-main {
+  #postcodeForm div input#sub:hover {
+    background:#333;
+  }
+
+  a#geolocate_link:hover {
+    text-decoration:none;
+    background:#2a2a2a;
+  }
+}
+
+.confirmation-header h1 a:hover {
+  text-decoration: none;
+  color: #0BA7D1; // default link colour
+}
+
+
+$nicetable-hover-background: rgba($primary, 0.15) !default; // duplicated from _base.scss :(
+.nicetable.hover {
+  tr:hover {
+    background: $nicetable-hover-background;
+  }
+
+  thead tr:hover {
+    background: transparent;
+  }
+}
+
 .internal-link-fixed-header {
     display: block;
     position: relative;

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -839,17 +839,20 @@ $.extend(fixmystreet.utils, {
             $(fixmystreet).trigger('maps:update_view');
         });
 
-        (function() {
-            var timeout;
-            $('#js-reports-list').on('mouseenter', '.item-list--reports__item', function(){
-                var href = $('a', this).attr('href');
-                var id = parseInt(href.replace(/^.*[\/]([0-9]+)$/, '$1'),10);
-                clearTimeout(timeout);
-                fixmystreet.maps.markers_highlight(id);
-            }).on('mouseleave', '.item-list--reports__item', function(){
-                timeout = setTimeout(fixmystreet.maps.markers_highlight, 50);
-            });
-        })();
+        if (!$("html").hasClass("mobile")) {
+            // On mobile go straight to the report
+            (function() {
+                var timeout;
+                $('#js-reports-list').on('mouseenter', '.item-list--reports__item', function(){
+                    var href = $('a', this).attr('href');
+                    var id = parseInt(href.replace(/^.*[\/]([0-9]+)$/, '$1'),10);
+                    clearTimeout(timeout);
+                    fixmystreet.maps.markers_highlight(id);
+                }).on('mouseleave', '.item-list--reports__item', function(){
+                    timeout = setTimeout(fixmystreet.maps.markers_highlight, 50);
+                });
+            })();
+        }
     });
 
 // End maps closure


### PR DESCRIPTION
iOS will activate the hover state, if present, the first time an element is tapped, meaning two taps are required to perform an action like following a link.

This PR moves the hover styles to the desktop-only stylesheet so iOS never even knows they’re there, and disables the JS that highlights pins when hovering over the report list on mobile.

Some concerns:

 - Still requires two taps on iPads (and iPhones in landscape)
 - This lift-and-shift of the styles doesn’t seem like a great solution but my Sassiness isn’t sassy enough to know if there’s a better way.
 - There are probably cobrand `base.scss` files with `:hover` styles too

Fixes #2294.