### PR TITLE
add report_mark_private permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
         - Simplify /auth sign in page. #2208
     - Admin improvements:
         - Allow moderation to potentially change category. #2320
+        - Add Mark/View private reports permission #2306
     - Open311 improvements:
         - Fix bug in contact group handling. #2323
 

--- a/docs/_includes/admin-tasks-content.md
+++ b/docs/_includes/admin-tasks-content.md
@@ -250,6 +250,29 @@ were made during the period when the user was banned — these remain unsent.
 
 </div>
 
+<div class="admin-task" markdown="1" id="create-reports-private">
+
+### Creating/Viewing private reports
+
+<span class="admin-task__permissions">Permissions required: User must be marked
+as staff; one or more of ‘View/Mark private reports’ and ‘Markup problem
+details’ must be ticked.</span>
+
+If a you are creating a report that has to contain information that should
+not be make public, e.g. Names and addresses, then you can create a
+Private report. This will still be visible to staff members with the
+relevant permissions and will be sent as normal but will not be visible
+to members of the public.
+
+You can also mark an existing report as private by visiting the report
+page while logged in, checking "Private" and clicking "Save Changes".
+
+In such cases, staff should make a new report just as a member of the public would — see ‘[The
+citizen’s experience](/pro-manual/citizens-experience/)'. Those with the appropriate permissions
+will see a "Private" checkbox underneath the user details which they should select.
+
+</div>
+
 <div class="admin-task" markdown="1" id="correct-reporter-errors">
 
 ### Correcting reporter errors

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -85,7 +85,7 @@ sub display :PathPart('') :Chained('id') :Args(0) {
     $c->forward( 'format_problem_for_display' );
 
     my $permissions = $c->stash->{_permissions} ||= $c->forward( 'check_has_permission_to',
-        [ qw/report_inspect report_edit_category report_edit_priority/ ] );
+        [ qw/report_inspect report_edit_category report_edit_priority report_mark_private/ ] );
     if (any { $_ } values %$permissions) {
         $c->stash->{template} = 'report/inspect.html';
         $c->forward('inspect');
@@ -131,8 +131,8 @@ sub load_problem_or_display_error : Private {
         # Creator, and inspection users can see non_public reports
         $c->stash->{problem} = $problem;
         my $permissions = $c->stash->{_permissions} = $c->forward( 'check_has_permission_to',
-            [ qw/report_inspect report_edit_category report_edit_priority/ ] );
-        if ( !$c->user || ($c->user->id != $problem->user->id && !$permissions->{report_inspect}) ) {
+            [ qw/report_inspect report_edit_category report_edit_priority report_mark_private / ] );
+        if ( !$c->user || ($c->user->id != $problem->user->id && !($permissions->{report_inspect} || $permissions->{report_mark_private})) ) {
             $c->detach(
                 '/page_error_403_access_denied',
                 [ sprintf(_('That report cannot be viewed on %s.'), $c->stash->{site_name}) ]

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -717,6 +717,7 @@ sub available_permissions {
             report_edit => _("Edit reports"),
             report_edit_category => _("Edit report category"), # future use
             report_edit_priority => _("Edit report priority"), # future use
+            report_mark_private => _("View/Mark private reports"),
             report_inspect => _("Markup problem details"),
             report_instruct => _("Instruct contractors to fix problems"), # future use
             planned_reports => _("Manage shortlist"),

--- a/perllib/FixMyStreet/DB/ResultSet/Problem.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Problem.pm
@@ -30,7 +30,8 @@ sub non_public_if_possible {
     if ($c->user_exists) {
         if ($c->user->is_superuser) {
             # See all reports, no restriction
-        } elsif ($c->user->has_body_permission_to('report_inspect')) {
+        } elsif ($c->user->has_body_permission_to('report_inspect') ||
+                 $c->user->has_body_permission_to('report_mark_private')) {
             $params->{'-or'} = [
                 non_public => 0,
                 $rs->body_query($c->user->from_body->id),

--- a/t/app/controller/admin/users.t
+++ b/t/app/controller/admin/users.t
@@ -168,6 +168,7 @@ for my $test (
 my %default_perms = (
     "permissions[moderate]" => undef,
     "permissions[planned_reports]" => undef,
+    "permissions[report_mark_private]" => undef,
     "permissions[report_edit]" => undef,
     "permissions[report_edit_category]" => undef,
     "permissions[report_edit_priority]" => undef,

--- a/templates/web/base/report/new/form_user_loggedin.html
+++ b/templates/web/base/report/new/form_user_loggedin.html
@@ -57,7 +57,7 @@
     <input class="form-control" type="text" value="[% report.user.email | html %]" name="email" id="form_email">
 [% END %]
 
-[% IF c.user.has_permission_to("report_inspect", bodies.keys) %]
+[% IF c.user.has_permission_to("report_inspect", bodies.keys) OR c.user.has_permission_to("report_mark_private", bodies.keys) %]
     <div class="checkbox-group">
         <input type="checkbox" name="non_public" id="form_non_public" value="1"[% ' checked' IF report.non_public %]>
         <label class="inline" for="form_non_public">[% loc('Private') %] </label>


### PR DESCRIPTION
Allows user's to see the inspector panel to mark reports as Private, and
also to view those non-public reports. Useful for call centre staff who
want to record private reports but don't need to other permissions.

Fixes mysociety/fixmystreet-commercial#1213

Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog