### PR TITLE
Disable questionnaires when closing/fixing reports via Open311

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
         - Fix subcategory issues when visiting /report/new directly #2276
         - Give superusers access to update staff dropdowns. #2286
         - Update report areas when moving its location. #2181
+        - Don't send questionnaires for closed reports. #2310
     - Development improvements:
         - Add cobrand hook for dashboard viewing permission. #2285
         - Have body.url work in hashref lookup. #2284

--- a/perllib/FixMyStreet/Script/Questionnaires.pm
+++ b/perllib/FixMyStreet/Script/Questionnaires.pm
@@ -53,7 +53,9 @@ sub send_questionnaires_period {
         # Cobrands can also override sending per row if they wish
         my $cobrand_send = $cobrand->call_hook('send_questionnaire', $row) // 1;
 
-        if ($row->is_from_abuser || !$row->user->email_verified || !$cobrand_send) {
+        if ($row->is_from_abuser || !$row->user->email_verified ||
+            !$cobrand_send || $row->is_closed
+           ) {
             $row->update( { send_questionnaire => 0 } );
             next;
         }


### PR DESCRIPTION
Stops questionnaires being sent for reports closed/fixed via Open311.

Not sure if we want this behaviour for situations where a report has been closed/fixed by an admin/council staff user too?

Connects to https://github.com/mysociety/fixmystreet-freshdesk/issues/24.

Please check the following:

- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
