### PR TITLE
send reports on highways agency roads to highways agency

### DIFF
--- a/.cypress/cypress/fixtures/highways.xml
+++ b/.cypress/cypress/fixtures/highways.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver https://tilma.mysociety.org:80/mapserver/highways?SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=Highways&amp;OUTPUTFORMAT=text/xml;%20subtype=gml/3.1.1  http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+      <gml:boundedBy>
+      	<gml:Envelope srsName="EPSG:3857">
+      		<gml:lowerCorner>-290458.39994864 6708826.7261869</gml:lowerCorner>
+      		<gml:upperCorner>-289178.07972504 6710250.3658385</gml:upperCorner>
+      	</gml:Envelope>
+      </gml:boundedBy>
+       <gml:featureMember>
+      <ms:Highways>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+      		<gml:lowerCorner>-290458.39994864 6708826.7261869</gml:lowerCorner>
+      		<gml:upperCorner>-289178.07972504 6710250.3658385</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:LineString srsName="EPSG:3857">
+            <gml:posList srsDimension="2">-289674.87858928 6709851.5161992 -289916.13295977 6709311.679687 -289885.08041704 6709302.1250585 -289636.66007514 6709882.5687419</gml:posList>
+          </gml:LineString>
+        </ms:msGeometry>
+        <ms:ROA_NUMBER>M6</ms:ROA_NUMBER>
+      </ms:Highways>
+    </gml:featureMember>
+</wfs:FeatureCollection>

--- a/.cypress/cypress/integration/highways.js
+++ b/.cypress/cypress/integration/highways.js
@@ -1,0 +1,25 @@
+describe('Highways England tests', function() {
+    it('report as defaults to body', function() {
+        cy.server();
+        cy.fixture('highways.xml');
+        cy.route('**/mapserver/highways*', 'fixture:highways.xml').as('highways-tilma');
+        cy.route('/report/new/ajax*').as('report-ajax');
+        cy.visit('/');
+        cy.contains('Go');
+        cy.get('[name=pc]').type(Cypress.env('postcode'));
+        cy.get('[name=pc]').parents('form').submit();
+        cy.url().should('include', '/around');
+        cy.get('#map_box').click(210, 200);
+        cy.wait('@report-ajax');
+        cy.wait('@highways-tilma');
+        cy.get('#highways').should('contain', 'M6');
+        cy.get('#js-councils_text').should('contain', 'Highways England');
+        cy.get('#single_body_only').should('have.value', 'Highways England');
+        cy.get('#js-not-highways').click();
+        cy.get('#js-councils_text').should('contain', 'Borsetshire');
+        cy.get('#single_body_only').should('have.value', '');
+        cy.get('#js-highways').click({ force: true });
+        cy.get('#js-councils_text').should('contain', 'Highways England');
+        cy.get('#single_body_only').should('have.value', 'Highways England');
+    });
+});

--- a/bin/browser-tests
+++ b/bin/browser-tests
@@ -90,7 +90,7 @@ sub run {
 
     if (($run_cypress && !$run_server) || $pid) {
         # Parent, run the test runner (then kill the child)
-        my $exit = system("cypress", $cmd, '--config', 'fixturesFolder=false,pluginsFile=false,supportFile=false,blacklistHosts=[gaze.mysociety.org,*.openstreetmap.org]', '--project', '.cypress', '--env', "cobrand=$cobrand", @ARGV);
+        my $exit = system("cypress", $cmd, '--config', 'pluginsFile=false,supportFile=false,blacklistHosts=[gaze.mysociety.org,*.openstreetmap.org]', '--project', '.cypress', '--env', "cobrand=$cobrand", @ARGV);
         kill 'TERM', $pid if $pid;
         exit $exit >> 8;
     } else {

--- a/perllib/FixMyStreet/SendReport.pm
+++ b/perllib/FixMyStreet/SendReport.pm
@@ -6,6 +6,7 @@ use MooX::Types::MooseLike::Base qw(:all);
 use Module::Pluggable
     sub_name    => 'senders',
     search_path => __PACKAGE__,
+    except => 'FixMyStreet::SendReport::Email::SingleBodyOnly',
     require     => 1;
 
 has 'body_config' => ( is => 'rw', isa => HashRef, default => sub { {} } );

--- a/perllib/FixMyStreet/SendReport/Email/Highways.pm
+++ b/perllib/FixMyStreet/SendReport/Email/Highways.pm
@@ -1,11 +1,11 @@
-package FixMyStreet::SendReport::Email::TfL;
+package FixMyStreet::SendReport::Email::Highways;
 
 use Moo;
 extends 'FixMyStreet::SendReport::Email::SingleBodyOnly';
 
 has contact => (
     is => 'ro',
-    default => 'Traffic lights'
+    default => 'Pothole'
 );
 
 1;

--- a/perllib/FixMyStreet/SendReport/Email/SingleBodyOnly.pm
+++ b/perllib/FixMyStreet/SendReport/Email/SingleBodyOnly.pm
@@ -1,0 +1,28 @@
+package FixMyStreet::SendReport::Email::SingleBodyOnly;
+
+use Moo;
+extends 'FixMyStreet::SendReport::Email';
+
+has contact => (
+    is => 'ro',
+    default => sub { die 'Need to override contact' }
+);
+
+sub build_recipient_list {
+    my ( $self, $row, $h ) = @_;
+
+    return unless @{$self->bodies} == 1;
+    my $body = $self->bodies->[0];
+
+    # We don't care what the category was, look up the relevant contact
+    my $contact = $row->result_source->schema->resultset("Contact")->not_deleted->find({
+        body_id => $body->id,
+        category => $self->contact,
+    });
+    return unless $contact;
+
+    @{$self->to} = map { [ $_, $body->name ] } split /,/, $contact->email;
+    return 1;
+}
+
+1;

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -41,6 +41,7 @@ for my $body (
     { area_id => 2227, name => 'Hampshire County Council' },
     { area_id => 2333, name => 'Hart Council' },
     { area_id => 2535, name => 'Sandwell Borough Council' },
+    { area_id => 1000, name => 'Highways England' },
 ) {
     my $body_obj = $mech->create_body_ok($body->{area_id}, $body->{name});
     push @bodies, $body_obj;
@@ -97,6 +98,11 @@ my $contact10 = $mech->create_contact_ok(
     body_id => $body_ids{2326}, # Cheltenham
     category => 'Street lighting',
     email => 'streetlights-2326@example.com',
+);
+my $contact11 = $mech->create_contact_ok(
+    body_id => $body_ids{1000}, # Highways
+    category => 'Pothole',
+    email => 'pothole-1000@example.com',
 );
 
 # test that the various bit of form get filled in and errors correctly
@@ -975,6 +981,13 @@ foreach my $test (
         category => 'Street lighting',
         councils => [ 2326 ],
         extra_fields => { do_not_send => 'Gloucestershire County Council' },
+        email_count => 1,
+    },
+    {
+        desc => "test single_body_only with Highways England",
+        category => 'Street lighting',
+        councils => [ 1000 ],
+        extra_fields => { single_body_only => 'Highways England' },
         email_count => 1,
     },
 ) {

--- a/t/app/sendreport/email/highways.t
+++ b/t/app/sendreport/email/highways.t
@@ -1,0 +1,32 @@
+use FixMyStreet::SendReport::Email::Highways;
+use FixMyStreet::TestMech;
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $bromley = $mech->create_body_ok(2482, 'Bromley Council');
+my $highways = $mech->create_body_ok(2482, 'Highways England');
+
+$mech->create_contact_ok(email => 'council@example.com', body_id => $bromley->id, category => 'Graffiti');
+$mech->create_contact_ok(email => 'council@example.com', body_id => $bromley->id, category => 'Faulty street light');
+$mech->create_contact_ok(email => 'highways@example.com', body_id => $highways->id, category => 'Pothole');
+
+my $row = FixMyStreet::DB->resultset('Problem')->new( {
+    bodies_str => '1000',
+    category => 'Pothole',
+    cobrand => '',
+} );
+
+my $e = FixMyStreet::SendReport::Email::Highways->new;
+is $e->build_recipient_list($row), undef, 'no recipients if no body';
+
+$e = FixMyStreet::SendReport::Email::Highways->new;
+$e->add_body($bromley);
+is $e->build_recipient_list($row), undef, 'no recipients if category missing';
+
+$e = FixMyStreet::SendReport::Email::Highways->new;
+$e->add_body($highways);
+is $e->build_recipient_list($row), 1, 'correct recipient list count';
+is_deeply $e->to, [ [ 'highways@example.com', 'Highways England' ] ], 'correct To line';
+
+done_testing();
+

--- a/templates/web/bristol/footer_extra_js.html
+++ b/templates/web/bristol/footer_extra_js.html
@@ -1,4 +1,5 @@
 [% scripts.push(
     version('/vendor/OpenLayers.Projection.OrdnanceSurvey.js')
     version('/cobrands/fixmystreet-uk-councils/js.js'),
+    version('/cobrands/highways/assets.js'),
 ) %]

--- a/templates/web/buckinghamshire/report/new/form_heading.html
+++ b/templates/web/buckinghamshire/report/new/form_heading.html
@@ -1,4 +1,4 @@
-<p>
+<p id="bucks_dangerous_msg">
 <strong>IMPORTANT:</strong>
 If you consider this to be dangerous or an emergency, please call us
 on: <strong>01296 382416</strong> (09:00 – 17:30 Mon-Thurs, 09:00 – 17:00 Friday)

--- a/templates/web/fixmystreet-uk-councils/footer_extra_js.html
+++ b/templates/web/fixmystreet-uk-councils/footer_extra_js.html
@@ -1,4 +1,5 @@
 [% scripts.push(
     version('/vendor/OpenLayers.Projection.OrdnanceSurvey.js')
     version('/cobrands/fixmystreet-uk-councils/js.js'),
+    version('/cobrands/highways/assets.js'),
 ) %]

--- a/templates/web/fixmystreet.com/footer_extra_js.html
+++ b/templates/web/fixmystreet.com/footer_extra_js.html
@@ -10,6 +10,7 @@ IF bodyclass.match('mappage');
     scripts.push( version('/cobrands/buckinghamshire/assets.js') );
     scripts.push( version('/cobrands/lincolnshire/assets.js') );
     scripts.push( version('/cobrands/oxfordshire/assets.js') );
+    scripts.push( version('/cobrands/highways/assets.js') );
     scripts.push(
         version('/vendor/OpenLayers.Projection.OrdnanceSurvey.js'),
     );

--- a/templates/web/oxfordshire/footer_extra_js.html
+++ b/templates/web/oxfordshire/footer_extra_js.html
@@ -1,5 +1,7 @@
 [% scripts.push(
+    version('/cobrands/fixmystreet/assets.js'),
     version('/vendor/OpenLayers.Projection.OrdnanceSurvey.js'),
     version('/cobrands/oxfordshire/js.js'),
     version('/cobrands/oxfordshire/assets.js'),
+    version('/cobrands/highways/assets.js'),
 ) %]

--- a/web/cobrands/bristol/base.scss
+++ b/web/cobrands/bristol/base.scss
@@ -126,3 +126,9 @@ label {
 #map #drag .square-map__tile {
   position: static;
 }
+
+// uses important because btn also uses it
+#highways .segmented-control--radio input:checked + label.btn {
+    color: $g7 !important;
+    font-weight: bold !important;
+}

--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -156,6 +156,18 @@ function is_only_body(body) {
     return false;
 }
 
+$(fixmystreet).on('report_new:highways_change', function() {
+    if (fixmystreet.body_overrides.get_only_send() === 'Highways England') {
+        hide_responsibility_errors();
+        enable_report_form();
+        $('#bucks_dangerous_msg').hide();
+    } else {
+        $('#bucks_dangerous_msg').show();
+        $(fixmystreet).trigger('report_new:category_change', [ $('#form_category') ]);
+    }
+});
+
+
 fixmystreet.assets.add($.extend(true, {}, defaults, {
     http_options: {
         params: {

--- a/web/cobrands/buckinghamshire/base.scss
+++ b/web/cobrands/buckinghamshire/base.scss
@@ -91,3 +91,8 @@ label {
 #map #drag .square-map__tile {
   position: static;
 }
+
+// uses important because btn also uses it
+#highways .segmented-control--radio input:checked + label.btn {
+    color: $g7 !important;
+}

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -807,6 +807,9 @@ return {
     allow_send: function(body) {
         do_not_send = $.grep(do_not_send, function(a) { return a !== body; });
         update();
+    },
+    get_only_send: function() {
+      return only_send;
     }
 };
 

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -131,7 +131,7 @@ OpenLayers.Layer.VectorNearest = OpenLayers.Class(OpenLayers.Layer.VectorAsset, 
         var feature = this.getFeatureAtPoint(point);
         if (feature == null) {
             // The click wasn't directly over a road, try and find one nearby
-            feature = this.getNearestFeature(point, 10);
+            feature = this.getNearestFeature(point, this.fixmystreet.nearest_radius || 10);
         }
         this.selected_feature = feature;
     },

--- a/web/cobrands/highways/assets.js
+++ b/web/cobrands/highways/assets.js
@@ -68,7 +68,9 @@ fixmystreet.assets.add($.extend(true, {}, defaults, {
         },
         not_found: function(layer) {
             fixmystreet.body_overrides.location = null;
-            fixmystreet.body_overrides.remove_only_send();
+            if (fixmystreet.body_overrides.get_only_send() === 'Highways England') {
+                fixmystreet.body_overrides.remove_only_send();
+            }
             $('#highways').remove();
         }
     }
@@ -87,6 +89,7 @@ function add_highways_warning(road_name) {
         .on('click', function() {
             fixmystreet.body_overrides.location = null;
             fixmystreet.body_overrides.only_send('Highways England');
+            $(fixmystreet).trigger('report_new:highways_change');
         })
         .appendTo($radios);
     $('<label>')
@@ -104,6 +107,7 @@ function add_highways_warning(road_name) {
                 longitude: $('#fixmystreet\\.longitude').val()
             };
             fixmystreet.body_overrides.remove_only_send();
+            $(fixmystreet).trigger('report_new:highways_change');
         })
         .appendTo($radios);
     $('<label>')
@@ -113,6 +117,9 @@ function add_highways_warning(road_name) {
         .appendTo($radios);
     $radios.appendTo($warning);
     $('.change_location').after($warning);
+    fixmystreet.body_overrides.location = null;
+    fixmystreet.body_overrides.only_send('Highways England');
+    $(fixmystreet).trigger('report_new:highways_change');
 }
 
 })();

--- a/web/cobrands/highways/assets.js
+++ b/web/cobrands/highways/assets.js
@@ -20,9 +20,7 @@ var defaults = {
     // the M6
     max_resolution: 20,
     min_resolution: 0.5971642833948135,
-    asset_id_field: 'CENTRAL_AS',
-    geometryName: 'msGeometry',
-    srsName: "EPSG:3857",
+    srsName: "EPSG:900913",
     strategy_class: OpenLayers.Strategy.FixMyStreet
 };
 

--- a/web/cobrands/highways/assets.js
+++ b/web/cobrands/highways/assets.js
@@ -1,0 +1,118 @@
+(function(){
+
+if (!fixmystreet.maps) {
+    return;
+}
+
+var defaults = {
+    http_options: {
+        url: "https://tilma.mysociety.org/mapserver/highways",
+        params: {
+            SERVICE: "WFS",
+            VERSION: "1.1.0",
+            REQUEST: "GetFeature",
+            SRSNAME: "urn:ogc:def:crs:EPSG::3857"
+        }
+    },
+    format_class: OpenLayers.Format.GML.v3.MultiCurveFix,
+    asset_type: 'area',
+    // this covers zoomed right out on Cumbrian sections of
+    // the M6
+    max_resolution: 20,
+    min_resolution: 0.5971642833948135,
+    asset_id_field: 'CENTRAL_AS',
+    geometryName: 'msGeometry',
+    srsName: "EPSG:3857",
+    strategy_class: OpenLayers.Strategy.FixMyStreet
+};
+
+var highways_stylemap = new OpenLayers.StyleMap({
+    'default': new OpenLayers.Style({
+        fill: false,
+        stroke: false,
+    })
+});
+
+fixmystreet.assets.add($.extend(true, {}, defaults, {
+    http_options: {
+        params: {
+            TYPENAME: "Highways"
+        }
+    },
+    stylemap: highways_stylemap,
+    always_visible: true,
+
+    non_interactive: true,
+    road: true,
+    all_categories: true,
+    // motorways are wide and the lines to define them are narrow so we
+    // need a bit more margin for error in finding the nearest to stop
+    // clicking in the middle of them being undetected
+    nearest_radius: 15,
+    actions: {
+        found: function(layer, feature) {
+            // if we've changed location then we want to reset things otherwise
+            // this is probably just being called again by a category change
+            var lat = $('#fixmystreet\\.latitude').val(),
+                lon = $('#fixmystreet\\.longitude').val();
+            if ( fixmystreet.body_overrides.location &&
+                 lat == fixmystreet.body_overrides.location.latitude &&
+                 lon == fixmystreet.body_overrides.location.longitude ) {
+                return;
+            }
+            $('#highways').remove();
+            if ( !fixmystreet.assets.selectedFeature() ) {
+                fixmystreet.body_overrides.only_send('Highways England');
+                add_highways_warning(feature.attributes.ROA_NUMBER);
+            }
+        },
+        not_found: function(layer) {
+            fixmystreet.body_overrides.location = null;
+            fixmystreet.body_overrides.remove_only_send();
+            $('#highways').remove();
+        }
+    }
+}));
+
+function add_highways_warning(road_name) {
+  var $warning = $('<div class="box-warning" id="highways"><p>It looks like you clicked on the <strong>' + road_name + '</strong> which is managed by <strong>Highways England</strong>. ' +
+                   'Does your report concern something on this road, or somewhere else (e.g a road crossing it)?<p></div>');
+  var $radios = $('<p class="segmented-control segmented-control--radio"></p>');
+
+    $('<input>')
+        .attr('type', 'radio')
+        .attr('name', 'highways-choice')
+        .attr('id', 'js-highways')
+        .prop('checked', true)
+        .on('click', function() {
+            fixmystreet.body_overrides.location = null;
+            fixmystreet.body_overrides.only_send('Highways England');
+        })
+        .appendTo($radios);
+    $('<label>')
+        .attr('for', 'js-highways')
+        .text('On the ' + road_name)
+        .addClass('btn')
+        .appendTo($radios);
+    $('<input>')
+        .attr('type', 'radio')
+        .attr('name', 'highways-choice')
+        .attr('id', 'js-not-highways')
+        .on('click', function() {
+            fixmystreet.body_overrides.location = {
+                latitude: $('#fixmystreet\\.latitude').val(),
+                longitude: $('#fixmystreet\\.longitude').val()
+            };
+            fixmystreet.body_overrides.remove_only_send();
+        })
+        .appendTo($radios);
+    $('<label>')
+        .attr('for', 'js-not-highways')
+        .text('Somewhere else')
+        .addClass('btn')
+        .appendTo($radios);
+    $radios.appendTo($warning);
+    $('.change_location').after($warning);
+}
+
+})();

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2445,6 +2445,14 @@ a#geolocate_link.loading, .btn--geolocate.loading {
             margin-bottom: 0;
         }
     }
+
+    .segmented-control {
+        .btn {
+            &:last-child {
+                margin-bottom: 1em;
+            }
+        }
+    }
 }
 
 .asset-spot:before {

--- a/web/js/map-fms.js
+++ b/web/js/map-fms.js
@@ -39,10 +39,14 @@ OpenLayers.Layer.BingUK = OpenLayers.Class(OpenLayers.Layer.Bing, {
         var c = this.map.getCenter();
         var in_uk = c ? this.in_uk(c) : true;
         if (z >= 16 && in_uk) {
-            copyrights = 'Contains Ordnance Survey data &copy; Crown copyright and database right 2016';
+            copyrights = 'Contains Highways England and Ordnance Survey data &copy; Crown copyright and database right 2016';
         } else {
             logo = '<a href="https://www.bing.com/maps/"><img border=0 src="//dev.virtualearth.net/Branding/logo_powered_by.png"></a>';
-            copyrights = '&copy; 2016 <a href="https://www.bing.com/maps/">Microsoft</a>. &copy; AND, Navteq, Ordnance Survey';
+            if (in_uk) {
+                copyrights = '&copy; 2016 <a href="https://www.bing.com/maps/">Microsoft</a>. &copy; AND, Navteq, Highways England, Ordnance Survey';
+            } else {
+                copyrights = '&copy; 2016 <a href="https://www.bing.com/maps/">Microsoft</a>. &copy; AND, Navteq, Ordnance Survey';
+            }
         }
         this._updateAttribution(copyrights, logo);
     },


### PR DESCRIPTION
Includes an option to send to the council instead for e.g. reports on
underpasses or bridges.

Fixes #736

Also demonstrates how mysociety/fixmystreet-commercial#1191 can be done

Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Are the changes tested for accessibility?
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]

![screen recording 2018-10-30 at 14 02 21](https://user-images.githubusercontent.com/5310/47723673-ef95d780-dc4c-11e8-9400-d7c08db28323.gif)

