### PR TITLE
[FixMyStreet.com] Enable category groups

### DIFF
--- a/.cypress/cypress/integration/category_tests.js
+++ b/.cypress/cypress/integration/category_tests.js
@@ -13,7 +13,7 @@ describe('Basic categories', function() {
         cy.get('#map_box').click(210, 200);
         cy.wait('@report-ajax');
         cy.get('[name=category]').should('not.be.visible');
-        var categories = ['-- Pick a category --', 'Graffiti', 'Potholes', 'Street lighting', 'Other', 'Bins' ];
+        var categories = ['-- Pick a category --', 'Bins', 'Graffiti', 'Potholes', 'Street lighting', 'Other' ];
         cy.get('select:eq(3) option').each(function (obj, i) {
             expect(obj[0].value).to.equal(categories[i]);
         });
@@ -29,7 +29,7 @@ describe('Basic categories', function() {
         cy.route('/report/new/ajax*').as('report-ajax');
         cy.visit('/report/new?latitude=51.496194&longitude=-2.603482');
         cy.get('[name=category]').should('not.be.visible');
-        var categories = ['-- Pick a category --', 'Graffiti', 'Potholes', 'Street lighting', 'Other', 'Bins' ];
+        var categories = ['-- Pick a category --', 'Bins', 'Graffiti', 'Potholes', 'Street lighting', 'Other' ];
         cy.get('select:eq(1) option').each(function (obj, i) {
             expect(obj[0].value).to.equal(categories[i]);
         });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
         - Clearer name for navigation colours in SCSS. #2080
     - Internal things:
         - Move send-comments code to package for testing. #2109 #2170
+    - Open311 improvements:
+        - Set contact group only if handling cobrand has groups enabled. #2312
+
 
 * v2.4.1 (2nd October 2018)
     - New features:

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -10,6 +10,8 @@ use constant COUNCIL_ID_BROMLEY => 2482;
 
 sub on_map_default_status { return 'open'; }
 
+sub enable_category_groups { 1 }
+
 # Special extra
 sub path_to_web_templates {
     my $self = shift;

--- a/t/open311/populate-service-list.t
+++ b/t/open311/populate-service-list.t
@@ -1,4 +1,21 @@
 #!/usr/bin/env perl
+package FixMyStreet::Cobrand::Tester;
+
+use parent 'FixMyStreet::Cobrand::Default';
+
+sub council_area_id { 1 }
+
+
+package FixMyStreet::Cobrand::TesterGroups;
+
+use parent 'FixMyStreet::Cobrand::Default';
+
+sub council_area_id { 1 }
+
+sub enable_category_groups { 1 }
+
+
+package main;
 
 use FixMyStreet::Test;
 use FixMyStreet::DB;
@@ -28,27 +45,36 @@ $bromley->body_areas->find_or_create({
     area_id => 2482
 } );
 
-subtest 'check basic functionality' => sub {
-    FixMyStreet::DB->resultset('Contact')->search( { body_id => 1 } )->delete();
+for my $test (
+    { cobrand => 'tester', groups => 0 },
+    { cobrand => 'testergroups', groups => 1 },
+) {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ $test->{cobrand} ],
+    }, sub {
+        subtest 'check basic functionality' => sub {
+            FixMyStreet::DB->resultset('Contact')->search( { body_id => 1 } )->delete();
 
-    my $service_list = get_xml_simple_object( get_standard_xml() );
+            my $service_list = get_xml_simple_object( get_standard_xml() );
 
-    my $processor = Open311::PopulateServiceList->new();
-    $processor->_current_body( $body );
-    $processor->process_services( $service_list );
+            my $processor = Open311::PopulateServiceList->new();
+            $processor->_current_body( $body );
+            $processor->process_services( $service_list );
 
-    my $contact_count = FixMyStreet::DB->resultset('Contact')->search( { body_id => 1 } )->count();
-    is $contact_count, 3, 'correct number of contacts';
+            my $contact_count = FixMyStreet::DB->resultset('Contact')->search( { body_id => 1 } )->count();
+            is $contact_count, 3, 'correct number of contacts';
 
-    for my $test (
-        { code => "001", group => "sanitation" },
-        { code => "002", group => "street" },
-        { code => "003", group => "street" },
-    ) {
-        my $contact = FixMyStreet::DB->resultset('Contact')->search( { body_id => 1, email => $test->{code} } )->first;
-        is $contact->get_extra->{group}, $test->{group}, "Group set correctly";
-    }
-};
+            for my $expects (
+                { code => "001", group => $test->{groups} ? "sanitation" : undef },
+                { code => "002", group => $test->{groups} ? "street" : undef },
+                { code => "003", group => $test->{groups} ? "street" : undef },
+            ) {
+                my $contact = FixMyStreet::DB->resultset('Contact')->search( { body_id => 1, email => $expects->{code} } )->first;
+                is $contact->get_extra->{group}, $expects->{group}, "Group set correctly";
+            }
+        };
+    };
+}
 
 subtest 'check non open311 contacts marked as deleted' => sub {
     FixMyStreet::DB->resultset('Contact')->search( { body_id => 1 } )->delete();

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -504,6 +504,17 @@ $.extend(fixmystreet.set_up, {
             add_option(this);
         }
     });
+    // Sort elements in place, but leave the first 'pick a category' option alone
+    $group_select.find("option").slice(1).sort(function(a, b) {
+        // 'Other' should always be at the end.
+        if (a.label === 'Other') {
+            return 1;
+        }
+        if (b.label === 'Other') {
+            return -1;
+        }
+        return a.label > b.label ? 1 : -1;
+    }).appendTo($group_select);
     $group_select.change();
   },
 


### PR DESCRIPTION
 - Fixes a bug that meant items in top-level category dropdown were out of order if there was a mix of grouped and ungrouped categories
 - There are existing Open311 contacts (Bristol, Greenwich) in the DB which have unhelpful groups applied, presumably because they weren't intended to be seen publicly.
 - This PR inspects the cobrand's `enable_category_groups` value when populating Open311 categories and only sets the contact's `group` metadata if the handling cobrand has groups enabled.

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

Connects to mysociety/fixmystreet-commercial#1148.