### PR TITLE
allow comment fetching to be limited by body name

### DIFF
--- a/bin/fixmystreet.com/backfill-open311-comments
+++ b/bin/fixmystreet.com/backfill-open311-comments
@@ -1,0 +1,64 @@
+#!/usr/bin/env perl
+#
+# This script utilises the Open311 extension explained at
+# https://github.com/mysociety/FixMyStreet/wiki/Open311-FMS---Proposed-differences-to-Open311
+# to fetch updates on service requests for a specified timeframe, optionally for a single body
+
+use strict;
+use warnings;
+require 5.8.0;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use DateTime;
+use DateTime::Format::W3CDTF;
+use DateTime::Format::ISO8601;
+use Getopt::Long::Descriptive;
+
+my ($opt, $usage) = describe_options(
+    '%c %o',
+    [ 'body:s', "Name of body to use" ],
+    [ 'start_date:s', "Date of first comment to fetch" ],
+    [ 'end_date:s', "Date of last comment to fetch" ],
+    [ 'verbose', "Print out info as we go" ],
+    [ 'help', "print usage message and exit", { shortcircuit => 1 } ],
+);
+print($usage->text), exit if $opt->help;
+
+use Open311::GetServiceRequestUpdates;
+
+my $start_date = DateTime::Format::W3CDTF->parse_datetime( $opt->start_date );
+my $end_date = DateTime::Format::W3CDTF->parse_datetime( $opt->end_date );
+
+die "start and end date required\n" unless $start_date and $end_date;
+
+die "start date must be before end date\n" unless $end_date > $start_date;
+
+my $current_date = $start_date->clone;
+
+while ( $current_date < $end_date ) {
+    my $current_plus_24 = $current_date->clone;
+    $current_plus_24->add( hours => 24 );
+
+    print "fetching updates from $current_date till $current_plus_24\n" if $opt->verbose;
+
+    my %params = (
+        verbose => $opt->verbose,
+        start_date => DateTime::Format::W3CDTF->format_datetime( $current_date ),
+        end_date => DateTime::Format::W3CDTF->format_datetime( $current_plus_24 )
+    );
+
+    $params{body} = $opt->body if $opt->body;
+
+    my $updates = Open311::GetServiceRequestUpdates->new( %params );
+    $updates->fetch;
+
+    $current_date = $current_plus_24;
+
+    sleep 5;
+}

--- a/perllib/Open311/GetServiceRequestUpdates.pm
+++ b/perllib/Open311/GetServiceRequestUpdates.pm
@@ -9,6 +9,7 @@ use DateTime::Format::W3CDTF;
 has system_user => ( is => 'rw' );
 has start_date => ( is => 'ro', default => sub { undef } );
 has end_date => ( is => 'ro', default => sub { undef } );
+has body => ( is => 'ro', default => sub { undef } );
 has suppress_alerts => ( is => 'rw', default => 0 );
 has verbose => ( is => 'ro', default => 0 );
 has schema => ( is =>'ro', lazy => 1, default => sub { FixMyStreet::DB->schema->connect } );
@@ -28,6 +29,10 @@ sub fetch {
             endpoint        => { '!=', '' },
         }
     );
+
+    if ( $self->body ) {
+        $bodies = $bodies->search( { name => $self->body } );
+    }
 
     while ( my $body = $bodies->next ) {
 


### PR DESCRIPTION
Allows creating scripts that fetch comments for a single body, e.g for
batch updating or because they require special setup.

Please check the following:

- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]