### PR TITLE
[FixaMinGata] cobrand customizations

### DIFF
--- a/perllib/FixMyStreet/Cobrand/FixaMinGata.pm
+++ b/perllib/FixMyStreet/Cobrand/FixaMinGata.pm
@@ -181,4 +181,8 @@ sub state_groups_inspect {
     ]
 }
 
+sub always_view_body_contribute_details {
+    return 1;
+}
+
 1;

--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -248,7 +248,9 @@ sub meta_line {
                 $body = "$body <img src='/cobrands/greenwich/favicon.png' alt=''>";
             }
         }
-        my $can_view_contribute = $c->user_exists && $c->user->has_permission_to('view_body_contribute_details', $self->problem->bodies_str_ids);
+        my $cobrand_always_view_body_user = $c->cobrand->call_hook("always_view_body_contribute_details");
+        my $can_view_contribute = $cobrand_always_view_body_user ||
+            ($c->user_exists && $c->user->has_permission_to('view_body_contribute_details', $self->problem->bodies_str_ids));
         if ($self->text) {
             if ($can_view_contribute) {
                 $meta = sprintf( _( 'Posted by <strong>%s</strong> (%s) at %s' ), $body, $user_name, Utils::prettify_dt( $self->confirmed ) );

--- a/t/cobrand/fixamingata.t
+++ b/t/cobrand/fixamingata.t
@@ -106,6 +106,18 @@ subtest "Test ajax decimal points" => sub {
     };
 };
 
+subtest "check user details always shown" => sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'fixamingata' ],
+    }, sub {
+        $user2->update({ from_body => $body });
+        $mech->get_ok('/report/' . $report->id);
+        my $update_meta = $mech->extract_update_metas;
+        like $update_meta->[0], qr/Body \(Commenter\) /;
+        $user2->update({ from_body => undef });
+    };
+};
+
 END {
     ok $mech->host("www.fixmystreet.com"), "change host back";
     done_testing();

--- a/templates/web/fixamingata/footer_extra_js.html
+++ b/templates/web/fixamingata/footer_extra_js.html
@@ -1,0 +1,3 @@
+[% scripts.push(
+    version('/cobrands/fixamingata/js.js'),
+) %]

--- a/web/cobrands/fixamingata/js.js
+++ b/web/cobrands/fixamingata/js.js
@@ -1,0 +1,1 @@
+fixmystreet.inspect_form_no_scroll_on_load = 1;


### PR DESCRIPTION
A couple of customizations for FixaMinGata:

 1. Show staff user names in updates
 2. Don't scroll reports on load

This is my first delivery to the FixaMinGata cobrand. Let me know if you need some kind of approval from someone at FixaMinGata/Sambruk in some way.