### PR TITLE
more granular staff permissions

### DIFF
--- a/.cypress/cypress/integration/staff.js
+++ b/.cypress/cypress/integration/staff.js
@@ -1,0 +1,46 @@
+Cypress.Commands.add('cleanUpXHR', function() {
+    cy.visit('/404', { failOnStatusCode: false });
+});
+
+describe('Staff user tests', function() {
+    it('report as defaults to body', function() {
+        cy.server();
+        cy.route('/report/new/ajax*').as('report-ajax');
+        cy.request({
+          method: 'POST',
+          url: '/auth?r=/',
+          form: true,
+          body: { username: 'cs_full@example.org', password_sign_in: 'password' }
+        });
+        cy.visit('/');
+        cy.contains('Go');
+        cy.get('[name=pc]').type(Cypress.env('postcode'));
+        cy.get('[name=pc]').parents('form').submit();
+        cy.url().should('include', '/around');
+        cy.get('#map_box').click(210, 200);
+        cy.get('[name=form_as]').should('have.value', 'body');
+        cy.cleanUpXHR();
+    });
+
+    it('report title and detail are correctly prefilled', function() {
+        cy.server();
+        cy.route('/report/new/ajax*').as('report-ajax');
+        cy.request({
+          method: 'POST',
+          url: '/auth?r=/',
+          form: true,
+          body: { username: 'cs_full@example.org', password_sign_in: 'password' }
+        });
+        cy.visit('/');
+        cy.contains('Go');
+        cy.get('[name=pc]').type(Cypress.env('postcode'));
+        cy.get('[name=pc]').parents('form').submit();
+        cy.url().should('include', '/around');
+        cy.get('#map_box').click(210, 200);
+        cy.wait('@report-ajax');
+        cy.get('select:eq(3)').select('Graffiti');
+        cy.get('[name=title]').should('have.value', 'A Graffiti problem has been found');
+        cy.get('[name=detail]').should('have.value', 'A Graffiti problem has been found by Borsetshire');
+        cy.cleanUpXHR();
+    });
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Releases
 
 * Unreleased
+    - New features:
+        - default_to_body permission to control default report as behaviour
     - Front end improvements:
         - Clearer relocation options while you’re reporting a problem #2238
         - Simplify /auth sign in page. #2208

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Unreleased
     - New features:
         - default_to_body permission to control default report as behaviour
+        - report_prefill permission to control report prefill behaviour
     - Front end improvements:
         - Clearer relocation options while you’re reporting a problem #2238
         - Simplify /auth sign in page. #2208

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -84,9 +84,15 @@ my $perms_cs = [
     'contribute_as_body', 'contribute_as_another_user',
     'moderate', 'view_body_contribute_details',
 ];
+my $perms_cs_full = [
+    'contribute_as_body', 'contribute_as_another_user',
+    'moderate', 'view_body_contribute_details',
+    'report_prefill', 'default_to_body'
+];
 foreach (
     { name => 'Inspector Gadget', email => 'inspector@example.org', email_verified => 1, body => $body, permissions => $perms_inspector },
     { name => 'Harriet Helpful', email_verified => 1, email => 'cs@example.org', body => $body, permissions => $perms_cs },
+    { name => 'Andrew Agreeable', email_verified => 1, email => 'cs_full@example.org', body => $body, permissions => $perms_cs_full },
     { name => 'Super User', email_verified => 1, email => 'super@example.org', body => $body, permissions => [
         @$perms_cs, @$perms_inspector, 'report_edit',
         'category_edit', 'template_edit', 'responsepriority_edit',

--- a/docs/_includes/admin-tasks-content.md
+++ b/docs/_includes/admin-tasks-content.md
@@ -166,6 +166,11 @@ citizen’s experience](/pro-manual/citizens-experience/)'. Those with the appro
 the report-making interface, labeled ‘Report As’. Select ‘the council’, ‘yourself’, ‘anonymous’ or
 ‘another user’.
 
+If a user has the ‘Default to creating reports/update as the council’
+permission then the dropdown will default to reporting as the council.
+Staff with the ’Markup problem details’ permission will also default to
+reporting as the council.
+
 </div>
 
 

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -724,6 +724,7 @@ sub available_permissions {
             contribute_as_another_user => _("Create reports/updates on a user's behalf"),
             contribute_as_anonymous_user => _("Create reports/updates as anonymous user"),
             contribute_as_body => _("Create reports/updates as the council"),
+            default_to_body => _("Default to creating reports/updates as the council"),
             view_body_contribute_details => _("See user detail for reports created as the council"),
 
             # NB this permission is special in that it can be assigned to users

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -720,6 +720,7 @@ sub available_permissions {
             report_mark_private => _("View/Mark private reports"),
             report_inspect => _("Markup problem details"),
             report_instruct => _("Instruct contractors to fix problems"), # future use
+            report_prefill => _("Automatically populate report subject/detail"),
             planned_reports => _("Manage shortlist"),
             contribute_as_another_user => _("Create reports/updates on a user's behalf"),
             contribute_as_anonymous_user => _("Create reports/updates as anonymous user"),

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -215,6 +215,7 @@ sub available_permissions {
     my $self = shift;
 
     my $perms = $self->next::method();
+    $perms->{Problems}->{default_to_body} = "Default to creating reports/updates as " . $self->council_name;
     $perms->{Problems}->{contribute_as_body} = "Create reports/updates as " . $self->council_name;
     $perms->{Problems}->{view_body_contribute_details} = "See user detail for reports created as " . $self->council_name;
     $perms->{Users}->{user_assign_areas} = "Assign users to areas in " . $self->council_name;

--- a/t/app/controller/admin/users.t
+++ b/t/app/controller/admin/users.t
@@ -177,6 +177,7 @@ my %default_perms = (
     "permissions[contribute_as_another_user]" => undef,
     "permissions[contribute_as_anonymous_user]" => undef,
     "permissions[contribute_as_body]" => undef,
+    "permissions[default_to_body]" => undef,
     "permissions[view_body_contribute_details]" => undef,
     "permissions[user_edit]" => undef,
     "permissions[user_manage_permissions]" => undef,

--- a/t/app/controller/admin/users.t
+++ b/t/app/controller/admin/users.t
@@ -174,6 +174,7 @@ my %default_perms = (
     "permissions[report_edit_priority]" => undef,
     "permissions[report_inspect]" => undef,
     "permissions[report_instruct]" => undef,
+    "permissions[report_prefill]" => undef,
     "permissions[contribute_as_another_user]" => undef,
     "permissions[contribute_as_anonymous_user]" => undef,
     "permissions[contribute_as_body]" => undef,

--- a/t/app/controller/report_as_other.t
+++ b/t/app/controller/report_as_other.t
@@ -282,6 +282,24 @@ subtest "Body user, has permission to add update as anonymous user" => sub {
     is $update->anonymous, 1, 'update anonymous';
 };
 
+for my $test_permission ( qw/planned_reports default_to_body/ ) {
+    subtest "$test_permission user defaults to reporting as body" => sub {
+        $_->delete for $user->user_body_permissions;
+        for my $permission ( 'contribute_as_another_user', 'contribute_as_anonymous_user', 'contribute_as_body', $test_permission ) {
+            $user->user_body_permissions->create({ body => $body, permission_type => $permission })
+        }
+        FixMyStreet::override_config {
+            ALLOWED_COBRANDS => [ 'fixmystreet' ],
+            MAPIT_URL => 'http://mapit.uk/',
+            PHONE_COUNTRY => 'GB',
+        }, sub {
+            $mech->get_ok('/report/new?latitude=51.7549262252&longitude=-1.25617899435');
+        };
+
+        is $mech->visible_form_values()->{form_as}, 'body', 'report as body is default';
+    };
+}
+
 done_testing();
 
 sub start_report {

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -2048,8 +2048,31 @@ subtest "check map click ajax response for inspector" => sub {
     }, sub {
         $extra_details = $mech->get_ok_json( '/report/new/ajax?latitude=55.952055&longitude=-3.189579' );
     };
-    like $extra_details->{category}, qr/data-role="inspector/, 'category has correct data-role';
+    like $extra_details->{category}, qr/data-prefill="0/, 'inspector prefill not set';
     ok !$extra_details->{contribute_as}, 'no contribute as section';
+};
+
+subtest "check map click ajax response for inspector and uk cobrand" => sub {
+    $mech->log_out_ok;
+
+    my $extra_details;
+    $inspector->user_body_permissions->find_or_create({
+        body => $bodies[4],
+        permission_type => 'planned_reports',
+    });
+    $inspector->user_body_permissions->find_or_create({
+        body => $bodies[4],
+        permission_type => 'report_inspect',
+    });
+
+    $mech->log_in_ok('inspector@example.org');
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ { bromley => '.' } ],
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $extra_details = $mech->get_ok_json( '/report/new/ajax?latitude=51.402096&longitude=0.015784' );
+    };
+    like $extra_details->{category}, qr/data-prefill="0/, 'inspector prefill not set';
 };
 
 for my $test (

--- a/templates/web/base/report/new/category.html
+++ b/templates/web/base/report/new/category.html
@@ -15,7 +15,8 @@
     </label>[% =%]
     <select class="form-control[% IF category_groups.size %] js-grouped-select[% END %]" name="category" id="form_category"
     [%~ IF c.user.from_body =%]
-      data-role="[% c.user.has_body_permission_to('planned_reports') ? 'inspector' : 'user'  %]" data-body="[% c.user.from_body.name %]" data-prefill="[% c.cobrand.prefill_report_fields_for_inspector %]"
+      [%~ prefill_report = ( c.cobrand.prefill_report_fields_for_inspector && inspector ) || c.user.has_body_permission_to('report_prefill') %]
+      data-body="[% c.user.from_body.name %]" data-prefill="[% prefill_report %]"
     [%~ END ~%]
     >
         [%~ IF category_groups.size ~%]

--- a/templates/web/base/report/new/category_wrapper.html
+++ b/templates/web/base/report/new/category_wrapper.html
@@ -3,7 +3,8 @@
     <label for="form_category">[% loc('Category') %]</label>
     <select class="form-control" name="category" id="form_category"
     [%~ IF c.user.from_body =%]
-      data-role="[% c.user.has_body_permission_to('planned_reports') ? 'inspector' : 'user'  %]" data-body="[% c.user.from_body.name %]" data-prefill="[% c.cobrand.prefill_report_fields_for_inspector %]"
+      [%~ prefill_report = c.cobrand.prefill_report_fields_for_inspector || c.user.has_body_permission_to('report_prefill') %]
+      data-body="[% c.user.from_body.name %]" data-prefill="[% prefill_report %]"
     [%~ END =%]
     required><option>[% loc('Loading...') %]</option></select>
 [% ELSE %]

--- a/templates/web/base/report/new/form_user_loggedin.html
+++ b/templates/web/base/report/new/form_user_loggedin.html
@@ -16,7 +16,7 @@
 [% BLOCK form_as %]
     <label for="form_as">[% loc('Report as') %]</label>
     <select id="form_as" class="form-control js-contribute-as" name="form_as">
-        <option value="myself" [% c.user.has_body_permission_to('planned_reports') ? '' : 'selected'  %]>[% loc('Yourself') %]</option>
+        <option value="myself" [% ( c.user.has_body_permission_to('planned_reports') || c.user.has_body_permission_to('default_to_body') ) ? '' : 'selected'  %]>[% loc('Yourself') %]</option>
       [% IF js || can_contribute_as_anonymous_user %]
         <option value="anonymous_user">[% loc('Anonymous user') %]</option>
       [% END %]
@@ -24,7 +24,7 @@
         <option value="another_user">[% loc('Another user') %]</option>
       [% END %]
       [% IF js || can_contribute_as_body %]
-        <option value="body" [% c.user.has_body_permission_to('planned_reports') ? 'selected' : ''  %]>[% c.user.from_body.name %]</option>
+        <option value="body" [% ( c.user.has_body_permission_to('planned_reports') || c.user.has_body_permission_to('default_to_body') ) ? 'selected' : ''  %]>[% c.user.from_body.name %]</option>
       [% END %]
     </select>
 [% END %]

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -455,10 +455,9 @@ $.extend(fixmystreet.set_up, {
 $(fixmystreet).on('report_new:category_change', function(evt, $this) {
     var category = $this.val();
     var prefill_reports = $this.data('prefill');
-    var role = $this.data('role');
     var body = $this.data('body');
 
-    if (prefill_reports && role == 'inspector') {
+    if (prefill_reports) {
         var title = 'A ' + category + ' problem has been found';
         var description = 'A ' + category + ' problem has been found by ' + body;
 


### PR DESCRIPTION
This adds `report_prefill` and `default_to_body` permissions for staff which split out some of the report_inspect behaviours into separate permissions.

Staff with the `report_prefill`/ permission will have the report title and detail auto populated with some default text.

Staff with the `default_to_body` permission will, assuming they also have the `can_contribute_as_body` permission, default to reporting new reports and updates as the body rather than themselves.

Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Are the changes tested for accessibility?
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1218
Connects https://github.com/mysociety/fixmystreet-freshdesk/issues/23