### PR TITLE
[Vagrant] Check and generate config file if necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
         - Have body.url work in hashref lookup. #2284
         - OSM based map types can now override zoom levels #2288
         - Clearer name for navigation colours in SCSS. #2080
+        - `script/setup` now creates `conf/general.yml` for Vagrant when needed.
     - Internal things:
         - Move send-comments code to package for testing. #2109 #2170
     - Open311 improvements:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,7 +55,7 @@ EOS
 # This just runs our update script, used on our offical box.
 $update = <<-EOS
     chown -R vagrant:vagrant /home/vagrant/.cpanm
-    su vagrant -c '/home/vagrant/fixmystreet/script/update ; exit $?'
+    su vagrant -c '/home/vagrant/fixmystreet/script/setup ; exit $?'
     if [ $? -eq 0 ]; then
       touch /tmp/success
     else

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,6 +50,11 @@ $full_setup = <<-EOS
     else
       rm -f /tmp/success 2>/dev/null
     fi
+    # Even if it failed somehow, we might as well update the port if possible
+    if [ -e fixmystreet/conf/general.yml ] && ! grep -q "^ *BASE_URL.*:3000'$" conf/general.yml; then
+      # We want to be on port 3000 for development
+      sed -i -r -e "s,^( *BASE_URL: .*)',\\1:3000'," fixmystreet/conf/general.yml
+    fi
 EOS
 
 # This just runs our update script, used on our offical box.
@@ -65,11 +70,6 @@ EOS
 
 # This will ensure that bits of config are set right.
 $configure = <<-EOS
-    # Even if it failed somehow, we might as well update the port if possible
-    if [ -e fixmystreet/conf/general.yml ]; then
-        # We want to be on port 3000 for development
-        sed -i -r -e "s,^( *BASE_URL: .*)',\\1:3000'," fixmystreet/conf/general.yml
-    fi
     # Create a superuser for the admin
     su vagrant -c 'fixmystreet/bin/createsuperuser superuser@example.org password'
     if [ -e /tmp/success ]; then

--- a/docs/install/manual-install.md
+++ b/docs/install/manual-install.md
@@ -7,10 +7,10 @@ title: Installing
 
 <p class="lead">
   This page describes how to install the FixMyStreet platform manually.
-  You can use this if you're used to setting up web applications &mdash; 
+  You can use this if you're used to setting up web applications &mdash;
   but the other installation options may be easier:</p>
 
-Note that this is just one of 
+Note that this is just one of
 [many ways to install FixMyStreet]({{ "/install/" | relative_url }})
 (the other ways are easier!).
 
@@ -129,7 +129,9 @@ and compiles any translation `.mo` files (using `commonlib/bin/gettext-makemo`).
 
 The settings for FixMyStreet are defined in `conf/general.yml` using the YAML
 markup language. There are some defaults in `conf/general.yml-example` which
-you should copy to `conf/general.yml`:
+you should copy to `conf/general.yml`; note that if you are using the Vagrant 
+environment, a simple `conf/general.yml` file should already have been
+configured for you.
 
 {% highlight bash %}
 $ cp conf/general.yml-example conf/general.yml
@@ -151,7 +153,7 @@ Some others you might want to look at, though the defaults are enough for it to 
 * [GEO_CACHE]({{ "/customising/config/#geo_cache" | relative_url }}) -- this is the location where Geolocation data will be cached. It should be accessible by and writeable by the FixMyStreet process.
 
 If you are using Bing or Google maps you should also set one of
-[BING_MAPS_API_KEY]({{ "/customising/config/#bing_maps_api_key" | relative_url }}) or 
+[BING_MAPS_API_KEY]({{ "/customising/config/#bing_maps_api_key" | relative_url }}) or
 [GOOGLE_MAPS_API_KEY]({{ "/customising/config/#google_maps_api_key" | relative_url }}).
 
 ### 6. Set up some required data

--- a/script/setup
+++ b/script/setup
@@ -3,5 +3,19 @@
 set -e
 cd "$(dirname "$0")/.."
 
-# Same as update for now
+# If we're running in Vagrant and there isn't a valid config file, set one up.
+if [ ! -f conf/general.yml ] && [ "$USER" = "vagrant" ]; then
+    echo -n "Setting up a default conf/general.yml file for Vagrant..."
+    sed -r \
+        -e "s,^( *FMS_DB_HOST:).*,\\1 ''," \
+        -e "s,^( *FMS_DB_NAME:).*,\\1 'fixmystreet'," \
+        -e "s,^( *FMS_DB_USER:).*,\\1 'vagrant'," \
+        -e "s,^( *BASE_URL:).*,\\1 'http://127.0.0.1.xip.io:3000'," \
+        -e "s,^( *EMAIL_DOMAIN:).*,\\1 '127.0.0.1.xip.io'," \
+        -e "s,^( *CONTACT_EMAIL:).*,\\1 'help@127.0.0.1.xip.io'," \
+        -e "s,^( *DO_NOT_REPLY_EMAIL:).*,\\1 'help@127.0.0.1.xip.io'," \
+        conf/general.yml-example > conf/general.yml
+fi
+
+# The rest should be the same as update for now
 script/update


### PR DESCRIPTION
This adds support in `script/setup` for generating a local `general.yml` if it doesn't already exist and is run as the `vagrant` user. This is called from the `Vagrantfile` when using the FixMyStreet Vagrant box.

In addition, the addition of `:3000` to `BASE_URL` is only applied when not using the FixMyStreet box as this will be supplied in by the `setup` script in that case. This should also only be applied when not already present to prevent it being added repeatedly.

Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] Have you updated the changelog? 

