### PR TITLE
Deal with possible multiple send_method_useds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
         - Give superusers access to update staff dropdowns. #2286
         - Update report areas when moving its location. #2181
         - Don't send questionnaires for closed reports. #2310
+        - Make sure Open311 send_method always recorded/spotted. #2121
     - Development improvements:
         - Add cobrand hook for dashboard viewing permission. #2285
         - Have body.url work in hashref lookup. #2284

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -905,7 +905,7 @@ sub report_edit : Path('report_edit') : Args(1) {
     if ( $c->get_param('resend') ) {
         $c->forward('/auth/check_csrf_token');
 
-        $problem->whensent(undef);
+        $problem->resend;
         $problem->update();
         $c->stash->{status_message} =
           '<p><em>' . _('That problem will now be resent.') . '</em></p>';
@@ -1023,7 +1023,7 @@ sub report_edit_category : Private {
         # If the report has changed bodies (and not to a subset!) we need to resend it
         my %old_map = map { $_ => 1 } @{$problem->bodies_str_ids};
         if (grep !$old_map{$_}, @new_body_ids) {
-            $problem->whensent(undef);
+            $problem->resend;
         }
         # If the send methods of the old/new contacts differ we need to resend the report
         my @new_send_methods = uniq map {
@@ -1034,7 +1034,7 @@ sub report_edit_category : Private {
         } @contacts;
         my %old_send_methods = map { $_ => 1 } split /,/, ($problem->send_method_used || "Email");
         if (grep !$old_send_methods{$_}, @new_send_methods) {
-            $problem->whensent(undef);
+            $problem->resend;
         }
 
         $problem->bodies_str(join( ',', @new_body_ids ));

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -893,7 +893,7 @@ bodies by some mechanism. Right now that mechanism is Open311.
 
 sub updates_sent_to_body {
     my $self = shift;
-    return unless $self->send_method_used && $self->send_method_used eq 'Open311';
+    return unless $self->send_method_used && $self->send_method_used =~ /Open311/;
 
     # Some bodies only send updates *to* FMS, they don't receive updates.
     my $cobrand = $self->get_cobrand_logged;
@@ -920,6 +920,12 @@ sub add_send_method {
     } else {
         $self->send_method_used($sender);
     }
+}
+
+sub resend {
+    my $self = shift;
+    $self->whensent(undef);
+    $self->send_method_used(undef);
 }
 
 sub as_hashref {

--- a/perllib/FixMyStreet/Script/Reports.pm
+++ b/perllib/FixMyStreet/Script/Reports.pm
@@ -211,12 +211,13 @@ sub send(;$) {
         # Multiply results together, so one success counts as a success.
         my $result = -1;
 
+        my @methods;
         for my $sender ( keys %reporters ) {
             debug_print("sending using " . $sender, $row->id) if $debug_mode;
             $sender = $reporters{$sender};
             my $res = $sender->send( $row, \%h );
             $result *= $res;
-            $row->add_send_method($sender) if !$res;
+            push @methods, $sender if !$res;
             if ( $sender->unconfirmed_counts) {
                 foreach my $e (keys %{ $sender->unconfirmed_counts } ) {
                     foreach my $c (keys %{ $sender->unconfirmed_counts->{$e} }) {
@@ -227,6 +228,12 @@ sub send(;$) {
             }
             $test_data->{test_req_used} = $sender->open311_test_req_used
                 if FixMyStreet->test_mode && $sender->can('open311_test_req_used');
+        }
+
+        # Add the send methods now because e.g. Open311
+        # send() calls $row->discard_changes
+        foreach (@methods) {
+            $row->add_send_method($_);
         }
 
         unless ($result) {

--- a/perllib/Open311/PostServiceRequestUpdates.pm
+++ b/perllib/Open311/PostServiceRequestUpdates.pm
@@ -60,7 +60,7 @@ sub process_body {
             'problem.whensent' => { '!=' => undef },
             'problem.external_id' => { '!=' => undef },
             'problem.bodies_str' => { -like => '%' . $body->id . '%' },
-            'problem.send_method_used' => 'Open311',
+            'problem.send_method_used' => { -like => '%Open311%' },
         },
         {
             join => 'problem',


### PR DESCRIPTION
Fixes #2121 
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
