### PR TITLE
Fix Open311 category group bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
         - Clearer relocation options while you’re reporting a problem #2238
     - Admin improvements:
         - Allow moderation to potentially change category. #2320
+    - Open311 improvements:
+        - Fix bug in contact group handling. #2323
 
 * v2.4.2 (6th November 2018)
     - New features:

--- a/t/open311/populate-service-list.t
+++ b/t/open311/populate-service-list.t
@@ -46,14 +46,16 @@ $bromley->body_areas->find_or_create({
 } );
 
 for my $test (
-    { cobrand => 'tester', groups => 0 },
-    { cobrand => 'testergroups', groups => 1 },
+    { desc => 'groups not set for new contacts', cobrand => 'tester', groups => 0, delete => 1 },
+    { desc => 'groups set for new contacts', cobrand => 'testergroups', groups => 1, delete => 1},
+    { desc => 'groups removed for existing contacts', cobrand => 'tester', groups => 0, delete => 0 },
+    { desc => 'groups added for existing contacts', cobrand => 'testergroups', groups => 1, delete => 0},
 ) {
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => [ $test->{cobrand} ],
     }, sub {
-        subtest 'check basic functionality' => sub {
-            FixMyStreet::DB->resultset('Contact')->search( { body_id => 1 } )->delete();
+        subtest 'check basic functionality, ' . $test->{desc} => sub {
+            FixMyStreet::DB->resultset('Contact')->search( { body_id => 1 } )->delete() if $test->{delete};
 
             my $service_list = get_xml_simple_object( get_standard_xml() );
 


### PR DESCRIPTION
 - Group wasn’t being set correctly by open311-populate-service-list as cobrand attribute
   not being updated for each body.
 - Extra metadata was being persisted to the DB every time even if nothing had changed,
   causing lots of duplicate entries in contacts_history.
