### PR TITLE
Store remaining original moderation data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - Admin improvements:
         - Allow moderation to potentially change category. #2320
         - Add Mark/View private reports permission #2306
+        - Store more original stuff on moderation.
     - Open311 improvements:
         - Fix bug in contact group handling. #2323
     - Development improvements:

--- a/bin/update-schema
+++ b/bin/update-schema
@@ -212,6 +212,7 @@ else {
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
     return 'EMPTY' if ! table_exists('problem');
+    return '0063' if column_exists('moderation_original_data', 'extra');
     return '0062' if column_exists('users', 'created');
     return '0061' if column_exists('body', 'extra');
     return '0060' if column_exists('body', 'convert_latlong');

--- a/db/downgrade_0063---0062.sql
+++ b/db/downgrade_0063---0062.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE moderation_original_data DROP extra;
+ALTER TABLE moderation_original_data DROP latitude;
+ALTER TABLE moderation_original_data DROP longitude;
+ALTER TABLE moderation_original_data DROP category;
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -449,7 +449,12 @@ create table moderation_original_data (
     anonymous bool not null,
 
     -- Metadata
-    created timestamp not null default current_timestamp
+    created timestamp not null default current_timestamp,
+
+    extra text,
+    category text,
+    latitude double precision,
+    longitude double precision
 );
 
 create table user_body_permissions (

--- a/db/schema_0063-add-extra-to-moderation.sql
+++ b/db/schema_0063-add-extra-to-moderation.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE moderation_original_data ADD extra text;
+ALTER TABLE moderation_original_data ADD category text;
+ALTER TABLE moderation_original_data ADD latitude double precision;
+ALTER TABLE moderation_original_data ADD longitude double precision;
+
+COMMIT;
+

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -1009,6 +1009,7 @@ sub report_edit : Path('report_edit') : Args(1) {
 =head2 report_edit_category
 
 Handles changing a problem's category and the complexity that comes with it.
+Returns 1 if category changed, 0 if no change.
 
 =cut
 
@@ -1053,7 +1054,9 @@ sub report_edit_category : Private {
                 anonymous => 0,
             });
         }
+        return 1;
     }
+    return 0;
 }
 
 =head2 report_edit_location
@@ -1062,7 +1065,8 @@ Handles changing a problem's location and the complexity that comes with it.
 For now, we reject the new location if the new location and old locations aren't
 covered by the same body.
 
-Returns 1 if the new position (if any) is acceptable, undef otherwise.
+Returns 2 if the new position (if any) is acceptable and changed,
+1 if acceptable and unchanged, undef otherwise.
 
 NB: This must be called before report_edit_category, as that might modify
 $problem->bodies_str.
@@ -1095,6 +1099,7 @@ sub report_edit_location : Private {
         $problem->longitude($c->stash->{longitude});
         my $areas = $c->stash->{all_areas_mapit};
         $problem->areas( ',' . join( ',', sort keys %$areas ) . ',' );
+        return 2;
     }
     return 1;
 }

--- a/perllib/FixMyStreet/DB/Result/ModerationOriginalData.pm
+++ b/perllib/FixMyStreet/DB/Result/ModerationOriginalData.pm
@@ -37,6 +37,14 @@ __PACKAGE__->add_columns(
     is_nullable   => 0,
     original      => { default_value => \"now()" },
   },
+  "extra",
+  { data_type => "text", is_nullable => 1 },
+  "category",
+  { data_type => "text", is_nullable => 1 },
+  "latitude",
+  { data_type => "double precision", is_nullable => 1 },
+  "longitude",
+  { data_type => "double precision", is_nullable => 1 },
 );
 __PACKAGE__->set_primary_key("id");
 __PACKAGE__->add_unique_constraint("moderation_original_data_comment_id_key", ["comment_id"]);
@@ -59,8 +67,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2015-08-13 16:33:38
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:DBtGjCJykDtLnGtkj638eA
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2018-11-13 10:48:41
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:OQAXPriTc3G2jKFPw0TqdQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -379,6 +379,7 @@ $.extend(fixmystreet.set_up, {
               $elem.find('.js-moderate').on('click', function () {
                   $elem.find('.moderate-display').hide();
                   $elem.find('.moderate-edit').show();
+                  $('#map_sidebar').scrollTop(0);
               });
 
               $elem.find('.revert-title').change( function () {
@@ -400,6 +401,7 @@ $.extend(fixmystreet.set_up, {
               $elem.find('.cancel').click( function () {
                   $elem.find('.moderate-display').show();
                   $elem.find('.moderate-edit').hide();
+                  $('#map_sidebar').scrollTop(0);
               });
 
               $elem.find('form').submit( function () {


### PR DESCRIPTION
Some new things are allowed to be moderated (category, location, extra) but these weren't being stored in original data.

Question: should this be bigger and store a history of changes rather than just the original?