### PR TITLE
Photo storage updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     - Front end improvements:
         - Clearer relocation options while you’re reporting a problem #2238
         - Simplify /auth sign in page. #2208
+        - Enforce maximum photo size server side, strip EXIF data. #2326 #2134
     - Admin improvements:
         - Allow moderation to potentially change category. #2320
         - Add Mark/View private reports permission #2306

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
         - Add Mark/View private reports permission #2306
     - Open311 improvements:
         - Fix bug in contact group handling. #2323
+    - Development improvements:
+        - Add option to symlink full size photos.
 
 * v2.4.2 (6th November 2018)
     - New features:

--- a/docs/customising/config.md
+++ b/docs/customising/config.md
@@ -64,6 +64,7 @@ The following are all the configuration settings that you can change in `conf/ge
 * <code><a href="#photo_storage_options">PHOTO_STORAGE_OPTIONS</a></code>
   * For local filesystem storage:
     * <code><a href="#upload_dir">UPLOAD_DIR</a></code>
+    * <code><a href="#symlink_full_size">SYMLINK_FULL_SIZE</a></code>
   * For Amazon S3 storage:
     * <code><a href="#bucket">BUCKET</a></code>
     * <code><a href="#access_key">ACCESS_KEY</a></code>
@@ -1158,6 +1159,7 @@ ALLOWED_COBRANDS:
     </p>
     <ul>
       <li><code><a href="#upload_dir">UPLOAD_DIR</a></code></li>
+      <li><code><a href="#symlink_full_size">SYMLINK_FULL_SIZE</a></code></li>
     </ul>
     <p>
       For the <code>S3</code> backend, the following apply:
@@ -1194,6 +1196,20 @@ PHOTO_STORAGE_OPTIONS:
         </li>
       </ul>
     </div>
+  </dd>
+
+  <dt>
+    <a name="upload_dir"><code>SYMLINK_FULL_SIZE</code></a>
+  </dt>
+  <dd>
+    <p>
+      Defaults to false; if this is true, then requests for full size images
+      will be symlinked from the photo cache, not copied there. You can use this
+      if static files are being served by your web server.
+    </p>
+    <p>
+      Only applies when <code>PHOTO_STORAGE_BACKEND</code> is <code>FileSystem</code>.
+    </p>
   </dd>
 
   <dt>

--- a/perllib/FixMyStreet/App/Controller/Photo.pm
+++ b/perllib/FixMyStreet/App/Controller/Photo.pm
@@ -5,8 +5,7 @@ use namespace::autoclean;
 BEGIN {extends 'Catalyst::Controller'; }
 
 use JSON::MaybeXS;
-use File::Path;
-use File::Slurp;
+use Path::Tiny;
 use Try::Tiny;
 use FixMyStreet::App::Model::PhotoSet;
 
@@ -81,8 +80,10 @@ sub output : Private {
     my ( $self, $c, $photo ) = @_;
 
     # Save to file
-    File::Path::make_path( FixMyStreet->path_to( 'web', 'photo', 'c' )->stringify );
-    File::Slurp::write_file( FixMyStreet->path_to( 'web', $c->req->path )->stringify, \$photo->{data} );
+    path(FixMyStreet->path_to('web', 'photo', 'c'))->mkpath;
+    my $out = FixMyStreet->path_to('web', $c->req->path);
+    my $symlink_exists = symlink($photo->{symlink}, $out) if $photo->{symlink};
+    path($out)->spew_raw($photo->{data}) unless $symlink_exists;
 
     $c->res->content_type( $photo->{content_type} );
     $c->res->body( $photo->{data} );

--- a/perllib/FixMyStreet/App/Model/PhotoSet.pm
+++ b/perllib/FixMyStreet/App/Model/PhotoSet.pm
@@ -165,6 +165,7 @@ has ids => ( #  Arrayref of $fileid tuples (always, so post upload/raw data proc
                 }
 
                 # we have an image we can use - save it to storage
+                $photo_blob = FixMyStreet::ImageMagick->new(blob => $photo_blob)->shrink('2048x2048')->as_blob;
                 return $self->storage->store_photo($photo_blob);
             }
 

--- a/perllib/FixMyStreet/ImageMagick.pm
+++ b/perllib/FixMyStreet/ImageMagick.pm
@@ -1,0 +1,68 @@
+package FixMyStreet::ImageMagick;
+
+use Moo;
+
+my $IM = eval {
+    require Image::Magick;
+    Image::Magick->import;
+    1;
+};
+
+has blob => ( is => 'ro' );
+
+has image => (
+    is => 'rwp',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        return unless $IM;
+        my $image = Image::Magick->new;
+        $image->BlobToImage($self->blob);
+        return $image;
+    },
+);
+
+sub strip {
+    my $self = shift;
+    return $self unless $self->image;
+    $self->image->Strip();
+    return $self;
+}
+
+sub rotate {
+    my ($self, $direction) = @_;
+    return $self unless $self->image;
+    my $err = $self->image->Rotate($direction);
+    return 0 if $err;
+    return $self;
+}
+
+# Shrinks a picture to the specified size, but keeping in proportion.
+sub shrink {
+    my ($self, $size) = @_;
+    return $self unless $self->image;
+    my $err = $self->image->Scale(geometry => "$size>");
+    throw Error::Simple("resize failed: $err") if "$err";
+    return $self->strip;
+}
+
+# Shrinks a picture to 90x60, cropping so that it is exactly that.
+sub crop {
+    my $self = shift;
+    return $self unless $self->image;
+    my $err = $self->image->Resize( geometry => "90x60^" );
+    throw Error::Simple("resize failed: $err") if "$err";
+    $err = $self->image->Extent( geometry => '90x60', gravity => 'Center' );
+    throw Error::Simple("resize failed: $err") if "$err";
+    return $self->strip;
+}
+
+sub as_blob {
+    my $self = shift;
+    return $self->blob unless $self->image;
+    my @blobs = $self->image->ImageToBlob();
+    $self->_set_image(undef);
+    return $blobs[0];
+}
+
+1;

--- a/perllib/FixMyStreet/PhotoStorage/FileSystem.pm
+++ b/perllib/FixMyStreet/PhotoStorage/FileSystem.pm
@@ -70,7 +70,8 @@ sub store_photo {
 =head2 retrieve_photo
 
 Fetches the file content of a particular photo from storage.
-Returns the binary blob and the filetype, if the photo exists in storage.
+Returns the binary blob, the filetype, and the file path, if
+the photo exists in storage.
 
 =cut
 
@@ -81,7 +82,7 @@ sub retrieve_photo {
     my $file = $self->get_file($fileid, $type);
     if ($file->exists) {
         my $photo = $file->slurp_raw;
-        return ($photo, $type);
+        return ($photo, $type, $file);
     }
 }
 

--- a/t/app/controller/photo.t
+++ b/t/app/controller/photo.t
@@ -98,12 +98,15 @@ subtest "Check photo uploading URL and endpoints work" => sub {
 
         my $p = FixMyStreet::DB->resultset("Problem")->first;
 
-        $mech->get_ok('/photo/temp.74e3362283b6ef0c48686fb0e161da4043bbcc97.jpeg');
-        $image_file = FixMyStreet->path_to('web/photo/temp.74e3362283b6ef0c48686fb0e161da4043bbcc97.jpeg');
-        ok -e $image_file, 'File uploaded to temp';
-        $mech->get_ok('/photo/' . $p->id . '.jpeg');
-        $image_file = FixMyStreet->path_to('web/photo/' . $p->id . '.jpeg');
-        ok -e $image_file, 'File uploaded to temp';
+        foreach my $i (
+          '/photo/temp.74e3362283b6ef0c48686fb0e161da4043bbcc97.jpeg',
+          '/photo/fulltemp.74e3362283b6ef0c48686fb0e161da4043bbcc97.jpeg',
+          '/photo/' . $p->id . '.jpeg',
+          '/photo/' . $p->id . '.full.jpeg') {
+            $mech->get_ok($i);
+            $image_file = FixMyStreet->path_to("web$i");
+            ok -e $image_file, 'File uploaded to temp';
+        }
         my $res = $mech->get('/photo/0.jpeg');
         is $res->code, 404, "got 404";
     };


### PR DESCRIPTION
This enforces server-side the current client-side restriction on maximum photo size, plus also allows an instance to state that we can symlink full size photos from the photo cache rather than copy them there. Plus makes the ImageMagick wrapper a lot neater :) Also fixes #2134