### PR TITLE
[Open311] Improve handling of created/updated datetimes of fetched reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
         - Sort user updates in reverse date order.
     - Open311 improvements:
         - Fix bug in contact group handling. #2323
+        - Improve validation of fetched reports timestamps. #2327
     - Development improvements:
         - Add option to symlink full size photos.
 


### PR DESCRIPTION
This should reduce the incidence of the ‘Problem id X for Y has an
invalid time, not creating’ cron errors we’ve been seeing.

See also mysociety/open311-adapter#26.