### PR TITLE
Store all moderation history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
         - Add Mark/View private reports permission #2306
         - Store more original stuff on moderation.
         - Sort user updates in reverse date order.
+        - Improve update display on admin report edit page.
     - Open311 improvements:
         - Fix bug in contact group handling. #2323
         - Improve validation of fetched reports timestamps. #2327

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
         - Store more original stuff on moderation.
         - Sort user updates in reverse date order.
         - Improve update display on admin report edit page.
+        - Keep all moderation history, and show in report/update admin. #2329
     - Open311 improvements:
         - Fix bug in contact group handling. #2323
         - Improve validation of fetched reports timestamps. #2327

--- a/bin/update-schema
+++ b/bin/update-schema
@@ -212,6 +212,7 @@ else {
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
     return 'EMPTY' if ! table_exists('problem');
+    return '0064' if index_exists('moderation_original_data_problem_id_comment_id_idx');
     return '0063' if column_exists('moderation_original_data', 'extra');
     return '0062' if column_exists('users', 'created');
     return '0061' if column_exists('body', 'extra');
@@ -319,4 +320,10 @@ sub constraint_contains {
 sub function_exists {
     my $fn = shift;
     return $db->dbh->selectrow_array('select count(*) from pg_proc where proname = ?', {}, $fn);
+}
+
+# Returns true if an index exists
+sub index_exists {
+    my $idx = shift;
+    return $db->dbh->selectrow_array('select count(*) from pg_indexes where indexname = ?', {}, $idx);
 }

--- a/bin/update-schema
+++ b/bin/update-schema
@@ -212,6 +212,7 @@ else {
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
     return 'EMPTY' if ! table_exists('problem');
+    return '0065' if constraint_contains('admin_log_object_type_check', 'moderation');
     return '0064' if index_exists('moderation_original_data_problem_id_comment_id_idx');
     return '0063' if column_exists('moderation_original_data', 'extra');
     return '0062' if column_exists('users', 'created');

--- a/db/downgrade_0064---0063.sql
+++ b/db/downgrade_0064---0063.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP INDEX moderation_original_data_problem_id_comment_id_idx;
+ALTER TABLE moderation_original_data
+    ADD CONSTRAINT moderation_original_data_comment_id_key UNIQUE (comment_id);
+
+COMMIT;

--- a/db/downgrade_0065---0064.sql
+++ b/db/downgrade_0065---0064.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+DELETE FROM admin_log WHERE object_type = 'moderation';
+
+ALTER TABLE admin_log DROP CONSTRAINT admin_log_object_type_check;
+
+ALTER TABLE admin_log ADD CONSTRAINT admin_log_object_type_check CHECK (
+    object_type = 'problem'
+    OR object_type = 'update'
+    OR object_type = 'user'
+);
+
+COMMIT;
+

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -441,7 +441,7 @@ create table moderation_original_data (
 
     -- Problem details
     problem_id int references problem(id) ON DELETE CASCADE not null,
-    comment_id int references comment(id) ON DELETE CASCADE unique,
+    comment_id int references comment(id) ON DELETE CASCADE,
 
     title text null,
     detail text null, -- or text for comment
@@ -456,6 +456,7 @@ create table moderation_original_data (
     latitude double precision,
     longitude double precision
 );
+create index moderation_original_data_problem_id_comment_id_idx on moderation_original_data(problem_id, comment_id);
 
 create table user_body_permissions (
     id serial not null primary key,

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -427,6 +427,7 @@ create table admin_log (
       object_type = 'problem'
       or object_type = 'update'
       or object_type = 'user'
+      or object_type = 'moderation'
     ),
     object_id integer not null,
     action text not null,

--- a/db/schema_0064-allow-multiple-moderations.sql
+++ b/db/schema_0064-allow-multiple-moderations.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE moderation_original_data
+    DROP CONSTRAINT moderation_original_data_comment_id_key;
+CREATE INDEX moderation_original_data_problem_id_comment_id_idx
+    ON moderation_original_data(problem_id, comment_id);
+
+COMMIT;

--- a/db/schema_0065-add-moderation-admin-log.sql
+++ b/db/schema_0065-add-moderation-admin-log.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+ALTER TABLE admin_log DROP CONSTRAINT admin_log_object_type_check;
+
+ALTER TABLE admin_log ADD CONSTRAINT admin_log_object_type_check CHECK (
+    object_type = 'problem'
+    OR object_type = 'update'
+    OR object_type = 'user'
+    OR object_type = 'moderation'
+);
+
+COMMIT;
+

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -889,7 +889,7 @@ sub report_edit : Path('report_edit') : Args(1) {
 
     $c->stash->{updates} =
       [ $c->model('DB::Comment')
-          ->search( { problem_id => $problem->id }, { order_by => 'created' } )
+          ->search( { problem_id => $problem->id }, { order_by => [ 'created', 'id' ] } )
           ->all ];
 
     if (my $rotate_photo_param = $self->_get_rotate_photo_param($c)) {

--- a/perllib/FixMyStreet/App/Controller/Moderate.pm
+++ b/perllib/FixMyStreet/App/Controller/Moderate.pm
@@ -63,7 +63,7 @@ sub report : Chained('moderate') : PathPart('report') : CaptureArgs(1) {
         longitude => $problem->longitude,
         latitude => $problem->latitude,
         category => $problem->category,
-        extra => $problem->extra,
+        $problem->extra ? (extra => $problem->extra) : (),
     });
     $c->stash->{original} = $problem->moderation_original_data || $c->stash->{history};
     $c->stash->{problem} = $problem;
@@ -299,7 +299,7 @@ sub update : Chained('report') : PathPart('update') : CaptureArgs(1) {
         detail => $comment->text,
         photo => $comment->photo,
         anonymous => $comment->anonymous,
-        extra => $comment->extra,
+        $comment->extra ? (extra => $comment->extra) : (),
     });
     $c->stash->{comment} = $comment;
     $c->stash->{original} = $comment->moderation_original_data || $c->stash->{history};

--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -197,6 +197,13 @@ __PACKAGE__->has_many(
   }
 );
 
+sub moderation_history {
+    my $self = shift;
+    return $self->moderation_original_datas->search({
+        problem_id => $self->problem_id,
+    }, { order_by => { -desc => 'id' } })->all;
+}
+
 # This will return the oldest moderation_original_data, if any.
 # The plural can be used to return all entries.
 __PACKAGE__->might_have(

--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -6,7 +6,6 @@ package FixMyStreet::DB::Result::Comment;
 
 use strict;
 use warnings;
-use FixMyStreet::Template;
 
 use base 'DBIx::Class::Core';
 __PACKAGE__->load_components("FilterColumn", "InflateColumn::DateTime", "EncodedColumn");
@@ -70,8 +69,8 @@ __PACKAGE__->add_columns(
   { data_type => "timestamp", is_nullable => 1 },
 );
 __PACKAGE__->set_primary_key("id");
-__PACKAGE__->might_have(
-  "moderation_original_data",
+__PACKAGE__->has_many(
+  "moderation_original_datas",
   "FixMyStreet::DB::Result::ModerationOriginalData",
   { "foreign.comment_id" => "self.id" },
   { cascade_copy => 0, cascade_delete => 0 },
@@ -90,8 +89,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2015-08-13 16:33:38
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ZR+YNA1Jej3s+8mr52iq6Q
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2018-11-20 16:13:59
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:5w/4Og9uCy54lGyyJiLzxA
 #
 
 __PACKAGE__->load_components("+FixMyStreet::DB::RABXColumn");
@@ -99,6 +98,7 @@ __PACKAGE__->rabx_column('extra');
 
 use Moo;
 use namespace::clean -except => [ 'meta' ];
+use FixMyStreet::Template;
 
 with 'FixMyStreet::Roles::Abuser',
      'FixMyStreet::Roles::Extra',
@@ -197,22 +197,17 @@ __PACKAGE__->has_many(
   }
 );
 
-# we already had the `moderation_original_data` rel above, as inferred by
-# Schema::Loader, but that doesn't know about the problem_id mapping, so we now
-# (slightly hackishly) redefine here:
-#
-# we also add cascade_delete, though this seems to be insufficient.
-#
-# TODO: should add FK on moderation_original_data field for this, to get S::L to
-# pick up without hacks.
-
+# This will return the oldest moderation_original_data, if any.
+# The plural can be used to return all entries.
 __PACKAGE__->might_have(
   "moderation_original_data",
   "FixMyStreet::DB::Result::ModerationOriginalData",
   { "foreign.comment_id" => "self.id",
     "foreign.problem_id" => "self.problem_id",
   },
-  { cascade_copy => 0, cascade_delete => 1 },
+  { order_by => 'id',
+    rows => 1,
+    cascade_copy => 0, cascade_delete => 1 },
 );
 
 =head2 meta_line

--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -102,6 +102,7 @@ use FixMyStreet::Template;
 
 with 'FixMyStreet::Roles::Abuser',
      'FixMyStreet::Roles::Extra',
+     'FixMyStreet::Roles::Moderation',
      'FixMyStreet::Roles::PhotoSet';
 
 my $stz = sub {
@@ -176,17 +177,6 @@ sub url {
     return "/report/" . $self->problem_id . '#update_' . $self->id;
 }
 
-=head2 latest_moderation_log_entry
-
-Return most recent ModerationLog object
-
-=cut
-
-sub latest_moderation_log_entry {
-    my $self = shift;
-    return $self->admin_log_entries->search({ action => 'moderation' }, { order_by => { -desc => 'id' } })->first;
-}
-
 __PACKAGE__->has_many(
   "admin_log_entries",
   "FixMyStreet::DB::Result::AdminLog",
@@ -196,13 +186,6 @@ __PACKAGE__->has_many(
       where => { 'object_type' => 'update' },
   }
 );
-
-sub moderation_history {
-    my $self = shift;
-    return $self->moderation_original_datas->search({
-        problem_id => $self->problem_id,
-    }, { order_by => { -desc => 'id' } })->all;
-}
 
 # This will return the oldest moderation_original_data, if any.
 # The plural can be used to return all entries.
@@ -216,6 +199,11 @@ __PACKAGE__->might_have(
     rows => 1,
     cascade_copy => 0, cascade_delete => 1 },
 );
+
+sub moderation_filter {
+    my $self = shift;
+    { problem_id => $self->problem_id };
+}
 
 =head2 meta_line
 

--- a/perllib/FixMyStreet/DB/Result/ModerationOriginalData.pm
+++ b/perllib/FixMyStreet/DB/Result/ModerationOriginalData.pm
@@ -47,7 +47,6 @@ __PACKAGE__->add_columns(
   { data_type => "double precision", is_nullable => 1 },
 );
 __PACKAGE__->set_primary_key("id");
-__PACKAGE__->add_unique_constraint("moderation_original_data_comment_id_key", ["comment_id"]);
 __PACKAGE__->belongs_to(
   "comment",
   "FixMyStreet::DB::Result::Comment",
@@ -67,8 +66,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2018-11-13 10:48:41
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:OQAXPriTc3G2jKFPw0TqdQ
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2018-11-20 16:13:59
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:zFOhQnS4WfVzD7qHxaAr6w
 
 use Moo;
 

--- a/perllib/FixMyStreet/DB/Result/ModerationOriginalData.pm
+++ b/perllib/FixMyStreet/DB/Result/ModerationOriginalData.pm
@@ -78,6 +78,16 @@ with 'FixMyStreet::Roles::Extra';
 __PACKAGE__->load_components("+FixMyStreet::DB::RABXColumn");
 __PACKAGE__->rabx_column('extra');
 
+sub admin_log {
+    my $self = shift;
+    my $rs = $self->result_source->schema->resultset("AdminLog");
+    my $log = $rs->search({
+        object_id => $self->id,
+        object_type => 'moderation',
+    })->first;
+    return $log;
+}
+
 sub compare_with {
     my ($self, $other) = @_;
     if ($self->comment_id) {

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -177,11 +177,15 @@ __PACKAGE__->has_one(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+# This will return the oldest moderation_original_data, if any.
+# The plural can be used to return all entries.
 __PACKAGE__->might_have(
   "moderation_original_data",
   "FixMyStreet::DB::Result::ModerationOriginalData",
   { "foreign.problem_id" => "self.id" },
   { where => { 'comment_id' => undef },
+    order_by => 'id',
+    rows => 1,
     cascade_copy => 0, cascade_delete => 1 },
 );
 

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -973,6 +973,13 @@ sub latest_moderation_log_entry {
     return $self->admin_log_entries->search({ action => 'moderation' }, { order_by => { -desc => 'id' } })->first;
 }
 
+sub moderation_history {
+    my $self = shift;
+    return $self->moderation_original_datas->search({
+        comment_id => undef,
+    }, { order_by => { -desc => 'id' } })->all;
+}
+
 __PACKAGE__->has_many(
   "admin_log_entries",
   "FixMyStreet::DB::Result::AdminLog",

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -210,6 +210,7 @@ my $IM = eval {
 
 with 'FixMyStreet::Roles::Abuser',
      'FixMyStreet::Roles::Extra',
+     'FixMyStreet::Roles::Moderation',
      'FixMyStreet::Roles::Translatable',
      'FixMyStreet::Roles::PhotoSet';
 
@@ -962,24 +963,6 @@ sub as_hashref {
     return $out;
 }
 
-=head2 latest_moderation_log_entry
-
-Return most recent ModerationLog object
-
-=cut
-
-sub latest_moderation_log_entry {
-    my $self = shift;
-    return $self->admin_log_entries->search({ action => 'moderation' }, { order_by => { -desc => 'id' } })->first;
-}
-
-sub moderation_history {
-    my $self = shift;
-    return $self->moderation_original_datas->search({
-        comment_id => undef,
-    }, { order_by => { -desc => 'id' } })->all;
-}
-
 __PACKAGE__->has_many(
   "admin_log_entries",
   "FixMyStreet::DB::Result::AdminLog",
@@ -989,6 +972,11 @@ __PACKAGE__->has_many(
       where => { 'object_type' => 'problem' },
   }
 );
+
+sub moderation_filter {
+    my $self = shift;
+    { comment_id => undef };
+}
 
 sub get_time_spent {
     my $self = shift;

--- a/perllib/FixMyStreet/ImageMagick.pm
+++ b/perllib/FixMyStreet/ImageMagick.pm
@@ -3,6 +3,7 @@ package FixMyStreet::ImageMagick;
 use Moo;
 
 my $IM = eval {
+    return 0 if FixMyStreet->test_mode;
     require Image::Magick;
     Image::Magick->import;
     1;

--- a/perllib/FixMyStreet/Roles/Moderation.pm
+++ b/perllib/FixMyStreet/Roles/Moderation.pm
@@ -1,0 +1,41 @@
+package FixMyStreet::Roles::Moderation;
+use Moo::Role;
+
+=head2 latest_moderation_log_entry
+
+Return most recent AdminLog object concerning moderation
+
+=cut
+
+sub latest_moderation_log_entry {
+    my $self = shift;
+
+    my $latest = $self->moderation_original_datas->search(
+        $self->moderation_filter,
+        { order_by => { -desc => 'id' } })->first;
+    return unless $latest;
+
+    my $rs = $self->result_source->schema->resultset("AdminLog");
+    my $log = $rs->search({
+        object_id => $latest->id,
+        object_type => 'moderation',
+    })->first;
+    return $log if $log;
+
+    return $self->admin_log_entries->search({ action => 'moderation' }, { order_by => { -desc => 'id' } })->first;
+}
+
+=head2 moderation_history
+
+Returns all moderation history, most recent first.
+
+=cut
+
+sub moderation_history {
+    my $self = shift;
+    return $self->moderation_original_datas->search(
+        $self->moderation_filter,
+        { order_by => { -desc => 'id' } })->all;
+}
+
+1;

--- a/t/app/controller/admin/search.t
+++ b/t/app/controller/admin/search.t
@@ -103,7 +103,7 @@ subtest 'report search' => sub {
     $update->update;
 
     $mech->get_ok('/admin/reports?search=' . $report->user->email);
-    $mech->content_like( qr{<tr [^>]*hidden[^>]*> \s* <td> \s* $u_id \s* </td>}xs );
+    $mech->content_like( qr{<tr [^>]*hidden[^>]*> \s* <td[^>]*> \s* $u_id \s* </td>}xs );
 
     $report->state('hidden');
     $report->update;

--- a/t/app/controller/moderate.t
+++ b/t/app/controller/moderate.t
@@ -459,4 +459,7 @@ subtest 'And do it as a superuser' => sub {
     $mech->content_contains('Moderated by an administrator');
 };
 
+subtest 'Check moderation history in admin' => sub {
+    $mech->get_ok('/admin/report_edit/' . $report->id);
+};
 done_testing();

--- a/t/app/controller/moderate.t
+++ b/t/app/controller/moderate.t
@@ -126,6 +126,11 @@ subtest 'Problem moderation' => sub {
         $report->discard_changes;
         is $report->title, 'Good bad good';
         is $report->detail, 'Good bad bad bad good bad';
+
+        my @history = $report->moderation_original_datas->search(undef, { order_by => 'id' })->all;
+        is @history, 2, 'Right number of entries';
+        is $history[0]->title, 'Good bad good', 'Correct original title';
+        is $history[1]->title, 'Good good', 'Correct second title';
     };
 
     subtest 'Make anonymous' => sub {

--- a/templates/email/default/problem-moderated.html
+++ b/templates/email/default/problem-moderated.html
@@ -25,8 +25,8 @@ the team at <a href="[% report_complain_uri %]">[% report_complain_uri %]</a></p
   [% end_padded_box %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = problem %]
-    <h2 style="[% h2_style %]">[% problem.moderation_original_data.title | html %]</h2>
-    <p style="[% secondary_p_style %]">[% problem.moderation_original_data.detail | html %]</p>
+    <h2 style="[% h2_style %]">[% moderated_data.title | html %]</h2>
+    <p style="[% secondary_p_style %]">[% moderated_data.detail | html %]</p>
 [% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/problem-moderated.txt
+++ b/templates/email/default/problem-moderated.txt
@@ -15,11 +15,11 @@ The following data has been changed:
 
 Your report had the title:
 
-[% problem.moderation_original_data.title %]
+[% moderated_data.title %]
 
 And details:
 
-[% problem.moderation_original_data.detail %]
+[% moderated_data.detail %]
 
 [% UNLESS types == 'hide' %]
 You can see the report at [% report_uri %]

--- a/templates/web/base/admin/list_updates.html
+++ b/templates/web/base/admin/list_updates.html
@@ -9,24 +9,25 @@
         <th>[% loc('Council') %]</th>
         <th>[% loc('Cobrand') %]</th>
         <th>[% loc('State') %]</th>
-        <th>[% loc('Text') %]</th>
         <th>*</th>
     </tr>
 [% FOREACH update IN updates -%]
     <tr[% ' class="adminhidden"' IF update.state == 'hidden' || update.problem.state == 'hidden' %]>
-        <td>[%- IF update.state == 'confirmed' && update.problem.state != 'hidden' -%]
-        [%- cobrand_data = update.cobrand_data;
-            cobrand_data = c.data_for_generic_update IF !update.cobrand;
-            IF cobrand_data;
+        <td rowspan=2>
+          [%~ IF update.state == 'confirmed' && update.problem.state != 'hidden' -%]
+          [%- cobrand_data = update.cobrand_data;
+              cobrand_data = c.data_for_generic_update IF !update.cobrand;
+              IF cobrand_data;
                 uri = c.uri_for_email( '/report', update.problem.id, cobrand_data );
-            ELSE;
+              ELSE;
                 uri = c.uri_for_email( '/report', update.problem.id );
-            END;
-        %]
-        <a href="[% uri %]#update_[% update.id %]" class="admin-offsite-link">[% update.id %]</a>
-        [%- ELSE %]
-        [%- update.id %]
-        [%- END -%]</td> 
+              END;
+          %]
+            <a href="[% uri %]#update_[% update.id %]" class="admin-offsite-link">[% update.id %]</a>
+          [%- ELSE %]
+            [%- update.id %]
+          [%- END ~%]
+        </td>
         <td>[% PROCESS value_or_nbsp value=update.name %]
             <br>[% PROCESS value_or_nbsp value=update.user.email %]
             <br>[% loc('Anonymous') %]: [% IF update.anonymous %][% loc('Yes') %][% ELSE %][% loc('No') %][% END %]
@@ -38,12 +39,14 @@
             [% loc('Created:') %] [% PROCESS format_time time=update.created %]
             <br>[% loc('Confirmed:') %] [% PROCESS format_time time=update.confirmed %]
         </small></td>
-        <td>[% update.text | html %]</td> 
-        <td>
+        <td rowspan=2>
             [% IF c.user.has_permission_to('report_edit', update.problem.bodies_str_ids) %]
                 <a href="[% c.uri_for( 'update_edit', update.id ) %]">[% loc('Edit') %]</a>
             [% END %]
         </td>
+    </tr>
+    <tr>
+        <td colspan=5>[% update.text | html %]</td>
     </tr>
 [% END -%]
 </table>

--- a/templates/web/base/admin/report_edit.html
+++ b/templates/web/base/admin/report_edit.html
@@ -182,6 +182,29 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
 
 </div>
 
+[% moderation_history = problem.moderation_history %]
+[% IF moderation_history %]
+<div class="full-width" style="margin-bottom:-2em; padding-bottom: 2em">
+    <h2>[% loc('Moderation history') %]</h2>
+    [% last_history = problem %]
+    <ul>
+      [% FOR history IN moderation_history %]
+        [% SET diff = history.compare_with(last_history) %]
+        <li>[% PROCESS format_time time=history.created %]:
+            [% IF diff.title %]<br>[% loc('Subject:') %] [% diff.title %][% END %]
+            [% IF diff.detail %]<br>[% loc('Details:') %] [% diff.detail %][% END %]
+            [% IF diff.photo %]<br>[% loc('Photo') %]: [% diff.photo %][% END %]
+            [% IF diff.anonymous %]<br>[% loc('Anonymous:') %] [% diff.anonymous %][% END %]
+            [% IF diff.coords %]<br>[% loc('Latitude/Longitude:') %] [% diff.coords %][% END %]
+            [% IF diff.category %]<br>[% loc('Category:') %] [% diff.category %][% END %]
+            [% IF diff.extra %]<br>[% loc('Extra data:') %] [% diff.extra %][% END %]
+        </li>
+        [% last_history = history %]
+      [% END %]
+    </ul>
+</div>
+[% END %]
+
 <div class="full-width full-width--bottom">
 [% INCLUDE 'admin/list_updates.html' %]
 </div>

--- a/templates/web/base/admin/report_edit.html
+++ b/templates/web/base/admin/report_edit.html
@@ -190,7 +190,9 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
     <ul>
       [% FOR history IN moderation_history %]
         [% SET diff = history.compare_with(last_history) %]
-        <li>[% PROCESS format_time time=history.created %]:
+        [% SET log = history.admin_log %]
+        <li><i>[% tprintf(loc('Moderated by %s at %s'), log.user.name OR loc('an administrator'), prettify_dt(history.created)) %]
+            [%~ IF log.reason %]<br>“[% log.reason %]”[% END %]</i>
             [% IF diff.title %]<br>[% loc('Subject:') %] [% diff.title %][% END %]
             [% IF diff.detail %]<br>[% loc('Details:') %] [% diff.detail %][% END %]
             [% IF diff.photo %]<br>[% loc('Photo') %]: [% diff.photo %][% END %]

--- a/templates/web/base/admin/update_edit.html
+++ b/templates/web/base/admin/update_edit.html
@@ -88,7 +88,9 @@
     <ul>
       [% FOR history IN moderation_history %]
         [% SET diff = history.compare_with(last_history) %]
-        <li>[% PROCESS format_time time=history.created %]:
+        [% SET log = history.admin_log %]
+        <li><i>[% tprintf(loc('Moderated by %s at %s'), log.user.name OR loc('an administrator'), prettify_dt(history.created)) %]
+            [%~ IF log.reason %]<br>“[% log.reason %]”[% END %]</i>
             [% IF diff.detail %]<br>[% loc('Text:') %] [% diff.detail %][% END %]
             [% IF diff.photo %]<br>[% loc('Photo') %]: [% diff.photo %][% END %]
             [% IF diff.anonymous %]<br>[% loc('Anonymous:') %] [% diff.anonymous %][% END %]

--- a/templates/web/base/admin/update_edit.html
+++ b/templates/web/base/admin/update_edit.html
@@ -81,4 +81,22 @@
 </ul>
 <input type="submit" class="btn" name="Submit changes" value="[% loc('Submit changes') %]" ></form>
 
+[% moderation_history = update.moderation_history %]
+[% IF moderation_history %]
+    <h2>[% loc('Moderation history') %]</h2>
+    [% last_history = update %]
+    <ul>
+      [% FOR history IN moderation_history %]
+        [% SET diff = history.compare_with(last_history) %]
+        <li>[% PROCESS format_time time=history.created %]:
+            [% IF diff.detail %]<br>[% loc('Text:') %] [% diff.detail %][% END %]
+            [% IF diff.photo %]<br>[% loc('Photo') %]: [% diff.photo %][% END %]
+            [% IF diff.anonymous %]<br>[% loc('Anonymous:') %] [% diff.anonymous %][% END %]
+            [% IF diff.extra %]<br>[% loc('Extra data:') %] [% diff.extra %][% END %]
+        </li>
+        [% last_history = history %]
+      [% END %]
+    </ul>
+[% END %]
+
 [% INCLUDE 'admin/footer.html' %]


### PR DESCRIPTION
This allows moderation_original_data to store all moderation changes, and shows them on admin report /update page.
Fixes https://github.com/mysociety/keepitinthecommunity/issues/121