### PR TITLE
Use standard email sending for handlemail.

### DIFF
--- a/bin/handlemail
+++ b/bin/handlemail
@@ -22,7 +22,6 @@ BEGIN {
 use FixMyStreet;
 use FixMyStreet::DB;
 use FixMyStreet::Email;
-use mySociety::EmailUtil;
 use mySociety::HandleMail;
 use mySociety::SystemMisc qw(print_log);
 
@@ -172,7 +171,7 @@ sub handle_non_bounce_to_null_address {
         To => $data{return_path},
         _body_ => $template,
     });
-    send_mail($mail->as_string, $data{return_path});
+    send_mail($mail, $data{return_path});
 }
 
 sub forward_on_to {
@@ -182,9 +181,10 @@ sub forward_on_to {
 }
 
 sub send_mail {
-    my ($text, $recipient) = @_;
-    if (mySociety::EmailUtil::EMAIL_SUCCESS
-            != mySociety::EmailUtil::send_email($text, '<>', $recipient)) {
+    my ($email, $recipient) = @_;
+    unless (FixMyStreet::Email::Sender->try_to_send(
+        $email, { from => '<>', to => $recipient }
+    )) {
         exit(75);
     }
 }

--- a/bin/handlemail-support
+++ b/bin/handlemail-support
@@ -22,7 +22,6 @@ BEGIN {
 }
 
 use FixMyStreet;
-use mySociety::EmailUtil;
 use mySociety::HandleMail;
 
 my %data = mySociety::HandleMail::get_message();
@@ -33,12 +32,13 @@ forward_on();
 
 sub forward_on {
     my ($l, $d) = split /\@/, FixMyStreet->config('CONTACT_EMAIL');
-    if (mySociety::EmailUtil::EMAIL_SUCCESS
-            != mySociety::EmailUtil::send_email(
-                join("\n", @{$data{lines}}) . "\n",
-                $data{return_path},
-                join('@', join('_deli', $l, 'very'), $d)
-            )) {
+    unless (FixMyStreet::Email::Sender->try_to_send(
+        join("\n", @{$data{lines}}) . "\n",
+        {
+            from => $data{return_path},
+            to => join('@', join('_deli', $l, 'very'), $d)
+        }
+    )) {
         exit 75;
     }
     exit 0;


### PR DESCRIPTION
The EmailUtil library expects "\n" line endings, otherwise it gets confused. It also doesn't handle a different SMTP port, and so on. Fixes #2332.

- [ ] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
