### PR TITLE
don't draw a pin for a problem with no location

### DIFF
--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -188,6 +188,9 @@ $.extend(fixmystreet.utils, {
         var selected_size = fixmystreet.maps.selected_marker_size();
         for (var i=0; i<pins.length; i++) {
             var pin = pins[i];
+            if (pin[1] == 0 && pin[0] == 0) {
+                continue;
+            }
             var loc = new OpenLayers.Geometry.Point(pin[1], pin[0]);
             if (transform) {
                 // The Strategy does this for us, so don't do it in that case.


### PR DESCRIPTION
This handles not drawing a pin for a report with no location.
In KiitC cobrand, still need to add:
- [x] When editing lat/lon directly using input fields, update display lat/lon, show a pin if not one already, move pin/map there
- [x] When 'use current location', add a pin if not one already (move pin/map already works if pin present)
- [x] When cancelling, don't move map if no pin (think might JS error anyway at present)

Connects https://github.com/mysociety/keepitinthecommunity/issues/96 [skip changelog]