### PR TITLE
bucks additional assets

### DIFF
--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -131,7 +131,7 @@ var labeled_defaults = $.extend(true, {}, defaults, {
 fixmystreet.assets.add($.extend(true, {}, labeled_defaults, {
     http_options: {
         params: {
-            TYPENAME: "StreetLights_Merged"
+            TYPENAME: "StreetLights_Union"
         }
     },
     asset_category: [
@@ -142,6 +142,106 @@ fixmystreet.assets.add($.extend(true, {}, labeled_defaults, {
     asset_item: 'street light'
 }));
 
+fixmystreet.assets.add($.extend(true, {}, labeled_defaults, {
+    http_options: {
+        params: {
+            TYPENAME: "IlluminatedBollards"
+        }
+    },
+    asset_category: ["Bollard light not working"],
+    asset_item: 'bollard'
+}));
+
+fixmystreet.assets.add($.extend(true, {}, labeled_defaults, {
+    http_options: {
+        params: {
+            TYPENAME: "Bollards"
+        }
+    },
+    asset_category: ["Bollards or railings"],
+    asset_item: 'bollard'
+}));
+
+fixmystreet.assets.add($.extend(true, {}, labeled_defaults, {
+    stylemap: streetlight_stylemap,
+    http_options: {
+        params: {
+            TYPENAME: "Beacons"
+        }
+    },
+    attributes: {
+        central_asset_id: 'central_as',
+    },
+    asset_category: [
+          'Belisha Beacon broken',
+        ],
+    asset_item: 'belisha beacon'
+}));
+
+fixmystreet.assets.add($.extend(true, {}, labeled_defaults, {
+    stylemap: streetlight_stylemap,
+    http_options: {
+        params: {
+            TYPENAME: "Beacon_Column"
+        }
+    },
+    attributes: {
+        central_asset_id: 'central_as',
+    },
+    asset_category: [
+          'Belisha Beacon broken',
+        ],
+    asset_item: 'belisha beacon'
+}));
+
+fixmystreet.assets.add($.extend(true, {}, labeled_defaults, {
+    stylemap: streetlight_stylemap_alt,
+    http_options: {
+        params: {
+            TYPENAME: "Crossings"
+        }
+    },
+    attributes: {
+        central_asset_id: 'central_as',
+    },
+    feature_code: 'asset_no',
+    asset_category: [
+          'Traffic lights & crossings problems with buttons, beep or lamps',
+          'Traffic lights & crossings problems with timings',
+        ],
+    asset_item: 'crossing'
+}));
+
+fixmystreet.assets.add($.extend(true, {}, labeled_defaults, {
+    http_options: {
+        params: {
+            TYPENAME: "Signs_Union"
+        }
+    },
+    attributes: {
+        central_asset_id: 'central_as',
+    },
+    asset_category: [
+          'Sign light not working',
+          'Sign problem',
+        ],
+    asset_item: 'sign'
+}));
+
+fixmystreet.assets.add($.extend(true, {}, defaults, {
+    http_options: {
+        params: {
+            TYPENAME: "Gullies"
+        }
+    },
+    attributes: {
+        central_asset_id: 'central_as',
+    },
+    asset_category: [
+        'Blocked drain'
+        ],
+    asset_item: 'drain'
+}));
 
 // The "whole street asset" layer indicates who is responsible for maintaining
 // a road via the 'feature_ty' attribute on features.

--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -77,32 +77,54 @@ var streetlight_stylemap = new OpenLayers.StyleMap({
     })
 });
 
-fixmystreet.assets.add($.extend(true, {}, defaults, {
+var streetlight_code_to_type = {
+  'LC': 'street light',
+  'S': 'sign',
+  'BB': 'belisha beacon',
+  'B': 'bollard',
+  'BS': 'traffic signal',
+  'VMS': 'sign',
+  'RB': 'bollard',
+  'CPS': 'sign',
+  'SF': 'sign'
+};
+
+var labeled_defaults = $.extend(true, {}, defaults, {
     select_action: true,
     stylemap: streetlight_stylemap,
+    attributes: {
+        central_asset_id: 'central_as',
+        site_code: 'site_code'
+    },
+    actions: {
+        asset_found: function(asset, config) {
+          var id = asset.attributes.feature_id || '';
+          if (id !== '') {
+              var code = id.replace(/[0-9]/g, '');
+              var asset_name = streetlight_code_to_type[code] || config.asset_item;
+              $('.category_meta_message').html('You have selected ' + asset_name + ' <b>' + id + '</b>');
+          } else {
+              $('.category_meta_message').html('You can pick a <b class="asset-spot">' + config.asset_item + '</b> from the map &raquo;');
+          }
+        },
+        asset_not_found: function(config) {
+           $('.category_meta_message').html('You can pick a <b class="asset-spot">' + config.asset_item + '</b> from the map &raquo;');
+        }
+    }
+});
+
+fixmystreet.assets.add($.extend(true, {}, labeled_defaults, {
     http_options: {
         params: {
             TYPENAME: "StreetLights_Merged"
         }
-    },
-    attributes: {
-        central_asset_id: 'central_as',
-        site_code: 'Site_code'
     },
     asset_category: [
         'Light on during the day',
         'Street light dim',
         'Street light intermittent',
         'Street light not working' ],
-    asset_item: 'street light',
-    actions: {
-        asset_found: function(asset) {
-          $('.category_meta_message').html('You have selected street light <b>' + asset.attributes.Feature_id + '</b>');
-        },
-        asset_not_found: function() {
-           $('.category_meta_message').html('You can pick a <b class="asset-spot">street light</b> from the map &raquo;');
-        }
-    }
+    asset_item: 'street light'
 }));
 
 

--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -44,37 +44,51 @@ fixmystreet.assets.add($.extend(true, {}, defaults, {
 }));
 
 var pin_prefix = fixmystreet.pin_prefix || document.getElementById('js-map-data').getAttribute('data-pin_prefix');
-var streetlight_stylemap = new OpenLayers.StyleMap({
-    'default': new OpenLayers.Style({
-        fillColor: "#FFFF00",
-        fillOpacity: 0.6,
-        strokeColor: "#000000",
-        strokeOpacity: 0.8,
-        strokeWidth: 2,
-        pointRadius: 6
-    }),
-    'select': new OpenLayers.Style({
-        externalGraphic: pin_prefix + "pin-spot.png",
-        fillColor: "#55BB00",
-        graphicWidth: 48,
-        graphicHeight: 64,
-        graphicXOffset: -24,
-        graphicYOffset: -56,
-        backgroundGraphic: pin_prefix + "pin-shadow.png",
-        backgroundWidth: 60,
-        backgroundHeight: 30,
-        backgroundXOffset: -7,
-        backgroundYOffset: -22,
-        popupYOffset: -40,
-        graphicOpacity: 1.0,
 
-        label: "${Feature_id}",
-        labelOutlineColor: "white",
-        labelOutlineWidth: 3,
-        labelYOffset: 65,
-        fontSize: '15px',
-        fontWeight: 'bold'
-    })
+var streetlight_default = {
+    fillColor: "#FFFF00",
+    fillOpacity: 0.6,
+    strokeColor: "#000000",
+    strokeOpacity: 0.8,
+    strokeWidth: 2,
+    pointRadius: 6
+};
+
+var streetlight_select = {
+    externalGraphic: pin_prefix + "pin-spot.png",
+    fillColor: "#55BB00",
+    graphicWidth: 48,
+    graphicHeight: 64,
+    graphicXOffset: -24,
+    graphicYOffset: -56,
+    backgroundGraphic: pin_prefix + "pin-shadow.png",
+    backgroundWidth: 60,
+    backgroundHeight: 30,
+    backgroundXOffset: -7,
+    backgroundYOffset: -22,
+    popupYOffset: -40,
+    graphicOpacity: 1.0,
+
+    label: "${feature_id}",
+    labelOutlineColor: "white",
+    labelOutlineWidth: 3,
+    labelYOffset: 65,
+    fontSize: '15px',
+    fontWeight: 'bold'
+};
+
+var streetlight_select_alt = $.extend(true, {}, streetlight_select, {
+  label: "${asset_no}"
+});
+
+var streetlight_stylemap = new OpenLayers.StyleMap({
+  'default': new OpenLayers.Style(streetlight_default),
+  'select': new OpenLayers.Style(streetlight_select)
+});
+
+var streetlight_stylemap_alt = new OpenLayers.StyleMap({
+  'default': new OpenLayers.Style(streetlight_default),
+  'select': new OpenLayers.Style(streetlight_select_alt)
 });
 
 var streetlight_code_to_type = {
@@ -96,9 +110,10 @@ var labeled_defaults = $.extend(true, {}, defaults, {
         central_asset_id: 'central_as',
         site_code: 'site_code'
     },
+    feature_code: 'feature_id',
     actions: {
         asset_found: function(asset, config) {
-          var id = asset.attributes.feature_id || '';
+          var id = asset.attributes[config.feature_code] || '';
           if (id !== '') {
               var code = id.replace(/[0-9]/g, '');
               var asset_name = streetlight_code_to_type[code] || config.asset_item;

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -112,13 +112,13 @@ OpenLayers.Layer.VectorAsset = OpenLayers.Class(OpenLayers.Layer.Vector, {
 
     asset_found: function() {
         if (this.fixmystreet.actions) {
-            this.fixmystreet.actions.asset_found(fixmystreet.assets.selectedFeature());
+            this.fixmystreet.actions.asset_found(fixmystreet.assets.selectedFeature(), this.fixmystreet);
         }
     },
 
     asset_not_found: function() {
         if (this.fixmystreet.actions) {
-            this.fixmystreet.actions.asset_not_found();
+            this.fixmystreet.actions.asset_not_found(this.fixmystreet);
         }
     },
 


### PR DESCRIPTION
Adds new assets to Bucks integration as well as making the message when you select an asset a bit more specific based on the type of asset.

Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]


Fixes mysociety/fixmystreet-freshdesk#36
