### PR TITLE
[Open311] warn on staging if fail to match updates

### DIFF
--- a/perllib/Open311/GetServiceRequestUpdates.pm
+++ b/perllib/Open311/GetServiceRequestUpdates.pm
@@ -195,6 +195,10 @@ sub update_comments {
                     }
                 }
             }
+        # we get lots of comments that are not related to FMS issues from Lewisham so ignore those otherwise
+        # way too many warnings.
+        } elsif (FixMyStreet->config('STAGING_SITE') and $body->name !~ /Lewisham/) {
+            warn "Failed to match comment to problem with external_id $request_id for " . $body->name . "\n";
         }
     }
 


### PR DESCRIPTION
If we fail to match an update to a problem on the staging server then
print a warning so we can diagnose issues.

Please check the following:

- [X] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [ ] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]