### PR TITLE
[Buckinghamshire] set incoming Bucks reports to non public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
     - Open311 improvements:
         - Fix bug in contact group handling. #2323
         - Improve validation of fetched reports timestamps. #2327
+        - Fetched reports can be marked non_public #2356
     - Development improvements:
         - Add option to symlink full size photos. #2326
         - default_to_body/report_prefill permissions to control default

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -109,6 +109,23 @@ sub open311_config_updates {
     $params->{mark_reopen} = 1;
 }
 
+sub filter_report_description {
+    my ($self, $description) = @_;
+
+    # this allows _ in the domain name but I figure it's unlikely to
+    # generate false positives so lets go with that for the same of
+    # a simpler regex
+    $description =~ s/\b[\w.!#$%&'*+\-\/=?^_{|}~]+\@[\w\-]+\.[^ ]+\b//g;
+    $description =~ s/ (?: \+ \d{2} \s? | \b 0 ) (?:
+        \d{2} \s? \d{4} \s? \d{4}   # 0xx( )xxxx( )xxxx
+      | \d{3} \s \d{3} \s? \d{4}    # 0xxx xxx( )xxxx
+      | \d{3} \s? \d{2} \s \d{4,5}  # 0xxx( )xx xxxx(x)
+      | \d{4} \s \d{5,6}            # 0xxxx xxxxx(x)
+    ) \b //gx;
+
+    return $description;
+}
+
 sub map_type { 'Buckinghamshire' }
 
 sub default_map_zoom { 3 }

--- a/perllib/Open311/GetServiceRequests.pm
+++ b/perllib/Open311/GetServiceRequests.pm
@@ -154,6 +154,10 @@ sub create_problems {
             next;
         }
 
+        if ( my $cobrand = $body->get_cobrand_handler ) {
+            my $filtered = $cobrand->call_hook('filter_report_description', $request->{description});
+            $request->{description} = $filtered if defined $filtered;
+        }
 
         my @contacts = grep { $request->{service_code} eq $_->email } $contacts->all;
         my $contact = $contacts[0] ? $contacts[0]->category : 'Other';

--- a/perllib/Open311/GetServiceRequests.pm
+++ b/perllib/Open311/GetServiceRequests.pm
@@ -160,6 +160,8 @@ sub create_problems {
 
         my $state = $open311->map_state($request->{status});
 
+        my $non_public = $request->{non_public} ? 1 : 0;
+
         my $problem = $self->schema->resultset('Problem')->new(
             {
                 user => $self->system_user,
@@ -182,6 +184,7 @@ sub create_problems {
                 send_method_used => 'Open311',
                 category => $contact,
                 send_questionnaire => 0,
+                non_public => $non_public,
             }
         );
 

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -82,4 +82,75 @@ subtest 'flytipping off road sent to extra email' => sub {
 
 };
 
+$cobrand = FixMyStreet::Cobrand::Buckinghamshire->new();
+
+for my $test (
+    {
+        desc => 'filters basic emails',
+        in => 'email: test@example.com',
+        out => 'email: ',
+    },
+    {
+        desc => 'filters emails in brackets',
+        in => 'email: <test@example.com>',
+        out => 'email: <>',
+    },
+    {
+        desc => 'filters emails from hosts',
+        in => 'email: test@mail.example.com',
+        out => 'email: ',
+    },
+    {
+        desc => 'filters multiple emails',
+        in => 'email: test@example.com and user@fixmystreet.com',
+        out => 'email:  and ',
+    },
+    {
+        desc => 'filters basic phone numbers',
+        in => 'number: 07700 900000',
+        out => 'number: ',
+    },
+    {
+        desc => 'filters multiple phone numbers',
+        in => 'number: 07700 900000 and 07700 900001',
+        out => 'number:  and ',
+    },
+    {
+        desc => 'filters 3 part phone numbers',
+        in => 'number: 0114 496 0999',
+        out => 'number: ',
+    },
+    {
+        desc => 'filters international phone numbers',
+        in => 'number: +44 114 496 0999',
+        out => 'number: ',
+    },
+    {
+        desc => 'filters 020 phone numbers',
+        in => 'number: 020 7946 0999',
+        out => 'number: ',
+    },
+    {
+        desc => 'filters no area phone numbers',
+        in => 'number: 01632 01632',
+        out => 'number: ',
+    },
+    {
+        desc => 'does not filter normal numbers',
+        in => 'number: 16320163236',
+        out => 'number: 16320163236',
+    },
+    {
+        desc => 'does not filter short numbers',
+        in => 'number: 0163 1632',
+        out => 'number: 0163 1632',
+    },
+) {
+    subtest $test->{desc} => sub {
+        is $cobrand->filter_report_description($test->{in}), $test->{out}, "filtered correctly";
+    };
+}
+
+
+
 done_testing();


### PR DESCRIPTION
Also adds some basic filtering of incoming report descriptions to remove emails and phone numbers.

Please check the following:

- [ ] Whether this PR should include changes to any documentation, or the FAQ;
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [ ] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [ ] Are the changes tested for accessibility?
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

Fixes https://github.com/mysociety/fixmystreet-freshdesk/issues/42