### PR TITLE
Show reopening/fixed questionnaire responses lacking updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
     - Bugfixes:
         - Restore map zoom out when navigating to /around from /report. #1649
         - Don’t escape HTML entities in report titles pulled in by ajax. #2346
+        - Show reopening/fixed questionnaire responses lacking updates. #2357
     - Open311 improvements:
         - Fix bug in contact group handling. #2323
         - Improve validation of fetched reports timestamps. #2327

--- a/perllib/FixMyStreet/DB/Result/Questionnaire.pm
+++ b/perllib/FixMyStreet/DB/Result/Questionnaire.pm
@@ -57,4 +57,11 @@ my $stz = sub {
 around whensent => $stz;
 around whenanswered => $stz;
 
+sub marks_fixed {
+    my $self = shift;
+    my $new_fixed = FixMyStreet::DB::Result::Problem->fixed_states()->{$self->new_state};
+    my $old_fixed = FixMyStreet::DB::Result::Problem->fixed_states()->{$self->old_state};
+    return $new_fixed && !$old_fixed;
+}
+
 1;

--- a/t/app/controller/report_updates.t
+++ b/t/app/controller/report_updates.t
@@ -186,6 +186,20 @@ subtest "several updates shown in correct order" => sub {
             old_state => 'confirmed',
             new_state => 'fixed - user',
         },
+        { # One reopening, no associated update
+            problem_id => $report_id,
+            whensent => '2011-03-16 08:12:36',
+            whenanswered => '2011-03-16 08:12:36',
+            old_state => 'fixed - user',
+            new_state => 'confirmed',
+        },
+        { # One marking fixed, no associated update
+            problem_id => $report_id,
+            whensent => '2011-03-17 08:12:36',
+            whenanswered => '2011-03-17 08:12:36',
+            old_state => 'confirmed',
+            new_state => 'fixed - user',
+        },
     ) {
         my $q = FixMyStreet::App->model('DB::Questionnaire')->find_or_create(
             $fields
@@ -240,13 +254,15 @@ subtest "several updates shown in correct order" => sub {
     $mech->get_ok("/report/$report_id");
 
     my $meta = $mech->extract_update_metas;
-    is scalar @$meta, 6, 'number of updates';
+    is scalar @$meta, 8, 'number of updates';
     is $meta->[0], 'Posted by Other User at 12:23, Thu 10 March 2011', 'first update';
     is $meta->[1], 'Posted by Main User at 12:23, Thu 10 March 2011 Still open, via questionnaire', 'second update';
     is $meta->[2], 'Still open, via questionnaire, 12:23, Fri 11 March 2011', 'questionnaire';
     is $meta->[3], 'Still open, via questionnaire, 12:23, Sat 12 March 2011', 'questionnaire';
     is $meta->[4], 'State changed to: Fixed', 'third update, part 1';
     is $meta->[5], 'Posted anonymously at 08:12, Tue 15 March 2011', 'third update, part 2';
+    is $meta->[6], 'Still open, via questionnaire, 08:12, Wed 16 March 2011', 'reopen questionnaire';
+    is $meta->[7], 'Questionnaire filled in by problem reporter; State changed to: Fixed, 08:12, Thu 17 March 2011', 'fix questionnaire';
     $report->questionnaires->delete;
 };
 

--- a/templates/web/base/report/updates.html
+++ b/templates/web/base/report/updates.html
@@ -12,9 +12,16 @@
 [% BLOCK meta_line %]
 
     [% IF update.whenanswered %]
+      [% IF update.marks_fixed %]
+        [%# A questionnaire update that marked the report fixed %]
+        [% loc("Questionnaire filled in by problem reporter") %];
+        [% loc('State changed to:') %] [% prettify_state('fixed') %],
+        [% prettify_dt( update.whenanswered ) %]
+      [% ELSE %]
         [%# A questionnaire update, currently saying report is still open %]
         [% loc('Still open, via questionnaire') %], [% prettify_dt( update.whenanswered ) %]
-        [% RETURN %]
+      [% END %]
+      [% RETURN %]
     [% END %]
 
     [% update.meta_line(c) %]


### PR DESCRIPTION
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

Should fix #2357 (cc @joesiltberg).