### PR TITLE
add private only report filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
         - Allow moderation to work without JavaScript. #2339
         - More prominent display of "state" on report page #2350
         - Improved report/update display on contact form. #2351
+        - Can limit /reports to non-public reports. #2363
     - Admin improvements:
         - Allow moderation to potentially change category. #2320
         - Add Mark/View private reports permission #2306

--- a/docs/_includes/admin-tasks-content.md
+++ b/docs/_includes/admin-tasks-content.md
@@ -276,6 +276,9 @@ In such cases, staff should make a new report just as a member of the public wou
 citizen’s experience](/pro-manual/citizens-experience/)'. Those with the appropriate permissions
 will see a "Private" checkbox underneath the user details which they should select.
 
+On the reports page you can select "Private only" from the status filter
+to display only the reports that have been marked private.
+
 </div>
 
 <div class="admin-task" markdown="1" id="correct-reporter-errors">

--- a/t/app/controller/around.t
+++ b/t/app/controller/around.t
@@ -171,6 +171,19 @@ for my $permission ( qw/ report_inspect report_mark_private/ ) {
         };
         $mech->content_contains( "Around page Test 3 for $body_edin_id",
             'problem marked non public is visible' );
+        $mech->content_contains( "Around page Test 2 for $body_edin_id",
+            'problem marked public is visible' );
+
+        FixMyStreet::override_config {
+            ALLOWED_COBRANDS => [ { 'fixmystreet' => '.' } ],
+            MAPIT_URL => 'http://mapit.uk/',
+        }, sub {
+            $mech->get_ok('/around?pc=EH1+1BB&status=non_public');
+        };
+        $mech->content_contains( "Around page Test 3 for $body_edin_id",
+            'problem marked non public is visible' );
+        $mech->content_lacks( "Around page Test 2 for $body_edin_id",
+            'problem marked public is not visible' );
 
         $user->user_body_permissions->delete();
         $user->update({ from_body => $body2 });
@@ -189,6 +202,19 @@ for my $permission ( qw/ report_inspect report_mark_private/ ) {
         };
         $mech->content_lacks( "Around page Test 3 for $body_edin_id",
             'problem marked non public is not visible' );
+        $mech->content_contains( "Around page Test 2 for $body_edin_id",
+            'problem marked public is visible' );
+
+        FixMyStreet::override_config {
+            ALLOWED_COBRANDS => [ { 'fixmystreet' => '.' } ],
+            MAPIT_URL => 'http://mapit.uk/',
+        }, sub {
+            $mech->get_ok('/around?pc=EH1+1BB&status=non_public');
+        };
+        $mech->content_lacks( "Around page Test 3 for $body_edin_id",
+            'problem marked non public is not visible' );
+        $mech->content_lacks( "Around page Test 2 for $body_edin_id",
+            'problem marked public is visible' );
     };
 }
 

--- a/templates/web/base/reports/_list-filters.html
+++ b/templates/web/base/reports/_list-filters.html
@@ -24,6 +24,9 @@
         <option value="shortlisted"[% ' selected' IF filter_status.shortlisted %]>[% loc('Shortlisted') %]</option>
         <option value="unshortlisted"[% ' selected' IF filter_status.unshortlisted %]>[% loc('Unshortlisted') %]</option>
       [% END %]
+      [% IF c.user_exists AND ( c.user.has_body_permission_to('report_inspect') OR c.user.has_body_permission_to('report_mark_private') ) %]
+        <option value="non_public"[% ' selected' IF filter_status.non_public %]>[% loc('Private only') %]</option>
+      [% END %]
       [% IF show_all_states %]
         [% FOR group IN filter_states %]
           [% FOR state IN group.1 %]


### PR DESCRIPTION
This adds an option on the reports screen to display only private reports.

Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
