### PR TITLE
add extra categories to demo site

### DIFF
--- a/.cypress/cypress/integration/category_tests.js
+++ b/.cypress/cypress/integration/category_tests.js
@@ -16,6 +16,7 @@ describe('Basic categories', function() {
         'Flytipping',
         'Footpath/bridleway away from road',
         'Graffiti',
+        'Licensing',
         'Parks/landscapes',
         'Pavements',
         'Potholes',

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -76,6 +76,15 @@ for my $cat (qw/Overflowing Broken Missing/) {
     $child_cat->update;
 }
 
+for my $cat ('Dropped Kerbs', 'Skips') {
+    my $child_cat = FixMyStreet::DB::Factory::Contact->find_or_create({
+        body => $body,
+        category => $cat
+    });
+    $child_cat->set_extra_metadata( group => 'Licensing' );
+    $child_cat->update;
+}
+
 FixMyStreet::DB::Factory::ResponseTemplate->create({
     body => $body, title => 'Generic',
     text => 'Thank you for your report, we will be in touch with an update soon.' });


### PR DESCRIPTION
Dropped Kerbs and Skips in a Licensing group.

Fixes mysociety/fixmystreet-commercial#1241

Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]