### PR TITLE
Add start and end date extra fields to licensing categories for demo

### DIFF
--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -82,6 +82,10 @@ for my $cat ('Dropped Kerbs', 'Skips') {
         category => $cat
     });
     $child_cat->set_extra_metadata( group => 'Licensing' );
+    $child_cat->set_extra_fields(
+        { description => 'Start date', code => 'start_date', datatype => 'string', fieldtype => 'date' },
+        { description => 'End date', code => 'end_date', datatype => 'string', fieldtype => 'date' }
+    );
     $child_cat->update;
 }
 

--- a/templates/web/base/report/new/category_extras_fields.html
+++ b/templates/web/base/report/new/category_extras_fields.html
@@ -21,7 +21,7 @@
             [% END %]
           </select>
         [% ELSE %]
-          <input class="form-control" type="text" value="[% report_meta.$meta_name.value | html %]" name="[% cat_prefix %][% meta_name %]" id="[% cat_prefix %]form_[% meta_name %]"[% meta.required == 'true' ? ' required' : '' %]>
+          <input class="form-control" type="[% meta.fieldtype OR 'text' %]" value="[% report_meta.$meta_name.value | html %]" name="[% cat_prefix %][% meta_name %]" id="[% cat_prefix %]form_[% meta_name %]"[% meta.required == 'true' ? ' required' : '' %]>
         [% END %]
       [% END %]
 


### PR DESCRIPTION
This also sneaks in the ability to set the type of extra field inputs so we can use the nice build in date picker for these fields.

Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
