### PR TITLE
More clearing/checking of cached photos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Releases
 
 * Unreleased
+    - Bugfixes
+        - Check cached reports do still have photos before being shown.
 
 * v2.5 (21st December 2018)
     - Front end improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Unreleased
     - Bugfixes
         - Check cached reports do still have photos before being shown.
+        - Delete cache photos upon photo moderation.
 
 * v2.5 (21st December 2018)
     - Front end improvements:

--- a/perllib/FixMyStreet/App/Controller/Moderate.pm
+++ b/perllib/FixMyStreet/App/Controller/Moderate.pm
@@ -227,6 +227,7 @@ sub moderate_boolean : Private {
         $c->stash->{history}->insert;
         if ($thing eq 'photo') {
             $object->update({ $thing => $new ? $original : undef });
+            $object->get_photoset->delete_cached;
         } else {
             $object->update({ $thing => $new });
         }

--- a/perllib/FixMyStreet/DB/ResultSet/Problem.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Problem.pm
@@ -154,7 +154,7 @@ sub _recent {
             # Need to reattach schema so that confirmed column gets reinflated.
             $probs->[0]->result_source->schema( $rs->result_source->schema ) if $probs->[0];
             # Catch any cached ones since hidden
-            $probs = [ grep { ! $_->is_hidden } @$probs ];
+            $probs = [ grep { $_->photo && ! $_->is_hidden } @$probs ];
         } else {
             $probs = [ $rs->search( $query, $attrs )->all ];
             Memcached::set($key, $probs, 3600);


### PR DESCRIPTION
Two separate small issues could combine to still show an already moderated photo on the front page:
1. The moderation was not clearing out the web cache of photos being moderated;
2. The code fetching the front page recent reports list from memcached checked they had not been hidden since they were cached, but wasn't checking whether they still had a photo (ie. moderated but report still present).
