### PR TITLE
Remove any use of `my $x if $foo`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     - Bugfixes
         - Check cached reports do still have photos before being shown.
         - Delete cache photos upon photo moderation.
+        - Remove any use of `my $x if $foo`.
 
 * v2.5 (21st December 2018)
     - Front end improvements:

--- a/perllib/FixMyStreet/App/Controller/Photo.pm
+++ b/perllib/FixMyStreet/App/Controller/Photo.pm
@@ -82,7 +82,7 @@ sub output : Private {
     # Save to file
     path(FixMyStreet->path_to('web', 'photo', 'c'))->mkpath;
     my $out = FixMyStreet->path_to('web', $c->req->path);
-    my $symlink_exists = symlink($photo->{symlink}, $out) if $photo->{symlink};
+    my $symlink_exists = $photo->{symlink} ? symlink($photo->{symlink}, $out) : undef;
     path($out)->spew_raw($photo->{data}) unless $symlink_exists;
 
     $c->res->content_type( $photo->{content_type} );

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -530,7 +530,7 @@ sub find_closest {
     my $problem = $data->{problem};
     my $lat = $problem ? $problem->latitude : $data->{latitude};
     my $lon = $problem ? $problem->longitude : $data->{longitude};
-    my $j = $problem->geocode if $problem;
+    my $j = $problem ? $problem->geocode : undef;
 
     if (!$j) {
         $j = FixMyStreet::Geocode::Bing::reverse( $lat, $lon,

--- a/perllib/FixMyStreet/Roles/Abuser.pm
+++ b/perllib/FixMyStreet/Roles/Abuser.pm
@@ -14,7 +14,8 @@ sub is_from_abuser {
     my $self = shift;
 
     my $email = $self->user->email;
-    my ($domain) = $email =~ m{ @ (.*) \z }x if $email;
+    my $domain;
+    ($domain) = $email =~ m{ @ (.*) \z }x if $email;
     my $phone = $self->user->phone;
 
     # search for an entry in the abuse table

--- a/perllib/FixMyStreet/Script/Reports.pm
+++ b/perllib/FixMyStreet/Script/Reports.pm
@@ -140,7 +140,9 @@ sub send(;$) {
             }
             $reporters{ $sender } ||= $sender->new();
 
-            my $inspection_required = $sender_info->{contact}->get_extra_metadata('inspection_required') if $sender_info->{contact};
+            my $inspection_required = $sender_info->{contact}
+                ? $sender_info->{contact}->get_extra_metadata('inspection_required')
+                : undef;
             if ( $inspection_required ) {
                 my $reputation_threshold = $sender_info->{contact}->get_extra_metadata('reputation_threshold') || 0;
                 my $reputation_threshold_met = 0;


### PR DESCRIPTION
As perlsyn says, "NOTE: The behaviour of a `my`, `state`, or `our` modified with a statement modifier conditional or loop construct (for example, `my $x if ...`) is undefined. The value of the `my` variable may be `undef`, any previously assigned value, or possibly anything else."

Noticed because a call to `/ajax/closest` was returning the previous call's result (as `$j` was being "remembered" between function calls).