### PR TITLE
Moderation in front end updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Releases
 
 * Unreleased
+    - Admin improvements:
+        - Include moderation history in report updates. #2379
     - Bugfixes
         - Check cached reports do still have photos before being shown.
         - Delete cache photos upon photo moderation.

--- a/docs/_includes/admin-tasks-content.md
+++ b/docs/_includes/admin-tasks-content.md
@@ -215,6 +215,9 @@ update. Clicking this button gives you the ability to:
 
 You can also add a note to indicate the reason for the change to the report.
 
+Moderation history will be shown within the report updates, and is only visible to people with
+the moderate permission.
+
 #### Hiding reports
 
 Clicking the moderation button also gives you the option to hide an entire report or its updates.

--- a/perllib/FixMyStreet/DB/Result/ModerationOriginalData.pm
+++ b/perllib/FixMyStreet/DB/Result/ModerationOriginalData.pm
@@ -167,7 +167,7 @@ sub compare_extra {
             push @s, string_diff("$_ = $old->{$_}", "");
         }
     }
-    return join ', ', @s;
+    return join ', ', grep { $_ } @s;
 }
 
 sub string_diff {

--- a/perllib/FixMyStreet/DB/Result/ModerationOriginalData.pm
+++ b/perllib/FixMyStreet/DB/Result/ModerationOriginalData.pm
@@ -170,6 +170,13 @@ sub compare_extra {
     return join ', ', grep { $_ } @s;
 }
 
+sub extra_diff {
+    my ($self, $other, $key) = @_;
+    my $o = $self->get_extra_metadata($key);
+    my $n = $other->get_extra_metadata($key);
+    return string_diff($o, $n);
+}
+
 sub string_diff {
     my ($old, $new, %options) = @_;
 

--- a/t/app/controller/moderate.t
+++ b/t/app/controller/moderate.t
@@ -257,8 +257,12 @@ subtest 'Problem moderation' => sub {
         $report->discard_changes;
         is $report->get_extra_metadata('weather'), 'snow';
         is $report->get_extra_metadata('moon'), 'waning full';
-        is $report->moderation_original_data->get_extra_metadata('moon'), 'waxing full';
-        is $report->moderation_original_data->get_extra_metadata('weather'), undef;
+        my $mod = $report->moderation_original_data;
+        is $mod->get_extra_metadata('moon'), 'waxing full';
+        is $mod->get_extra_metadata('weather'), undef;
+
+        my $diff = $mod->extra_diff($report, 'moon');
+        is $diff, "wa<del style='background-color:#fcc'>x</del><ins style='background-color:#cfc'>n</ins>ing full", 'Correct diff';
     };
 
     subtest 'Moderate category' => sub {
@@ -327,6 +331,7 @@ sub create_update {
         text      => 'update good good bad good',
         state     => 'confirmed',
         mark_fixed => 0,
+        confirmed => $dt,
     });
 }
 my %update_prepopulated = (

--- a/templates/web/base/admin/report_edit.html
+++ b/templates/web/base/admin/report_edit.html
@@ -189,17 +189,8 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
     [% last_history = problem %]
     <ul>
       [% FOR history IN moderation_history %]
-        [% SET diff = history.compare_with(last_history) %]
-        [% SET log = history.admin_log %]
-        <li><i>[% tprintf(loc('Moderated by %s at %s'), log.user.name OR loc('an administrator'), prettify_dt(history.created)) %]
-            [%~ IF log.reason %]<br>“[% log.reason %]”[% END %]</i>
-            [% IF diff.title %]<br>[% loc('Subject:') %] [% diff.title %][% END %]
-            [% IF diff.detail %]<br>[% loc('Details:') %] [% diff.detail %][% END %]
-            [% IF diff.photo %]<br>[% loc('Photo') %]: [% diff.photo %][% END %]
-            [% IF diff.anonymous %]<br>[% loc('Anonymous:') %] [% diff.anonymous %][% END %]
-            [% IF diff.coords %]<br>[% loc('Latitude/Longitude:') %] [% diff.coords %][% END %]
-            [% IF diff.category %]<br>[% loc('Category:') %] [% diff.category %][% END %]
-            [% IF diff.extra %]<br>[% loc('Extra data:') %] [% diff.extra %][% END %]
+        <li><i>[% INCLUDE 'report/update/moderation_meta.html' %]</i>
+            [% INCLUDE 'report/update/moderation_diff.html' diff=history.compare_with(last_history) %]
         </li>
         [% last_history = history %]
       [% END %]

--- a/templates/web/base/report/update.html
+++ b/templates/web/base/report/update.html
@@ -1,11 +1,11 @@
-[% can_moderate = NOT update.whenanswered AND (permissions.moderate OR c.user.can_moderate(update, staff = permissions.moderate)) %]
+[% can_moderate = NOT update.whenanswered AND update.type != 'moderation' AND (permissions.moderate OR c.user.can_moderate(update, staff = permissions.moderate)) %]
 [% IF loop.first %]
 <section class="full-width">
     <h4 class="static-with-rule">[% loc('Updates') %]</h4>
     <ul class="item-list item-list--updates">
 [% END %]
         <li class="item-list__item item-list__item--updates
-            [%~ ' show-moderation' IF show_moderation == update.id ~%]
+            [%~ ' show-moderation' IF update.id AND show_moderation == update.id ~%]
             ">
             <a name="update_[% update.id %]" class="internal-link-fixed-header"></a>
           [% IF can_moderate; original_update = update.moderation_original_data %]
@@ -29,6 +29,8 @@
                 <div class="item-list__update-text">
                     <p class="meta-2">[% INCLUDE meta_line %]</p>
                 </div>
+            [% ELSIF update.type == 'moderation' %]
+                [% PROCESS 'report/update/moderation.html' %]
             [% ELSE %]
                 [% INCLUDE 'report/photo.html' object=update %]
                 <div class="item-list__update-text">

--- a/templates/web/base/report/update/moderation.html
+++ b/templates/web/base/report/update/moderation.html
@@ -1,0 +1,6 @@
+<div class="item-list__update-text">
+    [% INCLUDE 'report/update/moderation_diff.html' diff=update.entry.compare_with(update.last) %]
+    <p class="meta-2">
+        [% INCLUDE 'report/update/moderation_meta.html' history=update.entry %]
+    </p>
+</div>

--- a/templates/web/base/report/update/moderation_diff.html
+++ b/templates/web/base/report/update/moderation_diff.html
@@ -1,0 +1,9 @@
+<ul>
+    [% IF diff.title %]<li>[% loc('Subject:') %] [% diff.title %][% END %]
+    [% IF diff.detail %]<li>[% loc('Details:') %] [% diff.detail %][% END %]
+    [% IF diff.photo %]<li>[% loc('Photo') %]: [% diff.photo %][% END %]
+    [% IF diff.anonymous %]<li>[% loc('Anonymous:') %] [% diff.anonymous %][% END %]
+    [% IF diff.coords %]<li>[% loc('Latitude/Longitude:') %] [% diff.coords %][% END %]
+    [% IF diff.category %]<li>[% loc('Category:') %] [% diff.category %][% END %]
+    [% IF diff.extra %]<li>[% loc('Extra data:') %] [% diff.extra %][% END %]
+</ul>

--- a/templates/web/base/report/update/moderation_meta.html
+++ b/templates/web/base/report/update/moderation_meta.html
@@ -1,0 +1,3 @@
+[% SET log = history.admin_log %]
+[%~ tprintf(loc('Moderated by %s at %s'), log.user.name OR loc('an administrator'), prettify_dt(history.created)) %]
+[%~ IF log.reason %], “[% log.reason %]”[% END %]


### PR DESCRIPTION
This adds moderation history, currently only shown on admin report edit page, to the front end report page if the user has moderation permission, interleaved with any normal updates/questionnaires to the report.

Please check the following:
- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
