### PR TITLE
[Oxfordshire] length checking for names, emails and phone Nos

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -17,6 +17,18 @@ sub report_validation {
         $errors->{detail} = sprintf( _('Reports are limited to %s characters in length. Please shorten your report'), 1700 );
     }
 
+    if ( length( $report->name ) > 70 ) {
+        $errors->{name} = sprintf( 'Names are limited to %d characters in length.', 70 );
+    }
+
+    if ( length( $report->user->phone ) > 30 ) {
+        $errors->{phone} = sprintf( 'Phone numbers are limited to %s characters in length.', 30 );
+    }
+
+    if ( length( $report->user->email ) > 50 ) {
+        $errors->{username} = sprintf( 'Emails are limited to %s characters in length.', 50 );
+    }
+
     return $errors;
 }
 

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -594,6 +594,26 @@ foreach my $test (
         changes => { },
         errors => [ 'Please enter a subject', 'Please enter some details', 'Names are limited to 40 characters in length.' ],
     },
+    {
+        msg    => 'Oxfordshire validation',
+        pc     => 'OX20 1SZ',
+        fields => {
+            title         => '',
+            detail        => '',
+            photo1        => '',
+            photo2        => '',
+            photo3        => '',
+            name          => 'This is a really extraordinarily long name that definitely should fail validation',
+            may_show_name => '1',
+            username      => 'bob.has.a.very.long.email@thisisalonghostname.example.com',
+            phone         => '01234 5678910 09876 54321 ext 203',
+            category      => 'Trees',
+            password_sign_in => '',
+            password_register => '',
+        },
+        changes => { },
+        errors => [ 'Please enter a subject', 'Please enter some details', 'Emails are limited to 50 characters in length.', 'Phone numbers are limited to 30 characters in length.', 'Names are limited to 70 characters in length.'],
+    },
   )
 {
     subtest "check form errors where $test->{msg}" => sub {

--- a/templates/web/oxfordshire/footer_extra_js.html
+++ b/templates/web/oxfordshire/footer_extra_js.html
@@ -4,4 +4,5 @@
     version('/cobrands/oxfordshire/js.js'),
     version('/cobrands/oxfordshire/assets.js'),
     version('/cobrands/highways/assets.js'),
+    version('/cobrands/fixmystreet-uk-councils/council_validation_rules.js'),
 ) %]

--- a/web/cobrands/fixmystreet-uk-councils/council_validation_rules.js
+++ b/web/cobrands/fixmystreet-uk-councils/council_validation_rules.js
@@ -32,6 +32,16 @@ body_validation_rules = {
         detail: {
           required: true,
           maxlength: 1700
+        },
+        name: {
+          required: true,
+          maxlength: 70
+        },
+        phone: {
+          maxlength: 30
+        },
+        email: {
+          maxlength: 50
         }
     }
 };


### PR DESCRIPTION
Add in validation to check names, email and phone numbers don't exceed
maximum lengths permitted by HIAMS.

Fixes mysociety/fixmystreet-commercial#1244

Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]