### PR TITLE
Allow state editing via moderation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## Releases
 
 * Unreleased
+    - Admin improvements:
+        - Allow moderation to potentially change state. #2381
     - Bugfixes
-        - Check cached reports do still have photos before being shown.
-        - Delete cache photos upon photo moderation.
-        - Remove any use of `my $x if $foo`.
+        - Check cached reports do still have photos before being shown. #2374
+        - Delete cache photos upon photo moderation. #2374
+        - Remove any use of `my $x if $foo`. #2377
 
 * v2.5 (21st December 2018)
     - Front end improvements:


### PR DESCRIPTION
If a state is passed in (on a cobrand), update problem state and add a comment to record this (as state changes are updates not moderations).

- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog