### PR TITLE
[Buckinghamshire] Question for on-road flytipping.

### DIFF
--- a/bin/fixmystreet.com/buckinghamshire-flytipping
+++ b/bin/fixmystreet.com/buckinghamshire-flytipping
@@ -1,0 +1,80 @@
+#!/usr/bin/env perl
+#
+# If a district flytipping report within Buckinghamshire has not been closed
+# after three weeks, close it with a message. If it's older than six weeks,
+# use a different message and suppress any alerts.
+
+use v5.14;
+use warnings;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use constant BUCKS_AREA_ID => 2217;
+use constant DISTRICT_IDS => (2255, 2256, 2257, 2258);
+use constant TIME_OPEN => '3 weeks';
+use constant TIME_OPEN_ALERT => '6 weeks';
+
+use FixMyStreet::DB;
+use FixMyStreet::Script::ArchiveOldEnquiries;
+use Getopt::Long::Descriptive;
+
+my ($opts, $usage) = describe_options(
+    '%c %o',
+    ['commit|c', "actually close reports and send emails. Omitting this flag will do a dry-run"],
+    ['help|h', "print usage message and exit" ],
+);
+print($usage->text), exit if $opts->help;
+
+my $body = FixMyStreet::DB->resultset("Body")->for_areas(BUCKS_AREA_ID)->first;
+die "Could not find Bucks body" unless $body;
+
+my @districts = FixMyStreet::DB->resultset("Body")->for_areas(DISTRICT_IDS)->all;
+my @district_ids = map { $_->id } @districts;
+die "Did not find all districts" unless @district_ids == 4;
+
+find_problems(TIME_OPEN_ALERT, TIME_OPEN, 'Auto-closure', 1);
+find_problems(undef, TIME_OPEN_ALERT, 'Auto-closure (old)', 0);
+
+sub find_problems {
+    my ($from, $to, $title, $retain_alerts) = @_;
+
+    my $template = FixMyStreet::DB->resultset("ResponseTemplate")->search({
+        body_id => $body->id, title => $title,
+    })->first;
+    die "Could not find Bucks Flytipping template" unless $template;
+
+    $to = "current_timestamp - '$to'::interval";
+    my $time_param;
+    if ($from) {
+        $from = "current_timestamp - '$from'::interval";
+        $time_param = [ -and => { '>=', \$from }, { '<', \$to } ],
+    } else {
+        $time_param = { '<', \$to };
+    }
+
+    # Fetch all Flytipping problems sent only to districts, between $from and $to
+    my $q = FixMyStreet::DB->resultset("Problem")->search(
+        \[ "? @> regexp_split_to_array(bodies_str, ',')", [ {} => \@district_ids ] ]
+    )->search({
+        state => [ FixMyStreet::DB::Result::Problem->open_states() ],
+        category => 'Flytipping',
+        confirmed => $time_param,
+    });
+
+    # Provide some variables to the archiving script
+    FixMyStreet::Script::ArchiveOldEnquiries::update_options({
+        user => $body->comment_user,
+        user_name => $body->comment_user->name,
+        closure_text => $template->text,
+        retain_alerts => $retain_alerts,
+        commit => $opts->commit,
+    });
+
+    # Close the reports
+    FixMyStreet::Script::ArchiveOldEnquiries::close_problems($q);
+}

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1069,26 +1069,12 @@ sub set_report_extras : Private {
     my ($self, $c, $contacts, $param_prefix) = @_;
 
     $param_prefix ||= "";
-    my @extra;
-    foreach my $contact (@$contacts) {
-        my $metas = $contact->get_metadata_for_input;
-        foreach my $field ( @$metas ) {
-            if ( lc( $field->{required} ) eq 'true' && !$c->cobrand->category_extra_hidden($field)) {
-                unless ( $c->get_param($param_prefix . $field->{code}) ) {
-                    $c->stash->{field_errors}->{ $field->{code} } = _('This information is required');
-                }
-            }
-            push @extra, {
-                name => $field->{code},
-                description => $field->{description},
-                value => $c->get_param($param_prefix . $field->{code}) || '',
-            };
-        }
-    }
+    my @metalist = map { [ $_->get_metadata_for_input, $param_prefix ] } @$contacts;
+    push @metalist, map { [ $_->get_extra_fields, "extra[" . $_->id . "]" ] } @{$c->stash->{report_extra_fields}};
 
-    foreach my $extra_fields (@{ $c->stash->{report_extra_fields} }) {
-        my $metas = $extra_fields->get_extra_fields;
-        $param_prefix = "extra[" . $extra_fields->id . "]";
+    my @extra;
+    foreach my $item (@metalist) {
+        my ($metas, $param_prefix) = @$item;
         foreach my $field ( @$metas ) {
             if ( lc( $field->{required} ) eq 'true' && !$c->cobrand->category_extra_hidden($field)) {
                 unless ( $c->get_param($param_prefix . $field->{code}) ) {

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -196,5 +196,44 @@ sub open311_pre_send {
     }
 }
 
+sub open311_contact_meta_override {
+    my ($self, $service, $contact, $meta) = @_;
+
+    $contact->set_extra_metadata( id_field => 'service_request_id_ext');
+
+    # Lights we want to store feature ID, PROW on all categories.
+    push @$meta, {
+        code => 'prow_reference',
+        datatype => 'string',
+        description => 'Right of way reference',
+        order => 101,
+        required => 'false',
+        variable => 'true',
+        automated => 'hidden_field',
+    };
+    push @$meta, {
+        code => 'feature_id',
+        datatype => 'string',
+        description => 'Feature ID',
+        order => 100,
+        required => 'false',
+        variable => 'true',
+        automated => 'hidden_field',
+    } if $service->{service_code} eq 'SLRS';
+
+    my @override = qw(
+        requested_datetime
+        report_url
+        title
+        last_name
+        email
+        report_title
+        public_anonymity_required
+        email_alerts_requested
+    );
+    my %ignore = map { $_ => 1 } @override;
+    @$meta = grep { !$ignore{$_->{code}} } @$meta;
+}
+
 1;
 

--- a/perllib/FixMyStreet/Cobrand/Warwickshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Warwickshire.pm
@@ -34,4 +34,12 @@ sub contact_name { 'Warwickshire County Council (do not reply)'; }
 
 sub send_questionnaires { 0 }
 
+sub open311_contact_meta_override {
+    my ($self, $service, $contact, $meta) = @_;
+
+    $contact->set_extra_metadata( id_field => 'external_id');
+
+    @$meta = grep { $_->{code} ne 'closest_address' } @$meta;
+}
+
 1;

--- a/t/cobrand/warwickshire.t
+++ b/t/cobrand/warwickshire.t
@@ -1,0 +1,84 @@
+#!/usr/bin/env perl
+
+use FixMyStreet::Test;
+use FixMyStreet::DB;
+
+use_ok( 'Open311::PopulateServiceList' );
+use_ok( 'Open311' );
+
+my $processor = Open311::PopulateServiceList->new();
+ok $processor, 'created object';
+
+my $warks = FixMyStreet::DB->resultset('Body')->create({
+    name => 'Warwickshire County Council',
+});
+$warks->body_areas->create({ area_id => 2243 });
+
+subtest 'check Warwickshire override' => sub {
+    my $processor = Open311::PopulateServiceList->new();
+
+    my $meta_xml = '<?xml version="1.0" encoding="utf-8"?>
+<service_definition>
+    <service_code>100</service_code>
+    <attributes>
+        <attribute>
+            <variable>true</variable>
+            <code>closest_address</code>
+            <datatype>string</datatype>
+            <required>true</required>
+            <order>1</order>
+            <description>Closest address</description>
+        </attribute>
+        <attribute>
+            <variable>true</variable>
+            <code>size</code>
+            <datatype>string</datatype>
+            <required>true</required>
+            <order>2</order>
+            <description>How big is the pothole</description>
+        </attribute>
+    </attributes>
+</service_definition>
+    ';
+
+    my $contact = FixMyStreet::DB->resultset('Contact')->create({
+        body_id => $warks->id,
+        email => '100',
+        category => 'Pothole',
+        state => 'confirmed',
+        editor => $0,
+        whenedited => \'current_timestamp',
+        note => 'test contact',
+    });
+
+    my $o = Open311->new(
+        jurisdiction => 'mysociety',
+        endpoint => 'http://example.com',
+        test_mode => 1,
+        test_get_returns => { 'services/100.xml' => $meta_xml }
+    );
+
+    $processor->_current_open311( $o );
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'warwickshire' ],
+    }, sub {
+        $processor->_current_body( $warks );
+    };
+    $processor->_current_service( { service_code => 100, service_name => 'Pothole' } );
+    $processor->_add_meta_to_contact( $contact );
+
+    my $extra = [ {
+        variable => 'true',
+        code => 'size',
+        datatype => 'string',
+        required => 'true',
+        order => 2,
+        description => 'How big is the pothole',
+    } ];
+
+    $contact->discard_changes;
+    is_deeply $contact->get_extra_fields, $extra, 'No closest_address field returned for Warks';
+    is $contact->get_extra_metadata('id_field'), 'external_id', 'id_field set correctly';
+};
+
+done_testing();

--- a/t/open311/populate-service-list.t
+++ b/t/open311/populate-service-list.t
@@ -552,7 +552,11 @@ subtest 'check Bromley skip code' => sub {
     );
 
     $processor->_current_open311( $o );
-    $processor->_current_body( $bromley );
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'bromley' ],
+    }, sub {
+        $processor->_current_body( $bromley );
+    };
     $processor->_current_service( { service_code => 100 } );
 
     $processor->_add_meta_to_contact( $contact );

--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -377,6 +377,11 @@ fixmystreet.assets.add($.extend(true, {}, defaults, {
         found: function(layer, feature) {
             fixmystreet.body_overrides.allow_send(layer.fixmystreet.body);
             fixmystreet.body_overrides.remove_only_send();
+
+            // Make sure Flytipping related things reset
+            $('#category_meta').show();
+            $('#form_road-placement').attr('required', '');
+
             if (fixmystreet.assets.selectedFeature()) {
                 hide_responsibility_errors();
                 enable_report_form();
@@ -414,9 +419,18 @@ fixmystreet.assets.add($.extend(true, {}, defaults, {
                 fixmystreet.body_overrides.allow_send(layer.fixmystreet.body);
                 hide_responsibility_errors();
                 enable_report_form();
-            } else if (is_only_body(layer.fixmystreet.body)){
+            } else if (is_only_body(layer.fixmystreet.body)) {
                 show_responsibility_error("#js-not-a-road");
                 disable_report_form();
+            }
+
+            // If flytipping is picked, we don't want to ask the extra question
+            var cat = $('select#form_category').val();
+            if (cat === 'Flytipping') {
+                $('#category_meta').hide();
+                $('#form_road-placement').removeAttr('required');
+            } else {
+                $('#category_meta').show();
             }
         }
     },
@@ -427,6 +441,18 @@ fixmystreet.assets.add($.extend(true, {}, defaults, {
     filter_key: 'feature_ty',
     filter_value: types_to_show,
 }));
+
+// As with the road found/not_found above, we want to change the destination
+// depending upon the answer to the extra question shown when on a road
+$("#problem_form").on("change", "#form_road-placement", function() {
+    if (this.value == 'road') {
+        fixmystreet.body_overrides.allow_send(defaults.body);
+        fixmystreet.body_overrides.only_send(defaults.body);
+    } else if (this.value == 'off-road') {
+        fixmystreet.body_overrides.do_not_send(defaults.body);
+        fixmystreet.body_overrides.remove_only_send();
+    }
+});
 
 fixmystreet.assets.add($.extend(true, {}, defaults, {
     http_options: {


### PR DESCRIPTION
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]

Fixes https://github.com/mysociety/fixmystreet-freshdesk/issues/45

* Tidies up test file to not hard-code IDs, new test is at bottom.
* JS for showing/hiding extra question.
* Perl to get extra question into DB, not being pulled from Open311.
* Server side code to work out what to do if both bodies still given (question made mandatory in most cases, but not if district only).
* Script to auto close >3 weeks old district flytipping