### PR TITLE
Spot moderation conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     - Admin improvements:
         - Include moderation history in report updates. #2379
         - Allow moderation to potentially change state. #2381
+        - Spot moderation conflicts and raise an error. #2384
     - Bugfixes
         - Check cached reports do still have photos before being shown. #2374
         - Delete cache photos upon photo moderation. #2374

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -243,6 +243,7 @@ sub load_updates : Private {
         my $last_history = $problem;
         foreach my $history (@history) {
             push @combined, [ $history->created, {
+                id => 'm' . $history->id,
                 type => 'moderation',
                 last => $last_history,
                 entry => $history,

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -255,7 +255,7 @@ sub load_updates : Private {
     $c->stash->{updates} = \@combined;
 
     if ($c->sessionid) {
-        foreach (qw(alert_to_reporter anonymized moderate_errors)) {
+        foreach (qw(alert_to_reporter anonymized)) {
             $c->stash->{$_} = $c->flash->{$_} if $c->flash->{$_};
         }
     }

--- a/perllib/FixMyStreet/Roles/Moderation.pm
+++ b/perllib/FixMyStreet/Roles/Moderation.pm
@@ -7,12 +7,18 @@ Return most recent AdminLog object concerning moderation
 
 =cut
 
+sub latest_moderation {
+    my $self = shift;
+
+    return $self->moderation_original_datas->search(
+        $self->moderation_filter,
+        { order_by => { -desc => 'id' } })->first;
+}
+
 sub latest_moderation_log_entry {
     my $self = shift;
 
-    my $latest = $self->moderation_original_datas->search(
-        $self->moderation_filter,
-        { order_by => { -desc => 'id' } })->first;
+    my $latest = $self->latest_moderation;
     return unless $latest;
 
     my $rs = $self->result_source->schema->resultset("AdminLog");

--- a/t/app/controller/moderate.t
+++ b/t/app/controller/moderate.t
@@ -139,6 +139,20 @@ subtest 'Problem moderation' => sub {
         is $history[1]->title, 'Good good', 'Correct second title';
     };
 
+    subtest 'Post modified title after edited elsewhere' => sub {
+        $mech->submit_form_ok({ with_fields => {
+            %problem_prepopulated,
+            problem_title => 'Good good',
+            form_started => 1, # January 1970!
+        }});
+        $mech->base_like( qr{\Q/moderate$REPORT_URL\E} );
+        $mech->content_contains('Good bad good'); # Displayed title
+        $mech->content_contains('Good good'); # Form edit
+
+        $report->discard_changes;
+        is $report->title, 'Good bad good', 'title unchanged';
+    };
+
     subtest 'Make anonymous' => sub {
         $mech->content_lacks('Reported anonymously');
 

--- a/templates/web/base/report/_main.html
+++ b/templates/web/base/report/_main.html
@@ -121,7 +121,7 @@ can_moderate_title = c.user.can_moderate_title(problem, can_moderate)
         </p>
         <p>
             <input type="submit" class="green-btn" value="[% loc('Save changes') %]">
-            <input type="button" class="btn cancel" value="[% loc('Discard changes') %]">
+            <input type="button" class="hidden-nojs btn cancel" value="[% loc('Discard changes') %]">
         </p>
     </div>
   [% END %]

--- a/templates/web/base/report/_main.html
+++ b/templates/web/base/report/_main.html
@@ -1,4 +1,5 @@
 [%
+USE date;
 can_moderate = permissions.moderate OR c.user.can_moderate(problem, staff = permissions.moderate)
 can_moderate_title = c.user.can_moderate_title(problem, can_moderate)
 %]
@@ -43,6 +44,7 @@ can_moderate_title = c.user.can_moderate_title(problem, can_moderate)
     [% original = problem_original %]
     <form method="post" action="/moderate/report/[% problem.id %]">
         <input type="hidden" name="token" value="[% csrf_token %]">
+        <input type="hidden" name="form_started" value="[% date.now %]">
   [% END %]
 
   [% FOR error IN moderate_errors %]
@@ -54,11 +56,11 @@ can_moderate_title = c.user.can_moderate_title(problem, can_moderate)
     <div class="moderate-edit">
       [% IF problem.title != original.title %]
         <label>
-            <input type="checkbox" name="problem_revert_title" class="revert-title">
+            <input type="checkbox" name="problem_revert_title" class="revert-title"[% " checked" IF c.req.params.problem_revert_title %]>
             [% loc('Revert to original title') %]
         </label>
       [% END %]
-        <h1><input class="form-control" type="text" name="problem_title" value="[% problem.title | html %]" data-original-value="[% original.title | html %]"></h1>
+        <h1><input class="form-control" type="text" name="problem_title" value="[% (c.req.params.problem_title || problem.title) | html %]" data-original-value="[% original.title | html %]"></h1>
     </div>
   [% ELSE %]
     <h1>[% problem.title | html %]</h1>
@@ -66,7 +68,7 @@ can_moderate_title = c.user.can_moderate_title(problem, can_moderate)
 
     <div class="moderate-edit">
         <label>
-            <input type="checkbox" name="problem_show_name" [% 'checked' UNLESS problem.anonymous %]>
+            <input type="checkbox" name="problem_show_name" [% 'checked' IF !problem.anonymous OR c.req.params.problem_show_name %]>
             [% loc('Show reporter&rsquo;s name') %]
         </label>
     </div>
@@ -89,7 +91,7 @@ can_moderate_title = c.user.can_moderate_title(problem, can_moderate)
     [% IF problem.photo or original.photo %]
         <p class="moderate-edit">
             <label>
-                <input type="checkbox" name="problem_photo" [% problem.photo ? 'checked' : '' %]>
+                <input type="checkbox" name="problem_photo" [% 'checked' IF problem.photo OR c.req.params.problem_photo %]>
                 [% loc('Show photo') %]
             </label>
         </p>
@@ -105,23 +107,23 @@ can_moderate_title = c.user.can_moderate_title(problem, can_moderate)
     <p class="moderate-edit">
       [% IF problem.detail != original.detail %]
         <label>
-            <input type="checkbox" name="problem_revert_detail" class="revert-textarea">
+            <input type="checkbox" name="problem_revert_detail" class="revert-textarea"[% ' checked' IF c.req.params.problem_revert_detail %]>
             [% loc('Revert to original text') %]
         </label>
       [% END %]
-        <textarea class="form-control" name="problem_detail" data-original-value="[% original.detail | html %]">[% problem.detail | html %]</textarea>
+        <textarea class="form-control" name="problem_detail" data-original-value="[% original.detail | html %]">[% (c.req.params.problem_detail || problem.detail) | html %]</textarea>
     </p>
 
     <div class="moderate-edit">
         <p>
             <label>
-                <input type="checkbox" class="hide-document" name="problem_hide" [% problem.hidden ? 'checked' : '' %]>
+                <input type="checkbox" class="hide-document" name="problem_hide" [% 'checked' IF problem.hidden OR c.req.params.problem_hide %]>
                 [% loc('Hide entire report') %]
             </label>
         </p>
         <p>
             <label for="moderation_reason">[% loc('Describe why you are moderating this') %]</label>
-            <input type="text" class="form-control" name="moderation_reason">
+            <input type="text" class="form-control" name="moderation_reason" value="[% (c.req.params.moderation_reason || '') | html %]">
         </p>
         <p>
             <input type="submit" class="green-btn" value="[% loc('Save changes') %]">

--- a/templates/web/base/report/_main.html
+++ b/templates/web/base/report/_main.html
@@ -45,6 +45,10 @@ can_moderate_title = c.user.can_moderate_title(problem, can_moderate)
         <input type="hidden" name="token" value="[% csrf_token %]">
   [% END %]
 
+  [% FOR error IN moderate_errors %]
+    <p class="form-error js-moderation-error">[% error %]</p>
+  [% END %]
+
   [% IF can_moderate_title %]
     <h1 class="moderate-display">[% problem.title | html %]</h1>
     <div class="moderate-edit">

--- a/templates/web/base/report/update.html
+++ b/templates/web/base/report/update.html
@@ -56,7 +56,7 @@
                     <label for="moderation_reason">[% loc('Describe why you are moderating this') %]</label>
                     <input type="text" class="form-control" name="moderation_reason">
                     <input type="submit" class="green-btn" value="[% loc('Save changes') %]">
-                    <input type="button" class="btn cancel" value="[% loc('Discard changes') %]">
+                    <input type="button" class="hidden-nojs btn cancel" value="[% loc('Discard changes') %]">
                 </div>
                 </form>
             [% END %]

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -400,6 +400,7 @@ $.extend(fixmystreet.set_up, {
 
               $elem.find('.cancel').click( function () {
                   $elem.toggleClass('show-moderation');
+                  $('.js-moderation-error').hide();
                   $('#map_sidebar').scrollTop(word === 'problem' ? 0 : $elem[0].offsetTop);
               });
 


### PR DESCRIPTION
Two commits - the first stops the redirect on any error in moderation, doesn't commit changes to the db until the end, and tidies up the related code a bit; the second then adds a new error if it looks like the report has been edited since you started, reshowing the form (hopefully with all your changes still present, bit worried about that bit) and a link to the latest history (hooray that it's already being shown, made that easy at least).