### PR TITLE
[UK Councils] Only load map JavaScript on map pages.

### DIFF
--- a/templates/web/fixmystreet-uk-councils/footer_extra_js.html
+++ b/templates/web/fixmystreet-uk-councils/footer_extra_js.html
@@ -1,5 +1,12 @@
 [% scripts.push(
-    version('/vendor/OpenLayers.Projection.OrdnanceSurvey.js')
     version('/cobrands/fixmystreet-uk-councils/js.js'),
-    version('/cobrands/highways/assets.js'),
 ) %]
+[%~
+IF bodyclass.match('mappage');
+    scripts.push(
+        version('/vendor/OpenLayers.Projection.OrdnanceSurvey.js'),
+        version('/cobrands/fixmystreet/assets.js'),
+        version('/cobrands/highways/assets.js'),
+    );
+END
+%]

--- a/templates/web/oxfordshire/footer_extra_js.html
+++ b/templates/web/oxfordshire/footer_extra_js.html
@@ -1,8 +1,12 @@
-[% scripts.push(
+[%
+IF bodyclass.match('mappage');
+  scripts.push(
     version('/cobrands/fixmystreet/assets.js'),
     version('/vendor/OpenLayers.Projection.OrdnanceSurvey.js'),
     version('/cobrands/oxfordshire/js.js'),
     version('/cobrands/oxfordshire/assets.js'),
     version('/cobrands/highways/assets.js'),
     version('/cobrands/fixmystreet-uk-councils/council_validation_rules.js'),
-) %]
+  );
+END;
+%]


### PR DESCRIPTION
And load main assets script so highways script does not error. [skip changelog]

In mysociety/fixmystreet@0e8c7453c highways/assets.js was added to council footer JS, which assumes fixmystreet/assets.js is loaded which it isn't on all cobrands. I assume easiest fix is to also include fixmystreet/assets.js in line before highways/assets.js and have that load on all pages (and wrap it al in a `IF mappage` statement) but wanted someone to check/confirm that :)