### PR TITLE
Stop keys/values in category extra data "List" field lost when saving 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
         - Remove any use of `my $x if $foo`. #2377
         - Fix saving of inspect form data offline.
         - Add CSRF and time to contact form.
+        - Make sure admin metadata dropdown index numbers are updated too.
 
 * v2.5 (21st December 2018)
     - Front end improvements:

--- a/perllib/FixMyStreet/Cobrand/BathNES.pm
+++ b/perllib/FixMyStreet/Cobrand/BathNES.pm
@@ -96,8 +96,9 @@ sub default_show_name { 0 }
 sub default_map_zoom { 3 }
 
 sub map_js_extra {
-    my ($self, $c) = @_;
+    my $self = shift;
 
+    my $c = $self->{c};
     return unless $c->user_exists;
 
     my $banes_user = $c->user->from_body && $c->user->from_body->areas->{$self->council_area_id};

--- a/templates/web/base/admin/extra-metadata-form.html
+++ b/templates/web/base/admin/extra-metadata-form.html
@@ -12,7 +12,7 @@
         <div class="admin-hint"><p>[% loc('Whether the field is displayed to the user, included as a hidden field and automatically populated, or set by the server upon Open311 submission. This field is usually set automatically.') %]</p></div>
         <label>
             [% loc('Automated') %]
-            <select name="metadata[[% loop.index %]].automated" data-field-name="automated" class="js-metadata-item-type">
+            <select name="metadata[[% loop.index %]].automated" data-field-name="automated">
                 <option value="" [% meta.automated == '' ? 'selected' : '' %]></option>
                 <option value="server_set" [% meta.automated == 'server_set' ? 'selected' : '' %]>[% loc('Server Set') %]</option>
                 <option value="hidden_field" [% meta.automated == 'hidden_field' ? 'selected' : '' %]>[% loc('Hidden Field') %]</option>

--- a/templates/web/base/common_header_tags.html
+++ b/templates/web/base/common_header_tags.html
@@ -38,7 +38,7 @@
     <link rel="prefetch" href="[% version('/cobrands/fixmystreet/fixmystreet.js') %]">
 [% END %]
 [% IF NOT bodyclass.match('mappage') %]
-    [% FOR script IN map_js.merge(c.cobrand.call_hook('map_js_extra', c)) %]
+    [% FOR script IN map_js.merge(c.cobrand.call_hook('map_js_extra')) %]
         <link rel="prefetch" href="[% IF script.match('^/'); version(script); ELSE; script; END %]">
     [% END %]
     <link rel="prefetch" href="[% version('/cobrands/fixmystreet/map.js') %]">

--- a/templates/web/base/common_scripts.html
+++ b/templates/web/base/common_scripts.html
@@ -47,7 +47,7 @@ IF c.user_exists AND (c.user.from_body OR c.user.is_superuser);
 END;
 
 IF bodyclass.match('mappage');
-    FOR script IN map_js.merge(c.cobrand.call_hook('map_js_extra', c));
+    FOR script IN map_js.merge(c.cobrand.call_hook('map_js_extra'));
         IF script.match('^/');
             scripts.push(version(script));
         ELSE;

--- a/web/cobrands/fixmystreet/admin.js
+++ b/web/cobrands/fixmystreet/admin.js
@@ -165,7 +165,7 @@ $(function(){
 
     function renumber_metadata_fields($item) {
         var item_index = $item.data("index");
-        $item.find("input[data-field-name").each(function(i) {
+        $item.find("[data-field-name]").each(function(i) {
             var $input = $(this);
             var prefix = "metadata["+item_index+"].";
             var name = prefix + $input.data("fieldName");


### PR DESCRIPTION
Also the automated setting was being dropped in the same scenario, as both selects had the wrong ID number. Fixes #2369.