### PR TITLE
Allow Open311 codes starting with ‘_’ to function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
         - Remove any use of `my $x if $foo`. #2377
         - Fix saving of inspect form data offline.
         - Add CSRF and time to contact form.
+        - Fix issue with Open311 codes starting with ‘_’.
 
 * v2.5 (21st December 2018)
     - Front end improvements:

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -373,7 +373,7 @@ sub inspect : Private {
     my $permissions = $c->stash->{_permissions};
 
     $c->forward('/admin/categories_for_point');
-    $c->stash->{report_meta} = { map { $_->{name} => $_ } @{ $c->stash->{problem}->get_extra_fields() } };
+    $c->stash->{report_meta} = { map { 'x' . $_->{name} => $_ } @{ $c->stash->{problem}->get_extra_fields() } };
 
     if ($c->cobrand->can('council_area_id')) {
         my $priorities_by_category = FixMyStreet::App->model('DB::ResponsePriority')->by_categories($c->cobrand->council_area_id, @{$c->stash->{contacts}});

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1078,7 +1078,7 @@ sub set_report_extras : Private {
         foreach my $field ( @$metas ) {
             if ( lc( $field->{required} ) eq 'true' && !$c->cobrand->category_extra_hidden($field)) {
                 unless ( $c->get_param($param_prefix . $field->{code}) ) {
-                    $c->stash->{field_errors}->{ $field->{code} } = _('This information is required');
+                    $c->stash->{field_errors}->{ 'x' . $field->{code} } = _('This information is required');
                 }
             }
             push @extra, {
@@ -1093,7 +1093,7 @@ sub set_report_extras : Private {
         if ( scalar @$contacts );
 
     if ( @extra ) {
-        $c->stash->{report_meta} = { map { $_->{name} => $_ } @extra };
+        $c->stash->{report_meta} = { map { 'x' . $_->{name} => $_ } @extra };
         $c->stash->{report}->set_extra_fields( @extra );
     }
 }

--- a/templates/web/base/report/new/category_extras_fields.html
+++ b/templates/web/base/report/new/category_extras_fields.html
@@ -1,27 +1,28 @@
 [%- FOR meta IN metas %]
   [%- meta_name = meta.code -%]
+  [%- x_meta_name = 'x' _ meta.code # For report_meta and field_erros lookup, as TT hides codes starting "_" -%]
 
   [% IF c.cobrand.category_extra_hidden(meta) AND NOT show_hidden %]
 
-      <input type="hidden" value="[% report_meta.$meta_name.value | html %]" name="[% cat_prefix %][% meta_name %]" id="[% cat_prefix %]form_[% meta_name %]">
+      <input type="hidden" value="[% report_meta.$x_meta_name.value | html %]" name="[% cat_prefix %][% meta_name %]" id="[% cat_prefix %]form_[% meta_name %]">
 
   [% ELSIF meta.variable != 'false' || NOT hide_notices %]
 
       <label for="[% cat_prefix %]form_[% meta_name %]">[% meta.description %]</label>
       [% TRY %][% INCLUDE 'report/new/_category_extra_field_notice.html' %][% CATCH file %][% END %]
-      [% IF field_errors.$meta_name %]
-      <p class='form-error'>[% field_errors.$meta_name %]</p>
+      [% IF field_errors.$x_meta_name %]
+      <p class='form-error'>[% field_errors.$x_meta_name %]</p>
       [% END -%]
       [% IF meta.variable != 'false' %]
         [% IF meta.exists('values') %]
           <select class="form-control" name="[% cat_prefix %][% meta_name %]" id="[% cat_prefix %]form_[% meta_name %]"[% meta.required == 'true' ? ' required' : '' %]>
             <option value="">[% loc('-- Pick an option --') %]</option>
             [% FOR option IN meta.values %]
-              <option value="[% option.key %]"[% IF option.key == report_meta.$meta_name.value %] selected[% END %]>[% option.name %]</option>
+              <option value="[% option.key %]"[% IF option.key == report_meta.$x_meta_name.value %] selected[% END %]>[% option.name %]</option>
             [% END %]
           </select>
         [% ELSE %]
-          <input class="form-control" type="[% meta.fieldtype OR 'text' %]" value="[% report_meta.$meta_name.value | html %]" name="[% cat_prefix %][% meta_name %]" id="[% cat_prefix %]form_[% meta_name %]"[% meta.required == 'true' ? ' required' : '' %]>
+          <input class="form-control" type="[% meta.fieldtype OR 'text' %]" value="[% report_meta.$x_meta_name.value | html %]" name="[% cat_prefix %][% meta_name %]" id="[% cat_prefix %]form_[% meta_name %]"[% meta.required == 'true' ? ' required' : '' %]>
         [% END %]
       [% END %]
 


### PR DESCRIPTION
Template Toolkit treats keys starting with ‘_’ as private and does not expose them. It is possible for an Open311 server to return fields starting with an underscore, and we want to use those in the template.