### PR TITLE
Make front page cache time configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
         - Fix saving of inspect form data offline.
         - Add CSRF and time to contact form.
         - Make sure admin metadata dropdown index numbers are updated too.
+    - Development improvements:
+        - Make front page cache time configurable.
 
 * v2.5 (21st December 2018)
     - Front end improvements:

--- a/conf/general.yml-docker
+++ b/conf/general.yml-docker
@@ -95,7 +95,7 @@ PHOTO_STORAGE_OPTIONS:
                     # it doesn't already exist. Requires the appropriate AWS
                     # permissions.
 #  REGION: 'eu-west-1' # optional, only used if CREATE_BUCKET is set. Controls
-# which AWS region the S3 bucket will be created in.
+                       # which AWS region the S3 bucket will be created in.
 
 # Location of MapIt, to map points to administrative areas, and what types of
 # area from it you want to use. If left blank, a default area will be used
@@ -224,6 +224,10 @@ GAZE_URL: 'https://gaze.mysociety.org/gaze'
 # Memcached host
 # This can be safely left out and will default to '127.0.0.1' even if not present.
 MEMCACHED_HOST: 'memcached.svc'
+
+# Cache timeout - integer, optional, default 3600s (1 hour)
+# Used for cache of front page stats/recent list, and /reports max-age.
+CACHE_TIMEOUT: 3600
 
 # Should problem reports link to the council summary pages?
 AREA_LINKS_FROM_PROBLEMS: '0'

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -221,6 +221,10 @@ GAZE_URL: 'https://gaze.mysociety.org/gaze'
 # This can be safely left out and will default to '127.0.0.1' even if not present.
 MEMCACHED_HOST: '127.0.0.1'
 
+# Cache timeout - integer, optional, default 3600s (1 hour)
+# Used for cache of front page stats/recent list, and /reports max-age.
+CACHE_TIMEOUT: 3600
+
 # Should problem reports link to the council summary pages?
 AREA_LINKS_FROM_PROBLEMS: '0'
 

--- a/docs/customising/config.md
+++ b/docs/customising/config.md
@@ -50,6 +50,7 @@ The following are all the configuration settings that you can change in `conf/ge
 * <code><a href="#open311_limit">OPEN311_LIMIT</a></code>
 * <code><a href="#all_reports_per_page">ALL_REPORTS_PER_PAGE</a></code>
 * <code><a href="#area_links_from_problems">AREA_LINKS_FROM_PROBLEMS</a></code>
+* <code><a href="#cache_timeout">CACHE_TIMEOUT</a></code>
 
 ### URLs and directories
 
@@ -1088,6 +1089,14 @@ ALLOWED_COBRANDS:
         </li>
       </ul>
     </div>
+  </dd>
+
+  <dt>
+    <a name="cache_timeout"><code>CACHE_TIMEOUT</code></a>
+  </dt>
+  <dd>
+    The time, in seconds, that the front page stats/recent list should be cached for.
+    Also used for the max-age of <code>/reports</code>. Defaults to 3600s (1 hour).
   </dd>
 
   <dt>

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -74,7 +74,8 @@ sub index : Path : Args(0) {
     }
 
     # Down here so that error pages aren't cached.
-    $c->response->header('Cache-Control' => 'max-age=3600');
+    my $max_age = FixMyStreet->config('CACHE_TIMEOUT') // 3600;
+    $c->response->header('Cache-Control' => 'max-age=' . $max_age);
 }
 
 =head2 display_body_stats

--- a/perllib/FixMyStreet/DB/ResultSet/Problem.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Problem.pm
@@ -67,6 +67,10 @@ sub to_body {
 
 # Front page statistics
 
+sub _cache_timeout {
+    FixMyStreet->config('CACHE_TIMEOUT') // 3600;
+}
+
 sub recent_fixed {
     my $rs = shift;
     my $key = "recent_fixed:$site_key";
@@ -76,7 +80,7 @@ sub recent_fixed {
             state => [ FixMyStreet::DB::Result::Problem->fixed_states() ],
             lastupdate => { '>', \"current_timestamp-'1 month'::interval" },
         } )->count;
-        Memcached::set($key, $result, 3600);
+        Memcached::set($key, $result, _cache_timeout());
     }
     return $result;
 }
@@ -90,7 +94,7 @@ sub number_comments {
             { 'comments.state' => 'confirmed' },
             { join => 'comments' }
         )->count;
-        Memcached::set($key, $result, 3600);
+        Memcached::set($key, $result, _cache_timeout());
     }
     return $result;
 }
@@ -105,7 +109,7 @@ sub recent_new {
             state => [ FixMyStreet::DB::Result::Problem->visible_states() ],
             confirmed => { '>', \"current_timestamp-'$interval'::interval" },
         } )->count;
-        Memcached::set($key, $result, 3600);
+        Memcached::set($key, $result, _cache_timeout());
     }
     return $result;
 }
@@ -157,7 +161,7 @@ sub _recent {
             $probs = [ grep { $_->photo && ! $_->is_hidden } @$probs ];
         } else {
             $probs = [ $rs->search( $query, $attrs )->all ];
-            Memcached::set($key, $probs, 3600);
+            Memcached::set($key, $probs, _cache_timeout());
         }
     }
 


### PR DESCRIPTION
Add a configuration variable to use for the front page stats/ recent list, plus the max-age of `/reports`. Fixes #2375.

Please check the following:
- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog