### PR TITLE
[fixmystreet.com] Improve two-tier unresponsive.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
         - Fix issue with Open311 codes starting with ‘_’.
     - Development improvements:
         - Make front page cache time configurable.
+        - Better working of /fakemapit/ under https.
 
 * v2.5 (21st December 2018)
     - Front end improvements:

--- a/perllib/FixMyStreet/App.pm
+++ b/perllib/FixMyStreet/App.pm
@@ -237,9 +237,9 @@ sub setup_request {
     $c->stash->{map_js} = FixMyStreet::Map::map_javascript();
 
     unless ( FixMyStreet->config('MAPIT_URL') ) {
-        my $port = $c->req->uri->port;
-        $host = "$host:$port" unless $port == 80;
-        mySociety::MaPit::configure( "http://$host/fakemapit/" );
+        my $host_port = $c->req->uri->host_port;
+        my $scheme = $c->req->uri->scheme;
+        mySociety::MaPit::configure( "$scheme://$host_port/fakemapit/" );
     }
 
     $c->stash->{has_fixed_state} = FixMyStreet::DB::Result::Problem::fixed_states->{fixed};

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -1807,9 +1807,9 @@ subtest "unresponsive body handling works" => sub {
         my $body_id = $contact1->body->id;
         my $extra_details = $mech->get_ok_json('/report/new/ajax?latitude=55.952055&longitude=-3.189579');
         like $extra_details->{top_message}, qr{Edinburgh.*accept reports.*/unresponsive\?body=$body_id};
-        is $extra_details->{unresponsive}, $body_id, "unresponsive json set";
+        is_deeply $extra_details->{unresponsive}, { $body_id => 1 }, "unresponsive json set";
         $extra_details = $mech->get_ok_json('/report/new/category_extras?category=Street%20lighting&latitude=55.952055&longitude=-3.189579');
-        is $extra_details->{unresponsive}, $body_id, "unresponsive json set";
+        is_deeply $extra_details->{unresponsive}, { $body_id => 1 }, "unresponsive json set";
 
         my $test_email = 'test-2@example.com';
         $mech->log_out_ok;
@@ -1886,7 +1886,7 @@ subtest "unresponsive body handling works" => sub {
         $extra_details = $mech->get_ok_json('/report/new/ajax?latitude=51.896268&longitude=-2.093063');
         like $extra_details->{by_category}{$contact3->category}{category_extra}, qr/Cheltenham.*Trees.*unresponsive.*category=Trees/s;
         $extra_details = $mech->get_ok_json('/report/new/category_extras?category=Trees&latitude=51.896268&longitude=-2.093063');
-        is $extra_details->{unresponsive}, $contact3->body->id, "unresponsive json set";
+        is_deeply $extra_details->{unresponsive}, { $contact3->body->id => 1 }, "unresponsive json set";
 
         $mech->get_ok('/around');
         $mech->submit_form_ok( { with_fields => { pc => 'GL50 2PR', } }, "submit location" );

--- a/templates/web/fixmystreet.com/report/new/unresponsive_body.html
+++ b/templates/web/fixmystreet.com/report/new/unresponsive_body.html
@@ -1,8 +1,10 @@
-[% SET soon = bodies.$body_id.name == 'Northamptonshire County Council' %]
+[%
+SET first = body_id.keys.first; # Might be more than one, but showing one will do
+SET soon = bodies.$first.name == 'Northamptonshire County Council' %]
 <div class="box-warning">
     <h1>Important message</h1>
     <p>
-        <span class="unresponsive-council">[% bodies.$body_id.name %]</span> doesn’t currently accept
+        <span class="unresponsive-council">[% bodies.$first.name %]</span> doesn’t currently accept
       [% IF soon %]
         FixMyStreet reports – though it will do so soon.
       [% ELSE %]
@@ -12,6 +14,7 @@
         reports from third party reporting sites such as FixMyStreet.
       [% END %]
     </p>
-    <p>We can make your report public, but [% 'at the moment' IF soon %] we can’t send it to the council.</p>
-    <a href="[% c.cobrand.base_url %]/unresponsive?body=[% body_id %][% IF category %];category=[% category | uri %][% END %]" class="btn">[% soon ? 'Find out more' : 'What can I do instead?' %]</a>
+    <p>We can make your report public, but [% 'at the moment' IF soon %] we can’t send it to
+    [% IF bodies.size > 1 %] that [% ELSE %] the [% END %] council.</p>
+    <a href="[% c.cobrand.base_url %]/unresponsive?body=[% first %][% IF category %];category=[% category | uri %][% END %]" class="btn">[% soon ? 'Find out more' : 'What can I do instead?' %]</a>
 </div>


### PR DESCRIPTION
Similarly to 1f69e28c, we were previously only checking the first matching entry, which led to confusing behaviour in places. Include consequential amendments for e.g. one body being unresponsive, the other not.