### PR TITLE
[Bromley] Store service_sub_code as subcategory.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -20,6 +20,15 @@ sub report_validation {
     return $errors;
 }
 
+# This makes sure that the subcategory Open311 attribute question is
+# also stored in the report's subcategory column. This could be done
+# in process_open311_extras, but seemed easier to keep that separate
+sub report_new_munge_before_insert {
+    my ($self, $report) = @_;
+
+    $report->subcategory($report->get_extra_field_value('service_sub_code'));
+}
+
 sub base_url {
     my $self = shift;
     return $self->next::method() if FixMyStreet->config('STAGING_SITE');

--- a/templates/web/bromley/admin/category-checkboxes.html
+++ b/templates/web/bromley/admin/category-checkboxes.html
@@ -1,0 +1,18 @@
+  <p>
+    <strong>[% loc('Categories:') %]</strong>
+  </p>
+  <ul>
+    <li>
+      [% loc('Select:') %]
+      <a href="#" data-select-all>[% loc('all') %]</a> /
+      <a href="#" data-select-none>[% loc('none') %]</a>
+    </li>
+    [% FOR contact IN c.cobrand.add_admin_subcategories # Bromley-specific function %]
+      <li>
+        <label title="[% contact.email | html %]">
+          <input type="checkbox" name="contacts[[% contact.id %]]" [% 'checked' IF contact.active %]/>
+          [% contact.category %]
+        </label>
+      </li>
+    [% END %]
+  </ul>


### PR DESCRIPTION
Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1271