### PR TITLE
Add parameter to URL when “Show older” clicked.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
         - Add CSRF and time to contact form.
         - Make sure admin metadata dropdown index numbers are updated too.
         - Fix issue with Open311 codes starting with ‘_’.
+        - Add parameter to URL when “Show older” clicked.
     - Development improvements:
         - Make front page cache time configurable.
         - Better working of /fakemapit/ under https.

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -483,10 +483,9 @@ $.extend(fixmystreet.utils, {
         }
         var qs = fixmystreet.utils.parse_query_string();
 
-        var show_old_reports = '';
+        var show_old_reports = replace_query_parameter(qs, 'show_old_reports', 'show_old_reports');
         var page = $('.pagination:first').data('page');
         if (page > 1) {
-            show_old_reports = replace_query_parameter(qs, 'show_old_reports', 'show_old_reports');
             qs.p = page;
         } else {
             delete qs.p;


### PR DESCRIPTION
The behaviour should be the same whether “Show older” or “Show older reports” is clicked, but only the latter was updating the URL. Fixes #2397.