### PR TITLE
Don't ask for email on alert signup if logged in.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@
         - Delete cache photos upon photo moderation. #2374
         - Remove any use of `my $x if $foo`. #2377
         - Fix saving of inspect form data offline.
-        - Add CSRF and time to contact form.
-        - Make sure admin metadata dropdown index numbers are updated too.
-        - Fix issue with Open311 codes starting with ‘_’.
-        - Add parameter to URL when “Show older” clicked.
+        - Add CSRF and time to contact form. #2388
+        - Make sure admin metadata dropdown index numbers are updated too. #2369
+        - Fix issue with Open311 codes starting with ‘_’. #2391
+        - Add parameter to URL when “Show older” clicked. #2397
+        - Don't ask for email on alert signup if logged in. #2402
     - Development improvements:
         - Make front page cache time configurable.
         - Better working of /fakemapit/ under https.

--- a/templates/web/base/report/display_tools.html
+++ b/templates/web/base/report/display_tools.html
@@ -43,13 +43,15 @@
         </a>
         [% loc('Receive email when updates are left on this problem.' ) %]</p>
         <fieldset>
+      [% IF c.user_exists %]
+        <input class="green-btn" type="submit" name="alert" value="[% loc('Subscribe') %]">
+      [% ELSE %]
         <label for="alert_rznvy">[% loc('Your email') %]</label>
         <div class="form-txt-submit-box">
-          [% IF NOT c.user_exists %]
             <input type="email" class="form-control" name="rznvy" id="alert_rznvy" value="[% email | html %]" size="30">
-          [% END %]
-            <input class="green-btn" type="submit" value="[% loc('Subscribe') %]">
+            <input class="green-btn" type="submit" name="alert" value="[% loc('Subscribe') %]">
         </div>
+      [% END %]
         <input type="hidden" name="token" value="[% csrf_token %]">
         <input type="hidden" name="id" value="[% problem.id %]">
         <input type="hidden" name="type" value="updates">


### PR DESCRIPTION
The “Get updates” flow on a report page, if logged in, was showing an input label but no input field (because one is not needed), but then on submission asking for your email address. Add missing name on submit button to fix this.

- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
