### PR TITLE
[FixaMinGata] Adds a cobrand hook (threshold for responsiveness top 5 list)

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Dashboard.pm
+++ b/perllib/FixMyStreet/App/Controller/Dashboard.pm
@@ -292,7 +292,7 @@ sub generate_summary_figures {
 sub generate_body_response_time : Private {
     my ( $self, $c ) = @_;
 
-    my $avg = $c->stash->{body}->calculate_average;
+    my $avg = $c->stash->{body}->calculate_average($c->cobrand->call_hook("body_responsiveness_threshold"));
     $c->stash->{body_average} = $avg ? int($avg / 60 / 60 / 24 + 0.5) : 0;
 }
 

--- a/perllib/FixMyStreet/Cobrand/FixaMinGata.pm
+++ b/perllib/FixMyStreet/Cobrand/FixaMinGata.pm
@@ -185,4 +185,11 @@ sub always_view_body_contribute_details {
     return 1;
 }
 
+# Average responsiveness will only be calculated if a body
+# has at least this many fixed reports.
+# (Used in the Top 5 list in /reports)
+sub body_responsiveness_threshold {
+    return 5;
+}
+
 1;

--- a/perllib/FixMyStreet/DB/Result/Body.pm
+++ b/perllib/FixMyStreet/DB/Result/Body.pm
@@ -215,6 +215,7 @@ sub calculate_average {
         ],
         'me.id' => \"= ($substmt)",
         'me.state' => 'confirmed',
+        'problem.state' => [ FixMyStreet::DB::Result::Problem->visible_states() ],
     }, {
         select   => [
             { extract => "epoch from me.confirmed-problem.confirmed", -as => 'time' },

--- a/perllib/FixMyStreet/Script/UpdateAllReports.pm
+++ b/perllib/FixMyStreet/Script/UpdateAllReports.pm
@@ -269,7 +269,7 @@ sub calculate_top_five_bodies {
 
     my $bodies = FixMyStreet::DB->resultset('Body')->search;
     while (my $body = $bodies->next) {
-        my $avg = $body->calculate_average;
+        my $avg = $body->calculate_average($cobrand_cls->call_hook("body_responsiveness_threshold"));
         push @top_five_bodies, { name => $body->name, days => int($avg / 60 / 60 / 24 + 0.5) }
             if defined $avg;
     }


### PR DESCRIPTION
This adds an optional threshold so that a body with very few fixed reports don't end up in the top 5 list under /reports.

I haven't tested the change in App/Controller/Dashboard.pm, am I supposed to be able to see the responsiveness somewhere under /dashboard? Or should I look somewhere else?

Fixes #1957
