### PR TITLE
[Buckinghamshire] Add contributed_by to CSV export

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -197,6 +197,39 @@ sub default_map_zoom { 3 }
 
 sub enable_category_groups { 1 }
 
+sub _dashboard_export_add_columns {
+    my $self = shift;
+    my $c = $self->{c};
+
+    push @{$c->stash->{csv}->{headers}}, "Staff User";
+    push @{$c->stash->{csv}->{columns}}, "staff_user";
+
+    # All staff users, for contributed_by lookup
+    my @user_ids = $c->model('DB::User')->search(
+        { from_body => $self->body->id },
+        { columns => [ 'id', 'email', ] })->all;
+    my %user_lookup = map { $_->id => $_->email } @user_ids;
+
+    $c->stash->{csv}->{extra_data} = sub {
+        my $report = shift;
+        my $staff_user = '';
+        if (my $contributed_by = $report->get_extra_metadata('contributed_by')) {
+            $staff_user = $user_lookup{$contributed_by};
+        }
+        return {
+            staff_user => $staff_user,
+        };
+    };
+}
+
+sub dashboard_export_updates_add_columns {
+    shift->_dashboard_export_add_columns;
+}
+
+sub dashboard_export_problems_add_columns {
+    shift->_dashboard_export_add_columns;
+}
+
 # Enable adding/editing of parish councils in the admin
 sub add_extra_areas {
     my ($self, $areas) = @_;

--- a/perllib/FixMyStreet/TestMech.pm
+++ b/perllib/FixMyStreet/TestMech.pm
@@ -716,4 +716,15 @@ sub encoded_content {
     return encode_utf8($self->content);
 }
 
+sub content_as_csv {
+    my $self = shift;
+    open my $data_handle, '<', \$self->content;
+    my $csv = Text::CSV->new({ binary => 1 });
+    my @rows;
+    while (my $row = $csv->getline($data_handle)) {
+        push @rows, $row;
+    }
+    return @rows;
+}
+
 1;

--- a/t/app/controller/dashboard.t
+++ b/t/app/controller/dashboard.t
@@ -167,12 +167,7 @@ FixMyStreet::override_config {
             areas => ",$alt_area_id,2651,",
         });
         $mech->get_ok('/dashboard?export=1');
-        open my $data_handle, '<', \$mech->content;
-        my $csv = Text::CSV->new( { binary => 1 } );
-        my @rows;
-        while ( my $row = $csv->getline( $data_handle ) ) {
-            push @rows, $row;
-        }
+        my @rows = $mech->content_as_csv;
         is scalar @rows, 19, '1 (header) + 18 (reports) = 19 lines';
 
         is scalar @{$rows[0]}, 20, '20 columns present';
@@ -209,12 +204,7 @@ FixMyStreet::override_config {
 
     subtest 'export updates as csv' => sub {
         $mech->get_ok('/dashboard?updates=1&export=1');
-        open my $data_handle, '<', \$mech->content;
-        my $csv = Text::CSV->new( { binary => 1 } );
-        my @rows;
-        while ( my $row = $csv->getline( $data_handle ) ) {
-            push @rows, $row;
-        }
+        my @rows = $mech->content_as_csv;
         is scalar @rows, 15, '1 (header) + 14 (updates) = 15 lines';
         is scalar @{$rows[0]}, 8, '8 columns present';
 

--- a/t/cobrand/bathnes.t
+++ b/t/cobrand/bathnes.t
@@ -64,12 +64,7 @@ subtest 'extra CSV columns are absent if permission not granted' => sub {
 
     $mech->get_ok('/dashboard?export=1');
 
-    open my $data_handle, '<', \$mech->content;
-    my $csv = Text::CSV->new( { binary => 1 } );
-    my @rows;
-    while ( my $row = $csv->getline( $data_handle ) ) {
-        push @rows, $row;
-    }
+    my @rows = $mech->content_as_csv;
     is scalar @rows, 5, '1 (header) + 4 (reports) = 5 lines';
 
     is scalar @{$rows[0]}, 20, '20 columns present';
@@ -125,12 +120,7 @@ subtest 'extra CSV columns are present if permission granted' => sub {
 
     $mech->get_ok('/dashboard?export=1');
 
-    open my $data_handle, '<', \$mech->content;
-    my $csv = Text::CSV->new( { binary => 1 } );
-    my @rows;
-    while ( my $row = $csv->getline( $data_handle ) ) {
-        push @rows, $row;
-    }
+    my @rows = $mech->content_as_csv;
     is scalar @rows, 5, '1 (header) + 4 (reports) = 5 lines';
 
     is scalar @{$rows[0]}, 24, '24 columns present';
@@ -194,13 +184,7 @@ subtest 'extra CSV columns are present if permission granted' => sub {
 
     $mech->get_ok('/dashboard?export=1&updates=1');
 
-    open $data_handle, '<', \$mech->content;
-    $csv = Text::CSV->new( { binary => 1 } );
-    @rows = ();
-    while ( my $row = $csv->getline( $data_handle ) ) {
-        push @rows, $row;
-    }
-
+    @rows = $mech->content_as_csv;
     is scalar @rows, 1, '1 (header) + 0 (updates)';
     is scalar @{$rows[0]}, 10, '10 columns present';
     is_deeply $rows[0],

--- a/t/cobrand/fixmystreet.t
+++ b/t/cobrand/fixmystreet.t
@@ -59,12 +59,7 @@ FixMyStreet::override_config {
         });
 
         $mech->get_ok('/reports/Birmingham/summary?csv=1');
-        open my $data_handle, '<', \$mech->content;
-        my $csv = Text::CSV->new( { binary => 1 } );
-        my @rows;
-        while ( my $row = $csv->getline( $data_handle ) ) {
-            push @rows, $row;
-        }
+        my @rows = $mech->content_as_csv;
         is scalar @rows, 101, '1 (header) + 100 (reports) = 101 lines';
 
         is scalar @{$rows[0]}, 10, '10 columns present';


### PR DESCRIPTION
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
Fixes https://github.com/mysociety/fixmystreet-freshdesk/issues/49