### PR TITLE
[open311] optionally use fixmystreet_id to match update to problem

### DIFF
--- a/perllib/Open311/GetServiceRequestUpdates.pm
+++ b/perllib/Open311/GetServiceRequestUpdates.pm
@@ -91,7 +91,7 @@ sub update_comments {
 
         # If there's no request id then we can't work out
         # what problem it belongs to so just skip
-        next unless $request_id;
+        next unless $request_id || $request->{fixmystreet_id};
 
         my $comment_time = eval {
             DateTime::Format::W3CDTF->parse_datetime( $request->{updated_datetime} || "" );
@@ -101,9 +101,19 @@ sub update_comments {
         next if @args && ($updated lt $args[0] || $updated gt $args[1]);
 
         my $problem;
+        my $match_field = 'external_id';
         my $criteria = {
             external_id => $request_id,
         };
+
+        # in some cases we only have the FMS id and not the request id so use that
+        if ( $request->{fixmystreet_id} ) {
+            $criteria = {
+                id => $request->{fixmystreet_id},
+            };
+            $match_field = 'fixmystreet id';
+        }
+
         $problem = $self->schema->resultset('Problem')->to_body($body)->search( $criteria );
 
         if (my $p = $problem->first) {
@@ -198,7 +208,7 @@ sub update_comments {
         # we get lots of comments that are not related to FMS issues from Lewisham so ignore those otherwise
         # way too many warnings.
         } elsif (FixMyStreet->config('STAGING_SITE') and $body->name !~ /Lewisham/) {
-            warn "Failed to match comment to problem with external_id $request_id for " . $body->name . "\n";
+            warn "Failed to match comment to problem with $match_field $request_id for " . $body->name . "\n";
         }
     }
 


### PR DESCRIPTION
If an update has a fixmystreet_id field then use the contents of that in
preference to the external_id field to match an update to a problem.

This handles the case where a report in a third party system passes
through different types (eg inspection and defect), resulting in the
external id changing. In this case it is sometimes possible to include
the fixmystreet id in each type and hence use that to match things up at
the fixmystreet side.

Please check the following:

- [ ] Whether this PR should include changes to any documentation, or the FAQ;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [ ] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
