### PR TITLE
Make sure raw RABX column is utf8-encoded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
         - Add space below "map page" contents on narrow screens.
         - Use relative report links where possible. #1995
         - Improve inline checkbox spacing. #2411
+        - Prevent duplicate contact history creation with Unicode data.
     - Development improvements:
         - Make front page cache time configurable.
         - Better working of /fakemapit/ under https.


### PR DESCRIPTION
Without doing this, a call to e.g. `$contact->set_extra_fields(@meta)` in PopulateServiceList.pm, with an unchanged meta that contains some Unicode values, can write to the database (and cause an unneeded row in the history table), because the column from the database is UTF-8 decoded, whilst the new text is UTF-8 encoded.

It looks like an attempt was made in filter_from_storage to fix this issue, but the column comparison for marking a column as dirty takes place without this being called.

- [ ] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog