### PR TITLE
Show all Open311 extra fields in edit admin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
         - Use relative report links where possible. #1995
         - Improve inline checkbox spacing. #2411
         - Prevent duplicate contact history creation with Unicode data.
+        - Show all Open311 extra fields in edit admin.
     - Development improvements:
         - Make front page cache time configurable.
         - Better working of /fakemapit/ under https.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
         - Add space below "map page" contents on narrow screens.
         - Use relative report links where possible. #1995
         - Improve inline checkbox spacing. #2411
+        - Prevent duplicate contact history creation with Unicode data.
     - Development improvements:
         - Make front page cache time configurable.
         - Better working of /fakemapit/ under https.

--- a/perllib/FixMyStreet/DB/Result/Contact.pm
+++ b/perllib/FixMyStreet/DB/Result/Contact.pm
@@ -96,10 +96,7 @@ sub category_display {
 
 sub get_metadata_for_editing {
     my $self = shift;
-    my $id_field = $self->id_field;
     my @metadata = @{$self->get_extra_fields};
-    # First, ones we always want to ignore (hard-coded, old system)
-    @metadata = grep { $_->{code} !~ /^(easting|northing|closest_address|$id_field)$/ } @metadata;
 
     # Just in case the extra data is in an old parsed format
     foreach (@metadata) {


### PR DESCRIPTION
Otherwise any such fields are lost upon a manual edit.

- [ ] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog