### PR TITLE
[Buckinghamshire] Send drainage reports via email as well as Open311

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -107,11 +107,17 @@ sub open311_post_send {
     # Check Open311 was successful
     return unless $row->external_id;
 
-    # For Flytipping, send an email also
-    return unless $row->category eq 'Flytipping';
+    # For certain categories, send an email also
+    my $addresses = {
+        'Flytipping' => [ join('@', 'illegaldumpingcosts', $self->admin_user_domain), "TfB" ],
+        'Blocked drain' => [ join('@', 'floodmanagement', $self->admin_user_domain), "Flood Management" ],
+        'Ditch issue' => [ join('@', 'floodmanagement', $self->admin_user_domain), "Flood Management" ],
+        'Flooded subway' => [ join('@', 'floodmanagement', $self->admin_user_domain), "Flood Management" ],
+    };
+    my $dest = $addresses->{$row->category};
+    return unless $dest;
 
-    my $e = join('', 'illegaldumpingcosts', '@', $self->admin_user_domain);
-    my $sender = FixMyStreet::SendReport::Email->new( to => [ [ $e, 'TfB' ] ] );
+    my $sender = FixMyStreet::SendReport::Email->new( to => [ $dest ] );
     $sender->send($row, $h);
 }
 


### PR DESCRIPTION
Bucks want drainage reports sent via email as well as Confirm.

Includes a slight refactor of `Buckinghamshire::open311_post_send` to allow multiple categories to be sent via email once they've been sent to Confirm.

Fixes mysociety/fixmystreet-commercial#1306

Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
