### PR TITLE
[Oxfordshire] always send easting/northing over open311

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -178,13 +178,11 @@ sub open311_config {
 
     my $extra = $row->get_extra_fields;
     push @$extra, { name => 'external_id', value => $row->id };
+    push @$extra, { name => 'northing', value => $h->{northing} };
+    push @$extra, { name => 'easting', value => $h->{easting} };
 
     if ($h->{closest_address}) {
         push @$extra, { name => 'closest_address', value => "$h->{closest_address}" }
-    }
-    if ( $row->used_map || ( !$row->used_map && !$row->postcode ) ) {
-        push @$extra, { name => 'northing', value => $h->{northing} };
-        push @$extra, { name => 'easting', value => $h->{easting} };
     }
     $row->set_extra_fields( @$extra );
 


### PR DESCRIPTION
Remove the config that stopped us sending easting/northing if the user
had not clicked the map.

Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
