### PR TITLE
[BANES,Bucks,Lincs] Include reference in .com confirm sent email

### DIFF
--- a/perllib/FixMyStreet/Cobrand/BathNES.pm
+++ b/perllib/FixMyStreet/Cobrand/BathNES.pm
@@ -151,7 +151,7 @@ sub available_permissions {
     return $permissions;
 }
 
-sub report_sent_confirmation_email { 1 }
+sub report_sent_confirmation_email { 'id' }
 
 sub lookup_usrn {
     my $self = shift;

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -447,7 +447,7 @@ sub should_skip_sending_update {
 
 sub disable_phone_number_entry { 1 }
 
-sub report_sent_confirmation_email { 1 }
+sub report_sent_confirmation_email { 'external_id' }
 
 sub is_council_with_case_management { 1 }
 

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -1031,7 +1031,7 @@ sub report_check_for_errors {
     );
 }
 
-sub report_sent_confirmation_email { 0; }
+sub report_sent_confirmation_email { '' }
 
 =item never_confirm_reports
 

--- a/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
@@ -20,7 +20,7 @@ sub is_two_tier { 1 }
 
 sub enable_category_groups { 1 }
 sub send_questionnaires { 0 }
-sub report_sent_confirmation_email { 1 }
+sub report_sent_confirmation_email { 'external_id' }
 
 sub admin_user_domain { 'lincolnshire.gov.uk' }
 

--- a/perllib/FixMyStreet/Script/Reports.pm
+++ b/perllib/FixMyStreet/Script/Reports.pm
@@ -127,10 +127,19 @@ sub send(;$) {
             $missing = join(' / ', @missing) if @missing;
         }
 
+        my $send_confirmation_email = $cobrand->report_sent_confirmation_email;
+
         my @dear;
         my %reporters = ();
         my $skip = 0;
         while (my $body = $bodies->next) {
+            # See if this body wants confirmation email (in case report made on national site, for example)
+            if (my $cobrand_body = $body->get_cobrand_handler) {
+                if (my $id_ref = $cobrand_body->report_sent_confirmation_email) {
+                    $send_confirmation_email = $id_ref;
+                }
+            }
+
             my $sender_info = $cobrand->get_body_sender( $body, $row->category );
             my $sender = "FixMyStreet::SendReport::" . $sender_info->{method};
 
@@ -243,7 +252,8 @@ sub send(;$) {
                 whensent => \'current_timestamp',
                 lastupdate => \'current_timestamp',
             } );
-            if ( $cobrand->report_sent_confirmation_email && !$h{anonymous_report}) {
+            if ($send_confirmation_email && !$h{anonymous_report}) {
+                $h{sent_confirm_id_ref} = $row->$send_confirmation_email;
                 _send_report_sent_email( $row, \%h, $nomail, $cobrand );
             }
             debug_print("send successful: OK", $row->id) if $debug_mode;

--- a/t/app/controller/report_as_other.t
+++ b/t/app/controller/report_as_other.t
@@ -123,7 +123,7 @@ subtest "Body user, has permission to add report as another (existing) user with
 
     my $send_confirmation_mail_override = Sub::Override->new(
         "FixMyStreet::Cobrand::Default::report_sent_confirmation_email",
-        sub { return 1; }
+        sub { return 'external_id'; }
     );
     FixMyStreet::Script::Reports::send();
     $mech->email_count_is(2);
@@ -168,7 +168,7 @@ subtest "Body user, has permission to add report as anonymous user" => sub {
 
     my $send_confirmation_mail_override = Sub::Override->new(
         "FixMyStreet::Cobrand::Default::report_sent_confirmation_email",
-        sub { return 1; }
+        sub { return 'external_id'; }
     );
 
     FixMyStreet::Script::Reports::send();

--- a/t/app/model/problem.t
+++ b/t/app/model/problem.t
@@ -633,7 +633,7 @@ subtest 'check can set multiple emails as a single contact' => sub {
 subtest 'check can turn on report sent email alerts' => sub {
     my $send_confirmation_mail_override = Sub::Override->new(
         "FixMyStreet::Cobrand::Default::report_sent_confirmation_email",
-        sub { return 1; }
+        sub { return 'external_id'; }
     );
     $mech->clear_emails_ok;
 

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -51,9 +51,10 @@ my ($report) = $mech->create_problems_for_body(1, $body->id, 'On Road', {
 
 subtest 'flytipping on road sent to extra email' => sub {
     FixMyStreet::Script::Reports::send();
-    my $email = $mech->get_email;
+    my @email = $mech->get_email;
     my $tfb = join('', 'illegaldumpingcosts', '@', 'buckscc.gov.uk');
-    is $email->header('To'), '"TfB" <' . $tfb . '>';
+    is $email[0]->header('To'), '"TfB" <' . $tfb . '>';
+    like $mech->get_text_body_from_email($email[1]), qr/report's reference number/;
     $report->discard_changes;
     is $report->external_id, 248, 'Report has right external ID';
 };
@@ -67,10 +68,11 @@ subtest 'flytipping on road sent to extra email' => sub {
     },
 });
 
-subtest 'pothole on road not sent to extra email' => sub {
+subtest 'pothole on road not sent to extra email, only confirm sent' => sub {
     $mech->clear_emails_ok;
     FixMyStreet::Script::Reports::send();
-    $mech->email_count_is(0);
+    $mech->email_count_is(1);
+    like $mech->get_text_body_from_email, qr/report's reference number/;
     $report->discard_changes;
     is $report->external_id, 248, 'Report has right external ID';
 };
@@ -96,9 +98,10 @@ my ($report2) = $mech->create_problems_for_body(1, $body->id, 'Drainage problem'
 subtest 'blocked drain sent to extra email' => sub {
     $mech->clear_emails_ok;
     FixMyStreet::Script::Reports::send();
-    my $email = $mech->get_email;
+    my @email = $mech->get_email;
     my $e = join('@', 'floodmanagement', 'buckscc.gov.uk');
-    is $email->header('To'), '"Flood Management" <' . $e . '>';
+    is $email[0]->header('To'), '"Flood Management" <' . $e . '>';
+    like $mech->get_text_body_from_email($email[1]), qr/report's reference number/;
 };
 
 $cobrand = FixMyStreet::Cobrand::Buckinghamshire->new();

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -76,13 +76,14 @@ subtest 'pothole on road not sent to extra email' => sub {
 };
 
 ($report) = $mech->create_problems_for_body(1, $district->id, 'Off Road', {
-    category => 'Flytipping', cobrand => 'fixmystreet',
+    category => 'Flytipping', cobrand => 'buckinghamshire',
     latitude => 51.813173, longitude => -0.826741,
 });
 subtest 'flytipping off road sent to extra email' => sub {
     FixMyStreet::Script::Reports::send();
-    my $email = $mech->get_email;
-    is $email->header('To'), '"Chiltern" <flytipping@chiltern>';
+    my @email = $mech->get_email;
+    is $email[0]->header('To'), '"Chiltern" <flytipping@chiltern>';
+    like $mech->get_text_body_from_email($email[1]), qr/Please note that Buckinghamshire County Council is not responsible/;
     $report->discard_changes;
     is $report->external_id, undef, 'Report has right external ID';
 };

--- a/templates/email/buckinghamshire/other-reported.html
+++ b/templates/email/buckinghamshire/other-reported.html
@@ -12,8 +12,8 @@ INCLUDE '_email_top.html';
   [% start_padded_box %]
   <h1 style="[% h1_style %]">Your report has been&nbsp;logged</h1>
   <p style="[% p_style %]">Your report to [% report.body %] has been logged on [% site_name %].</p>
-[% IF c.cobrand.is_council && !c.cobrand.owns_problem( report ) %]
-<p style="[% p_style %]">Please note that [% c.cobrand.council_name %] is not responsible for this type
+[% IF cobrand.is_council && !cobrand.owns_problem( report ) %]
+<p style="[% p_style %]">Please note that [% cobrand.council_name %] is not responsible for this type
 of report, so it will instead be sent to [% report.body %].</p>
 [% ELSE %]
 [% TRY %][% INCLUDE '_council_reference.html' problem=report %][% CATCH file %][% END %]

--- a/templates/email/buckinghamshire/other-reported.txt
+++ b/templates/email/buckinghamshire/other-reported.txt
@@ -4,8 +4,8 @@ Hello [% report.name %],
 
 Your report to [% report.body %] has been logged on [% site_name %].
 
-[% IF c.cobrand.is_council && !c.cobrand.owns_problem( report ) %]
-Please note that [% c.cobrand.council_name %] is not responsible for this type
+[% IF cobrand.is_council && !cobrand.owns_problem( report ) %]
+Please note that [% cobrand.council_name %] is not responsible for this type
 of report, so it will instead be sent to [% report.body %].
 [% ELSE %]
 [% TRY %][% INCLUDE '_council_reference.txt' problem=report %][% CATCH file %][% END %]

--- a/templates/email/default/other-reported.html
+++ b/templates/email/default/other-reported.html
@@ -12,8 +12,8 @@ INCLUDE '_email_top.html';
   [% start_padded_box %]
   <h1 style="[% h1_style %]">Your report has been&nbsp;logged</h1>
   <p style="[% p_style %]">Your report to [% report.body %] has been logged on [% site_name %].</p>
-[% IF c.cobrand.is_council && !c.cobrand.owns_problem( report ) %]
-<p style="[% p_style %]">Please note that [% c.cobrand.council_name %] is not responsible for this type
+[% IF cobrand.is_council && !cobrand.owns_problem( report ) %]
+<p style="[% p_style %]">Please note that [% cobrand.council_name %] is not responsible for this type
 of report, so it will instead be sent to [% report.body %].</p>
 [% ELSE %]
 [% TRY %][% INCLUDE '_council_reference.html' problem=report %][% CATCH file %][% END %]

--- a/templates/email/default/other-reported.txt
+++ b/templates/email/default/other-reported.txt
@@ -4,8 +4,8 @@ Hello [% report.name %],
 
 Your report to [% report.body %] has been logged on [% site_name %].
 
-[% IF c.cobrand.is_council && !c.cobrand.owns_problem( report ) %]
-Please note that [% c.cobrand.council_name %] is not responsible for this type
+[% IF cobrand.is_council && !cobrand.owns_problem( report ) %]
+Please note that [% cobrand.council_name %] is not responsible for this type
 of report, so it will instead be sent to [% report.body %].
 [% ELSE %]
 [% TRY %][% INCLUDE '_council_reference.txt' problem=report %][% CATCH file %][% END %]

--- a/templates/email/fixamingata/other-reported.html
+++ b/templates/email/fixamingata/other-reported.html
@@ -12,8 +12,8 @@ INCLUDE '_email_top.html';
   [% start_padded_box %]
   <h1 style="[% h1_style %]">Din rapport har&nbsp;loggats</h1>
   <p style="[% p_style %]">Din rapport till [% report.body %] har blivit loggad på [% site_name %].
-[% IF c.cobrand.is_council && !c.cobrand.owns_problem( report ) %]
-Eftersom [% c.cobrand.council_name %] inte är ansvarig för den här typen av
+[% IF cobrand.is_council && !cobrand.owns_problem( report ) %]
+Eftersom [% cobrand.council_name %] inte är ansvarig för den här typen av
 rapporter, så kommer rapporten istället att skickas till [% report.body %].
 [% END %]
   </p>

--- a/templates/email/fixamingata/other-reported.txt
+++ b/templates/email/fixamingata/other-reported.txt
@@ -4,8 +4,8 @@ Hej [% report.name %],
 
 Din rapport till [% report.body %] har blivit loggad på [% site_name %].
 
-[% IF c.cobrand.is_council && !c.cobrand.owns_problem( report ) %]
-Eftersom [% c.cobrand.council_name %] inte är ansvarig för den här typen av
+[% IF cobrand.is_council && !cobrand.owns_problem( report ) %]
+Eftersom [% cobrand.council_name %] inte är ansvarig för den här typen av
 rapporter, så kommer rapporten istället att skickas till [% report.body %].
 [% END %]
 

--- a/templates/email/fixmystreet.com/_council_reference.html
+++ b/templates/email/fixmystreet.com/_council_reference.html
@@ -1,0 +1,4 @@
+[% IF sent_confirm_id_ref ~%]
+<p style="[% p_style %]">The report's reference number is <strong>[% sent_confirm_id_ref %]</strong>.
+  Please quote this if you need to contact the council about this report.</p>
+[%~ END %]

--- a/templates/email/fixmystreet.com/_council_reference.txt
+++ b/templates/email/fixmystreet.com/_council_reference.txt
@@ -1,0 +1,4 @@
+[% IF sent_confirm_id_ref ~%]
+The report's reference number is [% sent_confirm_id_ref %]. Please quote this
+if you need to contact the council about this report.
+[%~ END %]

--- a/templates/email/fixmystreet.com/confirm_report_sent.html
+++ b/templates/email/fixmystreet.com/confirm_report_sent.html
@@ -1,0 +1,1 @@
+[% INCLUDE 'other-reported.html' %]

--- a/templates/email/fixmystreet.com/confirm_report_sent.txt
+++ b/templates/email/fixmystreet.com/confirm_report_sent.txt
@@ -1,0 +1,1 @@
+[% INCLUDE 'other-reported.txt' %]


### PR DESCRIPTION
And fix bug where two-tier message not appearing in confirm sent email.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1273 [skip changelog]
