### PR TITLE
A tidy up of some category change bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
         - Proper bodies check for sending updates.
         - Check better if extra question has values.
         - Stop filter category overriding chosen category.
+        - Allow things to reset if "Pick a category" picked.
     - Development improvements:
         - Make front page cache time configurable.
         - Better working of /fakemapit/ under https.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
         - Show all Open311 extra fields in edit admin.
         - Proper bodies check for sending updates.
         - Check better if extra question has values.
+        - Stop filter category overriding chosen category.
     - Development improvements:
         - Make front page cache time configurable.
         - Better working of /fakemapit/ under https.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
         - Check better if extra question has values.
         - Stop filter category overriding chosen category.
         - Allow things to reset if "Pick a category" picked.
+        - Stop category_change firing more than it should.
     - Development improvements:
         - Make front page cache time configurable.
         - Better working of /fakemapit/ under https.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
         - Stop filter category overriding chosen category.
         - Allow things to reset if "Pick a category" picked.
         - Stop category_change firing more than it should.
+        - Fix extra question display when only one category.
     - Development improvements:
         - Make front page cache time configurable.
         - Better working of /fakemapit/ under https.

--- a/templates/web/base/report/new/category.html
+++ b/templates/web/base/report/new/category.html
@@ -1,7 +1,15 @@
+[%
+# If only one option, pre-select that as if it were already selected. This
+# carries through to the category_extras template because this template is
+# included with PROCESS.
+IF category_options.size == 2;
+    category = category_options.1.category;
+END
+~%]
 [% IF category_options.size OR category_groups.size ~%]
     [%~ BLOCK category_option ~%]
     [% cat_op_lc = cat_op.category | lower =%]
-    <option value='[% cat_op.category | html %]'[% ' selected' IF report.category == cat_op.category || category_lc == cat_op_lc || (category_options.size == 2 AND loop.last) ~%]
+    <option value='[% cat_op.category | html %]'[% ' selected' IF report.category == cat_op.category || category_lc == cat_op_lc ~%]
     >[% IF loop.first %][% cat_op.category_display %][% ELSE %][% cat_op.category_display | html %][% END %]
     [%~ IF cat_op.get_extra_metadata('help_text') %] ([% cat_op.get_extra_metadata('help_text') %])[% END ~%]
     </option>

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1170,15 +1170,22 @@ fixmystreet.update_pin = function(lonlat, savePushState) {
         }
         $('#side-form, #site-logo').show();
         var category_group = $('#category_group').val(),
-          old_category = $("select#form_category").val();
+            old_category = $("#form_category").val(),
+            filter_category = $("#filter_categories").val();
 
         fixmystreet.reporting_data = data;
 
         fixmystreet.update_councils_text(data);
         $('#js-top-message').html(data.top_message || '');
+
         $('#form_category_row').html(data.category);
-        if ($("select#form_category option[value=\""+old_category+"\"]").length) {
-            $("select#form_category").val(old_category);
+        if ($("#form_category option[value=\"" + old_category + "\"]").length) {
+            $("#form_category").val(old_category);
+        } else if (filter_category !== undefined && $("#form_category option[value='" + filter_category + "']").length) {
+            // If the category filter appears on the map and the user has selected
+            // something from it, then pre-fill the category field in the report,
+            // if it's a value already present in the drop-down.
+            $("#form_category").val(filter_category);
         }
         if ( data.extra_name_info && !$('#form_fms_extra_title').length ) {
             // there might be a first name field on some cobrands
@@ -1190,14 +1197,6 @@ fixmystreet.update_pin = function(lonlat, savePushState) {
         fixmystreet.bodies = data.bodies || [];
         if (fixmystreet.body_overrides) {
             fixmystreet.body_overrides.clear();
-        }
-
-        // If the category filter appears on the map and the user has selected
-        // something from it, then pre-fill the category field in the report,
-        // if it's a value already present in the drop-down.
-        var category = $("#filter_categories").val();
-        if (category !== undefined && $("#form_category option[value='"+category+"']").length) {
-            $("#form_category").val(category);
         }
 
         var category_select = $("select#form_category");

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -388,23 +388,18 @@ $.extend(fixmystreet.set_up, {
             data = fixmystreet.reporting_data.by_category[category],
             $category_meta = $('#category_meta');
 
-        if (!data) {
-            // The Pick a category option, or something gone wrong
-            return;
-        }
-
-        fixmystreet.bodies = data.bodies || [];
+        fixmystreet.bodies = data && data.bodies ? data.bodies : [];
         if (fixmystreet.body_overrides) {
             fixmystreet.body_overrides.clear();
         }
 
-        if (data.councils_text) {
+        if (data && data.councils_text) {
             fixmystreet.update_councils_text(data);
         } else {
             // Use the original returned texts
             fixmystreet.update_councils_text(fixmystreet.reporting_data);
         }
-        if ( data.category_extra ) {
+        if (data && data.category_extra) {
             if ( $category_meta.length ) {
                 $category_meta.replaceWith( data.category_extra );
                 // Preserve any existing values
@@ -428,7 +423,7 @@ $.extend(fixmystreet.set_up, {
         });
         // apply new validation rules
         fixmystreet.set_up.reapply_validation(core_validation_rules);
-        $.each(data.bodies, function(index, body) {
+        $.each(fixmystreet.bodies, function(index, body) {
             if ( typeof body_validation_rules !== 'undefined' && body_validation_rules[body] ) {
                 var rules = body_validation_rules[body];
                 fixmystreet.set_up.reapply_validation(rules);

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -446,11 +446,15 @@ $.extend(fixmystreet.set_up, {
         });
   },
 
-  category_groups: function() {
-    var $category_select = $("select#form_category.js-grouped-select");
-    if ($category_select.length === 0) {
+  category_groups: function(old_group) {
+    var $category_select = $("select#form_category");
+    if (!$category_select.hasClass('js-grouped-select')) {
+        if ($category_select.val() !== '-- Pick a category --') {
+            $category_select.change();
+        }
         return;
     }
+
     var $group_select = $("<select></select>").addClass("form-control validCategory").attr('id', 'category_group');
     var $subcategory_label = $("#form_subcategory_label");
     var $empty_option = $category_select.find("option").first();
@@ -526,6 +530,10 @@ $.extend(fixmystreet.set_up, {
         }
         return a.label > b.label ? 1 : -1;
     }).appendTo($group_select);
+
+    if (old_group !== '-- Pick a category --' && $category_select.val() == '-- Pick a category --') {
+        $group_select.val(old_group);
+    }
     $group_select.change();
   },
 
@@ -1164,7 +1172,7 @@ fixmystreet.update_pin = function(lonlat, savePushState) {
             return;
         }
         $('#side-form, #site-logo').show();
-        var category_group = $('#category_group').val(),
+        var old_category_group = $('#category_group').val(),
             old_category = $("#form_category").val(),
             filter_category = $("#filter_categories").val();
 
@@ -1182,6 +1190,9 @@ fixmystreet.update_pin = function(lonlat, savePushState) {
             // if it's a value already present in the drop-down.
             $("#form_category").val(filter_category);
         }
+
+        fixmystreet.set_up.category_groups(old_category_group);
+
         if ( data.extra_name_info && !$('#form_fms_extra_title').length ) {
             // there might be a first name field on some cobrands
             var lb = $('#form_first_name').prev();
@@ -1192,15 +1203,6 @@ fixmystreet.update_pin = function(lonlat, savePushState) {
         fixmystreet.bodies = data.bodies || [];
         if (fixmystreet.body_overrides) {
             fixmystreet.body_overrides.clear();
-        }
-
-        var category_select = $("select#form_category");
-        if (category_select.val() != '-- Pick a category --') {
-            category_select.change();
-        }
-        fixmystreet.set_up.category_groups();
-        if (category_group !== '-- Pick a category --' && category_select.val() == '-- Pick a category --') {
-            $('#category_group').val(category_group).change();
         }
 
         if (data.contribute_as) {


### PR DESCRIPTION
* Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1307 (Allow things to reset if "Pick a category" picked. This is most noticable with category groups, where changing the parent would leave visible any asset/attribute questions.)
* If you had one filter category selected, clicked the map (category auto pre-selected), changed the category, and clicked the map again, it would re-select the filter category, not the changed category.
* Previously, when update_pin was called, category change events were fired: 1. if category wasn't blank, 2. if category groups were enabled, and 3. if category groups were enabled, a group was selected, and a category was not.
* If the site only has the one category, it was being preselected but the extra attribute questions were not being shown.