### PR TITLE
make sure the archive report script sets up lang etc

### DIFF
--- a/perllib/FixMyStreet/Script/ArchiveOldEnquiries.pm
+++ b/perllib/FixMyStreet/Script/ArchiveOldEnquiries.pm
@@ -138,8 +138,16 @@ sub close_problems {
     return unless $opts->{commit};
 
     my $problems = shift;
+
+    return unless $problems->count;
+
     my $extra = { auto_closed_by_script => 1 };
     $extra->{is_superuser} = 1 if !$opts->{user_name};
+
+    # need to do this again in case no reports were closed with an
+    # email in which case we won't have set the lang and domain
+    my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker($opts->{cobrand})->new();
+    $cobrand->set_lang_and_domain($problems->first->lang, 1);
 
     while (my $problem = $problems->next) {
         my $timestamp = \'current_timestamp';


### PR DESCRIPTION
Previously if no reports were closed with an email this meant that the
lang setup never ran and you got an error when _ was called in
close_problems. So, we call the lang setup in close_problems too.

Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
