### PR TITLE
[Northamptonshire] prevent report submission without asset selection

### DIFF
--- a/templates/web/fixmystreet.com/report/new/roads_message.html
+++ b/templates/web/fixmystreet.com/report/new/roads_message.html
@@ -16,4 +16,17 @@
         <p>The location you have selected doesn't appear to be on a road.</p>
         <p>Please select a road on which to make a report.</p>
     </div>
+    <div id="js-not-an-asset" class="hidden js-responsibility-message">
+        <p>Please select <span id="js-roads-asset">an item</span> from the map on which to make a report.</p>
+    </div>
+    <div id="js-not-a-speedhump" class="hidden js-responsibility-message">
+        <p>Please select <b>a speed hump</b> from the map on which to make a report.</p>
+    </div>
+    <div id="js-not-a-ped-barrier" class="hidden js-responsibility-message">
+        <p>Please select <b>a pedestrian barrier</b> from the map on which to make a report.</p>
+    </div>
+    <div id="js-not-a-prow" class="hidden js-responsibility-message">
+        <p>The location you have selected doesn't appear to be on a right of way.</p>
+        <p>Please select a right of way on which to make a report.</p>
+    </div>
 </div>

--- a/templates/web/northamptonshire/report/new/roads_message.html
+++ b/templates/web/northamptonshire/report/new/roads_message.html
@@ -1,0 +1,19 @@
+<div id="js-roads-responsibility" class="box-warning hidden">
+    <div id="js-not-an-asset" class="hidden js-responsibility-message">
+        <p>Please select <span id="js-roads-asset">an item</span> from the map on which to make a report.</p>
+    </div>
+    <div id="js-not-a-speedhump" class="hidden js-responsibility-message">
+        <p>Please select <b>a speed hump</b> from the map on which to make a report.</p>
+    </div>
+    <div id="js-not-a-ped-barrier" class="hidden js-responsibility-message">
+        <p>Please select <b>a pedestrian barrier</b> from the map on which to make a report.</p>
+    </div>
+    <div id="js-not-a-prow" class="hidden js-responsibility-message">
+        <p>The location you have selected doesn't appear to be on a right of way.</p>
+        <p>Please select a right of way on which to make a report.</p>
+    </div>
+    <div id="js-not-a-road" class="hidden js-responsibility-message">
+        <p>The location you have selected doesn't appear to be on a road.</p>
+        <p>Please select a road on which to make a report.</p>
+    </div>
+</div>

--- a/web/cobrands/northamptonshire/assets.js
+++ b/web/cobrands/northamptonshire/assets.js
@@ -483,4 +483,30 @@ fixmystreet.assets.add($.extend(true, {}, northants_road_defaults, {
     ]
 }));
 
+// Hide form when emergency category used
+function check_emergency() {
+    var relevant_body = OpenLayers.Util.indexOf(fixmystreet.bodies, northants_defaults.body) > -1;
+    var relevant_cat = !!$('label[for=form_emergency]').length;
+    var relevant = relevant_body && relevant_cat;
+    var currently_shown = !!$('#northants-emergency-message').length;
+    var body = $('#form_category').data('body');
+
+    if (relevant === currently_shown || body) {
+        // Either should be shown and already is, or shouldn't be shown and isn't
+        return;
+    }
+
+    if (!relevant) {
+        $('#northants-emergency-message').remove();
+        $('.js-hide-if-invalid-category').show();
+        return;
+    }
+
+    var $msg = $('<div class="box-warning" id="northants-emergency-message"></div>');
+    $msg.html($('label[for=form_emergency]').html());
+    $msg.insertBefore('#js-post-category-messages');
+    $('.js-hide-if-invalid-category').hide();
+}
+$(fixmystreet).on('report_new:category_change', check_emergency);
+
 })();

--- a/web/cobrands/northamptonshire/assets.js
+++ b/web/cobrands/northamptonshire/assets.js
@@ -313,6 +313,14 @@ var layers = [
 ];
 
 var northants_defaults = $.extend(true, {}, fixmystreet.assets.alloy_defaults, {
+  protocol_class: OpenLayers.Protocol.Alloy,
+  non_interactive: false,
+  body: "Northamptonshire County Council",
+  attributes: {
+    asset_resource_id: function() {
+      return this.fid;
+    }
+  },
   select_action: true,
   actions: {
     asset_found: function(asset) {
@@ -353,39 +361,23 @@ var northants_defaults = $.extend(true, {}, fixmystreet.assets.alloy_defaults, {
 $.each(layers, function(index, layer) {
     if ( layer.categories ) {
         fixmystreet.assets.add($.extend(true, {}, northants_defaults, {
-            protocol_class: OpenLayers.Protocol.Alloy,
             http_options: {
               layerid: layer.layer,
               layerVersion: layer.version,
             },
-            non_interactive: false,
             asset_type: layer.asset_type || 'spot',
-            body: "Northamptonshire County Council",
             asset_category: layer.categories,
             asset_item: layer.item_name || layer.layer_name.toLowerCase(),
-            attributes: {
-              asset_resource_id: function() {
-                return this.fid;
-              }
-            }
         }));
     }
 });
 
-fixmystreet.assets.add($.extend(true, {}, fixmystreet.assets.alloy_defaults, {
+var northants_road_defaults = $.extend(true, {}, fixmystreet.assets.alloy_defaults, {
     protocol_class: OpenLayers.Protocol.Alloy,
-    http_options: {
-      layerid: 221,
-      layerVersion: '221.4-',
-    },
     body: "Northamptonshire County Council",
     road: true,
-    asset_type: "area",
     always_visible: false,
     non_interactive: true,
-    asset_category: [
-        "Damaged Speed Humps",
-    ],
     usrn: {
         attribute: 'fid',
         field: 'asset_resource_id'
@@ -393,6 +385,17 @@ fixmystreet.assets.add($.extend(true, {}, fixmystreet.assets.alloy_defaults, {
     getUSRN: function(feature) {
       return feature.fid;
     }
+});
+
+fixmystreet.assets.add($.extend(true, {}, northants_road_defaults, {
+    http_options: {
+      layerid: 221,
+      layerVersion: '221.4-',
+    },
+    asset_type: "area",
+    asset_category: [
+        "Damaged Speed Humps",
+    ]
 }));
 
 var barrier_style = new OpenLayers.Style({
@@ -402,8 +405,7 @@ var barrier_style = new OpenLayers.Style({
     strokeWidth: 4
 });
 
-fixmystreet.assets.add($.extend(true, {}, fixmystreet.assets.alloy_defaults, {
-    protocol_class: OpenLayers.Protocol.Alloy,
+fixmystreet.assets.add($.extend(true, {}, northants_road_defaults, {
     http_options: {
       layerid: 230,
       layerVersion: '230.2-',
@@ -411,20 +413,9 @@ fixmystreet.assets.add($.extend(true, {}, fixmystreet.assets.alloy_defaults, {
     stylemap: new OpenLayers.StyleMap({
         'default': barrier_style
     }),
-    body: "Northamptonshire County Council",
-    road: true,
-    always_visible: false,
-    non_interactive: true,
     asset_category: [
         "Pedestrian Barriers - Damaged / Missing",
-    ],
-    usrn: {
-        attribute: 'fid',
-        field: 'asset_resource_id'
-    },
-    getUSRN: function(feature) {
-      return feature.fid;
-    }
+    ]
 }));
 
 var highways_style = new OpenLayers.Style({
@@ -434,8 +425,7 @@ var highways_style = new OpenLayers.Style({
     strokeWidth: 7
 });
 
-fixmystreet.assets.add($.extend(true, {}, fixmystreet.assets.alloy_defaults, {
-    protocol_class: OpenLayers.Protocol.Alloy,
+fixmystreet.assets.add($.extend(true, {}, northants_road_defaults, {
     http_options: {
       layerid: 308,
       layerVersion: '308.8-',
@@ -443,10 +433,6 @@ fixmystreet.assets.add($.extend(true, {}, fixmystreet.assets.alloy_defaults, {
     stylemap: new OpenLayers.StyleMap({
         'default': highways_style
     }),
-    body: "Northamptonshire County Council",
-    road: true,
-    always_visible: false,
-    non_interactive: true,
     asset_category: [
         "Loose / Raised/Sunken",
         "Broken / Missing",
@@ -473,14 +459,7 @@ fixmystreet.assets.add($.extend(true, {}, fixmystreet.assets.alloy_defaults, {
         "Icy Footpath",
         "Icy Road",
         "Missed published Gritted Route",
-    ],
-    usrn: {
-        attribute: 'fid',
-        field: 'asset_resource_id'
-    },
-    getUSRN: function(feature) {
-      return feature.fid;
-    }
+    ]
 }));
 
 var prow_style = new OpenLayers.Style({
@@ -490,8 +469,7 @@ var prow_style = new OpenLayers.Style({
     strokeWidth: 7
 });
 
-fixmystreet.assets.add($.extend(true, {}, fixmystreet.assets.alloy_defaults, {
-    protocol_class: OpenLayers.Protocol.Alloy,
+fixmystreet.assets.add($.extend(true, {}, northants_road_defaults, {
     http_options: {
       layerid: 173,
       layerVersion: '173.1-',
@@ -499,21 +477,10 @@ fixmystreet.assets.add($.extend(true, {}, fixmystreet.assets.alloy_defaults, {
     stylemap: new OpenLayers.StyleMap({
         'default': prow_style
     }),
-    body: "Northamptonshire County Council",
-    road: true,
-    always_visible: false,
-    non_interactive: true,
     asset_category: [
       "Livestock",
       "Passage-Obstructed/Overgrown"
-    ],
-    usrn: {
-        attribute: 'fid',
-        field: 'asset_resource_id'
-    },
-    getUSRN: function(feature) {
-      return feature.fid;
-    }
+    ]
 }));
 
 })();


### PR DESCRIPTION
Prevent users from making report unless they have selected an asset from the map.

Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
