### PR TITLE
[Northamptonshire] restrict title to 120 characters

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
@@ -94,4 +94,12 @@ sub open311_config {
 # sending updates not part of initial phase
 sub should_skip_sending_update { 1; }
 
+sub report_validation {
+    my ($self, $report, $errors) = @_;
+
+    if ( length( $report->title ) > 120 ) {
+        $errors->{title} = sprintf( _('Summaries are limited to %s characters in length. Please shorten your summary'), 120 );
+    }
+}
+
 1;

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -37,6 +37,7 @@ my @PLACES = (
     [ 'LE15 0GJ', 52.670447, -0.727877, 2600, 'Rutland County Council', 'CTY'],
     [ 'BR1 3UH', 51.4021, 0.01578, 2482, 'Bromley Council', 'LBO' ],
     [ 'BR1 3UH', 51.402096, 0.015784, 2482, 'Bromley Council', 'LBO' ],
+    [ 'NN1 1NS', 52.236251, 0.892052, 2234, 'Northamptonshire County Council', 'CTY' ],
     [ '?', 50.78301, -0.646929 ],
     [ 'TA1 1QP', 51.023569, -3.099055, 2239, 'Somerset County Council', 'CTY', 2429, 'Taunton Deane Borough Council', 'DIS' ],
     [ 'GU51 4AE', 51.279456, -0.846216, 2333, 'Hart District Council', 'DIS', 2227, 'Hampshire County Council', 'CTY' ],

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -51,6 +51,7 @@ for my $body (
     { area_id => 2232, name => 'Lincolnshire County Council' },
     { area_id => 2237, name => 'Oxfordshire County Council' },
     { area_id => 2600, name => 'Rutland County Council' },
+    { area_id => 2234, name => 'Northamptonshire County Council' },
 ) {
     my $body_obj = $mech->create_body_ok($body->{area_id}, $body->{name});
     push @bodies, $body_obj;
@@ -132,6 +133,11 @@ my $contact15 = $mech->create_contact_ok(
     body_id => $body_ids{2600}, # Rutland
     category => 'Trees',
     email => 'trees-2600@example.com',
+);
+my $contact16 = $mech->create_contact_ok(
+    body_id => $body_ids{2234}, # Northamptonshire
+    category => 'Trees',
+    email => 'trees-2234@example.com',
 );
 
 # test that the various bit of form get filled in and errors correctly
@@ -614,6 +620,26 @@ foreach my $test (
         changes => { },
         errors => [ 'Please enter a subject', 'Please enter some details', 'Emails are limited to 50 characters in length.', 'Phone numbers are limited to 20 characters in length.', 'Names are limited to 50 characters in length.'],
     },
+    {
+        msg    => 'Northamptonshire validation',
+        pc     => 'NN1 1NS',
+        fields => {
+            title         => 'This is a very long title that should fail the validation as it is really much too long to pass the validation of 120 characters',
+            detail        => '',
+            photo1        => '',
+            photo2        => '',
+            photo3        => '',
+            name          => 'A User',
+            may_show_name => '1',
+            username      => 'user@example.org',
+            phone         => '',
+            category      => 'Trees',
+            password_sign_in => '',
+            password_register => '',
+        },
+        changes => { },
+        errors => [ 'Summaries are limited to 120 characters in length. Please shorten your summary', 'Please enter some details'],
+    },
   )
 {
     subtest "check form errors where $test->{msg}" => sub {
@@ -621,7 +647,7 @@ foreach my $test (
 
         # submit initial pc form
         FixMyStreet::override_config {
-            ALLOWED_COBRANDS => [ { fixmystreet => '.' }, 'bromley', 'oxfordshire', 'rutland', 'lincolnshire', 'buckinghamshire' ],
+            ALLOWED_COBRANDS => [ { fixmystreet => '.' }, 'bromley', 'oxfordshire', 'rutland', 'lincolnshire', 'buckinghamshire', 'northamptonshire' ],
             MAPIT_URL => 'http://mapit.uk/',
         }, sub {
             $mech->submit_form_ok( { with_fields => { pc => $test->{pc} } },

--- a/templates/web/base/js/translation_strings.html
+++ b/templates/web/base/js/translation_strings.html
@@ -4,7 +4,10 @@ fixmystreet.password_minimum_length = [% c.cobrand.password_minimum_length %];
 
     translation_strings = {
         update: '[% loc('Please enter a message') | replace("'", "\\'") %]',
-        title: '[% loc('Please enter a subject') | replace("'", "\\'") %]',
+        title: {
+            required: '[% loc('Please enter a subject') | replace("'", "\\'") %]',
+            maxlength: '[% loc('Summaries are limited to {0} characters in length. Please shorten your summary') | replace("'", "\\'") %]'
+        },
         detail: {
             required: '[% loc('Please enter some details') | replace("'", "\\'") %]',
             maxlength: '[% loc('Reports are limited to {0} characters in length. Please shorten your report') | replace("'", "\\'") %]',

--- a/web/cobrands/fixmystreet-uk-councils/council_validation_rules.js
+++ b/web/cobrands/fixmystreet-uk-councils/council_validation_rules.js
@@ -43,5 +43,11 @@ body_validation_rules = {
         email: {
           maxlength: 50
         }
+    },
+    'Northamptonshire County Council': {
+        title: {
+          required: true,
+          maxlength: 120
+        }
     }
 };

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -446,6 +446,11 @@ $.extend(fixmystreet.set_up, {
             var $el = $('#form_' + name);
             if ($el.length) {
                 $el.rules('add', rule);
+                if (rule.maxlength) {
+                  $el.attr('maxlength', rule.maxlength);
+                } else {
+                  $el.removeAttr('maxlength');
+                }
             }
         });
   },


### PR DESCRIPTION
Prevent people from using very long titles.

Fixes mysociety/fixmystreet-commercial#1344

Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
