### PR TITLE
[fixmystreet.org] docs update

### DIFF
--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -46,15 +46,3 @@ href="irc/">web IRC interface</a>).</p>
 <p>You can follow and tweet <a href="https://twitter.com/fixmystreet">@fixmystreet</a>.</p>
 </div>
 </div>
-
-<div class="contact-options">
-<div class="column">
-<h3>Email</h3>
-<p>
-If you're trying to set a FixMyStreet project up outside the UK, let mySociety's
-<a href="https://www.mysociety.org/about/mysociety-around-the-world/">international team</a>
-know by emailing
-<a href="mailto:international&#64;mysociety.org">international&#64;mysociety.org</a>.</p>
-</div>
-</div>
-

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -150,8 +150,6 @@ explains why these sites work, and what you need to think about before you start
 
 If you still want to be involved, we welcome questions about how it works
 [on our mailing list]({{ "/community/" | relative_url }}).
-Or, if you're outside the UK, email
-<a href="mailto:international&#64;mysociety.org">international&#64;mysociety.org.</a>
 
 There's also the [FixMyStreet blog]({{ "/blog/" | relative_url }}) where we post version release
 information and other progress reports. And we often post FixMyStreet news on

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,7 +118,7 @@ title: Welcome
       <h3 class="secondary-heading spacer-top title">Get in touch</h3>
       <p class="tertiary-heading">Say hello, we&rsquo;ll help you make <br>your new site awesome</p>
       <ul class="action-buttons spacer-top">
-        <li><a href="mailto:international&#64;mysociety.org" class="btn--blue"><i class="icon icon-email">&nbsp;</i> Email us</a></li>
+        <li><a href="https://github.com/mysociety/fixmystreet" class="btn--blue"><i class="icon icon-github">&nbsp;</i> GitHub</a></li>
         <li><a href="https://twitter.com/fixmystreet" class="btn--blue"><i class="icon icon-twitter">&nbsp;</i> Follow us</a></li>
         <li><a href="{{ "/community/" | relative_url }}" class="btn--blue"><i class="icon icon-irc">&nbsp;</i> Chat on IRC</a></li>
         <li><a href="{{ "/community/" | relative_url }}" class="btn--blue"><i class="icon icon-post">&nbsp;</i> Mailing list</a></li>

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -25,8 +25,3 @@ If you're not technical, this can be a little daunting &mdash; if you haven't
 already done so, [get in touch]({{ "/community" | relative_url }}) and ask for help.
 
 Please also see the instructions for [updating your code](/updating/) once it's installed.
-
-If you're trying to set a FixMyStreet project up outside the UK, let the 
-[international team](https://www.mysociety.org/about/mysociety-around-the-world/)
-know by emailing
-<a href="mailto:international&#64;mysociety.org">international&#64;mysociety.org</a>.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -77,8 +77,6 @@ these sites work, and what you need to think about before you start.
 If you're thinking of getting involved, we welcome questions about how it
 works [on our mailing
 list](https://groups.google.com/a/mysociety.org/forum/#!forum/fixmystreet).
-Or, if you're outside the UK, email
-<a href="mailto:international&#64;mysociety.org">international&#64;mysociety.org.</a>
 
 There's also the [FixMyStreet blog](blog/) where we post version release
 information and other progress reports. And we often post FixMyStreet news on

--- a/docs/running/admin_manual.md
+++ b/docs/running/admin_manual.md
@@ -962,8 +962,6 @@ there.
 
 We wish you all the best with your FixMyStreet problem reporting site.
 
-If you're running an installation outside the UK please let us know by
-emailing international&#64;mysociety.org. If you have any questions, don't
-hesitate to <a href="{{ "/community/" | relative_url }}">contact us</a> and we'll get back to you as
-soon as possible with an answer.
-
+If you have any questions, don't hesitate to <a href="{{ "/community/" |
+relative_url }}">contact us</a> and we'll get back to you as soon as possible
+with an answer.


### PR DESCRIPTION
[skip changelog]

Removes the mySociety international email address from the documentation, making the Google Group the main focus for email-based interaction.