### PR TITLE
ignore always_visible layers in layer visibility change

### DIFF
--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -411,7 +411,7 @@ function layer_visibilitychanged() {
     var layers = fixmystreet.map.getLayersBy('assets', true);
     var visible = 0;
     for (var i = 0; i<layers.length; i++) {
-        if (layers[i].getVisibility()) {
+        if (!layers[i].fixmystreet.always_visible && layers[i].getVisibility()) {
             visible++;
         }
     }


### PR DESCRIPTION
Layers that are always visible mean that we can end up with a count of 1
which means we don't re-display the pin

Please check the following:


- [ ] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
