### PR TITLE
[Northamptonshire] use the correct layer environment for assets

### DIFF
--- a/web/cobrands/fixmystreet-uk-councils/alloy.js
+++ b/web/cobrands/fixmystreet-uk-councils/alloy.js
@@ -28,7 +28,7 @@ OpenLayers.Protocol.Alloy = OpenLayers.Class(OpenLayers.Protocol.HTTP, {
     },
 
     getURL: function(coords, options) {
-        return OpenLayers.String.format(options.base, {'layerid': options.layerid, 'layerVersion': options.layerVersion, 'z': 15, 'x': coords[0], 'y': coords[1]});
+        return OpenLayers.String.format(options.base, {'layerid': options.layerid, 'environment': options.environment, 'layerVersion': options.layerVersion, 'z': 15, 'x': coords[0], 'y': coords[1]});
     },
 
     getTileRange_: function(bounds, maxExtent, map) {
@@ -117,7 +117,7 @@ OpenLayers.Strategy.Alloy = OpenLayers.Class(OpenLayers.Strategy.FixMyStreet, {
 
 fixmystreet.assets.alloy_defaults = {
     http_options: {
-      base: "https://alloy-api-tile01.yotta.co.uk/api/render-layer/tile/${layerid}/28/${layerVersion}-/${z}/${x}/${y}",
+      base: "https://alloy-api-tile01.yotta.co.uk/api/render-layer/tile/${layerid}/${environment}/${layerVersion}/${z}/${x}/${y}",
     },
     format_class: OpenLayers.Format.GeoJSON,
     srsName: "EPSG:3857",

--- a/web/cobrands/northamptonshire/assets.js
+++ b/web/cobrands/northamptonshire/assets.js
@@ -360,12 +360,19 @@ OpenLayers.Layer.NCCVectorAsset = OpenLayers.Class(OpenLayers.Layer.VectorAsset,
     CLASS_NAME: 'OpenLayers.Layer.NCCVectorAsset'
 });
 
+var is_live = false;
+if ( location.hostname === 'www.fixmystreet.com' || location.hostname == 'fixmystreet.northamptonshire.gov.uk' ) {
+    is_live = true;
+}
 // default options for northants assets include
 // a) checking for multiple assets in same location
 // b) preventing submission unless an asset is selected
 var northants_defaults = $.extend(true, {}, fixmystreet.assets.alloy_defaults, {
   class: OpenLayers.Layer.NCCVectorAsset,
   protocol_class: OpenLayers.Protocol.Alloy,
+  http_options: {
+      environment: is_live ? 26 : 28
+  },
   non_interactive: false,
   body: "Northamptonshire County Council",
   attributes: {
@@ -442,6 +449,9 @@ $.each(layers, function(index, layer) {
 // an asset.
 var northants_road_defaults = $.extend(true, {}, fixmystreet.assets.alloy_defaults, {
     protocol_class: OpenLayers.Protocol.Alloy,
+    http_options: {
+        environment: is_live ? 26 : 28
+    },
     body: "Northamptonshire County Council",
     road: true,
     always_visible: false,


### PR DESCRIPTION
The tile URL includes a parameter for the client number which we were
not using so configure this based on live or staging.

Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
