### PR TITLE
[Open311] handle bad FixMyStreet id in updates

### DIFF
--- a/perllib/Open311/GetServiceRequestUpdates.pm
+++ b/perllib/Open311/GetServiceRequestUpdates.pm
@@ -108,6 +108,11 @@ sub update_comments {
 
         # in some cases we only have the FMS id and not the request id so use that
         if ( $request->{fixmystreet_id} ) {
+            unless ( $request->{fixmystreet_id} =~ /^\d+$/ ) {
+                warn "skipping bad fixmystreet id in updates for " . $body->name . ": [" . $request->{fixmystreet_id} . "], external id is $request_id\n";
+                next;
+            }
+
             $criteria = {
                 id => $request->{fixmystreet_id},
             };


### PR DESCRIPTION
If an update has a fixmystreet id in it check that it looks like an
integer and if not issue a warning and skip the update.

Please check the following:

- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
