### PR TITLE
[Northamptonshire] only clear current layer on reload

### DIFF
--- a/web/cobrands/fixmystreet-uk-councils/alloy.js
+++ b/web/cobrands/fixmystreet-uk-councils/alloy.js
@@ -11,7 +11,7 @@ OpenLayers.Protocol.Alloy = OpenLayers.Class(OpenLayers.Protocol.HTTP, {
         var rresp;
         var start = new Date();
         var max = all_tiles.length;
-        $(fixmystreet).trigger('alloy:start_request', [start, max]);
+        options.scope.newRequest(start, max);
         for (var i = 0; i < max; i++) {
             var resp = new OpenLayers.Protocol.Response({requestType: "read"});
             resp.start = start;
@@ -69,9 +69,8 @@ OpenLayers.Strategy.Alloy = OpenLayers.Class(OpenLayers.Strategy.FixMyStreet, {
     requestStart: 0,
     initialize: function(name, options) {
         OpenLayers.Strategy.FixMyStreet.prototype.initialize.apply(this, arguments);
-        $(fixmystreet).on('alloy:start_request', this.newRequest.bind(this));
     },
-    newRequest: function(evt, start, max) {
+    newRequest: function(start, max) {
       this.max = max;
       this.requestStart = start;
       this.count = 0;


### PR DESCRIPTION
Call newRequest directly rather than with an event to avoid resetting
all the layers that have been used and hence removing all the features.

Fixes mysociety/fixmystreet-commercial#1354

Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
