### PR TITLE
show open311 failure details in admin report edit page

### DIFF
--- a/templates/web/base/admin/report_edit.html
+++ b/templates/web/base/admin/report_edit.html
@@ -87,6 +87,11 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
     <input type="submit" class="btn" name="mark_sent" value="[% loc('Mark as sent') %]">
   [% END %]
 </li>
+[% IF c.user.is_superuser AND problem.send_fail_count > 0 %]
+<li class="sm">[% loc('Send Fail Count:') %] [% problem.send_fail_count %]</li>
+<li class="sm">[% loc('Last failure:') %] [% PROCESS format_time time=problem.send_fail_timestamp %]</li>
+<li class="sm truncate_height">[% loc('Reason:') %] [% problem.send_fail_reason | html %]</li>
+[% END %]
 <li class="sm">[% loc('Last update:') %] [% PROCESS format_time time=problem.lastupdate %]</li>
 <li>[% loc('Alerts:') %] [% alert_count %]</li>
 <li>[% loc('Service:') %] [% problem.service OR '<em>' _ loc('None') _ '</em>' %]</li>

--- a/web/cobrands/sass/_admin.scss
+++ b/web/cobrands/sass/_admin.scss
@@ -240,3 +240,13 @@ $button_bg_col: #a1a1a1;  // also search bar (tables)
         font-weight: normal;
     }
 }
+
+.truncate_height {
+  max-height: 3em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &:hover {
+    max-height: initial;
+  }
+}


### PR DESCRIPTION
Rather than having to go into the database to see any error details
display it in the admin. The error only shows the first few lines by
default and expands on hover.

Please check the following:

- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
