### PR TITLE
Prevent creation of two templates with same title.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Releases
 
 * Unreleased
+    - Bugfixes:
+        - Prevent creation of two templates with same title.
 
 * v2.6 (3rd May 2019)
     - New features:

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -782,6 +782,15 @@ sub template_edit : Path('templates') : Args(2) {
             }
 
             $template->title( $c->get_param('title') );
+            my $query = { title => $template->title };
+            if ($template->in_storage) {
+                $query->{id} = { '!=', $template->id };
+            }
+            if ($c->stash->{body}->response_templates->search($query)->count) {
+                $c->stash->{errors} ||= {};
+                $c->stash->{errors}->{title} = _("There is already a template with that title.");
+            }
+
             $template->text( $c->get_param('text') );
             $template->state( $c->get_param('state') );
             $template->external_status_code( $c->get_param('external_status_code') );

--- a/t/app/controller/admin/templates.t
+++ b/t/app/controller/admin/templates.t
@@ -66,6 +66,30 @@ subtest "response templates can be added" => sub {
      is $oxfordshire->response_templates->count, 1, "Response template was added";
 };
 
+subtest "but not another with the same title" => sub {
+    my $fields = {
+        title => "Report acknowledgement",
+        text => "Another report acknowledgement.",
+        auto_response => undef,
+        "contacts[".$oxfordshirecontact->id."]" => 1,
+    };
+    my $list_url = "/admin/templates/" . $oxfordshire->id;
+    $mech->get_ok( "$list_url/new" );
+    $mech->submit_form_ok( { with_fields => $fields } );
+    is $mech->uri->path, "$list_url/new", 'not redirected';
+    $mech->content_contains( 'Please correct the errors below' );
+    $mech->content_contains( 'There is already a template with that title.' );
+
+    my @ts = $oxfordshire->response_templates->all;
+    is @ts, 1, "No new response template was added";
+
+    my $url = "$list_url/" . $ts[0]->id;
+    $mech->get_ok($url);
+    $mech->submit_form_ok( { with_fields => $fields } );
+    is $mech->uri->path, $list_url, 'redirected';
+    is $oxfordshire->response_templates->count, 1, "No new response template was added";
+};
+
 subtest "response templates are included on page" => sub {
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => [ 'oxfordshire' ],

--- a/templates/web/base/admin/template_edit.html
+++ b/templates/web/base/admin/template_edit.html
@@ -13,7 +13,9 @@
         <p class="error">[% loc('Please correct the errors below') %]</p>
     [% END %]
 
-
+    [% IF errors.title %]
+        <div class="form-error">[% errors.title %]</div>
+    [% END %]
     <div class="admin-hint">
       <p>
         [% loc('This is a <strong>private</strong> name for this template so you can identify it when updating reports or editing in the admin.') %]

--- a/templates/web/zurich/admin/template_edit.html
+++ b/templates/web/zurich/admin/template_edit.html
@@ -16,6 +16,9 @@
     accept-charset="utf-8"
     class="validate">
 
+    [% IF errors.title %]
+        <div class="form-error">[% errors.title %]</div>
+    [% END %]
     <p>
         <strong>[% loc('Title:') %] </strong>
         <input type="text" name="title" class="form-control required" size="30" value="[% rt.title| html %]">


### PR DESCRIPTION
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1364