### PR TITLE
[Buckinghamshire] fix zoom level issues

### DIFF
--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -16,8 +16,11 @@ var defaults = {
     },
     format_class: OpenLayers.Format.GML.v3.MultiCurveFix,
     asset_type: 'spot',
-    max_resolution: 4.777314267158508,
-    min_resolution: 0.5971642833948135,
+    max_resolution: {
+      'buckinghamshire': 2.116670900008467,
+      'fixmystreet': 4.777314267158508
+    },
+    min_resolution: 0.00001,
     asset_id_field: 'central_as',
     attributes: {
         central_asset_id: 'central_as',


### PR DESCRIPTION
Allows assets to display when zoomed in.
Remove very zoomed out views as not useful.

Please check the following:


- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]