### PR TITLE
display category under multiple groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
         - Mobile users can now filter the pins on the `/around` map view. #2366
     - Admin improvements:
         - Add new roles system, to group permissions and apply to users.
+    - New features:
+        - Categories can be listed under more than one group #2475
     - Bugfixes:
         - Prevent creation of two templates with same title.
         - Fix bug going between report/new pages client side

--- a/bin/browser-tests
+++ b/bin/browser-tests
@@ -75,6 +75,9 @@ sub run {
             ALLOWED_COBRANDS => $cobrand,
             MAPIT_URL => $mapit_url,
             BASE_URL => 'http://fixmystreet.localhost:3001',
+            COBRAND_FEATURES => {
+                category_groups => { map { $_ => 1 } @$cobrand },
+            }
         });
         $ENV{FMS_OVERRIDE_CONFIG} = $config_out;
 
@@ -95,10 +98,8 @@ sub run {
         kill 'TERM', $pid if $pid;
         exit $exit >> 8;
     } else {
-        use Test::MockModule;
-        my $c = Test::MockModule->new('FixMyStreet::Cobrand::FixMyStreet');
-        $c->mock('enable_category_groups', sub { 1 });
         # Child, run the server on port 3001
+        require FixMyStreet;
         FixMyStreet->test_mode(1); # So email doesn't try to send
         local $ENV{FIXMYSTREET_APP_DEBUG} = 0;
         require Plack::Runner;

--- a/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
@@ -273,8 +273,13 @@ sub update_contacts : Private {
         if ( $c->get_param('reputation_threshold') ) {
             $contact->set_extra_metadata( reputation_threshold => int($c->get_param('reputation_threshold')) );
         }
-        if ( my $group = $c->get_param('group') ) {
-            $contact->set_extra_metadata( group => $group );
+        if ( my @group = $c->get_param_list('group') ) {
+            @group = grep { $_ } @group;
+            if (scalar @group == 0) {
+                $contact->unset_extra_metadata( 'group' );
+            } else {
+                $contact->set_extra_metadata( group => \@group );
+            }
         } else {
             $contact->unset_extra_metadata( 'group' );
         }

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -741,7 +741,7 @@ sub setup_categories_and_bodies : Private {
     $c->stash->{missing_details_bodies} = \@missing_details_bodies;
     $c->stash->{missing_details_body_names} = \@missing_details_body_names;
 
-    if ( $c->cobrand->call_hook('enable_category_groups') ) {
+    if ( $c->cobrand->enable_category_groups ) {
         my %category_groups = ();
         for my $category (@category_options) {
             my $group = $category->{group} // $category->get_extra_metadata('group') // '';

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -744,8 +744,10 @@ sub setup_categories_and_bodies : Private {
     if ( $c->cobrand->enable_category_groups ) {
         my %category_groups = ();
         for my $category (@category_options) {
-            my $group = $category->{group} // $category->get_extra_metadata('group') // '';
-            push @{$category_groups{$group}}, $category;
+            my $group = $category->{group} // $category->get_extra_metadata('group') // [''];
+            # this could be an array ref or a string
+            my @groups = ref $group eq 'ARRAY' ? @$group : ($group);
+            push( @{$category_groups{$_}}, $category ) for @groups;
         }
 
         my @category_groups = ();

--- a/perllib/FixMyStreet/Cobrand/BathNES.pm
+++ b/perllib/FixMyStreet/Cobrand/BathNES.pm
@@ -74,8 +74,6 @@ sub pin_colour {
 
 sub send_questionnaires { 0 }
 
-sub enable_category_groups { 1 }
-
 sub default_map_zoom { 3 }
 
 sub map_js_extra {

--- a/perllib/FixMyStreet/Cobrand/Borsetshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Borsetshire.pm
@@ -27,6 +27,4 @@ sub send_questionnaires {
 
 sub bypass_password_checks { 1 }
 
-sub enable_category_groups { 1 }
-
 1;

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -185,8 +185,6 @@ sub map_type { 'Buckinghamshire' }
 
 sub default_map_zoom { 3 }
 
-sub enable_category_groups { 1 }
-
 sub _dashboard_export_add_columns {
     my $self = shift;
     my $c = $self->{c};

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -1085,6 +1085,18 @@ sub show_unconfirmed_reports {
     0;
 }
 
+=item enable_category_groups
+
+Whether body category groups should be displayed on the new report form. If this is
+not enabled then any groups will be ignored and a flat list of categories displayed.
+
+=cut
+
+sub enable_category_groups {
+    my $self = shift;
+    return $self->feature('category_groups');
+}
+
 sub default_problem_state { 'unconfirmed' }
 
 sub state_groups_admin {

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -1097,6 +1097,18 @@ sub enable_category_groups {
     return $self->feature('category_groups');
 }
 
+=item enable_multiple_category_groups
+
+Whether a category can be included in multiple groups. Required enable_category_groups
+to alse be true.
+
+=cut
+
+sub enable_multiple_category_groups {
+    my $self = shift;
+    return $self->enable_category_groups && $self->feature('multiple_category_groups');
+}
+
 sub default_problem_state { 'unconfirmed' }
 
 sub state_groups_admin {

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -10,8 +10,6 @@ use constant COUNCIL_ID_BROMLEY => 2482;
 
 sub on_map_default_status { return 'open'; }
 
-sub enable_category_groups { 1 }
-
 # Special extra
 sub path_to_web_templates {
     my $self = shift;

--- a/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
@@ -18,7 +18,6 @@ sub council_name { return 'Lincolnshire County Council'; }
 sub council_url { return 'lincolnshire'; }
 sub is_two_tier { 1 }
 
-sub enable_category_groups { 1 }
 sub send_questionnaires { 0 }
 sub report_sent_confirmation_email { 'external_id' }
 

--- a/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
@@ -47,8 +47,6 @@ sub privacy_policy_url {
     'https://www3.northamptonshire.gov.uk/councilservices/council-and-democracy/transparency/information-policies/privacy-notice/place/Pages/street-doctor.aspx'
 }
 
-sub enable_category_groups { 1 }
-
 sub is_two_tier { 1 }
 
 sub get_geocoder { 'OSM' }

--- a/perllib/Open311/PopulateServiceList.pm
+++ b/perllib/Open311/PopulateServiceList.pm
@@ -262,7 +262,7 @@ sub _normalize_service_name {
 sub _set_contact_group {
     my ($self, $contact) = @_;
 
-    my $groups_enabled = $self->_current_body_cobrand && $self->_current_body_cobrand->call_hook('enable_category_groups');
+    my $groups_enabled = $self->_current_body_cobrand && $self->_current_body_cobrand->enable_category_groups;
     my $old_group = $contact->get_extra_metadata('group') || '';
     my $new_group = $groups_enabled ? $self->_current_service->{group} || '' : '';
 

--- a/t/app/controller/admin/bodies.t
+++ b/t/app/controller/admin/bodies.t
@@ -1,10 +1,3 @@
-package FixMyStreet::Cobrand::Tester;
-
-use parent 'FixMyStreet::Cobrand::Default';
-
-sub enable_category_groups { 1 }
-
-package main;
 use FixMyStreet::TestMech;
 
 my $mech = FixMyStreet::TestMech->new;
@@ -210,10 +203,12 @@ subtest 'check text output' => sub {
 }; # END of override wrap
 
 FixMyStreet::override_config {
-    ALLOWED_COBRANDS => ['tester'],
     MAPIT_URL => 'http://mapit.uk/',
     MAPIT_TYPES => [ 'UTA' ],
     BASE_URL => 'http://www.example.org',
+    COBRAND_FEATURES => {
+        category_groups => { default => 1 },
+    }
 }, sub {
     subtest 'group editing works' => sub {
         $mech->get_ok('/admin/body/' . $body->id);

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -1271,11 +1271,12 @@ subtest "Test inactive categories" => sub {
 };
 
 subtest "category groups" => sub {
-    my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::FixMyStreet');
-    $cobrand->mock('enable_category_groups', sub { 1 });
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => 'fixmystreet',
         MAPIT_URL => 'http://mapit.uk/',
+        COBRAND_FEATURES => {
+            category_groups => { fixmystreet => 1 }
+        }
     }, sub {
         $contact2->update( { extra => { group => 'Roads' } } );
         $contact9->update( { extra => { group => 'Roads' } } );

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -1278,10 +1278,11 @@ subtest "category groups" => sub {
             category_groups => { fixmystreet => 1 }
         }
     }, sub {
-        $contact2->update( { extra => { group => 'Roads' } } );
+        $contact2->update( { extra => { group => ['Roads','Pavements'] } } );
         $contact9->update( { extra => { group => 'Roads' } } );
         $contact10->update( { extra => { group => 'Roads' } } );
         $mech->get_ok("/report/new?lat=$saved_lat&lon=$saved_lon");
+        $mech->content_like(qr{<optgroup label="Pavements">\s*<option value='Potholes'>Potholes</option></optgroup>});
         $mech->content_like(qr{<optgroup label="Roads">\s*<option value='Potholes'>Potholes</option>\s*<option value='Street lighting'>Street lighting</option></optgroup>});
     };
 };

--- a/t/open311/populate-service-list.t
+++ b/t/open311/populate-service-list.t
@@ -9,6 +9,7 @@ package main;
 
 use FixMyStreet::Test;
 use FixMyStreet::DB;
+use Test::Warn;
 use utf8;
 
 use_ok( 'Open311::PopulateServiceList' );
@@ -75,6 +76,147 @@ for my $test (
         };
     };
 }
+
+my $last_update = {};
+for my $test (
+    { desc => 'set multiple groups for contact', enable_multi => 1, groups => ['sanitation', 'street']  },
+    { desc => 'groups not edited if unchanged', enable_multi => 1, groups => ['sanitation', 'street'], unchanged => 1  },
+    { desc => 'multiple groups has to be configured', enable_multi => 0, groups => 'sanitation,street'},
+) {
+    subtest $test->{desc} => sub {
+        FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->delete();
+
+        my $services_xml = '<?xml version="1.0" encoding="utf-8"?>
+        <services>
+          <service>
+            <service_code>100</service_code>
+            <service_name>Cans left out 24x7</service_name>
+            <description>Garbage or recycling cans that have been left out for more than 24 hours after collection. Violators will be cited.</description>
+            <metadata>false</metadata>
+            <type>realtime</type>
+            <keywords>lorem, ipsum, dolor</keywords>
+            <group>sanitation,street</group>
+          </service>
+          <service>
+            <service_code>002</service_code>
+            <metadata>false</metadata>
+            <type>realtime</type>
+            <keywords>lorem, ipsum, dolor</keywords>
+            <group>street</group>
+            <service_name>Construction plate shifted</service_name>
+            <description>Metal construction plate covering the street or sidewalk has been moved.</description>
+          </service>
+        </services>
+        ';
+
+        my $service_list = get_xml_simple_object($services_xml);
+
+        FixMyStreet::override_config {
+            ALLOWED_COBRANDS => [ 'tester' ],
+            COBRAND_FEATURES => {
+               category_groups => { tester => 1 },
+               multiple_category_groups => { tester => $test->{enable_multi} },
+            }
+        }, sub {
+            my $processor = Open311::PopulateServiceList->new();
+            $processor->_current_body( $body );
+            $processor->process_services( $service_list );
+        };
+        my $contact_count = FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->count();
+        is $contact_count, 2, 'correct number of contacts';
+
+        my $contact = FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id, email => 100 } )->first;
+        is_deeply $contact->get_extra->{group}, $test->{groups}, "Multi groups set correctly";
+        if ($test->{unchanged}) {
+            is $contact->whenedited, $last_update->{100}, "contact unchanged";
+        }
+        $last_update->{100} = $contact->whenedited;
+
+        $contact = FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id, email => '002'} )->first;
+        is $contact->get_extra->{group}, 'street', "Single groups set correctly";
+        if ($test->{unchanged}) {
+            is $contact->whenedited, $last_update->{002}, "contact unchanged";
+        }
+        $last_update->{002} = $contact->whenedited;
+    };
+}
+
+subtest "set multiple groups with quoted csv" => sub {
+    FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->delete();
+
+    my $services_xml = '<?xml version="1.0" encoding="utf-8"?>
+    <services>
+      <service>
+        <service_code>100</service_code>
+        <service_name>Cans left out 24x7</service_name>
+        <description>Garbage or recycling cans that have been left out for more than 24 hours after collection. Violators will be cited.</description>
+        <metadata>false</metadata>
+        <type>realtime</type>
+        <keywords>lorem, ipsum, dolor</keywords>
+        <group>&quot;sanitation &amp; cleaning&quot;,street</group>
+      </service>
+    </services>
+    ';
+
+    my $service_list = get_xml_simple_object($services_xml);
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'tester' ],
+        COBRAND_FEATURES => {
+           category_groups => { tester => 1 },
+           multiple_category_groups => { tester => 1 },
+        }
+    }, sub {
+        my $processor = Open311::PopulateServiceList->new();
+        $processor->_current_body( $body );
+        $processor->process_services( $service_list );
+    };
+    my $contact_count = FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->count();
+    is $contact_count, 1, 'correct number of contacts';
+
+    my $contact = FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id, email => 100 } )->first;
+    is_deeply $contact->get_extra->{group}, ['sanitation & cleaning','street'], "groups set correctly";
+};
+
+subtest "set multiple groups with bad csv" => sub {
+    FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->delete();
+
+    my $services_xml = '<?xml version="1.0" encoding="utf-8"?>
+    <services>
+      <service>
+        <service_code>100</service_code>
+        <service_name>Cans left out 24x7</service_name>
+        <description>Garbage or recycling cans that have been left out for more than 24 hours after collection. Violators will be cited.</description>
+        <metadata>false</metadata>
+        <type>realtime</type>
+        <keywords>lorem, ipsum, dolor</keywords>
+        <group>"sanitation,street</group>
+      </service>
+    </services>
+    ';
+
+    my $service_list = get_xml_simple_object($services_xml);
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'tester' ],
+        COBRAND_FEATURES => {
+           category_groups => { tester => 1 },
+           multiple_category_groups => { tester => 1 },
+        }
+    }, sub {
+        my $processor = Open311::PopulateServiceList->new();
+        $processor->_current_body( $body );
+        warning_like {
+            $processor->process_services( $service_list );
+        } qr/error parsing groups for testercontact Cans left out 24x7: "sanitation,street/,
+        "warning printed for bad csv";
+    };
+    my $contact_count = FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->count();
+    is $contact_count, 1, 'correct number of contacts';
+
+    my $contact = FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id, email => 100 } )->first;
+    is_deeply $contact->get_extra->{group}, ['"sanitation,street'], "groups set correctly";
+};
 
 subtest 'check non open311 contacts marked as deleted' => sub {
     FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->delete();

--- a/t/open311/populate-service-list.t
+++ b/t/open311/populate-service-list.t
@@ -5,16 +5,6 @@ use parent 'FixMyStreet::Cobrand::Default';
 
 sub council_area_id { 1 }
 
-
-package FixMyStreet::Cobrand::TesterGroups;
-
-use parent 'FixMyStreet::Cobrand::Default';
-
-sub council_area_id { 1 }
-
-sub enable_category_groups { 1 }
-
-
 package main;
 
 use FixMyStreet::Test;
@@ -51,13 +41,16 @@ $bucks->body_areas->create({
 });
 
 for my $test (
-    { desc => 'groups not set for new contacts', cobrand => 'tester', groups => 0, delete => 1 },
-    { desc => 'groups set for new contacts', cobrand => 'testergroups', groups => 1, delete => 1},
-    { desc => 'groups removed for existing contacts', cobrand => 'tester', groups => 0, delete => 0 },
-    { desc => 'groups added for existing contacts', cobrand => 'testergroups', groups => 1, delete => 0},
+    { desc => 'groups not set for new contacts', enable_groups => 0, groups => 0, delete => 1 },
+    { desc => 'groups set for new contacts', enable_groups => 1, groups => 1, delete => 1},
+    { desc => 'groups removed for existing contacts', enable_groups => 0, groups => 0, delete => 0 },
+    { desc => 'groups added for existing contacts', enable_groups => 1, groups => 1, delete => 0},
 ) {
     FixMyStreet::override_config {
-        ALLOWED_COBRANDS => [ $test->{cobrand} ],
+        ALLOWED_COBRANDS => [ 'tester' ],
+        COBRAND_FEATURES => {
+           category_groups => { tester => $test->{enable_groups} },
+        }
     }, sub {
         subtest 'check basic functionality, ' . $test->{desc} => sub {
             FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->delete() if $test->{delete};

--- a/templates/web/base/admin/bodies/contact-form.html
+++ b/templates/web/base/admin/bodies/contact-form.html
@@ -132,7 +132,21 @@ as well.") %]
     <p>
       <label>
         [% loc('Group') %]
+        [% IF body.get_cobrand_handler.enable_multiple_category_groups %]
+            [% IF contact.extra.group %]
+                [% FOR group IN contact.extra.group %]
+                <input class="form-control" type="text" name="group" value="[% group | html %]" size="30">
+                [% END %]
+            [% ELSE %]
+                <input class="form-control" type="text" name="group" value="" size="30">
+            [% END %]
+            <input class="hidden-js js-group-item-template form-control" type="text" name="group" value="" size="30">
+            <p class="hidden-nojs">
+              <button class="btn btn--small js-group-item-add">[% loc('Add group') %]</button>
+            </p>
+        [% ELSE %]
         <input class="form-control" type="text" name="group" value="[% contact.extra.group | html %]" size="30">
+        [% END %]
       </label>
     </p>
   [% END %]

--- a/web/cobrands/fixmystreet/admin.js
+++ b/web/cobrands/fixmystreet/admin.js
@@ -165,6 +165,16 @@ $(function(){
         return true;
     });
 
+    $(".js-group-item-add").on("click", function(e) {
+        e.preventDefault();
+        var $template_item = $(".js-group-item-template");
+        var $new_item = $template_item.clone();
+        $new_item.removeClass("hidden-js js-group-item-template");
+        $new_item.insertBefore($template_item);
+        $new_item.focus();
+        return true;
+    });
+
     // Fields can be added/removed
     $(".js-metadata-item-add").on("click", function(e) {
         e.preventDefault();


### PR DESCRIPTION
The group metadata of a contact can now be a comma separated list of
groups under which to display the category

For #2475

Please check the following:

- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
