### PR TITLE
Small improvements from Hounslow branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
         - Prevent creation of two templates with same title.
     - Development improvements:
         - Upgrade the underlying framework and a number of other packages.
+    - Open311 improvements:
+        - Support use of 'private' service definition <keywords> to mark
+          reports made in that category private.
 
 * v2.6 (3rd May 2019)
     - New features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Unreleased
     - Bugfixes:
         - Prevent creation of two templates with same title.
+        - Don't include private reports when searching by ref from front page.
     - Development improvements:
         - Upgrade the underlying framework and a number of other packages.
     - Open311 improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
     - Open311 improvements:
         - Support use of 'private' service definition <keywords> to mark
           reports made in that category private.
+        - Ensure any reports fetched in a category marked private are also
+          marked private on the site.
 
 * v2.6 (3rd May 2019)
     - New features:

--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -416,7 +416,7 @@ sub lookup_by_ref : Private {
             external_id => $ref
         ];
 
-    my $problems = $c->cobrand->problems->search( $criteria );
+    my $problems = $c->cobrand->problems->search({ non_public => 0, -or => $criteria });
 
     my $count = try {
         $problems->count;

--- a/perllib/Open311/GetServiceRequests.pm
+++ b/perllib/Open311/GetServiceRequests.pm
@@ -157,6 +157,7 @@ sub create_problems {
         my $state = $open311->map_state($request->{status});
 
         my $non_public = $request->{non_public} ? 1 : 0;
+        $non_public ||= $contacts[0] ? $contacts[0]->non_public : 0;
 
         my $problem = $self->schema->resultset('Problem')->new(
             {

--- a/perllib/Open311/PopulateServiceList.pm
+++ b/perllib/Open311/PopulateServiceList.pm
@@ -165,6 +165,7 @@ sub _handle_existing_contact {
     }
 
     $self->_set_contact_group($contact);
+    $self->_set_contact_non_public($contact);
 
     push @{ $self->found_contacts }, $self->_current_service->{service_code};
 }
@@ -201,6 +202,7 @@ sub _create_contact {
     }
 
     $self->_set_contact_group($contact);
+    $self->_set_contact_non_public($contact);
 
     if ( $contact ) {
         push @{ $self->found_contacts }, $self->_current_service->{service_code};
@@ -281,6 +283,21 @@ sub _set_contact_group {
             });
         }
     }
+}
+
+sub _set_contact_non_public {
+    my ($self, $contact) = @_;
+
+    # We never want to make a private category unprivate.
+    return if $contact->non_public;
+
+    my %keywords = map { $_ => 1 } split /,/, ( $self->_current_service->{keywords} || '' );
+    $contact->update({
+        non_public => 1,
+        editor => $0,
+        whenedited => \'current_timestamp',
+        note => 'marked private automatically by script',
+    }) if $keywords{private};
 }
 
 sub _delete_contacts_not_in_service_list {

--- a/t/app/controller/around.t
+++ b/t/app/controller/around.t
@@ -100,6 +100,16 @@ subtest 'check lookup by reference' => sub {
     is $mech->uri->path, "/report/$id", "redirected to report page";
 };
 
+subtest 'check lookup by reference does not show non_public reports' => sub {
+    $edinburgh_problems[0]->update({
+        non_public => 1
+    });
+    my $id = $edinburgh_problems[0]->id;
+    $mech->get_ok('/');
+    $mech->submit_form_ok( { with_fields => { pc => "ref:$id" } }, 'non_public ref');
+    $mech->content_contains('Searching found no reports');
+};
+
 subtest 'check non public reports are not displayed on around page' => sub {
     $mech->get_ok('/');
     FixMyStreet::override_config {

--- a/templates/email/default/login.html
+++ b/templates/email/default/login.html
@@ -1,6 +1,6 @@
 [%
 
-email_summary = "Click this link to confirm your email address and log into " _ site_name;
+email_summary = "Click the link below to confirm your email address and log into " _ site_name;
 email_columns = 1;
 
 PROCESS '_email_settings.html';


### PR DESCRIPTION
A few small things that have come from the Hounslow cobrand work.

 - Support `<keywords>private</keywords>` in Open311 service definitions to mark that contact as non_public
 - Ensure non_public reports aren't included in results when searching by ref from front page
 - Ensure reports fetched via Open311 are marked private if the category they're in is also marked private. NB this situation shouldn't arise through normal use, it's just a belt-and-braces check that we don't expose things that shouldn't be public.

 - [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
 - [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
