### PR TITLE
Fix bug going between report/new pages client side.

### DIFF
--- a/.cypress/cypress/integration/regressions.js
+++ b/.cypress/cypress/integration/regressions.js
@@ -42,4 +42,16 @@ describe('Regression tests', function() {
         cy.get('#map_sidebar').contains('M&S').click();
         cy.title().should('contain', 'M&S "brill" says <glob>');
     });
+
+    it('hides the report when going from around to report to form', function() {
+        cy.server();
+        cy.route('/report/*').as('show-report');
+        cy.visit('/around?lon=-2.295894&lat=51.526877&zoom=6');
+        // force to hopefully work around apparent Cypress SVG issue
+        cy.get('image[title="Lights out in tunnel"]:last').click({force: true});
+        cy.wait('@show-report');
+        cy.get('.report-a-problem-btn').eq(0).should('contain', 'Report another problem here').click();
+        cy.get('.content').should('not.contain', 'toddler');
+    });
+
 });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Unreleased
     - Bugfixes:
         - Prevent creation of two templates with same title.
+        - Fix bug going between report/new pages client side
     - Development improvements:
         - Upgrade the underlying framework and a number of other packages.
 

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -7,6 +7,7 @@
 use strict;
 use warnings;
 use v5.14;
+use utf8;
 
 BEGIN {
     use File::Basename qw(dirname);

--- a/perllib/FixMyStreet/DB/Factories.pm
+++ b/perllib/FixMyStreet/DB/Factories.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use v5.14;
+use utf8;
 
 use FixMyStreet::DB;
 

--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -382,6 +382,7 @@ fixmystreet.assets.add($.extend(true, {}, defaults, {
     },
     asset_category: "Snow and ice problem/winter salting",
     asset_item: "road",
+    asset_type: "road",
     non_interactive: true,
     road: true,
     actions: {

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1286,6 +1286,9 @@ fixmystreet.display = {
     }
     $('#side').hide();
     $('#map_box .big-green-banner').hide();
+    $('#side-report').remove();
+    $('.two_column_sidebar').remove();
+    $('body').removeClass('with-actions');
 
     if (fixmystreet.map.updateSize) {
         fixmystreet.map.updateSize(); // required after changing the size of the map element
@@ -1355,6 +1358,8 @@ fixmystreet.display = {
 
         if ($sideReport.length) {
             $('#side').hide(); // Hide the list of reports
+            $('#side-form').hide(); // And the form
+            $('body').removeClass('with-notes');
             $('#map_box .big-green-banner').hide();
             // Remove any existing report page content from sidebar
             $('#side-report').remove();


### PR DESCRIPTION
A few bits weren't being correctly hidden, as the code didn't account for someone going directly from a report page to a reporting page via the Report another problem here button.

Also Bucks spot fix, and spotted Unicode issue with fixture.

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

