### PR TITLE
Add OS Names geocoder

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -1137,8 +1137,7 @@ Return the default geocoder from config.
 =cut
 
 sub get_geocoder {
-    my ($self, $c) = @_;
-    return $c->config->{GEOCODER};
+    FixMyStreet->config('GEOCODER');
 }
 
 

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -21,7 +21,9 @@ sub example_places {
 }
 
 sub disambiguate_location {
+    my $self = shift;
     return {
+        %{ $self->SUPER::disambiguate_location() },
         country => 'gb',
         google_country => 'uk',
         bing_culture => 'en-GB',

--- a/perllib/FixMyStreet/Geocode/Bing.pm
+++ b/perllib/FixMyStreet/Geocode/Bing.pm
@@ -11,13 +11,19 @@ use strict;
 use FixMyStreet::Geocode;
 use Utils;
 
+sub setup {
+    my $cls = shift;
+    return 1 if FixMyStreet->config('BING_MAPS_API_KEY');
+    return 0;
+}
+
 # string STRING CONTEXT
 # Looks up on Bing Maps API, and caches, a user-inputted location.
 # Returns array of (LAT, LON, ERROR), where ERROR is either undef, a string, or
 # an array of matches if there are more than one. The information in the query
 # may be used to disambiguate the location in cobranded versions of the site.
 sub string {
-    my ( $s, $c ) = @_;
+    my ( $cls, $s, $c ) = @_;
 
     my $params = $c->cobrand->disambiguate_location($s);
     # Allow cobrand to fixup the user input

--- a/perllib/FixMyStreet/Geocode/Google.pm
+++ b/perllib/FixMyStreet/Geocode/Google.pm
@@ -16,7 +16,7 @@ use URI::Escape;
 # an array of matches if there are more than one. The information in the query
 # may be used to disambiguate the location in cobranded versions of the site.
 sub string {
-    my ( $s, $c ) = @_;
+    my ( $cls, $s, $c ) = @_;
 
     my $params = $c->cobrand->disambiguate_location($s);
     # Allow cobrand to fixup the user input

--- a/perllib/FixMyStreet/Geocode/OSM.pm
+++ b/perllib/FixMyStreet/Geocode/OSM.pm
@@ -23,7 +23,7 @@ my $nominatimbase = "http://nominatim.openstreetmap.org/";
 # an array of matches if there are more than one. The information in the query
 # may be used to disambiguate the location in cobranded versions of the site.
 sub string {
-    my ( $s, $c ) = @_;
+    my ( $cls, $s, $c ) = @_;
 
     my $params = $c->cobrand->disambiguate_location($s);
     # Allow cobrand to fixup the user input

--- a/perllib/FixMyStreet/Geocode/OSNames.pm
+++ b/perllib/FixMyStreet/Geocode/OSNames.pm
@@ -1,0 +1,58 @@
+# FixMyStreet::Geocode::OSNames
+# Geocoding with OS Names API for FixMyStreet.
+
+package FixMyStreet::Geocode::OSNames;
+
+use strict;
+
+use FixMyStreet::Geocode;
+use Utils;
+
+# string STRING CONTEXT
+# Looks up on OS Names API, and caches, a user-inputted location.
+# Returns array of (LAT, LON, ERROR), where ERROR is either undef, a string, or
+# an array of matches if there are more than one. The information in the query
+# may be used to disambiguate the location in cobranded versions of the site.
+sub string {
+    my ( $cls, $s, $c ) = @_;
+
+    my $params = $c->cobrand->disambiguate_location($s);
+    my $key = $params->{key};
+
+    $s = $params->{string} if $params->{string};
+    $s = FixMyStreet::Geocode::escape($s);
+
+    my $url = "https://api.ordnancesurvey.co.uk/opennames/v1/find?maxresults=10";
+    $url .= "&query=$s";
+    $url .= '&fq=BBOX:' . join(',', @{$params->{bounds_en}})
+        if $params->{bounds_en};
+
+    my $js = FixMyStreet::Geocode::cache('osnames', $url, 'key=' . $key);
+    if (!$js) {
+        return { error => _('Sorry, we could not parse that location. Please try again.') };
+    }
+
+    my $results = $js->{results};
+    my ( $error, @valid_locations, $latitude, $longitude );
+
+    foreach (map { $_->{GAZETTEER_ENTRY} } @$results) {
+        my $address = $_->{NAME1} . ", " . $_->{POSTCODE_DISTRICT};
+        next if $params->{match_borough} && $_->{DISTRICT_BOROUGH} ne $params->{match_borough};
+        next if $params->{match_unitary} && $_->{COUNTY_UNITARY} ne $params->{match_unitary};
+        next if $params->{match_place} && $_->{POPULATED_PLACE} ne $params->{match_place};
+
+        ( $latitude, $longitude ) =
+            Utils::convert_en_to_latlon_truncated($_->{GEOMETRY_X}, $_->{GEOMETRY_Y});
+        push (@$error, {
+            address => $address,
+            latitude => $latitude,
+            longitude => $longitude
+        });
+        push (@valid_locations, $_);
+    }
+
+    return { latitude => $latitude, longitude => $longitude } if scalar @valid_locations == 1;
+    return { error => $error };
+}
+
+1;

--- a/perllib/FixMyStreet/Geocode/Zurich.pm
+++ b/perllib/FixMyStreet/Geocode/Zurich.pm
@@ -60,7 +60,7 @@ sub setup_soap {
 # versions of the site.
 
 sub string {
-    my ( $s, $c ) = @_;
+    my ( $cls, $s, $c ) = @_;
 
     setup_soap();
 

--- a/t/geocode/google.t
+++ b/t/geocode/google.t
@@ -11,12 +11,12 @@ use Catalyst::Test 'FixMyStreet::App';
 use t::Mock::GoogleGeocoder;
 
 my $c = ctx_request('/');
-my $r = FixMyStreet::Geocode::Google::string("one result", $c);
+my $r = FixMyStreet::Geocode::Google->string("one result", $c);
 ok $r->{latitude};
 ok $r->{longitude};
 
 $c->stash->{cobrand} = FixMyStreet::Cobrand::Tester->new;
-$r = FixMyStreet::Geocode::Google::string("two results", $c);
+$r = FixMyStreet::Geocode::Google->string("two results", $c);
 is scalar @{$r->{error}}, 2;
 
 done_testing;


### PR DESCRIPTION
```
GEOCODING_DISAMBIGUATION:
  bounds_en: [507073,170203,522016,179675]
  match_borough: 'Hounslow'
```

For a search for 'grove', this returns 

<ul>
        <li><a href="/around?lat=51.48164&amp;lon=-0.27048">Grove Park, W4</a>        </li>
        <li><a href="/around?lat=51.475414&amp;lon=-0.344356">Spring Grove, TW7</a>        </li>
        <li><a href="/around?lat=51.497377&amp;lon=-0.251084">Addison Grove, W4</a>        </li>
        <li><a href="/around?lat=51.482173&amp;lon=-0.320766">Almond Grove, TW8</a>        </li>
        <li><a href="/around?lat=51.447906&amp;lon=-0.426589">Ash Grove, TW14</a>        </li>
        <li><a href="/around?lat=51.480986&amp;lon=-0.390628">Ash Grove, TW5</a>        </li>
    </ul>

For a search for church road, you get:

<ul>
<li> <a href="/around?lat=51.429763&amp;lon=-0.396327">Church Road, TW13</a> </li>
<li> <a href="/around?lat=51.480619&amp;lon=-0.343621">Church Road, TW7</a> </li>
<li> <a href="/around?lat=51.490114&amp;lon=-0.406512">Church Road, TW5</a> </li>
<li> <a href="/around?lat=51.483154&amp;lon=-0.373773">Church Road, TW5</a> </li>
</ul>

Can't see any way to split the final two, sadly, but perhaps worth as an option.