### PR TITLE
[Northamptonshire] one off script to fetch historic reports

### DIFF
--- a/bin/northamptonshire/fetch-hisoric-reports
+++ b/bin/northamptonshire/fetch-hisoric-reports
@@ -1,0 +1,45 @@
+#!/usr/bin/env perl
+#
+# This script utilises Open311 as described at
+# http://wiki.open311.org/GeoReport_v2/#get-service-requests
+# to fetch service requests.
+
+use strict;
+use warnings;
+require 5.8.0;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use Open311::GetServiceRequests;
+
+my $start_date = DateTime->now()->add( months => -3 );
+my $end_date = DateTime->now()->add( months => -1 );
+
+my $reports = Open311::GetServiceRequests->new(
+    start_date => $start_date,
+    end_date => $end_date,
+    historic => 1,
+    verbose => 1
+);
+
+my $bodies = $reports->schema->resultset('Body')->search(
+    {
+        send_method     => 'Open311',
+        fetch_problems  => 1,
+        comment_user_id => { '!=', undef },
+        endpoint        => { '!=', '' },
+        name => 'Northamptonshire County Council',
+    }
+);
+
+if ( my $ncc = $bodies->first ) {
+    my $o = $reports->create_open311_object( $ncc );
+
+    $reports->system_user( $ncc->comment_user );
+    $reports->create_problems($o, $ncc);
+}

--- a/perllib/Open311/GetServiceRequests.pm
+++ b/perllib/Open311/GetServiceRequests.pm
@@ -14,6 +14,7 @@ has fetch_all => ( is => 'rw', default => 0 );
 has verbose => ( is => 'ro', default => 0 );
 has schema => ( is =>'ro', lazy => 1, default => sub { FixMyStreet::DB->schema->connect } );
 has convert_latlong => ( is => 'rw', default => 0 );
+has historic => ( is => 'ro', default => 0 );
 
 sub fetch {
     my $self = shift;
@@ -67,6 +68,10 @@ sub create_problems {
 
         $args->{start_date} = DateTime::Format::W3CDTF->format_datetime( $start_dt );
         $args->{end_date} = DateTime::Format::W3CDTF->format_datetime( $end_dt );
+    }
+
+    if ( $self->historic ) {
+        $args->{historic} = 'true';
     }
 
     my $requests = $open311->get_service_requests( $args );


### PR DESCRIPTION
On migration the NCC system pulled existing reports in but they are
stored in a different format from other reports so we need a special
command to pull these in.

Please check the following:

- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]