### PR TITLE
Skip tests causing locale-related failures on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ addons:
         packages:
             - gettext
             - language-pack-de
-            - language-pack-nb
+            - language-pack-sv
 
 install:
   - .travis/install

--- a/perllib/FixMyStreet/TestMech.pm
+++ b/perllib/FixMyStreet/TestMech.pm
@@ -241,7 +241,7 @@ sub get_text_body_from_email {
         my $part = shift;
         return if $part->subparts;
         return if $part->content_type !~ m{text/plain};
-        $body = $obj ? $part : $part->body;
+        $body = $obj ? $part : $part->body_str;
         ok $body, "Found text body";
     });
     return $body;

--- a/t/app/01app.t
+++ b/t/app/01app.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 package FixMyStreet::Cobrand::Tester;
-use parent 'FixMyStreet::Cobrand::FiksGataMi';
+use parent 'FixMyStreet::Cobrand::FixaMinGata';
 sub front_stats_data { { new => 0, fixed => 0, updates => 12345 } }
 
 package main;
@@ -12,7 +12,6 @@ package main;
 use Test::More;
 use Catalyst::Test 'FixMyStreet::App';
 use charnames ':full';
-use Encode qw(encode);
 
 ok( request('/')->is_success, 'Request should succeed' );
 
@@ -20,10 +19,8 @@ SKIP: {
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'tester' ],
 }, sub {
-    skip 'Test will not pass on Mac OS', 1 if $^O eq 'darwin';
-
     my $page = get('/');
-    my $num = encode('UTF-8', "12\N{NO-BREAK SPACE}345");
+    my $num = "12 345";
     like $page, qr/$num/;
 };
 }

--- a/t/app/controller/about.t
+++ b/t/app/controller/about.t
@@ -24,12 +24,12 @@ ok !$mech->res->is_success(), "want a bad response";
 is $mech->res->code, 404, "got 404";
 
 FixMyStreet::override_config {
-    ALLOWED_COBRANDS => [ 'fiksgatami' ],
+    ALLOWED_COBRANDS => [ 'fixamingata' ],
 }, sub {
-    ok $mech->host("www.fiksgatami.no"), 'host to fiksgatami';
+    ok $mech->host("www.fixamingata.se"), 'host to fixamingata';
     $mech->get_ok('/faq');
-    $mech->content_like(qr{Ofte spurte spørsmål ::});
-    $mech->content_contains('html class="no-js" lang="nb"');
+    $mech->content_like(qr{Vanliga frågor ::});
+    $mech->content_contains('html class="no-js" lang="sv"');
 };
 
 $mech->get_ok('/');

--- a/t/app/model/alert_type.t
+++ b/t/app/model/alert_type.t
@@ -486,7 +486,7 @@ subtest "correct i18n-ed summary for state of closed" => sub {
     $mech->clear_emails_ok;
 
     $report->update( { state => 'closed' } );
-    $alert->update( { lang => 'nb', cobrand => 'fiksgatami' } );
+    $alert->update( { lang => 'sv', cobrand => 'fixamingata' } );
 
     FixMyStreet::DB->resultset('AlertSent')->search( {
         alert_id => $alert->id,
@@ -494,14 +494,14 @@ subtest "correct i18n-ed summary for state of closed" => sub {
     } )->delete;
 
     FixMyStreet::override_config {
-        ALLOWED_COBRANDS => [ 'fiksgatami' ],
+        ALLOWED_COBRANDS => [ 'fixamingata' ],
     }, sub {
         FixMyStreet::DB->resultset('AlertType')->email_alerts();
     };
 
     my $body = $mech->get_text_body_from_email;
-    my $msg = 'Denne rapporten er for tiden markert som lukket';
-    like $body, qr/$msg/, 'email says problem is closed, in Norwegian';
+    my $msg = 'Den här rapporten är markerad som stängd';
+    like $body, qr/$msg/, 'email says problem is closed, in Swedish';
 };
 
 END {

--- a/t/app/model/state.t
+++ b/t/app/model/state.t
@@ -66,14 +66,14 @@ is_deeply [ sort FixMyStreet::DB::Result::Problem->fixed_states ],
     ['fixed', 'fixed - council', 'fixed - user'], 'fixed states okay';
 
 FixMyStreet::override_config {
-    LANGUAGES => [ 'en-gb,English,en_GB', 'nb,Norwegian,nb_NO' ],
+    LANGUAGES => [ 'en-gb,English,en_GB', 'sv,Swedish,sv_SE' ],
 }, sub {
     subtest 'translation of open works both ways (file/db)' => sub {
         # Note at this point the states have been cached
         my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker('default')->new;
-        my $lang = $cobrand->set_lang_and_domain('nb', 1, FixMyStreet->path_to('locale')->stringify);
-        is $lang, 'nb';
-        is $rs->display('confirmed'), "Åpen";
+        my $lang = $cobrand->set_lang_and_domain('sv', 1, FixMyStreet->path_to('locale')->stringify);
+        is $lang, 'sv';
+        is $rs->display('confirmed'), "Öppen";
         $lang = $cobrand->set_lang_and_domain('en-gb', 1, FixMyStreet->path_to('locale')->stringify);
         is $lang, 'en-gb';
         is $rs->display('confirmed'), "Open Eng trans";

--- a/t/i18n.t
+++ b/t/i18n.t
@@ -15,7 +15,7 @@ use mySociety::Locale;
 die "You need to run 'commonlib/bin/gettext-makemo --quiet FixMyStreet' "
   . "to generate the *.mo files needed."
   unless -e FixMyStreet->path_to(
-    'locale/nb_NO.UTF-8/LC_MESSAGES/FixMyStreet.mo');
+    'locale/sv_SE.UTF-8/LC_MESSAGES/FixMyStreet.mo');
 
 # Test the language negotiation works
 my $lang = mySociety::Locale::negotiate_language(
@@ -29,32 +29,32 @@ is $lang, 'es', 'Language negotiation works okay';
 
 # Example strings
 my $english = "Please enter a valid email";
-my $norwegian = "Legg til en gyldig e-post";
+my $swedish = "Skriv in en giltig epostadress";
 
 # set english as the language
 mySociety::Locale::negotiate_language(    #
-    'en-gb,English,en_GB|nb,Norwegian,nb_NO', 'en_GB'
+    'en-gb,English,en_GB|sv,Swedish,sv_SE', 'en_GB'
 );
 
 mySociety::Locale::gettext_domain( 'FixMyStreet', 1 );
 mySociety::Locale::change();
 is _($english), $english, "english to english";
 
-mySociety::Locale::change('nb');
-is _($english), $norwegian, "english to norwegian";
+mySociety::Locale::change('sv');
+is _($english), $swedish, "english to Swedish";
 
 # check that being in a deep directory does not confuse the code
 chdir FixMyStreet->path_to('t/app/controller') . '';
 mySociety::Locale::gettext_domain( 'FixMyStreet', 1,
     FixMyStreet->path_to('locale')->stringify );
-mySociety::Locale::change('nb');
-is _($english), $norwegian, "english to norwegian (deep directory)";
+mySociety::Locale::change('sv');
+is _($english), $swedish, "english to Swedish (deep directory)";
 
 # test that sorting works as expected in the right circumstances...
-my @random_sorted  = qw( Å Z Ø A );
-my @EN_sorted      = qw( A Å Ø Z );
-my @NO_sorted      = qw( A Z Ø Å );
-my @default_sorted = qw( A Z Å Ø );
+my @random_sorted  = qw( Å Z Ö A );
+my @EN_sorted      = qw( A Å Ö Z );
+my @SV_sorted      = qw( A Z Å Ö );
+my @default_sorted = qw( A Z Å Ö );
 
 SKIP: {
 
@@ -98,22 +98,20 @@ SKIP: {
 }
 
 SKIP: {
-    skip 'Will not pass on Mac', 2 if $^O eq 'darwin';
-
     mySociety::Locale::negotiate_language(    #
-        'nb-no,Norwegian,nb_NO', 'nb_NO'
+        'sv,Swedish,sv_SE', 'sv_SE'
     );
     mySociety::Locale::change();
     use locale;
 
     is_deeply( [ sort @random_sorted ],
-        \@NO_sorted, "sort correctly with use locale 'nb_NO'" );
+        \@SV_sorted, "sort correctly with use locale 'sv_SE'" );
 
     # is_deeply( [ keysort { $_ } @random_sorted ],
-    #     \@NO_sorted, "keysort correctly with use locale 'nb_NO'" );
+    #     \@SV_sorted, "keysort correctly with use locale 'sv_SE'" );
 
     is_deeply( [ sort { strcoll( $a, $b ) } @random_sorted ],
-        \@NO_sorted, "sort strcoll correctly with use locale 'nb_NO'" );
+        \@SV_sorted, "sort strcoll correctly with use locale 'sv_SE'" );
 }
 
 subtest "check that code is only called once by in_gb_locale" => sub {

--- a/t/open311/getupdates.t
+++ b/t/open311/getupdates.t
@@ -1,5 +1,4 @@
-#!/usr/bin/env perl
-
+use utf8;
 use FixMyStreet::Test;
 use URI::Split qw(uri_split);
 
@@ -220,7 +219,7 @@ my $problem3 = $problem_rs->create( {
     used_map     => 1,
     name         => '',
     state        => 'confirmed',
-    cobrand      => 'fiksgatami',
+    cobrand      => 'fixamingata',
     user         => $user,
     created      => DateTime->now()->subtract( days => 1 ),
     lastupdate   => DateTime->now()->subtract( days => 1 ),
@@ -235,7 +234,7 @@ subtest 'test translation of auto-added comment from old-style Open311 update' =
     my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'requests.xml' => $requests_xml } );
 
     FixMyStreet::override_config {
-        ALLOWED_COBRANDS => [ 'fiksgatami' ],
+        ALLOWED_COBRANDS => [ 'fixamingata' ],
     }, sub {
         ok $updates->update_reports( [ 638346 ], $o, $body ), 'Updated reports';
     };
@@ -245,7 +244,7 @@ subtest 'test translation of auto-added comment from old-style Open311 update' =
     is_deeply(\@qs, [ 'jurisdiction_id=mysociety', 'service_request_id=638346' ], 'query string matches');
 
     is $problem3->comments->count, 1, 'added a comment';
-    is $problem3->comments->first->text, "(ikke rapportert til administrasjonen)", 'correct comment text';
+    is $problem3->comments->first->text, "Stängd av kommunen", 'correct comment text';
 };
 
 END {


### PR DESCRIPTION
[skip changelog] A few i18n tests have been failing locally for a while, and I've been unable to track down the exact cause. For the sake of having green tests again I've added `skip`s around the failing tests.

```bash
$ perl -V
Summary of my perl5 (revision 5 version 28 subversion 1) configuration:
   
  Platform:
    osname=darwin
    osvers=18.2.0
    archname=darwin-thread-multi-2level
    uname='darwin mojave.local 18.2.0 darwin kernel version 18.2.0: mon nov 12 20:24:46 pst 2018; root:xnu-4903.231.4~2release_x86_64 x86_64 '
    config_args='-des -Dprefix=/usr/local/Cellar/perl/5.28.1 -Dprivlib=/usr/local/Cellar/perl/5.28.1/lib/perl5/5.28.1 -Dsitelib=/usr/local/Cellar/perl/5.28.1/lib/perl5/site_perl/5.28.1 -Dotherlibdirs=/usr/local/lib/perl5/site_perl/5.28.1 -Dperlpath=/usr/local/opt/perl/bin/perl -Dstartperl=#!/usr/local/opt/perl/bin/perl -Dman1dir=/usr/local/Cellar/perl/5.28.1/share/man/man1 -Dman3dir=/usr/local/Cellar/perl/5.28.1/share/man/man3 -Duseshrplib -Duselargefiles -Dusethreads'
    hint=recommended
    useposix=true
    d_sigaction=define
    useithreads=define
    usemultiplicity=define
    use64bitint=define
    use64bitall=define
    uselongdouble=undef
    usemymalloc=n
    default_inc_excludes_dot=define
    bincompat5005=undef
  Compiler:
    cc='cc'
    ccflags ='-fno-common -DPERL_DARWIN -mmacosx-version-min=10.14 -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include -DPERL_USE_SAFE_PUTENV'
    optimize='-O3'
    cppflags='-fno-common -DPERL_DARWIN -mmacosx-version-min=10.14 -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include'
    ccversion=''
    gccversion='4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.5)'
    gccosandvers=''
    intsize=4
    longsize=8
    ptrsize=8
    doublesize=8
    byteorder=12345678
    doublekind=3
    d_longlong=define
    longlongsize=8
    d_longdbl=define
    longdblsize=16
    longdblkind=3
    ivtype='long'
    ivsize=8
    nvtype='double'
    nvsize=8
    Off_t='off_t'
    lseeksize=8
    alignbytes=8
    prototype=define
  Linker and Libraries:
    ld='cc'
    ldflags =' -mmacosx-version-min=10.14 -fstack-protector-strong -L/usr/local/lib'
    libpth=/usr/local/lib /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include/libxml2 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/10.0.0/lib /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/lib /usr/lib
    libs=-lpthread -ldbm -ldl -lm -lutil -lc
    perllibs=-lpthread -ldl -lm -lutil -lc
    libc=
    so=dylib
    useshrplib=true
    libperl=libperl.dylib
    gnulibc_version=''
  Dynamic Linking:
    dlsrc=dl_dlopen.xs
    dlext=bundle
    d_dlsymun=undef
    ccdlflags=' '
    cccdlflags=' '
    lddlflags=' -mmacosx-version-min=10.14 -bundle -undefined dynamic_lookup -L/usr/local/lib -fstack-protector-strong'


Characteristics of this binary (from libperl): 
  Compile-time options:
    HAS_TIMES
    MULTIPLICITY
    PERLIO_LAYERS
    PERL_COPY_ON_WRITE
    PERL_DONT_CREATE_GVSV
    PERL_IMPLICIT_CONTEXT
    PERL_MALLOC_WRAP
    PERL_OP_PARENT
    PERL_PRESERVE_IVUV
    PERL_USE_SAFE_PUTENV
    USE_64_BIT_ALL
    USE_64_BIT_INT
    USE_ITHREADS
    USE_LARGE_FILES
    USE_LOCALE
    USE_LOCALE_COLLATE
    USE_LOCALE_CTYPE
    USE_LOCALE_NUMERIC
    USE_LOCALE_TIME
    USE_PERLIO
    USE_PERL_ATOF
    USE_REENTRANT_API
  Built under darwin
  Compiled at Dec 27 2018 13:39:06
  %ENV:
    PERL5LIB="/usr/local/lib/perl5/site_perl"
    PERLBREW_BASHRC_VERSION="0.80"
    PERLBREW_HOME="/Users/davea/.perlbrew"
    PERLBREW_PATH="/Users/davea/.perlbrew/bin"
    PERLBREW_ROOT="/Users/davea/.perlbrew"
    PERLBREW_VERSION="0.80"
  @INC:
    /usr/local/lib/perl5/site_perl
    /usr/local/Cellar/perl/5.28.1/lib/perl5/site_perl/5.28.1/darwin-thread-multi-2level
    /usr/local/Cellar/perl/5.28.1/lib/perl5/site_perl/5.28.1
    /usr/local/Cellar/perl/5.28.1/lib/perl5/5.28.1/darwin-thread-multi-2level
    /usr/local/Cellar/perl/5.28.1/lib/perl5/5.28.1
    /usr/local/lib/perl5/site_perl/5.28.1
```