### PR TITLE
Duplicate/asset message interaction fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
         - Fix bug going between report/new pages client side
     - Development improvements:
         - Upgrade the underlying framework and a number of other packages.
+        - Add feature cobrand helper function.
 
 * v2.6 (3rd May 2019)
     - New features:

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -188,9 +188,13 @@ ALLOWED_COBRANDS:
   - cobrand2: 'hostname_substring2'
   - cobrand3
 
-# This is used in e.g. "offensive report" emails to provide a link directly to
-# the admin interface. Defaults to BASE_URL with "/admin" on the end.
-ADMIN_BASE_URL: ''
+# If your site has many cobrands, you may want to have per-cobrand settings. To
+# do this, make a hash of feature keys, each of which is a hash of monikers, eg
+#   COBRAND_FEATURES:
+#     suggest_duplicates:
+#       buckinghamshire: 1
+#       oxfordshire: 1
+COBRAND_FEATURES: ''
 
 # How many items are returned in the GeoRSS and Open311 feeds by default
 RSS_LIMIT: '20'

--- a/perllib/FixMyStreet/Cobrand/BathNES.pm
+++ b/perllib/FixMyStreet/Cobrand/BathNES.pm
@@ -22,8 +22,6 @@ sub contact_email {
     return join( '@', 'councilconnect_rejections', 'bathnes.gov.uk' );
 }
 
-sub suggest_duplicates { 1 }
-
 sub admin_user_domain { 'bathnes.gov.uk' }
 
 sub base_url {

--- a/perllib/FixMyStreet/Cobrand/Borsetshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Borsetshire.pm
@@ -33,6 +33,4 @@ sub bypass_password_checks { 1 }
 
 sub enable_category_groups { 1 }
 
-sub suggest_duplicates { 1 }
-
 1;

--- a/perllib/FixMyStreet/Cobrand/Bristol.pm
+++ b/perllib/FixMyStreet/Cobrand/Bristol.pm
@@ -9,8 +9,6 @@ sub council_area { return 'Bristol'; }
 sub council_name { return 'Bristol County Council'; }
 sub council_url { return 'bristol'; }
 
-sub suggest_duplicates { 1 }
-
 sub base_url {
     my $self = shift;
     return $self->next::method() if FixMyStreet->config('STAGING_SITE');

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -14,8 +14,6 @@ sub council_area { return 'Bromley'; }
 sub council_name { return 'Bromley Council'; }
 sub council_url { return 'bromley'; }
 
-sub suggest_duplicates { 1 }
-
 sub report_validation {
     my ($self, $report, $errors) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -12,8 +12,6 @@ sub council_area { return 'Buckinghamshire'; }
 sub council_name { return 'Buckinghamshire County Council'; }
 sub council_url { return 'buckinghamshire'; }
 
-sub suggest_duplicates { 1 }
-
 sub example_places {
     return ( 'HP19 7QF', "Walton Road" );
 }

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -59,6 +59,21 @@ sub path_to_email_templates {
     return $paths;
 }
 
+=item feature
+
+A helper utility to let you provide per-cobrand hooks for configuration.
+Mostly useful if running a site with multiple cobrands.
+
+=cut
+
+sub feature {
+    my ($self, $feature) = @_;
+    my $features = FixMyStreet->config('COBRAND_FEATURES');
+    return unless $features && ref $features eq 'HASH';
+    return unless $features->{$feature} && ref $features->{$feature} eq 'HASH';
+    return $features->{$feature}->{$self->moniker};
+}
+
 =item password_minimum_length
 
 Returns the minimum length a password can be set to.

--- a/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
@@ -19,7 +19,6 @@ sub council_url { return 'lincolnshire'; }
 sub is_two_tier { 1 }
 
 sub enable_category_groups { 1 }
-sub suggest_duplicates { 1 }
 sub send_questionnaires { 0 }
 sub report_sent_confirmation_email { 'external_id' }
 

--- a/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
@@ -12,8 +12,6 @@ sub council_area { 'Northamptonshire' }
 sub council_name { 'Northamptonshire County Council' }
 sub council_url { 'northamptonshire' }
 
-sub suggest_duplicates { 1 }
-
 sub example_places { ( 'NN1 1NS', "Bridge Street" ) }
 
 sub enter_postcode_text { 'Enter a Northamptonshire postcode, street name and area, or check an existing report number' }

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -10,8 +10,6 @@ sub council_name { return 'Oxfordshire County Council'; }
 sub council_url { return 'oxfordshire'; }
 sub is_two_tier { return 1; }
 
-sub suggest_duplicates { 1 }
-
 sub report_validation {
     my ($self, $report, $errors) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -15,6 +15,11 @@ sub is_council {
     1;
 }
 
+sub suggest_duplicates {
+    my $self = shift;
+    return $self->feature('suggest_duplicates');
+}
+
 sub path_to_web_templates {
     my $self = shift;
     return [

--- a/t/cobrand/features.t
+++ b/t/cobrand/features.t
@@ -2,15 +2,19 @@ use FixMyStreet::Test;
 use FixMyStreet::Cobrand;
 
 FixMyStreet::override_config {
+    ALLOWED_COBRANDS => ['bromley'],
     COBRAND_FEATURES => {
         foo => { tester => 1 },
-        bar => { default => 1 }
+        bar => { default => 1 },
+        suggest_duplicates => { bromley => 1 },
     }
 }, sub {
     my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker('default')->new;
+    my $bromley = FixMyStreet::Cobrand->get_class_for_moniker('bromley')->new;
 
     is $cobrand->feature('foo'), undef;
     is $cobrand->feature('bar'), 1;
+    is $bromley->suggest_duplicates, 1;
 };
 
 done_testing();

--- a/t/cobrand/features.t
+++ b/t/cobrand/features.t
@@ -1,0 +1,16 @@
+use FixMyStreet::Test;
+use FixMyStreet::Cobrand;
+
+FixMyStreet::override_config {
+    COBRAND_FEATURES => {
+        foo => { tester => 1 },
+        bar => { default => 1 }
+    }
+}, sub {
+    my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker('default')->new;
+
+    is $cobrand->feature('foo'), undef;
+    is $cobrand->feature('bar'), 1;
+};
+
+done_testing();

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -972,10 +972,10 @@ fixmystreet.message_controller = (function() {
     }
 
     // This hides the responsibility message, and (unless a
-    // stopper message is shown) reenables the report form
+    // stopper message or dupes are shown) reenables the report form
     function responsibility_off() {
         hide_responsibility_errors();
-        if (!document.getElementById(stopperId)) {
+        if (!document.getElementById(stopperId) && !$('#js-duplicate-reports').is(':visible')) {
             enable_report_form();
         }
     }
@@ -1034,7 +1034,7 @@ fixmystreet.message_controller = (function() {
 
         if (!matching.length) {
             $id.remove();
-            if ( !$('#js-roads-responsibility').is(':visible') ) {
+            if ( !$('#js-roads-responsibility').is(':visible') && !$('#js-duplicate-reports').is(':visible') ) {
                 enable_report_form();
             }
             return;

--- a/web/js/duplicates.js
+++ b/web/js/duplicates.js
@@ -36,7 +36,7 @@
             data: url_params,
             dataType: 'json'
         }).done(function(response) {
-            if ( response.pins.length ){
+            if (response.pins.length && take_effect()) {
                 render_duplicate_list(response);
                 render_duplicate_pins(response);
             } else {
@@ -132,7 +132,7 @@
             $(this).addClass('hidden');
             $(this).find('ul').empty();
         });
-        if ( $('#problem_form').length ) {
+        if ($('#problem_form').length && take_effect()) {
             $('.js-hide-if-invalid-category').slideDown();
         }
     }
@@ -156,6 +156,17 @@
             return;
         }
         refresh_duplicate_list();
+    }
+
+    function take_effect() {
+        // We do not want to do anything if any other message is being shown
+        if (document.getElementById('js-category-stopper')) {
+            return false;
+        }
+        if ($('.js-responsibility-message:visible').length) {
+            return false;
+        }
+        return true;
     }
 
     // Want to show potential duplicates when a regular user starts a new

--- a/web/js/duplicates.js
+++ b/web/js/duplicates.js
@@ -127,23 +127,14 @@
         current_duplicate_markers = markers;
     }
 
-    function remove_duplicate_list(cb) {
-        var animations = [];
-
-        animations.push( $.Deferred() );
+    function remove_duplicate_list() {
         $('#js-duplicate-reports').slideUp(function(){
             $(this).addClass('hidden');
             $(this).find('ul').empty();
-            animations[0].resolve();
         });
         if ( $('#problem_form').length ) {
-            animations.push( $.Deferred() );
-            $('.js-hide-if-invalid-category').slideDown(function(){
-                animations[1].resolve();
-            });
+            $('.js-hide-if-invalid-category').slideDown();
         }
-
-        $.when.apply(this, animations).then(cb);
     }
 
     function remove_duplicate_pins() {
@@ -180,9 +171,7 @@
     $('.js-hide-duplicate-suggestions').on('click', function(e){
         e.preventDefault();
         remove_duplicate_pins();
-        remove_duplicate_list(function(){
-            $('#form_title').focus();
-        });
+        remove_duplicate_list();
     });
 
 })();


### PR DESCRIPTION
Fixes a couple of small issues where the new duplicate suggestion code was interacting with the asset messaging code and reshowing the form at some times when it shouldn't.
Also stop focussing on title when duplicates removed, as this bothered me while fixing this, and start to move UK cobrand config out of files.

[skip changelog]
