### PR TITLE
[UK] Put some things in config

### DIFF
--- a/perllib/FixMyStreet/Cobrand/BathNES.pm
+++ b/perllib/FixMyStreet/Cobrand/BathNES.pm
@@ -17,26 +17,11 @@ sub council_area { return 'Bath and North East Somerset'; }
 sub council_name { return 'Bath and North East Somerset Council'; }
 sub council_url { return 'bathnes'; }
 
-sub contact_email {
-    my $self = shift;
-    return join( '@', 'councilconnect_rejections', 'bathnes.gov.uk' );
-}
-
 sub admin_user_domain { 'bathnes.gov.uk' }
-
-sub base_url {
-    my $self = shift;
-    return $self->next::method() if FixMyStreet->config('STAGING_SITE');
-    return 'https://fix.bathnes.gov.uk';
-}
 
 sub map_type { 'BathNES' }
 
 sub on_map_default_status { 'open' }
-
-sub example_places {
-    return ( 'BA1 1JQ', "Lansdown Grove" );
-}
 
 sub get_geocoder {
     return 'OSM'; # default of Bing gives poor results, let's try overriding.

--- a/perllib/FixMyStreet/Cobrand/Bexley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley.pm
@@ -8,18 +8,10 @@ sub council_area_id { 2494 }
 sub council_area { 'Bexley' }
 sub council_name { 'London Borough of Bexley' }
 sub council_url { 'bexley' }
-sub example_places { ( 'DA6 7AT', "Chieveley Road" ) }
 sub get_geocoder { 'OSM' }
 
 sub enable_category_groups { 1 }
 sub suggest_duplicates { 1 }
-
-sub base_url {
-    my $self = shift;
-    return $self->next::method() if FixMyStreet->config('STAGING_SITE');
-    # uncoverable statement
-    return 'https://fix.bexley.gov.uk';
-}
 
 sub disambiguate_location {
     my $self    = shift;
@@ -33,11 +25,6 @@ sub disambiguate_location {
 }
 
 sub on_map_default_status { 'open' }
-
-sub contact_email {
-    my $self = shift;
-    return join( '@', 'customer.services', $self->council_url . '.gov.uk' );
-}
 
 sub open311_munge_update_params {
     my ($self, $params, $comment, $body) = @_;

--- a/perllib/FixMyStreet/Cobrand/Borsetshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Borsetshire.pm
@@ -9,10 +9,6 @@ sub council_area { return 'Borsetshire'; }
 sub council_name { return 'Borsetshire County Council'; }
 sub council_url { return 'demo'; }
 
-sub example_places {
-    return ( 'BS36 2NS', 'Coalpit Heath' );
-}
-
 sub pin_colour {
     my ( $self, $p, $context ) = @_;
     return 'grey' if $p->is_closed;

--- a/perllib/FixMyStreet/Cobrand/Bristol.pm
+++ b/perllib/FixMyStreet/Cobrand/Bristol.pm
@@ -9,16 +9,6 @@ sub council_area { return 'Bristol'; }
 sub council_name { return 'Bristol County Council'; }
 sub council_url { return 'bristol'; }
 
-sub base_url {
-    my $self = shift;
-    return $self->next::method() if FixMyStreet->config('STAGING_SITE');
-    return 'https://fixmystreet.bristol.gov.uk';
-}
-
-sub example_places {
-    return ( 'BS1 5TR', "Broad Quay" );
-}
-
 sub map_type {
     'Bristol';
 }
@@ -48,11 +38,6 @@ sub pin_colour {
     return 'green' if $p->is_fixed || $p->is_closed;
     return 'red' if $p->state eq 'confirmed';
     return 'yellow';
-}
-
-sub contact_email {
-    my $self = shift;
-    return join( '@', 'customer.services', 'bristol.gov.uk' );
 }
 
 sub send_questionnaires {

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -33,12 +33,6 @@ sub report_new_munge_before_insert {
     $report->subcategory($report->get_extra_field_value('service_sub_code'));
 }
 
-sub base_url {
-    my $self = shift;
-    return $self->next::method() if FixMyStreet->config('STAGING_SITE');
-    return 'https://fix.bromley.gov.uk';
-}
-
 sub problems_on_map_restriction {
     my ($self, $rs) = @_;
     return $rs if FixMyStreet->staging_flag('skip_checks');
@@ -87,10 +81,6 @@ sub get_geocoder {
     return 'OSM'; # default of Bing gives poor results, let's try overriding.
 }
 
-sub example_places {
-    return ( 'BR1 3UH', 'Glebe Rd, Bromley' );
-}
-
 sub map_type {
     'Bromley';
 }
@@ -120,12 +110,6 @@ sub process_open311_extras {
     my $self = shift;
     $self->SUPER::process_open311_extras( @_, [ 'first_name', 'last_name' ] );
 }
-
-sub contact_email {
-    my $self = shift;
-    return join( '@', 'info', 'bromley.gov.uk' );
-}
-sub contact_name { 'Bromley Council (do not reply)'; }
 
 sub abuse_reports_only { 1; }
 

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -12,16 +12,6 @@ sub council_area { return 'Buckinghamshire'; }
 sub council_name { return 'Buckinghamshire County Council'; }
 sub council_url { return 'buckinghamshire'; }
 
-sub example_places {
-    return ( 'HP19 7QF', "Walton Road" );
-}
-
-sub base_url {
-    my $self = shift;
-    return $self->next::method() if FixMyStreet->config('STAGING_SITE');
-    return 'https://fixmystreet.buckscc.gov.uk';
-}
-
 sub disambiguate_location {
     my $self    = shift;
     my $string  = shift;
@@ -52,11 +42,6 @@ sub pin_colour {
 }
 
 sub admin_user_domain { 'buckscc.gov.uk' }
-
-sub contact_email {
-    my $self = shift;
-    return join( '@', 'fixmystreetbs', 'email.buckscc.gov.uk' );
-}
 
 sub send_questionnaires {
     return 0;

--- a/perllib/FixMyStreet/Cobrand/EastHerts.pm
+++ b/perllib/FixMyStreet/Cobrand/EastHerts.pm
@@ -9,20 +9,9 @@ sub council_area { return 'East Hertfordshire'; }
 sub council_name { return 'East Hertfordshire District Council'; }
 sub council_url { return 'eastherts'; }
 
-sub base_url {
-    my $self = shift;
-    return $self->next::method() if FixMyStreet->config('STAGING_SITE');
-    return 'https://fixmystreet.eastherts.gov.uk';
-}
-
-
 sub enter_postcode_text {
     my ($self) = @_;
     return 'Enter an ' . $self->council_area . ' postcode, or street name and area';
-}
-
-sub example_places {
-    return ( 'SG14 2AP', "Mangrove Road" );
 }
 
 sub disambiguate_location {
@@ -44,11 +33,6 @@ sub pin_colour {
     return 'green' if $p->is_fixed || $p->is_closed;
     return 'red' if $p->state eq 'confirmed';
     return 'yellow';
-}
-
-sub contact_email {
-    my $self = shift;
-    return join( '@', 'enquiries', 'eastherts.gov.uk' );
 }
 
 1;

--- a/perllib/FixMyStreet/Cobrand/Greenwich.pm
+++ b/perllib/FixMyStreet/Cobrand/Greenwich.pm
@@ -9,16 +9,6 @@ sub council_area { return 'Greenwich'; }
 sub council_name { return 'Royal Borough of Greenwich'; }
 sub council_url { return 'greenwich'; }
 
-sub base_url {
-    my $self = shift;
-    return $self->next::method() if FixMyStreet->config('STAGING_SITE');
-    return 'https://fix.royalgreenwich.gov.uk';
-}
-
-sub example_places {
-    return ( 'SE18 6HQ', "Woolwich Road" );
-}
-
 sub enter_postcode_text {
     my ($self) = @_;
     return 'Enter a Royal Greenwich postcode, or street name and area';
@@ -48,11 +38,6 @@ sub pin_colour {
     return 'green' if $p->is_fixed || $p->is_closed;
     return 'red' if $p->state eq 'confirmed';
     return 'yellow';
-}
-
-sub contact_email {
-    my $self = shift;
-    return join( '@', 'fixmystreet', 'royalgreenwich.gov.uk' );
 }
 
 sub reports_per_page { return 20; }

--- a/perllib/FixMyStreet/Cobrand/Hart.pm
+++ b/perllib/FixMyStreet/Cobrand/Hart.pm
@@ -26,10 +26,6 @@ sub disambiguate_location {
     };
 }
 
-sub example_places {
-    return ( 'GU51 4JX', 'Primrose Drive' );
-}
-
 sub categories_restriction {
     my ($self, $rs) = @_;
     return $rs->search( { category => { '!=' => 'Graffiti on bridges/subways' } } );
@@ -42,12 +38,6 @@ sub send_questionnaires {
 sub ask_ever_reported {
     return 0;
 }
-
-sub contact_email {
-    my $self = shift;
-    return join( '@', 'info', 'hart.gov.uk' );
-}
-sub contact_name { 'Hart District Council (do not reply)'; }
 
 sub default_map_zoom { 3 }
 

--- a/perllib/FixMyStreet/Cobrand/Hounslow.pm
+++ b/perllib/FixMyStreet/Cobrand/Hounslow.pm
@@ -8,15 +8,8 @@ sub council_area_id { 2483 }
 sub council_area { 'Hounslow' }
 sub council_name { 'Hounslow Highways' }
 sub council_url { 'hounslow' }
-sub example_places { ( 'TW3 1SN', "Depot Road" ) }
 
 sub map_type { 'Hounslow' }
-
-sub base_url {
-    my $self = shift;
-    return $self->next::method() if FixMyStreet->config('STAGING_SITE');
-    return 'https://fms.hounslowhighways.org';
-}
 
 sub enter_postcode_text {
     my ($self) = @_;
@@ -51,11 +44,6 @@ sub get_geocoder {
 }
 
 sub on_map_default_status { 'open' }
-
-sub contact_email {
-    my $self = shift;
-    return join( '@', 'enquiries', $self->council_url . 'highways.org' );
-}
 
 sub send_questionnaires { 0 }
 

--- a/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
@@ -29,23 +29,6 @@ sub enter_postcode_text {
     return 'Enter a Lincolnshire postcode, street name and area, or check an existing report number';
 }
 
-
-sub base_url {
-    my $self = shift;
-    return $self->next::method() if FixMyStreet->config('STAGING_SITE');
-    return 'https://fixmystreet.lincolnshire.gov.uk';
-}
-
-sub contact_email {
-    my $self = shift;
-    return join( '@', 'confirm_support', 'lincolnshire.gov.uk' );
-}
-
-
-sub example_places {
-    return ( 'LN1 1YL', 'Orchard Street, Lincoln' );
-}
-
 sub disambiguate_location {
     my $self    = shift;
     my $string  = shift;

--- a/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
@@ -12,15 +12,7 @@ sub council_area { 'Northamptonshire' }
 sub council_name { 'Northamptonshire County Council' }
 sub council_url { 'northamptonshire' }
 
-sub example_places { ( 'NN1 1NS', "Bridge Street" ) }
-
 sub enter_postcode_text { 'Enter a Northamptonshire postcode, street name and area, or check an existing report number' }
-
-sub base_url {
-    my $self = shift;
-    return $self->next::method() if FixMyStreet->config('STAGING_SITE');
-    return 'https://fixmystreet.northamptonshire.gov.uk';
-}
 
 sub disambiguate_location {
     my $self    = shift;
@@ -49,11 +41,6 @@ sub problems_on_map_restriction {
     # Northamptonshire don't want to show district/borough reports
     # on the site
     return $self->problems_restriction($rs);
-}
-
-sub contact_email {
-    my $self = shift;
-    return join( '@', 'highways', $self->council_url . '.gov.uk' );
 }
 
 sub privacy_policy_url {

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -37,12 +37,6 @@ sub is_council_with_case_management {
     return FixMyStreet->config('STAGING_SITE');
 }
 
-sub base_url {
-    my $self = shift;
-    return $self->next::method() if FixMyStreet->config('STAGING_SITE');
-    return 'https://fixmystreet.oxfordshire.gov.uk';
-}
-
 sub enter_postcode_text {
     my ($self) = @_;
     return 'Enter an Oxfordshire postcode, or street name and area';
@@ -58,10 +52,6 @@ sub disambiguate_location {
         span   => '0.709058,0.849434',
         bounds => [ 51.459413, -1.719500, 52.168471, -0.870066 ],
     };
-}
-
-sub example_places {
-    return ( 'OX20 1SZ', 'Park St, Woodstock' );
 }
 
 # don't send questionnaires to people who used the OCC cobrand to report their problem
@@ -155,11 +145,6 @@ sub should_skip_sending_update {
 }
 
 sub on_map_default_status { return 'open'; }
-
-sub contact_email {
-    my $self = shift;
-    return join( '@', 'highway.enquiries', 'oxfordshire.gov.uk' );
-}
 
 sub admin_user_domain { 'oxfordshire.gov.uk' }
 

--- a/perllib/FixMyStreet/Cobrand/Rutland.pm
+++ b/perllib/FixMyStreet/Cobrand/Rutland.pm
@@ -35,10 +35,6 @@ sub open311_config {
     $params->{multi_photos} = 1;
 }
 
-sub example_places {
-    return ( 'LE15 6HP', 'High Street', 'Oakham' );
-}
-
 sub disambiguate_location {
     my $self    = shift;
     my $string  = shift;

--- a/perllib/FixMyStreet/Cobrand/Stevenage.pm
+++ b/perllib/FixMyStreet/Cobrand/Stevenage.pm
@@ -10,12 +10,6 @@ sub council_name { return 'Stevenage Council'; }
 sub council_url { return 'stevenage'; }
 sub is_two_tier { return 1; }
 
-sub base_url {
-    my $self = shift;
-    return $self->next::method() if FixMyStreet->config('STAGING_SITE');
-    return 'http://fixmystreet.stevenage.gov.uk';
-}
-
 sub disambiguate_location {
     my $self = shift;
     return {
@@ -27,18 +21,9 @@ sub disambiguate_location {
     };
 }
 
-sub example_places {
-    return [ 'SG1 1HN', 'Lyton Way' ];
-}
-
 sub default_map_zoom { return 3; }
 
 sub users_can_hide { return 1; }
-
-sub contact_email {
-    my $self = shift;
-    return join( '@', 'csc', 'stevenage.gov.uk' );
-}
 
 1;
 

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -110,13 +110,22 @@ sub users_restriction {
 
 sub base_url {
     my $self = shift;
-    my $base_url = FixMyStreet->config('BASE_URL');
+
+    my $base_url = $self->feature('base_url');
+    return $base_url if $base_url;
+
+    $base_url = FixMyStreet->config('BASE_URL');
     my $u = $self->council_url;
     if ( $base_url !~ /$u/ ) {
         $base_url =~ s{(https?://)(?!www\.)}{$1$u.}g;
         $base_url =~ s{(https?://)www\.}{$1$u.}g;
     }
     return $base_url;
+}
+
+sub example_places {
+    my $self = shift;
+    return $self->feature('example_places') || $self->next::method();
 }
 
 sub enter_postcode_text {
@@ -323,6 +332,16 @@ sub lookup_site_code {
     }
 
     return $site_code;
+}
+
+sub contact_name {
+    my $self = shift;
+    return $self->feature('contact_name') || $self->next::method();
+}
+
+sub contact_email {
+    my $self = shift;
+    return $self->feature('contact_email') || $self->next::method();
 }
 
 sub extra_contact_validation {

--- a/perllib/FixMyStreet/Cobrand/Warwickshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Warwickshire.pm
@@ -22,16 +22,6 @@ sub disambiguate_location {
     };
 }
 
-sub example_places {
-    return [ 'CV34 4RL', 'Stratford Rd' ];
-}
-
-sub contact_email {
-    my $self = shift;
-    return join( '@', 'fmstest', 'warwickshire.gov.uk' );
-}
-sub contact_name { 'Warwickshire County Council (do not reply)'; }
-
 sub send_questionnaires { 0 }
 
 sub open311_contact_meta_override {

--- a/t/cobrand/bexley.t
+++ b/t/cobrand/bexley.t
@@ -12,10 +12,18 @@ $ukc->mock('lookup_site_code', sub {
     return "Road ID";
 });
 
-my $cobrand = FixMyStreet::Cobrand::Bexley->new;
-like $cobrand->contact_email, qr/bexley/;
-is $cobrand->on_map_default_status, 'open';
-is_deeply $cobrand->disambiguate_location->{bounds}, [ 51.408484, 0.074653, 51.515542, 0.2234676 ];
+FixMyStreet::override_config {
+    COBRAND_FEATURES => {
+        contact_email => {
+            bexley => 'foo@bexley',
+        }
+    },
+}, sub {
+    my $cobrand = FixMyStreet::Cobrand::Bexley->new;
+    like $cobrand->contact_email, qr/bexley/;
+    is $cobrand->on_map_default_status, 'open';
+    is_deeply $cobrand->disambiguate_location->{bounds}, [ 51.408484, 0.074653, 51.515542, 0.2234676 ];
+};
 
 my $mech = FixMyStreet::TestMech->new;
 


### PR DESCRIPTION
This moves four options from code to config, which would make it easier to change any of them in future (for these, perhaps unlikely, but still). This change would necessitate the following being done in the server config:

```
COBRAND_FEATURES:
  contact_name:
    bromley: 'Bromley Council (do not reply)'
    hart: 'Hart District Council (do not reply)'
    warwickshire: 'Warwickshire County Council (do not reply)'
  contact_email:
    [...]
  example_places:
    bathnes: [  'BA1 1JQ', "Lansdown Grove" ]
    bexley: [ 'DA6 7AT', "Chieveley Road" ]
    borsetshire: [ 'BS36 2NS', 'Coalpit Heath' ]
    bristol: [ 'BS1 5TR', "Broad Quay" ]
    bromley: [ 'BR1 3UH', 'Glebe Rd, Bromley' ]
    buckinghamshire: [ 'HP19 7QF', "Walton Road" ]
    eastherts: [ 'SG14 2AP', "Mangrove Road" ]
    greenwich: [ 'SE18 6HQ', "Woolwich Road" ]
    hart: [ 'GU51 4JX', 'Primrose Drive' ]
    lincolnshire: [ 'LN1 1YL', 'Orchard Street, Lincoln' ]
    northamptonshire: [ 'NN1 1NS', "Bridge Street" ] 
    oxfordshire: [ 'OX20 1SZ', 'Park St, Woodstock' ]
    rutland: [ 'LE15 6HP', 'High Street, Oakham' ]
    stevenage: [ 'SG1 1HN', 'Lyton Way' ]
    warwickshire: [ 'CV34 4RL', 'Stratford Rd' ]
  base_url:
    bathnes: 'https://fix.bathnes.gov.uk'
    bexley: 'https://fix.bexley.gov.uk'
    bristol: 'https://fixmystreet.bristol.gov.uk'
    bromley: 'https://fix.bromley.gov.uk'
    buckinghamshire: 'https://fixmystreet.buckscc.gov.uk'
    eastherts: 'https://fixmystreet.eastherts.gov.uk'
    greenwich: 'https://fix.royalgreenwich.gov.uk'
    lincolnshire: 'https://fixmystreet.lincolnshire.gov.uk'
    northamptonshire: 'https://fixmystreet.northamptonshire.gov.uk'
    oxfordshire: 'https://fixmystreet.oxfordshire.gov.uk'
    stevenage: 'http://fixmystreet.stevenage.gov.uk'
```

[skip changelog]
