### PR TITLE
make sure council_name exists before trying to call it

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -202,7 +202,9 @@ sub report_form_ajax : Path('ajax') : Args(0) {
 
     my @list_of_names = map { $_->name } values %{$c->stash->{bodies}};
     my %display_names = map {
-        my $name = $_->get_cobrand_handler ? $_->get_cobrand_handler->council_name : $_->name;
+        my $name = $_->get_cobrand_handler && $_->get_cobrand_handler->can('council_name')
+            ? $_->get_cobrand_handler->council_name
+            : $_->name;
         ( $_->name ne $name ) ? ( $_->name => $name ) : ();
     } values %{$c->stash->{bodies}};
     my $contribute_as = {};

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -1,3 +1,10 @@
+package FixMyStreet::Cobrand::HounslowNoName;
+use base 'FixMyStreet::Cobrand::UK';
+
+sub council_area_id { 2483 };
+
+package main;
+
 use Test::MockModule;
 use FixMyStreet::TestMech;
 use FixMyStreet::App;
@@ -1401,6 +1408,14 @@ subtest "check map click ajax response" => sub {
         $extra_details = $mech->get_ok_json( '/report/new/ajax?latitude=51.482286&longitude=-0.328163' );
     };
     is_deeply $extra_details->{display_names}, { 'Hounslow Borough Council' => 'Hounslow Highways' }, 'council display name mapping correct';
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'hounslownoname',
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $extra_details = $mech->get_ok_json( '/report/new/ajax?latitude=51.482286&longitude=-0.328163' );
+    };
+    isnt defined $extra_details->{display_names}, 'no council display names if none defined';
 };
 
 #### test uploading an image


### PR DESCRIPTION
Not all cobrands have a council_name method.

[skip changelog]