### PR TITLE
[Bristol] redirect national site categories

### DIFF
--- a/web/cobrands/bristol/assets.js
+++ b/web/cobrands/bristol/assets.js
@@ -116,4 +116,21 @@ fixmystreet.assets.add(lighting_options, {
     filter_value: 'SL: Sign'
 });
 
+var redirects = {
+    "Abandoned vehicles": "https://www.bristol.gov.uk/streets-travel/abandoned-vehicles",
+    "Flytipping": "https://www.bristol.gov.uk/streets-travel/flytipping",
+    "Flyposting": "https://www.bristol.gov.uk/streets-travel/flyposting",
+    "Graffiti": "https://www.bristol.gov.uk/streets-travel/graffiti",
+    "Dog fouling": "https://www.bristol.gov.uk/streets-travel/dog-fouling",
+    "Street cleaning": "https://www.bristol.gov.uk/streets-travel/street-that-needs-cleaning"
+};
+
+$.each(redirects, function(name, value) {
+    fixmystreet.message_controller.register_category({
+        body: common_options.body,
+        category: name,
+        message: 'If you wish to report an issue with ' + name + ', please use <a href="' + value + '">this service</a>.'
+    });
+});
+
 })();


### PR DESCRIPTION
Add a message to various categories on the national site asking people
to use a separate Bristol site to make reports.

Please check the following:

- [ ] Whether this PR should include changes to any documentation, or the FAQ;
- [ ] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [ ] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [ ] Are the changes tested for accessibility?
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
