### PR TITLE
better error if category for report does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
         - Don't include private reports when searching by ref from front page.
         - Set fixmystreet.bodies sooner client-side, for two-tier locations.
         - Fix front-end testing script when run with Vagrant.
+        - Handle missing category when sending open311 reports #2502
     - Development improvements:
         - Upgrade the underlying framework and a number of other packages.
         - Add feature cobrand helper function.

--- a/perllib/FixMyStreet/SendReport.pm
+++ b/perllib/FixMyStreet/SendReport.pm
@@ -60,4 +60,21 @@ sub add_body {
     $self->body_config->{ $body->id } = $config;
 }
 
+sub fetch_category {
+    my ($self, $body, $row, $category_override) = @_;
+
+    my $contact = $row->result_source->schema->resultset("Contact")->not_deleted->find( {
+        body_id => $body->id,
+        category => $category_override || $row->category,
+    } );
+
+    unless ($contact) {
+        my $error = "Category " . $row->category . " does not exist for body " . $body->id . " and report " . $row->id . "\n";
+        $self->error( "Failed to send over Open311\n" ) unless $self->error;
+        $self->error( $self->error . "\n" . $error );
+    }
+
+    return $contact;
+}
+
 1;

--- a/perllib/FixMyStreet/SendReport/Email.pm
+++ b/perllib/FixMyStreet/SendReport/Email.pm
@@ -12,10 +12,7 @@ sub build_recipient_list {
     my $all_confirmed = 1;
     foreach my $body ( @{ $self->bodies } ) {
 
-        my $contact = $row->result_source->schema->resultset("Contact")->not_deleted->find( {
-            body_id => $body->id,
-            category => $row->category
-        } );
+        my $contact = $self->fetch_category($body, $row) or next;
 
         my ($body_email, $state, $note) = ( $contact->email, $contact->state, $contact->note );
 

--- a/perllib/FixMyStreet/SendReport/Email/SingleBodyOnly.pm
+++ b/perllib/FixMyStreet/SendReport/Email/SingleBodyOnly.pm
@@ -15,11 +15,7 @@ sub build_recipient_list {
     my $body = $self->bodies->[0];
 
     # We don't care what the category was, look up the relevant contact
-    my $contact = $row->result_source->schema->resultset("Contact")->not_deleted->find({
-        body_id => $body->id,
-        category => $self->contact,
-    });
-    return unless $contact;
+    my $contact = $self->fetch_category($body, $row, $self->contact) or return;
 
     @{$self->to} = map { [ $_, $body->name ] } split /,/, $contact->email;
     return 1;

--- a/perllib/FixMyStreet/SendReport/Open311.pm
+++ b/perllib/FixMyStreet/SendReport/Open311.pm
@@ -36,13 +36,9 @@ sub send {
         my $cobrand = $body->get_cobrand_handler || $row->get_cobrand_logged;
         $cobrand->call_hook(open311_config => $row, $h, \%open311_params);
 
+        my $contact = $self->fetch_category($body, $row) or next;
+
         # Try and fill in some ones that we've been asked for, but not asked the user for
-
-        my $contact = $row->result_source->schema->resultset("Contact")->not_deleted->find( {
-            body_id => $body->id,
-            category => $row->category
-        } );
-
         my $extra = $row->get_extra_fields();
 
         my $id_field = $contact->id_field;

--- a/perllib/FixMyStreet/SendReport/Zurich.pm
+++ b/perllib/FixMyStreet/SendReport/Zurich.pm
@@ -29,10 +29,7 @@ sub build_recipient_list {
     my $parent = $body->parent;
     if ($parent && !$parent->parent) {
         # Division, might have an individual contact email address
-        my $contact = $row->result_source->schema->resultset("Contact")->find( {
-            body_id => $body->id,
-            category => $row->category
-        } );
+        my $contact = $self->fetch_category($body, $row);
         $body_email = $contact->email if $contact && $contact->email;
     }
 

--- a/t/app/sendreport/email/highways.t
+++ b/t/app/sendreport/email/highways.t
@@ -11,6 +11,7 @@ $mech->create_contact_ok(email => 'council@example.com', body_id => $bromley->id
 $mech->create_contact_ok(email => 'highways@example.com', body_id => $highways->id, category => 'Pothole');
 
 my $row = FixMyStreet::DB->resultset('Problem')->new( {
+    id => 123,
     bodies_str => '1000',
     category => 'Pothole',
     cobrand => '',

--- a/t/app/sendreport/email/tfl.t
+++ b/t/app/sendreport/email/tfl.t
@@ -11,6 +11,7 @@ $mech->create_contact_ok(email => 'council@example.com', body_id => $bromley->id
 $mech->create_contact_ok(email => 'tfl@example.com', body_id => $tfl->id, category => 'Traffic lights');
 
 my $row = FixMyStreet::DB->resultset('Problem')->new( {
+    id => 456,
     bodies_str => '1000',
     category => 'Faulty street light',
     cobrand => '',


### PR DESCRIPTION
It is possible that the category of a report no longer exists and in
that case the Open311 send process was falling over. This checks that
we've found a contact and if not sets the error and skips the report.

Please check the following:

- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog