### PR TITLE
[Hounslow] Hide all reports made before go-live entirely

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Hounslow.pm
+++ b/perllib/FixMyStreet/Cobrand/Hounslow.pm
@@ -189,4 +189,13 @@ sub lookup_site_code_config { {
     accept_feature => sub { 1 }
 } }
 
+# Hounslow don't want any reports made before their go-live date visible on
+# their cobrand at all.
+sub problems_restriction {
+    my ($self, $rs) = @_;
+    return $rs->to_body($self->body)->search({
+      'me.confirmed' => { '>=', '2019-05-06' }
+    });
+}
+
 1;

--- a/t/cobrand/hounslow.t
+++ b/t/cobrand/hounslow.t
@@ -1,0 +1,44 @@
+use FixMyStreet::TestMech;
+
+ok( my $mech = FixMyStreet::TestMech->new, 'Created mech object' );
+
+my $hounslow_id = $mech->create_body_ok(2483, 'Hounslow Borough Council')->id;
+
+$mech->create_problems_for_body(1, $hounslow_id, 'An old problem made before Hounslow FMS launched', {
+    confirmed => '2018-12-25 09:00',
+    lastupdate => '2018-12-25 09:00',
+});
+$mech->create_problems_for_body(1, $hounslow_id, 'A brand new problem made on the Hounslow site', {
+    cobrand => 'hounslow'
+});
+$mech->create_problems_for_body(1, $hounslow_id, 'A brand new problem made on fixmystreet.com', {
+    cobrand => 'fixmystreet'
+});
+
+subtest "it still shows old reports on fixmystreet.com" => sub {
+    FixMyStreet::override_config {
+        MAPIT_URL => 'http://mapit.uk/',
+        ALLOWED_COBRANDS => 'fixmystreet',
+    }, sub {
+        $mech->get_ok('/reports/Hounslow');
+
+        $mech->content_contains('An old problem made before Hounslow FMS launched');
+        $mech->content_contains('A brand new problem made on the Hounslow site');
+        $mech->content_contains('A brand new problem made on fixmystreet.com');
+    };
+};
+
+subtest "it does not show old reports on Hounslow" => sub {
+    FixMyStreet::override_config {
+        MAPIT_URL => 'http://mapit.uk/',
+        ALLOWED_COBRANDS => 'hounslow',
+    }, sub {
+        $mech->get_ok('/reports/Hounslow');
+
+        $mech->content_lacks('An old problem made before Hounslow FMS launched');
+        $mech->content_contains('A brand new problem made on the Hounslow site') or diag $mech->content;
+        $mech->content_contains('A brand new problem made on fixmystreet.com');
+    };
+};
+
+done_testing();


### PR DESCRIPTION
Hounslow has requested that any report made on FixMyStreet before their cobrand launched should not be visible at all on the cobrand.

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [ ] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]

