### PR TITLE
Fix frontend testing when done with vagrant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
         - Fix bug going between report/new pages client side
         - Don't include private reports when searching by ref from front page.
         - Set fixmystreet.bodies sooner client-side, for two-tier locations.
+        - Fix front-end testing script when run with Vagrant.
     - Development improvements:
         - Upgrade the underlying framework and a number of other packages.
         - Add feature cobrand helper function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     - Development improvements:
         - Upgrade the underlying framework and a number of other packages.
         - Add feature cobrand helper function.
+        - Add front-end testing support for WSL.
     - Open311 improvements:
         - Support use of 'private' service definition <keywords> to mark
           reports made in that category private.

--- a/bin/browser-tests
+++ b/bin/browser-tests
@@ -2,40 +2,50 @@
 
 use strict;
 use warnings;
-
-BEGIN {
-    use File::Basename qw(dirname);
-    use File::Spec;
-    my $d = dirname(File::Spec->rel2abs($0));
-    require "$d/../setenv.pl";
-}
+use lib '.'; # For the mock MapIt module
 
 use Getopt::Long ':config' => qw(pass_through auto_help);
 
-my ($run_server, $run_cypress, $vagrant);
-my $config_file = 'conf/general.yml-example';
-my $cobrand = [ 'fixmystreet', 'northamptonshire', 'bathnes', 'buckinghamshire' ];
-my $coords = '51.532851,-2.284277';
-my $area_id = 2608;
-my $name = 'Borsetshire';
-my $mapit_url = 'https://mapit.uk/';
+my ($run_server, $run_cypress, $vagrant, $config_file);
+my ($cobrand, $coords, $area_id, $name, $mapit_url);
 
-GetOptions(
-    'config=s' => \$config_file,
-    'server' => \$run_server,
-    'cypress' => \$run_cypress,
-    'vagrant' => \$vagrant,
-    'cobrand=s@' => \$cobrand,
-    'coords=s' => \$coords,
-    'area_id=s' => \$area_id,
-    'name=s' => \$name,
-    'mapit_url=s' => \$mapit_url,
-);
-$cobrand = [ split(',', join(',', @$cobrand)) ];
+BEGIN {
+    $config_file = 'conf/general.yml-example';
+    $cobrand = [ 'fixmystreet', 'northamptonshire', 'bathnes', 'buckinghamshire' ];
+    $coords = '51.532851,-2.284277';
+    $area_id = 2608;
+    $name = 'Borsetshire';
+    $mapit_url = 'https://mapit.uk/';
+
+    GetOptions(
+        'config=s' => \$config_file,
+        'server' => \$run_server,
+        'cypress' => \$run_cypress,
+        'vagrant' => \$vagrant,
+        'cobrand=s@' => \$cobrand,
+        'coords=s' => \$coords,
+        'area_id=s' => \$area_id,
+        'name=s' => \$name,
+        'mapit_url=s' => \$mapit_url,
+    );
+    $cobrand = [ split(',', join(',', @$cobrand)) ];
+
+    if (!$run_server && !$run_cypress) {
+        # If asked for neither, run both
+        $run_server = $run_cypress = 1;
+    }
+
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    if (!$vagrant && $run_server) {
+        require "$d/../setenv.pl";
+    }
+}
 
 if ($vagrant) {
     # Test inception
-    system('vagrant ssh -c "cd fixmystreet && bin/browser-tests --server 2>/dev/null" &');
+    system('vagrant ssh -- "cd fixmystreet && bin/browser-tests --server 2>/dev/null" &');
 
     require IO::Socket;
     sub check_connection {
@@ -53,13 +63,8 @@ if ($vagrant) {
     }
     print " done\n";
     system('bin/browser-tests', '--cypress', @ARGV);
-    system('vagrant', 'ssh', '-c', 'kill $(cat /tmp/cypress-server.pid)');
+    system('vagrant', 'ssh', '--', 'kill $(cat /tmp/cypress-server.pid)');
     exit;
-}
-
-if (!$run_server && !$run_cypress) {
-    # If asked for neither, run both
-    $run_server = $run_cypress = 1;
 }
 
 sub run {
@@ -95,7 +100,7 @@ sub run {
         kill 'TERM', $pid if $pid;
         exit $exit >> 8;
     } else {
-        use Test::MockModule;
+        require Test::MockModule;
         my $c = Test::MockModule->new('FixMyStreet::Cobrand::FixMyStreet');
         $c->mock('enable_category_groups', sub { 1 });
         # Child, run the server on port 3001

--- a/bin/browser-tests
+++ b/bin/browser-tests
@@ -6,7 +6,7 @@ use lib '.'; # For the mock MapIt module
 
 use Getopt::Long ':config' => qw(pass_through auto_help);
 
-my ($run_server, $run_cypress, $vagrant, $config_file);
+my ($run_server, $run_cypress, $vagrant, $wsl, $node, $config_file);
 my ($cobrand, $coords, $area_id, $name, $mapit_url);
 
 BEGIN {
@@ -16,12 +16,15 @@ BEGIN {
     $area_id = 2608;
     $name = 'Borsetshire';
     $mapit_url = 'https://mapit.uk/';
+    $node = 'C:\Program Files\nodejs\node.exe';
 
     GetOptions(
         'config=s' => \$config_file,
         'server' => \$run_server,
         'cypress' => \$run_cypress,
         'vagrant' => \$vagrant,
+        'wsl=s' => \$wsl,
+        'node=s' => \$node,
         'cobrand=s@' => \$cobrand,
         'coords=s' => \$coords,
         'area_id=s' => \$area_id,
@@ -29,6 +32,11 @@ BEGIN {
         'mapit_url=s' => \$mapit_url,
     );
     $cobrand = [ split(',', join(',', @$cobrand)) ];
+
+    if ($vagrant && $wsl) {
+        print 'You cannot use both --vagrant and --wsl';
+        exit 1;
+    }
 
     if (!$run_server && !$run_cypress) {
         # If asked for neither, run both
@@ -96,7 +104,11 @@ sub run {
 
     if (($run_cypress && !$run_server) || $pid) {
         # Parent, run the test runner (then kill the child)
-        my $exit = system("cypress", $cmd, '--config', 'pluginsFile=false,supportFile=false', '--project', '.cypress', @ARGV);
+        my @cypress = ('cypress');
+        if ($wsl) {
+            @cypress = ('cmd.exe', '/c', $node, $wsl);
+        }
+        my $exit = system(@cypress, $cmd, '--config', 'pluginsFile=false,supportFile=false', '--project', '.cypress', @ARGV);
         kill 'TERM', $pid if $pid;
         exit $exit >> 8;
     } else {
@@ -131,6 +143,7 @@ browser-tests [running options] [fixture options] [cypress options]
    --server         only run the test server, not cypress
    --cypress        only run cypress, not the test server
    --vagrant        run test server inside Vagrant, cypress outside
+   --wsl            provide path to cypress node script, to run test server inside WSL, cypress outside
    --help           this help message
 
  Fixture option:
@@ -149,6 +162,7 @@ server in the VM and Cypress outside of it.
  $ browser-tests run                 # run headlessly
  $ browser-tests run --record --key  # record and upload a run
  $ browser-tests --vagrant run       # run if you use Vagrant
+ $ browser-tests --wsl ..cypress run # run if you use WSL
 
 You need to have installed cypress already using npm, and it needs to be on
 your PATH.


### PR DESCRIPTION
Noticed this week that it’s not been possible to run the cypress browser tests when you have FMS running an a Vagrant VM (and the tests running outside on the host) since the FMS Vagrant config was changed to use an FMS-specific box.

@dracos and I changed a couple of things to get it working again. I think this was all of it?