### PR TITLE
set autocomplete to off for report title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
         - Fix front-end testing script when run with Vagrant. #2514
         - Handle missing category when sending open311 reports #2502
         - Fix label associations with category groups. #2541
+    - Front end improvements:
+        - Set report title autocomplete to off to prevent email autocompleting
     - Development improvements:
         - Upgrade the underlying framework and a number of other packages. #2473
         - Add feature cobrand helper function.

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -362,6 +362,9 @@ sub check_for_errors {
     $errors{title} = _('Please enter a subject')
       unless $self->title =~ m/\S/;
 
+    $errors{title} = _('Please make sure you are not including an email address')
+        if mySociety::EmailUtil::is_valid_email($self->title);
+
     $errors{detail} = _('Please enter some details')
       unless $self->detail =~ m/\S/;
 

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -519,6 +519,29 @@ foreach my $test (
         errors => [ "Please enter a subject" ],
     },
     {
+        msg    => 'email in title',
+        pc     => 'SW1A 1AA',
+        fields => {
+            title         => 'user@example.com',
+            detail        => 'Test detail',
+            photo1        => '',
+            photo2        => '',
+            photo3        => '',
+            name          => 'Joe Smith',
+            may_show_name => '1',
+            username      => 'user@example.com',
+            phone         => '',
+            category      => 'Street lighting',
+            password_sign_in => '',
+            password_register => '',
+        },
+        changes => {
+            username => 'user@example.com',
+            title => 'User@example.com'
+        },
+        errors  => [ 'Please make sure you are not including an email address', ],
+    },
+    {
         msg    => 'Bromley long detail',
         pc     => 'BR1 3UH',
         fields => {

--- a/templates/web/base/js/translation_strings.html
+++ b/templates/web/base/js/translation_strings.html
@@ -7,7 +7,8 @@ fixmystreet.password_minimum_length = [% c.cobrand.password_minimum_length %];
         error: '[% loc('Error') | replace("'", "\\'") %]',
         title: {
             required: '[% loc('Please enter a subject') | replace("'", "\\'") %]',
-            maxlength: '[% loc('Summaries are limited to {0} characters in length. Please shorten your summary') | replace("'", "\\'") %]'
+            maxlength: '[% loc('Summaries are limited to {0} characters in length. Please shorten your summary') | replace("'", "\\'") %]',
+            notEmail: '[% loc('Please make sure you are not including an email address') %]'
         },
         detail: {
             required: '[% loc('Please enter some details') | replace("'", "\\'") %]',

--- a/templates/web/base/report/new/form_title.html
+++ b/templates/web/base/report/new/form_title.html
@@ -5,4 +5,4 @@
 [% IF field_errors.title %]
     <p class='form-error'>[% field_errors.title %]</p>
 [% END %]
-<input class="form-control" type="text" value="[% report.title | html %]" name="title" id="form_title" aria-describedby="title-hint" required>
+<input class="form-control" type="text" value="[% report.title | html %]" name="title" id="form_title" aria-describedby="title-hint" required autocomplete="off">

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -294,6 +294,8 @@ $.extend(fixmystreet.set_up, {
         jQuery.validator.addMethod('js-password-validate', function(value, element) {
             return !value || value.length >= fixmystreet.password_minimum_length;
         }, translation_strings.password_register.short);
+        jQuery.validator.addMethod('notEmail', function(value, element) {
+            return this.optional(element) || !/^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@(?:\S{1,63})$/.test( value ); }, translation_strings.title );
     }
 
     var submitted = false;

--- a/web/js/validation_rules.js
+++ b/web/js/validation_rules.js
@@ -1,5 +1,5 @@
     core_validation_rules = {
-        title: { required: true },
+        title: { required: true, notEmail: true },
         detail: { required: true },
         update: { required: true },
         password_register: {


### PR DESCRIPTION
Some browsers seem to be autocompleting title with the user's email
address so try turning this off to see if it helps.


- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
