### PR TITLE
[Bromley] Add temporary maintenance banner

### DIFF
--- a/templates/web/bromley/before_wrapper.html
+++ b/templates/web/bromley/before_wrapper.html
@@ -1,0 +1,10 @@
+<div class="top_banner">
+    <p>
+        Whilst reports will be actioned in the usual way, please be aware that
+        there will be a temporary slightly longer response of 1 working day as
+        a back office software upgrade is taking place.
+    </p>
+    <p>
+        <a href="https://www.bromley.gov.uk/info/200119/customer_services/1022/contact_us_by_telephone">Please report urgent matters by calling us</a>.
+    </p>
+</div>

--- a/templates/web/bromley/report/new/top_message.html
+++ b/templates/web/bromley/report/new/top_message.html
@@ -1,0 +1,1 @@
+[% INCLUDE 'before_wrapper.html' %]

--- a/web/cobrands/bromley/base.scss
+++ b/web/cobrands/bromley/base.scss
@@ -371,6 +371,10 @@ body.mappage {
   }
 }
 
+body.mappage > .top_banner {
+  display: none;
+}
+
 // Bromley's footer
 .site-footer {
   width: 100%;


### PR DESCRIPTION
Adds a temporary banner to Bromley for the upcoming maintenance window.

[skip changelog]

For https://github.com/mysociety/fixmystreet-freshdesk/issues/65