### PR TITLE
[Westminster] Add OpenID Connect single sign-on support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
         - Add new roles system, to group permissions and apply to users.
     - New features:
         - Categories can be listed under more than one group #2475
+        - OpenID Connect login support. #2523
     - Bugfixes:
         - Prevent creation of two templates with same title.
         - Fix bug going between report/new pages client side

--- a/bin/update-schema
+++ b/bin/update-schema
@@ -212,6 +212,7 @@ else {
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
     return 'EMPTY' if ! table_exists('problem');
+    return '0068' if column_exists('users', 'oidc_ids');
     return '0067' if table_exists('roles');
     return '0066' if column_exists('users', 'area_ids');
     return '0065' if constraint_contains('admin_log_object_type_check', 'moderation');

--- a/cpanfile
+++ b/cpanfile
@@ -107,6 +107,7 @@ requires 'Net::Facebook::Oauth2', '0.11';
 requires 'Net::OAuth';
 requires 'Net::Twitter::Lite::WithAPIv1_1', '0.12008';
 requires 'Number::Phone', '3.5000';
+requires 'OIDC::Lite';
 requires 'Path::Class';
 requires 'POSIX';
 requires 'Readonly';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -292,6 +292,12 @@ DISTRIBUTIONS
       Storable 0
       String::CRC32 0
       Time::HiRes 0
+  Canary-Stability-2013
+    pathname: M/ML/MLEHMANN/Canary-Stability-2013.tar.gz
+    provides:
+      Canary::Stability 2013
+    requirements:
+      ExtUtils::MakeMaker 0
   Capture-Tiny-0.40
     pathname: D/DA/DAGOLDEN/Capture-Tiny-0.40.tar.gz
     provides:
@@ -846,6 +852,13 @@ DISTRIBUTIONS
       Class::Data::Inheritable 0.08
     requirements:
       ExtUtils::MakeMaker 0
+  Class-ErrorHandler-0.04
+    pathname: T/TO/TOKUHIROM/Class-ErrorHandler-0.04.tar.gz
+    provides:
+      Class::ErrorHandler 0.04
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.008_001
   Class-Factory-Util-1.7
     pathname: D/DR/DROLSKY/Class-Factory-Util-1.7.tar.gz
     provides:
@@ -1064,12 +1077,70 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
+  Crypt-OpenSSL-Guess-0.11
+    pathname: A/AK/AKIYM/Crypt-OpenSSL-Guess-0.11.tar.gz
+    provides:
+      Crypt::OpenSSL::Guess 0.11
+    requirements:
+      Config 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 6.64
+      File::Spec 0
+      Symbol 0
+      perl 5.008001
+  Crypt-OpenSSL-RSA-0.31
+    pathname: T/TO/TODDR/Crypt-OpenSSL-RSA-0.31.tar.gz
+    provides:
+      Crypt::OpenSSL::RSA 0.31
+    requirements:
+      Crypt::OpenSSL::Random 0
+      ExtUtils::MakeMaker 0
+      Test::More 0
+      perl 5.006
+  Crypt-OpenSSL-Random-0.15
+    pathname: R/RU/RURBAN/Crypt-OpenSSL-Random-0.15.tar.gz
+    provides:
+      Crypt::OpenSSL::Random 0.15
+    requirements:
+      Crypt::OpenSSL::Guess 0.11
+      ExtUtils::MakeMaker 0
   Crypt-RC4-2.02
     pathname: S/SI/SIFUKURT/Crypt-RC4-2.02.tar.gz
     provides:
       Crypt::RC4 2.02
     requirements:
       ExtUtils::MakeMaker 0
+  Crypt-Random-Source-0.14
+    pathname: E/ET/ETHER/Crypt-Random-Source-0.14.tar.gz
+    provides:
+      Crypt::Random::Source 0.14
+      Crypt::Random::Source::Base 0.14
+      Crypt::Random::Source::Base::File 0.14
+      Crypt::Random::Source::Base::Handle 0.14
+      Crypt::Random::Source::Base::Proc 0.14
+      Crypt::Random::Source::Base::RandomDevice 0.14
+      Crypt::Random::Source::Factory 0.14
+      Crypt::Random::Source::Strong 0.14
+      Crypt::Random::Source::Strong::devrandom 0.14
+      Crypt::Random::Source::Weak 0.14
+      Crypt::Random::Source::Weak::devurandom 0.14
+    requirements:
+      Capture::Tiny 0.08
+      Carp 0
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      IO::File 1.14
+      IO::Handle 0
+      Module::Build::Tiny 0.034
+      Module::Find 0
+      Module::Runtime 0
+      Moo 1.002000
+      Sub::Exporter 0
+      Types::Standard 0
+      namespace::clean 0.11
+      perl 5.008
+      strict 0
+      warnings 0
   CryptX-0.059
     pathname: M/MI/MIK/CryptX-0.059.tar.gz
     provides:
@@ -1463,7 +1534,7 @@ DISTRIBUTIONS
       DBIx::Class::IntrospectableM2M 0.001001
     requirements:
       DBIx::Class 0
-      ExtUtils::MakeMaker 6.72
+      ExtUtils::MakeMaker 7.34
       Test::More 0
   DBIx-Class-QueryLog-1.005001
     pathname: F/FR/FREW/DBIx-Class-QueryLog-1.005001.tar.gz
@@ -2468,6 +2539,7 @@ DISTRIBUTIONS
       Dir::Self 0.11
     requirements:
       Carp 0
+      ExtUtils::MakeMaker 6.48
       File::Spec 0
       strict 0
   Dist-CheckConflicts-0.09
@@ -3674,6 +3746,34 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Scalar::Util 1.08
       Test::More 0
+  JSON-WebToken-0.10
+    pathname: X/XA/XAICRON/JSON-WebToken-0.10.tar.gz
+    provides:
+      JSON::WebToken 0.10
+      JSON::WebToken::Constants undef
+      JSON::WebToken::Crypt undef
+      JSON::WebToken::Crypt::HMAC undef
+      JSON::WebToken::Crypt::RSA undef
+      JSON::WebToken::Exception undef
+    requirements:
+      Carp 0
+      Digest::SHA 0
+      Exporter 0
+      JSON 0
+      MIME::Base64 0
+      Module::Build 0.38
+      Module::Runtime 0
+      parent 0
+      perl 5.008001
+  JSON-XS-4.02
+    pathname: M/ML/MLEHMANN/JSON-XS-4.02.tar.gz
+    provides:
+      JSON::XS 4.02
+    requirements:
+      Canary::Stability 0
+      ExtUtils::MakeMaker 6.52
+      Types::Serialiser 0
+      common::sense 0
   LWP-MediaTypes-6.02
     pathname: G/GA/GAAS/LWP-MediaTypes-6.02.tar.gz
     provides:
@@ -3978,6 +4078,15 @@ DISTRIBUTIONS
       Net::Domain 1.05
       Net::SMTP 1.03
       Test::More 0
+  Math-Random-ISAAC-1.004
+    pathname: J/JA/JAWNSY/Math-Random-ISAAC-1.004.tar.gz
+    provides:
+      Math::Random::ISAAC 1.004
+      Math::Random::ISAAC::PP 1.004
+    requirements:
+      ExtUtils::MakeMaker 6.31
+      Test::More 0.62
+      Test::NoWarnings 0.084
   Math-Random-MT-1.17
     pathname: F/FA/FANGLY/Math-Random-MT-1.17.tar.gz
     provides:
@@ -3986,6 +4095,16 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Test::More 0
       Test::Number::Delta 0
+  Math-Random-Secure-0.080001
+    pathname: F/FR/FREW/Math-Random-Secure-0.080001.tar.gz
+    provides:
+      Math::Random::Secure 0.080001
+      Math::Random::Secure::RNG 0.080001
+    requirements:
+      Crypt::Random::Source 0.07
+      ExtUtils::MakeMaker 0
+      Math::Random::ISAAC 1.001
+      Moo 2
   Memoize-ExpireLRU-0.55
     pathname: B/BP/BPOWERS/Memoize-ExpireLRU-0.55.tar.gz
     provides:
@@ -5643,6 +5762,128 @@ DISTRIBUTIONS
       Scalar::Util 1.48
       Test::More 0.96
       Test::utf8 0
+  OAuth-Lite2-0.11
+    pathname: R/RI/RITOU/OAuth-Lite2-0.11.tar.gz
+    provides:
+      OAuth::Lite2 0.11
+      OAuth::Lite2::Agent undef
+      OAuth::Lite2::Agent::Dump undef
+      OAuth::Lite2::Agent::PSGIMock undef
+      OAuth::Lite2::Agent::Strict undef
+      OAuth::Lite2::Client::ClientCredentials undef
+      OAuth::Lite2::Client::Error undef
+      OAuth::Lite2::Client::Error::InsecureRequest undef
+      OAuth::Lite2::Client::Error::InsecureResponse undef
+      OAuth::Lite2::Client::Error::InvalidResponse undef
+      OAuth::Lite2::Client::ExternalService undef
+      OAuth::Lite2::Client::ServerState undef
+      OAuth::Lite2::Client::StateResponseParser undef
+      OAuth::Lite2::Client::Token undef
+      OAuth::Lite2::Client::TokenResponseParser undef
+      OAuth::Lite2::Client::UsernameAndPassword undef
+      OAuth::Lite2::Client::WebServer undef
+      OAuth::Lite2::Formatter undef
+      OAuth::Lite2::Formatter::FormURLEncoded undef
+      OAuth::Lite2::Formatter::JSON undef
+      OAuth::Lite2::Formatter::Text undef
+      OAuth::Lite2::Formatter::XML undef
+      OAuth::Lite2::Formatters undef
+      OAuth::Lite2::Model::AccessToken undef
+      OAuth::Lite2::Model::AuthInfo undef
+      OAuth::Lite2::Model::ServerState undef
+      OAuth::Lite2::ParamMethod undef
+      OAuth::Lite2::ParamMethod::AuthHeader undef
+      OAuth::Lite2::ParamMethod::FormEncodedBody undef
+      OAuth::Lite2::ParamMethod::URIQueryParameter undef
+      OAuth::Lite2::ParamMethods undef
+      OAuth::Lite2::Server::Context undef
+      OAuth::Lite2::Server::DataHandler undef
+      OAuth::Lite2::Server::Endpoint::Token undef
+      OAuth::Lite2::Server::Error undef
+      OAuth::Lite2::Server::Error::AccessDenied undef
+      OAuth::Lite2::Server::Error::ExpiredToken undef
+      OAuth::Lite2::Server::Error::ExpiredTokenLegacy undef
+      OAuth::Lite2::Server::Error::InsufficientScope undef
+      OAuth::Lite2::Server::Error::InvalidClient undef
+      OAuth::Lite2::Server::Error::InvalidGrant undef
+      OAuth::Lite2::Server::Error::InvalidRequest undef
+      OAuth::Lite2::Server::Error::InvalidScope undef
+      OAuth::Lite2::Server::Error::InvalidServerState undef
+      OAuth::Lite2::Server::Error::InvalidToken undef
+      OAuth::Lite2::Server::Error::RedirectURIMismatch undef
+      OAuth::Lite2::Server::Error::ServerError undef
+      OAuth::Lite2::Server::Error::TemporarilyUnavailable undef
+      OAuth::Lite2::Server::Error::UnauthorizedClient undef
+      OAuth::Lite2::Server::Error::UnsupportedGrantType undef
+      OAuth::Lite2::Server::Error::UnsupportedResourceType undef
+      OAuth::Lite2::Server::Error::UnsupportedResponseType undef
+      OAuth::Lite2::Server::GrantHandler undef
+      OAuth::Lite2::Server::GrantHandler::AuthorizationCode undef
+      OAuth::Lite2::Server::GrantHandler::ClientCredentials undef
+      OAuth::Lite2::Server::GrantHandler::ExternalService undef
+      OAuth::Lite2::Server::GrantHandler::GroupingRefreshToken undef
+      OAuth::Lite2::Server::GrantHandler::Password undef
+      OAuth::Lite2::Server::GrantHandler::RefreshToken undef
+      OAuth::Lite2::Server::GrantHandler::ServerState undef
+      OAuth::Lite2::Server::GrantHandlers undef
+      OAuth::Lite2::Signer undef
+      OAuth::Lite2::Signer::Algorithm undef
+      OAuth::Lite2::Signer::Algorithm::HMAC_SHA1 undef
+      OAuth::Lite2::Signer::Algorithm::HMAC_SHA256 undef
+      OAuth::Lite2::Signer::Algorithms undef
+      OAuth::Lite2::Util undef
+      Plack::Middleware::Auth::OAuth2::ProtectedResource undef
+    requirements:
+      Class::Accessor::Fast 0.34
+      Class::ErrorHandler 0.01
+      Data::Dump 1.17
+      Digest::SHA 5.48
+      ExtUtils::MakeMaker 6.36
+      Hash::MultiValue 0.08
+      IO::String 1.08
+      JSON::XS 0
+      LWP::UserAgent 0
+      Module::Build::Tiny 0.035
+      Params::Validate 0.95
+      Plack 0.09942
+      Scalar::Util 1.23
+      String::Random 0.22
+      Test::More 0
+      Try::Tiny 0.06
+      URI 1.54
+      XML::LibXML 1.7
+  OIDC-Lite-0.10
+    pathname: R/RI/RITOU/OIDC-Lite-0.10.tar.gz
+    provides:
+      OIDC::Lite 0.10
+      OIDC::Lite::Client::Token undef
+      OIDC::Lite::Client::TokenResponseParser undef
+      OIDC::Lite::Client::WebServer undef
+      OIDC::Lite::Model::AuthInfo undef
+      OIDC::Lite::Model::IDToken undef
+      OIDC::Lite::Server::AuthorizationHandler undef
+      OIDC::Lite::Server::DataHandler undef
+      OIDC::Lite::Server::Endpoint::Token undef
+      OIDC::Lite::Server::GrantHandler::AuthorizationCode undef
+      OIDC::Lite::Server::GrantHandlers undef
+      OIDC::Lite::Server::Scope undef
+      OIDC::Lite::Util::JWT undef
+      Plack::Middleware::Auth::OIDC::ProtectedResource undef
+    requirements:
+      Class::Accessor::Fast 0.34
+      Crypt::OpenSSL::RSA 0
+      Data::Dump 1.17
+      ExtUtils::MakeMaker 6.62
+      JSON::WebToken 0.10
+      JSON::XS 0
+      MIME::Base64 3.11
+      Module::Build 0.38
+      OAuth::Lite2 0.10
+      Params::Validate 0.95
+      Test::Mock::LWP::Conditional 0
+      Test::MockObject 0
+      Test::More 0
+      perl 5.008001
   OLE-Storage_Lite-0.19
     pathname: J/JM/JMCNAMARA/OLE-Storage_Lite-0.19.tar.gz
     provides:
@@ -6723,6 +6964,18 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       Test::More 0
+  String-Random-0.30
+    pathname: S/SH/SHLOMIF/String-Random-0.30.tar.gz
+    provides:
+      String::Random 0.30
+    requirements:
+      Carp 0
+      Exporter 0
+      Module::Build 0.28
+      parent 0
+      perl 5.006_001
+      strict 0
+      warnings 0
   String-RewritePrefix-0.006
     pathname: R/RJ/RJBS/String-RewritePrefix-0.006.tar.gz
     provides:
@@ -7087,6 +7340,22 @@ DISTRIBUTIONS
       perl 5.006001
       strict 0
       warnings 0
+  Test-Fake-HTTPD-0.08
+    pathname: M/MA/MASAKI/Test-Fake-HTTPD-0.08.tar.gz
+    provides:
+      Test::Fake::HTTPD 0.08
+    requirements:
+      Carp 0
+      Exporter 0
+      HTTP::Daemon 0
+      HTTP::Message::PSGI 0
+      Module::Build::Tiny 0.035
+      Scalar::Util 1.14
+      Test::SharedFork 0.29
+      Test::TCP 0
+      Time::HiRes 0
+      URI 0
+      perl 5.008001
   Test-Fatal-0.010
     pathname: R/RJ/RJBS/Test-Fatal-0.010.tar.gz
     provides:
@@ -7171,6 +7440,22 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 6.03
       Test::More 0
+  Test-Mock-LWP-Conditional-0.04
+    pathname: M/MA/MASAKI/Test-Mock-LWP-Conditional-0.04.tar.gz
+    provides:
+      Test::Mock::LWP::Conditional 0.04
+      Test::Mock::LWP::Conditional::Stubs undef
+    requirements:
+      Class::Method::Modifiers 0
+      LWP::UserAgent 0
+      Math::Random::Secure 0
+      Module::Build::Tiny 0.035
+      Scalar::Util 1.14
+      Sub::Install 0
+      Test::Fake::HTTPD 0.03
+      Test::More 0.98
+      Test::UseAllModules 0
+      perl 5.008001
   Test-MockModule-0.11
     pathname: G/GF/GFRANKS/Test-MockModule-0.11.tar.gz
     provides:
@@ -7423,6 +7708,16 @@ DISTRIBUTIONS
       strict 0
       version 0
       warnings 0
+  Test-UseAllModules-0.17
+    pathname: I/IS/ISHIGAKI/Test-UseAllModules-0.17.tar.gz
+    provides:
+      Test::UseAllModules 0.17
+    requirements:
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      ExtUtils::Manifest 0
+      Test::Builder 0.30
+      Test::More 0.60
   Test-WWW-Mechanize-1.44
     pathname: P/PE/PETDANCE/Test-WWW-Mechanize-1.44.tar.gz
     provides:
@@ -7764,6 +8059,16 @@ DISTRIBUTIONS
       Exporter::Tiny 0.026
       ExtUtils::MakeMaker 6.17
       perl 5.006001
+  Types-Serialiser-1.0
+    pathname: M/ML/MLEHMANN/Types-Serialiser-1.0.tar.gz
+    provides:
+      JSON::PP::Boolean 1.0
+      Types::Serialiser 1.0
+      Types::Serialiser::BooleanBase 1.0
+      Types::Serialiser::Error 1.0
+    requirements:
+      ExtUtils::MakeMaker 0
+      common::sense 0
   UNIVERSAL-can-1.20140328
     pathname: C/CH/CHROMATIC/UNIVERSAL-can-1.20140328.tar.gz
     provides:
@@ -8265,6 +8570,12 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.008001
+  common-sense-3.74
+    pathname: M/ML/MLEHMANN/common-sense-3.74.tar.gz
+    provides:
+      common::sense 3.74
+    requirements:
+      ExtUtils::MakeMaker 0
   gettext-1.05
     pathname: P/PV/PVANDRY/gettext-1.05.tar.gz
     provides:

--- a/db/downgrade_0068---0067.sql
+++ b/db/downgrade_0068---0067.sql
@@ -1,0 +1,3 @@
+begin;
+alter table users drop column oidc_ids;
+commit;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -35,6 +35,7 @@ create table users (
     title           text,
     twitter_id      bigint  unique,
     facebook_id     bigint  unique,
+    oidc_ids        text    ARRAY,
     area_ids        integer ARRAY,
     extra           text
 );

--- a/db/schema_0068-oidc_login.sql
+++ b/db/schema_0068-oidc_login.sql
@@ -1,0 +1,3 @@
+begin;
+alter table users add column oidc_ids text ARRAY;
+commit;

--- a/perllib/FixMyStreet/App/Controller/Auth.pm
+++ b/perllib/FixMyStreet/App/Controller/Auth.pm
@@ -180,6 +180,9 @@ sub email_sign_in : Private {
         name => $c->get_param('name'),
         password => $user->password,
     };
+    $token_data->{name} = $c->session->{oauth}{name}
+        if $c->get_param('oauth_need_email') && $c->session->{oauth}{name} && !$token_data->{name};
+
     $token_data->{facebook_id} = $c->session->{oauth}{facebook_id}
         if $c->get_param('oauth_need_email') && $c->session->{oauth}{facebook_id};
     $token_data->{twitter_id} = $c->session->{oauth}{twitter_id}

--- a/perllib/FixMyStreet/App/Controller/Auth/Social.pm
+++ b/perllib/FixMyStreet/App/Controller/Auth/Social.pm
@@ -179,6 +179,7 @@ sub oauth_success : Private {
         } else {
             # No matching ID, store ID for use later
             $c->session->{oauth}{$type . '_id'} = $uid;
+            $c->session->{oauth}{name} = $name;
             $c->stash->{oauth_need_email} = 1;
         }
     }

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1146,7 +1146,7 @@ sub check_for_errors : Private {
     }
 
     # if using social login then we don't care about other errors
-    $c->stash->{is_social_user} = $c->get_param('facebook_sign_in') || $c->get_param('twitter_sign_in');
+    $c->stash->{is_social_user} = $c->get_param('social_sign_in') ? 1 : 0;
     if ( $c->stash->{is_social_user} ) {
         delete $field_errors{name};
         delete $field_errors{username};
@@ -1188,10 +1188,8 @@ sub tokenize_user : Private {
         password => $report->user->password,
         title => $report->user->title,
     };
-    $c->stash->{token_data}{facebook_id} = $c->session->{oauth}{facebook_id}
-        if $c->get_param('oauth_need_email') && $c->session->{oauth}{facebook_id};
-    $c->stash->{token_data}{twitter_id} = $c->session->{oauth}{twitter_id}
-        if $c->get_param('oauth_need_email') && $c->session->{oauth}{twitter_id};
+    $c->forward('/auth/set_oauth_token_data', [ $c->stash->{token_data} ])
+        if $c->get_param('oauth_need_email');
 }
 
 sub send_problem_confirm_email : Private {
@@ -1299,6 +1297,7 @@ sub process_confirmation : Private {
         for (qw(name title facebook_id twitter_id)) {
             $problem->user->$_( $data->{$_} ) if $data->{$_};
         }
+        $problem->user->add_oidc_id($data->{oidc_id}) if $data->{oidc_id};
         $problem->user->update;
     }
     if ($problem->user->email_verified) {
@@ -1359,11 +1358,7 @@ sub save_user_and_report : Private {
         $c->stash->{detach_to} = '/report/new/oauth_callback';
         $c->stash->{detach_args} = [$token->token];
 
-        if ( $c->get_param('facebook_sign_in') ) {
-            $c->detach('/auth/social/facebook_sign_in');
-        } elsif ( $c->get_param('twitter_sign_in') ) {
-            $c->detach('/auth/social/twitter_sign_in');
-        }
+        $c->forward('/auth/social/handle_sign_in') if $c->get_param('social_sign_in');
     }
 
     # Save or update the user if appropriate

--- a/perllib/FixMyStreet/App/Controller/Report/Update.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/Update.pm
@@ -366,7 +366,7 @@ sub check_for_errors : Private {
     );
 
     # if using social login then we don't care about name and email errors
-    $c->stash->{is_social_user} = $c->get_param('facebook_sign_in') || $c->get_param('twitter_sign_in');
+    $c->stash->{is_social_user} = $c->get_param('social_sign_in') ? 1 : 0;
     if ( $c->stash->{is_social_user} ) {
         delete $field_errors{name};
         delete $field_errors{username};
@@ -404,10 +404,8 @@ sub tokenize_user : Private {
         name => $update->user->name,
         password => $update->user->password,
     };
-    $c->stash->{token_data}{facebook_id} = $c->session->{oauth}{facebook_id}
-        if $c->get_param('oauth_need_email') && $c->session->{oauth}{facebook_id};
-    $c->stash->{token_data}{twitter_id} = $c->session->{oauth}{twitter_id}
-        if $c->get_param('oauth_need_email') && $c->session->{oauth}{twitter_id};
+    $c->forward('/auth/set_oauth_token_data', [ $c->stash->{token_data} ])
+        if $c->get_param('oauth_need_email');
 }
 
 =head2 save_update
@@ -440,11 +438,7 @@ sub save_update : Private {
         $c->stash->{detach_to} = '/report/update/oauth_callback';
         $c->stash->{detach_args} = [$token->token];
 
-        if ( $c->get_param('facebook_sign_in') ) {
-            $c->detach('/auth/social/facebook_sign_in');
-        } elsif ( $c->get_param('twitter_sign_in') ) {
-            $c->detach('/auth/social/twitter_sign_in');
-        }
+        $c->forward('/auth/social/handle_sign_in') if $c->get_param('social_sign_in');
     }
 
     if ( $c->cobrand->never_confirm_updates ) {
@@ -585,6 +579,7 @@ sub process_confirmation : Private {
         for (qw(name facebook_id twitter_id)) {
             $comment->user->$_( $data->{$_} ) if $data->{$_};
         }
+        $comment->user->add_oidc_id($data->{oidc_id}) if $data->{oidc_id};
         $comment->user->password( $data->{password}, 1 ) if $data->{password};
         $comment->user->update;
     }

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -1264,7 +1264,7 @@ sub allow_report_extra_fields { 0 }
 
 sub social_auth_enabled {
     my $self = shift;
-    my $key_present = FixMyStreet->config('FACEBOOK_APP_ID') or FixMyStreet->config('TWITTER_KEY');
+    my $key_present = FixMyStreet->config('FACEBOOK_APP_ID') || FixMyStreet->config('TWITTER_KEY');
     return $key_present && !$self->call_hook("social_auth_disabled");
 }
 

--- a/perllib/FixMyStreet/Cobrand/Westminster.pm
+++ b/perllib/FixMyStreet/Cobrand/Westminster.pm
@@ -26,4 +26,10 @@ sub enter_postcode_text {
 
 sub send_questionnaires { 0 }
 
+sub social_auth_enabled {
+    my $self = shift;
+
+    return $self->feature('oidc_login') ? 1 : 0;
+ }
+
 1;

--- a/perllib/OIDC/Lite/Client/IDTokenResponseParser.pm
+++ b/perllib/OIDC/Lite/Client/IDTokenResponseParser.pm
@@ -1,0 +1,72 @@
+package OIDC::Lite::Client::IDTokenResponseParser;
+
+use strict;
+use warnings;
+
+use Try::Tiny qw/try catch/;
+use OIDC::Lite::Model::IDToken;
+use OAuth::Lite2::Formatters;
+use OAuth::Lite2::Client::Error;
+
+=head1 NAME
+
+OIDC::Lite::Client::IDTokenResponseParser - parse id_token JWT into an
+L<OIDC::Lite::Model::IDToken> object.
+
+Acts the same as L<OIDC::Lite::Client::TokenResponseParser> but looks for an
+id_token in the HTTP response instead of access_token.
+
+=cut
+
+sub new {
+    bless {}, $_[0];
+}
+
+sub parse {
+    my ($self, $http_res) = @_;
+
+    my $formatter =
+        OAuth::Lite2::Formatters->get_formatter_by_type(
+            $http_res->content_type);
+
+    my $token;
+
+    if ($http_res->is_success) {
+
+        OAuth::Lite2::Client::Error::InvalidResponse->throw(
+            message => sprintf(q{Invalid response content-type: %s},
+                $http_res->content_type||'')
+        ) unless $formatter;
+
+        my $result = try {
+            return $formatter->parse($http_res->content);
+        } catch {
+            OAuth::Lite2::Client::Error::InvalidResponse->throw(
+                message => sprintf(q{Invalid response format: %s}, $_),
+            );
+        };
+
+        OAuth::Lite2::Client::Error::InvalidResponse->throw(
+            message => sprintf("Response doesn't include 'id_token'")
+        ) unless exists $result->{id_token};
+
+        $token = OIDC::Lite::Model::IDToken->load($result->{id_token});
+
+    } else {
+
+        my $errmsg = $http_res->content || $http_res->status_line;
+        if ($formatter && $http_res->content) {
+            try {
+                my $result = $formatter->parse($http_res->content);
+                $errmsg = $result->{error}
+                    if exists $result->{error};
+            } catch {
+        	return OAuth::Lite2::Client::Error::InvalidResponse->throw;
+            };
+        }
+        OAuth::Lite2::Client::Error::InvalidResponse->throw( message => $errmsg );
+    }
+    return $token;
+}
+
+1;

--- a/perllib/OIDC/Lite/Client/WebServer/Azure.pm
+++ b/perllib/OIDC/Lite/Client/WebServer/Azure.pm
@@ -1,0 +1,39 @@
+package OIDC::Lite::Client::WebServer::Azure;
+
+use strict;
+use warnings;
+use parent 'OIDC::Lite::Client::WebServer';
+
+use OIDC::Lite::Client::IDTokenResponseParser;
+
+=head1 NAME
+
+OIDC::Lite::Client::WebServer::Azure - extension to auth against Azure AD B2C
+
+OIDC::Lite doesn't appear to support the authorisation code flow to get an
+ID token - only an access token. Azure returns all its claims in the id_token
+and doesn't support a UserInfo endpoint, so this extension adds support for
+parsing the id_token when calling get_access_token.
+
+=cut
+
+=head2 new
+
+Overrides response_parser so that get_access_token returns a
+L<OIDC::Lite::Model::IDToken> object.
+
+NB this does not perform any verification of the id_token. It's assumed to be
+safe as it's come directly from the OpenID IdP and not an untrusted user's
+browser.
+
+=cut
+
+sub new {
+    my $self = shift->next::method(@_);
+
+    $self->{response_parser} = OIDC::Lite::Client::IDTokenResponseParser->new;
+
+    return $self;
+}
+
+1;

--- a/t/Mock/OpenIDConnect.pm
+++ b/t/Mock/OpenIDConnect.pm
@@ -1,0 +1,70 @@
+package t::Mock::OpenIDConnect;
+
+use JSON::MaybeXS;
+use Web::Simple;
+use DateTime;
+use MIME::Base64 qw(encode_base64);
+use MooX::Types::MooseLike::Base qw(:all);
+
+has json => (
+    is => 'lazy',
+    default => sub {
+        JSON->new->pretty->allow_blessed->convert_blessed;
+    },
+);
+
+has returns_email => (
+    is => 'rw',
+    isa => Bool,
+    default => 1,
+);
+
+sub dispatch_request {
+    my $self = shift;
+
+    sub (GET + /oauth2/v2.0/authorize + ?*) {
+        my ($self) = @_;
+        return [ 200, [ 'Content-Type' => 'text/html' ], [ 'OpenID Connect login page' ] ];
+    },
+
+    sub (POST + /oauth2/v2.0/token + ?*) {
+        my ($self) = @_;
+        my $header = {
+            typ => "JWT",
+            alg => "RS256",
+            kid => "XXXfakeKEY1234",
+        };
+        my $now = DateTime->now->epoch;
+        my $payload = {
+            exp => $now + 3600,
+            nbf => $now,
+            ver => "1.0",
+            iss => "https://login.example.org/12345-6789-4321-abcd-12309812309/v2.0/",
+            sub => "my_cool_user_id",
+            aud => "example_client_id",
+            iat => $now,
+            auth_time => $now,
+            given_name => "Andy",
+            family_name => "Dwyer",
+            tfp => "B2C_1_default"
+        };
+        $payload->{emails} = ['oidc@example.org'] if $self->returns_email;
+        my $signature = "dummy";
+        my $id_token = join(".", (
+            encode_base64($self->json->encode($header), ''),
+            encode_base64($self->json->encode($payload), ''),
+            encode_base64($signature, '')
+        ));
+        my $data = {
+            id_token => $id_token,
+            token_type => "Bearer",
+            not_before => $now,
+            id_token_expires_in => 3600,
+            profile_info => encode_base64($self->json->encode({}), ''),
+        };
+        my $json = $self->json->encode($data);
+        return [ 200, [ 'Content-Type' => 'application/json' ], [ $json ] ];
+    },
+}
+
+__PACKAGE__->run_if_script;

--- a/t/app/model/user.t
+++ b/t/app/model/user.t
@@ -75,6 +75,31 @@ subtest 'Check non-existent methods on user object die' => sub {
     );
 };
 
+subtest 'OIDC ids can be manipulated correctly' => sub {
+    my $user = $problem->user;
+
+    is $user->oidc_ids, undef, 'user starts with no OIDC ids';
+
+    $user->add_oidc_id("fixmystreet:1234:5678");
+    is_deeply $user->oidc_ids, ["fixmystreet:1234:5678"], 'OIDC id added correctly';
+
+    $user->add_oidc_id("mycobrand:0123:abcd");
+    is_deeply [ sort @{$user->oidc_ids} ], ["fixmystreet:1234:5678", "mycobrand:0123:abcd"], 'Second OIDC id added correctly';
+
+    $user->add_oidc_id("mycobrand:0123:abcd");
+    is_deeply [ sort @{$user->oidc_ids} ], ["fixmystreet:1234:5678", "mycobrand:0123:abcd"], 'Adding existing OIDC id does not add duplicate';
+
+    $user->remove_oidc_id("mycobrand:0123:abcd");
+    is_deeply $user->oidc_ids, ["fixmystreet:1234:5678"], 'OIDC id can be removed OK';
+
+    $user->remove_oidc_id("mycobrand:0123:abcd");
+    is_deeply $user->oidc_ids, ["fixmystreet:1234:5678"], 'Removing non-existent OIDC id has no effect';
+
+    $user->remove_oidc_id("fixmystreet:1234:5678");
+    is $user->oidc_ids, undef, 'Removing last OIDC id results in undef';
+
+};
+
 done_testing();
 
 sub create_update {

--- a/t/cobrand/westminster.t
+++ b/t/cobrand/westminster.t
@@ -1,0 +1,74 @@
+use FixMyStreet::TestMech;
+
+ok( my $mech = FixMyStreet::TestMech->new, 'Created mech object' );
+
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => 'westminster',
+    MAPIT_URL => 'http://mapit.uk/',
+    COBRAND_FEATURES => {
+        oidc_login => {
+            westminster => {
+                client_id => 'example_client_id',
+                secret => 'example_secret_key',
+                auth_uri => 'http://oidc.example.org/oauth2/v2.0/authorize',
+                token_uri => 'http://oidc.example.org/oauth2/v2.0/token',
+                display_name => 'MyWestminster'
+            }
+        }
+    }
+}, sub {
+    subtest 'Cobrand allows social auth' => sub {
+        my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker('westminster')->new();
+        ok $cobrand->social_auth_enabled;
+    };
+
+    subtest 'Login button displayed correctly' => sub {
+        $mech->get_ok("/auth");
+        $mech->content_contains("Login with MyWestminster");
+    };
+};
+
+for (
+    {
+        ALLOWED_COBRANDS => 'westminster',
+        MAPIT_URL => 'http://mapit.uk/',
+        COBRAND_FEATURES => {
+            oidc_login => {
+                westminster => 0
+            }
+        }
+    },
+    {
+        ALLOWED_COBRANDS => 'westminster',
+        MAPIT_URL => 'http://mapit.uk/',
+        COBRAND_FEATURES => {
+            oidc_login => {
+                hounslow => {
+                    client_id => 'example_client_id',
+                    secret => 'example_secret_key',
+                    auth_uri => 'http://oidc.example.org/oauth2/v2.0/authorize',
+                    token_uri => 'http://oidc.example.org/oauth2/v2.0/token',
+                    display_name => 'MyHounslow'
+                }
+            }
+        }
+    },
+    {
+        ALLOWED_COBRANDS => 'westminster',
+        MAPIT_URL => 'http://mapit.uk/',
+    }
+) {
+    FixMyStreet::override_config $_, sub {
+        subtest 'Cobrand disallows social auth' => sub {
+            my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker('westminster')->new();
+            ok !$cobrand->social_auth_enabled;
+        };
+
+        subtest 'Login button not displayed' => sub {
+            $mech->get_ok("/auth");
+            $mech->content_lacks("Login with MyWestminster");
+        };
+    };
+}
+
+done_testing();

--- a/templates/web/base/auth/general.html
+++ b/templates/web/base/auth/general.html
@@ -24,15 +24,22 @@
 [% IF NOT oauth_need_email AND c.cobrand.social_auth_enabled %]
     [% IF c.config.FACEBOOK_APP_ID %]
       <div class="form-box">
-        <button name="facebook_sign_in" id="facebook_sign_in" value="facebook_sign_in" class="btn btn--block btn--social btn--facebook">
+        <button name="social_sign_in" id="facebook_sign_in" value="facebook" class="btn btn--block btn--social btn--facebook">
             <img alt="" src="/i/facebook-icon-32.png" width="17" height="32">
             [% loc('Log in with Facebook') %]
         </button>
       </div>
     [% END %]
+    [% IF c.cobrand.feature('oidc_login') %]
+      <div class="form-box">
+        <button name="social_sign_in" id="oidc_sign_in" value="oidc" class="btn btn--block btn--social btn--oidc">
+            [% tprintf(loc('Login with %s'), c.cobrand.feature('oidc_login').display_name) %]
+        </button>
+      </div>
+    [% END %]
     [% IF c.config.TWITTER_KEY %]
       <div class="form-box">
-        <button name="twitter_sign_in" id="twitter_sign_in" value="twitter_sign_in" class="btn btn--block btn--social btn--twitter">
+        <button name="social_sign_in" id="twitter_sign_in" value="twitter" class="btn btn--block btn--social btn--twitter">
             <img alt="" src="/i/twitter-icon-32.png" width="17" height="32">
             [% loc('Log in with Twitter') %]
         </button>

--- a/templates/web/base/report/form/user.html
+++ b/templates/web/base/report/form/user.html
@@ -8,13 +8,18 @@
     <button class="btn btn--block hidden-nojs js-new-report-user-show">[% loc('Continue') %]</button>
 [% ELSE %]
   [% IF c.config.FACEBOOK_APP_ID %]
-    <button name="facebook_sign_in" id="facebook_sign_in" value="facebook_sign_in" class="btn btn--block btn--social btn--facebook">
+    <button name="social_sign_in" id="facebook_sign_in" value="facebook" class="btn btn--block btn--social btn--facebook">
         <img alt="" src="/i/facebook-icon-32.png" width="17" height="32">
         [% loc('Log in with Facebook') %]
     </button>
   [% END %]
+  [% IF c.cobrand.feature('oidc_login') %]
+    <button name="social_sign_in" id="oidc_sign_in" value="oidc" class="btn btn--block btn--social btn--oidc">
+        [% tprintf(loc('Login with %s'), c.cobrand.feature('oidc_login').display_name) %]
+    </button>
+  [% END %]
   [% IF c.config.TWITTER_KEY %]
-    <button name="twitter_sign_in" id="twitter_sign_in" value="twitter_sign_in" class="btn btn--block btn--social btn--twitter">
+    <button name="social_sign_in" id="twitter_sign_in" value="twitter" class="btn btn--block btn--social btn--twitter">
         <img alt="" src="/i/twitter-icon-32.png" width="17" height="32">
         [% loc('Log in with Twitter') %]
     </button>

--- a/templates/web/westminster/auth/general.html
+++ b/templates/web/westminster/auth/general.html
@@ -21,7 +21,7 @@
 [% IF NOT oauth_need_email AND c.cobrand.social_auth_enabled %]
     [% IF c.cobrand.feature('oidc_login') %]
       <div class="form-box">
-        <button name="oidc_sign_in" id="oidc_sign_in" value="oidc_sign_in" class="btn btn--block btn--social btn--oidc">
+        <button name="social_sign_in" id="oidc_sign_in" value="oidc" class="btn btn--block btn--social btn--oidc">
             [% tprintf(loc('Login with %s'), c.cobrand.feature('oidc_login').display_name) %]
         </button>
       </div>

--- a/templates/web/westminster/report/form/user.html
+++ b/templates/web/westminster/report/form/user.html
@@ -1,0 +1,30 @@
+<!-- report/form/user.html -->
+<div class="js-new-report-user-hidden form-section-preview form-section-preview--next
+    [%~ ' hidden-nojs' IF c.user_exists OR NOT c.cobrand.social_auth_enabled %]">
+    <h2 class="form-section-heading form-section-heading--private hidden-nojs">
+        [% loc('Next:') %] [% loc('Tell us about you') %]
+    </h2>
+[% IF c.user_exists OR NOT c.cobrand.social_auth_enabled %]
+    <button class="btn btn--block hidden-nojs js-new-report-user-show">[% loc('Continue') %]</button>
+[% ELSE %]
+  [% IF c.config.FACEBOOK_APP_ID %]
+    <button name="social_sign_in" id="facebook_sign_in" value="facebook" class="btn btn--block btn--social btn--facebook">
+        <img alt="" src="/i/facebook-icon-32.png" width="17" height="32">
+        [% loc('Log in with Facebook') %]
+    </button>
+  [% END %]
+  [% IF c.cobrand.feature('oidc_login') %]
+    <button name="social_sign_in" id="oidc_sign_in" value="oidc" class="btn btn--block btn--social btn--oidc">
+        [% tprintf(loc('Login with %s'), c.cobrand.feature('oidc_login').display_name) %]
+    </button>
+  [% END %]
+  [% IF c.config.TWITTER_KEY %]
+    <button name="social_sign_in" id="twitter_sign_in" value="twitter" class="btn btn--block btn--social btn--twitter">
+        <img alt="" src="/i/twitter-icon-32.png" width="17" height="32">
+        [% loc('Log in with Twitter') %]
+    </button>
+  [% END %]
+    <button class="btn btn--block hidden-nojs js-new-report-user-show">Confirm by email</button>
+[% END %]
+</div>
+<!-- /report/form/user.html -->

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -338,7 +338,7 @@ $.extend(fixmystreet.set_up, {
         $('.js-form-name').addClass('required');
     } );
 
-    $('#facebook_sign_in, #twitter_sign_in').click(function(e){
+    $('#facebook_sign_in, #twitter_sign_in, #oidc_sign_in').click(function(e){
         $('#username, #form_username_register, #form_username_sign_in').removeClass('required');
     });
 


### PR DESCRIPTION
Extends social login functionality to authenticate against an (MS Active Directory B2C-specific) OpenID Connect identity provider.