### PR TITLE
[UK] Improve server-side nearest road lookup

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley.pm
@@ -48,7 +48,7 @@ sub lookup_site_code_config {
     # uncoverable subroutine
     # uncoverable statement
     {
-        buffer => 200, # metres
+        buffer => 1000, # metres
         url => "https://tilma.mysociety.org/mapserver/bexley",
         srsname => "urn:ogc:def:crs:EPSG::27700",
         typename => "Streets",

--- a/t/app/controller/contact_enquiry.t
+++ b/t/app/controller/contact_enquiry.t
@@ -238,7 +238,7 @@ FixMyStreet::override_config {
 
     subtest 'Check Open311 sending of the above report' => sub {
         my $module = Test::MockModule->new('FixMyStreet::Cobrand::UKCouncils');
-        $module->mock(get => sub ($) { '' });
+        $module->mock(get => sub ($) { '{}' });
         my $test_data = FixMyStreet::Script::Reports::send();
         my $req = $test_data->{test_req_used};
         my $found = 0;

--- a/t/cobrand/bexley.t
+++ b/t/cobrand/bexley.t
@@ -112,4 +112,22 @@ FixMyStreet::override_config {
 
 };
 
+subtest 'nearest road returns correct road' => sub {
+    my $cobrand = FixMyStreet::Cobrand::Bexley->new;
+    my $cfg = {
+        accept_feature => sub { 1 },
+        property => 'fid',
+    };
+    my $features = [
+        { geometry => { type => 'Polygon' } },
+        { geometry => { type => 'MultiLineString',
+            coordinates => [ [ [ 545499, 174361 ], [ 545420, 174359 ], [ 545321, 174352 ] ] ] },
+          properties => { fid => '20101226' } },
+        { geometry => { type => 'LineString',
+            coordinates => [ [ 545420, 174359 ], [ 545419, 174375 ], [ 545418, 174380 ], [ 545415, 174391 ] ] },
+          properties => { fid => '20100024' } },
+    ];
+    is $cobrand->_nearest_feature($cfg, 545451, 174380, $features), '20101226';
+};
+
 done_testing();

--- a/web/cobrands/bexley/js.js
+++ b/web/cobrands/bexley/js.js
@@ -95,7 +95,7 @@ fixmystreet.assets.add(defaults, {
     },
     always_visible: true,
     non_interactive: true,
-    nearest_radius: 20,
+    nearest_radius: 100,
     usrn: {
         attribute: 'NSG_REF',
         field: 'NSGRef'


### PR DESCRIPTION
[skip changelog]
This makes the server-side check behave as the client-side, doing nearest-point-on-line checks rather than only nearest point *of* line checks.