### PR TITLE
Update UI text when selecting a private category

### DIFF
--- a/.cypress/cypress/integration/hounslow.js
+++ b/.cypress/cypress/integration/hounslow.js
@@ -1,0 +1,35 @@
+describe('private categories', function() {
+
+  beforeEach(function() {
+    cy.server();
+    cy.route('/report/new/ajax*').as('report-ajax');
+  });
+
+  it('shows the correct UI text for private and public categories on cobrand', function() {
+    cy.visit('http://hounslow.localhost:3001/');
+    cy.contains('Hounslow Highways');
+    cy.get('[name=pc]').type('TW7 5JN');
+    cy.get('[name=pc]').parents('form').submit();
+    cy.get('.olMapViewport #fms_pan_zoom_zoomin').click();
+    cy.get('#map_box').click(290, 307);
+    cy.wait('@report-ajax');
+    cy.get('select:eq(4)').select('Potholes');
+    cy.get("#js-councils_text").contains('sent to Hounslow Highways and also published online');
+    cy.get('select:eq(4)').select('Other');
+    cy.get("#js-councils_text").contains('sent to Hounslow Highways but not published online');
+  });
+
+  it('shows the correct UI text for private and public categories on FMS.com', function() {
+    cy.visit('http://fixmystreet.localhost:3001/');
+    cy.get('[name=pc]').type('TW7 5JN');
+    cy.get('[name=pc]').parents('form').submit();
+    cy.get('.olMapViewport #fms_pan_zoom_zoomin').click();
+    cy.get('#map_box').click(290, 307);
+    cy.wait('@report-ajax');
+    cy.get('select:eq(4)').select('Potholes');
+    cy.contains('sent to Hounslow Borough Council and also published online');
+    cy.get('select:eq(4)').select('Other');
+    cy.contains('sent to Hounslow Borough Council but not published online');
+  });
+
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
         - Mobile users can now filter the pins on the `/around` map view. #2366
         - Maintain whitespace formatting in email report/update lists.
         - Improve keyboard accessibility.
+        - Report form now indicates that details are kept private if report is
+          made in a private category. #2528
     - Admin improvements:
         - Add new roles system, to group permissions and apply to users.
     - New features:

--- a/bin/browser-tests
+++ b/bin/browser-tests
@@ -11,7 +11,7 @@ my ($cobrand, $coords, $area_id, $name, $mapit_url);
 
 BEGIN {
     $config_file = 'conf/general.yml-example';
-    $cobrand = [ 'fixmystreet', 'northamptonshire', 'bathnes', 'buckinghamshire' ];
+    $cobrand = [ 'fixmystreet', 'northamptonshire', 'bathnes', 'buckinghamshire', 'hounslow' ];
     $coords = '51.532851,-2.284277';
     $area_id = 2608;
     $name = 'Borsetshire';

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -98,6 +98,7 @@ if ($opt->test_fixtures) {
         { area_id => 2217, categories => ['Flytipping', 'Roads'], name => 'Buckinghamshire County Council' },
         { area_id => 2257, categories => ['Flytipping', 'Graffiti'], name => 'Chiltern District Council' },
         { area_id => 2397, categories => [ 'Graffiti' ], name => 'Northampton Borough Council' },
+        { area_id => 2483, categories => [ 'Potholes', 'Other' ], name => 'Hounslow Borough Council' },
     ) {
         $bodies->{$_->{area_id}} = FixMyStreet::DB::Factory::Body->find_or_create($_);
         my $cats = join(', ', @{$_->{categories}});
@@ -134,6 +135,14 @@ if ($opt->test_fixtures) {
         ],
     });
     $child_cat->update;
+
+    $child_cat = FixMyStreet::DB->resultset("Contact")->find({
+        body => $bodies->{2483},
+        category => 'Other',
+    });
+    $child_cat->update({
+        non_public => 1
+    });
 }
 
 FixMyStreet::DB::Factory::ResponseTemplate->create({

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -274,8 +274,10 @@ sub by_category_ajax_data : Private {
         $category ? (list_of_names => $list_of_names) : (),
     };
 
+    my $non_public = $c->stash->{non_public_categories}->{$category};
     my $body = {
         bodies => $list_of_names,
+        $non_public ? (non_public => JSON->true) : (),
     };
 
     if ($generate) {

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -43,6 +43,8 @@ my @PLACES = (
     [ 'NN1 2NS', 52.238301, -0.889992, 2234, 'Northamptonshire County Council', 'CTY', 2397, 'Northampton Borough Council', 'DIS' ],
     [ '?', 52.238827, -0.894970, 2234, 'Northamptonshire County Council', 'CTY', 2397, 'Northampton Borough Council', 'DIS' ],
     [ 'TW7 5JN', 51.482286, -0.328163, 2483, 'Hounslow Borough Council', 'LBO' ],
+    [ '?', 51.48111, -0.327219, 2483, 'Hounslow Borough Council', 'LBO' ],
+    [ '?', 51.482045, -0.327219, 2483, 'Hounslow Borough Council', 'LBO' ],
     [ '?', 50.78301, -0.646929 ],
     [ 'TA1 1QP', 51.023569, -3.099055, 2239, 'Somerset County Council', 'CTY', 2429, 'Taunton Deane Borough Council', 'DIS' ],
     [ 'GU51 4AE', 51.279456, -0.846216, 2333, 'Hart District Council', 'DIS', 2227, 'Hampshire County Council', 'CTY' ],

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -152,6 +152,12 @@ my $contact17 = $mech->create_contact_ok(
     category => 'Trees',
     email => 'trees-2483@example.com',
 );
+my $contact18 = $mech->create_contact_ok(
+    body_id => $body_ids{2483}, # Hounslow
+    category => 'General Enquiry',
+    email => 'general-enquiry-2483@example.com',
+    non_public => 1,
+);
 
 # test that the various bit of form get filled in and errors correctly
 # generated.
@@ -1418,6 +1424,15 @@ subtest "check map click ajax response" => sub {
         $extra_details = $mech->get_ok_json( '/report/new/ajax?latitude=51.482286&longitude=-0.328163' );
     };
     isnt defined $extra_details->{display_names}, 'no council display names if none defined';
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'hounslow',
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $extra_details = $mech->get_ok_json( '/report/new/ajax?latitude=51.482286&longitude=-0.328163' );
+    };
+    ok $extra_details->{by_category}->{'General Enquiry'}->{non_public}, 'non_public set correctly for private category';
+    isnt defined $extra_details->{by_category}->{Tree}->{non_public}, 'non_public omitted for public category';
 };
 
 #### test uploading an image

--- a/templates/web/base/report/new/councils_text_all.html
+++ b/templates/web/base/report/new/councils_text_all.html
@@ -2,12 +2,21 @@
 [% DEFAULT list_of_names = default_list %]
 
 <p>
-[%
+[% UNLESS non_public_categories.$category;
+
     tprintf(
         loc('These will be sent to <strong>%s</strong> and also published online for others to see, in accordance with our <a href="%s">privacy policy</a>.'),
         list_of_names.join( '</strong>' _ loc(' or ') _ '<strong>' ), c.cobrand.privacy_policy_url
     );
-%]
+
+ELSE;
+
+    tprintf(
+        loc('These will be sent to <strong>%s</strong> but not published online.'),
+        list_of_names.join( '</strong>' _ loc(' or ') _ '<strong>' )
+    );
+
+END %]
 
 [% TRY %][% INCLUDE 'report/new/councils_extra_text.html' %][% CATCH file %][% END %]
 </p>

--- a/templates/web/base/report/new/form_report.html
+++ b/templates/web/base/report/new/form_report.html
@@ -10,7 +10,8 @@
 <div class="js-hide-if-invalid-category">
 [% TRY %][% PROCESS 'report/new/_form_labels.html' %][% CATCH file %][% END %]
 
-    <h2 class="form-section-heading">[% loc( 'Public details' ) %]</h2>
+    <h2 class="form-section-heading js-hide-if-private-category">[% loc( 'Public details' ) %]</h2>
+    <h2 class="form-section-heading form-section-heading--private js-hide-if-public-category">[% loc( 'Report details' ) %]</h2>
     <div class="form-section-description" id="js-councils_text">
       [% IF js %]
         [% PROCESS 'report/new/councils_text_all.html' list_of_names = [ loc('the local council') ] %]

--- a/templates/web/hounslow/report/new/councils_text_all.html
+++ b/templates/web/hounslow/report/new/councils_text_all.html
@@ -1,5 +1,8 @@
 <p>
-    These will be sent to <strong>Hounslow Highways</strong> and also published
-    online for others to see, in accordance with our
-    <a href="[% c.cobrand.privacy_policy_url %]">privacy policy</a>.
+    [% UNLESS non_public_categories.$category %]
+        These will be sent to <strong>Hounslow Highways</strong> and also published online for others to see, in accordance with our
+        <a href="[% c.cobrand.privacy_policy_url %]">privacy policy</a>.
+    [% ELSE %]
+        These will be sent to <strong>Hounslow Highways</strong> but not published online.
+    [% END %]
 </p>

--- a/templates/web/oxfordshire/report/new/councils_text_all.html
+++ b/templates/web/oxfordshire/report/new/councils_text_all.html
@@ -1,5 +1,8 @@
 <p>
     All the information you provide here will be sent to the
-    <strong>relevant department</strong>. The summary and description
-    will also be made public, plus your name if you give us permission.
+    <strong>relevant department</strong>.
+    [% UNLESS non_public_categories.$category %]
+        The summary and description
+        will also be made public, plus your name if you give us permission.
+    [% END %]
 </p>

--- a/templates/web/oxfordshire/report/new/councils_text_all.html
+++ b/templates/web/oxfordshire/report/new/councils_text_all.html
@@ -1,6 +1,8 @@
 <p>
     All the information you provide here will be sent to the
-    <strong>relevant department</strong>.
+    [% # NB this empty class attribute is so fixmystreet.update_public_councils_text
+       # doesn't clobber the text by matching on the <strong>. %]
+    <strong class="">relevant department</strong>.
     [% UNLESS non_public_categories.$category %]
         The summary and description
         will also be made public, plus your name if you give us permission.

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -441,6 +441,13 @@ $.extend(fixmystreet.set_up, {
         } else {
             $category_meta.empty();
         }
+        if (data && data.non_public) {
+            $(".js-hide-if-private-category").hide();
+            $(".js-hide-if-public-category").show();
+        } else {
+            $(".js-hide-if-private-category").show();
+            $(".js-hide-if-public-category").hide();
+        }
 
         // remove existing validation rules
         validation_rules = fixmystreet.validator.settings.rules;

--- a/web/cobrands/hounslow/js.js
+++ b/web/cobrands/hounslow/js.js
@@ -20,11 +20,14 @@ if (fixmystreet.cobrand == 'hounslow') {
     // as the destination for reports in the "Public details" section.
     // This is OK because the cobranded site only shows categories which
     // Hounslow Highways actually handle.
-    // Replacing this function with a no-op stops the changes made
-    // to the cobranded councils_text_all.html from being clobbered and
-    // the 'correct' (according to bodies set up within FMS) body names
-    // being shown.
-    fixmystreet.update_public_councils_text = function() {};
+    // To achieve this we ignore the passed list of bodies and always
+    // use "Hounslow Highways" when calling the original function.
+    // NB calling the original function is required so that private categories
+    // cause the correct text to be shown in the UI.
+    var original_update_public_councils_text = fixmystreet.update_public_councils_text;
+    fixmystreet.update_public_councils_text = function(text, bodies) {
+        original_update_public_councils_text.call(this, text, ['Hounslow Highways']);
+    };
 }
 
 })();

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2103,6 +2103,10 @@ label .muted {
     }
 }
 
+.js-hide-if-public-category {
+  display: none;
+}
+
 .asset-spot:before {
     content: "";
     display: inline-block;


### PR DESCRIPTION
This makes it clearer that all details for a report made in a private category will not be shown publicly.

Fixes mysociety/fixmystreet-commercial#1405