### PR TITLE
[Hounslow] Use ‘Hounslow Highways’ in report confirmation emails

### DIFF
--- a/templates/email/default/problem-confirm.html
+++ b/templates/email/default/problem-confirm.html
@@ -20,7 +20,7 @@ of problem, so it will instead be sent to [% report.body %].
 
 [% TRY %][% INCLUDE '_problem-confirm_extra.html' %][% CATCH file %][% END %]
   </p>
-  <p style="[% p_style %]">Your report will also appear on the [% site_name %] website.</p>
+  [% UNLESS report.non_public %]<p style="[% p_style %]">Your report will also appear on the [% site_name %] website.</p>[% END %]
   <p style="margin: 20px auto; text-align: center">
     <a style="[% button_style %]" href="[% token_url %]">Yes, send my report</a>
   </p>

--- a/templates/email/default/problem-confirm.txt
+++ b/templates/email/default/problem-confirm.txt
@@ -3,8 +3,8 @@ Subject: Confirm your report on [% site_name %]
 Hello [% report.name %],
 
 Please click on the link below to confirm that you want to send your report to
-[% report.body %]. Note that your report will also appear on the [% site_name %]
-website:
+[% report.body %].[% UNLESS report.non_public %] Note that your report will also
+appear on the [% site_name %] website.[% END %]
 
 [% token_url %]
 

--- a/templates/email/hounslow/problem-confirm.html
+++ b/templates/email/hounslow/problem-confirm.html
@@ -1,0 +1,31 @@
+[%
+
+email_summary = "You need to confirm your " _ site_name _ " report before it can be sent to Hounslow Highways.";
+email_columns = 2;
+
+PROCESS '_email_settings.html';
+
+INCLUDE '_email_top.html';
+
+%]
+
+<th style="[% td_style %][% primary_column_style %]" id="primary_column">
+  [% start_padded_box %]
+  <h1 style="[% h1_style %]">Please confirm your&nbsp;report</h1>
+  <p style="[% p_style %]">Please click on the link below to confirm that you want to send your report to Hounslow Highways.
+
+[% TRY %][% INCLUDE '_problem-confirm_extra.html' %][% CATCH file %][% END %]
+  </p>
+  [% UNLESS report.non_public %]<p style="[% p_style %]">Your report will also appear on the [% site_name %] website.</p>[% END %]
+  <p style="margin: 20px auto; text-align: center">
+    <a style="[% button_style %]" href="[% token_url %]">Yes, send my report</a>
+  </p>
+  <p style="[% p_style %]">If you no longer wish to send this report, please take no further action.</p>
+  [% end_padded_box %]
+</th>
+[% WRAPPER '_email_sidebar.html' object = report, url = token_url %]
+    <h2 style="[% h2_style %]">[% report.title | html %]</h2>
+    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+[% END %]
+
+[% INCLUDE '_email_bottom.html' %]

--- a/templates/email/hounslow/problem-confirm.txt
+++ b/templates/email/hounslow/problem-confirm.txt
@@ -1,0 +1,31 @@
+Subject: Confirm your report on [% site_name %]
+
+Hello [% report.name %],
+
+Please click on the link below to confirm that you want to send your report to
+Hounslow Highways.[% UNLESS report.non_public %] Note that your report will also
+appear on the [% site_name %] website.[% END %]
+
+[% token_url %]
+
+If your email program does not let you click on this link, copy and paste it
+into your web browser and press return.
+[% TRY %][% INCLUDE '_problem-confirm_extra.txt' %][% CATCH file %][% END %]
+Your problem had the title:
+
+[% report.title %]
+
+And details:
+
+[% report.detail %]
+
+If you no longer wish to send this report, please take no further action.
+
+Thank you for submitting a report through [% site_name %].
+
+
+
+[% signature %]
+
+This email was sent automatically, from an unmonitored email account - so
+please do not reply to it.


### PR DESCRIPTION
Another instance of the borough council being mentioned where it shouldn't be. Also fixes some misleading text indicating that a private report would be published when in reality it wouldn't.

[skip changelog]

Fixes https://github.com/mysociety/fixmystreet-freshdesk/issues/71