### PR TITLE
[Bexley] Include subcategory in dashboard export.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley.pm
@@ -131,4 +131,31 @@ sub open311_post_send {
     $sender->send($row, $h);
 }
 
+sub dashboard_export_problems_add_columns {
+    my $self = shift;
+    my $c = $self->{c};
+
+    my %groups;
+    if ($c->stash->{body}) {
+        %groups = FixMyStreet::DB->resultset('Contact')->active->search({
+            body_id => $c->stash->{body}->id,
+        })->group_lookup;
+    }
+
+    splice @{$c->stash->{csv}->{headers}}, 5, 0, 'Subcategory';
+    splice @{$c->stash->{csv}->{columns}}, 5, 0, 'subcategory';
+
+    $c->stash->{csv}->{extra_data} = sub {
+        my $report = shift;
+
+        if ($groups{$report->category}) {
+            return {
+                category => $groups{$report->category},
+                subcategory => $report->category,
+            };
+        }
+        return {};
+    };
+}
+
 1;

--- a/perllib/FixMyStreet/DB/ResultSet/Contact.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Contact.pm
@@ -37,4 +37,13 @@ sub summary_count {
     );
 }
 
+sub group_lookup {
+    my $rs = shift;
+    map {
+        my $group = $_->get_extra_metadata('group') || '';
+        $group = join(',', ref $group ? @$group : $group);
+        $_->category => $group
+    } $rs->all;
+}
+
 1;

--- a/t/cobrand/bexley.t
+++ b/t/cobrand/bexley.t
@@ -33,7 +33,9 @@ $mech->create_contact_ok(body_id => $body->id, category => 'Abandoned and untaxe
 $mech->create_contact_ok(body_id => $body->id, category => 'Lamp post', email => "LAMP");
 $mech->create_contact_ok(body_id => $body->id, category => 'Parks and open spaces', email => "PARK");
 $mech->create_contact_ok(body_id => $body->id, category => 'Dead animal', email => "ANIM");
-$mech->create_contact_ok(body_id => $body->id, category => 'Something dangerous', email => "DANG");
+my $category = $mech->create_contact_ok(body_id => $body->id, category => 'Something dangerous', email => "DANG");
+$category->set_extra_metadata(group => 'Danger things');
+$category->update;
 
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'bexley' ],
@@ -117,6 +119,12 @@ FixMyStreet::override_config {
         $mech->get_ok('/admin/report_edit/' . $report->id);
         $mech->content_contains('View report on site');
         $mech->content_lacks('Resend report');
+    };
+
+    subtest 'extra CSV column present' => sub {
+        $mech->get_ok('/dashboard?export=1');
+        $mech->content_contains(',Category,Subcategory,');
+        $mech->content_contains('"Danger things","Something dangerous"');
     };
 
 };


### PR DESCRIPTION
[skip changelog]
I thought about doing it in all cobrands with category groups, but B&NES fetch their CSV file programmatically, so I don't know if they'd handle that or not. (Also they have the option of multiple groups for one category, so might not make sense for them.) So this inserts it just after Category in the export, for Bexley only. I don't know if any others do manual exports; alternatively we could add it to all that have groups and don't have multiple-groups-per-category, meh.