### PR TITLE
[IsleOfWight] fix all reports link

### DIFF
--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -177,7 +177,11 @@ sub reports_body_check {
     }
 
     # We want to make sure we're only on our page.
-    unless ( $self->council_name =~ /^\Q$code\E/ ) {
+    my $council_name = $self->council_name;
+    if (my $override = $self->all_reports_single_body) {
+        $council_name = $override->{name};
+    }
+    unless ( $council_name =~ /^\Q$code\E/ ) {
         $c->res->redirect( 'https://www.fixmystreet.com' . $c->req->uri->path_query, 301 );
         $c->detach();
     }

--- a/t/cobrand/isleofwight.t
+++ b/t/cobrand/isleofwight.t
@@ -29,6 +29,19 @@ my @reports = $mech->create_problems_for_body(1, $isleofwight->id, 'An Isle of w
     user => $user
 });
 
+subtest "check clicking all reports link" => sub {
+    FixMyStreet::override_config {
+        MAPIT_URL => 'http://mapit.uk/',
+        ALLOWED_COBRANDS => 'isleofwight',
+    }, sub {
+        $mech->get_ok('/');
+        $mech->follow_link_ok({ text => 'All reports' });
+    };
+
+    $mech->content_contains("An Isle of wight report", "Isle of Wight report there");
+    $mech->content_contains("Island Roads", "is still on cobrand");
+};
+
 subtest "only original reporter can comment" => sub {
     FixMyStreet::override_config {
         MAPIT_URL => 'http://mapit.uk/',


### PR DESCRIPTION
The area name does not match the council name so it redirects to the
national site, so check for the all_reports_single_body and use that as
the matching instead.

Please check the following:

[skip changelog]