### PR TITLE
unset the external_status_code if blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
         - Do not store display-only extra fields on new reports.
         - Support receiving updates from external source.
         - Improve JSON output of controller.
+        - unset external_status_code if blank in update
 
 * v2.6 (3rd May 2019)
     - New features:

--- a/perllib/Open311/GetServiceRequestUpdates.pm
+++ b/perllib/Open311/GetServiceRequestUpdates.pm
@@ -181,6 +181,8 @@ sub process_update {
     if ( $external_status_code ) {
         $comment->set_extra_metadata(external_status_code => $external_status_code);
         $p->set_extra_metadata(external_status_code => $external_status_code);
+    } else {
+        $p->set_extra_metadata(external_status_code => '');
     }
 
     # if the customer reference to display in the report metadata is


### PR DESCRIPTION
If an update with a blank external_status_code is fetched then unset it
otherwise we will always a detect a change in the external_status_code
which might mean phantom updates.