### PR TITLE
Enable pre-filling of report form group/category from front page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
         - Report form now indicates that details are kept private if report is
           made in a private category. #2528
         - Improve map JavaScript defensiveness.
+        - Pass ‘filter_category’ param to front page to pre-filter map.
     - Admin improvements:
         - Add new roles system, to group permissions and apply to users.
     - New features:

--- a/t/app/controller/index.t
+++ b/t/app/controller/index.t
@@ -92,9 +92,10 @@ subtest "prefilters /around if user has categories" => sub {
 };
 
 subtest "prefilters /around if filter_category given in URL" => sub {
-    $mech->get_ok('/?filter_category=MyUniqueTestCategory');
-    # NB can't use visible_form_values because categories field is hidden
+    $mech->get_ok('/?filter_category=MyUniqueTestCategory&filter_group=MyUniqueTestGroup');
+    # NB can't use visible_form_values because fields are hidden
     $mech->content_contains("MyUniqueTestCategory");
+    $mech->content_contains("MyUniqueTestGroup");
 };
 
 END {

--- a/t/app/controller/index.t
+++ b/t/app/controller/index.t
@@ -91,6 +91,12 @@ subtest "prefilters /around if user has categories" => sub {
     $mech->content_contains("Cows,Potholes");
 };
 
+subtest "prefilters /around if filter_category given in URL" => sub {
+    $mech->get_ok('/?filter_category=MyUniqueTestCategory');
+    # NB can't use visible_form_values because categories field is hidden
+    $mech->content_contains("MyUniqueTestCategory");
+};
+
 END {
     done_testing();
 }

--- a/templates/web/base/around/_error_multiple.html
+++ b/templates/web/base/around/_error_multiple.html
@@ -10,7 +10,7 @@
           [% IF match.icon %]
             <img src="[% match.icon %]" alt="">
           [% END %]
-             <a href="/around?lat=[% match.latitude | uri %]&amp;lon=[% match.longitude | uri %][% IF c.req.params.category %]&amp;category=[% c.req.params.category | uri %][% END %]">[% match.address | html %]</a>
+             <a href="/around?lat=[% match.latitude | uri %]&amp;lon=[% match.longitude | uri %][% IF c.get_param('category') %]&amp;category=[% c.get_param('category') | uri %][% END %][% IF c.get_param('filter_category') %]&amp;filter_category=[% c.get_param('filter_category') | uri %][% END %]">[% match.address | html %]</a>
         </li>
       [% END %]
     </ul>

--- a/templates/web/base/around/_error_multiple.html
+++ b/templates/web/base/around/_error_multiple.html
@@ -10,7 +10,10 @@
           [% IF match.icon %]
             <img src="[% match.icon %]" alt="">
           [% END %]
-             <a href="/around?lat=[% match.latitude | uri %]&amp;lon=[% match.longitude | uri %][% IF c.get_param('category') %]&amp;category=[% c.get_param('category') | uri %][% END %][% IF c.get_param('filter_category') %]&amp;filter_category=[% c.get_param('filter_category') | uri %][% END %]">[% match.address | html %]</a>
+             <a href="/around?lat=[% match.latitude | uri %]&amp;lon=[% match.longitude | uri ~%]
+             [%~ IF c.get_param('category') %]&amp;category=[% c.get_param('category') | uri %][% END ~%]
+             [%~ IF c.get_param('filter_category') %]&amp;filter_category=[% c.get_param('filter_category') | uri %][% END ~%]
+             [%~ IF c.get_param('filter_group') %]&amp;filter_group=[% c.get_param('filter_group') | uri %][% END %]">[% match.address | html %]</a>
         </li>
       [% END %]
     </ul>

--- a/templates/web/base/around/display_location.html
+++ b/templates/web/base/around/display_location.html
@@ -51,6 +51,10 @@
 
     <input type="hidden" name="latitude" id="fixmystreet.latitude" value="[% latitude | html %]">
     <input type="hidden" name="longitude" id="fixmystreet.longitude" value="[% longitude | html %]">
+
+    [% IF c.get_param('filter_group') %]
+        <input type="hidden" name="filter_group" id="filter_group" value="[% c.get_param('filter_group') | html %]">
+    [% END %]
 [% END %]
 
     [% map_html %]

--- a/templates/web/base/around/postcode_form.html
+++ b/templates/web/base/around/postcode_form.html
@@ -20,8 +20,9 @@
                 <input type="hidden" name="partial" value="[% partial_token.token %]">
             [% END %]
 
-            [% IF c.get_param('filter_category') %]
+            [% IF c.get_param('filter_category') OR c.get_param('filter_group') %]
               <input type="hidden" name="filter_category" value="[% c.get_param('filter_category') | html %]">
+              <input type="hidden" name="filter_group" value="[% c.get_param('filter_group') | html %]">
             [% ELSIF c.user_exists AND c.user.categories.size %]
               <input type="hidden" name="filter_category" value="[% c.user.categories_string | html %]">
             [% END %]

--- a/templates/web/base/around/postcode_form.html
+++ b/templates/web/base/around/postcode_form.html
@@ -20,7 +20,9 @@
                 <input type="hidden" name="partial" value="[% partial_token.token %]">
             [% END %]
 
-            [% IF c.user_exists AND c.user.categories.size %]
+            [% IF c.get_param('filter_category') %]
+              <input type="hidden" name="filter_category" value="[% c.get_param('filter_category') | html %]">
+            [% ELSIF c.user_exists AND c.user.categories.size %]
               <input type="hidden" name="filter_category" value="[% c.user.categories_string | html %]">
             [% END %]
         </form>

--- a/templates/web/base/reports/_list-filters.html
+++ b/templates/web/base/reports/_list-filters.html
@@ -47,9 +47,10 @@
 
 [% select_category = BLOCK %]
   [% IF filter_categories.size %]
+    [% SET filter_group = c.get_param('filter_group') %]
     <select class="form-control js-multiple" name="filter_category" id="filter_categories" multiple data-all="[% loc('Everything') %]">
         [% FOR cat IN filter_categories %]
-            <option value="[% cat.category | html %]"[% ' selected' IF filter_category.${cat.category} %]>
+            <option value="[% cat.category | html %]"[% ' selected' IF filter_category.${cat.category} OR ( filter_group AND ( cat.get_extra_metadata('group') == filter_group OR cat.category == filter_group ) ) %]>
                 [% cat.category_display | html %]
                 [%~ IF cat.get_extra_metadata('help_text') %] ([% cat.get_extra_metadata('help_text') %])[% END ~%]
             </option>

--- a/templates/web/oxfordshire/around/postcode_form.html
+++ b/templates/web/oxfordshire/around/postcode_form.html
@@ -19,7 +19,9 @@
                 <input type="hidden" name="partial" value="[% partial_token.token %]">
             [% END %]
 
-            [% IF c.user_exists AND c.user.categories.size %]
+            [% IF c.get_param('filter_category') %]
+              <input type="hidden" name="filter_category" value="[% c.get_param('filter_category') | html %]">
+            [% ELSIF c.user_exists AND c.user.categories.size %]
               <input type="hidden" name="filter_category" value="[% c.user.categories.join(",") | html %]">
             [% END %]
         </form>

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1230,7 +1230,7 @@ fixmystreet.fetch_reporting_data = function() {
             return;
         }
         $('#side-form').show();
-        var old_category_group = $('#category_group').val(),
+        var old_category_group = $('#category_group').val() || $('#filter_group').val(),
             old_category = $("#form_category").val(),
             filter_category = $("#filter_categories").val();
 


### PR DESCRIPTION
Adds `filter_group` and `filter_category` parameters to the front page URL which are carried through to filter the map on `/around` and pre-fill the appropriate fields on the new report form.