### PR TITLE
Disable ‘add user’ form on admin user search when role selected

### DIFF
--- a/templates/web/base/admin/users/index.html
+++ b/templates/web/base/admin/users/index.html
@@ -90,7 +90,7 @@
 
 [% END %]
 
-[% IF NOT searched %]
+[% IF NOT ( searched || role_selected )%]
 <h2>[% loc('Add user') %]</h2>
 [% INCLUDE 'admin/users/form.html', user = '' %]
 [% ELSE %]


### PR DESCRIPTION
The error was due to CSRF token not being included in the page when filtering by role, but this approach is consistent with existing behaviour when searching.

Fixes mysociety/fixmystreet-commercial#1485

[skip changelog]