### PR TITLE
[Westminster] Some small changes

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Auth.pm
+++ b/perllib/FixMyStreet/App/Controller/Auth.pm
@@ -219,7 +219,7 @@ sub get_token : Private {
 sub set_oauth_token_data : Private {
     my ( $self, $c, $token_data ) = @_;
 
-    foreach (qw/facebook_id twitter_id oidc_id extra logout_redirect_uri/) {
+    foreach (qw/facebook_id twitter_id oidc_id extra logout_redirect_uri change_password_uri/) {
         $token_data->{$_} = $c->session->{oauth}{$_} if $c->session->{oauth}{$_};
     }
 }
@@ -291,9 +291,11 @@ sub process_login : Private {
     $user->update_or_insert;
     $c->authenticate( { $type => $data->{$type}, $ver => 1 }, 'no_password' );
 
-    if ($data->{logout_redirect_uri}) {
-        $c->session->{oauth} ||= ();
-        $c->session->{oauth}{logout_redirect_uri} = $data->{logout_redirect_uri};
+    foreach (qw/logout_redirect_uri change_password_uri/) {
+        if ($data->{$_}) {
+            $c->session->{oauth} ||= ();
+            $c->session->{oauth}{$_} = $data->{$_};
+        }
     }
 
 

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1331,10 +1331,12 @@ sub process_confirmation : Private {
 
         $problem->user->update;
 
-        # Make sure OIDC logout redirection happens, if applicable
-        if ($data->{logout_redirect_uri}) {
-            $c->session->{oauth} ||= ();
-            $c->session->{oauth}{logout_redirect_uri} = $data->{logout_redirect_uri};
+        # Make sure extra oauth state is restored, if applicable
+        foreach (qw/logout_redirect_uri change_password_uri/) {
+            if ($data->{$_}) {
+                $c->session->{oauth} ||= ();
+                $c->session->{oauth}{$_} = $data->{$_};
+            }
         }
     }
     if ($problem->user->email_verified) {

--- a/perllib/FixMyStreet/App/Controller/Report/Update.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/Update.pm
@@ -585,10 +585,12 @@ sub process_confirmation : Private {
         }) if $data->{extra};
         $comment->user->password( $data->{password}, 1 ) if $data->{password};
         $comment->user->update;
-        # Make sure OIDC logout redirection happens, if applicable
-        if ($data->{logout_redirect_uri}) {
-            $c->session->{oauth} ||= ();
-            $c->session->{oauth}{logout_redirect_uri} = $data->{logout_redirect_uri};
+        # Make sure extra oauth state is restored, if applicable
+        foreach (qw/logout_redirect_uri change_password_uri/) {
+            if ($data->{$_}) {
+                $c->session->{oauth} ||= ();
+                $c->session->{oauth}{$_} = $data->{$_};
+            }
         }
     }
 

--- a/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
@@ -27,7 +27,7 @@ sub disambiguate_location {
 
 sub categories_restriction {
     my ($self, $rs) = @_;
-    return $rs->search( [ { 'body.name' => 'Northamptonshire County Council' } ], { join => { body => 'body_areas' } });
+    return $rs->search( { 'body.name' => 'Northamptonshire County Council' }, { join => 'body' });
 }
 
 sub send_questionnaires { 0 }

--- a/perllib/FixMyStreet/Cobrand/Westminster.pm
+++ b/perllib/FixMyStreet/Cobrand/Westminster.pm
@@ -45,6 +45,8 @@ sub updates_disallowed {
 
 sub suppress_reporter_alerts { 1 }
 
+sub report_age { '3 months' }
+
 sub social_auth_enabled {
     my $self = shift;
 

--- a/perllib/FixMyStreet/Cobrand/Westminster.pm
+++ b/perllib/FixMyStreet/Cobrand/Westminster.pm
@@ -145,4 +145,12 @@ sub _fetch_features_url {
     return $cfg->{proxy_url} . "?" . $uri->as_string;
 }
 
+sub categories_restriction {
+    my ($self, $rs) = @_;
+    # Westminster don't want TfL categories on their cobrand
+    # XXX This still shows "These will be sent to TfL or Westminster City Council"
+    # on /report/new before a category is selected...
+    return $rs->search( { 'body.name' => 'Westminster City Council' }, { join => 'body' });
+}
+
 1;

--- a/perllib/FixMyStreet/SendReport/Open311.pm
+++ b/perllib/FixMyStreet/SendReport/Open311.pm
@@ -30,6 +30,7 @@ sub send {
             extended_description    => 1,
             multi_photos            => 0,
             upload_files            => 0,
+            always_upload_photos    => 0,
             fixmystreet_body => $body,
         );
 

--- a/perllib/Open311.pm
+++ b/perllib/Open311.pm
@@ -35,6 +35,7 @@ has extended_statuses => ( is => 'ro', isa => Bool, default => 0 );
 has always_send_email => ( is => 'ro', isa => Bool, default => 0 );
 has multi_photos => ( is => 'ro', isa => Bool, default => 0 );
 has upload_files => ( is => 'ro', isa => Bool, default => 0 );
+has always_upload_photos => ( is => 'ro', isa => Bool, default => 0 );
 has use_customer_reference => ( is => 'ro', isa => Bool, default => 0 );
 has mark_reopen => ( is => 'ro', isa => Bool, default => 0 );
 has fixmystreet_body => ( is => 'ro', isa => InstanceOf['FixMyStreet::DB::Result::Body'] );
@@ -218,7 +219,7 @@ sub _populate_service_request_uploads {
         }
     }
 
-    if ( $problem->photo && $problem->non_public ) {
+    if ( $self->always_upload_photos || ( $problem->photo && $problem->non_public ) ) {
         # open311-adapter won't be able to download any photos if they're on
         # a private report, so instead of sending the media_url parameter
         # send the actual photo content with the POST request.

--- a/t/app/controller/auth_social.t
+++ b/t/app/controller/auth_social.t
@@ -65,6 +65,7 @@ for my $test (
                     auth_uri => 'http://oidc.example.org/oauth2/v2.0/authorize',
                     token_uri => 'http://oidc.example.org/oauth2/v2.0/token',
                     logout_uri => 'http://oidc.example.org/oauth2/v2.0/logout',
+                    password_change_uri => 'http://oidc.example.org/oauth2/v2.0/password_change',
                     display_name => 'MyWestminster'
                 }
             }
@@ -79,6 +80,7 @@ for my $test (
     success_callback => '/auth/OIDC?code=response-code&state=login',
     redirect_pattern => qr{oidc\.example\.org/oauth2/v2\.0/authorize},
     logout_redirect_pattern => qr{oidc\.example\.org/oauth2/v2\.0/logout},
+    password_change_pattern => qr{oidc\.example\.org/oauth2/v2\.0/password_change},
     user_extras => [
         [westminster_account_id => "1c304134-ef12-c128-9212-123908123901"],
     ],
@@ -240,6 +242,9 @@ for my $state ( 'refused', 'no email', 'existing UID', 'okay' ) {
                     my $report_id = $report->id;
                     $mech->content_contains( $report->title );
                     $mech->content_contains( "/report/$report_id" );
+                }
+                if ($test->{type} eq 'oidc') {
+                    ok $mech->find_link( text => 'Change password', url_regex => $test->{password_change_pattern} );
                 }
             }
 

--- a/t/app/controller/auth_social.t
+++ b/t/app/controller/auth_social.t
@@ -14,7 +14,7 @@ my $mech = FixMyStreet::TestMech->new;
 FixMyStreet::App->log->disable('info');
 END { FixMyStreet::App->log->enable('info'); }
 
-my $body = $mech->create_body_ok(2504, 'Westminster Council');
+my $body = $mech->create_body_ok(2504, 'Westminster City Council');
 
 my ($report) = $mech->create_problems_for_body(1, $body->id, 'My Test Report');
 

--- a/templates/web/base/my/my.html
+++ b/templates/web/base/my/my.html
@@ -60,13 +60,17 @@ li .my-account-buttons a {
 </ul>
 
 <p class="my-account-buttons">
+  [% IF c.session.oauth.change_password_uri %]
+    <a href="[% c.session.oauth.change_password_uri | html %]">[% loc('Change password') %]</a>
+  [% ELSE %]
     <a href="/auth/change_password">
-  [%~ IF c.user.password ~%]
-    [% loc('Change password') %]
-  [%~ ELSE ~%]
-    [% loc('Set password') %]
-  [%~ END ~%]
+    [%~ IF c.user.password ~%]
+      [% loc('Change password') %]
+    [%~ ELSE ~%]
+      [% loc('Set password') %]
+    [%~ END ~%]
     </a>
+  [% END %]
   [% IF c.user AND (c.user.from_body OR c.user.is_superuser) %]
   <a href="/auth/generate_token">[% loc('Security') %]</a>
   [% END %]

--- a/templates/web/base/my/my.html
+++ b/templates/web/base/my/my.html
@@ -34,7 +34,7 @@ li .my-account-buttons a {
 <ul>
 <li>[% loc('Name:') %] [% c.user.name %]
 <li>[% loc('Email:') %] [% c.user.email OR '-' %]
-    <p class="my-account-buttons">
+    <p class="my-account-buttons my-account-buttons--email">
       [% IF NOT c.user.email %]
         <a href="/auth/change_email">[% loc('Add') %]</a>
       [% ELSIF c.user.email_verified %]
@@ -61,9 +61,9 @@ li .my-account-buttons a {
 
 <p class="my-account-buttons">
   [% IF c.session.oauth.change_password_uri %]
-    <a href="[% c.session.oauth.change_password_uri | html %]">[% loc('Change password') %]</a>
+    <a class="change-password" href="[% c.session.oauth.change_password_uri | html %]">[% loc('Change password') %]</a>
   [% ELSE %]
-    <a href="/auth/change_password">
+    <a class="change-password" href="/auth/change_password">
     [%~ IF c.user.password ~%]
       [% loc('Change password') %]
     [%~ ELSE ~%]

--- a/web/cobrands/westminster/assets.js
+++ b/web/cobrands/westminster/assets.js
@@ -248,7 +248,7 @@ layer_data = [
     { group: 'Street lights', item: 'street light', layers: [ 18, 50, 60 ] },
     { category: 'Pavement damage', layers: [ 14 ], road: true },
     { category: 'Pothole', layers: [ 11, 44 ], road: true },
-    { group: 'Drains', item: 'gully', layers: [ 16 ] },
+    { group: 'Drains', item: 'drain', layers: [ 16 ] },
 
     { category: 'Signs and bollards', subcategories: [ '1' ], subcategory_id: '#form_featuretypecode', item: 'bollard', layers: [ 42, 52 ] },
     { category: 'Signs and bollards', subcategories: [ 'PLFP' ], subcategory_id: '#form_featuretypecode', item: 'feeder pillar', layers: [ 56 ] },

--- a/web/cobrands/westminster/base.scss
+++ b/web/cobrands/westminster/base.scss
@@ -230,3 +230,12 @@ ol.big-numbers>li:before {
 .item-list__item--expandable__actions a.btn--primary {
     display: none; // No updates
 }
+
+
+.my-account-buttons--email {
+    display: none; // hide 'change email' link
+}
+
+.my-account-buttons a.change-password {
+    display: none;
+}


### PR DESCRIPTION
 - Replace ‘gully’ with ‘drain’ in asset UI ([Basecamp](https://3.basecamp.com/4020879/buckets/12002933/todos/1972169811))
 - ~Upload all photos over Open311~ ([Basecamp](https://3.basecamp.com/4020879/buckets/12002933/messages/1969231294)) (supporting code is included in this PR, but not enabled for the Westminster cobrand)
 - Hide 'change password' & 'change email' links on `/my` ([Basecamp](https://3.basecamp.com/4020879/buckets/12002933/messages/1945441618#__recording_1978717754))
 - Remove TfL categories ([Basecamp](https://3.basecamp.com/4020879/buckets/12002933/todos/1978021687))
 - Show 3 months on `/around` by default ([Basecamp](https://3.basecamp.com/4020879/buckets/12002933/messages/1939205134#__recording_1974850946))

[skip changelog]