### PR TITLE
Fix some reporting interaction bugs

### DIFF
--- a/.cypress/cypress/integration/regressions.js
+++ b/.cypress/cypress/integration/regressions.js
@@ -71,6 +71,27 @@ describe('Regression tests', function() {
       cy.contains(/These will be sent to Northampton Borough Council and also/);
     });
 
+    it('remembers extra fields when you sign in during reporting', function() {
+      cy.server();
+      cy.route('/report/new/ajax*').as('report-ajax');
+      cy.visit('/around?lon=-2.295894&lat=51.526877&zoom=6&js=1');
+      cy.get('#map_box').click();
+      cy.wait('@report-ajax');
+      cy.get('[id=category_group]').select('Licensing');
+      cy.get('[id=subcategory_Licensing]').select('Skips');
+      cy.get('[name=title]').type('Title');
+      cy.get('[name=detail]').type('Detail');
+      cy.get('[name=start_date').type('2019-01-01');
+      cy.get('.js-new-report-user-show').click();
+      cy.get('.js-new-report-show-sign-in').should('be.visible').click();
+      cy.get('#form_username_sign_in').type('user@example.org');
+      cy.get('[name=password_sign_in]').type('password');
+      cy.get('[name=password_sign_in]').parents('form').submit();
+      cy.get('#map_sidebar').should('contain', 'check and confirm your details');
+      cy.wait('@report-ajax');
+      cy.get('#form_start_date').should('have.value', '2019-01-01');
+    });
+
     it('hides everything when duplicate suggestions are shown', function() {
       cy.server();
       cy.route('/report/new/ajax*').as('report-ajax');

--- a/.cypress/cypress/integration/regressions.js
+++ b/.cypress/cypress/integration/regressions.js
@@ -54,7 +54,7 @@ describe('Regression tests', function() {
         cy.get('.content').should('not.contain', 'toddler');
     });
 
-    it.only('has the correct send-to text at all times', function() {
+    it('has the correct send-to text at all times', function() {
       cy.server();
       cy.route('/report/new/ajax*').as('report-ajax');
       cy.visit('/');
@@ -71,4 +71,16 @@ describe('Regression tests', function() {
       cy.contains(/These will be sent to Northampton Borough Council and also/);
     });
 
+    it('hides everything when duplicate suggestions are shown', function() {
+      cy.server();
+      cy.route('/report/new/ajax*').as('report-ajax');
+      cy.visit('http://borsetshire.localhost:3001/_test/setup/regression-duplicate-hide'); // Server-side setup
+      cy.visit('http://borsetshire.localhost:3001/report/1');
+      cy.contains('Report another problem here').click();
+      cy.wait('@report-ajax');
+      cy.get('[id=category_group]').select('Licensing');
+      cy.get('[id=subcategory_Licensing]').select('Skips');
+      cy.get('.extra-category-questions').should('not.be.visible');
+      cy.visit('http://borsetshire.localhost:3001/_test/teardown/regression-duplicate-hide');
+    });
 });

--- a/.cypress/cypress/integration/regressions.js
+++ b/.cypress/cypress/integration/regressions.js
@@ -104,4 +104,26 @@ describe('Regression tests', function() {
       cy.get('.extra-category-questions').should('not.be.visible');
       cy.visit('http://borsetshire.localhost:3001/_test/teardown/regression-duplicate-hide');
     });
+
+    it('does not show duplicate suggestions when signing in during reporting', function() {
+      cy.server();
+      cy.route('/report/new/ajax*').as('report-ajax');
+      cy.route('/around/nearby*').as('nearby-ajax');
+      cy.visit('http://borsetshire.localhost:3001/report/1');
+      cy.contains('Report another problem here').click();
+      cy.wait('@report-ajax');
+      cy.get('[id=category_group]').select('Potholes');
+      cy.wait('@nearby-ajax');
+      cy.get('.js-hide-duplicate-suggestions:first').should('be.visible').click();
+      cy.get('[name=title]').type('Title');
+      cy.get('[name=detail]').type('Detail');
+      cy.get('.js-new-report-user-show').click();
+      cy.get('.js-new-report-show-sign-in').should('be.visible').click();
+      cy.get('#form_username_sign_in').type('user@example.org');
+      cy.get('[name=password_sign_in]').type('password');
+      cy.get('[name=password_sign_in]').parents('form').submit();
+      cy.get('#map_sidebar').should('contain', 'check and confirm your details');
+      cy.get('#js-duplicate-reports').should('not.exist');
+    });
+
 });

--- a/.cypress/cypress/integration/simple_spec.js
+++ b/.cypress/cypress/integration/simple_spec.js
@@ -9,6 +9,7 @@ describe('Clicking the map', function() {
     it('allows me to report a new problem', function() {
         cy.url().should('include', '/around');
         cy.get('#map_box').click(200, 200);
+        cy.get('#category_group').select('Flyposting');
         cy.get('[name=title]').type('Title');
         cy.get('[name=detail]').type('Detail');
         cy.get('.js-new-report-user-show').click();

--- a/.cypress/cypress/integration/staff.js
+++ b/.cypress/cypress/integration/staff.js
@@ -40,7 +40,7 @@ describe('Staff user tests', function() {
         cy.wait('@report-ajax');
         cy.get('select:eq(3)').select('Graffiti');
         cy.get('[name=title]').should('have.value', 'A Graffiti problem has been found');
-        cy.get('[name=detail]').should('have.value', 'A Graffiti problem has been found by Borsetshire');
+        cy.get('[name=detail]').should('have.value', 'A Graffiti problem has been found by Borsetshire County Council');
         cy.cleanUpXHR();
     });
 });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
         - Handle missing category when sending open311 reports #2502
         - Fix label associations with category groups. #2541
         - Hide category extras when duplicate suggestions shown.
+        - Hide duplicate suggestions when signing in during reporting.
         - Retain extra data if signing in during reporting.
     - Front end improvements:
         - Set report title autocomplete to off to prevent email autocompleting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
         - Handle missing category when sending open311 reports #2502
         - Fix label associations with category groups. #2541
         - Hide category extras when duplicate suggestions shown.
+        - Retain extra data if signing in during reporting.
     - Front end improvements:
         - Set report title autocomplete to off to prevent email autocompleting
     - Development improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
         - Fix front-end testing script when run with Vagrant. #2514
         - Handle missing category when sending open311 reports #2502
         - Fix label associations with category groups. #2541
+        - Hide category extras when duplicate suggestions shown.
     - Front end improvements:
         - Set report title autocomplete to off to prevent email autocompleting
     - Development improvements:

--- a/bin/browser-tests
+++ b/bin/browser-tests
@@ -11,7 +11,7 @@ my ($cobrand, $coords, $area_id, $name, $mapit_url);
 
 BEGIN {
     $config_file = 'conf/general.yml-example';
-    $cobrand = [ 'fixmystreet', 'northamptonshire', 'bathnes', 'buckinghamshire', 'hounslow' ];
+    $cobrand = [ 'borsetshire', 'fixmystreet', 'northamptonshire', 'bathnes', 'buckinghamshire', 'hounslow' ];
     $coords = '51.532851,-2.284277';
     $area_id = 2608;
     $name = 'Borsetshire';
@@ -91,6 +91,7 @@ sub run {
             STAGING_FLAGS => { skip_checks => 1 },
             COBRAND_FEATURES => {
                 category_groups => { map { $_ => 1 } @$cobrand },
+                suggest_duplicates => { map { $_ => 1 } @$cobrand },
             }
         });
         $ENV{FMS_OVERRIDE_CONFIG} = $config_out;

--- a/perllib/FixMyStreet/App/Controller/Test.pm
+++ b/perllib/FixMyStreet/App/Controller/Test.pm
@@ -1,0 +1,60 @@
+package FixMyStreet::App::Controller::Test;
+use Moose;
+use namespace::autoclean;
+
+use File::Basename;
+
+BEGIN { extends 'Catalyst::Controller'; }
+
+=head1 NAME
+
+FixMyStreet::App::Controller::Test - Catalyst Controller
+
+=head1 DESCRIPTION
+
+Test-helping Catalyst Controller.
+
+=head1 METHODS
+
+=over 4
+
+=item auto
+
+Makes sure this controller is only available when run in test.
+
+=cut
+
+sub auto : Private {
+    my ($self, $c) = @_;
+    $c->detach( '/page_error_404_not_found' ) unless FixMyStreet->test_mode;
+    return 1;
+}
+
+=item setup
+
+Sets up a particular browser test.
+
+=cut
+
+sub setup : Path('/_test/setup') : Args(1) {
+    my ( $self, $c, $test ) = @_;
+    if ($test eq 'regression-duplicate-hide') {
+        my $problem = FixMyStreet::DB->resultset("Problem")->find(1);
+        $problem->update({ category => 'Skips' });
+        $c->response->body("OK");
+    }
+}
+
+sub teardown : Path('/_test/teardown') : Args(1) {
+    my ( $self, $c, $test ) = @_;
+    if ($test eq 'regression-duplicate-hide') {
+        my $problem = FixMyStreet::DB->resultset("Problem")->find(1);
+        $problem->update({ category => 'Potholes' });
+        $c->response->body("OK");
+    }
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;
+

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -96,8 +96,8 @@ sub dispatch_request {
             }
         }
         my $response = {
-            "63999" => {"parent_area" => 2245, "generation_high" => 25, "all_names" => {}, "id" => 63999, "codes" => {"ons" => "00HYNS", "gss" => "E05008366", "unit_id" => "44025"}, "name" => "Kington", "country" => "E", "type_name" => "Unitary Authority electoral division (UTE)", "generation_low" => 12, "country_name" => "England", "type" => "UTE"},
-            "2245" => {"parent_area" => undef, "generation_high" => 25, "all_names" => {}, "id" => 2245, "codes" => {"ons" => "00HY", "gss" => "E06000054", "unit_id" => "43925"}, "name" => "Wiltshire Council", "country" => "E", "type_name" => "Unitary Authority", "generation_low" => 11, "country_name" => "England", "type" => "UTA"}
+            "153255" => {"parent_area" => 2608, "generation_high" => 36, "all_names" => {}, "id" => 153255, "codes" => {"gss" => "E05012110", "unit_id" => "174450"}, "name" => "Chipping Sodbury & Cotswold Edge", "country" => "E", "type_name" => "Unitary Authority ward (UTW)", "generation_low" => 36, "country_name" => "England", "type" => "UTW"},
+            "2608" => {"parent_area" => undef, "generation_high" => 36, "all_names" => {}, "id" => 2608, "codes" => {"ons" => "00HD", "gss" => "E06000025", "unit_id" => "25559"}, "name" => "South Gloucestershire Council", "country" => "E", "type_name" => "Unitary Authority", "generation_low" => 1, "country_name" => "England", "type" => "UTA"}
         };
         return $self->output($response);
     },

--- a/t/app/controller/report_import.t
+++ b/t/app/controller/report_import.t
@@ -17,7 +17,7 @@ ok -e $sample_file, "sample file $sample_file exists";
 FixMyStreet::App->log->disable('info');
 END { FixMyStreet::App->log->enable('info'); }
 
-my $body = $mech->create_body_ok(2245, 'Wiltshire Council');
+my $body = $mech->create_body_ok(2608, 'Borsetshire Council');
 $mech->create_contact_ok(
     body_id => $body->id,
     category => 'Street lighting',

--- a/t/app/controller/report_new_open311.t
+++ b/t/app/controller/report_new_open311.t
@@ -9,7 +9,7 @@ END { FixMyStreet::App->log->enable('info'); }
 
 my $mech = FixMyStreet::TestMech->new;
 
-my $body = $mech->create_body_ok(2245, 'Wiltshire Council');
+my $body = $mech->create_body_ok(2608, 'Borsetshire Council');
 $body->update({
     endpoint => 'http://example.com/open311',
     jurisdiction => 'mySociety',

--- a/templates/web/base/report/new/duplicate_suggestions.html
+++ b/templates/web/base/report/new/duplicate_suggestions.html
@@ -1,4 +1,4 @@
-[% IF c.cobrand.suggest_duplicates %]
+[% IF c.cobrand.suggest_duplicates AND NOT login_success AND NOT oauth_need_email %]
 [% extra_js.push(
     version('/js/duplicates.js'),
 ) -%]

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -440,9 +440,10 @@ $.extend(fixmystreet.set_up, {
         if (data && data.category_extra) {
             if ( $category_meta.length ) {
                 $category_meta.replaceWith( data.category_extra );
+                var $new_category_meta = $('#category_meta');
                 // Preserve any existing values
                 $category_meta.find("[name]").each(function() {
-                    $category_meta.find("[name="+this.name+"]").val(this.value);
+                    $new_category_meta.find("[name="+this.name+"]").val(this.value);
                 });
             } else {
                 $('#js-post-category-messages').prepend( data.category_extra );

--- a/web/js/duplicates.js
+++ b/web/js/duplicates.js
@@ -64,6 +64,7 @@
         $('#js-duplicate-reports').hide().removeClass('hidden').slideDown();
         if ( $('#problem_form').length ) {
             $('.js-hide-if-invalid-category').slideUp();
+            $('.js-hide-if-invalid-category_extras').slideUp();
         }
 
         // Highlight map pin when hovering associated list item.
@@ -137,6 +138,7 @@
         });
         if ($('#problem_form').length && take_effect()) {
             $('.js-hide-if-invalid-category').slideDown();
+            $('.js-hide-if-invalid-category_extras').slideDown();
         }
     }
 


### PR DESCRIPTION
Hide category extras when duplicate suggestions shown; conversely hide duplicate suggestions when signing in during reporting. Also retain extra data when signing in during reporting.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1481
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1482
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1483
