### PR TITLE
Fix category_extras using correct cobrand name

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -262,16 +262,20 @@ sub category_extras_ajax : Path('category_extras') : Args(0) {
 sub by_category_ajax_data : Private {
     my ($self, $c, $type, $category) = @_;
 
-    my $bodies = $c->forward('contacts_to_bodies', [ $category ]);
-    my $display_names = [ map { $_->cobrand_name } ($category ? @$bodies : values %{$c->stash->{bodies_to_list}}) ];
-    my $list_of_names = [ map { $_->name } ($category ? @$bodies : values %{$c->stash->{bodies_to_list}}) ];
-    my $vars = {
-        $category ? (list_of_names => $list_of_names, display_names => $display_names) : (),
-    };
+    my @bodies;
+    my $bodies = [];
+    my $vars = {};
+    if ($category) {
+        $bodies = $c->forward('contacts_to_bodies', [ $category ]);
+        @bodies = @$bodies;
+        $vars->{list_of_names} = [ map { $_->cobrand_name } @bodies ];
+    } else {
+        @bodies = values %{$c->stash->{bodies_to_list}};
+    }
 
     my $non_public = $c->stash->{non_public_categories}->{$category};
     my $body = {
-        bodies => $list_of_names,
+        bodies => [ map { $_->name } @bodies ],
         $non_public ? ( non_public => JSON->true ) : (),
     };
 

--- a/t/app/controller/report_new_open311.t
+++ b/t/app/controller/report_new_open311.t
@@ -197,6 +197,8 @@ foreach my $test (
         # check that we got the errors expected
         is_deeply $mech->page_errors, $test->{errors}, "check errors";
 
+        $mech->content_contains('Help <strong>Wiltshire Council</strong> resolve your problem quicker');
+
         # check that fields have changed as expected
         my $new_values = {
             %{ $test->{fields} },     # values added to form

--- a/templates/web/base/report/new/category_extras.html
+++ b/templates/web/base/report/new/category_extras.html
@@ -1,4 +1,4 @@
-[% SET default_list = [] %][% FOR b IN bodies_to_list.values %][% default_list.push(b.name) %][% END %]
+[% SET default_list = [] %][% FOR b IN bodies_to_list.values %][% default_list.push(b.cobrand_name) %][% END %]
 [% DEFAULT list_of_names = default_list %]
 
 <div id="category_meta">
@@ -14,7 +14,7 @@
         <p class="form-section-description">
           [% tprintf(
             loc('Help <strong>%s</strong> resolve your problem quicker, by providing some extra detail. This extra information will not be published online.'),
-            display_names.join( '</strong>' _ loc(' or ') _ '<strong>' )
+            list_of_names.join( '</strong>' _ loc(' or ') _ '<strong>' )
           ); %]
         </p>
         [% INCLUDE 'report/new/category_extras_fields.html' metas=category_extras.$category %]

--- a/templates/web/base/report/new/councils_text_all.html
+++ b/templates/web/base/report/new/councils_text_all.html
@@ -1,4 +1,4 @@
-[% SET default_list = [] %][% FOR b IN bodies_to_list.values %][% default_list.push(b.name) %][% END %]
+[% SET default_list = [] %][% FOR b IN bodies_to_list.values %][% default_list.push(b.cobrand_name) %][% END %]
 [% DEFAULT list_of_names = default_list %]
 
 <p>

--- a/templates/web/hounslow/report/new/councils_text_all.html
+++ b/templates/web/hounslow/report/new/councils_text_all.html
@@ -1,8 +1,0 @@
-<p>
-    [% UNLESS non_public_categories.$category %]
-        These will be sent to <strong>Hounslow Highways</strong> and also published online for others to see, in accordance with our
-        <a href="[% c.cobrand.privacy_policy_url %]">privacy policy</a>.
-    [% ELSE %]
-        These will be sent to <strong>Hounslow Highways</strong> but not published online.
-    [% END %]
-</p>

--- a/templates/web/isleofwight/report/new/councils_text_all.html
+++ b/templates/web/isleofwight/report/new/councils_text_all.html
@@ -1,5 +1,0 @@
-<p>
-    These will be sent to <strong>Island Roads</strong> and also published
-    online for others to see, in accordance with our
-    <a href="[% c.cobrand.privacy_policy_url %]">privacy policy</a>.
-</p>


### PR DESCRIPTION
#2574 broke non-JS display of the body name (added testing line to show that) because `display_names` did not exist in that case. The template only needs one variable, so tried to tidy this up a bit, and then did the same to councils_text_all which meant the Hounslow/IsleOfWight override templates for them can be removed.