### PR TITLE
Make sure existing attribute answers set up.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -104,6 +104,7 @@ sub report_new : Path : Args(0) {
     $c->forward('setup_report_extra_fields');
     $c->forward('generate_map');
     $c->forward('check_for_category');
+    $c->forward('setup_report_extras');
 
     # deal with the user and report and check both are happy
 
@@ -1073,6 +1074,14 @@ sub contacts_to_bodies : Private {
     [ map { $_->body } @contacts ];
 }
 
+sub setup_report_extras : Private {
+    my ($self, $c) = @_;
+
+    # report_meta is used by the templates to fill in the extra field values
+    my $extra = $c->stash->{report}->get_extra_fields;
+    $c->stash->{report_meta} = { map { 'x' . $_->{name} => $_ } @$extra };
+}
+
 sub set_report_extras : Private {
     my ($self, $c, $contacts, $param_prefix) = @_;
 
@@ -1458,7 +1467,7 @@ sub generate_map : Private {
 sub check_for_category : Private {
     my ( $self, $c ) = @_;
 
-    $c->stash->{category} = $c->get_param('category');
+    $c->stash->{category} = $c->get_param('category') || $c->stash->{report}->category;
 
     return 1;
 }

--- a/templates/web/base/report/new/category.html
+++ b/templates/web/base/report/new/category.html
@@ -21,12 +21,12 @@ END
     <label for='form_category' id="form_category_label">
         [%~ loc('Category') ~%]
     </label>[% =%]
-    <select class="validCategory form-control[% IF category_groups.size %] js-grouped-select[% END %]" name="category" id="form_category"
+    <select required class="validCategory form-control[% IF category_groups.size %] js-grouped-select[% END %]" name="category" id="form_category"
     [%~ IF c.user.from_body =%]
       [%~ prefill_report = ( c.cobrand.prefill_report_fields_for_inspector && inspector ) || c.user.has_body_permission_to('report_prefill') %]
       data-body="[% c.user.from_body.name %]" data-prefill="[% prefill_report %]"
     [%~ END ~%]
-    required>
+    >
         [%~ IF category_groups.size ~%]
             [%~ FOREACH group IN category_groups ~%]
                 [% IF group.name %]<optgroup label="[% group.name %]">[% END %]


### PR DESCRIPTION
If you come to /report/new with a part-filled report (say you've gone
via an OAuth flow), then the stash needs to get the category from the
report, not a query parameter, and report_meta needs initializing, as
that is what the template uses to fill in existing attribute answers.

Hopefully really fixes https://github.com/mysociety/fixmystreet-commercial/issues/1482 this time.
[skip changelog]
