### PR TITLE
Include ‘submit’ button at very bottom of report form when signing in during report

### DIFF
--- a/templates/web/base/report/new/login_success_form.html
+++ b/templates/web/base/report/new/login_success_form.html
@@ -13,6 +13,7 @@
       [% ELSE %]
         [% PROCESS "report/form/user_loggedout.html" type='report' object=report %]
       [% END %]
-        [% PROCESS 'report/new/form_report.html' %]
+      [% PROCESS 'report/new/form_report.html' %]
+      <input class="btn btn--primary btn--block btn--final js-submit_register" type="submit" name="submit_register" value="[% loc('Submit') %]">
     </div>
 </fieldset>

--- a/templates/web/base/report/new/oauth_email_form.html
+++ b/templates/web/base/report/new/oauth_email_form.html
@@ -17,5 +17,6 @@
 
         <input type="hidden" name="oauth_need_email" value="1">
         [% PROCESS 'report/new/form_report.html' %]
+        <input class="btn btn--primary btn--block btn--final js-submit_register" type="submit" name="submit_register" value="[% loc('Submit') %]">
     </div>
 </fieldset>


### PR DESCRIPTION
If the user has logged in as part of making the report, it's easy to overlook the ‘Submit’ button in the middle of the form when scrolling. This PR adds a second ‘Submit’ button right at the bottom of the page.

[skip changelog]