### PR TITLE
Add 'disable_form' flag to category extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     - Admin improvements:
         - Add new roles system, to group permissions and apply to users. #2483
         - Contact form emails now include user admin links.
+        - Allow categories/Open311 questions to disable the reporting form. #2599
     - New features:
         - Categories can be listed under more than one group #2475
         - OpenID Connect login support. #2523

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -115,6 +115,7 @@ if ($opt->test_fixtures) {
         description => 'Please call us instead, it is very urgent.',
         order => 1,
         variable => 'false',
+        disable_form => 'true',
     });
     $child_cat->update;
 

--- a/bin/fixmystreet.com/one-off-move-js-messages-to-db
+++ b/bin/fixmystreet.com/one-off-move-js-messages-to-db
@@ -1,0 +1,128 @@
+#!/usr/bin/env perl
+#
+# One off script to transfer the hardcoded JS messages to the database
+
+use strict;
+use warnings;
+use v5.14;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use FixMyStreet::DB;
+
+use Getopt::Long;
+
+my $commit;
+GetOptions(
+    'commit' => \$commit,
+);
+
+if (!$commit) {
+    say "*** DRY RUN ***";
+}
+
+my @messages = (
+    {
+        body => 'Oxfordshire County Council',
+        category => 'Countryside Paths / Public Rights of Way (usually not tarmac)',
+        message => 'Please report problems with rights of way using <a href="https://publicrightsofway.oxfordshire.gov.uk/web/standardmap.aspx">this page</a>.'
+    },
+    {
+        body => 'Buckinghamshire County Council',
+        category => 'Rights of Way',
+        message => 'If you wish to report an issue on a Public Right of Way, please use <a href="https://www.buckscc.gov.uk/services/environment/public-rights-of-way/report-a-rights-of-way-issue/">this service</a>.'
+    },
+    {
+        body => 'Northamptonshire County Council',
+        category => 'Street lighting',
+        message => 'Street lighting in Northamptonshire is maintained by Balfour Beatty on behalf of the County Council under a Street Lighting Private Finance Initiative (PFI) contract. Please view our <b><a href="https://www3.northamptonshire.gov.uk/councilservices/northamptonshire-highways/roads-and-streets/Pages/street-lighting.aspx">Street Lighting</a></b> page to report any issues.'
+    },
+);
+
+my %bristol = (
+    "Abandoned vehicles" => "https://www.bristol.gov.uk/streets-travel/abandoned-vehicles",
+    "Flytipping" => "https://www.bristol.gov.uk/streets-travel/flytipping",
+    "Flyposting" => "https://www.bristol.gov.uk/streets-travel/flyposting",
+    "Graffiti" => "https://www.bristol.gov.uk/streets-travel/graffiti",
+    "Dog fouling" => "https://www.bristol.gov.uk/streets-travel/dog-fouling",
+    "Street cleaning" => "https://www.bristol.gov.uk/streets-travel/street-that-needs-cleaning",
+);
+foreach (keys %bristol) {
+    push @messages, {
+        body => 'Bristol City Council',
+        category => $_,
+        message => "If you wish to report an issue with $_, please use <a href=\"$bristol{$_}\">this service</a>."
+    };
+}
+
+MESSAGE: foreach my $msg (@messages) {
+    my $body = FixMyStreet::DB->resultset("Body")->find({ name => $msg->{body} });
+    unless ($body) {
+        say STDERR "Could not find body $msg->{body}";
+        next;
+    }
+    my $category = FixMyStreet::DB->resultset("Contact")->find({ body_id => $body->id, category => $msg->{category} });
+    unless ($category) {
+        say STDERR "Could not find $msg->{category}, $msg->{body}";
+        next;
+    }
+    my $extra_fields = $category->get_extra_fields;
+    foreach (@$extra_fields) {
+        if ($_->{code} eq 'stopper-message') {
+            say "Stopper message already present for $msg->{category}, $msg->{body}";
+            next MESSAGE;
+        }
+    }
+    unshift @$extra_fields, {
+        code => 'stopper-message',
+        order => -1,
+        datatype => 'string',
+        required => 'true',
+        protected => 'true',
+        variable => 'false',
+        disable_form => 'true',
+        description => $msg->{message},
+        datatype_description => '',
+    };
+    $category->set_extra_fields(@$extra_fields);
+    say "Adding stopper message to $msg->{category}, $msg->{body}";
+    if ($commit) {
+        $category->update;
+    }
+}
+
+my $northants = FixMyStreet::DB->resultset("Body")->find({ name => 'Northamptonshire County Council' });
+if ($northants) {
+    my @northants_contacts = $northants->contacts->all;
+    my $found_total = 0;
+    foreach my $category (@northants_contacts) {
+        my $extra_fields = $category->get_extra_fields;
+        my $found = 0;
+        foreach (@$extra_fields) {
+            next unless $_->{code} eq 'emergency';
+            $found_total++;
+            if (!$_->{disable_form} || $_->{disable_form} eq 'false') {
+                $_->{disable_form} = 'true';
+                $_->{protected} = 'true';
+                $found = 1;
+            }
+        }
+        if ($found) {
+            $category->set_extra_fields(@$extra_fields);
+            say "Making emergency message disable form on " . $category->category . ", Northamptonshire";
+            if ($commit) {
+                $category->update;
+            }
+        }
+    }
+    if (!$found_total) {
+        say STDERR "No emergency messages found for Northamptonshire";
+    }
+} else {
+    say STDERR "Could not find Northamptonshire";
+}

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -1192,6 +1192,8 @@ sub update_extra_fields : Private {
         $meta->{variable} = $notice ? 'false' : 'true';
         my $protected = $c->get_param("metadata[$i].protected") && $c->get_param("metadata[$i].protected") eq 'on';
         $meta->{protected} = $protected ? 'true' : 'false';
+        my $disable_form = $c->get_param("metadata[$i].disable_form") && $c->get_param("metadata[$i].disable_form") eq 'on';
+        $meta->{disable_form} = $disable_form ? 'true' : 'false';
         $meta->{description} = $c->get_param("metadata[$i].description");
         $meta->{datatype_description} = $c->get_param("metadata[$i].datatype_description");
         $meta->{automated} = $c->get_param("metadata[$i].automated")

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -1207,9 +1207,11 @@ sub update_extra_fields : Private {
             foreach my $j (@vindices) {
                 my $name = $c->get_param("metadata[$i].values[$j].name");
                 my $key = $c->get_param("metadata[$i].values[$j].key");
+                my $disable = $c->get_param("metadata[$i].values[$j].disable");
                 push(@{$meta->{values}}, {
                     name => $name,
                     key => $key,
+                    $disable ? (disable => 1) : (),
                 }) if $name;
             }
         }

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -281,6 +281,11 @@ sub by_category_ajax_data : Private {
         $body->{category_extra_json} = $c->forward('generate_category_extra_json');
     }
 
+    if ( $c->stash->{category_extras}->{$category} && @{ $c->stash->{category_extras}->{$category} } >= 1 ) {
+        my $disable_form = $c->forward('disable_form_message');
+        $body->{disable_form} = $disable_form if $disable_form;
+    }
+
     my $unresponsive = $c->stash->{unresponsive}->{$category};
     $unresponsive ||= $c->stash->{unresponsive}->{ALL} || '' if $type eq 'one';
 
@@ -301,6 +306,18 @@ sub by_category_ajax_data : Private {
     }
 
     return $body;
+}
+
+sub disable_form_message : Private {
+    my ( $self, $c ) = @_;
+
+    my @descriptions = map {
+        $_->{description}
+    } grep {
+        $_->{disable_form} && $_->{disable_form} eq 'true'
+    } @{ $c->stash->{category_extras}->{$c->stash->{category}} };
+
+    return join " ", @descriptions;
 }
 
 =head2 report_import

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -311,13 +311,22 @@ sub by_category_ajax_data : Private {
 sub disable_form_message : Private {
     my ( $self, $c ) = @_;
 
-    my @descriptions = map {
-        $_->{description}
-    } grep {
-        $_->{disable_form} && $_->{disable_form} eq 'true'
-    } @{ $c->stash->{category_extras}->{$c->stash->{category}} };
-
-    return join " ", @descriptions;
+    my %out;
+    foreach (@{$c->stash->{category_extras}->{$c->stash->{category}}}) {
+        if ($_->{disable_form} && $_->{disable_form} eq 'true') {
+            $out{all} .= ' ' if $out{all};
+            $out{all} .= $_->{description};
+        } elsif (($_->{variable} || '') eq 'true' && @{$_->{values} || []}) {
+            foreach my $opt (@{$_->{values}}) {
+                if ($opt->{disable}) {
+                    $out{message} = $_->{datatype_description};
+                    $out{code} = $_->{code};
+                    push @{$out{answers}}, $opt->{key};
+                }
+            }
+        }
+    }
+    return \%out;
 }
 
 =head2 report_import

--- a/t/app/controller/admin/reportextrafields.t
+++ b/t/app/controller/admin/reportextrafields.t
@@ -82,6 +82,7 @@ FixMyStreet::override_config {
             description => "this is a test description",
             datatype_description => "hint here",
             datatype => "string",
+            disable_form => "false",
         };
         $contact->discard_changes;
         is_deeply $contact->get_extra_fields, $contact_extra_fields, 'new string field was added';
@@ -93,6 +94,7 @@ FixMyStreet::override_config {
             "metadata[1].code" => "list_test",
             "metadata[1].required" => undef,
             "metadata[1].notice" => "",
+            "metadata[1].disable_form" => "on",
             "metadata[1].description" => "this field is a list",
             "metadata[1].datatype_description" => "",
             "metadata[1].datatype" => "list",
@@ -108,6 +110,7 @@ FixMyStreet::override_config {
             required => "false",
             variable => "true",
             protected => "false",
+            disable_form => "true",
             description => "this field is a list",
             datatype_description => "",
             datatype => "singlevaluelist",
@@ -145,6 +148,7 @@ FixMyStreet::override_config {
             required => 'false',
             variable => 'true',
             protected => 'false',
+            disable_form => 'false',
             code => 'POT',
             automated => 'server_set'
         } ], "automated fields not unset";
@@ -181,6 +185,7 @@ FixMyStreet::override_config {
             required => "true",
             variable => "true",
             protected => "false",
+            disable_form => "false",
             description => "this is a test description",
             datatype_description => "hint here",
             datatype => "string",
@@ -209,6 +214,7 @@ FixMyStreet::override_config {
             required => "false",
             variable => "true",
             protected => "false",
+            disable_form => "false",
             description => "this field is a list",
             datatype_description => "",
             datatype => "singlevaluelist",
@@ -239,6 +245,7 @@ FixMyStreet::override_config {
             required => "false",
             variable => "true",
             protected => "false",
+            disable_form => "false",
             description => "",
             datatype_description => "",
             datatype => "string",

--- a/t/app/controller/report_new_open311.t
+++ b/t/app/controller/report_new_open311.t
@@ -293,6 +293,9 @@ subtest "Category extras includes form disabling string" => sub {
         MAPIT_URL => 'http://mapit.uk/',
     }, sub {
         $contact4->push_extra_fields({ description => 'Please ring us!', code => 'ring', variable => 'false', order => '0', disable_form => 'true' });
+        $contact4->push_extra_fields({ datatype_description => 'Please please ring', description => 'Is it dangerous?', code => 'dangerous',
+            variable => 'true', order => '0', values => [ { name => 'Yes', key => 'yes', disable => 1 }, { name => 'No', key => 'no' } ]
+        });
         $contact4->update;
         for (
           { url => '/report/new/ajax?' },
@@ -300,7 +303,12 @@ subtest "Category extras includes form disabling string" => sub {
         ) {
             my $json = $mech->get_ok_json($_->{url} . '&latitude=55.952055&longitude=-3.189579');
             my $output = $json->{by_category} ? $json->{by_category}{Pothole}{disable_form} : $json->{disable_form};
-            is $output, 'Please ring us!';
+            is_deeply $output, {
+                all => 'Please ring us!',
+                message => 'Please please ring',
+                code => 'dangerous',
+                answers => [ 'yes' ],
+            };
         }
     };
 };

--- a/t/app/controller/report_new_open311.t
+++ b/t/app/controller/report_new_open311.t
@@ -287,4 +287,22 @@ subtest "Category extras includes description label for user" => sub {
     };
 };
 
+subtest "Category extras includes form disabling string" => sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'fixmystreet',
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $contact4->push_extra_fields({ description => 'Please ring us!', code => 'ring', variable => 'false', order => '0', disable_form => 'true' });
+        $contact4->update;
+        for (
+          { url => '/report/new/ajax?' },
+          { url => '/report/new/category_extras?category=Pothole' },
+        ) {
+            my $json = $mech->get_ok_json($_->{url} . '&latitude=55.952055&longitude=-3.189579');
+            my $output = $json->{by_category} ? $json->{by_category}{Pothole}{disable_form} : $json->{disable_form};
+            is $output, 'Please ring us!';
+        }
+    };
+};
+
 done_testing();

--- a/templates/web/base/admin/extra-metadata-form.html
+++ b/templates/web/base/admin/extra-metadata-form.html
@@ -43,6 +43,12 @@
             <input name="metadata[[% loop.index %]].protected" data-field-name="protected" type=checkbox [% meta.protected == 'true' ? 'checked' : '' %]>
         </label>
 
+        <div class="admin-hint"><p>[% loc('If ticked the entire report form will be disabled when this category is selected.') %]</p></div>
+        <label>
+            [% loc('Disable form') %]
+            <input name="metadata[[% loop.index %]].disable_form" data-field-name="disable_form" type=checkbox [% meta.disable_form == 'true' ? 'checked' : '' %]>
+        </label>
+
         <div class="admin-hint"><p>[% loc('The field name as shown to the user on the report form.') %]</p></div>
         <label>
             [% loc('Description') %]

--- a/templates/web/base/admin/extra-metadata-form.html
+++ b/templates/web/base/admin/extra-metadata-form.html
@@ -69,7 +69,7 @@
             [% loc('Options') %]<span class="hidden-js"> [% loc('(ignored if type is "String")') %]</span>
             <ul>
                 [% outer_loop = loop %]
-                [% values = meta.values OR [] %]
+                [% SET values = meta.item('values') ? meta.values : [] %]
                 [% FOREACH option IN values.merge([{}]) %]
                 [%# the .merge() call is so there's an empty one on the end %]
                     <li class="js-metadata-option [% IF loop.last %]hidden-js js-metadata-option-template[% END %]">

--- a/templates/web/base/admin/extra-metadata-form.html
+++ b/templates/web/base/admin/extra-metadata-form.html
@@ -87,6 +87,10 @@
                             [% loc('Name') %]
                             <input class="js-metadata-option-name" name="metadata[[% outer_loop.index %]].values[[% loop.index %]].name" type="text" value="[% option.name | html %]">
                         </label>
+                        <label>
+                            [% loc('Disable form') %]
+                            <input class="js-metadata-option-disable" name="metadata[[% outer_loop.index %]].values[[% loop.index %]].disable" type="checkbox"[% ' checked' IF option.disable %]>
+                        </label>
                         <button type="button" class="btn btn--small js-metadata-option-remove hidden-nojs">[% loc('Remove') %]</button>
                     </li>
                 [% END %]

--- a/templates/web/fixmystreet.com/footer_extra_js.html
+++ b/templates/web/fixmystreet.com/footer_extra_js.html
@@ -12,7 +12,6 @@ IF bodyclass.match('mappage');
     scripts.push( version('/cobrands/buckinghamshire/assets.js') );
     scripts.push( version('/cobrands/lincolnshire/assets.js') );
     scripts.push( version('/cobrands/northamptonshire/assets.js') );
-    scripts.push( version('/cobrands/oxfordshire/assets.js') );
     scripts.push( version('/cobrands/hounslow/assets.js') );
     scripts.push( version('/cobrands/westminster/assets.js') );
     scripts.push( version('/cobrands/highways/assets.js') );

--- a/templates/web/oxfordshire/footer_extra_js.html
+++ b/templates/web/oxfordshire/footer_extra_js.html
@@ -4,7 +4,6 @@ IF bodyclass.match('mappage');
     version('/cobrands/fixmystreet/assets.js'),
     version('/vendor/OpenLayers.Projection.OrdnanceSurvey.js'),
     version('/cobrands/oxfordshire/js.js'),
-    version('/cobrands/oxfordshire/assets.js'),
     version('/cobrands/highways/assets.js'),
     version('/cobrands/fixmystreet-uk-councils/council_validation_rules.js'),
   );

--- a/web/cobrands/bexley/js.js
+++ b/web/cobrands/bexley/js.js
@@ -111,28 +111,5 @@ fixmystreet.assets.add(defaults, {
     asset_item: 'public toilet'
 });
 
-// We need to trigger the below function on subcategory change also
-$(function(){
-    $("#problem_form").on("change.category", "#form_DALocation", function() {
-        $(fixmystreet).trigger('report_new:category_change');
-    });
-});
-
-fixmystreet.message_controller.register_category({
-    body: defaults.body,
-    category: function() {
-        var cat = $('#form_category').val();
-        if (cat === 'Dead animal') {
-            var where = $('#form_DALocation').val();
-            if (where === 'Garden' || where === 'Other private property') {
-                return true;
-            }
-        }
-        return false;
-    },
-    keep_category_extras: true,
-    message: 'Please follow the link below to pay to remove a dead animal from a private property.'
-});
-
 })();
 

--- a/web/cobrands/bristol/assets.js
+++ b/web/cobrands/bristol/assets.js
@@ -80,21 +80,4 @@ fixmystreet.assets.add(options, {
     filter_value: 'S180'
 });
 
-var redirects = {
-    "Abandoned vehicles": "https://www.bristol.gov.uk/streets-travel/abandoned-vehicles",
-    "Flytipping": "https://www.bristol.gov.uk/streets-travel/flytipping",
-    "Flyposting": "https://www.bristol.gov.uk/streets-travel/flyposting",
-    "Graffiti": "https://www.bristol.gov.uk/streets-travel/graffiti",
-    "Dog fouling": "https://www.bristol.gov.uk/streets-travel/dog-fouling",
-    "Street cleaning": "https://www.bristol.gov.uk/streets-travel/street-that-needs-cleaning"
-};
-
-$.each(redirects, function(name, value) {
-    fixmystreet.message_controller.register_category({
-        body: options.body,
-        category: name,
-        message: 'If you wish to report an issue with ' + name + ', please use <a href="' + value + '">this service</a>.'
-    });
-});
-
 })();

--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -371,10 +371,4 @@ fixmystreet.assets.add(defaults, {
     }
 });
 
-fixmystreet.message_controller.register_category({
-    body: defaults.body,
-    category: 'Rights of Way',
-    message: 'If you wish to report an issue on a Public Right of Way, please use <a href="https://www.buckscc.gov.uk/services/environment/public-rights-of-way/report-a-rights-of-way-issue/">this service</a>.'
-});
-
 })();

--- a/web/cobrands/fixmystreet/admin.js
+++ b/web/cobrands/fixmystreet/admin.js
@@ -216,6 +216,7 @@ $(function(){
             var prefix = "metadata["+item_index+"].values["+i+"]";
             $li.find(".js-metadata-option-key").attr("name", prefix+".key");
             $li.find(".js-metadata-option-name").attr("name", prefix+".name");
+            $li.find(".js-metadata-option-disable").attr("name", prefix+".disable");
         });
     }
 });

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -1015,7 +1015,8 @@ must be on a road, taking into account Highways England roads.
 
 fixmystreet.message_controller = (function() {
     var stopperId = 'js-category-stopper',
-        stoppers = [];
+        stoppers = [],
+        ignored_bodies = [];
 
     // This shows an error message because e.g. an asset isn't selected or a road hasn't been clicked
     function show_responsibility_error(id, asset_item, asset_type) {
@@ -1107,19 +1108,11 @@ fixmystreet.message_controller = (function() {
         var $id = $('#' + stopperId);
         var body = $('#form_category').data('body');
         var matching = $.grep(stoppers, function(stopper, i) {
-            if (stopper.staff_ignore && body) {
+            if (OpenLayers.Util.indexOf(ignored_bodies, body) > -1) {
                 return false;
             }
 
-            var relevant_body = OpenLayers.Util.indexOf(fixmystreet.bodies, stopper.body) > -1;
-            var relevant_cat;
-            if (typeof stopper.category === 'function') {
-                relevant_cat = stopper.category();
-            } else {
-                relevant_cat = $('#form_category').val() == stopper.category;
-            }
-            var relevant = relevant_body && relevant_cat;
-            return relevant;
+            return $('#form_category').val() == stopper.category;
         });
 
         if (!matching.length) {
@@ -1135,7 +1128,7 @@ fixmystreet.message_controller = (function() {
         if (typeof stopper.message === 'function') {
             $msg = stopper.message();
         } else {
-            $msg = $('<p class="box-warning">' + stopper.message + '</p>');
+            $msg = $('<div class="box-warning">' + stopper.message + '</div>');
         }
         $msg.attr('id', stopperId);
         $msg.attr('role', 'alert');
@@ -1200,6 +1193,14 @@ fixmystreet.message_controller = (function() {
 
         register_category: function(params) {
             stoppers.push(params);
+        },
+
+        unregister_all_categories: function() {
+            stoppers = [];
+        },
+
+        add_ignored_body: function(body) {
+            ignored_bodies.push(body);
         }
     };
 

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -1112,7 +1112,20 @@ fixmystreet.message_controller = (function() {
                 return false;
             }
 
-            return $('#form_category').val() == stopper.category;
+            var category = $('#form_category').val();
+            if (category != stopper.category) {
+                return false;
+            }
+
+            if (stopper.answers) {
+                var answer = $('#form_' + stopper.code).val();
+                if (OpenLayers.Util.indexOf(stopper.answers, answer) > -1) {
+                    return true;
+                }
+                return false;
+            } else {
+                return true;
+            }
         });
 
         if (!matching.length) {

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -459,6 +459,12 @@ $.extend(fixmystreet.set_up, {
             $(".js-hide-if-public-category").hide();
         }
 
+        if (fixmystreet.message_controller && data && data.disable_form && data.disable_form.answers) {
+            $('#form_' + data.disable_form.code).on('change.category', function() {
+                $(fixmystreet).trigger('report_new:category_change');
+            });
+        }
+
         // remove existing validation rules
         validation_rules = fixmystreet.validator.settings.rules;
         $.each(validation_rules, function(rule) {
@@ -1259,11 +1265,19 @@ fixmystreet.fetch_reporting_data = function() {
         if (fixmystreet.message_controller) {
             fixmystreet.message_controller.unregister_all_categories();
             $.each(data.by_category, function(category, details) {
-                if (details.disable_form) {
+                if (!details.disable_form) {
+                    return;
+                }
+                if (details.disable_form.all) {
                     fixmystreet.message_controller.register_category({
                         category: category,
-                        message: details.disable_form
+                        message: details.disable_form.all
                     });
+                }
+                if (details.disable_form.answers) {
+                    details.disable_form.category = category;
+                    details.disable_form.keep_category_extras = true;
+                    fixmystreet.message_controller.register_category(details.disable_form);
                 }
             });
         }

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1256,6 +1256,18 @@ fixmystreet.fetch_reporting_data = function() {
         fixmystreet.update_councils_text(data);
         $('#js-top-message').html(data.top_message || '');
 
+        if (fixmystreet.message_controller) {
+            fixmystreet.message_controller.unregister_all_categories();
+            $.each(data.by_category, function(category, details) {
+                if (details.disable_form) {
+                    fixmystreet.message_controller.register_category({
+                        category: category,
+                        message: details.disable_form
+                    });
+                }
+            });
+        }
+
         $('#form_category_row').html(data.category);
         if ($("#form_category option[value=\"" + old_category + "\"]").length) {
             $("#form_category").val(old_category);

--- a/web/cobrands/northamptonshire/assets.js
+++ b/web/cobrands/northamptonshire/assets.js
@@ -552,21 +552,6 @@ fixmystreet.assets.add(northants_road_defaults, {
     ]
 });
 
-fixmystreet.message_controller.register_category({
-    body: northants_defaults.body,
-    category: function() {
-        return !!$('label[for=form_emergency]').length;
-    },
-    message: function() {
-        return $('<div class="box-warning">' + $('label[for=form_emergency]').html() + '</div>');
-    },
-    staff_ignore: true
-});
-
-fixmystreet.message_controller.register_category({
-    body: northants_defaults.body,
-    category: 'Street lighting',
-    message: 'Street lighting in Northamptonshire is maintained by Balfour Beatty on behalf of the County Council under a Street Lighting Private Finance Initiative (PFI) contract. Please view our <b><a href="https://www3.northamptonshire.gov.uk/councilservices/northamptonshire-highways/roads-and-streets/Pages/street-lighting.aspx">Street Lighting</a></b> page to report any issues.'
-});
+fixmystreet.message_controller.add_ignored_body(northants_defaults.body);
 
 })();

--- a/web/cobrands/oxfordshire/assets.js
+++ b/web/cobrands/oxfordshire/assets.js
@@ -1,5 +1,0 @@
-fixmystreet.message_controller.register_category({
-    body: 'Oxfordshire County Council',
-    category: 'Countryside Paths / Public Rights of Way (usually not tarmac)',
-    message: 'Please report problems with rights of way using <a href="https://publicrightsofway.oxfordshire.gov.uk/web/standardmap.aspx">this page</a>.'
-});


### PR DESCRIPTION
This replaces the cobrand-JS-specific way of adding messages that disable the report form with a new 'disable form' tickbox in the admin.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1515