### PR TITLE
[Bristol] add flooding assets

### DIFF
--- a/web/cobrands/bristol/assets.js
+++ b/web/cobrands/bristol/assets.js
@@ -48,6 +48,13 @@ fixmystreet.assets.add(options, {
 });
 
 fixmystreet.assets.add(options, {
+    asset_category: "Flooding",
+    asset_item: 'flood risk structure',
+    filter_key: 'COD_ASSET_TYPE',
+    filter_value: 'FRST'
+});
+
+fixmystreet.assets.add(options, {
     asset_category: "Street Light",
     asset_item: 'street light',
     filter_value: [ 'S070', 'S080', 'S100', 'S110', 'S120', 'S170', 'S220', 'S230' ]


### PR DESCRIPTION
Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
