### PR TITLE
[Westminster] UPRN lookup

### DIFF
--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -273,10 +273,9 @@ see Buckinghamshire or Lincolnshire for an example.
 sub lookup_site_code {
     my $self = shift;
     my $row = shift;
-    my $buffer = shift;
+    my $field = shift;
 
-    my $cfg = $self->lookup_site_code_config;
-    $cfg->{buffer} = $buffer if $buffer;
+    my $cfg = $self->lookup_site_code_config($field);
     my ($x, $y) = $row->local_coords;
 
     my $features = $self->_fetch_features($cfg, $x, $y);

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -19,7 +19,7 @@ $mech->create_contact_ok(body_id => $district->id, category => 'Graffiti', email
 
 my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Buckinghamshire');
 $cobrand->mock('lookup_site_code', sub {
-    my ($self, $row, $buffer) = @_;
+    my ($self, $row) = @_;
     return "Road ID" if $row->latitude == 51.812244;
 });
 

--- a/web/cobrands/westminster/assets.js
+++ b/web/cobrands/westminster/assets.js
@@ -128,7 +128,7 @@ fixmystreet.message_controller.register_category({
 
 var layer_data = [
     { category: [ 'Food safety/hygiene' ] },
-    { category: 'Damaged, dirty, or missing bin', subcategories: [ '1', '2' ], subcategory_id: '#form_bintype' },
+    { category: 'Damaged, dirty, or missing bin', subcategories: [ '1', '4' ], subcategory_id: '#form_bin_type' },
     { category: 'Noise', subcategories: [ '1', '3', '4', '7', '8', '9', '10' ] },
     { category: 'Smoke and odours' },
 ];
@@ -299,7 +299,7 @@ $.each(layer_data, function(i, o) {
 });
 
 $(function(){
-    $("#problem_form").on("change.category", "#form_type, #form_featuretypecode, #form_bintype", function() {
+    $("#problem_form").on("change.category", "#form_type, #form_featuretypecode, #form_bin_type", function() {
         $(fixmystreet).trigger('report_new:category_change', [ $('#form_category') ]);
     });
 });


### PR DESCRIPTION
Makes it easier to handle more than one call to `lookup_site_code` for a single report, and looks up the UPRN for reports that have that field in their report extras but not a value. Also restores the frontend UPRN lookup for bins, after the field was renamed.

Connects https://github.com/mysociety/fixmystreet-commercial/issues/1471

[skip changelog]