### PR TITLE
Always return a name string if login successful.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Auth.pm
+++ b/perllib/FixMyStreet/App/Controller/Auth.pm
@@ -466,7 +466,8 @@ sub ajax_sign_in : Path('ajax/sign_in') {
 
     my $return = {};
     if ( $c->forward( 'sign_in', [ $c->get_param('email') ] ) ) {
-        $return->{name} = $c->user->name;
+        $return->{name} = $c->user->name || '-'; # App currently requires something returned
+        $return->{success} = 1;
     } else {
         $return->{error} = 1;
     }


### PR DESCRIPTION
https://github.com/mysociety/fixmystreet-mobile/pull/275 should fix it in the app, but I thought we should do something for those who don't upgrade, perhaps?