### PR TITLE
Don’t reveal private report lat/lon in ‘report another’ link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
         - Hide duplicate suggestions when signing in during reporting.
         - Retain extra data if signing in during reporting.
         - Have duplicate suggestion and assets coexist better.
+        - Don't include lat/lon of private reports in ‘Report another problem
+          here’ link.
     - Front end improvements:
         - Set report title autocomplete to off to prevent email autocompleting
     - Development improvements:

--- a/t/app/controller/report_display.t
+++ b/t/app/controller/report_display.t
@@ -79,6 +79,9 @@ subtest "change report to non_public and check for 403 status" => sub {
     is $mech->res->code, 403, "access denied";
     is $mech->uri->path, "/report/$report_id", "at /report/$report_id";
     $mech->content_contains('permission to do that. If you are the problem reporter');
+    $mech->content_lacks('Report another problem here');
+    $mech->content_lacks($report->latitude);
+    $mech->content_lacks($report->longitude);
     ok $report->update( { non_public => 0 } ), 'make report public';
 };
 
@@ -95,6 +98,9 @@ subtest "check owner of report can view non public reports" => sub {
     is $mech->res->code, 403, "access denied to user who is not report creator";
     is $mech->uri->path, "/report/$report_id", "at /report/$report_id";
     $mech->content_contains('permission to do that. If you are the problem reporter');
+    $mech->content_lacks('Report another problem here');
+    $mech->content_lacks($report->latitude);
+    $mech->content_lacks($report->longitude);
     $mech->log_out_ok;
     ok $report->update( { non_public => 0 } ), 'make report public';
 };

--- a/templates/web/base/main_nav_items.html
+++ b/templates/web/base/main_nav_items.html
@@ -1,4 +1,4 @@
-[%~ IF problem ~%]
+[%~ IF problem AND NOT problem.non_public ~%]
     [%~ INCLUDE navitem uri='/report/new?longitude=' _ problem.longitude _ '&amp;latitude=' _ problem.latitude label=loc('Report another problem here') attrs='class="report-a-problem-btn"' ~%]
 [%~ ELSIF latitude AND longitude ~%]
     [%~ INCLUDE navitem uri='/report/new?longitude=' _ longitude _ '&amp;latitude=' _ latitude label=loc('Report a problem here') attrs='class="report-a-problem-btn"' ~%]

--- a/templates/web/bexley/main_nav_items.html
+++ b/templates/web/bexley/main_nav_items.html
@@ -1,4 +1,4 @@
-[%~ IF problem ~%]
+[%~ IF problem AND NOT problem.non_public ~%]
     [%~ INCLUDE navitem uri='/report/new?longitude=' _ problem.longitude _ '&amp;latitude=' _ problem.latitude label=loc('Report another problem here') attrs='class="report-a-problem-btn"' ~%]
 [%~ ELSIF latitude AND longitude ~%]
     [%~ INCLUDE navitem uri='/report/new?longitude=' _ longitude _ '&amp;latitude=' _ latitude label=loc('Report a problem here') attrs='class="report-a-problem-btn"' ~%]

--- a/templates/web/hounslow/main_nav_items.html
+++ b/templates/web/hounslow/main_nav_items.html
@@ -1,4 +1,4 @@
-[%~ IF problem ~%]
+[%~ IF problem AND NOT problem.non_public ~%]
     [%~ INCLUDE navitem uri='/report/new?longitude=' _ problem.longitude _ '&amp;latitude=' _ problem.latitude label=loc('Report another problem here') attrs='class="report-a-problem-btn"' ~%]
 [%~ ELSIF latitude AND longitude ~%]
     [%~ INCLUDE navitem uri='/report/new?longitude=' _ longitude _ '&amp;latitude=' _ latitude label=loc('Report a problem here') attrs='class="report-a-problem-btn"' ~%]


### PR DESCRIPTION
Adds a check to the template that generates the 'report another problem here' link to stop that link being generated if the report is `non_public`.

Please check the following:

- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
