### PR TITLE
Make sure anonymous reports are marked anon irrespective of permissions

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -949,6 +949,8 @@ sub process_report : Private {
     my $anon_button = $c->cobrand->allow_anonymous_reports eq 'button' && $c->get_param('report_anonymously');
     if ($anon_button) {
         $c->stash->{contributing_as_anonymous_user} = 1;
+        $c->stash->{contributing_as_body} = undef;
+        $c->stash->{contributing_as_another_user} = undef;
     }
 
     # set some simple bool values (note they get inverted)


### PR DESCRIPTION
There was a small bug where the 'default_to_body' permission would
override the 'report anonymously' button when staff users were adding
reports to the site. The result of this was that the name of the
anonymous user record would be shown. No harm done, as that user's name
would likely be set to "Anonymous user" in config, but it resulted in
reports pages showing the slightly odd wording along the lines of:

> Reported in the Bin bags category by Anonymous user at 14:57 today

This commit ensures the contributing_as_body flag is mutually exclusive
with the 'report_anonymously' request parameter.

Please check the following:

- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [ ] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
