### PR TITLE
Contact email admin improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
         - Pass ‘filter_category’ param to front page to pre-filter map.
     - Admin improvements:
         - Add new roles system, to group permissions and apply to users. #2483
+        - Contact form emails now include user admin links.
     - New features:
         - Categories can be listed under more than one group #2475
         - OpenID Connect login support. #2523

--- a/perllib/FixMyStreet/App/Controller/Contact.pm
+++ b/perllib/FixMyStreet/App/Controller/Contact.pm
@@ -202,11 +202,7 @@ sub prepare_params_for_email : Private {
         $c->stash->{user_admin_url} = $admin_url . '/users/' . $user->id;
         $c->stash->{user_reports_admin_url} = $admin_url . '/reports?search=' . $user->email;
 
-        my $user_latest_problem = $user->problems->search({
-            state => [ FixMyStreet::DB::Result::Problem->visible_states() ]
-        }, {
-            order_by => { -desc => 'id' }
-        })->single;
+        my $user_latest_problem = $user->latest_visible_problem();
         if ( $user_latest_problem) {
             $c->stash->{user_latest_report_admin_url} = $admin_url . '/report_edit/' . $user_latest_problem->id;
         }

--- a/perllib/FixMyStreet/App/Controller/Contact.pm
+++ b/perllib/FixMyStreet/App/Controller/Contact.pm
@@ -197,6 +197,21 @@ sub prepare_params_for_email : Private {
     my $base_url = $c->cobrand->base_url();
     my $admin_url = $c->cobrand->admin_base_url;
 
+    my $user = $c->cobrand->users->find( { email => $c->stash->{em} } );
+    if ( $user ) {
+        $c->stash->{user_admin_url} = $admin_url . '/users/' . $user->id;
+        $c->stash->{user_reports_admin_url} = $admin_url . '/reports?search=' . $user->email;
+
+        my $user_latest_problem = $user->problems->search({
+            state => [ FixMyStreet::DB::Result::Problem->visible_states() ]
+        }, {
+            order_by => { -desc => 'id' }
+        })->single;
+        if ( $user_latest_problem) {
+            $c->stash->{user_latest_report_admin_url} = $admin_url . '/report_edit/' . $user_latest_problem->id;
+        }
+    }
+
     if ( $c->stash->{update} ) {
 
         $c->stash->{problem_url} = $base_url . $c->stash->{update}->url;

--- a/perllib/FixMyStreet/App/Controller/Develop.pm
+++ b/perllib/FixMyStreet/App/Controller/Develop.pm
@@ -130,6 +130,16 @@ sub email_previewer : Path('/_dev/email') : Args(1) {
         );
         $vars->{problem_url} = $c->cobrand->base_url() . '/report/' . $vars->{problem}->id;
         $vars->{admin_url} = $c->cobrand->admin_base_url . '/report_edit/' . $vars->{problem}->id;
+        $vars->{user_admin_url} = $c->cobrand->admin_base_url . '/users/' . $c->user->id;
+        $vars->{user_reports_admin_url} = $c->cobrand->admin_base_url . '/reports?search=' . $c->user->email;
+        my $user_latest_problem = $c->user->problems->search({
+            state => [ FixMyStreet::DB::Result::Problem->visible_states() ]
+        }, {
+            order_by => { -desc => 'id' }
+        })->single;
+        if ( $user_latest_problem ) {
+            $vars->{user_latest_report_admin_url} = $c->cobrand->admin_base_url . '/report_edit/' . $user_latest_problem->id;
+        }
     }
 
     my $email = $c->construct_email("$template.txt", $vars);

--- a/perllib/FixMyStreet/App/Controller/Develop.pm
+++ b/perllib/FixMyStreet/App/Controller/Develop.pm
@@ -132,11 +132,7 @@ sub email_previewer : Path('/_dev/email') : Args(1) {
         $vars->{admin_url} = $c->cobrand->admin_base_url . '/report_edit/' . $vars->{problem}->id;
         $vars->{user_admin_url} = $c->cobrand->admin_base_url . '/users/' . $c->user->id;
         $vars->{user_reports_admin_url} = $c->cobrand->admin_base_url . '/reports?search=' . $c->user->email;
-        my $user_latest_problem = $c->user->problems->search({
-            state => [ FixMyStreet::DB::Result::Problem->visible_states() ]
-        }, {
-            order_by => { -desc => 'id' }
-        })->single;
+        my $user_latest_problem = $c->user->latest_visible_problem();
         if ( $user_latest_problem ) {
             $vars->{user_latest_report_admin_url} = $c->cobrand->admin_base_url . '/report_edit/' . $user_latest_problem->id;
         }

--- a/perllib/FixMyStreet/App/Controller/Develop.pm
+++ b/perllib/FixMyStreet/App/Controller/Develop.pm
@@ -115,6 +115,21 @@ sub email_previewer : Path('/_dev/email') : Args(1) {
         }
     } elsif ($template eq 'questionnaire') {
         $vars->{created} = 'N weeks';
+    } elsif ($template eq 'contact') {
+        $vars->{problem} = $c->model('DB::Problem')->search(undef, { rows => 1 } )->first;
+        $vars->{subject} = 'Please remove my details';
+        $vars->{message} = 'I accidentally put my phone number, address, mothers maiden name, and facebook password in my most recent report!! Please remove it!!';
+        $vars->{form_name} = $c->user->name;
+        $vars->{em} = $c->user->email;
+        $vars->{host} = $c->req->header('HOST');
+        $vars->{ip} = $c->req->address;
+        $vars->{user_agent} = $c->req->user_agent;
+        $vars->{complaint} = sprintf(
+            "Complaint about report %d",
+            $vars->{problem}->id,
+        );
+        $vars->{problem_url} = $c->cobrand->base_url() . '/report/' . $vars->{problem}->id;
+        $vars->{admin_url} = $c->cobrand->admin_base_url . '/report_edit/' . $vars->{problem}->id;
     }
 
     my $email = $c->construct_email("$template.txt", $vars);

--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -198,6 +198,15 @@ sub latest_anonymity {
     return $obj ? $obj->anonymous : 0;
 }
 
+sub latest_visible_problem {
+    my $self = shift;
+    return $self->problems->search({
+        state => [ FixMyStreet::DB::Result::Problem->visible_states() ]
+    }, {
+        order_by => { -desc => 'id' }
+    })->single;
+}
+
 =head2 check_for_errors
 
     $error_hashref = $user->check_for_errors();

--- a/templates/email/default/_email_settings.html
+++ b/templates/email/default/_email_settings.html
@@ -108,6 +108,7 @@ list_item_photo_style = "float: right; margin: 0 0 1em 1em; border: none;"
 contact_meta_style = "padding: 15px ${ column_padding }px; vertical-align: top; background-color: $secondary_column_background_color; border-bottom: 1px solid $column_divider_color;"
 contact_th_style = "vertical-align: top; padding: 0.4em 1em 0 0; white-space: nowrap; text-align: left;"
 contact_td_style = "vertical-align: top; padding: 0.4em 0 0.4em 0; width: 100%;"
+contact_admin_links_style = "display: block;"
 
 # The below is so the buttons work okay in Outlook: https://litmus.com/blog/a-guide-to-bulletproof-buttons-in-email-design
 button_style = "display: inline-block; border: 10px solid $button_background_color; border-width: 10px 15px; border-radius: $button_border_radius; background-color: $button_background_color; color: $button_text_color; font-size: 18px; line-height: 21px; font-weight: $button_font_weight; text-decoration: underline;"

--- a/templates/email/default/contact.html
+++ b/templates/email/default/contact.html
@@ -16,7 +16,18 @@ INCLUDE '_email_top.html';
   <table [% table_reset %]>
     <tr>
       <th style="[% contact_th_style %]">From</th>
-      <td style="[% contact_td_style %]">[% name %] &lt;<a href="mailto:[% em | html %]">[% em | html %]</a>&gt;</td>
+      <td style="[% contact_td_style %]">
+        [% name %] &lt;<a href="mailto:[% em | html %]">[% em | html %]</a>&gt;
+        [%~ IF user_admin_url %]
+        <small style="[% contact_admin_links_style %]">
+          <a href="[% user_admin_url | html %]">Edit user</a> –
+        [%~ IF user_latest_report_admin_url %]
+          <a href="[% user_latest_report_admin_url | html %]">Edit latest report</a> –
+        [%~ END %]
+          <a href="[% user_reports_admin_url | html %]">Show all reports</a>
+        </small>
+        [%~ END %]
+      </td>
     </tr>
   </table>
 </th>

--- a/templates/email/default/contact.txt
+++ b/templates/email/default/contact.txt
@@ -6,6 +6,14 @@ Subject: [% site_name %] message: [% subject %]
 [ [% complaint %] - [% problem_url %] - [% admin_url %] ]
 [% END %]
 
+[%~ IF user_admin_url %]
+[ Edit user: [% user_admin_url %] ]
+[%~ IF user_latest_report_admin_url %]
+[ Edit latest report: [% user_latest_report_admin_url %] ]
+[%~ END %]
+[ Show all reports: [% user_reports_admin_url %] ]
+[%~ END %]
+
 -- 
 Sent by contact form on [% host %].
 IP address [% ip %], user agent [% user_agent %]


### PR DESCRIPTION
It’s common for people to send contact form messages about their most recent report (usually they’ve included personal details and want them removed) but without actually linking to the report, or using the well hidden "Unsuitable?" link on the report page.

So the person handling the support email for that site has to go manually searching for the user’s profile, or their most recent report, in the admin interface.

After doing this for what seemed like the thousandth time this morning, I figured it’s time to get FMS to do the hard work for me, generating links to the user’s profile page, list of reports, and latest report, if a matching user (and report) is found in the database:

![Screenshot_2019-08-20 Screenshot(1)](https://user-images.githubusercontent.com/739624/63340192-5dc39c00-c33e-11e9-890a-b66b140e4c1e.png)

It also improves the `/_dev/email/contact` email preview endpoint, to show some dummy content, just like the problem/update/alert endpoints.

@dracos @davea @struan what do you think? Useful?