### PR TITLE
Improve asset selection/duplicate suggestion interactions on mobile

### DIFF
--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -386,6 +386,11 @@ function check_zoom_message_visibility() {
     if (this.relevant()) {
         if ($p.length === 0) {
             $p = $("<p>").prop("id", id).prop('class', 'category_meta_message');
+            if ($('html').hasClass('mobile')) {
+                $p.click(function() {
+                    $("#mob_ok").trigger('click');
+                }).addClass("btn");
+            }
             $p.prependTo('#js-post-category-messages');
         }
 

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -482,7 +482,7 @@ $.extend(fixmystreet.set_up, {
             }
         });
 
-        $(fixmystreet).trigger('report_new:category_change');
+        $(fixmystreet).trigger('report_new:category_change', { check_duplicates_dismissal: true });
     });
   },
 

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1460,6 +1460,9 @@ fixmystreet.display = {
                 $('html').addClass('only-map');
                 $('#mob_sub_map_links').removeClass('map_complete');
                 $('#mob_ok').text(translation_strings.ok);
+                if (fixmystreet.duplicates) {
+                    fixmystreet.duplicates.hide();
+                }
             });
         });
     }

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2170,6 +2170,10 @@ label .muted {
     }
 }
 
+.category_meta_message.btn {
+  display: block;
+}
+
 .js-hide-if-public-category {
   display: none;
 }

--- a/web/js/duplicates.js
+++ b/web/js/duplicates.js
@@ -209,4 +209,10 @@
         remove_duplicate_list();
     });
 
+    fixmystreet.duplicates = {
+        hide: function() {
+            remove_duplicate_pins();
+            remove_duplicate_list();
+        }
+    };
 })();

--- a/web/js/duplicates.js
+++ b/web/js/duplicates.js
@@ -4,6 +4,11 @@
     // quickly remove them when we’re finished showing duplicates.
     var current_duplicate_markers;
 
+    // keep track of whether the suggestion UI has already been dismissed
+    // for this category
+    var dismissed = false;
+    var dismissed_category = null;
+
     // Report ID will be available on report inspect page,
     // but undefined on new report page.
     var report_id = $("#report_inspect_form .js-report-id").text() || undefined;
@@ -33,6 +38,17 @@
             nearby_url = '/around/nearby';
             url_params.distance = 250; // Only want to bother public with very nearby reports (250 metres)
             url_params.pin_size = 'normal';
+        }
+
+        if (category && params && params.check_duplicates_dismissal ) {
+            dismissed = category === dismissed_category;
+            dismissed_category = category;
+
+            if (!take_effect()) {
+                remove_duplicate_pins();
+                remove_duplicate_list();
+                return;
+            }
         }
 
         $.ajax({
@@ -190,6 +206,10 @@
         if ($('.js-responsibility-message:visible').length) {
             return false;
         }
+        // On mobile only show once per category
+        if ($('html').hasClass('mobile') && dismissed) {
+            return false;
+        }
         return true;
     }
 
@@ -205,14 +225,14 @@
 
     $('.js-hide-duplicate-suggestions').on('click', function(e){
         e.preventDefault();
-        remove_duplicate_pins();
-        remove_duplicate_list();
+        fixmystreet.duplicates.hide();
     });
 
     fixmystreet.duplicates = {
         hide: function() {
             remove_duplicate_pins();
             remove_duplicate_list();
+            dismissed = true;
         }
     };
 })();


### PR DESCRIPTION
On mobile the asset selection process is a bit fiddly, and the duplicate suggestion UI makes this harder than it needs to be.

This PR adds three small changes to improve things a bit:

1.  Stops the duplicates code from removing the asset markers from the map if you happen to miss the asset when tapping:

Old | New
--- | ---
![mobile_dups](https://user-images.githubusercontent.com/4776/63758742-2c098280-c8b4-11e9-9c59-0fd9198d41ad.gif) | ![mobile_dups2](https://user-images.githubusercontent.com/4776/63758782-3b88cb80-c8b4-11e9-9733-5e547310911c.gif)


2. The duplicates are now dismissed when returning to the map to select the asset marker:
(Although I'm not super happy with this solution, as the user may actually want to go to the map to see the locations of the duplicate markers... So open to removing/rethinking this change.)

![mobile_dups_dismissed](https://user-images.githubusercontent.com/4776/63759019-b356f600-c8b4-11e9-9022-31c83e524f78.gif)


3. The "You can pick a _thing_ from the map" message is a button on mobile that takes you to the map:

![mobile_asset_button](https://user-images.githubusercontent.com/4776/63761561-472ac100-c8b9-11e9-8746-6010e4e46478.gif)


[skip changelog]