### PR TITLE
[UK Councils] Config specifying of update closure.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Westminster.pm
+++ b/perllib/FixMyStreet/Cobrand/Westminster.pm
@@ -32,17 +32,6 @@ sub enter_postcode_text {
 
 sub send_questionnaires { 0 }
 
-sub updates_disallowed {
-    my $self = shift;
-    my $c = $self->{c};
-
-    # Only WCC staff and superusers can leave updates
-    my $staff = $c->user_exists && $c->user->from_body && $c->user->from_body->name eq $self->council_name;
-    my $superuser = $c->user_exists && $c->user->is_superuser;
-
-    return ( $staff || $superuser ) ? 0 : 1;
- }
-
 sub suppress_reporter_alerts { 1 }
 
 sub report_age { '3 months' }

--- a/t/cobrand/councils.t
+++ b/t/cobrand/councils.t
@@ -47,4 +47,46 @@ foreach my $test (
 };
 
 
+subtest "Test update shown/not shown appropriately" => sub {
+    my $user = $mech->create_user_ok('test@example.com');
+    foreach my $cobrand ('oxfordshire', 'fixmystreet') {
+        foreach my $test (
+            # Three bools are logged out, reporter, staff user
+            { type => 'none', update => [0,0,0] },
+            { type => 'staff', update => [0,0,1] },
+            { type => 'reporter', update => [0,1,1] },
+            { type => 'open', state => 'closed', update => [0,0,0] },
+            { type => 'open', state => 'in progress', update => [1,1,1] },
+        ) {
+            FixMyStreet::override_config {
+                ALLOWED_COBRANDS => $cobrand,
+                MAPIT_URL => 'http://mapit.uk/',
+                COBRAND_FEATURES => {
+                    updates_allowed => {
+                        oxfordshire => $test->{type},
+                        fixmystreet => {
+                            Oxfordshire => $test->{type},
+                        }
+                    }
+                },
+            }, sub {
+                subtest "$cobrand, $test->{type}" => sub {
+                    $report->update({ state => $test->{state} || 'confirmed' });
+                    $mech->log_out_ok;
+                    $user->update({ from_body => undef });
+                    $mech->get_ok("/report/$report_id");
+                    $mech->contains_or_lacks($test->{update}[0], 'Provide an update');
+                    $mech->log_in_ok('test@example.com');
+                    $mech->get_ok("/report/$report_id");
+                    $mech->contains_or_lacks($test->{update}[1], 'Provide an update');
+                    $user->update({ from_body => $oxon->id });
+                    $mech->get_ok("/report/$report_id");
+                    $mech->contains_or_lacks($test->{update}[2], 'Provide an update');
+                };
+            };
+        }
+    }
+};
+
+
 done_testing();

--- a/t/cobrand/westminster.t
+++ b/t/cobrand/westminster.t
@@ -29,6 +29,9 @@ FixMyStreet::override_config {
     ALLOWED_COBRANDS => 'westminster',
     MAPIT_URL => 'http://mapit.uk/',
     COBRAND_FEATURES => {
+        updates_allowed => {
+            westminster => 'staff',
+        },
         oidc_login => {
             westminster => {
                 client_id => 'example_client_id',
@@ -64,6 +67,11 @@ subtest 'Reports have an update form for superusers' => sub {
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => 'westminster',
         MAPIT_URL => 'http://mapit.uk/',
+        COBRAND_FEATURES => {
+            updates_allowed => {
+                westminster => 'staff',
+            },
+        },
     }, sub {
         $mech->get_ok('/report/' . $report->id);
         $mech->content_contains('Provide an update');
@@ -77,6 +85,11 @@ subtest 'Reports have an update form for staff users' => sub {
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => 'westminster',
         MAPIT_URL => 'http://mapit.uk/',
+        COBRAND_FEATURES => {
+            updates_allowed => {
+                westminster => 'staff',
+            },
+        },
     }, sub {
         $mech->get_ok('/report/' . $report->id);
         $mech->content_contains('Provide an update');

--- a/templates/web/base/report/_updates_disallowed_message.html
+++ b/templates/web/base/report/_updates_disallowed_message.html
@@ -1,0 +1,5 @@
+<p>[% loc('This report is now closed to updates.') %]
+   [% tprintf(loc('You can <a href="%s">make a new report in the same location</a>.'),
+          c.uri_for( '/report/new', { longitude = longitude, latitude = latitude } )
+      ) %]
+</p>


### PR DESCRIPTION
A cobrand feature flag can be used to only allow updates on open
reports, by the original reporter, to staff only, or to no-one.
[skip changelog]