### PR TITLE
do not reproject uk wmts map if no coordinates

### DIFF
--- a/perllib/FixMyStreet/Map/UKCouncilWMTS.pm
+++ b/perllib/FixMyStreet/Map/UKCouncilWMTS.pm
@@ -36,6 +36,8 @@ sub tile_parameters {
 # Reproject a WGS84 lat/lon into BNG easting/northing
 sub reproject_from_latlon($$$) {
     my ($self, $lat, $lon) = @_;
+    # do not try to reproject if we have no co-ordindates as convert breaks
+    return (0.0, 0.0) if $lat == 0 && $lon == 0;
     my ($x, $y) = Utils::convert_latlon_to_en($lat, $lon);
     return ($x, $y);
 }

--- a/t/cobrand/bristol.t
+++ b/t/cobrand/bristol.t
@@ -21,6 +21,16 @@ my $email_contact = $mech->create_contact_ok(
     send_method => 'Email'
 );
 
+subtest 'Reports page works with no reports', sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'bristol' ],
+        MAPIT_URL => 'http://mapit.uk/',
+        MAP_TYPE => 'Bristol',
+    }, sub {
+        $mech->get_ok("/reports");
+    };
+};
+
 subtest 'Only Open311 categories are shown on Bristol cobrand', sub {
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => [ 'bristol' ],


### PR DESCRIPTION
If the coordinates are (0,0) then return that straight back as trying to
reproject causes Geography::NationalGrid::GB to fall over as 0 lat is
outside UK

Fixes #2617 [skip changelog]
