### PR TITLE
 Improve user flow when JavaScript is not available

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -143,6 +143,7 @@ sub report_new_ajax : Path('mobile') : Args(0) {
 
     $c->forward('setup_categories_and_bodies');
     $c->forward('setup_report_extra_fields');
+    $c->forward('check_for_category');
     $c->forward('process_report');
     $c->forward('process_user');
     $c->forward('/photo/process_photo');
@@ -253,10 +254,7 @@ sub category_extras_ajax : Path('category_extras') : Args(0) {
     $c->forward('setup_report_extra_fields');
 
     $c->forward('check_for_category');
-    my $category = $c->stash->{category} || "";
-    $category = '' if $category eq _('-- Pick a category --');
-
-    $c->stash->{json_response} = $c->forward('by_category_ajax_data', [ 'one', $category ]);
+    $c->stash->{json_response} = $c->forward('by_category_ajax_data', [ 'one', $c->stash->{category} ]);
     $c->forward('send_json_response');
 }
 
@@ -949,12 +947,12 @@ sub process_report : Private {
         'title', 'detail', 'pc',                 #
         'detail_size',
         'may_show_name',                         #
-        'category',                              #
         'subcategory',                              #
         'partial',                               #
         'service',                               #
         'non_public',
       );
+    $params{category} = $c->stash->{category};
 
     # load the report
     my $report = $c->stash->{report};
@@ -1520,9 +1518,10 @@ sub generate_map : Private {
 sub check_for_category : Private {
     my ( $self, $c ) = @_;
 
-    $c->stash->{category} = $c->get_param('category') || $c->stash->{report}->category;
+    my $category = $c->get_param('category') || '';
+    $category = '' if $category eq _('Loading...') || $category eq _('-- Pick a category --');
+    $c->stash->{category} = $category || $c->stash->{report}->category || '';
 
-    return 1;
 }
 
 =head2 redirect_or_confirm_creation

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -376,13 +376,6 @@ sub check_for_errors {
         $errors{name} = _('Please enter your name');
     }
 
-    if (   $self->category
-        && $self->category eq _('-- Pick a category --') )
-    {
-        $errors{category} = _('Please choose a category');
-        $self->category(undef);
-    }
-
     return \%errors;
 }
 

--- a/t/app/model/problem.t
+++ b/t/app/model/problem.t
@@ -106,15 +106,6 @@ for my $test (
         }
     },
     {
-        desc => 'bad category',
-        changed => {
-            category => '-- Pick a category --',
-        },
-        errors => {
-            category => 'Please choose a category',
-        }
-    },
-    {
         desc => 'correct category',
         changed => {
             category => 'Horse!',

--- a/templates/web/base/report/form/user_loggedout_by_email.html
+++ b/templates/web/base/report/form/user_loggedout_by_email.html
@@ -25,11 +25,7 @@
     </div>
   [% END %]
 
-  [% IF c.cobrand.social_auth_enabled AND NOT email_required %]
-    [% PROCESS 'report/form/user_loggedout_email.html' name='username_register' required=0 %]
-  [% ELSE %]
-    [% PROCESS 'report/form/user_loggedout_email.html' name='username_register' required=1 %]
-  [% END %]
+    [% PROCESS 'report/form/user_loggedout_email.html' name='username_register' %]
 
   [% IF type != 'update' AND c.config.SMS_AUTHENTICATION %]
     [% UNLESS c.cobrand.call_hook('disable_phone_number_entry') %]

--- a/templates/web/base/report/form/user_loggedout_email.html
+++ b/templates/web/base/report/form/user_loggedout_email.html
@@ -15,6 +15,5 @@
 [% END %]
 <input type="[% username_type %]" name="username" id="form_[% name %]"
        value="[% username_value | html %]"
-    [% IF required %]required[% END %]
     class="form-control required">
 <!-- /user_loggedout_email.html -->

--- a/templates/web/base/report/form/user_loggedout_password.html
+++ b/templates/web/base/report/form/user_loggedout_password.html
@@ -8,11 +8,7 @@
         <a class="js-new-report-hide-sign-in" href="#">[% loc('Fill in your details manually.') %]</a>
     </p>
 
-  [% IF c.cobrand.social_auth_enabled %]
-    [% PROCESS 'report/form/user_loggedout_email.html' name='username_sign_in' required=0 %]
-  [% ELSE %]
-    [% PROCESS 'report/form/user_loggedout_email.html' name='username_sign_in' required=1 %]
-  [% END %]
+    [% PROCESS 'report/form/user_loggedout_email.html' name='username_sign_in' %]
 
     <label for="password_sign_in">[% loc('Your password') %]</label>
     [% IF field_errors.password %]

--- a/templates/web/base/report/new/category_extras_fields.html
+++ b/templates/web/base/report/new/category_extras_fields.html
@@ -1,6 +1,6 @@
 [%- FOR meta IN metas %]
   [%- meta_name = meta.code -%]
-  [%- x_meta_name = 'x' _ meta.code # For report_meta and field_erros lookup, as TT hides codes starting "_" -%]
+  [%- x_meta_name = 'x' _ meta.code # For report_meta and field_errors lookup, as TT hides codes starting "_" -%]
 
   [% IF c.cobrand.category_extra_hidden(meta) AND NOT show_hidden %]
 

--- a/templates/web/base/report/new/category_wrapper.html
+++ b/templates/web/base/report/new/category_wrapper.html
@@ -19,6 +19,11 @@
 
 [% PROCESS "report/new/duplicate_suggestions.html" %]
 
+[% IF disable_form_message %]
+<div id="js-category-stopper" class="box-warning" role="alert" aria-live="assertive">
+    [% disable_form_message %]
+</div>
+[% ELSE %]
 <div id="js-post-category-messages" class="js-hide-if-invalid-category_extras">
     [%# This section includes 'Pick an asset' text, roadworks info, extra category questions %]
 
@@ -26,3 +31,4 @@
     [% PROCESS "report/new/category_extras.html" %]
   [%- END %]
 </div>
+[% END %]

--- a/templates/web/base/report/new/form_report.html
+++ b/templates/web/base/report/new/form_report.html
@@ -1,3 +1,5 @@
+[% SET form_show_category_only = NOT category || field_errors.category || disable_form_message || have_disable_qn_to_answer %]
+
 <!-- report/new/form_report.html -->
 [% INCLUDE 'report/new/form_heading.html' %]
 
@@ -7,7 +9,17 @@
 
 [% PROCESS "report/new/category_wrapper.html" %]
 [% TRY %][% PROCESS 'report/new/after_category.html' %][% CATCH file %][% END %]
-<div class="js-hide-if-invalid-category">
+
+[% IF form_show_category_only %]
+    <div class="hidden-js">
+        <input class="btn btn--primary btn--block btn--final" type="submit" name="submit_category_part_only" value="[% loc('Submit') %]">
+    </div>
+    [% SET field_required = '' %]
+[% ELSE %]
+    [% SET field_required = ' required' %]
+[% END %]
+
+<div class="js-hide-if-invalid-category[% ' hidden-nojs' IF form_show_category_only %]">
 [% TRY %][% PROCESS 'report/new/_form_labels.html' %][% CATCH file %][% END %]
 
     <h2 class="form-section-heading js-hide-if-private-category">[% loc( 'Public details' ) %]</h2>
@@ -67,7 +79,7 @@
     <p class='form-error'>[% field_errors.detail %]</p>
 [% END %]
 
-    <textarea class="form-control" rows="7" cols="26" name="detail" id="form_detail" [% IF form_detail_placeholder %]aria-describedby="detail-hint"[% END %] required>[% report.detail | html %]</textarea>
+    <textarea class="form-control" rows="7" cols="26" name="detail" id="form_detail" [% IF form_detail_placeholder %]aria-describedby="detail-hint"[% END %][% field_required %]>[% report.detail | html %]</textarea>
 
 [% TRY %][% PROCESS 'report/new/inline-tips.html' %][% CATCH file %][% END %]
 

--- a/templates/web/base/report/new/form_title.html
+++ b/templates/web/base/report/new/form_title.html
@@ -5,4 +5,4 @@
 [% IF field_errors.title %]
     <p class='form-error'>[% field_errors.title %]</p>
 [% END %]
-<input class="form-control" type="text" value="[% report.title | html %]" name="title" id="form_title" aria-describedby="title-hint" required autocomplete="off">
+<input class="form-control" type="text" value="[% report.title | html %]" name="title" id="form_title" aria-describedby="title-hint"[% field_required %] autocomplete="off">

--- a/templates/web/base/report/new/form_user.html
+++ b/templates/web/base/report/new/form_user.html
@@ -1,5 +1,5 @@
 <!-- report/new/form_user.html -->
-<div class="js-hide-if-invalid-category">
+<div class="js-hide-if-invalid-category[% ' hidden-nojs' IF form_show_category_only %]">
 
     [% PROCESS 'report/form/user.html' type='report' %]
 

--- a/templates/web/bromley/report/form/user_loggedout_email.html
+++ b/templates/web/bromley/report/form/user_loggedout_email.html
@@ -18,5 +18,4 @@
 [% END %]
 <input type="[% username_type %]" name="username" id="form_[% name %]"
        value="[% username_value | html %]"
-    [% IF required %]required[% END %]
     class="form-control required">


### PR DESCRIPTION
This improves the reporting journey to only ask for category, and then category extra questions if appropriate, first, so that if the choice would lead to the form being disabled, this can be shown immediately.

[skip changelog]