### PR TITLE
Asset code ordering issues

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1025,7 +1025,16 @@ sub process_report : Private {
         my $body_string = do {
             if (my $single_body_only = $c->get_param('single_body_only')) {
                 my $body = $c->model('DB::Body')->search({ name => $single_body_only })->first;
-                $body ? $body->id : '-1';
+                if ($body) {
+                    # Drop the contacts down to those in this body
+                    # (potentially none for e.g. Highways England)
+                    # so that set_report_extras doesn't error when
+                    # there are 'missing' extra fields
+                    @contacts = grep { $_->body->id == $body->id } @contacts;
+                    $body->id;
+                } else {
+                    '-1';
+                }
             } else {
                 my $contact_options = {};
                 $contact_options->{do_not_send} = [ $c->get_param_list('do_not_send', 1) ];

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -275,8 +275,9 @@ function init_asset_layer(layer, pins_layer) {
         layer.fixmystreet.fault_layer.setZIndex(layer.getZIndex()-1);
     }
 
-    if (fixmystreet.page == 'new' && (layer.fixmystreet.usrn || layer.fixmystreet.road)) {
-        // If the user visits /report/new directly and doesn't change the pin
+    if (layer.fixmystreet.usrn || layer.fixmystreet.road) {
+        // If an asset layer only loads once a category is selected, or if the
+        // user visits /report/new directly and doesn't change the pin
         // location, then the assets:selected/maps:update_pin events are never
         // fired and USRN's checkFeature is never called. This results in a
         // report whose location was never looked up against the USRN layer,

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -1217,6 +1217,8 @@ fixmystreet.message_controller = (function() {
             stoppers = [];
         },
 
+        check_for_stopper: check_for_stopper,
+
         add_ignored_body: function(body) {
             ignored_bodies.push(body);
         }

--- a/web/cobrands/westminster/assets.js
+++ b/web/cobrands/westminster/assets.js
@@ -101,6 +101,7 @@ fixmystreet.assets.add(defaults, {
         found: function(layer, feature) {
             if (!fixmystreet.assets.selectedFeature()) {
                 fixmystreet.body_overrides.only_send('TfL');
+                $('#category_meta').empty();
             } else {
                 fixmystreet.body_overrides.remove_only_send();
             }

--- a/web/cobrands/westminster/assets.js
+++ b/web/cobrands/westminster/assets.js
@@ -104,9 +104,11 @@ fixmystreet.assets.add(defaults, {
             } else {
                 fixmystreet.body_overrides.remove_only_send();
             }
+            fixmystreet.message_controller.check_for_stopper();
         },
         not_found: function(layer) {
             fixmystreet.body_overrides.remove_only_send();
+            fixmystreet.message_controller.check_for_stopper();
         }
     }
 });


### PR DESCRIPTION
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1543

I realise with this fix the stopper code is run more times than seems necessary (e.g. on a map pin click, checkFeature is called immediately, then when category data comes back, that will lead to a category change event firing, so it'll get called again, plus the stopper code runs in its own right on category change anyway) but given we don't know when/where data will be available, that seems safest, if a bit hmm. The stopper code doesn't do very much, at least.
Also due to the above, picking the roads category on Westminster will show the disabled bit before the TfL data comes back at which point the form comes back. I couldn't think of an easy fix except somehow telling the stopper code that it should wait for layer data, which also doesn't seem great; the only alternative I could think of is to load the TfL data all the time (as happens on Bromley) but that then seems a waste if you never need it. Bit of a compromise all round, looks like.

[skip changelog]
