### PR TITLE
Allow contact send method to be unset always.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
         - Have duplicate suggestion and assets coexist better.
         - Don't include lat/lon of private reports in ‘Report another problem
           here’ link.
+        - Allow contact send method to be unset always.
     - Front end improvements:
         - Set report title autocomplete to off to prevent email autocompleting
     - Development improvements:

--- a/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
@@ -241,7 +241,7 @@ sub update_contacts : Private {
 
         my $email = $c->get_param('email');
         $email =~ s/\s+//g;
-        my $send_method = $c->get_param('send_method') || $contact->send_method || $contact->body->send_method || "";
+        my $send_method = $c->get_param('send_method') || $contact->body->send_method || "";
         unless ( $send_method eq 'Open311' ) {
             $errors{email} = _('Please enter a valid email') unless is_valid_email_list($email) || $email eq 'REFUSED';
         }

--- a/t/app/controller/admin/bodies.t
+++ b/t/app/controller/admin/bodies.t
@@ -182,6 +182,7 @@ subtest 'check open311 configuring' => sub {
                 send_comments => 0,
                 send_method  => 'Open311',
                 fetch_all_problems => 0,
+                can_be_devolved => 1, # for next test
             }
         }
     );
@@ -190,6 +191,23 @@ subtest 'check open311 configuring' => sub {
 
     $conf = FixMyStreet::App->model('DB::Body')->find( $body->id );
     ok !$conf->get_extra_metadata('fetch_all_problems'), 'fetch all problems unset';
+};
+
+subtest 'check open311 devolved editing' => sub {
+    $mech->get_ok('/admin/body/' . $body->id . '/test%20category');
+    $mech->submit_form_ok( { with_fields => {
+        send_method => 'Email',
+        email => 'testing@example.org',
+        note => 'Updating contact to email',
+    } } );
+    $mech->content_contains('Values updated');
+    $mech->get_ok('/admin/body/' . $body->id . '/test%20category');
+    $mech->submit_form_ok( { with_fields => {
+        send_method => '',
+        email => 'open311-code',
+        note => 'Removing email send method',
+    } } );
+    $mech->content_contains('Values updated');
 };
 
 subtest 'check text output' => sub {


### PR DESCRIPTION
If a body was set to Open311, and a contact set to Email, it was
impossible to unset the contact's send method and set an Open311
code, because it would always demaned a valid email address.