### PR TITLE
Limit asset string finding to chosen ID.

### DIFF
--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -1030,7 +1030,7 @@ fixmystreet.message_controller = (function() {
     function show_responsibility_error(id, asset_item, asset_type) {
         $("#js-roads-responsibility").removeClass("hidden");
         $("#js-roads-responsibility .js-responsibility-message").addClass("hidden");
-        var asset_strings = $('.js-roads-asset');
+        var asset_strings = $(id).find('.js-roads-asset');
         if (asset_item) {
             asset_strings.html('a <b class="asset-' + asset_type + '">' + asset_item + '</b>');
         } else {


### PR DESCRIPTION
Without this, with the default template, it would find "an item" instead of "a road".  I think looking only inside the chosen ID is the right thing to do, but not 100% sure.

[skip changelog]
