### PR TITLE
Make sure determine_contact_type called later.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Contact.pm
+++ b/perllib/FixMyStreet/App/Controller/Contact.pm
@@ -33,7 +33,6 @@ sub begin : Private {
     my ($self, $c) = @_;
     $c->forward('/begin');
     $c->forward('setup_request');
-    $c->forward('determine_contact_type');
 }
 
 =head2 index
@@ -44,6 +43,7 @@ Display contact us page
 
 sub index : Path : Args(0) {
     my ( $self, $c ) = @_;
+    $c->forward('determine_contact_type');
 }
 
 =head2 submit
@@ -55,6 +55,7 @@ Handle contact us form submission
 sub submit : Path('submit') : Args(0) {
     my ( $self, $c ) = @_;
 
+    $c->forward('determine_contact_type');
     $c->res->redirect( '/contact' ) and return unless $c->req->method eq 'POST';
 
     $c->go('index') unless $c->forward('validate');


### PR DESCRIPTION
The request cobrand is set on the schema during the app's `setup_request()`, which is called by the root `auto` action. So anything in a controller's `begin` action (such as user permission for rejecting reports) will access an incorrect cobrand (if one has already been set).

[skip changelog]
