### PR TITLE
Rename categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
         - Contact form emails now include user admin links.
         - Allow categories/Open311 questions to disable the reporting form. #2599
         - Improve category edit form. #2469
+        - Allow editing of category name. #1398
     - New features:
         - Categories can be listed under more than one group #2475
         - OpenID Connect login support. #2523

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
         - Add front-end testing support for WSL. #2514
         - Allow cobrands to disable admin resending.
         - Sass variables for default link colour and decoration.
+        - Make contact edit note optional on staging sites.
     - Open311 improvements:
         - Support use of 'private' service definition <keywords> to mark
           reports made in that category private. #2488

--- a/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
@@ -220,7 +220,7 @@ sub update_contact : Private {
 
     my $category = $self->trim( $c->get_param('category') );
     $errors{category} = _("Please choose a category") unless $category;
-    $errors{note} = _('Please enter a message') unless $c->get_param('note');
+    $errors{note} = _('Please enter a message') unless $c->get_param('note') || FixMyStreet->config('STAGING_SITE');
 
     my $contact = $c->model('DB::Contact')->find_or_new(
         {

--- a/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
@@ -290,7 +290,7 @@ sub update_contact : Private {
 
 
     $c->forward('/admin/update_extra_fields', [ $contact ]);
-    $c->forward('contact_cobrand_extra_fields', [ $contact ]);
+    $c->forward('contact_cobrand_extra_fields', [ $contact, \%errors ]);
 
     # Special form disabling form
     if ($c->get_param('disable')) {
@@ -434,12 +434,13 @@ sub check_body_params : Private {
 }
 
 sub contact_cobrand_extra_fields : Private {
-    my ( $self, $c, $contact ) = @_;
+    my ( $self, $c, $contact, $errors ) = @_;
 
     my $extra_fields = $c->cobrand->call_hook('contact_extra_fields');
     foreach ( @$extra_fields ) {
         $contact->set_extra_metadata( $_ => $c->get_param("extra[$_]") );
     }
+    $c->cobrand->call_hook(contact_extra_fields_validation => $contact, $errors);
 }
 
 sub fetch_translations : Private {

--- a/perllib/FixMyStreet/App/Controller/My.pm
+++ b/perllib/FixMyStreet/App/Controller/My.pm
@@ -161,7 +161,7 @@ sub setup_page_data : Private {
     my @categories = $c->stash->{problems_rs}->search({
         state => [ FixMyStreet::DB::Result::Problem->visible_states() ],
     }, {
-        columns => [ 'category' ],
+        columns => [ 'category', 'bodies_str' ],
         distinct => 1,
         order_by => [ 'category' ],
     } )->all;

--- a/perllib/FixMyStreet/Cobrand/BathNES.pm
+++ b/perllib/FixMyStreet/Cobrand/BathNES.pm
@@ -27,6 +27,19 @@ sub get_geocoder {
     return 'OSM'; # default of Bing gives poor results, let's try overriding.
 }
 
+sub contact_extra_fields { [ 'display_name' ] }
+
+sub contact_extra_fields_validation {
+    my ($self, $contact, $errors) = @_;
+    return unless $contact->get_extra_metadata('display_name');
+
+    my @contacts = $contact->body->contacts->not_deleted->search({ id => { '!=', $contact->id } });
+    my %display_names = map { $_->get_extra_metadata('display_name') => 1 } @contacts;
+    if ($display_names{$contact->get_extra_metadata('display_name')}) {
+        $errors->{display_name} = 'That display name is already in use';
+    }
+}
+
 sub disambiguate_location {
     my $self    = shift;
     my $string  = shift;

--- a/perllib/FixMyStreet/Cobrand/Bexley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley.pm
@@ -31,10 +31,7 @@ sub open311_munge_update_params {
 
     $params->{service_request_id_ext} = $comment->problem->id;
 
-    my $contact = $comment->result_source->schema->resultset("Contact")->not_deleted->find({
-        body_id => $body->id,
-        category => $comment->problem->category
-    });
+    my $contact = $comment->problem->category_row;
     $params->{service_code} = $contact->email;
 }
 

--- a/perllib/FixMyStreet/DB/Result/Contact.pm
+++ b/perllib/FixMyStreet/DB/Result/Contact.pm
@@ -95,7 +95,7 @@ __PACKAGE__->many_to_many( defect_types => 'contact_defect_types', 'defect_type'
 
 sub category_display {
     my $self = shift;
-    $self->translate_column('category');
+    $self->get_extra_metadata('display_name') || $self->translate_column('category');
 }
 
 sub groups {

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -404,7 +404,28 @@ sub confirm {
 
 sub category_display {
     my $self = shift;
-    $self->translate_column('category');
+    my $contact = $self->category_row;
+    return $self->category unless $contact; # Fallback; shouldn't happen, but some tests
+    return $contact->category_display;
+}
+
+=head2 category_row
+
+Returns the corresponding Contact object for this problem's category and body.
+If the report was sent to multiple bodies, only returns the first.
+
+=cut
+
+sub category_row {
+    my $self = shift;
+    my $schema = $self->result_source->schema;
+    my $body_id = $self->bodies_str_ids->[0];
+    return unless $body_id && $body_id =~ /^[0-9]+$/;
+    my $contact = $schema->resultset("Contact")->find({
+        body_id => $body_id,
+        category => $self->category,
+    });
+    return $contact;
 }
 
 sub bodies_str_ids {

--- a/perllib/FixMyStreet/Roles/Translatable.pm
+++ b/perllib/FixMyStreet/Roles/Translatable.pm
@@ -40,19 +40,6 @@ sub _translate {
     my $translated = $self->translated->{$col}{$lang};
     return $translated if $translated;
 
-    # Deal with the fact problem table has denormalized copy of category string
-    if ($table eq 'problem' && $col eq 'category') {
-        my $body_id = $self->bodies_str_ids->[0];
-        return $fallback unless $body_id && $body_id =~ /^[0-9]+$/;
-        my $contact = $schema->resultset("Contact")->find( {
-            body_id => $body_id,
-            category => $fallback,
-        } );
-        return $fallback unless $contact; # Shouldn't happen, but some tests
-        $table = 'contact';
-        $id = $contact->id;
-    }
-
     if (ref $schema) {
         my $translation = $schema->resultset('Translation')->find({
             lang => $lang,

--- a/t/app/controller/admin/bodies.t
+++ b/t/app/controller/admin/bodies.t
@@ -51,7 +51,7 @@ subtest 'check contact creation' => sub {
         non_public => 'on',
     } } );
     $mech->get_ok('/admin/body/' . $body->id . '/test/category');
-    $mech->content_contains('<h1>test/category</h1>');
+    $mech->content_contains('test/category');
 };
 
 subtest 'check contact editing' => sub {
@@ -89,6 +89,21 @@ subtest 'check contact editing' => sub {
 
     $mech->get_ok('/admin/body/' . $body->id . '/test%20category');
     $mech->content_contains( '<td><strong>test2@example.com' );
+};
+
+subtest 'check contact renaming' => sub {
+    my ($report) = $mech->create_problems_for_body(1, $body->id, 'Title', { category => 'test category' });
+    $mech->get_ok('/admin/body/' . $body->id .'/test%20category');
+    $mech->submit_form_ok( { with_fields => { category => 'private category' } } );
+    $mech->content_contains('You cannot rename');
+    $mech->submit_form_ok( { with_fields => { category => 'testing category' } } );
+    $mech->content_contains( 'testing category' );
+    $mech->get('/admin/body/' . $body->id . '/test%20category');
+    is $mech->res->code, 404;
+    $mech->get_ok('/admin/body/' . $body->id . '/testing%20category');
+    $report->discard_changes;
+    is $report->category, 'testing category';
+    $mech->submit_form_ok( { with_fields => { category => 'test category' } } );
 };
 
 subtest 'check contact updating' => sub {

--- a/t/app/controller/admin/translations.t
+++ b/t/app/controller/admin/translations.t
@@ -59,7 +59,7 @@ subtest 'check add category with translation' => sub {
     $mech->submit_form_ok( { with_fields => {
         category => 'Potholes',
         translation_de => 'DE potholes',
-        email => 'potholes@example.org',
+        email => 'potholes',
     } } );
 
     # check that error page includes translations

--- a/t/roles/translatable.t
+++ b/t/roles/translatable.t
@@ -74,4 +74,11 @@ FixMyStreet::override_config {
     $mech->content_contains('Hull i veien');
 };
 
+subtest 'Check display_name override' => sub {
+    $contact->set_extra_metadata( display_name => 'Override name' );
+    $contact->update;
+    is $contact->category_display, "Override name";
+    is $problem->category_display, "Override name";
+};
+
 done_testing;

--- a/templates/web/base/admin/bodies/_category_field.html
+++ b/templates/web/base/admin/bodies/_category_field.html
@@ -1,0 +1,17 @@
+<div class="admin-hint">
+  <p>
+      [% loc('Choose a <strong>category</strong> name that makes sense to the public (e.g., "Pothole", "Street lighting") but is helpful
+                  to the body too. These will appear in the drop-down menu on the report-a-problem page.') %]
+      <br>
+      [% loc("If two or more bodies serve the same location, FixMyStreet combines identical categories into a single entry in
+                  the menu. Make sure you use the same category name in the bodies if you want this to happen.") %]
+  </p>
+</div>
+
+<p>
+  <strong>[% loc('Category') %] </strong><input type="text" class="form-control" name="category" size="30" value="[% contact.category | html %]" required>
+</p>
+
+[% IF contact.in_storage %]
+    <input type="hidden" name="current_category" value="[% current_contact.category | html %]" >
+[% END %]

--- a/templates/web/base/admin/bodies/contact-form.html
+++ b/templates/web/base/admin/bodies/contact-form.html
@@ -1,11 +1,5 @@
 <form method="post" action="[% c.uri_for_action('admin/bodies/edit', [ body_id ] ) %]" enctype="application/x-www-form-urlencoded" accept-charset="utf-8" id="category_edit">
 
-  [% IF contact.in_storage %]
-    <p>
-      <h1>[% contact.category_display | html %]</h1>
-      <input type="hidden" name="category" value="[% contact.category | html %]" >
-    </p>
-  [% ELSE %]
     <div class="admin-hint">
       <p>
           [% loc('Choose a <strong>category</strong> name that makes sense to the public (e.g., "Pothole", "Street lighting") but is helpful
@@ -18,6 +12,8 @@
     <p>
       <strong>[% loc('Category') %] </strong><input type="text" class="form-control" name="category" size="30" value="[% contact.category | html %]" required>
     </p>
+  [% IF contact.in_storage %]
+      <input type="hidden" name="current_category" value="[% current_contact.category | html %]" >
   [% END %]
 
   [% INCLUDE 'admin/bodies/_translations.html' %]

--- a/templates/web/base/admin/bodies/contact-form.html
+++ b/templates/web/base/admin/bodies/contact-form.html
@@ -143,7 +143,7 @@
     <p class="form-group" style="margin-top: 2em">
         <label for="note">[% loc('Summarise your changes') %]</label>
         <span class="form-hint" id="note-hint">[% loc("If you’ve made changes, leave a note explaining what, for other admins to see.") %]</span>
-        <input class="form-control" type="text" id="note" name="note" size="30" aria-describedby="note-hint" required>
+        <input class="form-control" type="text" id="note" name="note" size="30" aria-describedby="note-hint"[% ' required' UNLESS c.config.STAGING_SITE %]>
     </p>
 
   <p>

--- a/templates/web/base/admin/bodies/contact-form.html
+++ b/templates/web/base/admin/bodies/contact-form.html
@@ -1,20 +1,6 @@
 <form method="post" action="[% c.uri_for_action('admin/bodies/edit', [ body_id ] ) %]" enctype="application/x-www-form-urlencoded" accept-charset="utf-8" id="category_edit">
 
-    <div class="admin-hint">
-      <p>
-          [% loc('Choose a <strong>category</strong> name that makes sense to the public (e.g., "Pothole", "Street lighting") but is helpful
-                  to the body too. These will appear in the drop-down menu on the report-a-problem page.') %]
-          <br>
-          [% loc("If two or more bodies serve the same location, FixMyStreet combines identical categories into a single entry in
-                  the menu. Make sure you use the same category name in the bodies if you want this to happen.") %]
-      </p>
-    </div>
-    <p>
-      <strong>[% loc('Category') %] </strong><input type="text" class="form-control" name="category" size="30" value="[% contact.category | html %]" required>
-    </p>
-  [% IF contact.in_storage %]
-      <input type="hidden" name="current_category" value="[% current_contact.category | html %]" >
-  [% END %]
+  [% PROCESS 'admin/bodies/_category_field.html' %]
 
   [% INCLUDE 'admin/bodies/_translations.html' %]
 

--- a/templates/web/bathnes/admin/bodies/_category_field.html
+++ b/templates/web/bathnes/admin/bodies/_category_field.html
@@ -1,0 +1,21 @@
+[% IF contact.in_storage %]
+    <h1>[% contact.category | html %]</h1>
+    <input type="hidden" name="category" value="[% contact.category | html %]" >
+
+    <div class="admin-hint">
+        <p>A display name will be used in preference to the main category name on web pages and dropdown menus, but not in URLs.</p>
+  </div>
+
+    <p>
+      <label>
+      Display name:
+      <input type="text" class="form-control" name="extra[display_name]" id="display_name"
+        value="[% contact.get_extra_metadata('display_name') | html %]" size="30">
+      </label>
+    </p>
+
+[% ELSE %]
+    <p>
+      <strong>[% loc('Category') %] </strong><input type="text" class="form-control" name="category" size="30" value="[% contact.category | html %]" required>
+    </p>
+[% END %]

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -369,7 +369,7 @@ $(fixmystreet).on('display:report', function() {
 
 $(fixmystreet).on('report_new:category_change', function() {
     var $this = $('#form_category');
-    var category = $this.val();
+    var category = $this.find("option:selected").text();
     if (category === '-- Pick a category --') { return; }
     var prefill_reports = $this.data('prefill');
     var display_names = fixmystreet.reporting_data ? fixmystreet.reporting_data.display_names || {} : {};


### PR DESCRIPTION
This PR:
* [BANES] Adds a display name field to their admin so they can have an override name for a category, but keeping the same internal name (fixes https://github.com/mysociety/fixmystreet-freshdesk/issues/83)
* Has the core code necessary for that to work
* Lets categories be renamed in other cobrands (fixes #1398)
* Makes contact edit note optional on staging sites.
* Does a bit of refactor admin body creation/editing
* Stops some warning lines in Westminster/Zurich tests

Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog