### PR TITLE
[Hounslow] Send report to inbox before Open311 send, not after

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Hounslow.pm
+++ b/perllib/FixMyStreet/Cobrand/Hounslow.pm
@@ -73,15 +73,22 @@ sub link_to_council_cobrand { "Hounslow Highways" }
 # Instead, force the borough council name to be used.
 sub all_reports_single_body { { name => "Hounslow Borough Council" } }
 
-sub open311_post_send {
-    my ($self, $row, $h) = @_;
+sub open311_pre_send {
+    my ($self, $row, $open311, $h) = @_;
 
-    # Check Open311 was successful
-    return unless $row->external_id;
+    # Reload the problem from the DB, as we want to save our changes to it
+    # without affecting the existing instance.
+    $row = $row->result_source->resultset->find( { id => $row->id } );
+
+    # Stop the email being sent for each Open311 failure; only the once.
+    return if $row->get_extra_metadata('hounslow_email_sent');
 
     my $e = join( '@', 'enquiries', $self->council_url . 'highways.org' );
     my $sender = FixMyStreet::SendReport::Email->new( to => [ [ $e, 'Hounslow Highways' ] ] );
-    $sender->send($row, $h);
+    if (!$sender->send($row, $h)) {
+      $row->set_extra_metadata('hounslow_email_sent', 1);
+      $row->update;
+    }
 }
 
 sub open311_config {

--- a/perllib/FixMyStreet/SendReport/Open311.pm
+++ b/perllib/FixMyStreet/SendReport/Open311.pm
@@ -74,7 +74,7 @@ sub send {
 
         my $open311 = Open311->new( %open311_params );
 
-        $cobrand->call_hook(open311_pre_send => $row, $open311);
+        $cobrand->call_hook(open311_pre_send => $row, $open311, $h);
 
         my $resp = $open311->send_service_request( $row, $h, $contact->email );
         if (FixMyStreet->test_mode) {


### PR DESCRIPTION
Switches to using `open311_pre_send` for the Hounslow enquiries inbox, in order to ensure any Confirm unavailability doesn't stop new report emails being delivered.

[skip changelog]

Fixes https://github.com/mysociety/fixmystreet-freshdesk/issues/84