### PR TITLE
[IsleOfWight] swap to use OSM geocoder

### DIFF
--- a/perllib/FixMyStreet/Cobrand/IsleOfWight.pm
+++ b/perllib/FixMyStreet/Cobrand/IsleOfWight.pm
@@ -45,7 +45,7 @@ sub updates_disallowed {
     return 1;
 }
 
-# sub get_geocoder { 'OSM' }
+sub get_geocoder { 'OSM' }
 
 sub open311_pre_send {
     my ($self, $row, $open311) = @_;


### PR DESCRIPTION
This gives much better results for e.g Hight Street and also handle Rd
versus Road better.

Please check the following:
[skip changelog]