### PR TITLE
[Westminster] Add roadworks.org layer

### DIFF
--- a/templates/web/westminster/footer_extra_js.html
+++ b/templates/web/westminster/footer_extra_js.html
@@ -3,6 +3,8 @@ IF bodyclass.match('mappage');
     scripts.push(
         version('/vendor/OpenLayers.Projection.OrdnanceSurvey.js'),
         version('/cobrands/fixmystreet/assets.js'),
+        version('/cobrands/fixmystreet-uk-councils/roadworks.js'),
+        version('/cobrands/westminster/roadworks.js'),
         version('/cobrands/westminster/assets.js'),
     );
 END

--- a/web/cobrands/westminster/roadworks.js
+++ b/web/cobrands/westminster/roadworks.js
@@ -1,0 +1,18 @@
+(function(){
+
+if (!fixmystreet.maps) {
+    return;
+}
+
+var org_id = '1160';
+var body = "Westminster City Council";
+fixmystreet.assets.add(fixmystreet.roadworks.layer_future, {
+    http_options: { params: { organisation_id: org_id } },
+    body: body
+});
+fixmystreet.assets.add(fixmystreet.roadworks.layer_planned, {
+    http_options: { params: { organisation_id: org_id } },
+    body: body
+});
+
+})();

--- a/web/cobrands/westminster/roadworks.js
+++ b/web/cobrands/westminster/roadworks.js
@@ -15,4 +15,18 @@ fixmystreet.assets.add(fixmystreet.roadworks.layer_planned, {
     body: body
 });
 
+// Westminster want to also display the responsible party in roadworks messages
+var original_display_message = fixmystreet.roadworks.display_message;
+fixmystreet.roadworks.display_message = function(feature) {
+    var retval = original_display_message.apply(this, arguments);
+
+    if (feature.attributes.promoter) {
+        var $dl = $(".js-roadworks-message-" + feature.layer.id + " dl");
+        $dl.append("<dt>Responsibility</dt>");
+        $dl.append($("<dd></dd>").text(feature.attributes.promoter));
+    }
+
+    return retval;
+};
+
 })();


### PR DESCRIPTION
Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;

[skip changelog]

![image](https://user-images.githubusercontent.com/5426/65048123-27843700-d953-11e9-8993-7a48a25d581f.png)

Fixes: mysociety/fixmystreet-commercial#1566
