### PR TITLE
strip quote from contact group names

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -771,6 +771,8 @@ sub setup_categories_and_bodies : Private {
         my %category_groups = ();
         for my $category (@category_options) {
             my $group = $category->{group} // $category->get_extra_metadata('group') // [''];
+            # multiple groups from open311 can contain " which upsets the html so strip them
+            $group =~ s/^"|"$//g;
             # this could be an array ref or a string
             my @groups = ref $group eq 'ARRAY' ? @$group : ($group);
             push( @{$category_groups{$_}}, $category ) for @groups;


### PR DESCRIPTION
When an open311 category has multiple groups it puts them in the groups
element using CSV escaping. This means that group names can sometimes
feature double quotes. If we send these to the front end then putting
them into the optgroup name attribute breaks the HTML as if the group
name is in the database as `"group name"` you end up with

    <optgroup name="" group="" name="">

instead of

    <optgroup name="group name">

Hence, stripping the double quotes.

[skip changelog]