### PR TITLE
[Open311] Spot new <groups> parameter rather than use CSV.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
         - unset external_status_code if blank in update
         - Add support for account_id parameter to POST Service Request calls.
         - Do not overwrite/remove protected meta data. #2598
+        - Spot multiple groups inside a <groups> element.
 
 * v2.6 (3rd May 2019)
     - New features:

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -771,8 +771,6 @@ sub setup_categories_and_bodies : Private {
         my %category_groups = ();
         for my $category (@category_options) {
             my $group = $category->{group} // $category->get_extra_metadata('group') // [''];
-            # multiple groups from open311 can contain " which upsets the html so strip them
-            $group =~ s/^"|"$//g;
             # this could be an array ref or a string
             my @groups = ref $group eq 'ARRAY' ? @$group : ($group);
             push( @{$category_groups{$_}}, $category ) for @groups;

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -1112,18 +1112,6 @@ sub enable_category_groups {
     return $self->feature('category_groups');
 }
 
-=item enable_multiple_category_groups
-
-Whether a category can be included in multiple groups. Required enable_category_groups
-to alse be true.
-
-=cut
-
-sub enable_multiple_category_groups {
-    my $self = shift;
-    return $self->enable_category_groups && $self->feature('multiple_category_groups');
-}
-
 sub default_problem_state { 'unconfirmed' }
 
 sub state_groups_admin {

--- a/perllib/Open311.pm
+++ b/perllib/Open311.pm
@@ -614,6 +614,7 @@ sub _get_xml_object {
         service_requests => 'request',
         errors => 'error',
         service_request_updates => 'request_update',
+        groups => 'group',
     };
     my $simple = XML::Simple->new(
         ForceArray => [ values %$group_tags ],

--- a/templates/web/base/admin/bodies/contact-form.html
+++ b/templates/web/base/admin/bodies/contact-form.html
@@ -132,21 +132,17 @@ as well.") %]
     <p>
       <label>
         [% loc('Group') %]
-        [% IF body.get_cobrand_handler.enable_multiple_category_groups %]
-            [% IF contact.extra.group %]
-                [% FOR group IN contact.extra.group %]
-                <input class="form-control" type="text" name="group" value="[% group | html %]" size="30">
-                [% END %]
-            [% ELSE %]
-                <input class="form-control" type="text" name="group" value="" size="30">
+        [% IF contact.extra.group %]
+            [% FOR group IN contact.extra.group %]
+            <input class="form-control" type="text" name="group" value="[% group | html %]" size="30">
             [% END %]
-            <input class="hidden-js js-group-item-template form-control" type="text" name="group" value="" size="30">
-            <p class="hidden-nojs">
-              <button type="button" class="btn btn--small js-group-item-add">[% loc('Add group') %]</button>
-            </p>
         [% ELSE %]
-            <input class="form-control" type="text" name="group" value="[% contact.extra.group.join(',') | html %]" size="30">
+            <input class="form-control" type="text" name="group" value="" size="30">
         [% END %]
+        <input class="hidden-js js-group-item-template form-control" type="text" name="group" value="" size="30">
+        <p class="hidden-nojs">
+          <button type="button" class="btn btn--small js-group-item-add">[% loc('Add group') %]</button>
+        </p>
       </label>
     </p>
   [% END %]


### PR DESCRIPTION
Companion to https://github.com/mysociety/open311-adapter/pull/59 to read in `groups` when given, rather than parse a single entry as CSV (which doesn't then need to be used anywhere, I think).
This means we can drop all the enable multiple groups stuff to deal with comma edge cases, and let anyone have multiple groups if they should want to without worrying about it.