### PR TITLE
Restore single-line layout for admin index search inputs

### DIFF
--- a/templates/web/base/admin/index.html
+++ b/templates/web/base/admin/index.html
@@ -20,18 +20,22 @@ and to receive notices of updates.
   </p>
 [% END %]
 
-<div class="admin-index-search form-txt-submit-box clearfix">
+<div class="admin-index-search clearfix">
 
 <form method="get" action="[% c.uri_for('reports') %]" accept-charset="utf-8">
-    <p><label for="search_reports">[% loc('Search Reports') %]</label>
+    <label for="search_reports">[% loc('Search Reports') %]</label>
+    <div class="form-txt-submit-box">
         <input type="text" class="form-control" name="search"  size="30" id="search_reports" value="[% searched | html %]">
         <input type="submit" class="btn" value="[% loc('Go') %]">
+    </div>
 </form>
 
 <form method="get" action="[% c.uri_for('users') %]" accept-charset="utf-8">
-    <p><label for="search_users">[% loc('Search Users') %]</label>
+    <label for="search_users">[% loc('Search Users') %]</label>
+    <div class="form-txt-submit-box">
         <input type="text" class="form-control" name="search"  size="30" id="search_users" value="[% searched | html %]">
         <input type="submit" class="btn" value="[% loc('Go') %]">
+    </div>
 </form>
 
 [% IF c.user.is_superuser %]

--- a/templates/web/base/admin/index.html
+++ b/templates/web/base/admin/index.html
@@ -39,19 +39,21 @@ and to receive notices of updates.
 </form>
 
 [% IF c.user.is_superuser %]
-  <form method="get" action="[% c.uri_for('bodies') %]">
-  <label for="search_body">[% loc('Edit body details') %]</label>
-  <select class="form-control" id="search_body" name="body">
-  [% FOREACH body IN bodies %]
-    [%- SET id = body.id %]
-      <option[% IF body.deleted %] class="adminhidden"[% END %] value="[% body.id %]">
-          [% body.name | html %]
-          [%- IF body.parent %], [% body.parent.name | html %][% END -%]
-      </option>
-  [% END %]
-  </select>
-  <input type="submit" class="btn" value="[% loc('Go') %]">
-  </form>
+<form method="get" action="[% c.uri_for('bodies') %]">
+    <label for="search_body">[% loc('Edit body details') %]</label>
+    <div class="form-txt-submit-box">
+        <select class="form-control" id="search_body" name="body">
+          [% FOREACH body IN bodies %]
+            [%- SET id = body.id %]
+            <option[% IF body.deleted %] class="adminhidden"[% END %] value="[% body.id %]">
+            [% body.name | html %]
+            [%- IF body.parent %], [% body.parent.name | html %][% END -%]
+            </option>
+          [% END %]
+        </select>
+        <input type="submit" class="btn" value="[% loc('Go') %]">
+    </div>
+</form>
 [% END %]
 
 </div>

--- a/web/cobrands/sass/_admin.scss
+++ b/web/cobrands/sass/_admin.scss
@@ -167,12 +167,9 @@ $button_bg_col: #a1a1a1;  // also search bar (tables)
 
 .admin-index-search {
     width: 27em;
-    form {
-        clear: #{$left};
-    }
+
     select {
-        max-width: 65%;
-        float: #{$left};
+        width: 15em;
     }
 }
 

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -495,7 +495,8 @@ small#or:after {
   input[type=tel],
   input[type=number],
   input[type=text],
-  input[type=email] {
+  input[type=email],
+  select {
     width: auto;
     max-width: none;
     @include flex(72 0 auto);


### PR DESCRIPTION
Fixes a bug that was introduced by 6ac0633d87da551f25c3d7d4cf2c902acf2a9e51, I think.

![Screen Shot 2019-09-23 at 11 56 01](https://user-images.githubusercontent.com/739624/65420517-42462800-ddf9-11e9-9441-e6b8c452c2b4.png)

[skip changelog] because this is just fixing a bug in a feature that’s still in the "unreleased" section.