### PR TITLE
[Hounslow] Use Confirm validation rules for reports

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Hounslow.pm
+++ b/perllib/FixMyStreet/Cobrand/Hounslow.pm
@@ -4,6 +4,9 @@ use parent 'FixMyStreet::Cobrand::Whitelabel';
 use strict;
 use warnings;
 
+use Moo;
+with 'FixMyStreet::Roles::ConfirmValidation';
+
 sub council_area_id { 2483 }
 sub council_area { 'Hounslow' }
 sub council_name { 'Hounslow Highways' }

--- a/templates/web/hounslow/footer_extra_js.html
+++ b/templates/web/hounslow/footer_extra_js.html
@@ -1,3 +1,6 @@
+[% scripts.push(
+    version('/cobrands/fixmystreet-uk-councils/council_validation_rules.js'),
+) %]
 [%
 IF bodyclass.match('mappage');
   scripts.push(

--- a/web/cobrands/fixmystreet-uk-councils/council_validation_rules.js
+++ b/web/cobrands/fixmystreet-uk-councils/council_validation_rules.js
@@ -13,23 +13,20 @@ confirm_validation_rules = {
 };
 
 body_validation_rules = {
-    'Buckinghamshire County Council': confirm_validation_rules,
-    'Lincolnshire County Council': confirm_validation_rules,
     'Bath and North East Somerset Council': confirm_validation_rules,
-    'Rutland County Council': {
-        title: {
-          required: true,
-          maxlength: 254
-        },
-        name: {
-          required: true,
-          maxlength: 40
-        }
-    },
     'Bromley Council': {
         detail: {
           required: true,
           maxlength: 1750
+        }
+    },
+    'Buckinghamshire County Council': confirm_validation_rules,
+    'Hounslow Borough Council': confirm_validation_rules,
+    'Lincolnshire County Council': confirm_validation_rules,
+    'Northamptonshire County Council': {
+        title: {
+          required: true,
+          maxlength: 120
         }
     },
     'Oxfordshire County Council': {
@@ -48,10 +45,14 @@ body_validation_rules = {
           maxlength: 50
         }
     },
-    'Northamptonshire County Council': {
+    'Rutland County Council': {
         title: {
           required: true,
-          maxlength: 120
+          maxlength: 254
+        },
+        name: {
+          required: true,
+          maxlength: 40
         }
     }
 };


### PR DESCRIPTION
This was missed from the initial cobrand.

[skip changelog]