### PR TITLE
[IsleOfWight] script to add emergency categories

### DIFF
--- a/bin/fixmystreet.com/island_roads_setup_messages
+++ b/bin/fixmystreet.com/island_roads_setup_messages
@@ -1,0 +1,73 @@
+#!/usr/bin/env perl
+#
+# One off script to transfer the hardcoded JS messages to the database
+
+use strict;
+use warnings;
+use v5.14;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use FixMyStreet::DB;
+
+use Getopt::Long;
+
+my $commit;
+GetOptions(
+    'commit' => \$commit,
+);
+
+if (!$commit) {
+    say "*** DRY RUN ***";
+}
+
+my $urgent = {
+    order => 0,
+    required => 'true',
+    protected => 'true',
+    code => 'urgent',
+    description => 'To ensure your report is dealt with effectively, please tell us the severity of the issue:-',
+    datatype_description => 'You have indicated that the issue requires an urgent response, please phone Island Roads on 01983 822440 so that we can respond to the issue appropriately.',
+    datatype => 'singlevaluelist',
+    variable => 'true',
+    values => [
+        {
+            key => 'urgent',
+            name => 'The issue requires an urgent response/action',
+            disable => 1,
+        },
+        {
+            key => 'not_urgent',
+            name => 'The issue requires a routine/non-urgent response/action',
+        }
+    ],
+};
+
+my $iow = FixMyStreet::DB->resultset("Body")->find({ name => 'Isle of Wight Council' });
+if ($iow) {
+    my @iow_contacts = $iow->contacts->search({ send_method => 'Triage' })->all;
+    foreach my $category (@iow_contacts) {
+        my $extra_fields = $category->get_extra_fields;
+        my $found = 0;
+        foreach (@$extra_fields) {
+            next unless $_->{code} eq 'urgent';
+            $_ = $urgent;
+            $found = 1;
+        }
+        if (!$found) {
+            push @$extra_fields, $urgent;
+        }
+        $category->set_extra_fields(@$extra_fields);
+        say "Making emergency message disable form on " . $category->category . ", Isle of Wight";
+        if ($commit) {
+            $category->update;
+        }
+    }
+} else {
+    say STDERR "Could not find IoW";
+}


### PR DESCRIPTION
One off script that adds an question to each Triage category to ask if
the problem is urgent or not. Sets urgent answer to block form
submission.
[skip changelog]