### PR TITLE
Per-test file email addresses.

### DIFF
--- a/t/Mock/OpenIDConnect.pm
+++ b/t/Mock/OpenIDConnect.pm
@@ -55,7 +55,7 @@ sub dispatch_request {
             extension_CrmContactId => "1c304134-ef12-c128-9212-123908123901",
             nonce => 'MyAwesomeRandomValue',
         };
-        $payload->{emails} = ['oidc@example.org'] if $self->returns_email;
+        $payload->{emails} = ['pkg-tappcontrollerauth_social.t-oidc@example.org'] if $self->returns_email;
         my $signature = "dummy";
         my $id_token = join(".", (
             encode_base64($self->json->encode($header), ''),

--- a/t/app/controller/admin/update_edit.t
+++ b/t/app/controller/admin/update_edit.t
@@ -83,7 +83,7 @@ for my $test (
             state => 'confirmed',
             name => '',
             anonymous => 1,
-            username => 'test@example.com',
+            username => $update->user->email,
         },
         changes => {
             text => 'this is a changed update',
@@ -98,7 +98,7 @@ for my $test (
             state => 'confirmed',
             name => '',
             anonymous => 1,
-            username => 'test@example.com',
+            username => $update->user->email,
         },
         changes => {
             name => 'A User',
@@ -113,7 +113,7 @@ for my $test (
             state => 'confirmed',
             name => 'A User',
             anonymous => 1,
-            username => 'test@example.com',
+            username => $update->user->email,
         },
         changes => {
             anonymous => 0,
@@ -128,10 +128,10 @@ for my $test (
             state => 'confirmed',
             name => 'A User',
             anonymous => 0,
-            username => 'test@example.com',
+            username => $update->user->email,
         },
         changes => {
-            username => 'test2@example.com',
+            username => $user2->email,
         },
         log_count => 4,
         log_entries => [qw/edit edit edit edit/],
@@ -144,7 +144,7 @@ for my $test (
             state => 'confirmed',
             name => 'A User',
             anonymous => 0,
-            username => 'test2@example.com',
+            username => $user2->email,
         },
         changes => {
             state => 'unconfirmed',
@@ -159,7 +159,7 @@ for my $test (
             state => 'unconfirmed',
             name => 'A User',
             anonymous => 0,
-            username => 'test2@example.com',
+            username => $user2->email,
         },
         changes => {
             text => 'this is a twice changed update',

--- a/t/app/controller/admin/users.t
+++ b/t/app/controller/admin/users.t
@@ -264,7 +264,7 @@ FixMyStreet::override_config {
             desc => 'edit user name',
             fields => {
                 name => '',
-                email => 'test@example.com',
+                email => $user->email,
                 email_verified => 1,
                 body => $haringey->id,
                 phone => '',
@@ -285,7 +285,7 @@ FixMyStreet::override_config {
             desc => 'edit user email',
             fields => {
                 name => 'Changed User',
-                email => 'test@example.com',
+                email => $user->email,
                 email_verified => 1,
                 body => $haringey->id,
                 phone => '',
@@ -464,7 +464,7 @@ FixMyStreet::override_config {
         $mech->create_problems_for_body(2, 2514, 'Title', { user => $existing_user });
         my $count = FixMyStreet::DB->resultset('Problem')->search({ user_id => $user->id })->count;
         $mech->get_ok( '/admin/users/' . $user->id );
-        $mech->submit_form_ok( { with_fields => { email => 'existing@example.com' } }, 'submit email change' );
+        $mech->submit_form_ok( { with_fields => { email => $existing_user->email } }, 'submit email change' );
         is $mech->uri->path, '/admin/users/' . $existing_user->id, 'redirected';
         my $p = FixMyStreet::DB->resultset('Problem')->search({ user_id => $existing_user->id })->count;
         is $p, $count + 2, 'reports merged';
@@ -518,7 +518,7 @@ subtest "Send login email from admin for unverified email" => sub {
 
     is $email->header('Subject'), "Your FixMyStreet account details",
       "subject is correct";
-    is $email->header('To'), 'test@example.com', "to is correct";
+    is $email->header('To'), $user->email, "to is correct";
 
     my $link = $mech->get_link_from_email($email);
 

--- a/t/app/controller/alert_new.t
+++ b/t/app/controller/alert_new.t
@@ -4,56 +4,56 @@ use FixMyStreet::Script::Alerts;
 
 my $mech = FixMyStreet::TestMech->new;
 
-$mech->log_in_ok('test@example.com');
+my $user = $mech->log_in_ok('test@example.com');
 $mech->get_ok('/alert/subscribe?id=1');
 my ($csrf) = $mech->content =~ /name="token" value="([^"]*)"/;
 
 foreach my $test (
     {
-        email      => 'test@example.com',
+        email      => $user->email,
         type       => 'area_problems',
         content    => 'Click the link in our confirmation email to activate your alert',
         email_text => "confirms that you'd like to receive an email",
         uri =>
-'/alert/subscribe?type=local&rznvy=test@example.com&feed=area:1000:A_Location',
+'/alert/subscribe?type=local&rznvy=' . $user->email . '&feed=area:1000:A_Location',
         param1 => 1000
     },
     {
-        email      => 'test@example.com',
+        email      => $user->email,
         type       => 'council_problems',
         content    => 'Click the link in our confirmation email to activate your alert',
         email_text => "confirms that you'd like to receive an email",
         uri =>
-'/alert/subscribe?type=local&rznvy=test@example.com&feed=council:1000:A_Location',
+'/alert/subscribe?type=local&rznvy=' . $user->email . '&feed=council:1000:A_Location',
         param1 => 1000,
         param2 => 1000,
     },
     {
-        email      => 'test@example.com',
+        email      => $user->email,
         type       => 'ward_problems',
         content    => 'Click the link in our confirmation email to activate your alert',
         email_text => "confirms that you'd like to receive an email",
         uri =>
-'/alert/subscribe?type=local&rznvy=test@example.com&feed=ward:1000:1001:A_Location:Diff_Location',
+'/alert/subscribe?type=local&rznvy=' . $user->email . '&feed=ward:1000:1001:A_Location:Diff_Location',
         param1 => 1000,
         param2 => 1001,
     },
     {
-        email      => 'test@example.com',
+        email      => $user->email,
         type       => 'local_problems',
         content    => 'Click the link in our confirmation email to activate your alert',
         email_text => "confirms that you'd like to receive an email",
         uri =>
-'/alert/subscribe?type=local&rznvy=test@example.com&feed=local:10.2:20.1',
+'/alert/subscribe?type=local&rznvy=' . $user->email . '&feed=local:10.2:20.1',
         param1 => 20.1,
         param2 => 10.2,
     },
     {
-        email      => 'test@example.com',
+        email      => $user->email,
         type       => 'new_updates',
         content    => 'Click the link in our confirmation email to activate your alert',
         email_text => "confirms that you'd like to receive an email",
-        uri    => '/alert/subscribe?type=updates&rznvy=test@example.com&id=1',
+        uri    => '/alert/subscribe?type=updates&rznvy=' . $user->email . '&id=1',
         param1 => 1,
     }
   )
@@ -163,7 +163,7 @@ foreach my $test (
         # clear existing data so we can be sure we're creating it
         ok $alert->delete() if $alert && !$test->{exist};
 
-        $mech->get_ok( '/alert/subscribe?type=local&rznvy=test-new@example.com&feed=area:1000:A_Location&token=' . $csrf );
+        $mech->get_ok( '/alert/subscribe?type=local&rznvy=' . $user->email . '&feed=area:1000:A_Location&token=' . $csrf );
 
         $alert = FixMyStreet::App->model('DB::Alert')->find(
             {
@@ -232,11 +232,11 @@ foreach my $test (
 
 for my $test (
     {
-        email      => 'test@example.com',
+        email      => $user->email,
         type       => 'new_updates',
         content    => 'Click the link in our confirmation email to activate your alert',
         email_text => 'confirm the alert',
-        uri    => '/alert/subscribe?type=updates&rznvy=test@example.com&id=1',
+        uri    => '/alert/subscribe?type=updates&rznvy=' . $user->email . '&id=1',
         param1 => 1,
     }
   )

--- a/t/app/controller/auth_profile.t
+++ b/t/app/controller/auth_profile.t
@@ -428,10 +428,9 @@ subtest "Test generate token page" => sub {
 };
 
 subtest "Test two-factor authentication admin" => sub {
-    my $user = FixMyStreet::App->model('DB::User')->find( { email => $test_email } );
+    my $user = $mech->log_in_ok($test_email);
     ok $user->update({ is_superuser => 1 }), 'user set to superuser';
 
-    $mech->log_in_ok($test_email);
     $mech->get_ok('/auth/generate_token');
     ok !$user->get_extra_metadata('2fa_secret');
 

--- a/t/app/controller/contact.t
+++ b/t/app/controller/contact.t
@@ -382,6 +382,7 @@ for my $test (
 
         $mech->clear_emails_ok;
         $mech->get_ok('/contact');
+        $test->{fields}{em} = $user->email;
         $mech->submit_form_ok( { with_fields => $test->{fields} } );
 
         my $email = $mech->get_email;

--- a/t/app/controller/contact_enquiry.t
+++ b/t/app/controller/contact_enquiry.t
@@ -95,10 +95,10 @@ FixMyStreet::override_config {
 
     subtest 'Enquiry can be submitted when logged in' => sub {
         my $problems = FixMyStreet::App->model('DB::Problem')->to_body( $body->id );
-        my $user = $problems->first->user;
+        my $prob_user = $problems->first->user;
         $problems->delete_all;
 
-        $mech->log_in_ok( $user->email );
+        my $user = $mech->log_in_ok( $prob_user->email );
 
         $mech->get_ok( '/contact/enquiry' );
         $mech->submit_form_ok( {
@@ -123,7 +123,7 @@ FixMyStreet::override_config {
         ok $problem->confirmed, 'problem confirmed';
         is $problem->name, 'Test User', 'Report created with correct name';
         is $problem->user->name, 'Test User', 'User name updated in DB';
-        is $problem->user->email, 'testuser@example.org', 'Report user has correct email';
+        is $problem->user->email, $user->email, 'Report user has correct email';
 
         $mech->log_out_ok;
     };
@@ -139,7 +139,7 @@ FixMyStreet::override_config {
         $mech->submit_form_ok( {
             with_fields => {
                 name => 'Simon Neil',
-                username => 'testuser@example.org',
+                username => $user->email,
                 category => 'General Enquiry',
                 detail => 'This is a general enquiry',
             }
@@ -158,7 +158,7 @@ FixMyStreet::override_config {
         is $problem->longitude, -0.35, 'Problem has correct longitude';
         ok $problem->confirmed, 'problem confirmed';
         is $problem->name, 'Simon Neil', 'Report created with correct name';
-        is $problem->user->email, 'testuser@example.org', 'Report user has correct email';
+        is $problem->user->email, $user->email, 'Report user has correct email';
         $user->discard_changes;
         is $user->name, 'Test User', 'User name in DB not changed';
 

--- a/t/app/controller/moderate.t
+++ b/t/app/controller/moderate.t
@@ -204,7 +204,7 @@ subtest 'Problem moderation' => sub {
         is $report->state, 'hidden', 'Is hidden';
 
         my $email = $mech->get_email;
-        is $email->header('To'), '"Test User 2" <test-moderation2@example.com>', 'Sent to correct email';
+        is $email->header('To'), '"Test User 2" <' . $user2->email . '>', 'Sent to correct email';
         my $url = $mech->get_link_from_email($email);
         ok $url, "extracted complain url '$url'";
 

--- a/t/app/controller/report_as_other.t
+++ b/t/app/controller/report_as_other.t
@@ -106,7 +106,7 @@ subtest "Body user, has permission to add report as another (existing) user with
     FixMyStreet::Script::Reports::send();
     $mech->clear_emails_ok;
 
-    $mech->create_user_ok('existing@example.net', name => 'Existing User');
+    my $existing = $mech->create_user_ok('existing@example.net', name => 'Existing User');
     my $report = add_report(
         'contribute_as_another_user',
         form_as => 'another_user',
@@ -114,11 +114,11 @@ subtest "Body user, has permission to add report as another (existing) user with
         detail => 'Test report details.',
         category => 'Potholes',
         name => 'Existing Yooser',
-        username => 'existing@example.net',
+        username => $existing->email,
     );
     is $report->name, 'Existing Yooser', 'report name is given name';
     is $report->user->name, 'Existing User', 'user name remains same';
-    is $report->user->email, 'existing@example.net', 'user email correct';
+    is $report->user->email, $existing->email, 'user email correct';
     isnt $report->user->id, $user->id, 'user does not match';
     like $mech->get_text_body_from_email, qr/Your report to Oxfordshire County Council has been logged/;
     push @users, $report->user;
@@ -244,16 +244,17 @@ subtest "Body user, has permission to add update as another user with landline p
 };
 
 subtest "Body user, has permission to add update as another (existing) user with email" => sub {
+    my $existing = $mech->create_user_ok('existing@example.net', name => 'Existing User');
     my $update = add_update(
         'contribute_as_another_user',
         form_as => 'another_user',
         update => 'Test Update',
         name => 'Existing Yooser',
-        username => 'existing@example.net',
+        username => $existing->email,
     );
     is $update->name, 'Existing Yooser', 'update name is given name';
     is $update->user->name, 'Existing User', 'user name remains same';
-    is $update->user->email, 'existing@example.net', 'user email correct';
+    is $update->user->email, $existing->email, 'user email correct';
     isnt $update->user->id, $user->id, 'user does not match';
     like $mech->get_text_body_from_email, qr/Your update has been logged/;
 };

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -963,7 +963,7 @@ foreach my $test (
                     title         => 'Test Report',
                     detail        => 'Test report details.',
                     photo1        => '',
-                    username      => $test_email,
+                    username      => $user->email,
                     password_sign_in => 'secret2',
                     category      => 'Street lighting',
                 }
@@ -1347,7 +1347,7 @@ subtest "test report creation for a category that is non public" => sub {
                     title         => 'Test Report',
                     detail        => 'Test report details.',
                     photo1        => '',
-                    username      => 'test-2@example.com',
+                    username      => $user->email,
                     name          => 'Joe Bloggs',
                     category      => 'Street lighting',
                 }
@@ -1801,7 +1801,7 @@ subtest "test Hart" => sub {
 
             # check that the user has been created/ not changed
             $user =
-              FixMyStreet::App->model('DB::User')->find( { email => $test_email } );
+              FixMyStreet::App->model('DB::User')->find( { email => $user ? $user->email : $test_email } );
             ok $user, "user found";
 
             # find the report

--- a/t/app/controller/report_new_mobile.t
+++ b/t/app/controller/report_new_mobile.t
@@ -15,21 +15,20 @@ subtest "Check signed up for alert when logged in" => sub {
         MAPIT_URL => 'http://mapit.zurich',
         MAPIT_TYPES => [ 'O08' ],
     }, sub {
-        $mech->log_in_ok('user@example.org');
+        my $user = $mech->log_in_ok('user@example.org');
         $mech->post_ok( '/report/new/mobile', {
             service => 'iPhone',
             title => 'Title',
             detail => 'Problem detail',
             lat => 47.381817,
             lon => 8.529156,
-            email => 'user@example.org',
+            email => $user->email,
             pc => '',
             name => 'Name',
         });
         my $res = $mech->response;
         ok $res->header('Content-Type') =~ m{^application/json\b}, 'response should be json';
 
-        my $user = FixMyStreet::DB->resultset('User')->search({ email => 'user@example.org' })->first;
         my $a = FixMyStreet::DB->resultset('Alert')->search({ user_id => $user->id })->first;
         isnt $a, undef, 'User is signed up for alert';
     };

--- a/t/app/controller/report_updates.t
+++ b/t/app/controller/report_updates.t
@@ -1247,6 +1247,7 @@ for my $test (
     subtest $test->{desc} => sub {
         # Set things up
         my $user = $mech->create_user_ok( $test->{form_values}->{username} );
+        $test->{form_values}{username} = $user->email;
         my $pw = 'secret2';
         $user->update( { name => 'Mr Reg', password => $pw } );
         $report->comments->delete;
@@ -1303,7 +1304,7 @@ subtest 'submit an update for a registered user, creating update by email' => su
     $mech->submit_form_ok( {
         with_fields => {
             submit_update => 1,
-            username => 'registered@example.com',
+            username => $user->email,
             update        => 'Update from a user',
             add_alert     => undef,
             name          => 'New Name',
@@ -1338,7 +1339,7 @@ subtest 'submit an update for a registered user, creating update by email' => su
 
     ok $update, 'found update in database';
     is $update->state, 'unconfirmed', 'update unconfirmed';
-    is $update->user->email, 'registered@example.com', 'update email';
+    is $update->user->email, $user->email, 'update email';
     is $update->text, 'Update from a user', 'update text';
 
     $mech->get_ok( $url );
@@ -1505,7 +1506,7 @@ for my $test (
 
         $mech->clear_emails_ok();
 
-        $mech->log_in_ok( $test->{email} );
+        my $user = $mech->log_in_ok( $test->{email} );
         $mech->get_ok("/report/$report_id");
 
         my $values = $mech->visible_form_values( 'updateForm' );
@@ -1548,7 +1549,7 @@ for my $test (
         };
 
         is $update->text, $results->{update}, 'update text';
-        is $update->user->email, $test->{email}, 'update user';
+        is $update->user->email, $user->email, 'update user';
         is $update->state, 'confirmed', 'update confirmed';
         is $update->anonymous, $test->{anonymous}, 'user anonymous';
 
@@ -1678,7 +1679,7 @@ foreach my $test (
 
         $mech->clear_emails_ok();
 
-        $mech->log_in_ok( $test->{email} );
+        my $user = $mech->log_in_ok( $test->{email} );
         $mech->get_ok("/report/$report_id");
 
         my $values = $mech->visible_form_values('updateForm');
@@ -1708,7 +1709,7 @@ foreach my $test (
         my $update = $report->comments->first;
         ok $update, 'found update';
         is $update->text, $results->{update}, 'update text';
-        is $update->user->email, $test->{email}, 'update user';
+        is $update->user->email, $user->email, 'update user';
         is $update->state, 'confirmed', 'update confirmed';
         is $update->anonymous, $test->{anonymous}, 'user anonymous';
 
@@ -1752,7 +1753,7 @@ for my $test (
         fields => {
             submit_update => 1,
             name          => 'Test User',
-            username => 'test@example.com',
+            username => $report->user->email,
             may_show_name => 1,
             update        => 'update from owner',
             add_alert     => undef,
@@ -1774,7 +1775,7 @@ for my $test (
             submit_update => 1,
             name          => 'Test User',
             may_show_name => 1,
-            username => 'test@example.com',
+            username => $report->user->email,
             update        => 'update from owner',
             add_alert     => undef,
             fixed         => 1,

--- a/t/app/model/session.t
+++ b/t/app/model/session.t
@@ -2,13 +2,13 @@ use FixMyStreet::TestMech;
 
 my $mech = FixMyStreet::TestMech->new;
 
-$mech->log_in_ok('test@example.com');
+my $user = $mech->log_in_ok('test@example.com');
 
 my $session = FixMyStreet::DB->resultset("Session")->first;
 
 my $id = $session->id;
 $id =~ s/\s+$//;
 is $id, "session:" . $session->id_code;
-is $session->user->email, 'test@example.com';
+is $session->user->email, $user->email;
 
 done_testing;

--- a/t/app/model/user.t
+++ b/t/app/model/user.t
@@ -67,7 +67,7 @@ FixMyStreet::override_config {
 };
 
 subtest 'Check non-existent methods on user object die' => sub {
-    my $c = ctx_request(POST '/auth', { username => 'test@example.com', password_sign_in => 'secret' });
+    my $c = ctx_request(POST '/auth', { username => $problem->user->email, password_sign_in => 'secret' });
     throws_ok(
         sub { $c->user->is_super_user },
         qr/Can't locate object method 'is_super_user'/,

--- a/t/cobrand/bathnes.t
+++ b/t/cobrand/bathnes.t
@@ -156,28 +156,28 @@ subtest 'extra CSV columns are present if permission granted' => sub {
 
     is $rows[1]->[18], 'iOS', 'Site Used shows whether report made via app';
     is $rows[1]->[19], '', 'Reported As is empty if not made on behalf of another user/body';
-    is $rows[1]->[20], 'normaluser@example.com', 'User email is correct';
+    is $rows[1]->[20], $normaluser->email, 'User email is correct';
     is $rows[1]->[21], '+447123456789', 'User phone number is correct';
     is $rows[1]->[22], '', 'Staff User is empty if not made on behalf of another user';
     is $rows[1]->[23], 'width = 10cm; depth = 25cm', 'Attribute Data is correct';
 
     is $rows[2]->[18], 'bathnes', 'Site Used shows correct cobrand';
     is $rows[2]->[19], 'body', 'Reported As is correct if made on behalf of body';
-    is $rows[2]->[20], 'counciluser@example.com', 'User email is correct';
+    is $rows[2]->[20], $counciluser->email, 'User email is correct';
     is $rows[2]->[21], '', 'User phone number is correct';
     is $rows[2]->[22], '', 'Staff User is empty if not made on behalf of another user';
     is $rows[2]->[23], '', 'Attribute Data is correct';
 
     is $rows[3]->[18], 'bathnes', 'Site Used shows correct cobrand';
     is $rows[3]->[19], 'another_user', 'Reported As is set if reported on behalf of another user';
-    is $rows[3]->[20], 'normaluser@example.com', 'User email is correct';
+    is $rows[3]->[20], $normaluser->email, 'User email is correct';
     is $rows[3]->[21], '+447123456789', 'User phone number is correct';
-    is $rows[3]->[22], 'counciluser@example.com', 'Staff User is correct if made on behalf of another user';
+    is $rows[3]->[22], $counciluser->email, 'Staff User is correct if made on behalf of another user';
     is $rows[3]->[23], '', 'Attribute Data is correct';
 
     is $rows[4]->[18], 'bathnes', 'Site Used shows correct cobrand';
     is $rows[4]->[19], 'anonymous_user', 'Reported As is set if reported on behalf of another user';
-    is $rows[4]->[20], 'counciluser@example.com', 'User email is correct';
+    is $rows[4]->[20], $counciluser->email, 'User email is correct';
     is $rows[4]->[21], '', 'User phone number is correct';
     is $rows[4]->[22], '', 'Staff User is empty if not made on behalf of another user';
     is $rows[4]->[23], '', 'Attribute Data is correct';

--- a/t/script/inactive.t
+++ b/t/script/inactive.t
@@ -5,12 +5,12 @@ use_ok 'FixMyStreet::Script::Inactive';
 my $in = FixMyStreet::Script::Inactive->new( anonymize => 6, email => 3 );
 my $mech = FixMyStreet::TestMech->new;
 
-my $user = FixMyStreet::DB->resultset("User")->find_or_create({ email => 'test@example.com' });
+my $user = $mech->create_user_ok('test@example.com');
 my $t = DateTime->new(year => 2016, month => 1, day => 1, hour => 12);
 $user->last_active($t);
 $user->update;
 
-my $user_inactive = FixMyStreet::DB->resultset("User")->find_or_create({ email => 'inactive@example.com' });
+my $user_inactive = $mech->create_user_ok('inactive@example.com');
 $t = DateTime->now->subtract(months => 4);
 $user_inactive->last_active($t);
 $user_inactive->update;


### PR DESCRIPTION
We are getting occasional (though seems to be increasing) deadlocks in the test suite on Travis, always in the admin/bodies.t or permissions.t files, whereby the creation of a superuser account is deadlocked against another test process somehow. I have tried but cannot see any place where a deadlock could occur - all user creation happens in the same order in all the test files - but it is definitely happening. Rather than try and get the output of the server query log and find out what the other statement is, it seemed easier to change our test user creation functions to create per-test-file email addresses. I thought this might also speed up the test suite as no test file will block waiting for the same email address to become available when another test file using it finishes, but it doesn't appear to have done - I don't know if I've missed something or whether the test suite is fast enough that blocking on that didn't make much of a difference overall.

[skip changelog]
