### PR TITLE
[IsleOfWight] ignore description on fetched reports

### DIFF
--- a/perllib/FixMyStreet/Cobrand/IsleOfWight.pm
+++ b/perllib/FixMyStreet/Cobrand/IsleOfWight.pm
@@ -73,6 +73,9 @@ sub open311_config {
     $row->set_extra_fields(@$extra);
 }
 
+# Make sure fetched report description isn't shown.
+sub filter_report_description { "" }
+
 sub open311_munge_update_params {
     my ($self, $params, $comment, $body) = @_;
 


### PR DESCRIPTION
Use a generic report description for fetched reports rather than the one
fetched over open311

[skip changelog]