### PR TITLE
[IsleOfWight] do not send comment recording triage action

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Triage.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Triage.pm
@@ -141,7 +141,8 @@ sub update : Private {
             anonymous => 0,
             state => 'confirmed',
             problem_state => $problem->state,
-            extra => $extra
+            extra => $extra,
+            whensent => \'current_timestamp',
         } );
 
         my @alerts = FixMyStreet::DB->resultset('Alert')->search( {

--- a/t/app/controller/admin/triage.t
+++ b/t/app/controller/admin/triage.t
@@ -40,8 +40,6 @@ my ($report) = $mech->create_problems_for_body(
     }
 );
 
-warn $report->bodies_str;
-
 FixMyStreet::override_config {
     STAGING_FLAGS => { send_reports => 1, skip_checks => 0 },
     ALLOWED_COBRANDS => [ 'isleofwight' ],
@@ -110,6 +108,7 @@ FixMyStreet::override_config {
         is $extra->{triage_report}, 1, 'comment indicates it is for triage in extra';
         is $extra->{holding_category}, 'Potholes', 'comment extra has previous category';
         is $extra->{new_category}, 'Traffic lights', 'comment extra has new category';
+        ok $comment->whensent, 'comment is marked as sent';
 
         $mech->get_ok($report_url);
         $mech->content_contains('Report triaged from Potholes to Traffic lights');


### PR DESCRIPTION
This is only used for audit purposes on FixMyStreet and not required in
Confirm.

[ship changelog]