### PR TITLE
Stop empty Open311 group causing duplicate history

### DIFF
--- a/perllib/FixMyStreet/DB/Result/Contact.pm
+++ b/perllib/FixMyStreet/DB/Result/Contact.pm
@@ -98,6 +98,13 @@ sub category_display {
     $self->translate_column('category');
 }
 
+sub groups {
+    my $self = shift;
+    my $groups = $self->get_extra_metadata('group') || [];
+    $groups = [ $groups ] unless ref $groups eq 'ARRAY';
+    return $groups;
+}
+
 sub get_all_metadata {
     my $self = shift;
     my @metadata = @{$self->get_extra_fields};


### PR DESCRIPTION
It arises that `<group></group>` now passes to the code as a one-element
list containing undef, which compared differently to what was stored -
the code assumed lists would contain things. A new changelog entry was
created each time. Hopefully resolve this once and for all by treating
groups more formally and making sure we always have lists to compare.
[skip changelog]