### PR TITLE
Fix missing body message flash, and only call gaze once

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -234,7 +234,7 @@ sub check_and_stash_category : Private {
     my @list_of_names = map { $_->name } values %bodies;
     my $csv = Text::CSV->new();
     $csv->combine(@list_of_names);
-    $c->stash->{bodies} = \@bodies;
+    $c->stash->{around_bodies} = \@bodies;
     $c->{stash}->{list_of_names_as_string} = $csv->string;
 
     my $where  = { body_id => [ keys %bodies ], };

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -102,19 +102,18 @@ sub report_new : Path : Args(0) {
     $c->stash->{template} = "report/new/fill_in_details.html";
     $c->forward('setup_categories_and_bodies');
     $c->forward('setup_report_extra_fields');
-    $c->forward('generate_map');
     $c->forward('check_for_category');
     $c->forward('setup_report_extras');
 
     # deal with the user and report and check both are happy
 
-    return unless $c->forward('check_form_submitted');
+    $c->detach('generate_map') unless $c->forward('check_form_submitted');
 
     $c->forward('/auth/check_csrf_token');
     $c->forward('process_report');
     $c->forward('process_user');
     $c->forward('/photo/process_photo');
-    return unless $c->forward('check_for_errors');
+    $c->detach('generate_map') unless $c->forward('check_for_errors');
     $c->forward('save_user_and_report');
     $c->forward('redirect_or_confirm_creation');
 }

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -42,7 +42,7 @@ sub munge_around_category_where {
     my ($self, $where) = @_;
 
     my $user = $self->{c}->user;
-    my @iow = grep { $_->name eq 'Isle of Wight Council' } @{ $self->{c}->stash->{bodies} };
+    my @iow = grep { $_->name eq 'Isle of Wight Council' } @{ $self->{c}->stash->{around_bodies} };
     return unless @iow;
 
     # display all the categories on Isle of Wight at the moment as there's no way to

--- a/t/app/controller/around.t
+++ b/t/app/controller/around.t
@@ -137,6 +137,18 @@ subtest 'check non public reports are not displayed on around page' => sub {
         'problem marked non public is not visible' );
 };
 
+subtest 'check missing body message not shown when it does not need to be' => sub {
+    $mech->get_ok('/');
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'fixmystreet',
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $mech->submit_form_ok( { with_fields => { pc => 'EH1 1BB' } },
+            "good location" );
+    };
+    $mech->content_lacks('yet have details for the other councils that cover this location');
+};
+
 for my $permission ( qw/ report_inspect report_mark_private/ ) {
     subtest 'check non public reports are displayed on around page with $permission permission' => sub {
         my $body = FixMyStreet::DB->resultset('Body')->find( $body_edin_id );


### PR DESCRIPTION
Two unrelated commits, one to fix a bug where it flashes a message it doesn't need to, the second to not bother generating map data if we're not going to be displaying a map.
[skip changelog]

