### PR TITLE
[Westminster] Hide fixmystreet.com updates on Westminster cobrand

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Contact.pm
+++ b/perllib/FixMyStreet/App/Controller/Contact.pm
@@ -93,11 +93,11 @@ sub determine_contact_type : Private {
     } elsif ($id) {
         $c->forward( '/report/load_problem_or_display_error', [ $id ] );
         if ($update_id) {
-            my $update = $c->model('DB::Comment')->search(
+            my $update = $c->cobrand->updates->search(
                 {
-                    id => $update_id,
+                    "me.id" => $update_id,
                     problem_id => $id,
-                    state => 'confirmed',
+                    "me.state" => 'confirmed',
                 }
             )->first;
 

--- a/perllib/FixMyStreet/App/Controller/Photo.pm
+++ b/perllib/FixMyStreet/App/Controller/Photo.pm
@@ -52,7 +52,7 @@ sub index :LocalRegex('^(c/)?([1-9]\d*)(?:\.(\d+))?(?:\.(full|tn|fp))?\.(?:jpeg|
 
     my $item;
     if ( $is_update ) {
-        ($item) = $c->model('DB::Comment')->search( {
+        ($item) = $c->cobrand->updates->search( {
             'me.id' => $id,
             'me.state' => 'confirmed',
             'problem.state' => [ FixMyStreet::DB::Result::Problem->visible_states() ],

--- a/perllib/FixMyStreet/App/Controller/Questionnaire.pm
+++ b/perllib/FixMyStreet/App/Controller/Questionnaire.pm
@@ -290,9 +290,9 @@ sub display : Private {
 
     my $problem = $c->stash->{questionnaire}->problem;
 
-    $c->stash->{updates} = [ $c->model('DB::Comment')->search(
-        { problem_id => $problem->id, state => 'confirmed' },
-        { order_by => 'confirmed' }
+    $c->stash->{updates} = [ $c->cobrand->updates->search(
+        { problem_id => $problem->id, "me.state" => 'confirmed' },
+        { order_by => 'me.confirmed' }
     )->all ];
 
     $c->stash->{page} = 'questionnaire';

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -183,9 +183,9 @@ sub load_problem_or_display_error : Private {
 sub load_updates : Private {
     my ( $self, $c ) = @_;
 
-    my $updates = $c->model('DB::Comment')->search(
-        { problem_id => $c->stash->{problem}->id, state => 'confirmed' },
-        { order_by => [ 'confirmed', 'id' ] }
+    my $updates = $c->cobrand->updates->search(
+        { problem_id => $c->stash->{problem}->id, "me.state" => 'confirmed' },
+        { order_by => [ 'me.confirmed', 'me.id' ] }
     );
 
     my $questionnaires_still_open = $c->model('DB::Questionnaire')->search(

--- a/perllib/FixMyStreet/Cobrand/Westminster.pm
+++ b/perllib/FixMyStreet/Cobrand/Westminster.pm
@@ -153,4 +153,13 @@ sub categories_restriction {
         }, { join => 'body' });
 }
 
+sub updates_restriction {
+    my $self = shift;
+
+    # Westminster don't want any fms.com updates shown on their cobrand.
+    return $self->next::method(@_)->search({
+        "me.cobrand" => { '!=', 'fixmystreet' }
+    });
+}
+
 1;


### PR DESCRIPTION
Ensures that comments left on Westminster reports on fixmystreet.com don't show up on the Westminster cobrand.

[skip changelog]

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1509