### PR TITLE
[fixmystreet.com] Make summary dashboard easier to access if logged in

### DIFF
--- a/templates/web/fixmystreet.com/reports/cobrand_stats.html
+++ b/templates/web/fixmystreet.com/reports/cobrand_stats.html
@@ -1,6 +1,6 @@
 [% UNLESS c.req.params.show_wards %]
 <div class="full-width area-reports-dashboard-cta">
     <strong>New for council staff</strong>
-    <p>Don’t miss our stats dashboard, only available to council staff. Access detailed reports and statistics — for free. <a href="/about/council-dashboard/">Log in here.</a></p>
+    <p>Don’t miss our stats dashboard, only available to council staff. Access detailed reports and statistics — for free. <a href="[% body_url %]/summary">Log in here.</a></p>
 </div>
 [% END %]


### PR DESCRIPTION
Trying to access the summary dashboard without permission already redirects the user to a login page, so this change makes it easier for logged-in council staff and super users to access the dashboard without having to see the login form.

[skip changelog]
