### PR TITLE
Subcategory asset pick

### DIFF
--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -187,7 +187,6 @@ OpenLayers.Layer.VectorNearest = OpenLayers.Class(OpenLayers.Layer.VectorAsset, 
     initialize: function(name, options) {
         OpenLayers.Layer.VectorAsset.prototype.initialize.apply(this, arguments);
         $(fixmystreet).on('maps:update_pin', this.checkFeature.bind(this));
-        $(fixmystreet).on('assets:selected', this.checkFeature.bind(this));
         // Update fields/etc from data now available from category change
         $(fixmystreet).on('report_new:category_change', this.changeCategory.bind(this));
     },
@@ -348,13 +347,6 @@ function asset_selected(e) {
     // Keep track of selection in case layer is reloaded or hidden etc.
     selected_feature = feature.clone();
 
-    // Pick up the USRN for the location of this asset. NB we do this *before*
-    // handling the attributes on the selected feature in case the feature has
-    // its own USRN which should take precedence.
-    $(fixmystreet).trigger('assets:selected', [ lonlat ]);
-
-    this.setAttributeFields(feature);
-
     // Hide the normal markers layer to keep things simple, but
     // move the green marker to the point of the click to stop
     // it jumping around unexpectedly if the user deselects the asset.
@@ -363,6 +355,10 @@ function asset_selected(e) {
 
     // Need to ensure the correct coords are used for the report
     fixmystreet.maps.update_pin(lonlat);
+
+    this.setAttributeFields(feature);
+
+    $(fixmystreet).trigger('assets:selected', [ lonlat ]);
 
     // Make sure the marker that was clicked is drawn on top of its neighbours
     layer.eraseFeatures([feature]);

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -22,6 +22,7 @@ OpenLayers.Layer.VectorAsset = OpenLayers.Class(OpenLayers.Layer.Vector, {
         // Update layer based upon new data from category change
         $(fixmystreet).on('assets:selected', this.checkSelected.bind(this));
         $(fixmystreet).on('assets:unselected', this.checkSelected.bind(this));
+        $(fixmystreet).on('report_new:category_change', this.changeCategory.bind(this));
         $(fixmystreet).on('report_new:category_change', this.update_layer_visibility.bind(this));
     },
 
@@ -101,6 +102,21 @@ OpenLayers.Layer.VectorAsset = OpenLayers.Class(OpenLayers.Layer.Vector, {
             var firstVisibleResolution = this.resolutions[0];
             var zoomLevel = fixmystreet.map.getZoomForResolution(firstVisibleResolution);
             fixmystreet.map.zoomTo(zoomLevel);
+        }
+    },
+
+    // It's possible an asset has been selected before a category (e.g. if
+    // assets are showing for a whole category group. So on category change,
+    // make sure we check if any attribute fields need setting/clearing.
+    changeCategory: function() {
+        if (!fixmystreet.map) {
+            return;
+        }
+        var feature = fixmystreet.assets.selectedFeature();
+        if (feature) {
+            this.setAttributeFields(feature);
+        } else {
+            this.clearAttributeFields();
         }
     },
 


### PR DESCRIPTION
This fixes a bug where if a category group is picked for which assets are shown (e.g. Drains on Westminster) then an asset selected/auto-selected, then a subcategory picked, the asset's ID is not written to the hidden field. This is because it is only being done on asset selection, at which point the hidden field does not exist.

Also remove a needless event listen where every asset selection would cause checkFeature to run twice. I think.

[skip changelog]