### PR TITLE
Improve fetch scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
         - Refactor Script::Report into an object.
         - Move summary failures to a separate script.
         - Add script to export/import body data.
+        - Add fetch script that does combined job of fetch-comments and fetch-reports.
     - UK:
         - Added junction lookup, so you can search for things like "M60, Junction 2"
 

--- a/bin/fetch
+++ b/bin/fetch
@@ -1,0 +1,58 @@
+#!/usr/bin/env perl
+#
+# This script utilises Open311 as described at
+# http://wiki.open311.org/GeoReport_v2/#get-service-requests
+# and/or the Open311 extension explained at
+# https://github.com/mysociety/FixMyStreet/wiki/Open311-FMS---Proposed-differences-to-Open311
+# to fetch service requests or updates on service requests.
+
+use strict;
+use warnings;
+use v5.14;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../setenv.pl";
+}
+
+use DateTime;
+use Getopt::Long::Descriptive;
+use Open311::GetServiceRequests;
+use Open311::GetServiceRequestUpdates;
+
+my ($opts, $usage) = describe_options(
+    '%c %o',
+    ['reports', 'fetch reports'],
+    ['updates', 'fetch updates'],
+    ['start|s:i', 'start time to use (hours before now), defaults to one (reports) or two (updates)' ],
+    ['end|e:i', 'end time to use (hours before now), defaults to zero' ],
+    ['body|b:s', 'body name to only fetch this body' ],
+    ['verbose|v', 'more verbose output'],
+    ['help|h', "print usage message and exit" ],
+);
+$usage->die if $opts->help;
+
+my %params = (
+    verbose => $opts->verbose,
+    body => $opts->body,
+);
+
+my $dt = DateTime->now();
+if ($opts->start) {
+    $params{start_date} = $dt->clone->add(hours => -$opts->start);
+}
+if ($opts->end) {
+    $params{end_date} = $dt->clone->add(hours => -$opts->end);
+}
+
+if ($opts->reports) {
+    my $reports = Open311::GetServiceRequests->new(%params);
+    $reports->fetch;
+}
+
+if ($opts->updates) {
+    my $updates = Open311::GetServiceRequestUpdates->new(%params);
+    $updates->fetch;
+}

--- a/bin/fetch-comments
+++ b/bin/fetch-comments
@@ -1,25 +1,6 @@
-#!/usr/bin/env perl
+#!/bin/bash
 #
-# This script utilises the Open311 extension explained at
-# https://github.com/mysociety/FixMyStreet/wiki/Open311-FMS---Proposed-differences-to-Open311
-# to fetch updates on service requests.
+# Wrapper to call new script
 
-use strict;
-use warnings;
-require 5.8.0;
-
-BEGIN {
-    use File::Basename qw(dirname);
-    use File::Spec;
-    my $d = dirname(File::Spec->rel2abs($0));
-    require "$d/../setenv.pl";
-}
-
-use CronFns;
-my ($verbose, $nomail) = CronFns::options();
-
-use Open311::GetServiceRequestUpdates;
-
-my $updates = Open311::GetServiceRequestUpdates->new( verbose => $verbose );
-
-$updates->fetch;
+DIR="$(cd "$(dirname "$BASH_SOURCE")" && pwd -P)"
+$DIR/fetch --updates

--- a/bin/fetch-comments-24hs
+++ b/bin/fetch-comments-24hs
@@ -1,37 +1,6 @@
-#!/usr/bin/env perl
+#!/bin/bash
 #
-# This script utilises the Open311 extension explained at
-# https://github.com/mysociety/FixMyStreet/wiki/Open311-FMS---Proposed-differences-to-Open311
-# to fetch updates on service requests from the past 24 hours, to check none
-# were missed.
+# Wrapper to call new script
 
-use strict;
-use warnings;
-require 5.8.0;
-
-BEGIN {
-    use File::Basename qw(dirname);
-    use File::Spec;
-    my $d = dirname(File::Spec->rel2abs($0));
-    require "$d/../setenv.pl";
-}
-
-use DateTime;
-use DateTime::Format::W3CDTF;
-
-use CronFns;
-my ($verbose, $nomail) = CronFns::options();
-
-use Open311::GetServiceRequestUpdates;
-
-my $dt = DateTime->now();
-my $dt_24hrs_ago = $dt->clone;
-$dt_24hrs_ago->add( hours => -24 );
-
-my $updates = Open311::GetServiceRequestUpdates->new(
-    verbose => 1,
-    start_date => DateTime::Format::W3CDTF->format_datetime( $dt_24hrs_ago ),
-    end_date => DateTime::Format::W3CDTF->format_datetime( $dt )
-);
-
-$updates->fetch;
+DIR="$(cd "$(dirname "$BASH_SOURCE")" && pwd -P)"
+$DIR/fetch --updates --start 24

--- a/bin/fetch-reports
+++ b/bin/fetch-reports
@@ -1,25 +1,6 @@
-#!/usr/bin/env perl
+#!/bin/bash
 #
-# This script utilises Open311 as described at
-# http://wiki.open311.org/GeoReport_v2/#get-service-requests
-# to fetch service requests.
+# Wrapper to call new script
 
-use strict;
-use warnings;
-require 5.8.0;
-
-BEGIN {
-    use File::Basename qw(dirname);
-    use File::Spec;
-    my $d = dirname(File::Spec->rel2abs($0));
-    require "$d/../setenv.pl";
-}
-
-use CronFns;
-my ($verbose, $nomail) = CronFns::options();
-
-use Open311::GetServiceRequests;
-
-my $reports = Open311::GetServiceRequests->new( verbose => $verbose );
-
-$reports->fetch;
+DIR="$(cd "$(dirname "$BASH_SOURCE")" && pwd -P)"
+$DIR/fetch --reports

--- a/bin/fetch-reports-24hs
+++ b/bin/fetch-reports-24hs
@@ -1,35 +1,6 @@
-#!/usr/bin/env perl
+#!/bin/bash
 #
-# This script utilises Open311 as described at
-# http://wiki.open311.org/GeoReport_v2/#get-service-requests
-# to fetch service requests.
+# Wrapper to call new script
 
-use strict;
-use warnings;
-require 5.8.0;
-
-BEGIN {
-    use File::Basename qw(dirname);
-    use File::Spec;
-    my $d = dirname(File::Spec->rel2abs($0));
-    require "$d/../setenv.pl";
-}
-
-use DateTime;
-
-use CronFns;
-my ($verbose, $nomail) = CronFns::options();
-
-use Open311::GetServiceRequests;
-
-my $dt = DateTime->now();
-my $dt_24hrs_ago = $dt->clone;
-$dt_24hrs_ago->add( hours => -24 );
-
-my $reports = Open311::GetServiceRequests->new(
-    verbose => 1,
-    start_date => $dt_24hrs_ago,
-    end_date => $dt
-);
-
-$reports->fetch;
+DIR="$(cd "$(dirname "$BASH_SOURCE")" && pwd -P)"
+$DIR/fetch --reports --start 24

--- a/bin/open311-update-reports
+++ b/bin/open311-update-reports
@@ -4,7 +4,7 @@
 # (by fetching all reports for a body and looking for updates). If possible,
 # please use the extension explained at
 # https://github.com/mysociety/FixMyStreet/wiki/Open311-FMS---Proposed-differences-to-Open311
-# and the fetch-comments/send-comments scripts.
+# and the fetch/send-comments scripts.
 
 use strict;
 use warnings;

--- a/conf/crontab-example
+++ b/conf/crontab-example
@@ -18,10 +18,10 @@ PATH=/usr/local/bin:/usr/bin:/bin
 22,52 * * * * "$FMS/commonlib/bin/run-with-lockfile.sh" -n "$LOCK_DIR/send-questionnaires.lock" "$FMS/bin/send-questionnaires" || echo "stalled?"
 
 # If you utilise Open311 and the updates extension, you will need to run these scripts.
-# We currently run fetch-comments-24hs once a night to catch anything missed.
+# We currently run fetch --updates with a 24hr timespan once a night to catch anything missed.
 #*/5 * * * * "$FMS/commonlib/bin/run-with-lockfile.sh" -n "$LOCK_DIR/send-comments.lock" "$FMS/bin/send-comments" || echo "stalled?"
-#5,10,15,20,25,30,35,40,45,50,55 * * * * "$FMS/commonlib/bin/run-with-lockfile.sh" -n "$LOCK_DIR/fetch-comments.lock" "$FMS/bin/fetch-comments" || echo "stalled?"
-#0 1 * * * "$FMS/commonlib/bin/run-with-lockfile.sh" -n "$LOCK_DIR/fetch-comments.lock" "$FMS/bin/fetch-comments-24hs" || echo "stalled?"
+#5,10,15,20,25,30,35,40,45,50,55 * * * * "$FMS/commonlib/bin/run-with-lockfile.sh" -n "$LOCK_DIR/fetch-updates.lock" "$FMS/bin/fetch --updates" || echo "stalled?"
+#0 1 * * * "$FMS/commonlib/bin/run-with-lockfile.sh" -n "$LOCK_DIR/fetch-updates.lock" "$FMS/bin/fetch --updates --start 24" || echo "stalled?"
 
 47 0-7,9-23 * * * "$FMS/commonlib/bin/run-with-lockfile.sh" -n "$LOCK_DIR/open311-populate-service-list.lock" "$FMS/bin/open311-populate-service-list" || echo "stalled?"
 47 8 * * * "$FMS/commonlib/bin/run-with-lockfile.sh" -n "$LOCK_DIR/open311-populate-service-list.lock" "$FMS/bin/open311-populate-service-list --warn" || echo "stalled?"

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -261,3 +261,6 @@ LOGIN_REQUIRED: 0
 # If you want to stop new users from registering, set this to 1.
 # NB: This also disables all Facebook/Twitter logins.
 SIGNUPS_DISABLED: 0
+
+# Setting this variable to more than 1 will let fetch-comments run in parallel
+FETCH_COMMENTS_PROCESSES: 0

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -262,5 +262,9 @@ LOGIN_REQUIRED: 0
 # NB: This also disables all Facebook/Twitter logins.
 SIGNUPS_DISABLED: 0
 
-# Setting this variable to more than 1 will let fetch-comments run in parallel
-FETCH_COMMENTS_PROCESSES: 0
+# Setting these variable to more than 1 will let fetch-comments run in parallel
+# with MIN to MAX children (new children will be added if a child takes longer
+# than TIMEOUT on one body).
+FETCH_COMMENTS_PROCESSES_MIN: 0
+FETCH_COMMENTS_PROCESSES_MAX: 0
+FETCH_COMMENTS_PROCESS_TIMEOUT: 0

--- a/cpanfile
+++ b/cpanfile
@@ -110,6 +110,7 @@ requires 'Net::OAuth';
 requires 'Net::Twitter::Lite::WithAPIv1_1', '0.12008';
 requires 'Number::Phone', '3.5000';
 requires 'OIDC::Lite';
+requires 'Parallel::ForkManager';
 requires 'Path::Class';
 requires 'POSIX';
 requires 'Readonly';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -6028,6 +6028,24 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.008001
+  Parallel-ForkManager-2.02
+    pathname: Y/YA/YANICK/Parallel-ForkManager-2.02.tar.gz
+    provides:
+      Parallel::ForkManager 2.02
+      Parallel::ForkManager::Child 2.02
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+      File::Path 0
+      File::Spec 0
+      File::Temp 0
+      Moo 0
+      Moo::Role 0
+      POSIX 0
+      Storable 0
+      perl 5.006
+      strict 0
+      warnings 0
   Params-Classify-0.015
     pathname: Z/ZE/ZEFRAM/Params-Classify-0.015.tar.gz
     provides:

--- a/perllib/FixMyStreet.pm
+++ b/perllib/FixMyStreet.pm
@@ -154,6 +154,7 @@ sub dbic_connect_info {
 
     my $dbi_args = {
         AutoCommit     => 1,
+        AutoInactiveDestroy => 1,
     };
     my $local_time_zone = local_time_zone();
     my $dbic_args = {

--- a/t/open311/getservicerequests.t
+++ b/t/open311/getservicerequests.t
@@ -211,48 +211,6 @@ my $date = DateTime->new(
 
 for my $test (
   {
-      start_date => '1',
-      end_date => '',
-      desc => 'do not process if only a start_date',
-      subs => {},
-  },
-  {
-      start_date => '',
-      end_date => '1',
-      desc => 'do not process if only an end_date',
-      subs => {},
-  },
-) {
-    subtest $test->{desc} => sub {
-        my $xml = prepare_xml( $test->{subs} );
-        my $o = Open311->new(
-            jurisdiction => 'mysociety',
-            endpoint => 'http://example.com',
-            test_mode => 1,
-            test_get_returns => { 'requests.xml' => $xml}
-        );
-
-        my $update = Open311::GetServiceRequests->new(
-            start_date => $test->{start_date},
-            end_date => $test->{end_date},
-            system_user => $user,
-        );
-        my $ret = $update->create_problems( $o, $body );
-
-        is $ret, 0, 'failed correctly'
-    };
-}
-
-$date = DateTime->new(
-    year => 2010,
-    month => 4,
-    day => 14,
-    hour => 6,
-    minute => 37
-);
-
-for my $test (
-  {
       start_date => $date->clone->add(hours => -2),
       end_date => $date->clone->add(hours => -1),
       desc => 'do not process if update time after end_date',

--- a/t/open311/getservicerequestupdates.t
+++ b/t/open311/getservicerequestupdates.t
@@ -683,29 +683,11 @@ subtest 'using start and end date' => sub {
     my $local_requests_xml = $requests_xml;
     my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $local_requests_xml } );
 
-    my $start_dt = DateTime->now();
+    my $start_dt = DateTime->now(formatter => DateTime::Format::W3CDTF->new);
+    my $end_dt = $start_dt->clone;
     $start_dt->subtract( days => 1 );
-    my $end_dt = DateTime->now();
 
     my $update = Open311::GetServiceRequestUpdates->new( 
-        system_user => $user,
-        start_date => $start_dt,
-        current_open311 => $o,
-    );
-
-    my $res = $update->process_body;
-    is $res, 0, 'returns 0 if start but no end date';
-
-    $update = Open311::GetServiceRequestUpdates->new( 
-        system_user => $user,
-        end_date => $end_dt,
-        current_open311 => $o,
-    );
-
-    $res = $update->process_body;
-    is $res, 0, 'returns 0 if end but no start date';
-
-    $update = Open311::GetServiceRequestUpdates->new( 
         system_user => $user,
         start_date => $start_dt,
         end_date => $end_dt,


### PR DESCRIPTION
This PR combines fetch-comments and fetch-reports into one fetch script, and allows command line selection of start/end times.

It also (March 2020) parallelizes the fetching of comments - first commit providing a config number of workers to run in parallel, the second making a min/max with a timeout so you can start with lower and add more if backends are slow.