### PR TITLE
[Bexley] Map NSG_REF as site_code for Confirm

### DIFF
--- a/.cypress/cypress/integration/buckinghamshire.js
+++ b/.cypress/cypress/integration/buckinghamshire.js
@@ -42,4 +42,13 @@ describe('flytipping', function() {
     cy.get('body').should('contain', 'Thank you for your report');
   });
 
+  it('sets the site_code correctly', function() {
+    cy.get('.olMapViewport #fms_pan_zoom_zoomin').click();
+    cy.wait('@roads-layer');
+    cy.get('#map_box').click(290, 307);
+    cy.wait('@report-ajax');
+    cy.get('select:eq(4)').select('Parks');
+    cy.get('[name=site_code]').should('have.value', '7300268');
+  });
+
 });

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -95,7 +95,7 @@ if ($opt->test_fixtures) {
     my $bodies;
     foreach (
         { area_id => 2234, categories => ['Fallen Tree', 'Very Urgent'], name => 'Northamptonshire County Council' },
-        { area_id => 2217, categories => ['Flytipping', 'Roads'], name => 'Buckinghamshire County Council' },
+        { area_id => 2217, categories => ['Flytipping', 'Roads', 'Parks'], name => 'Buckinghamshire County Council' },
         { area_id => 2257, categories => ['Flytipping', 'Graffiti'], name => 'Chiltern District Council' },
         { area_id => 2397, categories => [ 'Graffiti' ], name => 'Northampton Borough Council' },
         { area_id => 2483, categories => [ 'Potholes', 'Other' ], name => 'Hounslow Borough Council' },
@@ -135,6 +135,21 @@ if ($opt->test_fixtures) {
             { key => 'road', name => 'The road' },
             { key => 'off-road', name => 'Off the road/on a verge' },
         ],
+    });
+    $child_cat->update;
+
+    $child_cat = FixMyStreet::DB->resultset("Contact")->find({
+        body => $bodies->{2217},
+        category => 'Parks',
+    });
+    $child_cat->set_extra_fields({
+        code => 'site_code',
+        datatype => 'string',
+        description => 'site code',
+        order => 100,
+        required => 'false',
+        variable => 'true',
+        automated => 'hidden_field',
     });
     $child_cat->update;
 

--- a/web/cobrands/bexley/js.js
+++ b/web/cobrands/bexley/js.js
@@ -74,10 +74,16 @@ fixmystreet.assets.add(road_defaults, {
         }
     },
     nearest_radius: 100,
-    usrn: {
-        attribute: 'NSG_REF',
-        field: 'NSGRef'
-    }
+    usrn: [
+        {
+            attribute: 'NSG_REF',
+            field: 'NSGRef'
+        },
+        {
+            attribute: 'NSG_REF',
+            field: 'site_code'
+        }
+    ]
 });
 
 fixmystreet.assets.add(defaults, {

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -236,14 +236,18 @@ OpenLayers.Layer.VectorNearest = OpenLayers.Class(OpenLayers.Layer.VectorAsset, 
 
     updateUSRNField: function() {
         if (this.fixmystreet.usrn) {
-            var usrn_field = this.fixmystreet.usrn.field;
-            var selected_usrn;
-            if ( this.selected_feature ) {
-                selected_usrn = this.fixmystreet.getUSRN ?
-                    this.fixmystreet.getUSRN(this.selected_feature) :
-                    this.selected_feature.attributes[this.fixmystreet.usrn.attribute];
+            if (!this.fixmystreet.usrn.length) {
+                this.fixmystreet.usrn = [this.fixmystreet.usrn];
             }
-            $("input[name=" + usrn_field + "]").val(selected_usrn);
+            $.each(this.fixmystreet.usrn, function(i, usrn) {
+                var selected_usrn;
+                if ( this.selected_feature ) {
+                    selected_usrn = this.fixmystreet.getUSRN ?
+                    this.fixmystreet.getUSRN(this.selected_feature) :
+                    this.selected_feature.attributes[usrn.attribute];
+                }
+                $("input[name=" + usrn.field + "]").val(selected_usrn);
+            });
         }
     },
 


### PR DESCRIPTION
Bexley's Confirm server needs the `NSG_REF` attribute from the Streets layer to appear in the `site_code` field.

We already had a `usrn` configuration for Bexley's assets, so this change includes a modification to the code that handles the `usrn` mapping to allow it to accept an array of configuration objects as well as just a single object.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1638

<!-- [skip changelog] -->