### PR TITLE
[UK] Factor out Confirm open311_config to role.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/BathNES.pm
+++ b/perllib/FixMyStreet/Cobrand/BathNES.pm
@@ -35,7 +35,7 @@ sub contact_extra_fields_validation {
     return unless $contact->get_extra_metadata('display_name');
 
     my @contacts = $contact->body->contacts->not_deleted->search({ id => { '!=', $contact->id } });
-    my %display_names = map { $_->get_extra_metadata('display_name') => 1 } @contacts;
+    my %display_names = map { ($_->get_extra_metadata('display_name') || '') => 1 } @contacts;
     if ($display_names{$contact->get_extra_metadata('display_name')}) {
         $errors->{display_name} = 'That display name is already in use';
     }

--- a/perllib/FixMyStreet/Cobrand/BathNES.pm
+++ b/perllib/FixMyStreet/Cobrand/BathNES.pm
@@ -6,6 +6,7 @@ use warnings;
 
 use Moo;
 with 'FixMyStreet::Roles::ConfirmValidation';
+with 'FixMyStreet::Roles::ConfirmOpen311';
 
 use LWP::Simple;
 use URI;
@@ -97,33 +98,6 @@ sub category_extra_hidden {
     return $self->SUPER::category_extra_hidden($meta);
 }
 
-sub open311_config {
-    my ($self, $row, $h, $params) = @_;
-
-    my $extra = $row->get_extra_fields;
-    push @$extra,
-        { name => 'report_url',
-          value => $h->{url} },
-        { name => 'title',
-          value => $row->title },
-        { name => 'description',
-          value => $row->detail };
-
-    # Reports made via FMS.com or the app probably won't have a USRN
-    # value because we don't display the adopted highways layer on those
-    # frontends. Instead we'll look up the closest asset from the WFS
-    # service at the point we're sending the report over Open311.
-    if (!$row->get_extra_field_value('site_code')) {
-        if (my $usrn = $self->lookup_usrn($row)) {
-            push @$extra,
-                { name => 'site_code',
-                value => $usrn };
-        }
-    }
-
-    $row->set_extra_fields(@$extra);
-}
-
 sub available_permissions {
     my $self = shift;
 
@@ -137,7 +111,7 @@ sub available_permissions {
 
 sub report_sent_confirmation_email { 'id' }
 
-sub lookup_usrn {
+sub lookup_site_code {
     my $self = shift;
     my $row = shift;
 

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -5,6 +5,7 @@ use strict;
 use warnings;
 
 use Moo;
+with 'FixMyStreet::Roles::ConfirmOpen311';
 with 'FixMyStreet::Roles::ConfirmValidation';
 
 sub council_area_id { return 2217; }
@@ -41,33 +42,6 @@ sub admin_user_domain { 'buckscc.gov.uk' }
 
 sub send_questionnaires {
     return 0;
-}
-
-sub open311_config {
-    my ($self, $row, $h, $params) = @_;
-
-    my $extra = $row->get_extra_fields;
-    push @$extra,
-        { name => 'report_url',
-          value => $h->{url} },
-        { name => 'title',
-          value => $row->title },
-        { name => 'description',
-          value => $row->detail };
-
-    # Reports made via FMS.com or the app probably won't have a site code
-    # value because we don't display the adopted highways layer on those
-    # frontends. Instead we'll look up the closest asset from the WFS
-    # service at the point we're sending the report over Open311.
-    if (!$row->get_extra_field_value('site_code')) {
-        if (my $site_code = $self->lookup_site_code($row)) {
-            push @$extra,
-                { name => 'site_code',
-                value => $site_code };
-        }
-    }
-
-    $row->set_extra_fields(@$extra);
 }
 
 sub open311_pre_send {

--- a/perllib/FixMyStreet/Cobrand/Hounslow.pm
+++ b/perllib/FixMyStreet/Cobrand/Hounslow.pm
@@ -5,6 +5,7 @@ use strict;
 use warnings;
 
 use Moo;
+with 'FixMyStreet::Roles::ConfirmOpen311';
 with 'FixMyStreet::Roles::ConfirmValidation';
 
 sub council_area_id { 2483 }
@@ -89,35 +90,12 @@ sub open311_post_send {
     }
 }
 
-sub open311_config {
-    my ($self, $row, $h, $params) = @_;
+around 'open311_config' => sub {
+    my ($orig, $self, $row, $h, $params) = @_;
 
-    my $extra = $row->get_extra_fields;
-    push @$extra,
-        { name => 'report_url',
-          value => $h->{url} },
-        { name => 'title',
-          value => $row->title },
-        { name => 'description',
-          value => $row->detail };
-
-    # Reports made via FMS.com or the app probably won't have a site code
-    # value because we don't display the adopted highways layer on those
-    # frontends. Instead we'll look up the closest asset from the WFS
-    # service at the point we're sending the report over Open311.
-    if (!$row->get_extra_field_value('site_code')) {
-        if (my $site_code = $self->lookup_site_code($row)) {
-            push @$extra,
-                { name => 'site_code',
-                value => $site_code };
-        }
-    }
-
-    $row->set_extra_fields(@$extra);
-
-    $params->{multi_photos} = 1;
     $params->{upload_files} = 1;
-}
+    $self->$orig($row, $h, $params);
+};
 
 sub open311_munge_update_params {
     my ($self, $params, $comment, $body) = @_;

--- a/perllib/FixMyStreet/Cobrand/IsleOfWight.pm
+++ b/perllib/FixMyStreet/Cobrand/IsleOfWight.pm
@@ -4,6 +4,9 @@ use parent 'FixMyStreet::Cobrand::Whitelabel';
 use strict;
 use warnings;
 
+use Moo;
+with 'FixMyStreet::Roles::ConfirmOpen311';
+
 sub council_area_id { 2636 }
 sub council_area { 'Isle of Wight' }
 sub council_name { 'Island Roads' }
@@ -76,29 +79,6 @@ sub open311_pre_send {
         @$extra = grep { $_->{name} ne 'urgent' } @$extra;
         $row->set_extra_fields(@$extra);
     }
-}
-
-sub open311_config {
-    my ($self, $row, $h, $params) = @_;
-
-    my $extra = $row->get_extra_fields;
-    push @$extra,
-        { name => 'report_url',
-          value => $h->{url} },
-        { name => 'title',
-          value => $row->title },
-        { name => 'description',
-          value => $row->detail };
-
-    if (!$row->get_extra_field_value('site_code')) {
-        if (my $site_code = $self->lookup_site_code($row)) {
-            push @$extra,
-                { name => 'site_code',
-                value => $site_code };
-        }
-    }
-
-    $row->set_extra_fields(@$extra);
 }
 
 # Make sure fetched report description isn't shown.

--- a/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
@@ -10,6 +10,7 @@ use Try::Tiny;
 use JSON::MaybeXS;
 
 use Moo;
+with 'FixMyStreet::Roles::ConfirmOpen311';
 with 'FixMyStreet::Roles::ConfirmValidation';
 
 sub council_area_id { return 2232; }
@@ -40,33 +41,6 @@ sub disambiguate_location {
     };
 }
 
-
-sub open311_config {
-    my ($self, $row, $h, $params) = @_;
-
-    my $extra = $row->get_extra_fields;
-    push @$extra,
-        { name => 'report_url',
-          value => $h->{url} },
-        { name => 'title',
-          value => $row->title },
-        { name => 'description',
-          value => $row->detail };
-
-    # Reports made via FMS.com or the app probably won't have a site code
-    # value because we don't display the adopted highways layer on those
-    # frontends. Instead we'll look up the closest asset from the WFS
-    # service at the point we're sending the report over Open311.
-    if (!$row->get_extra_field_value('site_code')) {
-        if (my $site_code = $self->lookup_site_code($row)) {
-            push @$extra,
-                { name => 'site_code',
-                value => $site_code };
-        }
-    }
-
-    $row->set_extra_fields(@$extra);
-}
 
 sub lookup_site_code_config { {
     buffer => 200, # metres

--- a/perllib/FixMyStreet/Roles/ConfirmOpen311.pm
+++ b/perllib/FixMyStreet/Roles/ConfirmOpen311.pm
@@ -1,0 +1,39 @@
+package FixMyStreet::Roles::ConfirmOpen311;
+use Moo::Role;
+
+=head1 NAME
+
+FixMyStreet::Roles::ConfirmOpen311 - role for adding various Open311 things specific to Confirm
+
+=cut
+
+sub open311_config {
+    my ($self, $row, $h, $params) = @_;
+
+    $params->{multi_photos} = 1;
+
+    my $extra = $row->get_extra_fields;
+    push @$extra,
+        { name => 'report_url',
+          value => $h->{url} },
+        { name => 'title',
+          value => $row->title },
+        { name => 'description',
+          value => $row->detail };
+
+    # Reports made via FMS.com or the app probably won't have a USRN
+    # value because we don't display the adopted highways layer on those
+    # frontends. Instead we'll look up the closest asset from the WFS
+    # service at the point we're sending the report over Open311.
+    if (!$row->get_extra_field_value('site_code')) {
+        if (my $site_code = $self->lookup_site_code($row)) {
+            push @$extra,
+                { name => 'site_code',
+                value => $site_code };
+        }
+    }
+
+    $row->set_extra_fields(@$extra);
+}
+
+1;

--- a/perllib/FixMyStreet/Roles/ConfirmValidation.pm
+++ b/perllib/FixMyStreet/Roles/ConfirmValidation.pm
@@ -24,7 +24,7 @@ sub report_validation {
         $errors->{name} = sprintf( _('Names are limited to %d characters in length.'), 50 );
     }
 
-    if ( length( $report->user->phone ) > 20 ) {
+    if ( $report->user->phone && length( $report->user->phone ) > 20 ) {
         $errors->{phone} = sprintf( _('Phone numbers are limited to %s characters in length.'), 20 );
     }
 

--- a/t/app/controller/auth_profile.t
+++ b/t/app/controller/auth_profile.t
@@ -1,5 +1,9 @@
+use Test::MockModule;
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;
+
+my $resolver = Test::MockModule->new('Email::Valid');
+$resolver->mock('address', sub { $_[1] });
 
 use t::Mock::Twilio;
 
@@ -9,10 +13,6 @@ LWP::Protocol::PSGI->register($twilio->to_psgi_app, host => 'api.twilio.com');
 my $test_email    = 'test@example.com';
 my $test_email2   = 'test@example.net';
 my $test_password = 'foobar123';
-
-END {
-    done_testing();
-}
 
 # get a sign in email and change password
 subtest "Test change password page" => sub {
@@ -449,3 +449,5 @@ subtest "Test two-factor authentication admin" => sub {
     $mech->submit_form_ok({ button => 'toggle_2fa' }, "submit 2FA deactivation");
     $mech->content_contains('has been deactivated', "2FA deactivated");
 };
+
+done_testing();

--- a/t/cobrand/fixmystreet.t
+++ b/t/cobrand/fixmystreet.t
@@ -1,8 +1,12 @@
 use utf8;
 use FixMyStreet::Script::UpdateAllReports;
 
+use Test::MockModule;
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;
+
+my $resolver = Test::MockModule->new('Email::Valid');
+$resolver->mock('address', sub { $_[1] });
 
 my $body = $mech->create_body_ok( 2514, 'Birmingham' );
 

--- a/t/cobrand/westminster.t
+++ b/t/cobrand/westminster.t
@@ -79,7 +79,7 @@ FixMyStreet::override_config {
         $mech->content_contains($comment3->text);
     };
 
-    subtest 'Reports don’t show updates from fixmystreet.com cobrand' => sub {
+    subtest "Reports don't show updates from fixmystreet.com cobrand" => sub {
         $mech->get_ok('/report/' . $report->id);
         $mech->content_lacks($comment2->text);
     };


### PR DESCRIPTION
[skip changelog]
This can then be used by in-progress Peterborough, Cheshire East, Bexley, to automatically catch the three photos thing (Bexley might be trickier due to multi-integration but hey).