### PR TITLE
[Mobile] Make sure disable message findable by app

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1699,12 +1699,23 @@ sub generate_category_extra_json : Private {
     my $false = JSON->false;
 
     my @fields = map {
-        {
-            %$_,
-            required => ($_->{required} || '') eq "true" ? $true : $false,
-            variable => ($_->{variable} || '') eq "true" ? $true : $false,
-            order => int($_->{order} || 0),
+        my %data = %$_;
+
+        # Mobile app still looks in datatype_description
+        if (($_->{variable} || '') eq 'true' && @{$_->{values} || []}) {
+            foreach my $opt (@{$_->{values}}) {
+                if ($opt->{disable}) {
+                    my $message = $opt->{disable_message} || $_->{datatype_description};
+                    $data{datatype_description} = $message;
+                }
+            }
         }
+
+        # Remove unneeded
+        delete $data{$_} for qw(datatype protected variable order);
+
+        $data{required} = ($_->{required} || '') eq "true" ? $true : $false;
+        \%data;
     } @{ $c->stash->{category_extras}->{$c->stash->{category}} };
 
     return \@fields;


### PR DESCRIPTION
The mobile app is looking at the old extra.datatype_description location
rather than the new disable_form location for per-question disabling (it
does look there for all-category disabling). So we need to make sure the
JSON includes the message in the place where it will be looking.

Note if an extra data question has two answers that disable the form and
they have different messaging, the app will only take one of them.

[skip changelog] (new feature included there already)