### PR TITLE
Only add filter strategy if HTTP WFS being used.

### DIFF
--- a/web/cobrands/bristol/assets.js
+++ b/web/cobrands/bristol/assets.js
@@ -19,7 +19,7 @@ var options = {
     wfs_url: "https://maps.bristol.gov.uk/arcgis/services/ext/FixMyStreetSupportData/MapServer/WFSServer",
     wfs_feature: "COD_ASSETS_POINT",
     asset_id_field: 'COD_ASSET_ID',
-    propertyNames: [ 'COD_ASSET_ID', 'COD_USRN', 'COD_ASSET_TYPE', 'SHAPE' ],
+    propertyNames: [ 'COD_ASSET_ID', 'COD_USRN', 'SHAPE' ],
     filter_key: 'COD_ASSET_TYPE',
     attributes: {
         asset_id: 'COD_ASSET_ID',
@@ -50,7 +50,6 @@ fixmystreet.assets.add(options, {
 fixmystreet.assets.add(options, {
     asset_category: "Flooding",
     asset_item: 'flood risk structure',
-    filter_key: 'COD_ASSET_TYPE',
     filter_value: 'FRST'
 });
 

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -596,8 +596,8 @@ function construct_layer_options(options, protocol) {
     }
 
     if (options.filter_key) {
-        // Add this filter to the layer, so it can potentially be used
-        // in the request (though only Bristol currently does this).
+        // Add this filter to the layer, so it can potentially be
+        // used in the request if non-HTTP WFS
         if (OpenLayers.Util.isArray(options.filter_value)) {
             layer_options.filter = new OpenLayers.Filter.Logical({
                 type: OpenLayers.Filter.Logical.OR,
@@ -621,10 +621,11 @@ function construct_layer_options(options, protocol) {
                 value: options.filter_value
             });
         }
-        // Add a strategy filter to the layer, to filter the incoming results
-        // after they are received. Bristol does not need this, but has to ask
-        // for the filter data in its response so it doesn't then disappear.
-        layer_options.strategies.push(new OpenLayers.Strategy.Filter({filter: layer_options.filter}));
+        // If using HTTP WFS, add a strategy filter to the layer,
+        // to filter the incoming results after being received.
+        if (options.http_options) {
+            layer_options.strategies.push(new OpenLayers.Strategy.Filter({filter: layer_options.filter}));
+        }
     }
 
     return layer_options;

--- a/web/cobrands/lincolnshire/assets.js
+++ b/web/cobrands/lincolnshire/assets.js
@@ -5,15 +5,7 @@ if (!fixmystreet.maps) {
 }
 
 var defaults = {
-    http_options: {
-        url: "https://tilma.mysociety.org/mapserver/lincs",
-        params: {
-            SERVICE: "WFS",
-            VERSION: "1.1.0",
-            REQUEST: "GetFeature",
-            SRSNAME: "urn:ogc:def:crs:EPSG::3857"
-        }
-    },
+    wfs_url: "https://tilma.mysociety.org/mapserver/lincs",
     asset_type: 'spot',
     max_resolution: 2.388657133579254,
     min_resolution: 0.5971642833948135,
@@ -29,21 +21,13 @@ var defaults = {
 };
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "SL_Bollards"
-        }
-    },
+    wfs_feature: "SL_Bollards",
     asset_category: "Bollards (lit)",
     asset_item: 'bollard'
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "SL_Street_Light_Units"
-        }
-    },
+    wfs_feature: "SL_Street_Light_Units",
     asset_category: "Street light",
     asset_item: 'street light',
     filter_key: 'Type',
@@ -53,11 +37,7 @@ fixmystreet.assets.add(defaults, {
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "SL_Street_Light_Units"
-        }
-    },
+    wfs_feature: "SL_Street_Light_Units",
     asset_category: "Subway light",
     asset_item: 'light',
     filter_key: 'Type',
@@ -86,11 +66,7 @@ function get_barrier_stylemap() {
 }
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Safety_Barriers"
-        }
-    },
+    wfs_feature: "Safety_Barriers",
     asset_category: ["Roadside safety barrier", "Missing safety fence"],
     asset_item: 'barrier or fence',
     filter_key: 'Type',
@@ -100,21 +76,13 @@ fixmystreet.assets.add(defaults, {
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "LCC_Drainage-GulliesOffletsManholes"
-        }
-    },
+    wfs_feature: "LCC_Drainage-GulliesOffletsManholes",
     asset_category: "Blocked drain",
     asset_item: 'drain'
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "ST_All_Structures"
-        }
-    },
+    wfs_feature: "ST_All_Structures",
     asset_category: "Damaged dyke, ditch or culvert",
     asset_item: 'culvert',
     filter_key: 'Type',
@@ -124,21 +92,13 @@ fixmystreet.assets.add(defaults, {
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "SL_Lit_Signs"
-        }
-    },
+    wfs_feature: "SL_Lit_Signs",
     asset_category: "Sign (lit)",
     asset_item: 'street sign'
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "ST_All_Structures"
-        }
-    },
+    wfs_feature: "ST_All_Structures",
     asset_category: [
         "Bridge",
         "Bridge or Structure"
@@ -153,11 +113,7 @@ fixmystreet.assets.add(defaults, {
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Carriageway"
-        }
-    },
+    wfs_feature: "Carriageway",
     asset_category: [
         "Damaged/missing cats eye",
         "Damaged road edge, encroaches less than 100mm",
@@ -176,11 +132,7 @@ fixmystreet.assets.add(defaults, {
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "NSG"
-        }
-    },
+    wfs_feature: "NSG",
     always_visible: true,
     non_interactive: true,
     usrn: {
@@ -207,11 +159,7 @@ var llpg_stylemap = new OpenLayers.StyleMap({
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "LLPG"
-        }
-    },
+    wfs_feature: "LLPG",
     // LLPG is only to be shown when fully zoomed in
     max_resolution: 0.5971642833948135,
     stylemap: llpg_stylemap,


### PR DESCRIPTION
If GET-based WFS is being used, no server-side filtering takes place, so we need a client side filter to perform the same job. But if normal POST WFS is being used, the server-side filtering has already been performed, so no need to do it again (in fact, no need to return the data necessary to do such filtering either).

Making this change to save bandwidth on Bristol and Lincolnshire and Cheshire East in progress.
Corresponding PR at https://github.com/mysociety/fixmystreet.com/pull/6 to reduce Lincs output.
[skip changelog]