### PR TITLE
Some small rename-category fallout

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Triage.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Triage.pm
@@ -57,8 +57,7 @@ sub index : Path : Args(0) {
     my @categories = $c->stash->{body}->contacts->not_deleted->search( undef, {
         columns => [ 'id', 'category', 'extra' ],
         distinct => 1,
-        order_by => [ 'category' ],
-    } )->all;
+    } )->all_sorted;
     $c->stash->{filter_categories} = \@categories;
     $c->stash->{filter_category} = { map { $_ => 1 } $c->get_param_list('filter_category', 1) };
     my $pins = $c->stash->{pins} || [];

--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -248,10 +248,9 @@ sub check_and_stash_category : Private {
         $where,
         {
             columns => [ 'category', 'extra' ],
-            order_by => [ 'category' ],
             distinct => 1
         }
-    )->all;
+    )->all_sorted;
     $c->stash->{filter_categories} = \@categories;
     my %categories_mapped = map { $_->category => 1 } @categories;
 

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -285,7 +285,7 @@ sub by_category_ajax_data : Private {
 
     if ( $c->stash->{category_extras}->{$category} && @{ $c->stash->{category_extras}->{$category} } >= 1 ) {
         my $disable_form = $c->forward('disable_form_message');
-        $body->{disable_form} = $disable_form if $disable_form;
+        $body->{disable_form} = $disable_form if %$disable_form;
     }
 
     my $unresponsive = $c->stash->{unresponsive}->{$category};

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -7,7 +7,6 @@ BEGIN { extends 'Catalyst::Controller'; }
 use Encode;
 use List::MoreUtils qw(uniq);
 use List::Util 'first';
-use POSIX 'strcoll';
 use HTML::Entities;
 use Path::Class;
 use Utils;
@@ -677,7 +676,7 @@ sub setup_categories_and_bodies : Private {
       ->model('DB::Contact')    #
       ->active
       ->search( { 'me.body_id' => [ keys %bodies ] }, { prefetch => 'body' } );
-    my @contacts = $c->cobrand->categories_restriction($contacts)->all;
+    my @contacts = $c->cobrand->categories_restriction($contacts)->all_sorted;
 
     # variables to populate
     my %bodies_to_list = ();       # Bodies with categories assigned
@@ -702,9 +701,6 @@ sub setup_categories_and_bodies : Private {
         }
         $c->stash->{unresponsive}{$k} = { map { $_ => 1 } keys %bodies };
     }
-
-    # keysort does not appear to obey locale so use strcoll (see i18n.t)
-    @contacts = sort { strcoll( $a->category, $b->category ) } @contacts;
 
     my %seen;
     foreach my $contact (@contacts) {

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -187,8 +187,7 @@ sub setup_categories_and_map :Private {
     my @categories = $c->stash->{body}->contacts->not_deleted->search( undef, {
         columns => [ 'id', 'category', 'extra', 'body_id', 'send_method' ],
         distinct => 1,
-        order_by => [ 'category' ],
-    } )->all;
+    } )->all_sorted;
 
     $c->cobrand->call_hook('munge_reports_category_list', \@categories);
 

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -334,9 +334,8 @@ sub report_page_data {
 
     my @categories = $c->model('DB::Contact')->not_deleted->search(undef, {
         columns => [ 'category', 'extra' ],
-        order_by => [ 'category' ],
         distinct => 1
-    })->all;
+    })->all_sorted;
     $c->stash->{filter_categories} = \@categories;
     $c->stash->{filter_category} = { map { $_ => 1 } $c->get_param_list('filter_category', 1) };
 

--- a/perllib/FixMyStreet/DB/Result/Contact.pm
+++ b/perllib/FixMyStreet/DB/Result/Contact.pm
@@ -93,6 +93,21 @@ __PACKAGE__->many_to_many( response_templates => 'contact_response_templates', '
 __PACKAGE__->many_to_many( response_priorities => 'contact_response_priorities', 'response_priority' );
 __PACKAGE__->many_to_many( defect_types => 'contact_defect_types', 'defect_type' );
 
+__PACKAGE__->might_have(
+  "translations",
+  "FixMyStreet::DB::Result::Translation",
+  sub {
+    my $args = shift;
+    return {
+        "$args->{foreign_alias}.object_id" => { -ident => "$args->{self_alias}.id" },
+        "$args->{foreign_alias}.tbl" => { '=' => \"?" },
+        "$args->{foreign_alias}.col" => { '=' => \"?" },
+        "$args->{foreign_alias}.lang" => { '=' => \"?" },
+    };
+  },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
 sub category_display {
     my $self = shift;
     $self->get_extra_metadata('display_name') || $self->translate_column('category');

--- a/t/cobrand/bathnes.t
+++ b/t/cobrand/bathnes.t
@@ -72,8 +72,7 @@ subtest 'check override contact display name' => sub {
         'extra[display_name]' => 'Wittering'
     }});
     $mech->get_ok('/reports/Bath+and+North+East+Somerset');
-    $mech->content_contains('Wittering</option>');
-    $mech->content_contains('value="Litter"');
+    $mech->content_like(qr/Traffic lights<\/option>\s*<option value="Litter">\s*Wittering<\/option>/);
     $mech->content_lacks('Litter</option>');
 };
 

--- a/templates/web/base/report/new/category_extras.html
+++ b/templates/web/base/report/new/category_extras.html
@@ -10,7 +10,7 @@
   [%- IF category_extras.$category.size %]
     [% UNLESS category_extras_hidden.$category %]
       <div class="extra-category-questions">
-        <h2 class="form-section-heading">[% category %]</h2>
+        <h2 class="visuallyhidden form-section-heading">[% loc('Extra details') %]</h2>
         <p class="form-section-description">
           [% tprintf(
             loc('Help <strong>%s</strong> resolve your problem quicker, by providing some extra detail. This extra information will not be published online.'),


### PR DESCRIPTION
Remove the extra questions heading visually, it's duplicating what's just above (plus wasn't showing the display name); make sure categories sorted in display order; and save a bit of bandwidth on the disable form call. [skip changelog]
