### PR TITLE
[Peterborough] Disable questionnaires

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -13,6 +13,8 @@ sub council_area { 'Peterborough' }
 sub council_name { 'Peterborough City Council' }
 sub council_url { 'peterborough' }
 
+sub send_questionnaires { 0 }
+
 sub disambiguate_location {
     my $self    = shift;
     my $string  = shift;


### PR DESCRIPTION
As requested by @LouiseMySociety in Slack:

> …the Peterborough co-brand is still set to send questionnaires out. I think they wanted that disabling

<!-- [skip changelog] -->