### PR TITLE
[TfL] Add CSV export columns

### DIFF
--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -107,4 +107,37 @@ sub available_permissions {
     return $perms;
 }
 
+sub dashboard_export_problems_add_columns {
+    my $self = shift;
+    my $c = $self->{c};
+
+    $c->stash->{csv}->{headers} = [
+        map { $_ eq 'Ward' ? 'Borough' : $_ } @{ $c->stash->{csv}->{headers} },
+        "Agent responsible",
+        "Safety critical",
+    ];
+
+    $c->stash->{csv}->{columns} = [
+        @{ $c->stash->{csv}->{columns} },
+        "agent_responsible",
+        "safety_critical",
+    ];
+
+    $c->stash->{csv}->{extra_data} = sub {
+        my $report = shift;
+
+        my $agent = $report->shortlisted_user;
+
+        my $safety_critical = 0;
+        for (@{$report->get_extra_fields}) {
+            $safety_critical = 1, last if $_->{safety_critical};
+        }
+        return {
+            acknowledged => $report->whensent,
+            agent_responsible => $agent ? $agent->name : '',
+            safety_critical => $safety_critical ? 'Yes' : 'No',
+        };
+    };
+}
+
 1;

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -139,6 +139,24 @@ for my $test (
     };
 }
 
+subtest 'Dashboard extra columns' => sub {
+    subtest 'extra CSV column present' => sub {
+        $mech->log_in_ok( $staffuser->email );
+        $mech->get_ok('/dashboard?export=1');
+        $mech->content_contains('Query,Borough');
+        $mech->content_contains(',"Safety critical"');
+        $mech->content_contains('"BR1 3UH",Bromley,');
+        $mech->content_contains(',,,No');
+        my $report = FixMyStreet::DB->resultset("Problem")->find({ title => 'Test Report 1'});
+        $report->set_extra_fields({ name => 'severity', value => 'Yes', safety_critical => 1 });
+        $report->update;
+        $mech->get_ok('/dashboard?export=1');
+        $mech->content_contains('Query,Borough');
+        $mech->content_contains(',"Safety critical"');
+        $mech->content_contains(',,,Yes');
+    };
+};
+
 subtest 'check report age on /around' => sub {
     my $report = FixMyStreet::DB->resultset("Problem")->find({ title => 'Test Report 1'});
     $report->update({ state => 'confirmed' });


### PR DESCRIPTION
[skip changelog]

Borrowed the LBO commit from the current inspectors PR (with added mock), and includes stuff for safety critical that is only currently in tfl-cobrand, even though this is branched off tfl-reviewed, so should work fine if those are merged together.

Connects https://github.com/mysociety/fixmystreet-commercial/issues/1613