### PR TITLE
[TfL] Inspector form tweaks

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -375,10 +375,16 @@ sub inspect : Private {
     $c->forward('/admin/categories_for_point');
     $c->stash->{report_meta} = { map { 'x' . $_->{name} => $_ } @{ $c->stash->{problem}->get_extra_fields() } };
 
-    if ($c->cobrand->can('council_area_id')) {
-        my $priorities_by_category = FixMyStreet::App->model('DB::ResponsePriority')->by_categories($c->cobrand->council_area_id, @{$c->stash->{contacts}});
+    if ($c->cobrand->can('body')) {
+        my $priorities_by_category = FixMyStreet::App->model('DB::ResponsePriority')->by_categories(
+            $c->stash->{contacts},
+            body_ids => [ $c->cobrand->body->id ]
+        );
         $c->stash->{priorities_by_category} = $priorities_by_category;
-        my $templates_by_category = FixMyStreet::App->model('DB::ResponseTemplate')->by_categories($c->cobrand->council_area_id, @{$c->stash->{contacts}});
+        my $templates_by_category = FixMyStreet::App->model('DB::ResponseTemplate')->by_categories(
+            $c->stash->{contacts},
+            body_ids => [ $c->cobrand->body->id ]
+        );
         $c->stash->{templates_by_category} = $templates_by_category;
     }
 

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -94,4 +94,15 @@ sub fetch_area_children {
     return $areas;
 }
 
+sub available_permissions {
+    my $self = shift;
+
+    my $perms = $self->next::method();
+
+    delete $perms->{Problems}->{report_edit_priority};
+    delete $perms->{Bodies}->{responsepriority_edit};
+
+    return $perms;
+}
+
 1;

--- a/perllib/FixMyStreet/Roles/ContactExtra.pm
+++ b/perllib/FixMyStreet/Roles/ContactExtra.pm
@@ -25,8 +25,15 @@ sub for_bodies {
 }
 
 sub by_categories {
-    my ($rs, $area_id, @contacts) = @_;
-    my %body_ids = map { $_->body_id => 1 } FixMyStreet::DB->resultset('BodyArea')->search({ area_id => $area_id });
+    my ($rs, $contacts, %params) = @_;
+
+    my %body_ids = ();
+    if ( $params{body_id} ) {
+        %body_ids = ( $params{body_id} => 1 );
+    } else {
+        %body_ids = map { $_->body_id => 1 } FixMyStreet::DB->resultset('BodyArea')->search({ area_id => $params{area_id} });
+    }
+    my @contacts = @$contacts;
     my @body_ids = keys %body_ids;
     my %extras = ();
     my @results = $rs->for_bodies(\@body_ids, undef);

--- a/t/app/controller/admin/templates.t
+++ b/t/app/controller/admin/templates.t
@@ -10,6 +10,30 @@ my $oxfordshire = $mech->create_body_ok(2237, 'Oxfordshire County Council');
 my $oxfordshirecontact = $mech->create_contact_ok( body_id => $oxfordshire->id, category => 'Potholes', email => 'potholes@example.com' );
 my $oxfordshireuser = $mech->create_user_ok('counciluser@example.com', name => 'Council User', from_body => $oxfordshire);
 
+my $bromley = $mech->create_body_ok(2482, 'Bromley Borough Council');
+my $bromleycontact = $mech->create_contact_ok( body_id => $bromley->id, category => 'Potholes', email => 'potholes@example.com' );
+my $bromleyuser = $mech->create_user_ok('bromleyuser@example.com', name => 'Council User', from_body => $bromley);
+$bromleyuser->user_body_permissions->find_or_create({
+    body => $bromley,
+    permission_type => 'report_inspect',
+});
+my $bromleytemplate = $bromley->response_templates->create({
+    title => "Bromley-specific response template.",
+    text => "This template will only appear on the Bromley cobrand.",
+});
+
+my $tfl = $mech->create_body_ok(2482, 'TfL');
+my $tflcontact = $mech->create_contact_ok( body_id => $tfl->id, category => 'Potholes', email => 'potholes@example.com' );
+my $tfluser = $mech->create_user_ok('tfluser@example.com', name => 'Council User', from_body => $tfl);
+$tfluser->user_body_permissions->find_or_create({
+    body => $tfl,
+    permission_type => 'report_inspect',
+});
+my $tfltemplate = $tfl->response_templates->create({
+    title => "TfL-specific response template.",
+    text => "This template will only appear on the TfL cobrand.",
+});
+
 my $dt = DateTime->new(
     year   => 2011,
     month  => 04,
@@ -253,6 +277,46 @@ subtest "templates that set state and external_status_code can't be added" => su
     $mech->content_contains( 'State and external status code cannot be used simultaneously.' );
 
     is $oxfordshire->response_templates->count, 0, "Invalid response template wasn't added";
+};
+
+subtest "TfL cobrand only shows TfL templates" => sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'tfl' ],
+    }, sub {
+        $report->update({
+            category => $tflcontact->category,
+            bodies_str => $tfl->id,
+            latitude => 51.402096,
+            longitude => 0.015784,
+            state => 'confirmed',
+        });
+        $mech->log_in_ok( $tfluser->email );
+
+        $mech->get_ok("/report/" . $report->id);
+        $mech->content_contains( $tfltemplate->text );
+        $mech->content_contains( $tfltemplate->title );
+        $mech->content_lacks( $bromleytemplate->text );
+        $mech->content_lacks( $bromleytemplate->title );
+
+        $mech->log_out_ok;
+    };
+};
+
+subtest "Bromley cobrand only shows Bromley templates" => sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'bromley' ],
+    }, sub {
+        $report->update({ category => $bromleycontact->category, bodies_str => $bromley->id });
+        $mech->log_in_ok( $bromleyuser->email );
+
+        $mech->get_ok("/report/" . $report->id);
+        $mech->content_contains( $bromleytemplate->text );
+        $mech->content_contains( $bromleytemplate->title );
+        $mech->content_lacks( $tfltemplate->text );
+        $mech->content_lacks( $tfltemplate->title );
+
+        $mech->log_out_ok;
+    };
 };
 
 done_testing();

--- a/t/app/model/defecttype.t
+++ b/t/app/model/defecttype.t
@@ -67,7 +67,7 @@ subtest 'Problem->defect_types behaves correctly' => sub {
 
 subtest 'by_categories returns all defect types grouped by category' => sub {
     my @contacts = FixMyStreet::DB->resultset('Contact')->not_deleted->search( { body_id => [ $oxfordshire->id ] } )->all;
-    my $defect_types = FixMyStreet::App->model('DB::DefectType')->by_categories($area_id, @contacts);
+    my $defect_types = FixMyStreet::App->model('DB::DefectType')->by_categories(\@contacts, body_id => $oxfordshire->id);
     my $potholes = decode_json($defect_types->{Potholes});
     my $traffic_lights = decode_json($defect_types->{'Traffic lights'});
     my $pavements = decode_json($defect_types->{Pavements});
@@ -89,7 +89,7 @@ subtest 'by_categories returns defect types for an area with multiple bodies' =>
     );
 
     my @contacts = FixMyStreet::DB->resultset('Contact')->not_deleted->search( { body_id => [ $oxfordshire->id ] } )->all;
-    my $defect_types = FixMyStreet::App->model('DB::DefectType')->by_categories($area_id, @contacts);
+    my $defect_types = FixMyStreet::App->model('DB::DefectType')->by_categories(\@contacts, area_id => $area_id);
     my $potholes = decode_json($defect_types->{Potholes});
     my $traffic_lights = decode_json($defect_types->{'Traffic lights'});
     my $pavements = decode_json($defect_types->{Pavements});

--- a/t/app/model/responsepriority.t
+++ b/t/app/model/responsepriority.t
@@ -50,9 +50,9 @@ subtest 'for_bodies returns correct results' => sub {
     is $priorities->first->name, $general_response_priority->name, 'Correct priority is returned for Traffic lights category';
 };
 
-subtest 'by_categories returns allresponse priorities grouped by category' => sub {
+subtest 'by_categories returns all response priorities grouped by category' => sub {
     my @contacts = FixMyStreet::DB->resultset('Contact')->not_deleted->search( { body_id => [ $oxfordshire->id ] } )->all;
-    my $priorities = FixMyStreet::App->model('DB::ResponsePriority')->by_categories($area_id, @contacts);
+    my $priorities = FixMyStreet::App->model('DB::ResponsePriority')->by_categories(\@contacts, body_id => $oxfordshire->id);
     my $potholes = decode_json($priorities->{Potholes});
     my $traffic_lights = decode_json($priorities->{'Traffic lights'});
 
@@ -70,7 +70,7 @@ subtest 'by_categories returns all response priorities for an area with multiple
     );
 
     my @contacts = FixMyStreet::DB->resultset('Contact')->not_deleted->search( { body_id => [ $oxfordshire->id ] } )->all;
-    my $priorities = FixMyStreet::App->model('DB::ResponsePriority')->by_categories($area_id, @contacts);
+    my $priorities = FixMyStreet::App->model('DB::ResponsePriority')->by_categories(\@contacts, area_id => $area_id);
     my $potholes = decode_json($priorities->{Potholes});
     my $traffic_lights = decode_json($priorities->{'Traffic lights'});
 

--- a/t/app/model/responsetemplate.t
+++ b/t/app/model/responsetemplate.t
@@ -16,7 +16,7 @@ $t2->add_to_contacts($c2);
 my @contacts = FixMyStreet::DB->resultset('Contact')->not_deleted->search( { body_id => [ $body->id ] } )->all;
 
 subtest 'by_categories returns allresponse templates grouped by category' => sub {
-    my $templates = FixMyStreet::App->model('DB::ResponseTemplate')->by_categories($area_id, @contacts);
+    my $templates = FixMyStreet::App->model('DB::ResponseTemplate')->by_categories(\@contacts, body_id => $body->id);
     my $potholes = decode_json($templates->{Potholes});
     my $graffiti = decode_json($templates->{Graffiti});
 

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -64,39 +64,7 @@
 
     [% IF permissions.report_edit_priority OR permissions.report_inspect %]
       <div class="inspect-section">
-        <p>
-          <label for="problem_priority">[% loc('Priority') %]</label>
-          <select name="priority" id="problem_priority" class="form-control">
-            <option value="" [% 'selected' UNLESS problem.response_priority_id OR has_default_priority %]>-</option>
-            [% FOREACH priority IN problem.response_priorities %]
-              <option value="[% priority.id %]" [% 'selected' IF ( problem.response_priority_id == priority.id ) OR priority.is_default %][% 'disabled' IF priority.deleted %]>[% priority.name | html %]</option>
-            [% END %]
-          </select>
-        </p>
-
-        [% IF permissions.report_inspect %]
-        <p>
-          <label for="traffic_information">[% loc('Traffic management required?') %]</label>
-          [% traffic_info = problem.get_extra_metadata('traffic_information') %]
-          <select id="traffic_information" name="traffic_information" class="form-control">
-            <option value=""[% ' selected' IF NOT traffic_info %]>-</option>
-            [% FOREACH option IN problem.traffic_management_options %]
-                <option value='[% option %]'[% ' selected' IF traffic_info == option %]>[% option %]</option>
-            [% END %]
-          </select>
-        </p>
-        <p>
-          <label for="detailed_information">[% loc('Extra details') %]</label>
-        [% IF max_detailed_info_length %]
-          <span id="detailed_information_length">
-              [% tprintf(loc('%d characters maximum'), max_detailed_info_length) %]
-          </span>
-        [% END %]
-          <textarea rows="2" name="detailed_information" id="detailed_information" class="form-control"
-            [% IF max_detailed_info_length %]data-max-length="[% max_detailed_info_length %]"[% END %]>[% problem.get_extra_metadata('detailed_information') | html %]</textarea>
-        </p>
-        [% END %]
-
+          [% INCLUDE 'report/inspect/extra_details.html' %]
       </div>
     [% END %]
 

--- a/templates/web/base/report/inspect/_extra_details_field.html
+++ b/templates/web/base/report/inspect/_extra_details_field.html
@@ -1,0 +1,10 @@
+<p>
+    <label for="detailed_information">[% loc('Extra details') %]</label>
+    [% IF max_detailed_info_length %]
+    <span id="detailed_information_length">
+        [% tprintf(loc('%d characters maximum'), max_detailed_info_length) %]
+    </span>
+    [% END %]
+    <textarea rows="2" name="detailed_information" id="detailed_information" class="form-control"
+        [% IF max_detailed_info_length %]data-max-length="[% max_detailed_info_length %]"[% END %]>[% problem.get_extra_metadata('detailed_information') | html %]</textarea>
+</p>

--- a/templates/web/base/report/inspect/extra_details.html
+++ b/templates/web/base/report/inspect/extra_details.html
@@ -1,0 +1,23 @@
+<p>
+    <label for="problem_priority">[% loc('Priority') %]</label>
+    <select name="priority" id="problem_priority" class="form-control">
+        <option value="" [% 'selected' UNLESS problem.response_priority_id OR has_default_priority %]>-</option>
+        [% FOREACH priority IN problem.response_priorities %]
+        <option value="[% priority.id %]" [% 'selected' IF ( problem.response_priority_id == priority.id ) OR priority.is_default %][% 'disabled' IF priority.deleted %]>[% priority.name | html %]</option>
+        [% END %]
+    </select>
+</p>
+
+[% IF permissions.report_inspect %]
+    <p>
+        <label for="traffic_information">[% loc('Traffic management required?') %]</label>
+        [% traffic_info = problem.get_extra_metadata('traffic_information') %]
+        <select id="traffic_information" name="traffic_information" class="form-control">
+            <option value=""[% ' selected' IF NOT traffic_info %]>-</option>
+            [% FOREACH option IN problem.traffic_management_options %]
+                <option value='[% option %]'[% ' selected' IF traffic_info == option %]>[% option %]</option>
+            [% END %]
+        </select>
+    </p>
+    [% INCLUDE 'report/inspect/_extra_details_field.html' %]
+[% END %]

--- a/templates/web/tfl/report/inspect/extra_details.html
+++ b/templates/web/tfl/report/inspect/extra_details.html
@@ -1,0 +1,3 @@
+[% IF permissions.report_inspect %]
+    [% INCLUDE 'report/inspect/_extra_details_field.html' %]
+[% END %]


### PR DESCRIPTION
 - Removes priority and traffic management fields & admin permissions
 - Ensures only TfL response templates are visible, not all London cobrands

