### PR TITLE
[TfL] Enable anonymous reports

### DIFF
--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -57,6 +57,18 @@ sub categories_restriction {
     return $rs->search( { 'body.name' => 'TfL' } );
 }
 
+sub admin_user_domain { 'tfl.gov.uk' }
+
+sub allow_anonymous_reports { 'button' }
+
+sub anonymous_account {
+    my $self = shift;
+    return {
+        email => $self->feature('anonymous_account') . '@' . $self->admin_user_domain,
+        name => 'Anonymous user',
+    };
+}
+
 sub lookup_by_ref_regex {
     return qr/^\s*((?:FMS\s*)?\d+)\s*$/i;
 }

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -151,10 +151,121 @@ FixMyStreet::override_config {
                 },
             ],
         } },
+        anonymous_account => {
+            tfl => 'anonymous'
+        },
     },
 }, sub {
 
 $mech->host("tfl.fixmystreet.com");
+
+subtest "test report creation anonymously by button" => sub {
+    $mech->get_ok('/around');
+    $mech->submit_form_ok( { with_fields => { pc => 'BR1 3UH', } }, "submit location" );
+    $mech->follow_link_ok( { text_regex => qr/skip this step/i, }, "follow 'skip this step' link" );
+    $mech->submit_form_ok(
+        {
+            button => 'submit_register',
+            with_fields => {
+                title => 'Anonymous Test Report 1',
+                detail => 'Test report details.',
+                name => 'Joe Bloggs',
+                may_show_name => '1',
+                category => 'Bus stops',
+            }
+        },
+        "submit good details"
+    );
+
+    is_deeply $mech->page_errors, [
+        'Please enter your email'
+    ], "check there were no errors";
+
+    $mech->get_ok('/around');
+    $mech->submit_form_ok( { with_fields => { pc => 'BR1 3UH', } }, "submit location" );
+    $mech->follow_link_ok( { text_regex => qr/skip this step/i, }, "follow 'skip this step' link" );
+    $mech->submit_form_ok(
+        {
+            button => 'report_anonymously',
+            with_fields => {
+                title => 'Anonymous Test Report 1',
+                detail => 'Test report details.',
+                category => 'Bus stops',
+            }
+        },
+        "submit good details"
+    );
+    my $report = FixMyStreet::DB->resultset("Problem")->find({ title => 'Anonymous Test Report 1'});
+    ok $report, "Found the report";
+
+    $mech->content_contains('Your issue is on its way to TfL');
+    $mech->content_contains('Your reference for this report is FMS' . $report->id) or diag $mech->content;
+
+    is_deeply $mech->page_errors, [], "check there were no errors";
+
+    is $report->state, 'confirmed', "report confirmed";
+    $mech->get_ok( '/report/' . $report->id );
+
+    is $report->bodies_str, $body->id;
+    is $report->name, 'Anonymous user';
+    is $report->user->email, 'anonymous@tfl.gov.uk';
+    is $report->anonymous, 1; # Doesn't change behaviour here, but uses anon account's name always
+    is $report->get_extra_metadata('contributed_as'), 'anonymous_user';
+
+    my $alert = FixMyStreet::App->model('DB::Alert')->find( {
+        user => $report->user,
+        alert_type => 'new_updates',
+        parameter => $report->id,
+    } );
+    is $alert, undef, "no alert created";
+
+    $mech->not_logged_in_ok;
+};
+
+subtest "test report creation anonymously by staff user" => sub {
+    $mech->log_in_ok( $staffuser->email );
+    $mech->get_ok('/around');
+    $mech->submit_form_ok( { with_fields => { pc => 'BR1 3UH', } }, "submit location" );
+    $mech->follow_link_ok( { text_regex => qr/skip this step/i, }, "follow 'skip this step' link" );
+    $mech->submit_form_ok(
+        {
+            button => 'report_anonymously',
+            with_fields => {
+                title => 'Anonymous Test Report 2',
+                detail => 'Test report details.',
+                category => 'Bus stops',
+            }
+        },
+        "submit good details"
+    );
+    is_deeply $mech->page_errors, [], "check there were no errors";
+
+    my $report = FixMyStreet::DB->resultset("Problem")->find({ title => 'Anonymous Test Report 2'});
+    ok $report, "Found the report";
+
+    $mech->content_contains('Your issue is on its way to TfL');
+    $mech->content_contains('Your reference for this report is FMS' . $report->id) or diag $mech->content;
+
+    is $report->state, 'confirmed', "report confirmed";
+    $mech->get_ok( '/report/' . $report->id );
+
+    is $report->bodies_str, $body->id;
+    is $report->name, 'Anonymous user';
+    is $report->user->email, 'anonymous@tfl.gov.uk';
+    is $report->anonymous, 1;
+    is $report->get_extra_metadata('contributed_as'), 'anonymous_user';
+
+    my $alert = FixMyStreet::App->model('DB::Alert')->find( {
+        user => $report->user,
+        alert_type => 'new_updates',
+        parameter => $report->id,
+    } );
+    is $alert, undef, "no alert created";
+
+    $mech->log_out_ok;
+};
+
+FixMyStreet::DB->resultset("Problem")->delete_all;
 
 subtest "test report creation and reference number" => sub {
     $mech->log_in_ok( $user->email );


### PR DESCRIPTION
 - Enable anonymous reporting with single button-click
 - ~Create unique user record for each anonymous report~

~The second point is probably not the right way of doing this, per discussion on the ticket. Opening the PR as-is though, to get this off the `tfl-cobrand` branch.~

Connects https://github.com/mysociety/fixmystreet-commercial/issues/1594