### PR TITLE
Fix password reset on 2FA accounts again.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Auth.pm
+++ b/perllib/FixMyStreet/App/Controller/Auth.pm
@@ -277,8 +277,11 @@ sub process_login : Private {
         if FixMyStreet->config('SIGNUPS_DISABLED') && !$user->in_storage && !$data->{old_user_id};
 
     # People using 2FA need to supply a code
-    $c->forward( 'token_2fa', [ $user, $url_token ] ) if $user->has_2fa;
-    $c->forward( 'signup_2fa', [ $user ] ) if $c->cobrand->call_hook('must_have_2fa', $user);
+    if ($user->has_2fa) {
+        $c->forward( 'token_2fa', [ $user, $url_token ] );
+    } elsif ($c->cobrand->call_hook('must_have_2fa', $user)) {
+        $c->forward( 'signup_2fa', [ $user ] );
+    }
 
     if ($data->{old_user_id}) {
         # Were logged in as old_user_id, want to switch to $user

--- a/t/app/controller/auth.t
+++ b/t/app/controller/auth.t
@@ -382,6 +382,11 @@ subtest "Test enforced two-factor authentication, no password yet set" => sub {
         is $token, $user_token, '2FA secret set';
 
         $mech->logged_in_ok;
+
+        $mech->get_ok($link);
+        $mech->content_contains('Please generate a two-factor code');
+        $mech->submit_form_ok({ with_fields => { '2fa_code' => $code } }, "provide correct 2FA code" );
+        $mech->content_lacks('requires two-factor');
     };
 };
 


### PR DESCRIPTION
Just after fixing it, 3d593bc68 broke it again, because it took anyone
who must have 2FA switched on to the must-have-2FA sign up flow, even
if they already had 2FA set up. [skip changelog]
