### PR TITLE
[Borsetshire] Hide mySociety header on map pages

### DIFF
--- a/web/cobrands/borsetshire/base.scss
+++ b/web/cobrands/borsetshire/base.scss
@@ -116,4 +116,8 @@ body.authpage {
   }
 }
 
+body.mappage .ms-header {
+    display: none;
+}
+
 @import "mysoc-header";


### PR DESCRIPTION
The extra header was causing layout issues on the mobile map page at the point when you confirm a new report’s location.

[skip changelog]