### PR TITLE
[TfL] Red route asset handling

### DIFF
--- a/templates/web/tfl/report/new/roads_message.html
+++ b/templates/web/tfl/report/new/roads_message.html
@@ -1,4 +1,9 @@
 <div id="js-roads-responsibility" class="box-warning hidden">
+    <div id="js-not-tfl-road" class="hidden js-responsibility-message">
+        <p>Transport for London does not maintain this road. Please use
+        <a href="https://www.fixmystreet.com/">FixMyStreet.com</a> to report it
+        to the appropriate borough.</p>
+    </div>
     <div id="js-not-an-asset" class="hidden js-responsibility-message">
         <p><strong>Select a marker</strong></p>
         <p>Please select <span class="js-roads-asset" data-original="an item">an item</span> from the map on which to make a report.</p>

--- a/templates/web/tfl/report/new/roads_message.html
+++ b/templates/web/tfl/report/new/roads_message.html
@@ -1,0 +1,6 @@
+<div id="js-roads-responsibility" class="box-warning hidden">
+    <div id="js-not-an-asset" class="hidden js-responsibility-message">
+        <p><strong>Select a marker</strong></p>
+        <p>Please select <span class="js-roads-asset" data-original="an item">an item</span> from the map on which to make a report.</p>
+    </div>
+</div>

--- a/web/cobrands/fixmystreet-uk-councils/roadworks.js
+++ b/web/cobrands/fixmystreet-uk-councils/roadworks.js
@@ -151,6 +151,17 @@ var roadworks_defaults = {
         },
         filterToParams: function(filter, params) {
             params = params || {};
+            // There may be more than one filter applied to the layer
+            // but we only care about the BBOX filter for the purposes of the
+            // API query string.
+            if (filter.filters) {
+                $.each(filter.filters, function() {
+                    if ( this.type == "BBOX") {
+                        filter = this;
+                        return false; // break out of the $.each loop
+                    }
+                });
+            }
             filter.value.transform('EPSG:4326', 'EPSG:27700');
             params.b = filter.value.toArray();
             var date = new Date();

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -804,6 +804,7 @@ fixmystreet.assets = {
         options = $.extend(true, {}, default_options, options);
         var asset_layer = this.add_layer(options);
         this.add_controls([asset_layer], options);
+        return asset_layer;
     },
 
     add_layer: function(options) {

--- a/web/cobrands/tfl/assets.js
+++ b/web/cobrands/tfl/assets.js
@@ -64,6 +64,75 @@ fixmystreet.assets.add(asset_defaults, {
     asset_item: 'bus stop'
 });
 
+
+/* Red routes (TLRN) asset layer & handling for disabling form when red route
+   is not selected for specific categories. */
+
+var tlrn_stylemap = new OpenLayers.StyleMap({
+    'default': new OpenLayers.Style({
+        fillColor: "#ff0000",
+        fillOpacity: 0.3,
+        strokeColor: "#ff0000",
+        strokeOpacity: 0.6,
+        strokeWidth: 2
+    })
+});
+
+
+/* Reports in these categories can only be made on a red route */
+var tlrn_categories = [
+    "All out - three or more street lights in a row",
+    "Blocked drain",
+    "Damage - general (Trees)",
+    "Dead animal in the carriageway or footway",
+    "Debris in the carriageway",
+    "Fallen Tree",
+    "Flooding",
+    "Flytipping",
+    "Graffiti / Flyposting (non-offensive)",
+    "Graffiti / Flyposting (offensive)",
+    "Graffiti / Flyposting on street light (non-offensive)",
+    "Graffiti / Flyposting on street light (offensive)",
+    "Grass Cutting and Hedges",
+    "Hoardings blocking carriageway or footway",
+    "Light on during daylight hours",
+    "Lights out in Pedestrian Subway",
+    "Low hanging branches and general maintenance",
+    "Manhole Cover - Damaged (rocking or noisy)",
+    "Manhole Cover - Missing",
+    "Mobile Crane Operation",
+    "Pavement Defect (uneven surface / cracked paving slab)",
+    "Pothole",
+    "Roadworks",
+    "Scaffolding blocking carriageway or footway",
+    "Single Light out (street light)",
+    "Standing water",
+    "Unstable hoardings",
+    "Unstable scaffolding",
+    "Worn out road markings"
+];
+
+fixmystreet.assets.add(defaults, {
+    http_options: {
+        url: "https://tilma.mysociety.org/mapserver/tfl",
+        params: {
+            TYPENAME: "RedRoutes"
+        }
+    },
+    max_resolution: 9.554628534317017,
+    road: true,
+    non_interactive: true,
+    asset_category: tlrn_categories,
+    nearest_radius: 0.1,
+    stylemap: tlrn_stylemap,
+    no_asset_msg_id: '#js-not-tfl-road',
+    actions: {
+        found: fixmystreet.message_controller.road_found,
+        not_found: fixmystreet.message_controller.road_not_found
+    }
+});
+
+
 /* Roadworks.org asset layer */
 
 var org_id = '1250';

--- a/web/cobrands/tfl/assets.js
+++ b/web/cobrands/tfl/assets.js
@@ -23,7 +23,20 @@ var defaults = {
     body: "TfL"
 };
 
-fixmystreet.assets.add($.extend(true, {}, defaults, {
+var asset_defaults = $.extend(true, {}, defaults, {
+    select_action: true,
+    no_asset_msg_id: '#js-not-an-asset',
+    actions: {
+        asset_found: function() {
+            fixmystreet.message_controller.asset_found();
+        },
+        asset_not_found: function() {
+            fixmystreet.message_controller.asset_not_found(this);
+        }
+    }
+});
+
+fixmystreet.assets.add(asset_defaults, {
     http_options: {
         params: {
             TYPENAME: "trafficsignals"
@@ -35,9 +48,9 @@ fixmystreet.assets.add($.extend(true, {}, defaults, {
     },
     asset_group: "Traffic Lights",
     asset_item: 'traffic signal'
-}));
+});
 
-fixmystreet.assets.add($.extend(true, {}, defaults, {
+fixmystreet.assets.add(asset_defaults, {
     http_options: {
         params: {
             TYPENAME: "busstops"
@@ -49,7 +62,9 @@ fixmystreet.assets.add($.extend(true, {}, defaults, {
     },
     asset_group: "Bus Stops and Shelters",
     asset_item: 'bus stop'
-}));
+});
+
+/* Roadworks.org asset layer */
 
 var org_id = '1250';
 var body = "TfL";


### PR DESCRIPTION
 - Ensures reports can only be made on red routes in specific categories.
 - Ensures a marker must be selected for bus stops/traffic lights layers
 - Only shows roadworks.org markers that are on red routes

Connects https://github.com/mysociety/fixmystreet-commercial/issues/1588

[skip changelog]
