### PR TITLE
[TfL] Highlight safety critical reports in email subject line

### DIFF
--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -362,6 +362,10 @@ cobrand class is returned, otherwise the default FixMyStreet cobrand is used.
 sub get_body_handler_for_problem {
     my ($self, $row) = @_;
 
+    if ($row->to_body_named('TfL')) {
+        return FixMyStreet::Cobrand::TfL->new;
+    }
+
     my @bodies = values %{$row->bodies};
     my %areas = map { %{$_->areas} } grep { $_->name ne 'TfL' } @bodies;
 

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -320,12 +320,14 @@ for my $host ( 'tfl.fixmystreet.com', 'www.fixmystreet.com', 'bromley.fixmystree
         {
             name => "test non-safety critical category",
             safety_critical => 'no',
-            category => "Traffic lights"
+            category => "Traffic lights",
+            subject => "Problem Report: Test Report",
         },
         {
             name => "test safety critical category",
             safety_critical => 'yes',
-            category => "Pothole"
+            category => "Pothole",
+            subject => "Dangerous Pothole Report: Test Report",
         },
         {
             name => "test category extra field - safety critical",
@@ -333,7 +335,8 @@ for my $host ( 'tfl.fixmystreet.com', 'www.fixmystreet.com', 'bromley.fixmystree
             category => "Flooding",
             extra_fields => {
                 location => "carriageway",
-            }
+            },
+            subject => "Dangerous Flooding Report: Test Report",
         },
         {
             name => "test category extra field - non-safety critical",
@@ -341,7 +344,8 @@ for my $host ( 'tfl.fixmystreet.com', 'www.fixmystreet.com', 'bromley.fixmystree
             category => "Flooding",
             extra_fields => {
                 location => "footway",
-            }
+            },
+            subject => "Problem Report: Test Report",
         },
     ) {
     subtest $test->{name} . ' on ' . $host => sub {
@@ -384,6 +388,16 @@ for my $host ( 'tfl.fixmystreet.com', 'www.fixmystreet.com', 'bromley.fixmystree
             ok $report, "Found the report";
 
             is $report->get_extra_field_value('safety_critical'), $test->{safety_critical}, "safety critical flag set to " . $test->{safety_critical};
+
+            $mech->clear_emails_ok;
+            FixMyStreet::Script::Reports::send();
+            my @email = $mech->get_email;
+            is $email[0]->header('Subject'), $test->{subject};
+            if ($test->{safety_critical} eq 'yes') {
+                like $mech->get_text_body_from_email($email[0]), qr/This report is marked as safety critical./, "Safety critical message included in email body";
+            }
+            $mech->clear_emails_ok;
+
 
             $mech->log_out_ok;
         };

--- a/templates/email/tfl/submit.html
+++ b/templates/email/tfl/submit.html
@@ -16,6 +16,8 @@ INCLUDE '_email_top.html';
   <p style="[% p_style %]">[% multiple %]A user of [% site_name %] has submitted the following report
 of a local problem that they believe might require your attention.</p>
 
+  [% IF report.get_extra_field_value('safety_critical') == 'yes' %]<p>This report is marked as safety critical.</p>[% END %]
+
   <p style="margin: 20px auto; text-align: center">
     <a style="[% button_style %]" href="[% url %]">Show full report</a>
   </p>

--- a/templates/email/tfl/submit.txt
+++ b/templates/email/tfl/submit.txt
@@ -1,8 +1,10 @@
-Subject: Problem Report: [% report.title %]
+Subject: [% IF report.get_extra_field_value('safety_critical') == 'yes' %]Dangerous [% report.category %][% ELSE %]Problem[% END %] Report: [% report.title %]
 
 [% multiple %]A user of
 [% site_name %] has submitted the following report
 of a local problem that they believe might require your attention.
+
+[% IF report.get_extra_field_value('safety_critical') == 'yes' %]This report is marked as safety critical.[% END %]
 
 [% fuzzy %], or to provide an update on the problem,
 please visit the following link:


### PR DESCRIPTION
Also fixes an issue where `tfl` cobrand not active when sending report emails.

Connects https://github.com/mysociety/fixmystreet-commercial/issues/1603

[skip changelog]