### PR TITLE
Store email addresses report sent to on the report.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
         - Allow cobrands to disable admin resending.
         - Sass variables for default link colour and decoration.
         - Make contact edit note optional on staging sites.
+        - Store email addresses report sent to on the report.
     - Open311 improvements:
         - Support use of 'private' service definition <keywords> to mark
           reports made in that category private. #2488

--- a/perllib/FixMyStreet/SendReport/Email.pm
+++ b/perllib/FixMyStreet/SendReport/Email.pm
@@ -110,12 +110,19 @@ sub send {
         $params, $sender, $nomail, $cobrand, $row->lang);
 
     unless ($result) {
+        $row->set_extra_metadata('sent_to' => email_list($params->{To}));
         $self->success(1);
     } else {
         $self->error( 'Failed to send email' );
     }
 
     return $result;
+}
+
+sub email_list {
+    my $list = shift;
+    my @list = map { ref $_ ? $_->[0] : $_ } @$list;
+    return \@list;
 }
 
 # SW&T has different contact addresses depending upon the old district

--- a/t/app/model/problem.t
+++ b/t/app/model/problem.t
@@ -616,6 +616,8 @@ subtest 'check can set multiple emails as a single contact' => sub {
         FixMyStreet::Script::Reports::send();
     };
 
+    $problem->discard_changes;
+    is_deeply $problem->get_extra_metadata('sent_to'), [ '2636@example.com', '2636-2@example.com' ];
     $mech->email_count_is(1);
     my $email = $mech->get_email;
     is $email->header('To'), '"City of Edinburgh Council" <2636@example.com>, "City of Edinburgh Council" <2636-2@example.com>', 'To contains two email addresses';
@@ -662,6 +664,7 @@ subtest 'check can turn on report sent email alerts' => sub {
 
     $problem->discard_changes;
     ok defined( $problem->whensent ), 'whensent set';
+    is_deeply $problem->get_extra_metadata('sent_to'), [ 'test@example.org' ];
 
     $email = $emails[1];
     like $email->header('Subject'), qr/FixMyStreet Report Sent/, 'report sent email title correct';


### PR DESCRIPTION
If email SendReport is used, this stores the email address(es) sent to on the report as a record. This could be worked out (in normal cases) from looking at the category details at the time the report was sent, but in complicated cases and ones that might change frequently, there doesn't seem any harm in freezing it at the point of sending. This could in future be displayed in admin, CSV export, etc.