### PR TITLE
[TfL] Delivered to and closure-email-at in CSV export

### DIFF
--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -121,12 +121,16 @@ sub dashboard_export_problems_add_columns {
         map { $_ eq 'Ward' ? 'Borough' : $_ } @{ $c->stash->{csv}->{headers} },
         "Agent responsible",
         "Safety critical",
+        "Delivered to",
+        "Closure email at",
     ];
 
     $c->stash->{csv}->{columns} = [
         @{ $c->stash->{csv}->{columns} },
         "agent_responsible",
         "safety_critical",
+        "delivered_to",
+        "closure_email_at",
     ];
 
     $c->stash->{csv}->{extra_data} = sub {
@@ -135,10 +139,17 @@ sub dashboard_export_problems_add_columns {
         my $agent = $report->shortlisted_user;
 
         my $safety_critical = $report->get_extra_field_value('safety_critical') || 'no';
+        my $delivered_to = $report->get_extra_metadata('sent_to') || [];
+        my $closure_email_at = $report->get_extra_metadata('closure_alert_sent_at') || '';
+        $closure_email_at = DateTime->from_epoch(
+            epoch => $closure_email_at, time_zone => FixMyStreet->local_time_zone
+        ) if $closure_email_at;
         return {
             acknowledged => $report->whensent,
             agent_responsible => $agent ? $agent->name : '',
             safety_critical => $safety_critical,
+            delivered_to => join(',', @$delivered_to),
+            closure_email_at => $closure_email_at,
         };
     };
 }

--- a/t/app/controller/alert_new.t
+++ b/t/app/controller/alert_new.t
@@ -414,6 +414,9 @@ subtest "Test normal alert signups and that alerts are sent" => sub {
     is +(my $c = () = $email->as_string =~ /Other User/g), 2, 'Update name given, twice';
     unlike $email->as_string, qr/Anonymous User/, 'Update name not given';
 
+    $report->discard_changes;
+    ok $report->get_extra_metadata('closure_alert_sent_at'), 'Closure time set';
+
     # The update alert was to the problem reporter, so has a special update URL
     $mech->log_out_ok;
     $mech->get_ok( "/report/$report_id" );


### PR DESCRIPTION
Connects mysociety/fixmystreet-commercial#1613.
Records the first time a fixed/closed update is sent to the reporter in an email.
The delivered-to will come from #2730 when merged.