### PR TITLE
[TfL] Red route handling for .com/cobrands

### DIFF
--- a/bin/tfl/import_categories
+++ b/bin/tfl/import_categories
@@ -53,6 +53,7 @@ my $groups = $config->{groups};
 for my $group (keys %$groups) {
     my $cats = $groups->{$group};
     for my $cat (@$cats) {
+        $cat->{category} = 'Other (TfL)' if $cat->{category} eq 'Other';
         my $child_cat = FixMyStreet::DB->resultset("Contact")->find_or_new({
             body => $body,
             category => $cat->{category}
@@ -62,13 +63,14 @@ for my $group (keys %$groups) {
         $child_cat->editor($0);
         $child_cat->whenedited(\'current_timestamp');
         $child_cat->note($child_cat->in_storage ? 'Updated by import_categories' : 'Created by import_categories');
-        say colored("WARNING", 'red') . " " . $child_cat->category . " already exists" if $child_cat->in_storage and $child_cat->category ne 'Other';
+        say colored("WARNING", 'red') . " " . $child_cat->category . " already exists" if $child_cat->in_storage and $child_cat->category ne 'Other (TfL)';
         my $groups = $child_cat->groups;
         my %groups = map { $_ => 1} @$groups;
         $groups{$group} = 1;
         my @groups = keys %groups;
         $child_cat->extra(undef) if $child_cat->in_storage;
         $child_cat->set_extra_metadata(group => \@groups);
+        $child_cat->set_extra_metadata(display_name => 'Other') if $child_cat->category eq 'Other (TfL)';
         if ($cat->{disable}) {
             $child_cat->update_extra_field({
                 code => "_fms_disable_",

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -276,15 +276,20 @@ sub by_category_ajax_data : Private {
         $non_public ? ( non_public => JSON->true ) : (),
     };
 
+    if ( $c->stash->{category_extras}->{$category} && @{ $c->stash->{category_extras}->{$category} } >= 1 ) {
+        my $disable_form = $c->forward('disable_form_message');
+        $body->{disable_form} = $disable_form if %$disable_form;
+
+        # Remove the full disable_form extras, as included in disable form output
+        @{$c->stash->{category_extras}->{$c->stash->{category}}} = grep {
+            !$_->{disable_form} || $_->{disable_form} ne 'true'
+        } @{$c->stash->{category_extras}->{$c->stash->{category}}};
+    }
+
     if (($c->stash->{category_extras}->{$category} && @{ $c->stash->{category_extras}->{$category} } >= 1) or
             $c->stash->{unresponsive}->{$category} or $c->stash->{report_extra_fields}) {
         $body->{category_extra} = $c->render_fragment('report/new/category_extras.html', $vars);
         $body->{category_extra_json} = $c->forward('generate_category_extra_json');
-    }
-
-    if ( $c->stash->{category_extras}->{$category} && @{ $c->stash->{category_extras}->{$category} } >= 1 ) {
-        my $disable_form = $c->forward('disable_form_message');
-        $body->{disable_form} = $disable_form if %$disable_form;
     }
 
     my $unresponsive = $c->stash->{unresponsive}->{$category};
@@ -331,6 +336,7 @@ sub disable_form_message : Private {
             }
         }
     }
+
     return \%out;
 }
 

--- a/templates/web/bromley/footer_extra_js.html
+++ b/templates/web/bromley/footer_extra_js.html
@@ -9,5 +9,7 @@
         version('/cobrands/fixmystreet/assets.js'),
         version('/cobrands/bromley/map.js'),
         version('/cobrands/bromley/assets.js'),
+        version('/cobrands/fixmystreet-uk-councils/roadworks.js'),
+        version('/cobrands/tfl/assets.js'),
     );
 END %]

--- a/templates/web/fixmystreet-uk-councils/report/new/roads_message.html
+++ b/templates/web/fixmystreet-uk-councils/report/new/roads_message.html
@@ -1,0 +1,5 @@
+<div id="js-roads-responsibility" class="box-warning hidden">
+    <div id="js-not-an-asset" class="hidden js-responsibility-message">
+        <p>Please select <span class="js-roads-asset" data-original="an item">an item</span> from the map on which to make a report.</p>
+    </div>
+</div>

--- a/templates/web/greenwich/footer_extra_js.html
+++ b/templates/web/greenwich/footer_extra_js.html
@@ -6,10 +6,8 @@ IF bodyclass.match('mappage');
     scripts.push(
         version('/vendor/OpenLayers.Projection.OrdnanceSurvey.js'),
         version('/cobrands/fixmystreet/assets.js'),
-        version('/cobrands/bexley/js.js'),
-        version('/cobrands/fixmystreet-uk-councils/roadworks.js'),
-        version('/cobrands/tfl/assets.js'),
         version('/cobrands/highways/assets.js'),
+        version('/cobrands/tfl/assets.js'),
     );
 END
 %]

--- a/templates/web/hounslow/footer_extra_js.html
+++ b/templates/web/hounslow/footer_extra_js.html
@@ -10,6 +10,7 @@ IF bodyclass.match('mappage');
     version('/cobrands/highways/assets.js'),
     version('/cobrands/hounslow/js.js'),
     version('/cobrands/hounslow/assets.js'),
+    version('/cobrands/tfl/assets.js'),
   );
 END
 %]

--- a/templates/web/westminster/footer_extra_js.html
+++ b/templates/web/westminster/footer_extra_js.html
@@ -6,6 +6,7 @@ IF bodyclass.match('mappage');
         version('/cobrands/fixmystreet-uk-councils/roadworks.js'),
         version('/cobrands/westminster/roadworks.js'),
         version('/cobrands/westminster/assets.js'),
+        version('/cobrands/tfl/assets.js'),
     );
 END
 %]

--- a/web/cobrands/bexley/js.js
+++ b/web/cobrands/bexley/js.js
@@ -136,32 +136,5 @@ fixmystreet.assets.add(defaults, {
     asset_item: 'public toilet'
 });
 
-fixmystreet.assets.add(road_defaults, {
-    http_options: {
-        url: "https://tilma.mysociety.org/mapserver/tfl",
-        params: {
-            TYPENAME: "RedRoutes"
-        }
-    },
-    road: true,
-    all_categories: true,
-    nearest_radius: 0.1,
-    actions: {
-        found: function(layer, feature) {
-            var category = $('select#form_category').val(),
-                relevant = (category !== 'Street cleaning');
-            if (!fixmystreet.assets.selectedFeature() && relevant) {
-                fixmystreet.body_overrides.only_send('TfL');
-                $('#category_meta').empty();
-            } else {
-                fixmystreet.body_overrides.remove_only_send();
-            }
-        },
-        not_found: function(layer) {
-            fixmystreet.body_overrides.remove_only_send();
-        }
-    }
-});
-
 })();
 

--- a/web/cobrands/bromley/assets.js
+++ b/web/cobrands/bromley/assets.js
@@ -75,52 +75,10 @@ fixmystreet.assets.add(defaults, {
     asset_item: 'tree'
 });
 
-var bromley_to_tfl = {
-    'Enforcement': ['ENF_NUI_SIGN', 'ENF_OBS_HIGH', 'ENF_OHANG_HANG', 'ENF_UNLIC_HIGH'],
-    'Graffiti and Flyposting': ['GF_NUI_SIGN'],
-    'Parks and Greenspace': ['PG_BLOC_DRAIN', 'PG_FLO_DISP', 'PG_GRASS_CUT'],
-    'Street Cleansing': ['SC_BLOCK_DRAIN'],
-    'Road and Pavement Issues': true,
-    'Street Lighting and Road Signs': true,
-    'Public Trees': true
-};
-var tfl_asset_categories = Object.keys(bromley_to_tfl);
-
 $(function(){
     $("#problem_form").on("change.category", "#form_service_sub_code", function() {
         $(fixmystreet).trigger('report_new:category_change');
     });
-});
-
-fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "TFL_Red_Route"
-        }
-    },
-    stylemap: fixmystreet.assets.stylemap_invisible,
-    always_visible: true,
-
-    asset_category: tfl_asset_categories,
-    non_interactive: true,
-    road: true,
-    body: 'Bromley Council',
-    actions: {
-        found: function(layer, feature) {
-            var category = $('select#form_category').val(),
-                subcategory = $('#form_service_sub_code').val(),
-                subcategories = bromley_to_tfl[category],
-                relevant = (subcategories === true || (subcategory && OpenLayers.Util.indexOf(subcategories, subcategory) > -1));
-            if (!fixmystreet.assets.selectedFeature() && relevant) {
-                fixmystreet.body_overrides.only_send('TfL');
-            } else {
-                fixmystreet.body_overrides.remove_only_send();
-            }
-        },
-        not_found: function(layer) {
-            fixmystreet.body_overrides.remove_only_send();
-        }
-    }
 });
 
 var prow_stylemap = new OpenLayers.StyleMap({

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -1119,7 +1119,6 @@ fixmystreet.message_controller = (function() {
     }
 
     function is_matching_stopper(stopper, i) {
-        var only_send = fixmystreet.body_overrides.get_only_send();
         var body = $('#form_category').data('body');
 
         if (OpenLayers.Util.indexOf(ignored_bodies, body) > -1) {
@@ -1128,9 +1127,6 @@ fixmystreet.message_controller = (function() {
 
         var category = $('#form_category').val();
         if (category != stopper.category) {
-            return false;
-        }
-        if (only_send == 'TfL') {
             return false;
         }
 

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -1213,11 +1213,11 @@ fixmystreet.message_controller = (function() {
             return ($('#' + stopperId).length);
         },
 
-        asset_not_found: function(layer) {
-            if (!layer.visibility) {
+        asset_not_found: function() {
+            if (!this.visibility) {
                 responsibility_off();
             } else {
-                responsibility_on('#js-not-an-asset', layer.fixmystreet.asset_item, layer.fixmystreet.asset_type);
+                responsibility_on('#js-not-an-asset', this.fixmystreet.asset_item, this.fixmystreet.asset_type);
             }
         },
 

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -503,10 +503,12 @@ $.extend(fixmystreet.set_up, {
         });
   },
 
-  category_groups: function(old_group) {
+  // no_event makes sure no change event is fired (so we don't end up in an infinite loop)
+  // and also only sets up the main group dropdown, assuming the subs are left alone
+  category_groups: function(old_group, no_event) {
     var $category_select = $("select#form_category");
     if (!$category_select.hasClass('js-grouped-select')) {
-        if ($category_select.val() !== '-- Pick a category --') {
+        if (!no_event && $category_select.val() !== '-- Pick a category --') {
             $category_select.change();
         }
         return;
@@ -544,7 +546,9 @@ $.extend(fixmystreet.set_up, {
         var $el = $(el);
         var $options = $el.find("option");
 
-        if ($options.length == 1) {
+        if ($options.length === 0) {
+            /// Pass empty optgroups
+        } else if ($options.length == 1) {
             add_option($options.get(0));
         } else {
             var label = $el.attr("label");
@@ -552,6 +556,16 @@ $.extend(fixmystreet.set_up, {
             var $opt = $("<option></option>").text(label).val(label);
             $opt.data("subcategory_id", subcategory_id);
             $group_select.append($opt);
+
+            if (no_event) {
+                $options.each(function() {
+                    // Make sure any preselected value is preserved in the new UI:
+                    if (this.selected) {
+                        $group_select.val(label);
+                    }
+                });
+                return;
+            }
 
             var $sub_select = $("<select></select>").addClass("form-control js-subcategory validCategory");
             $sub_select.attr("id", subcategory_id);
@@ -593,7 +607,9 @@ $.extend(fixmystreet.set_up, {
     if (old_group !== '-- Pick a category --' && $category_select.val() == '-- Pick a category --') {
         $group_select.val(old_group);
     }
-    $group_select.change();
+    if (!no_event) {
+        $group_select.change();
+    }
   },
 
   hide_name: function() {

--- a/web/cobrands/northamptonshire/assets.js
+++ b/web/cobrands/northamptonshire/assets.js
@@ -411,7 +411,7 @@ var northants_defaults = $.extend(true, {}, fixmystreet.assets.alloy_defaults, {
     },
     asset_not_found: function() {
       $("#overlapping_features_msg").addClass('hidden');
-      fixmystreet.message_controller.asset_not_found(this);
+      fixmystreet.message_controller.asset_not_found.call(this);
     }
   }
 });

--- a/web/cobrands/tfl/assets.js
+++ b/web/cobrands/tfl/assets.js
@@ -251,27 +251,16 @@ var org_id = '1250';
 var body = "TfL";
 
 var rw_stylemap = new OpenLayers.StyleMap({
-    'default': new OpenLayers.Style({
-        fillOpacity: 1,
-        fillColor: "#FFFF00",
-        strokeColor: "#000000",
-        strokeOpacity: 0.8,
-        strokeWidth: 2,
-        pointRadius: 6,
-        graphicWidth: 34,
-        graphicHeight: 38,
-        graphicXOffset: -17,
-        graphicYOffset: -38,
-        graphicOpacity: 1,
-        externalGraphic: '/cobrands/tfl/roadworks.png'
-    }),
+    'default': fixmystreet.assets.style_default,
+    'select': fixmystreet.assets.style_default_select,
     'hover': new OpenLayers.Style({
         fillColor: "#55BB00",
-        externalGraphic: '/cobrands/tfl/roadworks-green.png'
-    }),
-    'select': new OpenLayers.Style({
-        fillColor: "#55BB00",
-        externalGraphic: '/cobrands/tfl/roadworks-green.png'
+        fillOpacity: 0.8,
+        strokeColor: "#000000",
+        strokeOpacity: 1,
+        strokeWidth: 2,
+        pointRadius: 8,
+        cursor: 'pointer'
     })
 });
 

--- a/web/cobrands/tfl/assets.js
+++ b/web/cobrands/tfl/assets.js
@@ -115,6 +115,7 @@ var tlrn_categories = [
     "Manhole Cover - Damaged (rocking or noisy)",
     "Manhole Cover - Missing",
     "Mobile Crane Operation",
+    "Other (TfL)",
     "Pavement Defect (uneven surface / cracked paving slab)",
     "Pothole",
     "Roadworks",

--- a/web/cobrands/tfl/assets.js
+++ b/web/cobrands/tfl/assets.js
@@ -27,12 +27,8 @@ var asset_defaults = $.extend(true, {}, defaults, {
     select_action: true,
     no_asset_msg_id: '#js-not-an-asset',
     actions: {
-        asset_found: function() {
-            fixmystreet.message_controller.asset_found();
-        },
-        asset_not_found: function() {
-            fixmystreet.message_controller.asset_not_found(this);
-        }
+        asset_found: fixmystreet.message_controller.asset_found,
+        asset_not_found: fixmystreet.message_controller.asset_not_found
     }
 });
 

--- a/web/cobrands/tfl/assets.js
+++ b/web/cobrands/tfl/assets.js
@@ -40,7 +40,20 @@ if (fixmystreet.cobrand === 'tfl') {
     defaults.body = 'TfL';
 }
 
+// This is required so that the found/not found actions are fired on category
+// select and pin move rather than just on asset select/not select.
+OpenLayers.Layer.TfLVectorAsset = OpenLayers.Class(OpenLayers.Layer.VectorAsset, {
+    initialize: function(name, options) {
+        OpenLayers.Layer.VectorAsset.prototype.initialize.apply(this, arguments);
+        $(fixmystreet).on('maps:update_pin', this.checkSelected.bind(this));
+        $(fixmystreet).on('report_new:category_change', this.checkSelected.bind(this));
+    },
+
+    CLASS_NAME: 'OpenLayers.Layer.TfLVectorAsset'
+});
+
 var asset_defaults = $.extend(true, {}, defaults, {
+    class: OpenLayers.Layer.TfLVectorAsset,
     body: 'TfL',
     select_action: true,
     no_asset_msg_id: '#js-not-an-asset',

--- a/web/cobrands/tfl/assets.js
+++ b/web/cobrands/tfl/assets.js
@@ -52,46 +52,6 @@ OpenLayers.Layer.TfLVectorAsset = OpenLayers.Class(OpenLayers.Layer.VectorAsset,
     CLASS_NAME: 'OpenLayers.Layer.TfLVectorAsset'
 });
 
-var asset_defaults = $.extend(true, {}, defaults, {
-    class: OpenLayers.Layer.TfLVectorAsset,
-    body: 'TfL',
-    select_action: true,
-    no_asset_msg_id: '#js-not-an-asset',
-    actions: {
-        asset_found: fixmystreet.message_controller.asset_found,
-        asset_not_found: fixmystreet.message_controller.asset_not_found
-    }
-});
-
-fixmystreet.assets.add(asset_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "trafficsignals"
-        }
-    },
-    asset_id_field: 'Site',
-    attributes: {
-        site: 'Site',
-    },
-    asset_group: "Traffic Lights",
-    asset_item: 'traffic signal'
-});
-
-fixmystreet.assets.add(asset_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "busstops"
-        }
-    },
-    asset_id_field: 'STOP_CODE',
-    attributes: {
-        stop_code: 'STOP_CODE',
-    },
-    asset_group: "Bus Stops and Shelters",
-    asset_item: 'bus stop'
-});
-
-
 /* Red routes (TLRN) asset layer & handling for disabling form when red route
    is not selected for specific categories. */
 
@@ -244,6 +204,48 @@ if (red_routes_layer) {
     });
 }
 
+/* Point asset layers, bus stops and traffic lights. This comes after the red
+ * route so its check for asset not clicked on happens after whether red route
+ * clicked on or not */
+
+var asset_defaults = $.extend(true, {}, defaults, {
+    class: OpenLayers.Layer.TfLVectorAsset,
+    body: 'TfL',
+    select_action: true,
+    no_asset_msg_id: '#js-not-an-asset',
+    actions: {
+        asset_found: fixmystreet.message_controller.asset_found,
+        asset_not_found: fixmystreet.message_controller.asset_not_found
+    }
+});
+
+fixmystreet.assets.add(asset_defaults, {
+    http_options: {
+        params: {
+            TYPENAME: "trafficsignals"
+        }
+    },
+    asset_id_field: 'Site',
+    attributes: {
+        site: 'Site',
+    },
+    asset_group: "Traffic Lights",
+    asset_item: 'traffic signal'
+});
+
+fixmystreet.assets.add(asset_defaults, {
+    http_options: {
+        params: {
+            TYPENAME: "busstops"
+        }
+    },
+    asset_id_field: 'STOP_CODE',
+    attributes: {
+        stop_code: 'STOP_CODE',
+    },
+    asset_group: "Bus Stops and Shelters",
+    asset_item: 'bus stop'
+});
 
 /* Roadworks.org asset layer */
 

--- a/web/cobrands/westminster/assets.js
+++ b/web/cobrands/westminster/assets.js
@@ -88,32 +88,6 @@ fixmystreet.assets.add(defaults, {
     }
 });
 
-fixmystreet.assets.add(defaults, {
-    http_options: {
-        url: url_base + '2/query?'
-    },
-    asset_category: 'Road or pavement damage',
-    non_interactive: true,
-    road: true,
-    nearest_radius: 25,
-    stylemap: fixmystreet.assets.stylemap_invisible,
-    actions: {
-        found: function(layer, feature) {
-            if (!fixmystreet.assets.selectedFeature()) {
-                fixmystreet.body_overrides.only_send('TfL');
-                $('#category_meta').empty();
-            } else {
-                fixmystreet.body_overrides.remove_only_send();
-            }
-            fixmystreet.message_controller.check_for_stopper();
-        },
-        not_found: function(layer) {
-            fixmystreet.body_overrides.remove_only_send();
-            fixmystreet.message_controller.check_for_stopper();
-        }
-    }
-});
-
 var layer_data = [
     { category: [ 'Food safety/hygiene' ] },
     { category: 'Damaged, dirty, or missing bin', subcategories: [ '1', '4' ], subcategory_id: '#form_bin_type' },

--- a/web/cobrands/westminster/assets.js
+++ b/web/cobrands/westminster/assets.js
@@ -218,7 +218,7 @@ $.each(layer_data, function(i, o) {
             asset_not_found: function() {
                 $('.category_meta_message').html('You can pick a <b class="asset-spot">' + this.fixmystreet.asset_item + '</b> from the map &raquo;');
                 $("#uprn_select").remove();
-                fixmystreet.message_controller.asset_not_found(this);
+                fixmystreet.message_controller.asset_not_found.call(this);
             }
         }
     };


### PR DESCRIPTION
This PR sets up the UK site and London cobrands so that clicking on a TfL red route will show all TfL categories and any council street cleaning category/group, and clicking elsewhere in Greater London will show all council categories and TfL any-location categories (bus stops, traffic lights). It centralises all TfL handling in one JS file which should handle all the above.

Category groups need to be activated on all London cobrands for this to function correctly.

The only loss I have thought of is Bromley's "Blocked drain" in Street cleaning will no longer go to TfL (they don't have such a category for that to work; we could drop it if Bromley do not want to receive them).

To fix the issue of Other being a stopper category for TfL, but we don't want that on non-red route on non-tfl cobrand, I've pushed code so that TfL would be called "Other (TfL") with a display_name of TfL, which I think then handles as you'd expect everywhere. Hopefully.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1668