### PR TITLE
[TfL] Fix base url.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -44,9 +44,13 @@ sub body {
     FixMyStreet::DB->resultset('Body')->search({ name => 'TfL' })->first;
 }
 
-# This needs to be overridden so the method in UKCouncils doesn't create
+# These need to be overridden so the method in UKCouncils doesn't create
 # a fixmystreet.com link (because of the false-returning owns_problem call)
 sub relative_url_for_report { "" }
+sub base_url_for_report {
+    my $self = shift;
+    return $self->base_url;
+}
 
 sub categories_restriction {
     my ($self, $rs) = @_;


### PR DESCRIPTION
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1678
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1675
Probably fixes much else using base_url_for_report (links in emails, confirming an already confirmed report email link, etc).