### PR TITLE
Issues/commercial/1490 occ inspector tool

### DIFF
--- a/bin/fixmystreet.com/update_council_user_permissions
+++ b/bin/fixmystreet.com/update_council_user_permissions
@@ -1,0 +1,70 @@
+#!/usr/bin/env perl
+#
+# script to add/remove a list of permissions to all staff belonging to a body.
+
+use strict;
+use warnings;
+use v5.14;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use FixMyStreet::DB;
+
+use Getopt::Long::Descriptive;
+
+my ($opts, $usage) = describe_options(
+    '%c %o',
+    ['commit', 'whether to commit changes to the database'],
+    ['permissions=s', 'comma seperated list of permissions to add/delete', { required => 1 }],
+    ['council=s', 'name of council to update', { required => 1 }],
+    ['mode' => 'hidden' => { one_of => [
+        ['add', 'add permissions to council\'s users'],
+        ['remove', 'remove permissions from council\'s users'],
+    ], required => 1 }],
+    ['help|h', 'print usage message and exit']
+);
+$usage->die if $opts->help;
+
+if (!$opts->commit) {
+    say "*** DRY RUN ***";
+}
+
+my $body = FixMyStreet::DB->resultset("Body")->find({ name => $opts->council});
+
+if ($body) {
+    my @permissions_list = map { Utils::trim_text($_) } split(',', $opts->permissions);
+
+    my $staff = FixMyStreet::DB->resultset("User")->search({ from_body => $body->id });
+    for my $user ( $staff->all ) {
+        my $permissions = $user->user_body_permissions->search({
+            body_id => $body->id,
+            permission_type => { in => \@permissions_list}
+        });
+        if ( $opts->mode eq 'remove') {
+            next unless $permissions->count;
+            if ($opts->commit) {
+                $permissions->delete;
+            }
+        } elsif ( $opts->mode eq 'add' ) {
+            my %existing = map { $_->permission_type => 1 } $permissions->all;
+            my @permissions_to_add = grep { !$existing{$_} } @permissions_list;
+            next unless @permissions_to_add;
+            if ($opts->commit) {
+                for my $permission ( @permissions_to_add ) {
+                    $user->user_body_permissions->create({
+                        body_id => $body->id,
+                        permission_type => $permission
+                    });
+                }
+            }
+        }
+        say "updated permissions for user id " . $user->id;
+    }
+} else {
+    say STDERR "Could not find " . $opts->council;
+}

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -193,13 +193,6 @@ sub available_permissions {
     my $perms = $self->next::method();
     $perms->{Bodies}->{defect_type_edit} = "Add/edit defect types";
 
-    delete $perms->{Problems}->{report_edit};
-    delete $perms->{Problems}->{report_edit_category};
-    delete $perms->{Problems}->{report_edit_priority};
-    delete $perms->{Problems}->{report_inspect};
-    delete $perms->{Problems}->{report_instruct};
-    delete $perms->{Problems}->{planned_reports};
-
     return $perms;
 }
 

--- a/t/app/controller/admin/defecttypes.t
+++ b/t/app/controller/admin/defecttypes.t
@@ -1,5 +1,4 @@
 use FixMyStreet::TestMech;
-use Test::MockModule;
 
 my $mech = FixMyStreet::TestMech->new;
 
@@ -26,16 +25,6 @@ FixMyStreet::override_config { ALLOWED_COBRANDS => ['bromley'], }, sub {
 };
 
 FixMyStreet::override_config { ALLOWED_COBRANDS => ['oxfordshire'], }, sub {
-
-    my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Oxfordshire');
-    $cobrand->mock('available_permissions', sub {
-        my $self = shift;
-
-        my $perms = FixMyStreet::Cobrand::Default->available_permissions;
-        $perms->{Bodies}->{defect_type_edit} = "Add/edit defect types";
-
-        return $perms;
-    });
 
     my $body = $mech->create_body_ok( 2237, 'Oxfordshire County Council' );
 

--- a/t/app/controller/admin/permissions.t
+++ b/t/app/controller/admin/permissions.t
@@ -1,5 +1,4 @@
 use FixMyStreet::TestMech;
-use Test::MockModule;
 
 my $mech = FixMyStreet::TestMech->new;
 
@@ -28,13 +27,6 @@ my $report_id = $report->id;
 ok $report, "created test report - $report_id";
 
 $mech->log_in_ok( $oxfordshireuser->email );
-
-my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Oxfordshire');
-$cobrand->mock('available_permissions', sub {
-    my $self = shift;
-
-    return FixMyStreet::Cobrand::Default->available_permissions;
-});
 
 subtest "Users can't edit report without report_edit permission" => sub {
     FixMyStreet::override_config {

--- a/t/app/controller/my_planned.t
+++ b/t/app/controller/my_planned.t
@@ -1,5 +1,4 @@
 use FixMyStreet::TestMech;
-use Test::MockModule;
 my $mech = FixMyStreet::TestMech->new;
 
 $mech->get_ok('/my/planned');
@@ -188,13 +187,6 @@ FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'oxfordshire' ],
     BASE_URL => 'http://oxfordshire.fixmystreet.site',
 }, sub {
-    my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Oxfordshire');
-    $cobrand->mock('available_permissions', sub {
-        my $self = shift;
-
-        return FixMyStreet::Cobrand::Default->available_permissions;
-    });
-
     subtest "can remove problems not displayed in cobrand from shortlist" => sub {
         $user->user_planned_reports->remove();
         my ($problem1) = $mech->create_problems_for_body(2, $body->id, 'New Problem');


### PR DESCRIPTION
Reverse hard coded disabling of inspector tool on OCC, and add a script to do this at a staff permission level.

Required for mysociety/fixmystreet-commercial#1490

[skip changelog]