### PR TITLE
Make all links consistently underlined

### DIFF
--- a/web/cobrands/tfl/base.scss
+++ b/web/cobrands/tfl/base.scss
@@ -188,12 +188,6 @@ ol.big-numbers>li {
     }
 }
 
-#front-recently {
-    a {
-        text-decoration: none;
-    }
-}
-
 .item-list--reports li > a,
 #key-tools a,
 .problem-back {

--- a/web/cobrands/tfl/base.scss
+++ b/web/cobrands/tfl/base.scss
@@ -52,6 +52,10 @@ h3 {
     line-height: 1.238095238em; //26px
 }
 
+a, .fake-link {
+    text-decoration: underline;
+}
+
 .btn--primary,
 .btn,
 .green-btn {
@@ -73,6 +77,7 @@ div.form-error, p.form-error {
 input.form-error, textarea.form-error {
     border-color: $red;
 }
+
 
 .btn--back,
 .btn--forward,
@@ -181,6 +186,18 @@ ol.big-numbers>li {
     .item-list--reports__item {
         border-bottom: 1px solid $grey50;
     }
+}
+
+#front-recently {
+    a {
+        text-decoration: none;
+    }
+}
+
+.item-list--reports li > a,
+#key-tools a,
+.problem-back {
+    text-decoration: none;
 }
 
 /* Mobile navigation links */
@@ -306,3 +323,5 @@ ol.big-numbers>li {
         color: #fff;
     }
 }
+
+


### PR DESCRIPTION
This is a bit of a catch-all fix and I haven't been able to test it exhaustively. If we spot any links appearing underlined we can add them to the list in the stylesheet I guess