### PR TITLE
Tfl improve email contrast

### DIFF
--- a/templates/email/tfl/_email_color_overrides.html
+++ b/templates/email/tfl/_email_color_overrides.html
@@ -18,6 +18,7 @@ button_background_color = color_blue
 button_text_color = color_white
 
 logo_width = "220" # pixel measurement, but without 'px' suffix
-logo_height = "87" # pixel measurement, but without 'px' suffix
+logo_height = "86" # pixel measurement, but without 'px' suffix
+header_padding = "10px 20px"
 
 %]

--- a/templates/email/tfl/_email_color_overrides.html
+++ b/templates/email/tfl/_email_color_overrides.html
@@ -3,6 +3,11 @@
 color_blue = '#001aa8'
 color_black = '#000000'
 color_white = '#FFFFFF'
+color_tfl_grey = '#414b56'
+color_tfl_pale_blue = '#eff6fd'
+
+body_background_color = color_tfl_pale_blue
+body_text_color = color_tfl_grey
 
 header_background_color = color_blue
 header_text_color = color_white

--- a/templates/email/tfl/_email_setting_overrides.html
+++ b/templates/email/tfl/_email_setting_overrides.html
@@ -1,0 +1,7 @@
+[%
+
+only_column_style = "$only_column_style border: 1px solid $column_divider_color; border-top: none;"
+primary_column_style = "$primary_column_style border: 1px solid $column_divider_color; border-top: none;"
+secondary_column_style = "vertical-align: top; width: 50%; background-color: $secondary_column_background_color; color: $secondary_column_text_color; border: 1px solid $column_divider_color; border-top: none; border-left: none;"
+
+%]


### PR DESCRIPTION
Fixes the header/footer text contrast issue mentioned by @dracos in https://github.com/mysociety/fixmystreet-commercial/issues/1670.

![Screen Shot 2019-11-20 at 12 06 27-fullpage](https://user-images.githubusercontent.com/739624/69237915-9e75c000-0b8e-11ea-8959-267340468085.png)

Background `#EFF6FD` is taken from their website (eg the hover colour on [the download links here](https://tfl.gov.uk/info-for/suppliers-and-contractors/design-standards?intcmp=5837)) and text colour `#414B56` is one of their core brand colours. Contrast ratio is 8.14:1.

While I was there, I also fixed some awkward stretching and extra vertical space in the header.