### PR TITLE
[TfL] Privacy policy changes

### DIFF
--- a/perllib/DBIx/Class/FixMyStreet/EncodedColumn.pm
+++ b/perllib/DBIx/Class/FixMyStreet/EncodedColumn.pm
@@ -8,6 +8,20 @@ use base qw/DBIx::Class::EncodedColumn/;
 # mySociety override to allow direct setting without double encryption
 sub set_column {
   my $self = shift;
+  if ($_[0] eq 'password') {
+    my $cobrand = $self->result_source->schema->cobrand;
+    if ($cobrand->moniker eq 'tfl') {
+      if (defined $_[1]) {
+        if (defined $_[2]) {
+          $self->set_extra_metadata(tfl_password => $_[1]);
+        } else {
+          my $encoder = $self->_column_encoders->{password};
+          $self->set_extra_metadata(tfl_password => $encoder->($_[1]));
+        }
+      }
+      return $self->get_extra_metadata('tfl_password');
+    }
+  }
   return DBIx::Class::Row::set_column($self, @_) unless defined $_[1] and not defined $_[2];
   $self->next::method(@_);
 }

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -824,7 +824,12 @@ sub ajax : Private {
     my @pins = map {
         my $p = $_;
         # lat, lon, 'colour', ID, title, type/size, draggable
-        [ $p->{latitude}, $p->{longitude}, $p->{colour}, $p->{id}, $p->{title}, '', JSON->false ]
+        my $parts = [ $p->{latitude}, $p->{longitude}, $p->{colour}, $p->{id}, $p->{title}, '', JSON->false ];
+        # Some reports may only be visible on a specific cobrand on this FMS site.
+        # If that's the case, include the base URL for the pin's cobrand here so
+        # the app can link to the right place.
+        push @$parts, $p->{base_url} if $p->{base_url};
+        $parts;
     } @{$c->stash->{pins}};
 
     my $list_html = $c->render_fragment($template);

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -11,6 +11,13 @@ use constant COUNCIL_ID_ISLEOFWIGHT => 2636;
 
 sub on_map_default_status { return 'open'; }
 
+# Show TfL pins as grey
+sub pin_colour {
+    my ( $self, $p, $context ) = @_;
+    return 'grey' if $p->to_body_named('TfL');
+    return $self->next::method($p, $context);
+}
+
 # Special extra
 sub path_to_web_templates {
     my $self = shift;
@@ -36,6 +43,18 @@ sub add_response_headers {
 # FixMyStreet should return all cobrands
 sub restriction {
     return {};
+}
+
+# FixMyStreet needs to not show TfL reports...
+sub problems_restriction {
+    my ($self, $rs) = @_;
+    my $table = ref $rs eq 'FixMyStreet::DB::ResultSet::Nearby' ? 'problem' : 'me';
+    return $rs->search({ "$table.cobrand" => { '!=' => 'tfl' } });
+}
+
+sub relative_url_for_report {
+    my ( $self, $report ) = @_;
+    return $report->cobrand eq 'tfl' ? FixMyStreet::Cobrand::TfL->base_url : "";
 }
 
 sub munge_around_category_where {

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -338,6 +338,7 @@ around service => sub {
 sub title_safe {
     my $self = shift;
     return _('Awaiting moderation') if $self->cobrand eq 'zurich' && $self->state eq 'submitted';
+    return sprintf("%s problem", $self->category) if $self->cobrand eq 'tfl' && $self->result_source->schema->cobrand->moniker ne 'tfl';
     return $self->title;
 }
 
@@ -1034,6 +1035,7 @@ sub pin_data {
         problem => $self,
         draggable => $opts{draggable},
         type => $opts{type},
+        base_url => $c->cobrand->relative_url_for_report($self),
     }
 };
 

--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -163,9 +163,21 @@ __PACKAGE__->add_columns(
         encode_column => 1,
         encode_class => 'Crypt::Eksblowfish::Bcrypt',
         encode_args => { cost => cost() },
-        encode_check_method => 'check_password',
+        encode_check_method => '_check_password',
     },
 );
+
+sub check_password {
+    my $self = shift;
+    my $cobrand = $self->result_source->schema->cobrand;
+    if ($cobrand->moniker eq 'tfl') {
+        my $col_v = $self->get_extra_metadata('tfl_password');
+        return unless defined $col_v;
+        $self->_column_encoders->{password}->($_[0], $col_v) eq $col_v;
+    } else {
+        $self->_check_password(@_);
+    }
+}
 
 around password => sub {
     my ($orig, $self) = (shift, shift);

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -141,6 +141,9 @@ FixMyStreet::override_config {
     MAPIT_URL => 'http://mapit.uk/',
     COBRAND_FEATURES => {
         internal_ips => { tfl => [ '127.0.0.1' ] },
+        base_url => {
+            tfl => 'https://street.tfl'
+        },
         borough_email_addresses => { tfl => {
             AOAT => [
                 {
@@ -447,6 +450,35 @@ for my $test (
     };
 }
 
+subtest 'check correct base URL & title in AJAX pins' => sub {
+    my $report = FixMyStreet::DB->resultset("Problem")->find({ title => 'Test Report 1'});
+    my $url = '/around?ajax=1&bbox=' . ($report->longitude - 0.01) . ',' .  ($report->latitude - 0.01)
+        . ',' . ($report->longitude + 0.01) . ',' .  ($report->latitude + 0.01);
+
+    $report->update({ state => 'confirmed' });
+    $report->discard_changes;
+    is $report->cobrand, 'tfl', 'Report made on TfL cobrand';
+
+    $mech->host("fixmystreet.com");
+    my $json = $mech->get_ok_json( $url );
+    is $json->{pins}[0][4], $report->category . " problem", "category is used for title" or diag $mech->content;
+    is $json->{pins}[0][7], "https://street.tfl", "base_url is included and correct" or diag $mech->content;
+
+    $mech->host("tfl.fixmystreet.com");
+    $json = $mech->get_ok_json( $url );
+    is $json->{pins}[0][4], $report->title, "title is shown on TfL cobrand" or diag $mech->content;
+    is $json->{pins}[0][7], undef, "base_url is not present on TfL cobrand response";
+
+    $mech->host("fixmystreet.com");
+    $report->update({cobrand => 'fixmystreet'});
+    $json = $mech->get_ok_json( $url );
+    is $json->{pins}[0][4], $report->title, "title is shown if report made on fixmystreet cobrand" or diag $mech->content;
+    is $json->{pins}[0][7], undef, "base_url is not present if report made on fixmystreet cobrand";
+
+    $report->update({cobrand => 'tfl'});
+    $mech->host("tfl.fixmystreet.com");
+};
+
 subtest 'check report age on /around' => sub {
     my $report = FixMyStreet::DB->resultset("Problem")->find({ title => 'Test Report 1'});
     $report->update({ state => 'confirmed' });
@@ -533,6 +565,43 @@ subtest 'Test passwords work appropriately' => sub {
     $mech->content_lacks('Your account');
 };
 
+my $tfl_report;
+subtest 'Test user reports are visible on cobrands appropriately' => sub {
+    ($tfl_report) = $mech->create_problems_for_body(1, $body->id, 'Test TfL report made on TfL', { cobrand => 'tfl' });
+    $mech->create_problems_for_body(1, $body->id, 'Test TfL report made on .com', { cobrand => 'fixmystreet' });
+    $mech->create_problems_for_body(1, $bromley->id, 'Test Bromley report made on .com', { cobrand => 'fixmystreet' });
+
+    $mech->log_in_ok('test@example.com');
+    $mech->get_ok('/my');
+    $mech->content_contains('1 to 2 of 2');
+    $mech->content_contains('Test TfL report made on .com');
+    $mech->content_lacks('Test TfL report made on TfL');
+    $mech->content_contains('Test Bromley report');
+
+    $mech->host('tfl.fixmystreet.com');
+    $mech->log_in_ok('test@example.com');
+    $mech->get_ok('/my');
+    $mech->content_contains('1 to 2 of 2');
+    $mech->content_contains('Test TfL report made on .com');
+    $mech->content_contains('Test TfL report made on TfL');
+    $mech->content_lacks('Test Bromley report');
+};
+
+subtest 'Test public reports are visible on cobrands appropriately' => sub {
+    $mech->get_ok('/around?pc=SW1A+1AA');
+    $mech->content_contains('Test TfL report made on .com');
+    $mech->content_contains('Test TfL report made on TfL');
+    $mech->content_lacks('Test Bromley report');
+
+    $mech->host('www.fixmystreet.com');
+    $mech->get_ok('/around?pc=SW1A+1AA');
+    $mech->content_contains('Test TfL report made on .com');
+    $mech->content_lacks('Test TfL report made on TfL');
+    $mech->content_contains('Test Bromley report');
+    $mech->content_contains('https://street.tfl/report/' . $tfl_report->id);
+    $mech->content_contains('Other problem');
+};
+
 };
 
 FixMyStreet::override_config {
@@ -546,6 +615,9 @@ FixMyStreet::override_config {
                 location => [ "carriageway" ],
             },
         } },
+        anonymous_account => {
+            tfl => 'anonymous'
+        },
     },
 }, sub {
 

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -503,6 +503,36 @@ subtest 'Bromley staff cannot access TfL admin' => sub {
     $mech->log_out_ok;
 };
 
+subtest 'Test passwords work appropriately' => sub {
+    $mech->host('www.fixmystreet.com');
+    $mech->get_ok('/auth');
+    $user->password('dotcom');
+    $user->update;
+    $mech->submit_form_ok(
+        { with_fields => { username => $user->email, password_sign_in => 'dotcom' } },
+        "sign in using form" );
+    $mech->content_contains('Your account');
+    $mech->host('tfl.fixmystreet.com');
+    $mech->get_ok('/auth');
+    $mech->submit_form_ok(
+        { with_fields => { username => $user->email, password_sign_in => 'dotcom' } },
+        "sign in using form" );
+    $mech->content_lacks('Your account');
+
+    $user->password('tfl');
+    $user->update;
+    $mech->submit_form_ok(
+        { with_fields => { username => $user->email, password_sign_in => 'tfl' } },
+        "sign in using form" );
+    $mech->content_contains('Your account');
+    $mech->host('www.fixmystreet.com');
+    $mech->get_ok('/auth');
+    $mech->submit_form_ok(
+        { with_fields => { username => $user->email, password_sign_in => 'tfl' } },
+        "sign in using form" );
+    $mech->content_lacks('Your account');
+};
+
 };
 
 FixMyStreet::override_config {

--- a/templates/web/base/report/_item.html
+++ b/templates/web/base/report/_item.html
@@ -36,6 +36,9 @@
 <li class="item-list__item item-list--reports__item [% item_extra_class %]"
     data-report-id="[% problem.id | html %]" data-lastupdate="[% problem.lastupdate %]" id="report-[% problem.id | html %]">
 <a href="[% c.cobrand.relative_url_for_report( problem ) %][% problem.url %]">
+  [% TRY ~%]
+    [% PROCESS 'report/_item_photo_title.html' ~%]
+  [% CATCH file ~%]
     [% IF problem.photo %]
         <img class="img" height="60" width="90" src="[% problem.photos.first.url_fp %]" alt="">
     [% END %]
@@ -44,6 +47,8 @@
       [% CATCH file %]
         <h3 class="item-list__heading">[% problem.title | html %]</h3>
       [% END %]
+  [% END ~%]
+
     [% IF c.user.has_permission_to('report_inspect', problem.bodies_str_ids) %]
         <div class="item-list__description">[% problem.detail | html %]</div>
     [% END %]

--- a/templates/web/fixmystreet.com/report/_item_photo_title.html
+++ b/templates/web/fixmystreet.com/report/_item_photo_title.html
@@ -1,0 +1,5 @@
+[% IF problem.cobrand == 'tfl' %]
+    <h3 class="item-list__heading admin-offsite-link">[% problem.category | html %] problem</h3>
+[% ELSE %]
+    [% THROW file 'Not found' %]
+[% END %]


### PR DESCRIPTION
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1687
I considered having the cobrand bits in the cobrand file, but for password stuff it seemed clearer to have them present there as an exception, maybe?

Please check the following:
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
