### PR TITLE
[Bexley] Switch to new MasterMap URL

### DIFF
--- a/perllib/FixMyStreet/Map/Bexley.pm
+++ b/perllib/FixMyStreet/Map/Bexley.pm
@@ -23,7 +23,7 @@ sub map_tiles {
     my ( $self, %params ) = @_;
     my ( $x, $y, $z ) = ( $params{x_tile}, $params{y_tile}, $params{zoom_act} );
     if ($z >= 17) {
-        my $base = "//%stilma.mysociety.org/bexley/%d/%d/%d.png";
+        my $base = "//%stilma.mysociety.org/mastermap/%d/%d/%d.png";
         return [
             sprintf($base, 'a.', $z, $x-1, $y-1),
             sprintf($base, 'b.', $z, $x, $y-1),

--- a/web/js/map-bexley.js
+++ b/web/js/map-bexley.js
@@ -13,7 +13,7 @@ OpenLayers.Layer.Bexley = OpenLayers.Class(OpenLayers.Layer.BingUK, {
 
         var urls = [];
         var servers = [ '', 'a.', 'b.', 'c.' ];
-        var base = "//{S}tilma.mysociety.org/bexley/${z}/${x}/${y}.png";
+        var base = "//{S}tilma.mysociety.org/mastermap/${z}/${x}/${y}.png";
         for (var i=0; i < servers.length; i++) {
             urls.push( base.replace('{S}', servers[i]) );
         }


### PR DESCRIPTION
We now have a generic mastermap layer which contains the MasterMap files for both Bexley and Peterborough (and potentially others in the future), so switch to using that.

Related to the parallel change for Peterborough https://github.com/mysociety/fixmystreet/pull/2757

## Notes to deployer

Once this has been deployed we can remove the old "bexley-mm" layer bits in the tilma httpd config.

<!-- [skip changelog] -->
