### PR TITLE
Add configuration for setting CSP header.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
         - Sass variables for default link colour and decoration.
         - Make contact edit note optional on staging sites.
         - Store email addresses report sent to on the report.
+        - Add configuration for setting Content-Security-Policy header.
     - Open311 improvements:
         - Support use of 'private' service definition <keywords> to mark
           reports made in that category private. #2488

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -28,6 +28,10 @@ SECURE_PROXY_SSL_HEADER: ''
 # If you're behind a proxy, set this to a two-element list containing the
 # trusted HTTP header and the required value. For example:
 #   SECURE_PROXY_SSL_HEADER: [ 'X-Forwarded-Proto', 'https' ]
+CONTENT_SECURITY_POLICY: ''
+# To activate CSP, set this to 1. If you have additional third party domains to
+# allow JavaScript on, or want to specify extra script-src CSP directives, set
+# this to a e.g. space-separated list of domains or a list of the same.
 
 # Email domain used for emails, and contact name/email for admin use.
 EMAIL_DOMAIN: 'example.org'

--- a/docs/customising/config.md
+++ b/docs/customising/config.md
@@ -56,6 +56,7 @@ The following are all the configuration settings that you can change in `conf/ge
 
 * <code><a href="#base_url">BASE_URL</a></code>
 * <code><a href="#secure_proxy_ssl_header">SECURE_PROXY_SSL_HEADER</a></code>
+* <code><a href="#content_security_policy">CONTENT_SECURITY_POLICY</a></code>
 * <code><a href="#geo_cache">GEO_CACHE</a></code>
 * <code><a href="#admin_base_url">ADMIN_BASE_URL</a></code>
 
@@ -196,6 +197,33 @@ The following are all the configuration settings that you can change in `conf/ge
       <ul class="examples">
         <li>
           <code>SECURE_PROXY_SSL_HEADER: [ 'X-Forwarded-Proto', 'https' ]</code>
+        </li>
+      </ul>
+    </div>
+  </dd>
+
+  <dt>
+    <a name="content_security_policy"><code>CONTENT_SECURITY_POLICY</code></a>
+  </dt>
+  <dd>
+    A Content-Security-Policy header can prevent cross-site scripting,
+    clickjacking and other code injection attacks (see
+    <a href="https://en.wikipedia.org/wiki/Content_Security_Policy">Wikipedia</a>
+    for more). To have FixMyStreet output such a header, set this setting to 1.
+    If you load third-party JavaScript on your site, you will need to set this
+    setting to a space-separated list of domains; whatever is here, if not 1,
+    will be included in the header output.
+    <div class="more-info">
+      <p>Example:</p>
+      <ul class="examples">
+        <li>
+          <code>CONTENT_SECURITY_POLICY: 1</code>
+        </li>
+        <li>
+          <code>CONTENT_SECURITY_POLICY: 'www.example.org other.example.org'</code>
+        </li>
+        <li>
+          <code>CONTENT_SECURITY_POLICY: [ 'www.example.org', 'other.example.org' ]</code>
         </li>
       </ul>
     </div>

--- a/perllib/FixMyStreet/App.pm
+++ b/perllib/FixMyStreet/App.pm
@@ -198,7 +198,7 @@ sub setup_request {
     my $cobrand = $c->cobrand;
     FixMyStreet::DB->schema->cobrand($cobrand);
 
-    $cobrand->call_hook('add_response_headers');
+    $cobrand->add_response_headers;
 
     # append the cobrand templates to the include path
     $c->stash->{additional_template_paths} = $cobrand->path_to_web_templates;

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -4,8 +4,6 @@ use base 'FixMyStreet::Cobrand::UK';
 use strict;
 use warnings;
 
-use mySociety::Random;
-
 use constant COUNCIL_ID_BROMLEY => 2482;
 use constant COUNCIL_ID_ISLEOFWIGHT => 2636;
 
@@ -23,14 +21,6 @@ sub path_to_email_templates {
     return [
         FixMyStreet->path_to( 'templates', 'email', 'fixmystreet.com'),
     ];
-}
-
-sub add_response_headers {
-    my $self = shift;
-    # uncoverable branch true
-    return if $self->{c}->debug;
-    my $csp_nonce = $self->{c}->stash->{csp_nonce} = unpack('h*', mySociety::Random::random_bytes(16, 1));
-    $self->{c}->res->header('Content-Security-Policy', "script-src 'self' www.google-analytics.com www.googleadservices.com 'unsafe-inline' 'nonce-$csp_nonce'")
 }
 
 # FixMyStreet should return all cobrands

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -11,6 +11,11 @@ sub country             { return 'GB'; }
 sub area_types          { [ 'DIS', 'LBO', 'MTD', 'UTA', 'CTY', 'COI', 'LGD' ] }
 sub area_types_children { $mySociety::VotingArea::council_child_types }
 
+sub csp_config {
+    my $self = shift;
+    return $self->feature('content_security_policy');
+}
+
 sub enter_postcode_text {
     my ( $self ) = @_;
     return _("Enter a nearby UK postcode, or street name and area");


### PR DESCRIPTION
This allows you to output a working Content-Security-Policy header, with optional third-party domains, by setting a new CONTENT_SECURITY_POLICY configuration option.

In the UK, uses a cobrand feature to allow per-cobrand CSP setting.

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog