### PR TITLE
[Peterborough] Include email categories on cobrand

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -66,17 +66,4 @@ sub open311_munge_update_params {
     $params->{description} = "[Customer FMS update] " . $params->{description};
 }
 
-sub categories_restriction {
-    my ($self, $rs) = @_;
-    # Categories covering Peterborough have a mixture of Open311 and Email
-    # send methods. Peterborough only want specific categories to be visible on
-    # their cobrand, not the email categories from FMS.com.
-    # The FMS.com categories have a devolved send_method set to Email, so we can
-    # filter these out.
-    return $rs->search( { -or => [
-        'me.send_method' => undef, # Open311 categories
-        'me.send_method' => '', # Open311 categories that have been edited in the admin
-    ] } );
-}
-
 1;


### PR DESCRIPTION
They've requested that these be added to the cobrand.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1667

<!-- [skip changelog] -->