### PR TITLE
Guard against XSS from malicious admin user.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Users.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Users.pm
@@ -392,7 +392,7 @@ sub edit : Chained('user') : PathPart('') : Args(0) {
         my @live_contacts = $c->stash->{live_contacts}->all;
         my @all_contacts = map { {
             id => $_->id,
-            category => $_->category,
+            category => $_->category_display,
             active => $active_contacts{$_->id},
         } } @live_contacts;
         $c->stash->{contacts} = \@all_contacts;

--- a/t/cobrand/isleofwight.t
+++ b/t/cobrand/isleofwight.t
@@ -424,7 +424,7 @@ subtest "check not responsible as correct text" => sub {
         $mech->get_ok('/report/' . $p->id);
     };
 
-    $mech->content_contains("not Island Roads' responsibility", "not reponsible message contains correct text");
+    $mech->content_contains("not Island Roads&#39; responsibility", "not reponsible message contains correct text");
     $p->comments->delete;
     $p->delete;
 };

--- a/templates/web/base/admin/category-checkboxes.html
+++ b/templates/web/base/admin/category-checkboxes.html
@@ -17,7 +17,7 @@
       <li>
         <label class="inline" title="[% contact.email | html %]">
           <input type="checkbox" name="contacts[[% contact.id %]]" [% 'checked' IF contact.active %]/>
-          [% contact.category %]
+          [% contact.category | html %]
         </label>
       </li>
     [% END %]

--- a/templates/web/base/admin/council_contacts.txt
+++ b/templates/web/base/admin/council_contacts.txt
@@ -1,4 +1,4 @@
 [% WHILE ( contact = contacts.next ) -%]
 [%- NEXT IF contact.state != 'confirmed' %]
-[% contact.category_display %]	[% contact.email %]
+[% contact.category_display | html %]	[% contact.email | html %]
 [%- END %]

--- a/templates/web/base/admin/defecttypes/list.html
+++ b/templates/web/base/admin/defecttypes/list.html
@@ -19,7 +19,7 @@
                   <em>[% ('All categories') %]</em>
                 [% ELSE %]
                   [% FOR contact IN d.contacts %]
-                    [% contact.category_display %][% ',' UNLESS loop.last %]
+                    [% contact.category_display | html %][% ',' UNLESS loop.last %]
                   [% END %]
                 [% END %]
               </td>

--- a/templates/web/base/admin/list_updates.html
+++ b/templates/web/base/admin/list_updates.html
@@ -35,7 +35,7 @@
         <td>[% IF update.user.id == update.problem.user_id %][% loc('Yes') %][% ELSE %][% loc('No') %][% END %]</td>
         <td>[% IF update.user.belongs_to_body( update.problem.bodies_str ) %][% loc('Yes') %][% ELSE %][% loc('No') %][% END %]</td>
         <td>[% update.cobrand %]<br>[% update.cobrand_data | html %]</td> 
-        <td>[% prettify_state(update.state) %]<br><small>
+        <td>[% prettify_state(update.state) | html %]<br><small>
             [% loc('Created:') %] [% PROCESS format_time time=update.created %]
             <br>[% loc('Confirmed:') %] [% PROCESS format_time time=update.confirmed %]
         </small></td>

--- a/templates/web/base/admin/problem_row.html
+++ b/templates/web/base/admin/problem_row.html
@@ -30,12 +30,12 @@
             [%- END -%]
             <br>[% problem.cobrand %]<br>[% problem.cobrand_data | html %]
         </td>
-        <td>[% prettify_state(problem.state, 1) %]<br><small>
+        <td>[% prettify_state(problem.state, 1) | html %]<br><small>
             [% loc('Created') %]:&nbsp;[% PROCESS format_time time=problem.created %]
             <br>[% loc('When sent') %]:&nbsp;[% PROCESS format_time time=problem.whensent %]
             [%- IF problem.is_visible %]<br>[% loc('Confirmed:' ) %]&nbsp;[% PROCESS format_time time=problem.confirmed %][% END -%]
-            [%- IF problem.is_fixed %]<br>[% prettify_state('fixed') %]: [% PROCESS format_time time=problem.lastupdate %][% END -%]
-            [%- IF problem.is_closed %]<br>[% prettify_state('closed') %]: [% PROCESS format_time time=problem.lastupdate %][% END -%]
+            [%- IF problem.is_fixed %]<br>[% prettify_state('fixed') | html %]: [% PROCESS format_time time=problem.lastupdate %][% END -%]
+            [%- IF problem.is_closed %]<br>[% prettify_state('closed') | html %]: [% PROCESS format_time time=problem.lastupdate %][% END -%]
             [%- IF problem.is_open %]<br>[% loc('Last&nbsp;update:') %] [% PROCESS format_time time=problem.lastupdate %][% END -%]
         </small></td>
         <td>

--- a/templates/web/base/admin/responsepriorities/index.html
+++ b/templates/web/base/admin/responsepriorities/index.html
@@ -26,7 +26,7 @@
                 <em>[% loc('All categories') %]</em>
               [% ELSE %]
                 [% FOR contact IN p.contacts %]
-                  [% contact.category_display %][% ',' UNLESS loop.last %]
+                  [% contact.category_display | html %][% ',' UNLESS loop.last %]
                 [% END %]
               [% END %]
             </td>

--- a/templates/web/base/admin/stats/state.html
+++ b/templates/web/base/admin/stats/state.html
@@ -4,7 +4,7 @@
 [%- BLOCK states -%]
 [%- FOREACH state IN list %]
 [%- '<ul>' IF loop.first %]
-    <li>[% object.$state %] [% prettify_state(state) %]</li>
+    <li>[% object.$state %] [% prettify_state(state) | html %]</li>
 [%- "\n</ul>" IF loop.last %]
 [%- END %]
 [% END -%]

--- a/templates/web/base/admin/templates/view.html
+++ b/templates/web/base/admin/templates/view.html
@@ -19,7 +19,7 @@
                 <em>[% loc('All categories') %]</em>
             [% ELSE %]
                 [% FOR contact IN t.contacts %]
-                [% contact.category_display %][% ',' UNLESS loop.last %]
+                [% contact.category_display | html %][% ',' UNLESS loop.last %]
                 [% END %]
             [% END %]
         </td>

--- a/templates/web/base/admin/triage/_inspect.html
+++ b/templates/web/base/admin/triage/_inspect.html
@@ -39,7 +39,7 @@
     [% IF permissions.report_edit_category OR permissions.report_inspect OR permissions.triage %]
       <div class="inspect-section">
         <p>
-            <strong>Holding category:</strong> [% problem.category %]
+            <strong>Holding category:</strong> [% problem.category | html %]
         </p>
 
         <p>

--- a/templates/web/base/admin/update_edit.html
+++ b/templates/web/base/admin/update_edit.html
@@ -43,7 +43,7 @@
 [% END -%]
 </li>
 [% IF update.problem_state %]
-<li>[% tprintf(loc('Update changed problem state to %s'), update.problem_state) %]</li>
+<li>[% tprintf(loc('Update changed problem state to %s'), update.problem_state) | html %]</li>
 [% ELSIF update.mark_fixed %]
 <li>[% loc('Update marked problem as fixed') %]</li>
 [% ELSIF update.user.id == update.problem.user.id && update.mark_open %]

--- a/templates/web/base/auth/change_email.html
+++ b/templates/web/base/auth/change_email.html
@@ -12,7 +12,7 @@ END
 <h1>[% title %]</h1>
 
 [% IF c.user.email_verified OR (c.user.email AND NOT verifying) %]
-[% loc('Your email address') %]: [% c.user.email %]
+[% loc('Your email address') %]: [% c.user.email | html %]
 [% ELSIF c.user.email %]
 [% DEFAULT username = c.user.email %]
 [% END %]

--- a/templates/web/base/auth/change_phone.html
+++ b/templates/web/base/auth/change_phone.html
@@ -16,7 +16,7 @@ END
 [% END %]
 
 [% IF c.user.phone_verified OR (c.user.phone AND NOT verifying) %]
-[% loc('Your phone number') %]: [% c.user.phone_display %]
+[% loc('Your phone number') %]: [% c.user.phone_display | html %]
 [% ELSIF c.user.phone %]
 [% DEFAULT username = c.user.phone_display %]
 [% END %]

--- a/templates/web/base/dashboard/index.html
+++ b/templates/web/base/dashboard/index.html
@@ -65,7 +65,7 @@
           [% FOR group IN filter_states %]
           [% FOR state IN group.1 %]
             [% NEXT IF state == 'hidden' %]
-            <option [% 'selected ' IF state == q_state %] value="[% state %]">[% prettify_state(state, 1) %]</option>
+            <option [% 'selected ' IF state == q_state %] value="[% state %]">[% prettify_state(state, 1) | html %]</option>
           [% END %]
           [% END %]
         </select>
@@ -127,7 +127,7 @@
   [% FOR k IN rows %]
     <tr>
       [% IF group_by == 'state' %]
-        <th scope="row">[% prettify_state(k) %]</th>
+        <th scope="row">[% prettify_state(k) | html %]</th>
       [% ELSE %]
         <th scope="row">[% k %]</th>
       [% END %]

--- a/templates/web/base/my/my.html
+++ b/templates/web/base/my/my.html
@@ -32,8 +32,8 @@ li .my-account-buttons a {
 }
 </style>
 <ul>
-<li>[% loc('Name:') %] [% c.user.name %]
-<li>[% loc('Email:') %] [% c.user.email OR '-' %]
+<li>[% loc('Name:') %] [% c.user.name | html %]
+<li>[% loc('Email:') %] [% (c.user.email OR '-') | html %]
     <p class="my-account-buttons my-account-buttons--email">
       [% IF NOT c.user.email %]
         <a href="/auth/change_email">[% loc('Add') %]</a>
@@ -44,7 +44,7 @@ li .my-account-buttons a {
         <a href="/auth/change_email">[% loc('Change') %]</a>
       [% END %]
     </p>
-<li>[% loc('Phone:') %] [% c.user.phone_display OR '-' %]
+<li>[% loc('Phone:') %] [% (c.user.phone_display OR '-') | html %]
     <p class="my-account-buttons">
       [% IF NOT c.user.phone %]
         <a href="/auth/change_phone">[% loc('Add') %]</a>

--- a/templates/web/base/report/_item.html
+++ b/templates/web/base/report/_item.html
@@ -66,15 +66,15 @@
             </div>
             <div>
                 <h4>[% loc('State') %]</h4>
-                <p>[% prettify_state(problem.state, 1) %]</p>
+                <p>[% prettify_state(problem.state, 1) | html %]</p>
             </div>
             <div>
                 <h4>[% loc('Priority') %]</h4>
-                <p>[% problem.response_priority.name OR '-' %]</p>
+                <p>[% (problem.response_priority.name OR '-') | html %]</p>
             </div>
             <div>
                 <h4>[% loc('Traffic management required?') %]</h4>
-                <p>[% problem.get_extra_metadata('traffic_information') %]</p>
+                <p>[% problem.get_extra_metadata('traffic_information') | html %]</p>
             </div>
             <div>
                 <h4>[% loc('Extra details') %]</h4>

--- a/templates/web/base/report/_item_small.html
+++ b/templates/web/base/report/_item_small.html
@@ -1,7 +1,7 @@
 [% IF NOT no_fixed AND problem.is_fixed %]
-    <span class="item-list__item__state">[% prettify_state('fixed') %]</span>
+    <span class="item-list__item__state">[% prettify_state('fixed') | html %]</span>
 [% ELSIF NOT no_fixed AND problem.is_closed %]
-    <span class="item-list__item__state">[% prettify_state('closed') %]</span>
+    <span class="item-list__item__state">[% prettify_state('closed') | html %]</span>
 [% ELSIF (c.user.has_permission_to('report_edit_priority', problem.bodies_str_ids) OR c.user.has_permission_to('report_inspect', problem.bodies_str_ids)) AND problem.response_priority %]
     <span class="item-list__item__state">[% problem.response_priority.name %]</span>
 [% END %]

--- a/templates/web/base/report/_state_select_field.html
+++ b/templates/web/base/report/_state_select_field.html
@@ -9,12 +9,12 @@
     [% END ~%]
 [% END ~%]
 [% IF NOT found ~%]
-    <option selected value="[% current_state %]">[% prettify_state(current_state, single_fixed) %]</option>
+    <option selected value="[% current_state | html %]">[% prettify_state(current_state, single_fixed) | html %]</option>
 [% END ~%]
 [% FOREACH group IN state_groups %]
     <optgroup label="[% group.0 %]">
     [% FOREACH state IN group.1 %]
-        <option [% 'selected ' IF state == current_state %]value="[% state %]">[% prettify_state(state, single_fixed) %]</option>
+        <option [% 'selected ' IF state == current_state %]value="[% state | html %]">[% prettify_state(state, single_fixed) | html %]</option>
     [% END %]
     </optgroup>
 [% END %]

--- a/templates/web/base/report/_update_state.html
+++ b/templates/web/base/report/_update_state.html
@@ -4,7 +4,7 @@
       OR update.mark_fixed
       OR update.mark_open
 %]
-    <p class="meta-2">[% loc('State changed to:') %] [% update.problem_state_display(c) %]</p>
+    <p class="meta-2">[% loc('State changed to:') %] [% update.problem_state_display(c) | html %]</p>
     [%- global.last_state = update_state %]
     [%- IF update_state == "" AND update.mark_fixed %][% global.last_state = 'fixed - user' %][% END %]
     [%- IF update_state == "" AND update.mark_open %][% global.last_state = 'confirmed' %][% END %]

--- a/templates/web/base/report/banner.html
+++ b/templates/web/base/report/banner.html
@@ -4,7 +4,7 @@
     <div class="banner banner--[% id %]">
         <p>
             <img src="[% c.cobrand.path_to_pin_icons _ 'pin-' _ c.cobrand.pin_colour(problem, 'report') _ '.png' %]" alt="" class="pin">
-            [% text %]
+            [% text | html %]
         </p>
     </div>
 [% END %]

--- a/templates/web/base/report/updates.html
+++ b/templates/web/base/report/updates.html
@@ -18,7 +18,7 @@
       [% IF update.marks_fixed %]
         [%# A questionnaire update that marked the report fixed %]
         [% loc("Questionnaire filled in by problem reporter") %];
-        [% loc('State changed to:') %] [% prettify_state('fixed') %],
+        [% loc('State changed to:') %] [% prettify_state('fixed') | html %],
         [% prettify_dt( update.whenanswered ) %]
       [% ELSE %]
         [%# A questionnaire update, currently saying report is still open %]

--- a/templates/web/base/reports/_list-filter-status.html
+++ b/templates/web/base/reports/_list-filter-status.html
@@ -32,14 +32,14 @@
           [% FOR state IN group.1 %]
             [% NEXT IF state == 'hidden' %]
             [% SET state = 'fixed' IF state == 'fixed - council' ~%]
-            <option value="[% state %]"[% ' selected' IF filter_status.$state %]>[% prettify_state(state, 1) %]</option>
+            <option value="[% state %]"[% ' selected' IF filter_status.$state %]>[% prettify_state(state, 1) | html %]</option>
           [% END %]
         [% END %]
       [% ELSE %]
-        <option value="open"[% ' selected' IF filter_status.open %]>[% prettify_state('confirmed') %]</option>
-        <option value="closed"[% ' selected' IF filter_status.closed %]>[% prettify_state('closed') %]</option>
+        <option value="open"[% ' selected' IF filter_status.open %]>[% prettify_state('confirmed') | html %]</option>
+        <option value="closed"[% ' selected' IF filter_status.closed %]>[% prettify_state('closed') | html %]</option>
         [% IF has_fixed_state %]
-            <option value="fixed"[% ' selected' IF filter_status.fixed %]>[% prettify_state('fixed') %]</option>
+            <option value="fixed"[% ' selected' IF filter_status.fixed %]>[% prettify_state('fixed') | html %]</option>
         [% END %]
       [% END %]
 </select>

--- a/templates/web/base/reports/_status_filter_options.html
+++ b/templates/web/base/reports/_status_filter_options.html
@@ -1,3 +1,3 @@
     [%~ IF c.cobrand.on_map_default_status == 'open' %]
-      data-none="[% prettify_state('confirmed') %]"
+      data-none="[% prettify_state('confirmed') | html %]"
     [%~ END ~%]

--- a/templates/web/base/reports/index.html
+++ b/templates/web/base/reports/index.html
@@ -100,7 +100,7 @@
         <table class="dashboard-ranking-table">
             <tbody>
               [% FOR line IN wards %]
-                <tr><td>[% line.name %]</td><td>[% tprintf(nget("%s report", "%s reports", line.reports), line.reports) %]</td></tr>
+                <tr><td>[% line.name | html %]</td><td>[% tprintf(nget("%s report", "%s reports", line.reports), line.reports) %]</td></tr>
               [% END %]
             </tbody>
             <tfoot>
@@ -113,7 +113,7 @@
         <table class="dashboard-ranking-table">
             <tbody>
               [% FOR line IN top_five_bodies %]
-                <tr><td>[% line.name %]</td><td>[% tprintf(nget("%s day", "%s days", line.days), line.days) %]</td></tr>
+                <tr><td>[% line.name | html %]</td><td>[% tprintf(nget("%s day", "%s days", line.days), line.days) %]</td></tr>
               [% END %]
             </tbody>
             <tfoot>
@@ -129,7 +129,7 @@
             <tbody>
               [% FOR line IN top_five_categories %]
                 [% line_count = line.count | format_number ~%]
-                <tr><td>[% line.category %]</td><td>[% tprintf(nget("%s report", "%s reports", line.count), decode(line_count)) %]</td></tr>
+                <tr><td>[% line.category | html %]</td><td>[% tprintf(nget("%s report", "%s reports", line.count), decode(line_count)) %]</td></tr>
               [% END %]
             </tbody>
             <tfoot>

--- a/templates/web/base/tokens/confirm_problem.html
+++ b/templates/web/base/tokens/confirm_problem.html
@@ -2,7 +2,7 @@
 
 <div class="confirmation-header">
 
-  <h1><a href="[% c.cobrand.relative_url_for_report( report ) %][% report.url %]">[% report.title %]</a></h1>
+  <h1><a href="[% c.cobrand.relative_url_for_report( report ) %][% report.url %]">[% report.title | html %]</a></h1>
 
   [% IF c.cobrand.is_council %]
     [% IF c.cobrand.owns_problem( report ) %]

--- a/templates/web/base/tokens/confirm_update.html
+++ b/templates/web/base/tokens/confirm_update.html
@@ -11,7 +11,7 @@ END;
 
 <div class="confirmation-header">
 
-  <h1><a href="[% problem_url %]">[% problem.title %]</a></h1>
+  <h1><a href="[% problem_url %]">[% problem.title | html %]</a></h1>
 
   <h2>[% loc('Thank you for updating this issue!') %]</h2>
 

--- a/templates/web/bromley/admin/category-checkboxes.html
+++ b/templates/web/bromley/admin/category-checkboxes.html
@@ -17,7 +17,7 @@
       <li>
         <label class="inline" title="[% contact.email | html %]">
           <input type="checkbox" name="contacts[[% contact.id %]]" [% 'checked' IF contact.active %]/>
-          [% contact.category %]
+          [% contact.category | html %]
         </label>
       </li>
     [% END %]

--- a/templates/web/buckinghamshire/report/_item_heading.html
+++ b/templates/web/buckinghamshire/report/_item_heading.html
@@ -1,1 +1,1 @@
-<h3 class="item-list__heading">[% problem.category | html %]: [% problem.title | html %]</h3>
+<h3 class="item-list__heading">[% problem.category_display | html %]: [% problem.title | html %]</h3>

--- a/templates/web/cheshireeast/tokens/confirm_problem.html
+++ b/templates/web/cheshireeast/tokens/confirm_problem.html
@@ -4,7 +4,7 @@
 
   <h1>Thank you for your report</h1>
 
-  <p><a href="[% c.cobrand.relative_url_for_report( report ) %][% report.url %]">[% report.title %]</a>
+  <p><a href="[% c.cobrand.relative_url_for_report( report ) %][% report.url %]">[% report.title | html %]</a>
 
   [% IF c.cobrand.owns_problem( report ) %]
     <p>Your reference for this report is [% report.id %], please quote it in any enquiries.</p>

--- a/templates/web/cheshireeast/tokens/confirm_update.html
+++ b/templates/web/cheshireeast/tokens/confirm_update.html
@@ -13,7 +13,7 @@ END;
 
   <h1>Thank you for updating this issue</h1>
 
-  <h2><a href="[% problem_url %]">[% problem.title %]</a></h2>
+  <h2><a href="[% problem_url %]">[% problem.title | html %]</a></h2>
 
   <p><a href="https://www.cheshireeast.gov.uk/">Council homepage</a></p>
 

--- a/templates/web/fixmystreet.com/admin/stats/refused.html
+++ b/templates/web/fixmystreet.com/admin/stats/refused.html
@@ -9,7 +9,7 @@
             <li>ALL</li>
           [%~ END %]
           [%~ IF data.contacts.size; FOR c IN data.contacts %]
-            <li>[% c.category %]</li>
+            <li>[% c.category | html %]</li>
           [%~ END; END %]
         </ul>
     </li>

--- a/templates/web/fixmystreet.com/reports/summary.html
+++ b/templates/web/fixmystreet.com/reports/summary.html
@@ -117,7 +117,7 @@
               [% FOR k IN rows %]
                 <tr>
                   [% IF group_by == 'state' %]
-                    <th scope="row">[% prettify_state(k) %]</th>
+                    <th scope="row">[% prettify_state(k) | html %]</th>
                   [% ELSE %]
                     <th scope="row">[% k or loc('Website') %]</th>
                   [% END %]
@@ -145,11 +145,11 @@
         <table class="dashboard-ranking-table">
             <tbody>
               [% FOR line IN top_five_bodies %]
-                <tr><td>[% line.name %]</td><td>[% tprintf(nget("%s day", "%s days", line.days), line.days) %]</td></tr>
+                <tr><td>[% line.name | html %]</td><td>[% tprintf(nget("%s day", "%s days", line.days), line.days) %]</td></tr>
               [% END %]
             </tbody>
             <tfoot>
-                <tr><td>[% body.name %]</td><td>[% tprintf(nget("%s day", "%s days", body_average), body_average) %]</td></tr>
+                <tr><td>[% body.name | html %]</td><td>[% tprintf(nget("%s day", "%s days", body_average), body_average) %]</td></tr>
                 <tr><td>[% loc('Overall average') %]</td><td>[% tprintf(nget("%s day", "%s days", average), average) %]</td></tr>
             </tfoot>
         </table>
@@ -161,7 +161,7 @@
             <tbody>
               [% FOR line IN top_five_categories %]
                 [% line_count = line.count | format_number ~%]
-                <tr><td>[% line.category %]</td><td>[% tprintf(nget("%s report", "%s reports", line.count), decode(line_count)) %]</td></tr>
+                <tr><td>[% line.category | html %]</td><td>[% tprintf(nget("%s report", "%s reports", line.count), decode(line_count)) %]</td></tr>
               [% END %]
             </tbody>
             <tfoot>

--- a/templates/web/zurich/admin/bodies/body.html
+++ b/templates/web/zurich/admin/bodies/body.html
@@ -20,7 +20,7 @@
         </tr>
         [% WHILE ( cat = contacts.next ) %]
             <tr[% IF cat.state == 'deleted' %] class="is-deleted"[% END %]>
-                <td><a href="[% c.uri_for_action( 'admin/bodies/edit', [ body_id ], cat.category ) %]">[% cat.category_display %]</a></td>
+                <td><a href="[% c.uri_for_action( 'admin/bodies/edit', [ body_id ], cat.category ) %]">[% cat.category_display | html %]</a></td>
                 <td>[% cat.email | html %]</td>
                 <td>[% cat.editor %]</td>
                 <td>[% cat.note | html %]</td>

--- a/templates/web/zurich/admin/bodies/form.html
+++ b/templates/web/zurich/admin/bodies/form.html
@@ -26,7 +26,7 @@
         <select class="form-control" name="extra[category]" id="category">
             <option value="">[% loc('-- Pick a category --') %]</option>
             [% FOR cat IN c.cobrand.category_options %]
-            <option value="[% cat.category %]"[% ' selected' IF cat.category == body.get_extra_metadata('category') %]>[% cat.category_display | html %]</option>
+            <option value="[% cat.category | html %]"[% ' selected' IF cat.category == body.get_extra_metadata('category') %]>[% cat.category_display | html %]</option>
             [% END %]
         </select>
     </p>

--- a/templates/web/zurich/admin/index.html
+++ b/templates/web/zurich/admin/index.html
@@ -9,7 +9,7 @@
 <h2>[% loc('Problem breakdown by state') %]</h2>
 <ul>
   [% FOREACH state IN problems.keys.sort %]
-    <li>[% problems.$state %] [% prettify_state(state) %]</li>
+    <li>[% problems.$state %] [% prettify_state(state) | html %]</li>
   [% END %]
 </ul>
 

--- a/templates/web/zurich/admin/list_updates.html
+++ b/templates/web/zurich/admin/list_updates.html
@@ -24,7 +24,7 @@
         <div class="admin-note [% 'adminhidden' IF update.state == 'hidden' || update.problem.state == 'hidden' %]" title="[% loc('ID') %]: [% update.id %]">
           <p class="admin-note__text">[% update.text | html %]</p>
           <p class="admin-note__creator">
-            <a href="mailto:[% update.user.email %]">[% update.user.name || update.user.email %]</a>
+            <a href="mailto:[% update.user.email | html %]">[% (update.user.name || update.user.email) | html %]</a>
             &middot; [% PROCESS format_date this_date=update.created %] [% update.created.hms %]
           </p>
         </div>
@@ -38,7 +38,7 @@
         <div class="admin-note admininternal" title="[% loc('ID') %]: [% update.id %]">
           <p class="admin-note__text">[% update.text | html %]</p>
           <p class="admin-note__creator">
-            <a href="mailto:[% update.user.email %]">[% update.user.name || update.user.email %]</a>
+            <a href="mailto:[% update.user.email | html %]">[% (update.user.name || update.user.email) | html %]</a>
             &middot; [% PROCESS format_date this_date=update.created %] [% update.created.hms %]
           </p>
         </div>

--- a/templates/web/zurich/admin/problem_row.html
+++ b/templates/web/zurich/admin/problem_row.html
@@ -18,10 +18,10 @@
         <td>[% PROCESS value_or_nbsp value=problem.category_display %]</td>
         <td>[% PROCESS format_date this_date=problem.created %]</td>
         <td>[% PROCESS format_date this_date=problem.lastupdate %]</td>
-        <td>[% prettify_state(problem.state) %]
+        <td>[% prettify_state(problem.state) | html %]
             [% IF problem.state == 'feedback pending';
             SET cs=problem.get_extra_metadata('closure_status');
-            IF cs %] ([% prettify_state(cs) %]) [% END; END %]</td>
+            IF cs %] ([% prettify_state(cs) | html %]) [% END; END %]</td>
 
         [% IF include_subdiv %]
             <td>

--- a/templates/web/zurich/admin/report_edit-sdm.html
+++ b/templates/web/zurich/admin/report_edit-sdm.html
@@ -61,7 +61,7 @@
     <dd>[% problem.category_display | html %]</dd>
 
     <dt class="print-only">[% loc('State:') %] <!-- Status --></dt>
-    <dd class="print-only">[% prettify_state(problem.state) %]</dd>
+    <dd class="print-only">[% prettify_state(problem.state) | html %]</dd>
 
     <dt>[% loc('Time spent (in minutes):') %]</dt>
     <dd>[% problem.get_time_spent %]</dd>

--- a/templates/web/zurich/admin/reports/edit.html
+++ b/templates/web/zurich/admin/reports/edit.html
@@ -89,7 +89,7 @@
     <dd>[% problem.category_display | html %]</dd>
 
     <dt class="print-only">[% loc('State:') %] <!-- Status --></dt>
-    <dd class="print-only">[% prettify_state(problem.state) %]</dd>
+    <dd class="print-only">[% prettify_state(problem.state) | html %]</dd>
 
     <dt>[% loc('Time spent (in minutes):') %]</dt>
     <dd>[% problem.get_time_spent %]</dd>
@@ -142,8 +142,8 @@
         <select class="form-control" name="state"  id="state" data-pstate="[% pstate %]">
             <option value="">--</option>
           [% FOREACH s IN states %]
-            <option [% 'selected ' IF s.state == pstate %] value="[% s.state %]">
-            [% IF s.trans; s.trans; ELSE; prettify_state(s.state); END %]</option>
+            <option [% 'selected ' IF s.state == pstate %] value="[% s.state | html %]">
+            [% IF s.trans; s.trans; ELSE; prettify_state(s.state) | html; END %]</option>
           [% END %]
         </select>
     </dd>
@@ -159,7 +159,7 @@
             <select class="form-control" name="category" id="category">
                 <option value="">--</option>
               [% FOREACH cat IN category_options %]
-                <option value="[% cat.category %]">[% cat.category_display ~%]
+                <option value="[% cat.category | html %]">[% cat.category_display | html ~%]
                     [% ' (' _ cat.abbreviation _ ')' IF cat.abbreviation %]</option>
               [% END %]
             </select>

--- a/templates/web/zurich/admin/stats/index.html
+++ b/templates/web/zurich/admin/stats/index.html
@@ -27,7 +27,7 @@
   <select class="form-control" name="category" id="category">
     <option value="">--</option>
   [% FOREACH cat IN category_options %]
-    <option value="[% cat.category %]"[% ' selected' IF cat.category == category %]>[% cat.category_display ~%]
+    <option value="[% cat.category | html %]"[% ' selected' IF cat.category == category %]>[% cat.category_display | html ~%]
         [% ' (' _ cat.abbreviation _ ')' IF cat.abbreviation %]</option>
   [% END %]
   </select>
@@ -69,7 +69,7 @@
 
 <table>
 <tr><th>[% loc('Category') %]</th><th>[% loc('Count') %]</th></tr>
-[% WHILE ( cc = per_category.next ) %]<tr><td>[% cc.category %]</td><td>[% cc.get_column('c') %]</td></tr>[% END %]
+[% WHILE ( cc = per_category.next ) %]<tr><td>[% cc.category | html %]</td><td>[% cc.get_column('c') %]</td></tr>[% END %]
 </table>
 
 [% INCLUDE 'admin/footer.html' %]

--- a/templates/web/zurich/admin/templates/edit.html
+++ b/templates/web/zurich/admin/templates/edit.html
@@ -4,7 +4,7 @@
 <h2> [% tprintf(loc('Response Templates for %s'), body.name) %] </h2>
 
 <h3> [% IF rt.id %]
-    [% tprintf(loc('Template &laquo;%s&raquo;'), rt.title) %]
+    [% tprintf(loc('Template &laquo;%s&raquo;'), rt.title) | html %]
     [% ELSE %]
     [% loc('New template') %]
     [% END %]

--- a/templates/web/zurich/admin/templates/view.html
+++ b/templates/web/zurich/admin/templates/view.html
@@ -14,8 +14,8 @@
     <tbody>
 [% FOR t IN response_templates %]
     <tr>
-        <td>  [% t.title %] </td>
-        <td> [% t.text %] </td>
+        <td>  [% t.title | html %] </td>
+        <td> [% t.text | html %] </td>
         <td> [% t.created %] </td>
         <td> <a href="[% c.uri_for_action('/admin/templates/edit', body.id, t.id) %]" class="btn">[% loc('Edit') %]</a> </td>
     </tr>

--- a/templates/web/zurich/admin/update_edit.html
+++ b/templates/web/zurich/admin/update_edit.html
@@ -22,7 +22,7 @@
 <input type='hidden' name='name' id='name' value='[% update.name | html %]'>
 <input type='hidden' id='username' name='username' value='[% update.user.username | html %]'>
 [% IF update.problem_state %]
-<li>[% tprintf(loc('Update changed problem state to %s'), update.problem_state) %]</li>
+<li>[% tprintf(loc('Update changed problem state to %s'), update.problem_state) | html %]</li>
 [% END %]
 </li>
 

--- a/templates/web/zurich/footer.html
+++ b/templates/web/zurich/footer.html
@@ -8,7 +8,7 @@
                     <div id="main-nav" role="navigation">
                       [% IF c.user_exists %]
                         <p>
-                            [% tprintf(loc('Hi %s'), c.user.name || c.user.email) %]
+                            [% tprintf(loc('Hi %s'), c.user.name || c.user.email) | html %]
                         </p><p><a href="/admin">[% loc('Summary') %]</a> | <a href="/auth/sign_out">[% loc('sign out') %]</a>
                         </p>
                       [% END %]

--- a/templates/web/zurich/report/_main.html
+++ b/templates/web/zurich/report/_main.html
@@ -1,7 +1,7 @@
 [% INCLUDE 'report/banner.html' %]
 
 <div class="problem-header clearfix">
-    <h1>[% tprintf( loc('Reported in the %s category'), problem.category_display ) %]</h1>
+    <h1>[% tprintf( loc('Reported in the %s category'), problem.category_display ) | html %]</h1>
     <p class="sub">
         [% prettify_dt( problem.created, 'zurich' ) %]
         [%- IF !problem.used_map %]<br>[% loc('there is no pin shown as the user did not use the map') %][% END %]

--- a/templates/web/zurich/report/banner.html
+++ b/templates/web/zurich/report/banner.html
@@ -1,6 +1,6 @@
 [% USE date %]
 [% problem_hashref = c.cobrand.problem_as_hashref(problem, c) %]
 <div class="banner banner--[% problem_hashref.banner_id %]">
-    <p>[% problem_hashref.state_t %]</p>
+    <p>[% problem_hashref.state_t | html %]</p>
 </div>
 

--- a/templates/web/zurich/reports/_list-filter-status.html
+++ b/templates/web/zurich/reports/_list-filter-status.html
@@ -2,6 +2,6 @@
     data-all="[% loc('All') %]" data-all-options='["open","closed"]'
     [% INCLUDE 'reports/_status_filter_options.html' %]
 >
-    <option value="open"[% ' selected' IF filter_status.open %]>[% prettify_state('confirmed') %]</option>
-    <option value="closed"[% ' selected' IF filter_status.closed %]>[% prettify_state('closed') %]</option>
+    <option value="open"[% ' selected' IF filter_status.open %]>[% prettify_state('confirmed') | html %]</option>
+    <option value="closed"[% ' selected' IF filter_status.closed %]>[% prettify_state('closed') | html %]</option>
 </select>


### PR DESCRIPTION
The below breaks down into three things:
* Various templates assumed a problem's state would be safe, as it is only set by an admin (the front end state change is whitelisted);
* Various templates assumed a problem's category would be safe, for the same reason;
* In a couple of templates, you could submit a malicious payload to yourself.

- [ ] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog