### PR TITLE
add bodies_id to stash for around and report/new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
         - Fix issue with inspector duplication workflow.
         - Fix removal of cached photos on moderation. #2696
         - Checking of cached front page details against database. #2696
+        - Inconsistent display of mark private checkbox for staff users
     - Development improvements:
         - Upgrade the underlying framework and a number of other packages. #2473
         - Add feature cobrand helper function.

--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -235,6 +235,7 @@ sub check_and_stash_category : Private {
     my $csv = Text::CSV->new();
     $csv->combine(@list_of_names);
     $c->stash->{around_bodies} = \@bodies;
+    $c->stash->{bodies_ids} = [ map { $_->id } @bodies];
     $c->{stash}->{list_of_names_as_string} = $csv->string;
 
     my $where  = { body_id => [ keys %bodies ], };

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -749,6 +749,7 @@ sub setup_categories_and_bodies : Private {
     $c->stash->{bodies} = \%bodies;
     $c->stash->{contacts} = \@contacts;
     $c->stash->{bodies_to_list} = \%bodies_to_list;
+    $c->stash->{bodies_ids} = [ map { $_->id } @bodies];
     $c->stash->{category_options} = \@category_options;
     $c->stash->{category_extras}  = \%category_extras;
     $c->stash->{category_extras_hidden}  = \%category_extras_hidden;

--- a/templates/web/base/report/new/form_user_loggedin.html
+++ b/templates/web/base/report/new/form_user_loggedin.html
@@ -6,9 +6,9 @@
     [% INCLUDE form_as %]
   </div>
 [% ELSE %]
-  [% can_contribute_as_another_user = c.user.has_permission_to("contribute_as_another_user", bodies.keys) %]
-  [% can_contribute_as_anonymous_user = c.user.has_permission_to("contribute_as_anonymous_user", bodies.keys) %]
-  [% can_contribute_as_body = c.user.from_body AND c.user.has_permission_to("contribute_as_body", bodies.keys) %]
+  [% can_contribute_as_another_user = c.user.has_permission_to("contribute_as_another_user", bodies_ids) %]
+  [% can_contribute_as_anonymous_user = c.user.has_permission_to("contribute_as_anonymous_user", bodies_ids) %]
+  [% can_contribute_as_body = c.user.from_body AND c.user.has_permission_to("contribute_as_body", bodies_ids) %]
   [% IF can_contribute_as_another_user OR can_contribute_as_anonymous_user OR can_contribute_as_body %]
     [% INCLUDE form_as %]
   [% END %]
@@ -61,7 +61,7 @@
     <input class="form-control" type="text" value="[% report.user.email | html %]" name="email" id="form_email">
 [% END %]
 
-[% IF c.user.has_permission_to("report_inspect", bodies.keys) OR c.user.has_permission_to("report_mark_private", bodies.keys) %]
+[% IF c.user.has_permission_to("report_inspect", bodies_ids) OR c.user.has_permission_to("report_mark_private", bodies_ids) %]
     <div class="checkbox-group">
         <input type="checkbox" name="non_public" id="form_non_public" value="1"[% ' checked' IF report.non_public %]>
         <label class="inline" for="form_non_public">[% loc('Private') %] </label>


### PR DESCRIPTION
This resolved the problem of checking user body permissions on both
around and report/new by adding a variable to stash specifically for
this purpose. Previously staff users could not see the mark private tick
if the report form was loaded via javascript from the around page as
there was no bodies variable in the stash.