### PR TITLE
pass cobrand name to state display from alert script

### DIFF
--- a/perllib/FixMyStreet/Script/Alerts.pm
+++ b/perllib/FixMyStreet/Script/Alerts.pm
@@ -97,7 +97,7 @@ sub send() {
                     !( $last_problem_state eq '' && $row->{item_problem_state} eq 'confirmed' ) &&
                     $last_problem_state ne $row->{item_problem_state}
                 ) {
-                    my $state = FixMyStreet::DB->resultset("State")->display($row->{item_problem_state}, 1, $cobrand);
+                    my $state = FixMyStreet::DB->resultset("State")->display($row->{item_problem_state}, 1, $cobrand->moniker);
 
                     my $update = _('State changed to:') . ' ' . $state;
                     $row->{item_text} = $row->{item_text} ? $row->{item_text} . "\n\n" . $update :


### PR DESCRIPTION
This was passing the cobrand object so the checks in State::display that
were relying on the moniker were not working.

[skip changelog]