### PR TITLE
Default templates to escape all output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     - Security:
         - Fix XSS vulnerability in pagination page number.
         - Rotate session ID after successful login.
+        - Switch to auto-escaping of all template variables (see below).
     - Front end improvements:
         - Improved 403 message, especially for private reports. #2511
         - Mobile users can now filter the pins on the `/around` map view. #2366
@@ -77,6 +78,10 @@
         - Add support for account_id parameter to POST Service Request calls.
         - Do not overwrite/remove protected meta data. #2598
         - Spot multiple groups inside a <groups> element.
+    - Backwards incompatible changes:
+        - The FixMyStreet templating code will now escape all variables by
+          default. If you need to output HTML in a variable directly, you will
+          need to escape it with the `safe` filter, e.g. `[% some_html | safe %]`.
 
 * v2.6 (3rd May 2019)
     - New features:

--- a/locale/de_CH.UTF-8/LC_MESSAGES/FixMyStreet.po
+++ b/locale/de_CH.UTF-8/LC_MESSAGES/FixMyStreet.po
@@ -74,7 +74,7 @@ msgstr ""
 #: templates/web/base/status/stats.html:27
 #: templates/web/zurich/admin/index.html:6
 msgid "%s council contacts &ndash; %s confirmed, %s unconfirmed"
-msgstr "%s interne Stellen &ndash; %s best&auml;tigt, %s unbest&auml;tigt"
+msgstr "%s interne Stellen &ndash; %s bestätigt, %s unbestätigt"
 
 #. ("%s is the site name")
 #: templates/web/base/alert/index.html:8
@@ -149,7 +149,7 @@ msgstr ""
 
 #: templates/web/base/around/intro.html:2
 msgid "(like graffiti, fly tipping, broken paving slabs, or street lighting)"
-msgstr "(z.B. illegale Deponien, Strassensch&auml;den, Graffitis usw.)"
+msgstr "(z.B. illegale Deponien, Strassenschäden, Graffitis usw.)"
 
 #: templates/web/base/reports/index.html:82
 msgid "(no longer exists)"
@@ -206,7 +206,7 @@ msgstr ""
 #. ("The first %s is a dropdown of all/fixed/etc, the second is a dropdown of categories")
 #: templates/web/base/reports/_list-filters.html:70
 msgid "<label for=\"statuses\">Show</label> %s reports <label for=\"filter_categories\">about</label> %s"
-msgstr "<label for=\"statuses\">Zeige</label> %s Meldungen <label for=\"filter_categories\">&uuml;ber</label> %s"
+msgstr "<label for=\"statuses\">Zeige</label> %s Meldungen <label for=\"filter_categories\">über</label> %s"
 
 #: templates/web/base/js/translation_strings.html:101
 msgid "<span>%s</span> saved."
@@ -219,7 +219,7 @@ msgstr "<strong>%s</strong> Meldungen Total"
 
 #: templates/web/base/report/form/user_loggedout_by_email_heading.html:11
 msgid "<strong>No</strong> Let me confirm my report by email"
-msgstr "Meldung per E-Mail best&auml;tigen"
+msgstr "Meldung per E-Mail bestätigen"
 
 #: templates/web/base/report/form/user_loggedout_by_email_heading.html:5
 msgid "<strong>No</strong> Let me confirm my report by email/text"
@@ -273,7 +273,7 @@ msgstr ""
 #: templates/web/base/admin/bodies/index.html:78
 #: templates/web/zurich/admin/bodies/form.html:51
 msgid "Add body"
-msgstr "DA / Externe Adresse hinzuf&uuml;gen"
+msgstr "DA / Externe Adresse hinzufügen"
 
 #: templates/web/base/auth/change_email.html:1
 #: templates/web/base/auth/change_email.html:7
@@ -295,7 +295,7 @@ msgstr ""
 #: templates/web/base/admin/bodies/body.html:127
 #: templates/web/zurich/admin/bodies/body.html:33
 msgid "Add new category"
-msgstr "F&uuml;ge neue Kategorie hinzu"
+msgstr "Füge neue Kategorie hinzu"
 
 #: templates/web/base/admin/extra-metadata-form.html:82
 msgid "Add option"
@@ -318,11 +318,11 @@ msgstr ""
 #: templates/web/base/admin/users/index.html:48
 #: templates/web/base/admin/users/index.html:51
 msgid "Add user"
-msgstr "User hinzuf&uuml;gen"
+msgstr "User hinzufügen"
 
 #: perllib/FixMyStreet/Cobrand/Default.pm:736
 msgid "Add/edit problem categories"
-msgstr "F&uuml;ge neue Kategorie hinzu"
+msgstr "Füge neue Kategorie hinzu"
 
 #: perllib/FixMyStreet/Cobrand/Default.pm:738
 msgid "Add/edit response priorities"
@@ -447,7 +447,7 @@ msgstr "Anonym"
 #: templates/web/base/report/new/form_user_loggedin.html:25
 #: templates/web/base/report/update/form_user_loggedin.html:16
 msgid "Another user"
-msgstr "User hinzuf&uuml;gen"
+msgstr "User hinzufügen"
 
 #: templates/web/base/js/translation_strings.html:76
 msgid "Are you sure you want to cancel this upload?"
@@ -498,7 +498,7 @@ msgstr "User an Gegenden zuweisen"
 
 #: perllib/FixMyStreet/Cobrand/Zurich.pm:183
 msgid "Assigned to %s"
-msgstr "Besten Dank f&uuml;r Ihre Meldung. Wir haben Ihr Anliegen an %s weitergeleitet, da es nicht in den Zust&auml;ndigkeitsbereich der am Pilot beteiligten Fachbereiche f&auml;llt.<br/>Freundliche Gr&uuml;sse <br/>Ihre Stadt Z&uuml;rich"
+msgstr "Besten Dank für Ihre Meldung. Wir haben Ihr Anliegen an %s weitergeleitet, da es nicht in den Zuständigkeitsbereich der am Pilot beteiligten Fachbereiche fällt.<br/>Freundliche Grüsse <br/>Ihre Stadt Zürich"
 
 #: templates/web/base/open311/index.html:76
 msgid "At most %d requests are returned in each query.  The returned requests are ordered by requested_datetime, so to get all requests, do several searches with rolling start_date and end_date."
@@ -519,7 +519,7 @@ msgstr ""
 
 #: templates/web/base/admin/template_edit.html:80
 msgid "Auto-response:"
-msgstr "R&uuml;ckmeldung an User"
+msgstr "Rückmeldung an User"
 
 #: templates/web/base/admin/extra-metadata-form.html:14
 msgid "Automated"
@@ -539,7 +539,7 @@ msgstr ""
 
 #: templates/web/base/report/new/after_photo.html:7
 msgid "Avoid personal information and vehicle number plates"
-msgstr "Vermeiden Sie pers&ouml;nliche Informationen auf dem Foto wie Kfz-Kennzeichen oder Personen"
+msgstr "Vermeiden Sie persönliche Informationen auf dem Foto wie Kfz-Kennzeichen oder Personen"
 
 #: perllib/FixMyStreet/DB/Result/Problem.pm:349
 #: templates/web/zurich/report/_item.html:11
@@ -548,7 +548,7 @@ msgstr "Überprüfung ausstehend"
 
 #: templates/web/base/js/translation_strings.html:43
 msgid "Back"
-msgstr "Zur&uuml;ck"
+msgstr "Zurück"
 
 #: templates/web/base/report/_main.html:8
 msgid "Back to all reports"
@@ -590,11 +590,11 @@ msgstr ""
 
 #: templates/web/base/auth/token.html:27 templates/web/base/email_sent.html:20
 msgid "Can&rsquo;t find our email? Check your spam folder&nbsp;&ndash; that&rsquo;s the solution 99% of the time."
-msgstr "Falls Sie kein E-Mail erhalten haben, &uuml;berpr&uuml;fen Sie bitte Ihren Spamordner."
+msgstr "Falls Sie kein E-Mail erhalten haben, überprüfen Sie bitte Ihren Spamordner."
 
 #: templates/web/base/around/_report_banner.html:5
 msgid "Can't see the map? <em>Skip this step</em>"
-msgstr "Karte nicht sichtbar? <em>&Uuml;berspringen Sie diesen Schritt</em>"
+msgstr "Karte nicht sichtbar? <em>Überspringen Sie diesen Schritt</em>"
 
 #: perllib/FixMyStreet/Cobrand/Default.pm:647
 #: templates/web/base/admin/responsepriorities/list.html:8
@@ -630,7 +630,7 @@ msgstr ""
 
 #: perllib/FixMyStreet/App/Controller/Admin.pm:618
 msgid "Category changed from ‘%s’ to ‘%s’"
-msgstr "Kategorie von ‘%s’ nach ‘%s’ ge&auml;ndert"
+msgstr "Kategorie von ‘%s’ nach ‘%s’ geändert"
 
 #: templates/web/base/admin/stats/fix_rate.html:1
 #: templates/web/base/admin/stats/index.html:6
@@ -654,13 +654,13 @@ msgstr "Anpassen"
 #: templates/web/base/auth/change_email.html:1
 #: templates/web/base/auth/change_email.html:3
 msgid "Change email address"
-msgstr "E-Mail Adresse &auml;ndern"
+msgstr "E-Mail Adresse ändern"
 
 #: templates/web/base/auth/change_password.html:1
 #: templates/web/base/auth/change_password.html:5
 #: templates/web/base/my/my.html:65
 msgid "Change password"
-msgstr "Passwort &auml;ndern"
+msgstr "Passwort ändern"
 
 #: templates/web/base/auth/change_phone.html:1
 #: templates/web/base/auth/change_phone.html:3
@@ -702,19 +702,19 @@ msgstr "Schaden lokalisieren"
 
 #: templates/web/base/email_sent.html:13
 msgid "Click the link in our confirmation email to activate your alert."
-msgstr "Klicken Sie auf den Link im Best&auml;tigungsmail um diese Benachrichtigung zu aktivieren."
+msgstr "Klicken Sie auf den Link im Bestätigungsmail um diese Benachrichtigung zu aktivieren."
 
 #: templates/web/base/email_sent.html:9
 msgid "Click the link in our confirmation email to publish your problem."
-msgstr "Klicken Sie auf den Link im Best&auml;tigungsmail um &uuml;ber den Bearbeitungsstand Ihrer Meldung informiert zu bleiben."
+msgstr "Klicken Sie auf den Link im Bestätigungsmail um über den Bearbeitungsstand Ihrer Meldung informiert zu bleiben."
 
 #: templates/web/base/email_sent.html:11
 msgid "Click the link in our confirmation email to publish your update."
-msgstr "Klicken Sie auf den Link im Best&auml;tigungsmail um diese &Uuml;berarbeitung zu ver&ouml;ffentlichen."
+msgstr "Klicken Sie auf den Link im Bestätigungsmail um diese Überarbeitung zu veröffentlichen."
 
 #: templates/web/base/auth/token.html:23
 msgid "Click the link in our confirmation email to sign in."
-msgstr "Klicken Sie auf den Link im Best&auml;tigungsemail um sich anzumelden."
+msgstr "Klicken Sie auf den Link im Bestätigungsemail um sich anzumelden."
 
 #: templates/web/base/auth/token.html:20
 msgid "Click the link in that email to sign in."
@@ -786,12 +786,12 @@ msgstr ""
 
 #: templates/web/base/admin/bodies/body.html:78
 msgid "Confirm"
-msgstr "Best&auml;tigen"
+msgstr "Bestätigen"
 
 #: templates/web/base/auth/2faform.html:1
 #: templates/web/base/auth/smsform.html:1 templates/web/base/auth/token.html:1
 msgid "Confirm account"
-msgstr "Account best&auml;tigen"
+msgstr "Account bestätigen"
 
 #: templates/web/base/report/form/user_loggedout_password.html:30
 msgid "Confirm by email instead, providing a new password at that point. When you confirm, your password will be updated."
@@ -810,13 +810,13 @@ msgstr "Bestätigung"
 #: templates/web/zurich/admin/bodies/contact-form.html:35
 #: templates/web/zurich/admin/stats/index.html:61
 msgid "Confirmed"
-msgstr "Best&auml;tigt"
+msgstr "Bestätigt"
 
 #: templates/web/base/admin/list_updates.html:40
 #: templates/web/base/admin/problem_row.html:36
 #: templates/web/base/admin/report_edit.html:79
 msgid "Confirmed:"
-msgstr "Best&auml;tigt:"
+msgstr "Bestätigt:"
 
 #. ("%s is the site name")
 #: templates/web/base/about/_sidebar.html:6
@@ -903,7 +903,7 @@ msgstr "Kategorie erstellen"
 
 #: templates/web/base/admin/responsepriorities/edit.html:58
 msgid "Create priority"
-msgstr "Priorit&auml;t erstellen"
+msgstr "Priorität erstellen"
 
 #: perllib/FixMyStreet/Cobrand/Default.pm:718
 msgid "Create reports/updates as anonymous user"
@@ -973,7 +973,7 @@ msgstr ""
 
 #: templates/web/zurich/admin/stats/index.html:56
 msgid "Dealt with by subdivision within 5 working days"
-msgstr "Innerhalb von f&uuml;nf Arbeitstagen abgeschlossen"
+msgstr "Innerhalb von fünf Arbeitstagen abgeschlossen"
 
 #: templates/web/base/admin/responsepriorities/list.html:9
 msgid "Default"
@@ -1005,7 +1005,7 @@ msgstr "Vorlage löschen"
 #: templates/web/base/admin/bodies/index.html:31
 #: templates/web/zurich/admin/bodies/contact-form.html:36
 msgid "Deleted"
-msgstr "Gel&ouml;scht"
+msgstr "Gelöscht"
 
 #: templates/web/base/report/_main.html:125
 #: templates/web/base/report/update.html:56
@@ -1152,7 +1152,7 @@ msgstr ""
 
 #: perllib/FixMyStreet/Cobrand/Default.pm:711
 msgid "Edit report priority"
-msgstr "Priorit&auml;t editieren"
+msgstr "Priorität editieren"
 
 #: perllib/FixMyStreet/Cobrand/Default.pm:709
 msgid "Edit reports"
@@ -1221,7 +1221,7 @@ msgstr "E-Mail Benachrichtigung erstellt"
 
 #: templates/web/base/tokens/confirm_alert.html:10
 msgid "Email alert deleted"
-msgstr "E-Mail Benachrichtigung gel&ouml;scht"
+msgstr "E-Mail Benachrichtigung gelöscht"
 
 #: templates/web/base/auth/general.html:99
 msgid "Email me a link or text me a code to sign in"
@@ -1300,8 +1300,8 @@ msgid "Endpoint"
 msgstr ""
 
 #: perllib/FixMyStreet/Cobrand/Zurich.pm:81
-msgid "Enter a Z&uuml;rich street name"
-msgstr "Ungef&auml;hre Adresse des Schadens"
+msgid "Enter a Zürich street name"
+msgstr "Ungefähre Adresse des Schadens"
 
 #: perllib/FixMyStreet/Cobrand/UK.pm:16
 msgid "Enter a nearby UK postcode, or street name and area"
@@ -1310,12 +1310,12 @@ msgstr "Geben Sie eine Adresse an"
 #: perllib/FixMyStreet/Cobrand/FiksGataMi.pm:20
 #: perllib/FixMyStreet/Cobrand/FixaMinGata.pm:21
 msgid "Enter a nearby postcode, or street name and area"
-msgstr "Ungef&auml;hre Adresse des Schadens"
+msgstr "Ungefähre Adresse des Schadens"
 
 #: templates/web/base/around/postcode_form.html:7
 #: templates/web/base/around/postcode_form.html:8
 msgid "Enter a nearby street name and area"
-msgstr "Ungef&auml;hre Adresse des Schadens"
+msgstr "Ungefähre Adresse des Schadens"
 
 #: templates/web/base/index-steps.html:6
 msgid "Enter details of the problem"
@@ -1406,7 +1406,7 @@ msgstr ""
 #: templates/web/base/report/_inspect.html:168
 #: templates/web/base/report/_item.html:80
 msgid "Extra details"
-msgstr "Zus&auml;tzliche Details"
+msgstr "Zusätzliche Details"
 
 #: templates/web/zurich/admin/bodies/contact-form.html:22
 msgid "Extra fields:"
@@ -1460,7 +1460,7 @@ msgstr "Beantwortet"
 #: templates/web/base/admin/responsepriorities/edit.html:53
 #: templates/web/zurich/admin/bodies/form.html:35
 msgid "Flag as deleted"
-msgstr "Als gel&#246;scht markieren"
+msgstr "Als gelöscht markieren"
 
 #: templates/web/base/admin/report_blocks.html:23
 msgid "Flag user"
@@ -1494,7 +1494,7 @@ msgstr ""
 
 #: templates/web/base/report/new/after_photo.html:4
 msgid "For best results include a close-up and a wide shot"
-msgstr "Machen Sie ein Detail- und ein &Uuml;bersichtsfoto"
+msgstr "Machen Sie ein Detail- und ein Übersichtsfoto"
 
 #: templates/web/base/admin/extra-metadata-form.html:62
 msgid "For each option, <strong>Key</strong> is the value which is stored in the database for that option and <strong>Name</strong> is the value displayed to the user."
@@ -1616,11 +1616,11 @@ msgstr "Hilfe"
 #: templates/web/base/report/new/category_extras.html:15
 #: templates/web/base/report/new/category_extras.html:16
 msgid "Help <strong>%s</strong> resolve your problem quicker, by providing some extra detail. This extra information will not be published online."
-msgstr "Helfen Sie <strong>%s</strong> Ihre Meldung zu bearbeiten indem Sie zus&auml;tzliche Informationen angeben."
+msgstr "Helfen Sie <strong>%s</strong> Ihre Meldung zu bearbeiten indem Sie zusätzliche Informationen angeben."
 
 #: templates/web/base/around/on_map_list_items.html:8
 msgid "Here are some other nearby reports:"
-msgstr "Hier sind weitere Meldungen in der N&auml;he:"
+msgstr "Hier sind weitere Meldungen in der Nähe:"
 
 #: templates/web/zurich/footer.html:11
 msgid "Hi %s"
@@ -1853,7 +1853,7 @@ msgstr ""
 
 #: templates/web/zurich/admin/report_edit.html:225
 msgid "Include reporter personal details"
-msgstr "Pers&ouml;nliche Angaben des Meldenden mitsenden"
+msgstr "Persönliche Angaben des Meldenden mitsenden"
 
 #: perllib/FixMyStreet/App/Controller/Open311.pm:354
 msgid "Incorrect has_photo value \"%s\""
@@ -1947,7 +1947,7 @@ msgstr ""
 
 #: templates/web/base/reports/_list-filters.html:83
 msgid "Least recently updated"
-msgstr "&Auml;lteste Bearbeitung"
+msgstr "Älteste Bearbeitung"
 
 #: templates/web/base/admin/bodies/form.html:128
 msgid "Leave this blank if all reports to this body should be sent using the same send method (e.g., \"%s\")."
@@ -2189,7 +2189,7 @@ msgstr ""
 
 #: perllib/FixMyStreet/App/Controller/Admin/Bodies.pm:73
 msgid "New body added"
-msgstr "Neue Organisation hinzugef&uuml;gt"
+msgstr "Neue Organisation hinzugefügt"
 
 #: perllib/FixMyStreet/App/Controller/Admin/Bodies.pm:296
 msgid "New category contact added"
@@ -2225,7 +2225,7 @@ msgstr ""
 #: templates/web/base/admin/responsepriorities/edit.html:4
 #: templates/web/base/admin/responsepriorities/list.html:34
 msgid "New priority"
-msgstr "Neue Priorit&auml;t"
+msgstr "Neue Priorität"
 
 #: templates/web/base/admin/users/alerts.html:44
 msgid "New problems for %s"
@@ -2360,7 +2360,7 @@ msgstr ""
 
 #: templates/web/base/around/on_map_list_items.html:13
 msgid "No reports to show on map, here are some nearby:"
-msgstr "Keine Meldungen auf der Karte, hier sind ein paar in der N&auml;he:"
+msgstr "Keine Meldungen auf der Karte, hier sind ein paar in der Nähe:"
 
 #: templates/web/base/js/translation_strings.html:54
 msgid "No result returned"
@@ -2402,7 +2402,7 @@ msgstr ""
 
 #: templates/web/zurich/admin/report_edit-sdm.html:104
 msgid "Not for my subdivision"
-msgstr "Anderer Fachbereich zust&auml;ndig"
+msgstr "Anderer Fachbereich zuständig"
 
 #: templates/web/base/admin/stats/questionnaire.html:6
 msgid "Not reported before"
@@ -2460,7 +2460,7 @@ msgstr "Alter Status"
 
 #: templates/web/base/reports/_list-filters.html:81
 msgid "Oldest"
-msgstr "&Auml;lteste"
+msgstr "Älteste"
 
 #: perllib/FixMyStreet/SendReport/Email.pm:94
 msgid "On behalf of %s"
@@ -2556,7 +2556,7 @@ msgstr ""
 #: templates/web/base/admin/bodies/form.html:39
 #: templates/web/zurich/admin/bodies/form.html:14
 msgid "Parent"
-msgstr "Geh&ouml;rt zu"
+msgstr "Gehört zu"
 
 #: perllib/FixMyStreet/DB/ResultSet/State.pm:65
 msgid "Partial"
@@ -2633,11 +2633,11 @@ msgstr "Foto"
 
 #: perllib/FixMyStreet/App/Controller/Photo.pm:196
 msgid "Photo is required."
-msgstr "Foto wird ben&ouml;tigt"
+msgstr "Foto wird benötigt"
 
 #: templates/web/zurich/admin/bodies/contact-form.html:42
 msgid "Photo required"
-msgstr "Foto ben&ouml;tigt"
+msgstr "Foto benötigt"
 
 #: perllib/FixMyStreet/App/Controller/Photo.pm:113
 msgid "Photo upload failed."
@@ -2652,7 +2652,7 @@ msgstr "Fotos"
 
 #: templates/web/base/alert/list.html:23
 msgid "Photos of recent nearby reports"
-msgstr "Fotos von neuen Meldungen in der N&auml;he"
+msgstr "Fotos von neuen Meldungen in der Nähe"
 
 #: templates/web/base/reports/index.html:76
 #: templates/web/base/reports/index.html:79
@@ -2675,7 +2675,7 @@ msgstr ""
 
 #: templates/web/base/report/new/notes.html:5
 msgid "Please be polite, concise and to the point."
-msgstr "Bitte seien Sie freundlich und pr&auml;gnant."
+msgstr "Bitte seien Sie freundlich und prägnant."
 
 #: templates/web/base/auth/change_password.html:26
 #: templates/web/base/auth/change_password.html:31
@@ -2687,7 +2687,7 @@ msgstr ""
 #: templates/web/base/auth/change_email.html:24
 #: templates/web/base/auth/change_email.html:27
 msgid "Please check your email address is correct"
-msgstr "Bitte &uuml;berpr&uuml;fen Sie ob Ihre E-Mail Adresse korrekt ist"
+msgstr "Bitte überprüfen Sie ob Ihre E-Mail Adresse korrekt ist"
 
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:426
 #: perllib/FixMyStreet/DB/Result/User.pm:220
@@ -2703,7 +2703,7 @@ msgstr ""
 #: perllib/FixMyStreet/DB/Result/Problem.pm:388
 #: templates/web/base/js/translation_strings.html:19
 msgid "Please choose a category"
-msgstr "Bitte w&auml;hlen Sie eine Kategorie"
+msgstr "Bitte wählen Sie eine Kategorie"
 
 #: perllib/FixMyStreet/App/Controller/Auth.pm:387
 #: perllib/FixMyStreet/App/Controller/Auth.pm:413
@@ -2770,12 +2770,12 @@ msgstr ""
 #: templates/web/base/js/translation_strings.html:22
 #: templates/web/base/js/translation_strings.html:26
 msgid "Please enter a valid email"
-msgstr "Bitte geben Sie eine g&uuml;ltige E-Mail Adresse an"
+msgstr "Bitte geben Sie eine gültige E-Mail Adresse an"
 
 #: perllib/FixMyStreet/App/Controller/Alert.pm:355
 #: perllib/FixMyStreet/App/Controller/Contact.pm:143
 msgid "Please enter a valid email address"
-msgstr "Bitte geben Sie eine g&uuml;ltige E-Mail Adresse an"
+msgstr "Bitte geben Sie eine gültige E-Mail Adresse an"
 
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:199
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:99
@@ -2832,7 +2832,7 @@ msgstr "Bitte geben Sie Ihre E-Mail-Adresse an"
 #: templates/web/base/auth/sign_out.html:5
 #: templates/web/zurich/auth/sign_out.html:5
 msgid "Please feel free to <a href=\"%s\">sign in again</a>, or go back to the <a href=\"/\">front page</a>."
-msgstr "<a href=\"%s\">Erneut anmelden</a> oder <a href=\"/\">zur&uuml;ck zur Startseite</a>."
+msgstr "<a href=\"%s\">Erneut anmelden</a> oder <a href=\"/\">zurück zur Startseite</a>."
 
 #: templates/web/base/report/new/fill_in_details_text.html:1
 #: templates/web/base/report/new/fill_in_details_text.html:8
@@ -2842,7 +2842,7 @@ msgstr ""
 #: templates/web/base/report/new/sidebar.html:7
 #: templates/web/zurich/report/new/sidebar.html:14
 msgid "Please fill in the form below with details of the problem, and describe the location as precisely as possible in the details box."
-msgstr "F&uuml;llen Sie das Formular mit den Details des Schadens aus und beschreiben Sie den Ort des Schadens m&ouml;glichst genau."
+msgstr "Füllen Sie das Formular mit den Details des Schadens aus und beschreiben Sie den Ort des Schadens möglichst genau."
 
 #: templates/web/base/auth/2faform.html:9
 msgid "Please generate a two-factor code and enter it below:"
@@ -2962,7 +2962,7 @@ msgstr ""
 
 #: templates/web/base/pagination.html:4
 msgid "Previous"
-msgstr "Zur&uuml;ck"
+msgstr "Zurück"
 
 #: perllib/FixMyStreet/Cobrand/Default.pm:662
 msgid "Priorities"
@@ -3036,7 +3036,7 @@ msgstr ""
 
 #: templates/web/base/report/display_tools.html:22
 msgid "Problems nearby"
-msgstr "Meldungen in der N&auml;he"
+msgstr "Meldungen in der Nähe"
 
 #: templates/web/base/report/display_tools.html:20
 msgid "Problems on the map"
@@ -3044,7 +3044,7 @@ msgstr "Meldungen auf der Karte"
 
 #: db/alert_types.pl:14
 msgid "Problems recently reported fixed on FixMyStreet"
-msgstr "Meldungen, welche k&uuml;rzlich beantwortet wurden"
+msgstr "Meldungen, welche kürzlich beantwortet wurden"
 
 #: templates/web/base/alert/_list.html:29
 msgid "Problems within %.1fkm of %s"
@@ -3100,16 +3100,16 @@ msgstr ""
 #: templates/web/zurich/admin/report_edit.html:242
 #: templates/web/zurich/admin/report_edit.html:269
 msgid "Public response:"
-msgstr "R&uuml;ckmeldung an User"
+msgstr "Rückmeldung an User"
 
 #: templates/web/base/report/_inspect.html:192
 msgid "Public update:"
-msgstr "R&uuml;ckmeldung an User"
+msgstr "Rückmeldung an User"
 
 #: templates/web/zurich/admin/report_edit.html:122
 #: templates/web/zurich/admin/stats/index.html:59
 msgid "Publish photo"
-msgstr "Foto ver&ouml;ffentlichen"
+msgstr "Foto veröffentlichen"
 
 #: templates/web/base/questionnaire/completed.html:1
 #: templates/web/base/questionnaire/index.html:0
@@ -3204,11 +3204,11 @@ msgstr ""
 #: templates/web/base/around/display_location.html:0
 #: templates/web/base/around/display_location.html:35
 msgid "Recent local problems, %s"
-msgstr "K&uuml;rzlich erfasste Meldungen, %s"
+msgstr "Kürzlich erfasste Meldungen, %s"
 
 #: templates/web/base/front/recent.html:11
 msgid "Recently reported problems"
-msgstr "K&uuml;rzlich erfasste Meldungen:"
+msgstr "Kürzlich erfasste Meldungen:"
 
 #: templates/web/base/reports/_list-filters.html:82
 msgid "Recently updated"
@@ -3220,7 +3220,7 @@ msgstr ""
 
 #: templates/web/zurich/report/new/notes.html:5
 msgid "Remember that FixMyStreet is primarily for reporting physical problems that can be fixed. If your problem is not appropriate for submission via this site remember that you can contact your council directly using their own website."
-msgstr "&#171;Z&uuml;ri wie neu&#187; dient dazu Sch&auml;den an der Infrastruktur zu melden. Meldungen und W&uuml;nsche bez&uuml;glich Verbesserungen an der Infrastruktur sowie Gestaltungsvorschl&auml;ge k&ouml;nnen über &#171;Z&uuml;ri wie neu&#187; nicht ber&uuml;cksichtigt werden. Notf&auml;lle m&uuml;ssen der Polizei gemeldet werden via Telefon 117."
+msgstr "«Züri wie neu» dient dazu Schäden an der Infrastruktur zu melden. Meldungen und Wünsche bezüglich Verbesserungen an der Infrastruktur sowie Gestaltungsvorschläge können über «Züri wie neu» nicht berücksichtigt werden. Notfälle müssen der Polizei gemeldet werden via Telefon 117."
 
 #: templates/web/base/admin/extra-metadata-form.html:78
 msgid "Remove"
@@ -3322,7 +3322,7 @@ msgstr ""
 #: templates/web/base/around/intro.html:1
 #: templates/web/zurich/around/intro.html:1
 msgid "Report, view, or discuss local problems"
-msgstr "Melden Sie Sch&auml;den an der Infrastruktur von Z&uuml;rich"
+msgstr "Melden Sie Schäden an der Infrastruktur von Zürich"
 
 #: perllib/FixMyStreet/DB/Result/Problem.pm:616
 #: templates/web/base/contact/index.html:60
@@ -3407,7 +3407,7 @@ msgstr ""
 
 #: templates/web/zurich/admin/index-sdm.html:7
 msgid "Reports awaiting approval"
-msgstr "R&uuml;ckmeldung ausstehend"
+msgstr "Rückmeldung ausstehend"
 
 #: templates/web/base/alert/_list.html:54
 msgid "Reports by destination"
@@ -3634,7 +3634,7 @@ msgstr ""
 
 #: templates/web/base/admin/category-checkboxes.html:6
 msgid "Select:"
-msgstr "Ausw&auml;hlen"
+msgstr "Auswählen"
 
 #: templates/web/base/contact/index.html:116
 msgid "Send"
@@ -3655,7 +3655,7 @@ msgstr ""
 
 #: perllib/FixMyStreet/Cobrand/Zurich.pm:872
 msgid "Sent report back"
-msgstr "Meldung zur&uuml;ckgewiesen"
+msgstr "Meldung zurückgewiesen"
 
 #: perllib/FixMyStreet/DB/Result/Problem.pm:781
 msgid "Sent to %s %s later"
@@ -3786,7 +3786,7 @@ msgstr "Ausloggen"
 
 #: templates/web/base/report/new/fill_in_details_text.html:1
 msgid "Some categories may require additional information."
-msgstr "Einige Kategorien ben&ouml;tigen eventuell zus&auml;tzliche Informationen."
+msgstr "Einige Kategorien benötigen eventuell zusätzliche Informationen."
 
 #: templates/web/base/admin/bodies/open311-form-fields.html:40
 #: templates/web/base/admin/bodies/open311-form-fields.html:41
@@ -3818,7 +3818,7 @@ msgstr ""
 
 #: templates/web/base/auth/smsform.html:6 templates/web/base/auth/token.html:8
 msgid "Sorry, that wasn&rsquo;t a valid link"
-msgstr "Entschuldigung, dieser Link ist ung&uuml;ltig"
+msgstr "Entschuldigung, dieser Link ist ungültig"
 
 #: templates/web/base/auth/2faform.html:5
 #: templates/web/base/auth/smsform.html:16
@@ -4030,7 +4030,7 @@ msgstr ""
 
 #: templates/web/base/admin/bodies/contact-form.html:148
 msgid "Summarise your changes"
-msgstr "Fassen Sie Ihre &Auml;nderungen zusammen"
+msgstr "Fassen Sie Ihre Änderungen zusammen"
 
 #: perllib/FixMyStreet/Cobrand/Default.pm:633
 #: perllib/FixMyStreet/Cobrand/Zurich.pm:399
@@ -4133,7 +4133,7 @@ msgstr ""
 
 #: perllib/FixMyStreet/App/Controller/Council.pm:105
 msgid "That location does not appear to be covered by a council; perhaps it is offshore or outside the country. Please try again."
-msgstr "Sie k&ouml;nnen Sch&auml;den nur innerhalb der Stadt Z&uuml;rich melden. Verwenden Sie daf&uuml;r die Adressuche."
+msgstr "Sie können Schäden nur innerhalb der Stadt Zürich melden. Verwenden Sie dafür die Adressuche."
 
 #: perllib/FixMyStreet/App/Controller/Location.pm:141
 msgid "That location does not appear to be in the UK; please try again."
@@ -4155,11 +4155,11 @@ msgstr ""
 
 #: perllib/FixMyStreet/App/Controller/Report.pm:161
 msgid "That report cannot be viewed on %s."
-msgstr "Diese Meldung wurde von &#171;Z&uuml;ri wie neu&#187; entfernt."
+msgstr "Diese Meldung wurde von «Züri wie neu» entfernt."
 
 #: perllib/FixMyStreet/App/Controller/Report.pm:151
 msgid "That report has been removed from FixMyStreet."
-msgstr "Diese Meldung wurde von &#171;Z&uuml;ri wie neu&#187; entfernt."
+msgstr "Diese Meldung wurde von «Züri wie neu» entfernt."
 
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:486
 msgid "That user has been logged out."
@@ -4231,7 +4231,7 @@ msgstr ""
 #: templates/web/base/report/new/fill_in_details_text.html:1
 #: templates/web/base/report/new/fill_in_details_text.html:3
 msgid "The council won&rsquo;t be able to help unless you leave as much detail as you can. Please describe the exact location of the problem (e.g. on a wall), what it is, how long it has been there, a description (and a photo of the problem if you have one), etc."
-msgstr "Bitte machen Sie so genaue Angaben wie m&ouml;glich: Beschreiben Sie die Art des Schadens und wo er sich befindet (z.B. an der Wand). Senden Sie uns mindestens ein Foto des Schadens (inkl. Umgebung). <br/>Beschreiben Sie <b>nur einen Schaden pro Meldung</b>."
+msgstr "Bitte machen Sie so genaue Angaben wie möglich: Beschreiben Sie die Art des Schadens und wo er sich befindet (z.B. an der Wand). Senden Sie uns mindestens ein Foto des Schadens (inkl. Umgebung). <br/>Beschreiben Sie <b>nur einen Schaden pro Meldung</b>."
 
 #: templates/web/base/admin/bodies/edit-league.html:3
 #: templates/web/base/admin/bodies/edit-league.html:4
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid ""
 "The user's <strong>name</strong> is displayed publicly on reports that have not been marked <em>anonymous</em>.\n"
 "                Names are not necessarily unique."
-msgstr "Namen m&uuml;ssen nicht eindeutig sein."
+msgstr "Namen müssen nicht eindeutig sein."
 
 #: templates/web/base/around/_on_map_empty.html:1
 #: templates/web/base/my/_problem-list.html:8
@@ -4358,7 +4358,7 @@ msgstr ""
 
 #: perllib/FixMyStreet/App/Controller/Report/New.pm:857
 #: perllib/FixMyStreet/App/Controller/Report/Update.pm:146
-msgid "There was a problem with your login information. If you cannot remember your password, or do not have one, please fill in the &lsquo;No&rsquo; section of the form."
+msgid "There was a problem with your login information. If you cannot remember your password, or do not have one, please fill in the ‘No’ section of the form."
 msgstr ""
 
 #: perllib/FixMyStreet/App/Controller/Report/Update.pm:354
@@ -4441,7 +4441,7 @@ msgstr ""
 #: perllib/FixMyStreet/App/Controller/Report/New.pm:1127
 #: perllib/FixMyStreet/Cobrand/UK.pm:45
 msgid "This information is required"
-msgstr "Diese Information wird ben&ouml;tigt"
+msgstr "Diese Information wird benötigt"
 
 #: templates/web/base/admin/template_edit.html:19
 msgid "This is a <strong>private</strong> name for this template so you can identify it when updating reports or editing in the admin."
@@ -4487,7 +4487,7 @@ msgstr ""
 #: perllib/FixMyStreet/Cobrand/Zurich.pm:141
 #: templates/web/zurich/report/_main.html:14
 msgid "This report is awaiting moderation."
-msgstr "&Uuml;berpr&uuml;fung ausstehend"
+msgstr "Überprüfung ausstehend"
 
 #: perllib/FixMyStreet/Script/Alerts.pm:119
 msgid "This report is currently marked as closed."
@@ -4544,7 +4544,7 @@ msgstr ""
 
 #: templates/web/base/alert/index.html:28
 msgid "To find out what local alerts we have for you, please enter your postcode or street name and area"
-msgstr "Geben Sie Ihre Adresse an, um &uuml;ber Meldungen in Ihrer N&auml;he  informiert zu werden"
+msgstr "Geben Sie Ihre Adresse an, um über Meldungen in Ihrer Nähe  informiert zu werden"
 
 #: templates/web/base/admin/reportextrafields/edit.html:19
 msgid "To limit this collection of fields to a single cobrand, select it here."
@@ -4606,7 +4606,7 @@ msgstr ""
 
 #: templates/web/base/admin/users/form.html:142
 msgid "Trusted:"
-msgstr "Vertrauensw&uuml;rdig"
+msgstr "Vertrauenswürdig"
 
 #: templates/web/base/auth/2faform.html:6
 #: templates/web/base/auth/smsform.html:17
@@ -4644,7 +4644,7 @@ msgstr ""
 #: templates/web/zurich/admin/report_edit.html:94
 #: templates/web/zurich/admin/update_edit.html:18
 msgid "Unconfirmed"
-msgstr "Unbest&auml;tigt"
+msgstr "Unbestätigt"
 
 #: templates/web/base/report/banner.html:13
 msgid "Unknown"
@@ -4773,7 +4773,7 @@ msgstr ""
 #: templates/web/base/report/display.html:0
 #: templates/web/base/report/display.html:9
 msgid "Updates to this problem, %s"
-msgstr "&Auml;nderungen an dieser Meldung, %s"
+msgstr "Änderungen an dieser Meldung, %s"
 
 #: templates/web/base/admin/users/import.html:64
 msgid "Usage notes"
@@ -4846,7 +4846,7 @@ msgstr ""
 
 #: templates/web/base/admin/users/index.html:5
 msgid "User search finds matches in users' names and email addresses."
-msgstr "Diese Suche sucht in den Namen der Ben&uuml;tzer und deren E-Mail-Adressen."
+msgstr "Diese Suche sucht in den Namen der Benützer und deren E-Mail-Adressen."
 
 #: templates/web/base/admin/users/alerts.html:2
 msgid "User's alerts"
@@ -4928,7 +4928,7 @@ msgstr ""
 #: templates/web/base/alert/choose.html:7
 #: templates/web/base/around/_error_multiple.html:6
 msgid "We found more than one match for that location."
-msgstr "Ihre Anfrage ergab mehr als eine m&ouml;gliche Adresse."
+msgstr "Ihre Anfrage ergab mehr als eine mögliche Adresse."
 
 #: templates/web/base/around/lookup_by_ref.html:6
 msgid "We found more than one match for that problem reference:"
@@ -4960,7 +4960,7 @@ msgstr "Die ersten zehn Treffer werden unten aufgelistet."
 #: templates/web/base/report/new/notes.html:4
 #: templates/web/zurich/report/new/notes.html:4
 msgid "We will only use your personal information in accordance with our <a href=\"%s\">privacy policy.</a>"
-msgstr "Ihre pers&ouml;nlichen Angaben werden nur im Zusammenhang mit der Beantwortung der Meldung verwendet. <!-- %s -->"
+msgstr "Ihre persönlichen Angaben werden nur im Zusammenhang mit der Beantwortung der Meldung verwendet. <!-- %s -->"
 
 #: templates/web/base/questionnaire/completed-open.html:2
 msgid "We&rsquo;re sorry to hear the problem’s not fixed. Why not try writing to your local representatives?"
@@ -5029,7 +5029,7 @@ msgstr ""
 
 #: templates/web/base/report/new/notes.html:7
 msgid "Writing your message entirely in block capitals makes it hard to read, as does a lack of punctuation."
-msgstr "Meldungen g&auml;nzlich in Grossbuchstaben zu schreiben macht diese unleserlich. Ebenso wenn keine Satzzeichen verwendet werden."
+msgstr "Meldungen gänzlich in Grossbuchstaben zu schreiben macht diese unleserlich. Ebenso wenn keine Satzzeichen verwendet werden."
 
 #: perllib/FixMyStreet/Cobrand/Default.pm:1200
 #: perllib/FixMyStreet/DB/Result/ModerationOriginalData.pm:116
@@ -5075,7 +5075,7 @@ msgstr ""
 #: templates/web/zurich/tokens/confirm_problem.html:5
 #: templates/web/zurich/tokens/confirm_problem.html:8
 msgid "You can <a href=\"%s%s\">view the problem on this site</a>."
-msgstr "Danke! Sie k&ouml;nnen Ihre aktualisierte Meldung <a href=\"%s%s\">auf der Webseite anschauen</a>."
+msgstr "Danke! Sie können Ihre aktualisierte Meldung <a href=\"%s%s\">auf der Webseite anschauen</a>."
 
 #: templates/web/base/admin/users/form.html:116
 msgid "You can add an abusive user's email to the abuse list, which automatically hides (and never sends) reports they create."
@@ -5136,7 +5136,7 @@ msgstr "Sie haben sich abgemeldet"
 
 #: templates/web/zurich/report/new/sidebar.html:7
 msgid "You have located the problem at the point marked with a green pin on the map. If this is not the correct location, simply click on the map again. "
-msgstr "Der gr&uuml;ne Punkt lokalisiert Ihre Meldung auf der Karte. Falls dieser Ort nicht stimmt, kann der Pin verschoben werden."
+msgstr "Der grüne Punkt lokalisiert Ihre Meldung auf der Karte. Falls dieser Ort nicht stimmt, kann der Pin verschoben werden."
 
 #: perllib/FixMyStreet/App/Controller/Auth/Profile.pm:142
 msgid "You have successfully added your phone number."
@@ -5146,7 +5146,7 @@ msgstr ""
 #: templates/web/zurich/tokens/confirm_problem.html:5
 #: templates/web/zurich/tokens/confirm_problem.html:6
 msgid "You have successfully confirmed your email address."
-msgstr "Sie haben Ihre Meldung erfolgreich best&auml;tigt und werden &uuml;ber deren Status per E-Mail informiert. "
+msgstr "Sie haben Ihre Meldung erfolgreich bestätigt und werden über deren Status per E-Mail informiert. "
 
 #: templates/web/base/auth/change_phone.html:15
 msgid "You have successfully confirmed your phone number."
@@ -5250,7 +5250,7 @@ msgstr "Ihr Passwort"
 #: perllib/FixMyStreet/App/Controller/Auth/Profile.pm:170
 #: templates/web/base/auth/change_password.html:12
 msgid "Your password has been changed"
-msgstr "Ihr Passwort wurde ge&auml;ndert"
+msgstr "Ihr Passwort wurde geändert"
 
 #: templates/web/base/auth/create.html:52
 #: templates/web/base/report/form/user_loggedout_by_email.html:61
@@ -5438,7 +5438,7 @@ msgstr ""
 #: templates/web/base/report/_report_meta_info.html:5
 #: templates/web/zurich/report/_main.html:7
 msgid "there is no pin shown as the user did not use the map"
-msgstr "Es wird keine Stecknadel angezeigt, da der User die Karte nicht ben&uuml;tzt hat"
+msgstr "Es wird keine Stecknadel angezeigt, da der User die Karte nicht benützt hat"
 
 #: templates/web/base/alert/_list.html:1
 msgid "this location"

--- a/locale/de_DE.UTF-8/LC_MESSAGES/FixMyStreet.po
+++ b/locale/de_DE.UTF-8/LC_MESSAGES/FixMyStreet.po
@@ -140,7 +140,7 @@ msgstr ""
 
 #: templates/web/zurich/report/_item.html:19
 msgid "(fixed)"
-msgstr "(gel&ouml;st)"
+msgstr "(gelöst)"
 
 #: templates/web/base/admin/extra-metadata-form.html:63
 msgid "(ignored if type is \"String\")"
@@ -148,7 +148,7 @@ msgstr ""
 
 #: templates/web/base/around/intro.html:2
 msgid "(like graffiti, fly tipping, broken paving slabs, or street lighting)"
-msgstr "(z.B. illegale Deponien, Strassensch&auml;den, Graffitis usw.)"
+msgstr "(z.B. illegale Deponien, Strassenschäden, Graffitis usw.)"
 
 #: templates/web/base/reports/index.html:82
 msgid "(no longer exists)"
@@ -180,7 +180,7 @@ msgstr ""
 #: perllib/FixMyStreet/App/Controller/Report/New.pm:710
 #: perllib/FixMyStreet/DB/Result/Problem.pm:386
 msgid "-- Pick a category --"
-msgstr "-- W&auml;hlen Sie eine Kategorie --"
+msgstr "-- Wählen Sie eine Kategorie --"
 
 #: templates/web/base/report/new/category_extras_fields.html:19
 msgid "-- Pick an option --"
@@ -294,7 +294,7 @@ msgstr ""
 #: templates/web/base/admin/bodies/body.html:127
 #: templates/web/zurich/admin/bodies/body.html:33
 msgid "Add new category"
-msgstr "F&uuml;ge neue Kategorie hinzu"
+msgstr "Füge neue Kategorie hinzu"
 
 #: templates/web/base/admin/extra-metadata-form.html:82
 msgid "Add option"
@@ -659,7 +659,7 @@ msgstr "E-Mail-Adresse ändern"
 #: templates/web/base/auth/change_password.html:5
 #: templates/web/base/my/my.html:65
 msgid "Change password"
-msgstr "Passwort &auml;ndern"
+msgstr "Passwort ändern"
 
 #: templates/web/base/auth/change_phone.html:1
 #: templates/web/base/auth/change_phone.html:3
@@ -785,7 +785,7 @@ msgstr "Konfiguration"
 
 #: templates/web/base/admin/bodies/body.html:78
 msgid "Confirm"
-msgstr "Best&auml;tigen"
+msgstr "Bestätigen"
 
 #: templates/web/base/auth/2faform.html:1
 #: templates/web/base/auth/smsform.html:1 templates/web/base/auth/token.html:1
@@ -802,20 +802,20 @@ msgstr ""
 #: templates/web/zurich/tokens/confirm_problem.html:1
 #: templates/web/zurich/tokens/confirm_problem.html:3
 msgid "Confirmation"
-msgstr "Best&auml;tigung"
+msgstr "Bestätigung"
 
 #: templates/web/base/admin/bodies/contact-form.html:56
 #: templates/web/base/admin/users/alerts.html:10
 #: templates/web/zurich/admin/bodies/contact-form.html:35
 #: templates/web/zurich/admin/stats/index.html:61
 msgid "Confirmed"
-msgstr "Best&auml;tigt"
+msgstr "Bestätigt"
 
 #: templates/web/base/admin/list_updates.html:40
 #: templates/web/base/admin/problem_row.html:36
 #: templates/web/base/admin/report_edit.html:79
 msgid "Confirmed:"
-msgstr "Best&auml;tigt:"
+msgstr "Bestätigt:"
 
 #. ("%s is the site name")
 #: templates/web/base/about/_sidebar.html:6
@@ -1004,7 +1004,7 @@ msgstr "Vorlage löschen"
 #: templates/web/base/admin/bodies/index.html:31
 #: templates/web/zurich/admin/bodies/contact-form.html:36
 msgid "Deleted"
-msgstr "Gel&ouml;scht"
+msgstr "Gelöscht"
 
 #: templates/web/base/report/_main.html:125
 #: templates/web/base/report/update.html:56
@@ -1299,7 +1299,7 @@ msgid "Endpoint"
 msgstr "Endpunkt"
 
 #: perllib/FixMyStreet/Cobrand/Zurich.pm:81
-msgid "Enter a Z&uuml;rich street name"
+msgid "Enter a Zürich street name"
 msgstr ""
 
 #: perllib/FixMyStreet/Cobrand/UK.pm:16
@@ -1445,7 +1445,7 @@ msgstr ""
 #: templates/web/base/admin/stats/fix_rate.html:4
 #: templates/web/base/dashboard/index.html:118
 msgid "Fixed"
-msgstr "Gel&ouml;st"
+msgstr "Gelöst"
 
 #: perllib/FixMyStreet/DB/ResultSet/State.pm:66
 msgid "Fixed - Council"
@@ -2475,7 +2475,7 @@ msgstr ""
 #: templates/web/base/dashboard/index.html:116
 #: templates/web/zurich/admin/update_edit.html:18
 msgid "Open"
-msgstr "&Ouml;ffnen"
+msgstr "Öffnen"
 
 #: templates/web/base/admin/bodies/open311-form-fields.html:47
 msgid "Open311 API Key"
@@ -2651,7 +2651,7 @@ msgstr "Fotos"
 
 #: templates/web/base/alert/list.html:23
 msgid "Photos of recent nearby reports"
-msgstr "Fotos von neuen Meldungen in der N&auml;he"
+msgstr "Fotos von neuen Meldungen in der Nähe"
 
 #: templates/web/base/reports/index.html:76
 #: templates/web/base/reports/index.html:79
@@ -2674,7 +2674,7 @@ msgstr ""
 
 #: templates/web/base/report/new/notes.html:5
 msgid "Please be polite, concise and to the point."
-msgstr "Bitte seien Sie freundlich und pr&auml;gnant."
+msgstr "Bitte seien Sie freundlich und prägnant."
 
 #: templates/web/base/auth/change_password.html:26
 #: templates/web/base/auth/change_password.html:31
@@ -2686,7 +2686,7 @@ msgstr ""
 #: templates/web/base/auth/change_email.html:24
 #: templates/web/base/auth/change_email.html:27
 msgid "Please check your email address is correct"
-msgstr "Bitte &uuml;berpr&uuml;fen Sie ob Ihre eMail-Adresse korrekt ist"
+msgstr "Bitte überprüfen Sie ob Ihre eMail-Adresse korrekt ist"
 
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:426
 #: perllib/FixMyStreet/DB/Result/User.pm:220
@@ -2702,7 +2702,7 @@ msgstr ""
 #: perllib/FixMyStreet/DB/Result/Problem.pm:388
 #: templates/web/base/js/translation_strings.html:19
 msgid "Please choose a category"
-msgstr "Bitte w&auml;hlen Sie eine Kategorie"
+msgstr "Bitte wählen Sie eine Kategorie"
 
 #: perllib/FixMyStreet/App/Controller/Auth.pm:387
 #: perllib/FixMyStreet/App/Controller/Auth.pm:413
@@ -2769,12 +2769,12 @@ msgstr "Bitte geben Sie einen Betreff ein"
 #: templates/web/base/js/translation_strings.html:22
 #: templates/web/base/js/translation_strings.html:26
 msgid "Please enter a valid email"
-msgstr "Bitte geben Sie eine g&uuml;ltige eMail-Adresse an"
+msgstr "Bitte geben Sie eine gültige eMail-Adresse an"
 
 #: perllib/FixMyStreet/App/Controller/Alert.pm:355
 #: perllib/FixMyStreet/App/Controller/Contact.pm:143
 msgid "Please enter a valid email address"
-msgstr "Bitte geben Sie eine g&uuml;ltige eMail-Adresse an"
+msgstr "Bitte geben Sie eine gültige eMail-Adresse an"
 
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:199
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:99
@@ -3035,7 +3035,7 @@ msgstr ""
 
 #: templates/web/base/report/display_tools.html:22
 msgid "Problems nearby"
-msgstr "Meldungen in der N&auml;he"
+msgstr "Meldungen in der Nähe"
 
 #: templates/web/base/report/display_tools.html:20
 msgid "Problems on the map"
@@ -3043,7 +3043,7 @@ msgstr "Meldungen auf der Karte"
 
 #: db/alert_types.pl:14
 msgid "Problems recently reported fixed on FixMyStreet"
-msgstr "Meldungen, welche k&uuml;rzlich gel&ouml;st wurden"
+msgstr "Meldungen, welche kürzlich gelöst wurden"
 
 #: templates/web/base/alert/_list.html:29
 msgid "Problems within %.1fkm of %s"
@@ -3207,7 +3207,7 @@ msgstr ""
 
 #: templates/web/base/front/recent.html:11
 msgid "Recently reported problems"
-msgstr "K&uuml;rzlich erfasste Meldungen"
+msgstr "Kürzlich erfasste Meldungen"
 
 #: templates/web/base/reports/_list-filters.html:82
 msgid "Recently updated"
@@ -3219,7 +3219,7 @@ msgstr ""
 
 #: templates/web/zurich/report/new/notes.html:5
 msgid "Remember that FixMyStreet is primarily for reporting physical problems that can be fixed. If your problem is not appropriate for submission via this site remember that you can contact your council directly using their own website."
-msgstr "Fix My Z&uuml;rich wird prim&auml;r daf&uuml;r verwendet, physische M&auml;ngel zu melden, welche behoben werden k&ouml;nnen. Wenn Ihr Problem daf&uuml;r nicht passend erscheint, k&ouml;nnen sie die entsprechende Dienststelle weiterhin telefonisch oder per eMail erreichen."
+msgstr "Fix My Zürich wird primär dafür verwendet, physische Mängel zu melden, welche behoben werden können. Wenn Ihr Problem dafür nicht passend erscheint, können sie die entsprechende Dienststelle weiterhin telefonisch oder per eMail erreichen."
 
 #: templates/web/base/admin/extra-metadata-form.html:78
 msgid "Remove"
@@ -3321,7 +3321,7 @@ msgstr ""
 #: templates/web/base/around/intro.html:1
 #: templates/web/zurich/around/intro.html:1
 msgid "Report, view, or discuss local problems"
-msgstr "Melden sie M&auml;ngel an der Infrastruktur von Z&uuml;rich"
+msgstr "Melden sie Mängel an der Infrastruktur von Zürich"
 
 #: perllib/FixMyStreet/DB/Result/Problem.pm:616
 #: templates/web/base/contact/index.html:60
@@ -3547,7 +3547,7 @@ msgstr ""
 #: templates/web/zurich/admin/bodies/contact-form.html:49
 #: templates/web/zurich/admin/template_edit.html:29
 msgid "Save changes"
-msgstr "&Auml;nderungen speichern"
+msgstr "Änderungen speichern"
 
 #: templates/web/base/admin/reportextrafields/edit.html:64
 msgid "Save new fields"
@@ -4158,7 +4158,7 @@ msgstr "Dieser Bericht kann nicht auf %s angeschaut werden."
 
 #: perllib/FixMyStreet/App/Controller/Report.pm:151
 msgid "That report has been removed from FixMyStreet."
-msgstr "Diese Meldung wurde von Fix My Z&uuml;rich entfernt."
+msgstr "Diese Meldung wurde von Fix My Zürich entfernt."
 
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:486
 msgid "That user has been logged out."
@@ -4357,7 +4357,7 @@ msgstr ""
 
 #: perllib/FixMyStreet/App/Controller/Report/New.pm:857
 #: perllib/FixMyStreet/App/Controller/Report/Update.pm:146
-msgid "There was a problem with your login information. If you cannot remember your password, or do not have one, please fill in the &lsquo;No&rsquo; section of the form."
+msgid "There was a problem with your login information. If you cannot remember your password, or do not have one, please fill in the ‘No’ section of the form."
 msgstr ""
 
 #: perllib/FixMyStreet/App/Controller/Report/Update.pm:354
@@ -4440,7 +4440,7 @@ msgstr ""
 #: perllib/FixMyStreet/App/Controller/Report/New.pm:1127
 #: perllib/FixMyStreet/Cobrand/UK.pm:45
 msgid "This information is required"
-msgstr "Diese Information wird ben&ouml;tigt"
+msgstr "Diese Information wird benötigt"
 
 #: templates/web/base/admin/template_edit.html:19
 msgid "This is a <strong>private</strong> name for this template so you can identify it when updating reports or editing in the admin."
@@ -4643,7 +4643,7 @@ msgstr ""
 #: templates/web/zurich/admin/report_edit.html:94
 #: templates/web/zurich/admin/update_edit.html:18
 msgid "Unconfirmed"
-msgstr "Unbest&auml;tigt"
+msgstr "Unbestätigt"
 
 #: templates/web/base/report/banner.html:13
 msgid "Unknown"
@@ -5028,7 +5028,7 @@ msgstr ""
 
 #: templates/web/base/report/new/notes.html:7
 msgid "Writing your message entirely in block capitals makes it hard to read, as does a lack of punctuation."
-msgstr "Meldungen g&auml;nzlich in Grossbuchstaben zu schreiben macht diese unleserlich. Ebenso wenn keine Satzzeichen verwendet werden."
+msgstr "Meldungen gänzlich in Grossbuchstaben zu schreiben macht diese unleserlich. Ebenso wenn keine Satzzeichen verwendet werden."
 
 #: perllib/FixMyStreet/Cobrand/Default.pm:1200
 #: perllib/FixMyStreet/DB/Result/ModerationOriginalData.pm:116
@@ -5135,7 +5135,7 @@ msgstr "Sie wurden abgemeldet"
 
 #: templates/web/zurich/report/new/sidebar.html:7
 msgid "You have located the problem at the point marked with a green pin on the map. If this is not the correct location, simply click on the map again. "
-msgstr "Der gr&uml;ne Pin auf der Karte repr&auml;sentiert ihre Meldung. Falls dieser Ort nicht der Richtige ist, klicken Sie einfach nochmals am richtigen Ort auf die Karte."
+msgstr "Der grüne Pin auf der Karte repräsentiert ihre Meldung. Falls dieser Ort nicht der Richtige ist, klicken Sie einfach nochmals am richtigen Ort auf die Karte."
 
 #: perllib/FixMyStreet/App/Controller/Auth/Profile.pm:142
 msgid "You have successfully added your phone number."
@@ -5249,7 +5249,7 @@ msgstr "Ihr Passwort"
 #: perllib/FixMyStreet/App/Controller/Auth/Profile.pm:170
 #: templates/web/base/auth/change_password.html:12
 msgid "Your password has been changed"
-msgstr "Ihr Passwort wurde ge&auml;ndert"
+msgstr "Ihr Passwort wurde geändert"
 
 #: templates/web/base/auth/create.html:52
 #: templates/web/base/report/form/user_loggedout_by_email.html:61

--- a/locale/fr_FR.UTF-8/LC_MESSAGES/FixMyStreet.po
+++ b/locale/fr_FR.UTF-8/LC_MESSAGES/FixMyStreet.po
@@ -38,7 +38,7 @@ msgstr " ou "
 
 #: templates/web/base/report/_inspect.html:171
 msgid "%d characters maximum"
-msgstr "%d caract&egrave;res maximum"
+msgstr "%d caractères maximum"
 
 #: templates/web/base/admin/bodies/edit-league.html:12
 msgid "%d edits by %s"
@@ -50,7 +50,7 @@ msgstr "de %d à %d de %d"
 
 #: templates/web/base/admin/users/import.html:42
 msgid "%d users already existed"
-msgstr "%d les utilisateurs existent d&eacute;j&agrave;"
+msgstr "%d les utilisateurs existent déjà"
 
 #: templates/web/base/reports/body.html:0
 #: templates/web/base/reports/body.html:24
@@ -104,7 +104,7 @@ msgstr "%s mises à jour en temps réel"
 #: templates/web/base/dashboard/index.html:164
 #: templates/web/base/dashboard/index.html:168
 msgid "%s opened, %s closed, %s fixed"
-msgstr "%s ouvert, %s ferm&eacute;, %s fix&eacute;"
+msgstr "%s ouvert, %s fermé, %s fixé"
 
 #: templates/web/base/status/stats.html:25
 msgid "%s questionnaires sent &ndash; %s answered (%s%%)"
@@ -120,7 +120,7 @@ msgstr "&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap<
 
 #: templates/web/zurich/report/new/fill_in_details_form.html:21
 msgid "(Defect &amp; location of defect)"
-msgstr "(Défaut & amp; emplacement du défaut)"
+msgstr "(Défaut &amp; emplacement du défaut)"
 
 #: templates/web/zurich/admin/report_edit-sdm.html:62
 #: templates/web/zurich/admin/report_edit.html:90
@@ -162,7 +162,7 @@ msgstr "(n'existe plus)"
 
 #: templates/web/base/report/_item_small.html:30
 msgid "(not sent to council)"
-msgstr "(non signalé à l&rsquo;administration)"
+msgstr "(non signalé à l’administration)"
 
 #: templates/web/base/report/new/form_user_loggedin.html:39
 #: templates/web/zurich/report/new/fill_in_details_form.html:59
@@ -171,7 +171,7 @@ msgstr "(facultatif)"
 
 #: templates/web/base/report/_item_small.html:28
 msgid "(sent to all)"
-msgstr "(Envoy&eacute; &aacute; tous)"
+msgstr "(Envoyé à tous)"
 
 #: templates/web/base/report/_item_small.html:29
 msgid "(sent to both)"
@@ -259,7 +259,7 @@ msgstr ""
 
 #: templates/web/base/auth/generate_token.html:54
 msgid "Activate two-factor authentication"
-msgstr "Activer l&rsquo;authentification à deux facteurs"
+msgstr "Activer l’authentification à deux facteurs"
 
 #: templates/web/base/my/my.html:39 templates/web/base/my/my.html:50
 msgid "Add"
@@ -315,7 +315,7 @@ msgstr "Ajouter une option"
 #: templates/web/base/auth/change_phone.html:1
 #: templates/web/base/auth/change_phone.html:7
 msgid "Add phone number"
-msgstr "Ajouter un t&aacute;l&aacute;phone"
+msgstr "Ajouter un téléphone"
 
 #: templates/web/base/report/_item.html:10
 #: templates/web/base/report/_item.html:16
@@ -432,7 +432,7 @@ msgstr "Alternativement, nous pouvons cacher votre nom sur <strong>tous vos rapp
 
 #: templates/web/base/admin/bodies/open311-form-fields.html:165
 msgid "Always fetch all problems"
-msgstr "Toujours chercher tous les probl&egrave;mes"
+msgstr "Toujours chercher tous les problèmes"
 
 #: templates/web/base/questionnaire/index.html:31
 msgid "An update marked this problem as fixed."
@@ -526,7 +526,7 @@ msgstr "Les utilisateurs autorisés peuvent être associés aux catégories sur 
 
 #: templates/web/base/admin/templates.html:9
 msgid "Auto Response"
-msgstr "R&eacute;ponse auto"
+msgstr "Réponse auto"
 
 #: templates/web/base/admin/template_edit.html:80
 msgid "Auto-response:"
@@ -597,7 +597,7 @@ msgstr "Fichier CSV"
 
 #: templates/web/base/admin/extra-metadata-form.html:46
 msgid "Can be used to display extra text to the user alongside the field. The default template does not show this (<code>meta.datatype_description</code>), you must add it in <code>category_extras_fields.html</code>"
-msgstr "Peut être utilisé pour afficher du texte supplémentaire à l'utilisateur le long du champ. Le modèle par défaut ne montre pas ceci (<code>meta.datatype_description</code>), vous devez l&rsquo;ajouter <code>category_extras_fields.html</code>"
+msgstr "Peut être utilisé pour afficher du texte supplémentaire à l'utilisateur le long du champ. Le modèle par défaut ne montre pas ceci (<code>meta.datatype_description</code>), vous devez l’ajouter <code>category_extras_fields.html</code>"
 
 #: templates/web/base/auth/token.html:27 templates/web/base/email_sent.html:20
 msgid "Can&rsquo;t find our email? Check your spam folder&nbsp;&ndash; that&rsquo;s the solution 99% of the time."
@@ -637,7 +637,7 @@ msgstr "Catégorie"
 
 #: templates/web/base/dashboard/index.html:103
 msgid "Category and State"
-msgstr "Cat&eacute;gorie et Statistique"
+msgstr "Catégorie et Statistique"
 
 #: perllib/FixMyStreet/App/Controller/Admin.pm:618
 msgid "Category changed from ‘%s’ to ‘%s’"
@@ -676,7 +676,7 @@ msgstr "Changer le mot de passe"
 #: templates/web/base/auth/change_phone.html:1
 #: templates/web/base/auth/change_phone.html:3
 msgid "Change phone number"
-msgstr "Changer le T&eacute;l&eacute;phone"
+msgstr "Changer le Téléphone"
 
 #: templates/web/base/admin/bodies/contact-form.html:80
 msgid "Check <strong>inspection required</strong> if reports in this category <strong>must be inspected</strong> before being sent."
@@ -715,7 +715,7 @@ msgstr "Choisissez un autre"
 
 #: templates/web/base/js/translation_strings.html:95
 msgid "Clear offline data"
-msgstr "Effacer les donn&eacute;es hors ligne"
+msgstr "Effacer les données hors ligne"
 
 #: templates/web/base/around/_report_banner.html:2
 msgid "Click map to report a problem"
@@ -739,7 +739,7 @@ msgstr "Cliquez sur le lien dans notre courriel de confirmation pour vous connec
 
 #: templates/web/base/auth/token.html:20
 msgid "Click the link in that email to sign in."
-msgstr "Cliquez sur le lien dans ce courrier &eacute;lectronique pour vous connecter."
+msgstr "Cliquez sur le lien dans ce courrier électronique pour vous connecter."
 
 #: templates/web/base/report/new/fill_in_details_form.html:7
 msgid "Click the map or drag the pin to adjust the location"
@@ -767,7 +767,7 @@ msgstr "Clos par l'administration"
 
 #: templates/web/base/admin/report_edit.html:176
 msgid "Closed to updates"
-msgstr "Ferm&eacute; aux mises &agrave; jour"
+msgstr "Fermé aux mises à jour"
 
 #: templates/web/base/admin/report_edit.html:38
 msgid "Co-ordinates:"
@@ -797,7 +797,7 @@ msgstr "Code"
 
 #: templates/web/base/js/translation_strings.html:67
 msgid "Collapse map"
-msgstr "R&eacute;duire la carte"
+msgstr "Réduire la carte"
 
 #: perllib/FixMyStreet/Cobrand/Default.pm:642
 #: perllib/FixMyStreet/Cobrand/Zurich.pm:422
@@ -864,7 +864,7 @@ msgstr ""
 
 #: templates/web/base/admin/bodies/open311-form-fields.html:151
 msgid "Convert location from Easting/Northing"
-msgstr "Convertir l&rsquo;emplacement Est/Nord"
+msgstr "Convertir l’emplacement Est/Nord"
 
 #: templates/web/zurich/admin/report_edit-sdm.html:42
 #: templates/web/zurich/admin/report_edit.html:61
@@ -907,7 +907,7 @@ msgstr "Nombre"
 
 #: templates/web/base/admin/states/index.html:114
 msgid "Create"
-msgstr "Cr&eacute;er"
+msgstr "Créer"
 
 #: templates/web/base/email_sent.html:1
 msgid "Create a report"
@@ -928,7 +928,7 @@ msgstr "Créer une priorité"
 
 #: perllib/FixMyStreet/Cobrand/Default.pm:718
 msgid "Create reports/updates as anonymous user"
-msgstr "Cr&eacute;er un rapports / une mises &agrave; jour en tant qu&apos;utilisateur anonyme"
+msgstr "Créer un rapports / une mises à jour en tant qu'utilisateur anonyme"
 
 #: perllib/FixMyStreet/Cobrand/Default.pm:719
 msgid "Create reports/updates as the council"
@@ -950,7 +950,7 @@ msgstr "Créé"
 
 #: templates/web/base/admin/users/import.html:20
 msgid "Created %d new users"
-msgstr "Cr&eacute;ation %d de nouveaux utilisateurs"
+msgstr "Création %d de nouveaux utilisateurs"
 
 #: templates/web/base/admin/list_updates.html:39
 #: templates/web/base/admin/report_edit.html:78
@@ -969,7 +969,7 @@ msgstr "Jeton actuel:"
 
 #: templates/web/base/dashboard/index.html:92
 msgid "Currently grouped by %s"
-msgstr "Actuellement regroup&eacute; par %s"
+msgstr "Actuellement regroupé par %s"
 
 #: templates/web/base/admin/bodies/index.html:9
 #: templates/web/base/admin/index.html:17
@@ -990,7 +990,7 @@ msgstr "Tableau de bord"
 
 #: templates/web/base/auth/generate_token.html:54
 msgid "Deactivate two-factor authentication"
-msgstr "D&eacute;sactiver l&rsquo;authentification &agrave; deux facteurs"
+msgstr "Désactiver l’authentification à deux facteurs"
 
 #: templates/web/zurich/admin/stats/index.html:56
 msgid "Dealt with by subdivision within 5 working days"
@@ -1002,7 +1002,7 @@ msgstr "Défaut"
 
 #: templates/web/base/admin/responsepriorities/edit.html:39
 msgid "Default priority"
-msgstr "Priorit&eacute; par d&eacute;faut"
+msgstr "Priorité par défaut"
 
 #: perllib/FixMyStreet/Cobrand/Default.pm:720
 msgid "Default to creating reports/updates as the council"
@@ -1010,7 +1010,7 @@ msgstr ""
 
 #: templates/web/base/report/_inspect.html:96
 msgid "Defect type"
-msgstr "Type de d&eacute;faut"
+msgstr "Type de défaut"
 
 #: templates/web/base/admin/users/alerts.html:15
 msgid "Delete"
@@ -1031,7 +1031,7 @@ msgstr "Effacé"
 #: templates/web/base/report/_main.html:125
 #: templates/web/base/report/update.html:56
 msgid "Describe why you are moderating this"
-msgstr "D&eacute;crivez pourquoi vous mod&eacute;rez ceci"
+msgstr "Décrivez pourquoi vous modérez ceci"
 
 #: templates/web/base/admin/extra-metadata-form.html:42
 #: templates/web/base/admin/responsepriorities/list.html:7
@@ -1047,7 +1047,7 @@ msgstr "Description :"
 
 #: perllib/FixMyStreet/App/Controller/Report.pm:416
 msgid "Detailed information is limited to %d characters."
-msgstr "Les informations d&eacute;taill&eacute;es se &agrave; %d caract&agrave;re."
+msgstr "Les informations détaillées se à %d caractàre."
 
 #: templates/web/base/admin/users/alerts.html:12
 #: templates/web/base/js/translation_strings.html:45
@@ -1104,7 +1104,7 @@ msgstr "Avez-vous un mot de passe %s ?"
 
 #: templates/web/base/report/_inspect.html:111
 msgid "Do you want to automatically raise a defect?"
-msgstr "Voulez-vous &eacute;lever automatiquement un d&eacute;faut?"
+msgstr "Voulez-vous élever automatiquement un défaut?"
 
 #: templates/web/base/questionnaire/index.html:41
 msgid "Don&rsquo;t know"
@@ -1116,7 +1116,7 @@ msgstr "Vous n'aimez pas les formulaires ?"
 
 #: templates/web/base/report/_item.html:27
 msgid "Down one"
-msgstr "En bas d&apos;un"
+msgstr "En bas d'un"
 
 #: templates/web/base/js/translation_strings.html:75
 msgid "Drag and drop photos here or <u>click to upload</u>"
@@ -1128,7 +1128,7 @@ msgstr "Dupliquer de"
 
 #: templates/web/base/report/_inspect.html:132
 msgid "Duplicates"
-msgstr "Dupliqu&eacute;s"
+msgstr "Dupliqués"
 
 #: templates/web/base/admin/bodies/body.html:117
 msgid ""
@@ -1257,7 +1257,7 @@ msgstr ""
 
 #: templates/web/base/admin/users/form.html:25
 msgid "Email verified:"
-msgstr "Email verifi&eacute;:"
+msgstr "Email verifié:"
 
 #: templates/web/base/admin/report_edit.html:146
 #: templates/web/base/admin/users/form.html:19 templates/web/base/my/my.html:36
@@ -1319,7 +1319,7 @@ msgstr ""
 #: templates/web/base/admin/bodies/open311-form-fields.html:54
 #: templates/web/base/admin/bodies/open311-form-fields.html:55
 msgid "Enabling this will suppress the error message that is normally emitted when an update has no description"
-msgstr "Activer cela supprimera le message d&rsquo;erreur qui est normalement &eacute;mis lorsqu&rsquo;une mise &agrave; jour n&rsquo;a pas de description"
+msgstr "Activer cela supprimera le message d’erreur qui est normalement émis lorsqu’une mise à jour n’a pas de description"
 
 #: templates/web/base/dashboard/index.html:78
 msgid "End Date"
@@ -1331,7 +1331,7 @@ msgstr "destinataire"
 
 #: perllib/FixMyStreet/Cobrand/Zurich.pm:81
 msgid "Enter a Z&uuml;rich street name"
-msgstr "Saisir un nom de rue Z&uuml;complet"
+msgstr "Saisir un nom de rue Zücomplet"
 
 #: perllib/FixMyStreet/Cobrand/UK.pm:16
 msgid "Enter a nearby UK postcode, or street name and area"
@@ -1380,7 +1380,7 @@ msgstr "Catégorie existante"
 
 #: templates/web/base/admin/users/import.html:66
 msgid "Existing users won't be modified."
-msgstr "Les utilisateurs existants ne seront pas modifi&eacute;s."
+msgstr "Les utilisateurs existants ne seront pas modifiés."
 
 #: templates/web/base/js/translation_strings.html:66
 msgid "Expand map"
@@ -1410,11 +1410,11 @@ msgstr "Body extérieur"
 #: templates/web/base/admin/report_edit.html:107
 #: templates/web/base/admin/template_edit.html:66
 msgid "External status code"
-msgstr "Code de&rsquo;&eacute;tat externe"
+msgstr "Code de’état externe"
 
 #: templates/web/base/admin/update_edit.html:57
 msgid "External status code:"
-msgstr "Code de&rsquo;&eacute;tat externe:"
+msgstr "Code de’état externe:"
 
 #: templates/web/base/admin/report_edit.html:102
 msgid "External team"
@@ -1424,7 +1424,7 @@ msgstr "Équipe externe"
 #: templates/web/base/admin/reportextrafields/edit.html:1
 #: templates/web/base/admin/reportextrafields/index.html:1
 msgid "Extra Fields"
-msgstr "Champs suppl&eacute;mentaires"
+msgstr "Champs supplémentaires"
 
 #: templates/web/base/admin/bodies/contact-form.html:159
 #: templates/web/base/admin/report_edit.html:129
@@ -1440,7 +1440,7 @@ msgstr "Précisions supplémentaires"
 
 #: templates/web/zurich/admin/bodies/contact-form.html:22
 msgid "Extra fields:"
-msgstr "Champs suppl&eacute;mentaires:"
+msgstr "Champs supplémentaires:"
 
 #: templates/web/base/contact/submit.html:13
 msgid "Failed to send message"
@@ -1528,7 +1528,7 @@ msgstr "Pour de meilleurs résultats veuillez joindre un gros plan et un plan la
 
 #: templates/web/base/admin/extra-metadata-form.html:62
 msgid "For each option, <strong>Key</strong> is the value which is stored in the database for that option and <strong>Name</strong> is the value displayed to the user."
-msgstr "Pour chaque option, <strong>La cl&eacute;</strong> est la valeur qui est stock&eacute;e dans la base de donn&eacute;es pour cette option et Nom est la valeur affich&eacute;e pour l&apos;utilisateur."
+msgstr "Pour chaque option, <strong>La clé</strong> est la valeur qui est stockée dans la base de données pour cette option et Nom est la valeur affichée pour l'utilisateur."
 
 #: templates/web/base/admin/bodies/form.html:73
 msgid "For more information, see <a href='https://fixmystreet.org/customising/fms_and_mapit' class='admin-offsite-link'>How FixMyStreet uses Mapit</a>."
@@ -1560,7 +1560,7 @@ msgstr "Foire Aux Questions"
 
 #: templates/web/base/auth/generate_token.html:52
 msgid "Generate token"
-msgstr "G&eacute;n&eacute;rer un jeton"
+msgstr "Générer un jeton"
 
 #: templates/web/base/around/_updates.html:3
 #: templates/web/base/report/display_tools.html:14
@@ -1622,11 +1622,11 @@ msgstr "Groupe"
 
 #: templates/web/base/dashboard/index.html:94
 msgid "Group by %s"
-msgstr "Group&eacute; par %s"
+msgstr "Groupé par %s"
 
 #: templates/web/base/dashboard/index.html:99
 msgid "Group by:"
-msgstr "Group&eacute; par:"
+msgstr "Groupé par:"
 
 #: templates/web/base/questionnaire/index.html:32
 msgid "Has this problem been fixed?"
@@ -1650,7 +1650,7 @@ msgstr "Aide <strong>%s </ strong> résoud votre problème plus rapidement, en f
 
 #: templates/web/base/around/on_map_list_items.html:8
 msgid "Here are some other nearby reports:"
-msgstr "Voici quelques autres rapports &agrave; proximit&eacute;:"
+msgstr "Voici quelques autres rapports à proximité:"
 
 #: templates/web/zurich/footer.html:11
 msgid "Hi %s"
@@ -1665,11 +1665,11 @@ msgstr "Caché(s)"
 
 #: templates/web/base/admin/extra-metadata-form.html:18
 msgid "Hidden Field"
-msgstr "Champ cach&eacute"
+msgstr "Champ caché"
 
 #: templates/web/base/admin/users/form.html:204
 msgid "Hide all reports and updates"
-msgstr "Masquer tous les rapports et mises &agrave; jour"
+msgstr "Masquer tous les rapports et mises à jour"
 
 #: templates/web/base/report/_main.html:121
 msgid "Hide entire report"
@@ -1686,7 +1686,7 @@ msgstr "Cacher mon nom partout"
 
 #: templates/web/base/my/anonymize.html:10
 msgid "Hide my name in this update"
-msgstr "Cacher mon nom dans cette mise &agrave; jour"
+msgstr "Cacher mon nom dans cette mise à jour"
 
 #: templates/web/base/my/anonymize.html:16
 msgid "Hide my name on this report"
@@ -1700,7 +1700,7 @@ msgstr "Cacher les épingles"
 
 #: templates/web/base/report/update.html:18
 msgid "Hide update completely?"
-msgstr "Masquer la mise &agrave; jour compl&egrave;tement?"
+msgstr "Masquer la mise à jour complètement?"
 
 #: templates/web/base/report/_report_meta_info.html:3
 #: templates/web/base/report/_update_state.html:16
@@ -1763,19 +1763,19 @@ msgstr "Identifier un <strong>parent</strong> si cet interlocuteur fait lui-mêm
 
 #: templates/web/base/auth/token.html:19
 msgid "If there's a user associated with the address you entered, we've sent a confirmation email."
-msgstr "S&apos;il y a un utilisateur associ&eacute; à l&apos;adresse que vous avez saisie, nous avons envoy&eacute; un courrier &eacute;lectronique de confirmation."
+msgstr "S'il y a un utilisateur associé à l'adresse que vous avez saisie, nous avons envoyé un courrier électronique de confirmation."
 
 #: templates/web/base/admin/responsepriorities/edit.html:23
 msgid "If this priority is passed to an external service (e.g. Exor/Confirm) enter the priority code to use with that service here."
-msgstr "Si cette priorit&eacute; est transmise &agrave; un service externe (par exemple Exor / Confirm), entrez le code de priorit&eacute; &agrave; utiliser avec ce service ici."
+msgstr "Si cette priorité est transmise à un service externe (par exemple Exor / Confirm), entrez le code de priorité à utiliser avec ce service ici."
 
 #: templates/web/base/admin/extra-metadata-form.html:34
 msgid "If ticked the user won’t see an input field, just the ‘Description’ text."
-msgstr "Si coch&eacute;, l'utilisateur ne verra pas un champ de saisie, juste le texte 'Description'."
+msgstr "Si coché, l'utilisateur ne verra pas un champ de saisie, juste le texte 'Description'."
 
 #: templates/web/base/admin/template_edit.html:75
 msgid "If ticked, this template will be used for Open311 updates that put problems in this state."
-msgstr "Si cette option est coch&eacute;e, ce mod&egrave;le sera utilis&eacute pour les mises &agrave; jour Open311 qui posent des probl&egrave;mes dans cet &eacute;tat."
+msgstr "Si cette option est cochée, ce modèle sera utilisé pour les mises à jour Open311 qui posent des problèmes dans cet état."
 
 #: templates/web/base/admin/bodies/contact-form.html:14
 msgid ""
@@ -1785,11 +1785,11 @@ msgstr "Si deux interlocuteurs ou plus servent le même lieu, FixMyStreet combin
 
 #: templates/web/base/contact/index.html:112
 msgid "If you are contacting us about a specific report or update please include a link to the report in the message."
-msgstr "Si vous nous contact&eacute; pour un rapport ou une mise &agrave; jour sp&eacute;cifique, veuillez inclure un lien vers le rapport dans le message."
+msgstr "Si vous nous contacté pour un rapport ou une mise à jour spécifique, veuillez inclure un lien vers le rapport dans le message."
 
 #: templates/web/base/auth/generate_token.html:61
 msgid "If you generate a new token the existing token will no longer work."
-msgstr "Si vous g&eacute;n&eacute;rez un nouveau jeton, le jeton existant ne fonctionnera plus."
+msgstr "Si vous générez un nouveau jeton, le jeton existant ne fonctionnera plus."
 
 #: templates/web/base/questionnaire/completed.html:8
 msgid "If you get some more information about the status of your problem, please come back to the site and leave an update."
@@ -1814,11 +1814,11 @@ msgstr "Si vous soumettez un problème ici, le problème <strong>ne sera pas </s
 
 #: templates/web/base/admin/template_edit.html:62
 msgid "If you want to use this template to prefill the update field when a report&rsquo;s <strong>external</strong> (e.g. Confirm) status code changes, enter the status code here."
-msgstr "Si vous souhaitez utiliser ce mod&egrave;le pour pr&eacute;-remplir le champ de mise &agrave; jour lorsqu&rsquo;un rapport <strong>externe</strong> (exemple: Confirmer) d&rsquo;un rapport change, entrez le code d&rsquo&eacute;tat ici."
+msgstr "Si vous souhaitez utiliser ce modèle pour pré-remplir le champ de mise à jour lorsqu’un rapport <strong>externe</strong> (exemple: Confirmer) d’un rapport change, entrez le code d’état ici."
 
 #: templates/web/base/admin/template_edit.html:49
 msgid "If you want to use this template to prefill the update field when changing a report&rsquo;s state, select the state here."
-msgstr "Si vous souhaitez utiliser ce mod&egrave;le pour pr&eacute;traiter le champ de mise &agrave; jour lorsque vous modifiez l'&eacute;tat d'un rapport, s&eacute;lectionnez le ici."
+msgstr "Si vous souhaitez utiliser ce modèle pour prétraiter le champ de mise à jour lorsque vous modifiez l'état d'un rapport, sélectionnez le ici."
 
 #: templates/web/base/questionnaire/index.html:70
 msgid ""
@@ -1930,7 +1930,7 @@ msgstr "Il est souvent plus rapide <a href=\"%s\">de parcourir notre FAQs</a> et
 
 #: templates/web/base/tokens/confirm_problem.html:31
 msgid "It’s on its way to the council right now."
-msgstr "Il est sur le chemin de l&rsquo;administration en ce moment."
+msgstr "Il est sur le chemin de l’administration en ce moment."
 
 #: templates/web/base/admin/extra-metadata-form.html:71
 msgid "Key"
@@ -1952,7 +1952,7 @@ msgstr "Langues"
 
 #: templates/web/base/reports/index.html:40
 msgid "Last 7 days"
-msgstr "Les 7 derni&egrave;rs jours"
+msgstr "Les 7 dernièrs jours"
 
 #: templates/web/base/admin/bodies/body.html:75
 #: templates/web/zurich/admin/bodies/body.html:16
@@ -1961,7 +1961,7 @@ msgstr "Dernier auteur"
 
 #: templates/web/base/questionnaire/index.html:53
 msgid "Last update"
-msgstr "derni&egrave;res mise &agrave; jour"
+msgstr "dernières mise à jour"
 
 #: templates/web/base/admin/report_edit.html:90
 msgid "Last update:"
@@ -2044,7 +2044,7 @@ msgstr "Connectez-vous avec email/texte"
 
 #: templates/web/base/admin/users/form.html:202
 msgid "Log out of all sessions"
-msgstr "Se d&eacute;connecter de toutes les sessions"
+msgstr "Se déconnecter de toutes les sessions"
 
 #: templates/web/base/dashboard/index.html:82
 msgid "Look up"
@@ -2056,7 +2056,7 @@ msgstr "CARTE"
 
 #: templates/web/base/admin/users/form.html:203
 msgid "Make anonymous on all reports and updates"
-msgstr "Rendre anonyme tous les rapports et mises &agrave; jour"
+msgstr "Rendre anonyme tous les rapports et mises à jour"
 
 #: perllib/FixMyStreet/Cobrand/Default.pm:716
 msgid "Manage shortlist"
@@ -2116,14 +2116,14 @@ msgstr "Modérer ce rapport"
 
 #: templates/web/base/report/update.html:15
 msgid "Moderate this update"
-msgstr "Modifiez cette mise &agrave; jour"
+msgstr "Modifiez cette mise à jour"
 
 #: templates/web/base/admin/update_edit.html:92
 #: templates/web/base/report/_main.html:85
 #: templates/web/base/report/_update_state.html:19
 #: templates/web/base/report/update/moderation_meta.html:2
 msgid "Moderated by %s at %s"
-msgstr "Modifiez par %s &agrave; %s"
+msgstr "Modifiez par %s à %s"
 
 #: templates/web/zurich/admin/stats/index.html:55
 msgid "Moderated by division within one working day"
@@ -2219,7 +2219,7 @@ msgstr "Presque fini! Maintenant, veuillez vérifier votre email"
 #: templates/web/base/auth/2faform.html:8
 #: templates/web/base/auth/smsform.html:19
 msgid "Nearly done! Now check your phone&hellip;"
-msgstr "Presque fini! Maintenant, véeacute;rifiez votre t&eacute;l&eacute;phone&hellip;"
+msgstr "Presque fini! Maintenant, véeacute;rifiez votre téléphone&hellip;"
 
 #: perllib/FixMyStreet/App/Controller/Admin/Bodies.pm:73
 msgid "New body added"
@@ -2254,7 +2254,7 @@ msgstr "Nouveau mot de passe :"
 
 #: templates/web/base/auth/change_phone.html:38
 msgid "New phone number:"
-msgstr "Nouveau num&eacute;ro de t&eacute;l&eacute;phone:"
+msgstr "Nouveau numéro de téléphone:"
 
 #: templates/web/base/admin/responsepriorities/edit.html:4
 #: templates/web/base/admin/responsepriorities/list.html:34
@@ -2386,15 +2386,15 @@ msgstr "Pas d'autres mises à jour"
 
 #: perllib/FixMyStreet/App/Controller/Admin/ExorDefects.pm:70
 msgid "No inspections by that inspector in the selected date range."
-msgstr "Aucune inspection effectu&eacute;e par cet inspecteur dans la fourchette de dates s&eacute;lectionn&eacute;e."
+msgstr "Aucune inspection effectuée par cet inspecteur dans la fourchette de dates sélectionnée."
 
 #: perllib/FixMyStreet/App/Controller/Admin/ExorDefects.pm:72
 msgid "No inspections in the selected date range."
-msgstr "Aucune inspection dans la plage de dates s&eacute;lectionn&eacute;e."
+msgstr "Aucune inspection dans la plage de dates sélectionnée."
 
 #: templates/web/base/around/on_map_list_items.html:13
 msgid "No reports to show on map, here are some nearby:"
-msgstr "Aucun rapport &agrave; afficher sur la carte, en voici quelques-uns &agrave; proximit&eacute;:"
+msgstr "Aucun rapport à afficher sur la carte, en voici quelques-uns à proximité:"
 
 #: templates/web/base/js/translation_strings.html:54
 msgid "No result returned"
@@ -2478,11 +2478,11 @@ msgstr "Notification"
 
 #: templates/web/base/reports/index.html:127
 msgid "Number of problems reported in each category, in the last 7 days."
-msgstr "Nombre de probl&egrave;mes signal&eacute;s dans chaque cat&eacute;gorie, au cours des 7 derniers jours."
+msgstr "Nombre de problèmes signalés dans chaque catégorie, au cours des 7 derniers jours."
 
 #: templates/web/base/reports/index.html:99
 msgid "Number of problems reported in each ward, in the last 7 days."
-msgstr "Nombre de probl&egrave;mes signal&eacute;s dans chaque service au cours des 7 derniers jours."
+msgstr "Nombre de problèmes signalés dans chaque service au cours des 7 derniers jours."
 
 #: templates/web/base/js/translation_strings.html:60
 msgid "OK"
@@ -2490,11 +2490,11 @@ msgstr "OK"
 
 #: templates/web/base/js/translation_strings.html:97
 msgid "Offline data cleared"
-msgstr "Donn&eacute;es hors ligne effac&eacute;es"
+msgstr "Données hors ligne effacées"
 
 #: templates/web/base/js/translation_strings.html:94
 msgid "Offline update data saved"
-msgstr "Donn&eacute;es de mise &agrave; jour hors ligne enregistr&eacute;es"
+msgstr "Données de mise à jour hors ligne enregistrées"
 
 #: templates/web/base/admin/stats/questionnaire.html:24
 msgid "Old state"
@@ -2576,7 +2576,7 @@ msgstr "Autres"
 
 #: templates/web/base/reports/index.html:136
 msgid "Other categories"
-msgstr "Autres cat&eacute;gories"
+msgstr "Autres catégories"
 
 #: templates/web/base/reports/index.html:107
 msgid "Other wards"
@@ -2584,7 +2584,7 @@ msgstr "Autres quartiers"
 
 #: templates/web/base/reports/index.html:120
 msgid "Overall average"
-msgstr "Moyenne g&eacute;n&eacute;rale"
+msgstr "Moyenne générale"
 
 #: templates/web/base/admin/list_updates.html:8
 msgid "Owner"
@@ -2620,11 +2620,11 @@ msgstr "Autorisations :"
 
 #: templates/web/base/admin/bodies/open311-form-fields.html:61
 msgid "Permit blank updates"
-msgstr "Autoriser les mises &agrave; jour vierges"
+msgstr "Autoriser les mises à jour vierges"
 
 #: templates/web/base/report/_inspect.html:28
 msgid "Phone Reporter:"
-msgstr "T&eacute;l&eacute;phone Reporter:"
+msgstr "Téléphone Reporter:"
 
 #: templates/web/base/auth/change_phone.html:36
 #: templates/web/base/report/new/form_user_loggedin.html:34
@@ -2644,7 +2644,7 @@ msgstr ""
 
 #: templates/web/base/admin/users/form.html:29
 msgid "Phone verified:"
-msgstr "T&eacute;l&eacute;phone v&eacute;rifi&eacute;:"
+msgstr "Téléphone vérifié:"
 
 #: templates/web/base/admin/report_edit.html:143
 #: templates/web/base/admin/users/form.html:27 templates/web/base/my/my.html:47
@@ -2737,7 +2737,7 @@ msgstr "Merci de vérifier que votre adresse email est correcte"
 #: templates/web/base/auth/_username_error.html:1
 #: templates/web/base/auth/_username_error.html:7
 msgid "Please check your phone number is correct"
-msgstr "Veuillez v&eacute;rifier que votre num&eacute;ro de t&eacute;l&eacute;phone est correct"
+msgstr "Veuillez vérifier que votre numéro de téléphone est correct"
 
 #: perllib/FixMyStreet/App/Controller/Admin/Bodies.pm:232
 #: perllib/FixMyStreet/App/Controller/Report/New.pm:1003
@@ -2750,7 +2750,7 @@ msgstr "Merci de sélectionner une catégorie"
 #: perllib/FixMyStreet/App/Controller/Auth.pm:387
 #: perllib/FixMyStreet/App/Controller/Auth.pm:413
 msgid "Please choose a less commonly-used password"
-msgstr "Veuillez choisir un mot de passe moins utilis&eacute;"
+msgstr "Veuillez choisir un mot de passe moins utilisé"
 
 #: perllib/FixMyStreet/App/Controller/Admin/Bodies.pm:287
 #: templates/web/base/admin/bodies/body.html:12
@@ -2785,7 +2785,7 @@ msgstr "Merci d'entrer un message"
 #: templates/web/base/auth/_username_error.html:1
 #: templates/web/base/auth/_username_error.html:4
 msgid "Please enter a mobile number"
-msgstr "Merci d&rsquo;entrer un num&eacute;ro de t&eacute;l&eacute;phone portable"
+msgstr "Merci d’entrer un numéro de téléphone portable"
 
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:214
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:95
@@ -2825,7 +2825,7 @@ msgstr "Merci d'entrer une adresse email valide"
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:199
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:99
 msgid "Please enter a valid email or phone number"
-msgstr "Veuillez entrer un email ou un num&eacute;ro de t&eacute;l&eacute;phone valide"
+msgstr "Veuillez entrer un email ou un numéro de téléphone valide"
 
 #: perllib/FixMyStreet/DB/Result/Problem.pm:374
 #: templates/web/base/js/translation_strings.html:12
@@ -2891,7 +2891,7 @@ msgstr "Merci de remplir le formulaire ci-dessous avec les détails du problème
 
 #: templates/web/base/auth/2faform.html:9
 msgid "Please generate a two-factor code and enter it below:"
-msgstr "Veuillez g&eacute;n&eacute;rer un code &agrave; deux facteurs et entrez-le ci-dessous:"
+msgstr "Veuillez générer un code à deux facteurs et entrez-le ci-dessous:"
 
 #: perllib/FixMyStreet/App/Controller/Questionnaire.pm:253
 msgid "Please indicate whether you'd like to receive another questionnaire"
@@ -2926,7 +2926,7 @@ msgstr "Quelques remarques :"
 
 #: perllib/FixMyStreet/App/Controller/Report.pm:445
 msgid "Please provide a duplicate ID or public update for this report."
-msgstr "Veuillez fournir un ID en double ou une mise &agrave; jour publique pour ce rapport."
+msgstr "Veuillez fournir un ID en double ou une mise à jour publique pour ce rapport."
 
 #: perllib/FixMyStreet/App/Controller/Report.pm:427
 msgid "Please provide a public update for this report."
@@ -2971,7 +2971,7 @@ msgstr "Veuillez uniquement envoyer une image"
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:102
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:202
 msgid "Please verify at least one of email/phone"
-msgstr "Merci de v&eacute;rifier au moins l&rsquo;un des e-mail/t&eacute;l&eacute;phone"
+msgstr "Merci de vérifier au moins l’un des e-mail/téléphone"
 
 #: perllib/FixMyStreet/App/Controller/Contact.pm:134
 msgid "Please write a message"
@@ -3054,7 +3054,7 @@ msgstr "Problème %d confirmé"
 
 #: templates/web/base/admin/timeline.html:26
 msgid "Problem %s sent to council %s"
-msgstr "Problème %d signalé à l&rsquo;administration %s"
+msgstr "Problème %d signalé à l’administration %s"
 
 #: templates/web/base/admin/stats/index.html:5
 #: templates/web/base/admin/stats/state.html:12
@@ -3077,7 +3077,7 @@ msgstr "Problèmes"
 
 #: templates/web/base/alert/_list.html:22
 msgid "Problems in an area"
-msgstr "Probl&egrave;mes dans une zone"
+msgstr "Problèmes dans une zone"
 
 #: templates/web/base/report/display_tools.html:22
 msgid "Problems nearby"
@@ -3093,7 +3093,7 @@ msgstr "Problèmes récemment signalés sur FixMyStreet.fr"
 
 #: templates/web/base/alert/_list.html:29
 msgid "Problems within %.1fkm of %s"
-msgstr "Probl&egrave;mes entre %.1fkm de %s "
+msgstr "Problèmes entre %.1fkm de %s "
 
 #: perllib/FixMyStreet/Cobrand/Default.pm:847
 #: perllib/FixMyStreet/Cobrand/FiksGataMi.pm:141
@@ -3108,7 +3108,7 @@ msgstr "Problèmes dans la localité %s"
 
 #: perllib/FixMyStreet/Cobrand/UK.pm:264 perllib/FixMyStreet/Cobrand/UK.pm:276
 msgid "Problems within %s ward, %s"
-msgstr "Probl&egrave;mes entre%squartier,%s"
+msgstr "Problèmes entre%squartier,%s"
 
 #. ("First %s is the body name, second %s the site name")
 #: templates/web/base/reports/body.html:0
@@ -3140,7 +3140,7 @@ msgstr "Un mot de passe n'est pas obligatoire, mais vous permettra de créer, me
 
 #: templates/web/base/report/new/form_report.html:13
 msgid "Public details"
-msgstr "D&eacute;tails public"
+msgstr "Détails public"
 
 #: templates/web/zurich/admin/report_edit.html:242
 #: templates/web/zurich/admin/report_edit.html:269
@@ -3273,7 +3273,7 @@ msgstr "Retirer"
 
 #: templates/web/base/admin/users/form.html:205
 msgid "Remove account details"
-msgstr "Supprimer les d&eacute;tails du compte"
+msgstr "Supprimer les détails du compte"
 
 #: templates/web/base/admin/extra-metadata-form.html:4
 msgid "Remove field"
@@ -3352,7 +3352,7 @@ msgstr "Signaler sur %s"
 
 #: templates/web/base/dashboard/index.html:62
 msgid "Report state:"
-msgstr "&Eacute;tat du rapport:"
+msgstr "État du rapport:"
 
 #: templates/web/base/report/new/fill_in_details_form.html:1
 #: templates/web/base/report/new/login_success_form.html:1
@@ -3362,7 +3362,7 @@ msgstr "Signaler votre problème"
 
 #: templates/web/base/header_opengraph.html:4
 msgid "Report, view, and discuss local street-related problems."
-msgstr "Signalez des incidents sur l&rsquo;espace public et participez &agrave; l&rsquo;am&eacute;lioration de votre ville."
+msgstr "Signalez des incidents sur l’espace public et participez à l’amélioration de votre ville."
 
 #: templates/web/base/around/intro.html:1
 #: templates/web/zurich/around/intro.html:1
@@ -3464,7 +3464,7 @@ msgstr "Les déclarations faites par les utilisateurs de confiance seront envoy�
 
 #: templates/web/base/alert/_list.html:15
 msgid "Reports near %s are sent to different councils, depending on the type of problem."
-msgstr "Selon le type de probl&egrave;me, les rapports à proximit&eacute; sont envoy&eacute;s &agrave; diff&eacute;rentes administrations, "
+msgstr "Selon le type de problème, les rapports à proximité sont envoyés à différentes administrations, "
 
 #: templates/web/zurich/admin/index-sdm.html:10
 msgid "Reports published"
@@ -3472,15 +3472,15 @@ msgstr "Rapports publiés"
 
 #: templates/web/base/js/translation_strings.html:98
 msgid "Reports saved offline."
-msgstr "Rapports enregistr&eacute;s hors ligne."
+msgstr "Rapports enregistrés hors ligne."
 
 #: perllib/FixMyStreet/Cobrand/UK.pm:284 perllib/FixMyStreet/Cobrand/UK.pm:298
 msgid "Reports sent to %s"
-msgstr "Rapports envoy&eacute;s &agrave; %s"
+msgstr "Rapports envoyés à %s"
 
 #: perllib/FixMyStreet/Cobrand/UK.pm:291 perllib/FixMyStreet/Cobrand/UK.pm:305
 msgid "Reports sent to %s, within %s ward"
-msgstr "Rapports envoy&eacute;s &agrave; %s, entre %s quartier"
+msgstr "Rapports envoyés à %s, entre %s quartier"
 
 #: templates/web/base/admin/index.html:56
 msgid "Reports waiting to be sent"
@@ -3532,7 +3532,7 @@ msgstr "Modèles de réponse pour %s"
 
 #: templates/web/base/report/update.html:44
 msgid "Revert to original"
-msgstr "Revenir &agrave; l&apos;original"
+msgstr "Revenir à l'original"
 
 #: templates/web/base/report/_main.html:111
 msgid "Revert to original text"
@@ -3643,7 +3643,7 @@ msgstr "Aucun utilisateur trouvé lors de la recherche."
 #: templates/web/base/auth/generate_token.html:39
 #: templates/web/base/my/my.html:71
 msgid "Security"
-msgstr "S&eacute;curit&eacute;"
+msgstr "Sécurité"
 
 #: templates/web/base/report/form/private_details.html:14
 #: templates/web/base/report/new/councils_text_private.html:7
@@ -3652,7 +3652,7 @@ msgstr "Voir notre politique de confidentialité"
 
 #: perllib/FixMyStreet/Cobrand/Default.pm:721
 msgid "See user detail for reports created as the council"
-msgstr "Voir les d&eacute;tails des utilisateurs pour les rapports cr&eacute;&eacute;s en tant que conseil"
+msgstr "Voir les détails des utilisateurs pour les rapports créés en tant que conseil"
 
 #: templates/web/base/admin/bodies/form.html:41
 #: templates/web/zurich/admin/bodies/form.html:16
@@ -3667,15 +3667,15 @@ msgstr "Sélectionnez une zone"
 
 #: templates/web/base/admin/responsepriorities/edit.html:33
 msgid "Select if this is the default priority"
-msgstr "S&eacute;lectionnez si c&apos;est la priorit&eacute; par d&eacute;faut"
+msgstr "Sélectionnez si c'est la priorité par défaut"
 
 #: templates/web/base/reports/_ward-list.html:7
 msgid "Select multiple wards to view only reports within those wards."
-msgstr "S&eacute;lectionnez plusieurs services pour afficher uniquement les rapports dans ces services."
+msgstr "Sélectionnez plusieurs services pour afficher uniquement les rapports dans ces services."
 
 #: templates/web/base/reports/_ward-list.html:8
 msgid "Select multiple wards?"
-msgstr "S&eacute;lectionnez plusieurs quartiers?"
+msgstr "Sélectionnez plusieurs quartiers?"
 
 #: templates/web/base/admin/category-checkboxes.html:6
 msgid "Select:"
@@ -3683,7 +3683,7 @@ msgstr "Sélectionner :"
 
 #: templates/web/base/contact/index.html:116
 msgid "Send"
-msgstr "Envoy&eacute;"
+msgstr "Envoyé"
 
 #: templates/web/base/admin/bodies/open311-form-fields.html:121
 msgid "Send extended Open311 statuses with service request updates"
@@ -3696,7 +3696,7 @@ msgstr "Envoyer un e-mail de connexion"
 #: templates/web/base/auth/_username_error.html:1
 #: templates/web/base/auth/_username_error.html:5
 msgid "Sending a confirmation text failed: \"%s\""
-msgstr "L&rsquo;envoi d&rsquo;un texte de confirmation a &eacute;chou&eacute;: \"%s\""
+msgstr "L’envoi d’un texte de confirmation a échoué: \"%s\""
 
 #: perllib/FixMyStreet/Cobrand/Zurich.pm:872
 msgid "Sent report back"
@@ -3712,7 +3712,7 @@ msgstr "Envoyé :"
 
 #: templates/web/base/admin/extra-metadata-form.html:17
 msgid "Server Set"
-msgstr "D&eacute;finir le serveur"
+msgstr "Définir le serveur"
 
 #: templates/web/base/admin/report_edit.html:92
 #: templates/web/zurich/admin/stats/index.html:66
@@ -3723,7 +3723,7 @@ msgstr "Service:"
 #: templates/web/base/auth/change_password.html:4
 #: templates/web/base/my/my.html:67
 msgid "Set password"
-msgstr "D&eacute;finir un mot de passe"
+msgstr "Définir un mot de passe"
 
 #: templates/web/base/report/_inspect.html:56
 msgid "Set to my current location"
@@ -3742,7 +3742,7 @@ msgstr "Liste"
 
 #: templates/web/base/reports/body.html:32
 msgid "Shortlist all visible"
-msgstr "Liste abr&eacute;g&eacute;e visible"
+msgstr "Liste abrégée visible"
 
 #: templates/web/base/report/_main.html:147
 #: templates/web/base/report/_main.html:26
@@ -3813,7 +3813,7 @@ msgstr "Connectez-vous par e-mail à la place en fournissant un nouveau mot de p
 
 #: templates/web/base/auth/create.html:20
 msgid "Sign in by email or text, providing a new password. When you click the link in your email or enter the SMS authentication code, your password will be updated."
-msgstr "Connectez-vous par e-mail ou texte, en fournissant un nouveau mot de passe. Lorsque vous cliquez sur le lien dans votre e-mail ou entrez le code d&rsquo;authentification SMS, votre mot de passe sera mis &agrave; jour."
+msgstr "Connectez-vous par e-mail ou texte, en fournissant un nouveau mot de passe. Lorsque vous cliquez sur le lien dans votre e-mail ou entrez le code d’authentification SMS, votre mot de passe sera mis à jour."
 
 #: templates/web/base/auth/general.html:1
 #: templates/web/zurich/auth/general.html:1
@@ -3870,7 +3870,7 @@ msgstr "Désolé, cela n'est pas un lien valide"
 #: templates/web/base/auth/2faform.html:5
 #: templates/web/base/auth/smsform.html:16
 msgid "Sorry, that wasn&rsquo;t the correct code"
-msgstr "D&eacute;sol&eacute;, ce n&rsquo;&eacute;tait pas le bon code"
+msgstr "Désolé, ce n’était pas le bon code"
 
 #: templates/web/base/tokens/abuse.html:5
 msgid "Sorry, there has been an error confirming your problem."
@@ -3903,8 +3903,8 @@ msgid ""
 "Sorry, we don’t have a good enough connection to fetch that page, or the\n"
 "page wasn’t found or there was a server error. Please try again later."
 msgstr ""
-"D&eacute;sol&eacute;, nous n&apos;avons pas une connexion assez bonne pour r&eacute;cup&eacute;rer cette page ou\n"
-"la page n&apos;a pas &eacute;t&eacute; trouv&eacute;e ou il y a eu une erreur de serveur. Veuillez r&eacute;essayer plus tard."
+"Désolé, nous n'avons pas une connexion assez bonne pour récupérer cette page ou\n"
+"la page n'a pas été trouvée ou il y a eu une erreur de serveur. Veuillez réessayer plus tard."
 
 #: perllib/FixMyStreet/App/Controller/Root.pm:125
 msgid "Sorry, you don't have permission to do that."
@@ -3924,7 +3924,7 @@ msgstr "Personnel :"
 
 #: templates/web/base/dashboard/index.html:74
 msgid "Start Date"
-msgstr "Date de d&eacute;but"
+msgstr "Date de début"
 
 #: templates/web/base/admin/bodies/body.html:74
 #: templates/web/base/admin/bodies/category.html:30
@@ -3947,13 +3947,13 @@ msgstr "État actuel"
 #: perllib/FixMyStreet/App/Controller/Admin.pm:791
 #: perllib/FixMyStreet/App/Controller/Admin.pm:792
 msgid "State and external status code cannot be used simultaneously."
-msgstr "L&rsquo;&eacute;tat et le code d&rsquo;&eacute;tat externe ne peuvent pas etre utilis&eacute;s simultan&eacute;ment."
+msgstr "L’état et le code d’état externe ne peuvent pas etre utilisés simultanément."
 
 #: perllib/FixMyStreet/Script/Alerts.pm:102
 #: templates/web/base/report/_update_state.html:7
 #: templates/web/base/report/updates.html:18
 msgid "State changed to:"
-msgstr "L&apos;&eacute;tat a chang&eacute; pour:"
+msgstr "L'état a changé pour:"
 
 #: templates/web/base/admin/report_edit.html:123
 #: templates/web/base/admin/update_edit.html:28
@@ -3968,7 +3968,7 @@ msgstr "État actuel :"
 #: perllib/FixMyStreet/Cobrand/Zurich.pm:421
 #: templates/web/base/admin/states/index.html:1
 msgid "States"
-msgstr "&Eacute;tat"
+msgstr "État"
 
 #: perllib/FixMyStreet/Cobrand/Default.pm:635
 #: perllib/FixMyStreet/Cobrand/Zurich.pm:403
@@ -3998,7 +3998,7 @@ msgstr "Street View"
 
 #: templates/web/base/admin/extra-metadata-form.html:56
 msgid "String"
-msgstr "Cha&icirc;ne"
+msgstr "Chaîne"
 
 #: templates/web/base/report/new/category.html:46
 msgid "Subcategory"
@@ -4059,7 +4059,7 @@ msgstr "S'abonner"
 
 #: templates/web/base/alert/_list.html:72
 msgid "Subscribe by email"
-msgstr "S&apos;abonner par email"
+msgstr "S'abonner par email"
 
 #: templates/web/base/admin/users/alerts.html:22
 msgid "Subscribed:"
@@ -4101,7 +4101,7 @@ msgstr "Rapports résumés"
 #: templates/web/base/admin/stats/index.html:7
 #: templates/web/base/dashboard/index.html:21
 msgid "Summary statistics"
-msgstr "Statistiques r&eacute;capitulatives"
+msgstr "Statistiques récapitulatives"
 
 #: templates/web/base/admin/users/form.html:157
 msgid "Superuser:"
@@ -4150,7 +4150,7 @@ msgstr "Texte :"
 
 #: templates/web/base/tokens/confirm_problem.html:29
 msgid "Thank you for reporting this issue!"
-msgstr "Merci d&rsquo;avoir signalé ce problème!"
+msgstr "Merci d’avoir signalé ce problème!"
 
 #: templates/web/base/tokens/error.html:6
 msgid "Thank you for trying to confirm your update or problem. We seem to have an error ourselves though, so <a href=\"%s\">please let us know what went on</a> and we'll look into it."
@@ -4158,7 +4158,7 @@ msgstr "Merci d'essayer de confirmer votre mise à jour ou un problème. Nous se
 
 #: templates/web/base/tokens/confirm_update.html:16
 msgid "Thank you for updating this issue!"
-msgstr "Merci d'&rsquo;avoir mis à jour ce problème!"
+msgstr "Merci d’avoir mis à jour ce problème!"
 
 #: templates/web/base/contact/submit.html:6
 msgid "Thank you for your enquiry"
@@ -4212,19 +4212,19 @@ msgstr "Ce rapport a été retiré de FixMyStreet.fr."
 
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:486
 msgid "That user has been logged out."
-msgstr "Cet utilisateur a &eacute;t&eacute; d&eacute;connect&eacute;."
+msgstr "Cet utilisateur a été déconnecté."
 
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:493
 msgid "That user has been made anonymous on all reports and updates."
-msgstr "Cet utilisateur a &eacute;t&eacute; rendu anonyme sur tous les rapports et mises &agrave; jour."
+msgstr "Cet utilisateur a été rendu anonyme sur tous les rapports et mises à jour."
 
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:541
 msgid "That user’s personal details have been removed."
-msgstr "Les informations personnelles de cet utilisateur ont &eacute;t&eacute; supprim&eacute;es."
+msgstr "Les informations personnelles de cet utilisateur ont été supprimées."
 
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:507
 msgid "That user’s reports and updates have been hidden."
-msgstr "Les rapports et mises &agrave; jour de cet utilisateur ont &eacute;t&eacute; masqu&eacute;s."
+msgstr "Les rapports et mises à jour de cet utilisateur ont été masqués."
 
 #: templates/web/base/admin/bodies/contact-form.html:27
 msgid ""
@@ -4249,8 +4249,8 @@ msgid ""
 "The <strong>group</strong> is used for the top-level category field when\n"
 "          subcategory grouping is enabled."
 msgstr ""
-"Le <strong>groupe</strong> est utilis&eacute; pour le champ cat&eacute;gorie lorsque\n"
-"          le regroupement des sous-cat&eacute;gories est activ&eacute;."
+"Le <strong>groupe</strong> est utilisé pour le champ catégorie lorsque\n"
+"          le regroupement des sous-catégories est activé."
 
 #: templates/web/base/admin/bodies/open311-form-fields.html:27
 #: templates/web/base/admin/bodies/open311-form-fields.html:28
@@ -4287,7 +4287,7 @@ msgstr ""
 
 #: templates/web/base/admin/extra-metadata-form.html:22
 msgid "The code used to store this field value in the database. e.g. <code>address</code> would be available as <code>problem.extra.address</code> in the templates."
-msgstr "Le code utilis&eacute; pour stocker cette valeur de champ dans la base de donn&eacute;es. par exemple. <code>address</code> serait disponible sous la forme <code>problem.extra.address</code> dans les mod&egrave;les."
+msgstr "Le code utilisé pour stocker cette valeur de champ dans la base de données. par exemple. <code>address</code> serait disponible sous la forme <code>problem.extra.address</code> dans les modèles."
 
 #: templates/web/base/report/new/fill_in_details_text.html:1
 #: templates/web/base/report/new/fill_in_details_text.html:3
@@ -4306,7 +4306,7 @@ msgstr "L'erreur était : %s"
 
 #: templates/web/base/admin/extra-metadata-form.html:40
 msgid "The field name as shown to the user on the report form."
-msgstr "Le nom du champ tel qu&rsquo;indiqu&eacute; &aacute; l&rsquo;utilisateur sur le formulaire de rapport."
+msgstr "Le nom du champ tel qu’indiqué &aacute; l’utilisateur sur le formulaire de rapport."
 
 #: templates/web/base/open311/index.html:78
 msgid "The following Open311 v2 attributes are returned for each request: service_request_id, description, lat, long, media_url, status, requested_datetime, updated_datetime, service_code and service_name."
@@ -4343,7 +4343,7 @@ msgstr "Les derniers problèmes à l'intérieur de {{NAME}} rapportés par les u
 
 #: templates/web/base/auth/smsform.html:7 templates/web/base/auth/token.html:9
 msgid "The link might have expired, or maybe you didn&rsquo;t quite copy and paste it correctly."
-msgstr "Le lien à expiré, ou peut-être vous ne l&rsquo;avez pas copier coller correctement."
+msgstr "Le lien à expiré, ou peut-être vous ne l’avez pas copier coller correctement."
 
 #: templates/web/base/admin/bodies/form.html:66
 msgid "The list of available areas is being provided by the MapIt service at %s."
@@ -4351,7 +4351,7 @@ msgstr "La liste des zones disponibles est donnée par le service Mapit de %s. "
 
 #: templates/web/base/admin/extra-metadata-form.html:6
 msgid "The ordering of this field on the report page. Fields are shown in ascending order according to this value."
-msgstr "L&rsquo;ordre de ce champ sur la page de rapport. Les champs sont affichés en ordre croissant selon cette valeur."
+msgstr "L’ordre de ce champ sur la page de rapport. Les champs sont affichés en ordre croissant selon cette valeur."
 
 #: templates/web/base/auth/change_password.html:26
 #: templates/web/base/auth/change_password.html:30
@@ -4364,11 +4364,11 @@ msgstr "L'URL demandée « %s » n'a pas été trouvée sur ce serveur"
 
 #: templates/web/base/admin/extra-metadata-form.html:52
 msgid "The type of input field to show to the user. <strong>Text</strong> is a simple text field, <strong>List</strong> is a drop-down selection."
-msgstr "Le type de champ de saisie &agrave; afficher &agrave; l&apos;utilisateur.<strong>Text</strong> est un champ de texte simple, <strong>Liste</strong> est une s&eacute;lection d&eacute;roulante."
+msgstr "Le type de champ de saisie à afficher à l'utilisateur.<strong>Text</strong> est un champ de texte simple, <strong>Liste</strong> est une sélection déroulante."
 
 #: templates/web/base/admin/users/import.html:68
 msgid "The uploaded CSV file must contain a header row, and records must have the following fields (in this order):"
-msgstr "Le fichier CSV t&eacute;l&eacute;charg&eacute; doit contenir une ligne d'en-t&ecirc;te et les enregistrements doivent avoir les champs suivants (dans cet ordre):"
+msgstr "Le fichier CSV téléchargé doit contenir une ligne d'en-tête et les enregistrements doivent avoir les champs suivants (dans cet ordre):"
 
 #: perllib/FixMyStreet/Script/Reports.pm:98
 msgid "The user could not locate the problem on a map, but to see the area around the location they entered"
@@ -4376,7 +4376,7 @@ msgstr "L'utilisateur n'a pas pu localiser le problème sur une carte, mais pour
 
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:532
 msgid "The user has been sent a login email"
-msgstr "L&rsquo;utilisateur a reçu un email de connexion"
+msgstr "L’utilisateur a reçu un email de connexion"
 
 #: templates/web/base/admin/users/form.html:10
 #: templates/web/base/admin/users/form.html:11
@@ -4399,7 +4399,7 @@ msgstr ""
 
 #: perllib/FixMyStreet/App/Controller/Admin.pm:819
 msgid "There is already an auto-response template for this category/state."
-msgstr "Il existe d&eacute;j&agrave; un mod&egrave;le de r&eacute;ponse automatique pour cette cat&eacute;gorie/Emplacement."
+msgstr "Il existe déjà un modèle de réponse automatique pour cette catégorie/Emplacement."
 
 #: perllib/FixMyStreet/App/Controller/Reports.pm:55
 msgid "There was a problem showing the All Reports page. Please try again later."
@@ -4421,8 +4421,8 @@ msgstr ""
 
 #: perllib/FixMyStreet/App/Controller/Report/New.pm:857
 #: perllib/FixMyStreet/App/Controller/Report/Update.pm:146
-msgid "There was a problem with your login information. If you cannot remember your password, or do not have one, please fill in the &lsquo;No&rsquo; section of the form."
-msgstr "Il y a un probl&egrave;me avec vos informations de connexion. Si vous ne vous souvenez plus de votre mot de passe ou n&rsquo;en avez pas, veuillez remplir le champ &lsquo;Non&lsquo; du formulaire."
+msgid "There was a problem with your login information. If you cannot remember your password, or do not have one, please fill in the ‘No’ section of the form."
+msgstr "Il y a un problème avec vos informations de connexion. Si vous ne vous souvenez plus de votre mot de passe ou n’en avez pas, veuillez remplir le champ ‘Non’ du formulaire."
 
 #: perllib/FixMyStreet/App/Controller/Report/Update.pm:354
 msgid "There was a problem with your update. Please try again."
@@ -4460,7 +4460,7 @@ msgstr ""
 
 #: templates/web/base/admin/users/import.html:43
 msgid "These users weren't updated."
-msgstr "Ces utilisateurs n&rsquo;ont pas &eacute;t&eacute; mis &agrave; jour."
+msgstr "Ces utilisateurs n’ont pas été mis à jour."
 
 #: templates/web/base/report/new/councils_text.html:3
 #: templates/web/base/report/new/councils_text.html:4
@@ -4516,7 +4516,7 @@ msgstr "Ces renseignements sont nécessaires"
 
 #: templates/web/base/admin/template_edit.html:19
 msgid "This is a <strong>private</strong> name for this template so you can identify it when updating reports or editing in the admin."
-msgstr "Ceci est un nom <strong>priv&eacute;</strong>  pour ce mod&egrave;le afin que vous puissiez l&rsquo;identifier lors de la mise &agrave; jour de rapports ou de sa modification dans la section d&rsquo;'administration."
+msgstr "Ceci est un nom <strong>privé</strong>  pour ce modèle afin que vous puissiez l’identifier lors de la mise à jour de rapports ou de sa modification dans la section d’administration."
 
 #: templates/web/base/debug_header.html:3
 msgid "This is a developer site; things might break at any time, and the database will be periodically deleted."
@@ -4524,7 +4524,7 @@ msgstr "Ceci est un site en développement, le service peut être interrompu à 
 
 #: templates/web/base/admin/template_edit.html:29
 msgid "This is the <strong>public</strong> text that will be shown on the site."
-msgstr "Ceci est le texte <strong>public</strong> qui sera affich&eacute; sur le site."
+msgstr "Ceci est le texte <strong>public</strong> qui sera affiché sur le site."
 
 #: templates/web/base/js/translation_strings.html:48
 msgid "This is the problem"
@@ -4532,7 +4532,7 @@ msgstr ""
 
 #: templates/web/base/admin/users/import.html:65
 msgid "This page is a quick way to create many new staff users in one go."
-msgstr "Cette page est un moyen rapide de cr&eacute;er de nombreux nouveaux utilisateurs en une seule fois."
+msgstr "Cette page est un moyen rapide de créer de nombreux nouveaux utilisateurs en une seule fois."
 
 #: templates/web/base/report/update/form_state_checkbox.html:14
 msgid "This problem has been fixed"
@@ -4544,7 +4544,7 @@ msgstr "Ce problème n'a pas été résolu"
 
 #: templates/web/base/report/update/form_state_checkbox.html:5
 msgid "This problem is still ongoing"
-msgstr "Ce probl&egrave;me est toujours en cours"
+msgstr "Ce problème est toujours en cours"
 
 #: templates/web/base/js/translation_strings.html:47
 msgid "This report"
@@ -4552,7 +4552,7 @@ msgstr ""
 
 #: templates/web/base/report/duplicate-no-updates.html:5
 msgid "This report is a duplicate. Please leave updates on the original report:"
-msgstr "Ce rapport est un dupliqua. Veuillez mettre &egrave; jour le rapport original:"
+msgstr "Ce rapport est un dupliqua. Veuillez mettre è jour le rapport original:"
 
 #: perllib/FixMyStreet/Cobrand/Zurich.pm:140
 #: perllib/FixMyStreet/Cobrand/Zurich.pm:141
@@ -4574,7 +4574,7 @@ msgstr "Ce rapport est actuellement marqué comme ouvert."
 
 #: templates/web/base/report/display.html:58
 msgid "This report is now closed to updates."
-msgstr "Ce rapport est maintenant ferm&eacute aux mises &agrave; jour."
+msgstr "Ce rapport est maintenant fermé aux mises à jour."
 
 #: perllib/FixMyStreet/Script/Reports.pm:89
 msgid "This web page also contains a photo of the problem, provided by the user."
@@ -4619,11 +4619,11 @@ msgstr "Pour afficher les alertes qui vous concernent, saisissez votre code post
 
 #: templates/web/base/admin/reportextrafields/edit.html:19
 msgid "To limit this collection of fields to a single cobrand, select it here."
-msgstr "Pour limiter cette collection de champs &agrave; un seul cobrand, sélectionnez-la ici."
+msgstr "Pour limiter cette collection de champs à un seul cobrand, sélectionnez-la ici."
 
 #: templates/web/base/admin/reportextrafields/edit.html:40
 msgid "To limit this collection of fields to a single language, select it here."
-msgstr "Pour limiter cette collection de champs &agrave; une seule langue, sélectionnez-la ici."
+msgstr "Pour limiter cette collection de champs à une seule langue, sélectionnez-la ici."
 
 #: perllib/FixMyStreet/Script/Reports.pm:97
 msgid "To view a map of the precise location of this issue"
@@ -4635,11 +4635,11 @@ msgstr "Jeton:"
 
 #: templates/web/base/reports/index.html:126
 msgid "Top 5 most used categories"
-msgstr "Top 5 des cat&eacute;gories les plus utilis&eacute;es"
+msgstr "Top 5 des catégories les plus utilisées"
 
 #: templates/web/base/reports/index.html:111
 msgid "Top 5 responsive councils"
-msgstr "Top 5 des administrations les plus r&eacute;actives"
+msgstr "Top 5 des administrations les plus réactives"
 
 #: templates/web/base/reports/index.html:98
 msgid "Top 5 wards"
@@ -4691,11 +4691,11 @@ msgstr "Essayez en nous envoyant un e-mail directement:"
 
 #: templates/web/base/auth/generate_token.html:21
 msgid "Two-factor authentication has been activated"
-msgstr "L&rsquo;authentification &agrave; deux facteurs a &eacute;t&eacute; activ&eacute;e"
+msgstr "L’authentification à deux facteurs a été activée"
 
 #: templates/web/base/auth/generate_token.html:32
 msgid "Two-factor authentication has been deactivated"
-msgstr "L&rsquo;authentification &agrave; deux facteurs a &eacute;t&eacute; d&eacute;sactiv&eacute;e"
+msgstr "L’authentification à deux facteurs a été désactivée"
 
 #: templates/web/base/admin/extra-metadata-form.html:54
 #: templates/web/base/admin/states/index.html:10
@@ -4706,7 +4706,7 @@ msgstr "Type"
 
 #: templates/web/base/admin/users/form.html:34
 msgid "Unban"
-msgstr "D&eacute;bannir"
+msgstr "Débannir"
 
 #: perllib/FixMyStreet/DB/ResultSet/State.pm:63
 #: templates/web/base/admin/bodies/contact-form.html:55
@@ -4742,15 +4742,15 @@ msgstr "ID de problème inconnu"
 
 #: perllib/FixMyStreet/App/Controller/Contact.pm:99
 msgid "Unknown update ID"
-msgstr "ID de mise &agrave; jour inconnu"
+msgstr "ID de mise à jour inconnu"
 
 #: templates/web/base/reports/_list-filters.html:25
 msgid "Unshortlisted"
-msgstr "D&eacute;-S&eacute;lectionn&eacute;"
+msgstr "Dé-Sélectionné"
 
 #: templates/web/base/report/_item.html:26
 msgid "Up one"
-msgstr "Remonter d&apos;un"
+msgstr "Remonter d'un"
 
 #: templates/web/base/admin/states/index.html:76
 #: templates/web/base/admin/users/alerts.html:58
@@ -4808,11 +4808,11 @@ msgstr "Mis à jour"
 
 #: perllib/FixMyStreet/DB/Result/Comment.pm:252
 msgid "Updated by <strong>%s</strong> (%s) at %s"
-msgstr "Mis &agrave; par <strong>%s</strong> (%s) &agrave; %s"
+msgstr "Mis à par <strong>%s</strong> (%s) à %s"
 
 #: perllib/FixMyStreet/DB/Result/Comment.pm:254
 msgid "Updated by <strong>%s</strong> at %s"
-msgstr "Mis &agrave; par <strong>%s</strong> &agrave; %s"
+msgstr "Mis à par <strong>%s</strong> à %s"
 
 #: perllib/FixMyStreet/App/Controller/Admin.pm:575
 #: perllib/FixMyStreet/App/Controller/Admin.pm:915
@@ -4848,7 +4848,7 @@ msgstr "Mises à jour de ce problème, %s"
 
 #: templates/web/base/admin/users/import.html:64
 msgid "Usage notes"
-msgstr "Notes d&rsquo;utilisation"
+msgstr "Notes d’utilisation"
 
 #: templates/web/base/admin/bodies/contact-form.html:43
 #: templates/web/base/admin/bodies/contact-form.html:44
@@ -4860,16 +4860,16 @@ msgid ""
 "map filters, and <strong>deleted</strong> will remove the category from there\n"
 "as well."
 msgstr ""
-"L&apos;utilisation <strong>confirmed</strong> est pour indiquer que ce contact a &eacute;t&eacute;\n"
-"confirm&eacute; comme valide. Si vous n&apos;&ecirc;tes pas s&ucirc;r de l&apos;origine ou de la validit&eacute; du\n"
+"L'utilisation <strong>confirmed</strong> est pour indiquer que ce contact a été\n"
+"confirmé comme valide. Si vous n'êtes pas sûr de l'origine ou de la validité du\n"
 "contact, utiliser <strong>unconfirmed</strong>. <strong>inactive</strong>\n"
-"supprimera la cat&eacute;gorie de l&apos;utilisation lors de la d&eacute;claration de probl&egrave;mes, mais la\n"
+"supprimera la catégorie de l'utilisation lors de la déclaration de problèmes, mais la\n"
 "conserve dans les filtres de la carte, et <strong>deleted</strong> supprime la \n"
 "catégorie."
 
 #: templates/web/base/admin/bodies/open311-form-fields.html:137
 msgid "Use Open311 problem fetching"
-msgstr "Utiliser la r&eacute;cup&eacute;ration de probl&egrave;mes Open311"
+msgstr "Utiliser la récupération de problèmes Open311"
 
 #: templates/web/base/admin/bodies/open311-form-fields.html:76
 msgid "Use Open311 update-sending extension"
@@ -4895,17 +4895,17 @@ msgstr "Import utilisateur"
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:568
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:578
 msgid "User added to abuse list"
-msgstr "Utilisateur ajout&eacute; à la liste d&rsquo;abus"
+msgstr "Utilisateur ajouté à la liste d’abus"
 
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:113
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:226
 msgid "User already exists"
-msgstr "L&rsquo;utilisateur existe d&eacute;j&agrave;"
+msgstr "L’utilisateur existe déjà"
 
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:565
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:575
 msgid "User already in abuse list"
-msgstr "Utilisateur d&eacute;j&agrave; dans la liste d&rsquo;abus"
+msgstr "Utilisateur déjà dans la liste d’abus"
 
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:657
 msgid "User flag removed"
@@ -4919,7 +4919,7 @@ msgstr "Utilisateur signalé"
 #: templates/web/base/admin/users/form.html:34
 #: templates/web/base/admin/users/index.html:32
 msgid "User in abuse table"
-msgstr "Utilisateur dans le tableau d&rsquo;abus"
+msgstr "Utilisateur dans le tableau d’abus"
 
 #: templates/web/base/admin/users/index.html:5
 msgid "User search finds matches in users' names and email addresses."
@@ -4953,17 +4953,17 @@ msgstr "Valeurs mises à jour"
 
 #: templates/web/base/my/my.html:43 templates/web/base/my/my.html:55
 msgid "Verify"
-msgstr "V&eacute;rifier"
+msgstr "Vérifier"
 
 #: templates/web/base/auth/change_email.html:1
 #: templates/web/base/auth/change_email.html:5
 msgid "Verify email address"
-msgstr "V&eacute;rifier votre email"
+msgstr "Vérifier votre email"
 
 #: templates/web/base/auth/change_phone.html:1
 #: templates/web/base/auth/change_phone.html:5
 msgid "Verify phone number"
-msgstr "V&eacute;rifier votre num&eacute;ro de t&eacute;l&eacute;phone"
+msgstr "Vérifier votre numéro de téléphone"
 
 #: templates/web/base/admin/report_edit.html:36
 #: templates/web/base/admin/update_edit.html:18
@@ -5005,7 +5005,7 @@ msgstr "Localités de cette administration"
 #: templates/web/base/alert/choose.html:7
 #: templates/web/base/around/_error_multiple.html:6
 msgid "We found more than one match for that location."
-msgstr "Nous avons trouv&eacute; plusieurs r&eacute;sultat pour cet endroit."
+msgstr "Nous avons trouvé plusieurs résultat pour cet endroit."
 
 #: templates/web/base/around/lookup_by_ref.html:6
 msgid "We found more than one match for that problem reference:"
@@ -5013,7 +5013,7 @@ msgstr "Nous avons trouvé plus d'une correspondance pour cette référence de p
 
 #: templates/web/base/auth/smsform.html:20
 msgid "We have sent a confirmation code to your phone. Please enter it below:"
-msgstr "Nous avons envoy&eacute; un code de confirmation &agrave; votre t&eacute;l&eacute;phone. Veuillez l&rsquo;entrer ci-dessous:"
+msgstr "Nous avons envoyé un code de confirmation à votre téléphone. Veuillez l’entrer ci-dessous:"
 
 #: templates/web/base/auth/general.html:13
 #: templates/web/base/report/display.html:35
@@ -5032,7 +5032,7 @@ msgstr "Nous l'envoyons à l'administration en votre nom"
 #: templates/web/base/alert/choose.html:13
 #: templates/web/base/around/_error_multiple.html:17
 msgid "We show up to ten matches, please try a different search if yours is not here."
-msgstr "Nous trouvons jusqu&rsquo;&agrave; dix r&eacute;sultats, veuillez essayez une recherche différente si la vôtre n&rsquo;est trouv&eacute;e."
+msgstr "Nous trouvons jusqu’à dix résultats, veuillez essayez une recherche différente si la vôtre n’est trouvée."
 
 #: templates/web/base/report/new/notes.html:4
 #: templates/web/zurich/report/new/notes.html:4
@@ -5041,7 +5041,7 @@ msgstr ""
 
 #: templates/web/base/questionnaire/completed-open.html:2
 msgid "We&rsquo;re sorry to hear the problem’s not fixed. Why not try writing to your local representatives?"
-msgstr "Nous sommes désolés d&rsquo;apprendre que le problème n&esquo;est pas résolu. Pourquoi ne pas essayer d'écrire directement à vos élus locaux ?"
+msgstr "Nous sommes désolés d’apprendre que le problème n’est pas résolu. Pourquoi ne pas essayer d'écrire directement à vos élus locaux ?"
 
 #: templates/web/base/dashboard/index.html:122
 msgid "Website"
@@ -5066,11 +5066,11 @@ msgstr "Envoyé le"
 
 #: templates/web/base/admin/extra-metadata-form.html:12
 msgid "Whether the field is displayed to the user, included as a hidden field and automatically populated, or set by the server upon Open311 submission. This field is usually set automatically."
-msgstr "Indique si le champ est affich&eacute; pour l'utilisateur, inclus en tant que champ masqu&eacute; et renseign&eacute; automatiquement ou d&eacute;fini par le serveur lors de la soumission d'Open311. Ce champ est g&eacute;n&eacute;ralement d&eacute;fini automatiquement."
+msgstr "Indique si le champ est affiché pour l'utilisateur, inclus en tant que champ masqué et renseigné automatiquement ou défini par le serveur lors de la soumission d'Open311. Ce champ est généralement défini automatiquement."
 
 #: templates/web/base/admin/extra-metadata-form.html:28
 msgid "Whether the user is required to provide a value for this field."
-msgstr "l&apos;utilisateur doit fournir une valeur pour ce domaine."
+msgstr "l'utilisateur doit fournir une valeur pour ce domaine."
 
 #: templates/web/base/alert/_list.html:9
 msgid "Which problems do you want alerts about?"
@@ -5078,11 +5078,11 @@ msgstr "De quels problèmes voulez-vous alerter?"
 
 #: templates/web/base/report/_inspect.html:123
 msgid "Which report is it a duplicate of?"
-msgstr "De quel rapport ? s&apos;agit-il d'un double exemplaire?"
+msgstr "De quel rapport ? s'agit-il d'un double exemplaire?"
 
 #: templates/web/base/tokens/confirm_alert.html:7
 msgid "Why stop there? <a href=\"/alert\">Set up more alerts</a> for free."
-msgstr "Pourquoi arrêter là ? <a href=\"/alert\"> déclarer plus d&rsquo;alertes </a> gratuitement."
+msgstr "Pourquoi arrêter là ? <a href=\"/alert\"> déclarer plus d’alertes </a> gratuitement."
 
 #: templates/web/base/open311/index.html:84
 msgid "With request searches, it is also possible to search for agency_responsible to limit the requests to those sent to a single administration.  The search term is the administration ID provided by <a href=\"%s\">MaPit</a>."
@@ -5090,7 +5090,7 @@ msgstr "Avec les recherches à requètes, il est également possible de recherch
 
 #: templates/web/base/dashboard/index.html:163
 msgid "Within the specified timeframe:"
-msgstr "Dans les d&eacute;lais sp&eacute;cifi&eacute;s:"
+msgstr "Dans les délais spécifiés:"
 
 #: templates/web/base/front/footer-marketing.html:3
 msgid "Would you like to contribute to FixMyStreet? Our code is open source and <a href=\"https://fixmystreet.org\">available at fixmystreet.org</a>."
@@ -5135,7 +5135,7 @@ msgstr "Vous ne comprenez pas les raisons pour lesquelles ce rapport a été inu
 
 #: templates/web/base/js/translation_strings.html:100
 msgid "You are offline"
-msgstr "vous &ecirc;tes hors ligne"
+msgstr "vous êtes hors ligne"
 
 #: templates/web/base/contact/unsuitable-text.html:2
 msgid "You are reporting the following problem report for being abusive, containing personal information, or similar:"
@@ -5147,7 +5147,7 @@ msgstr "Vous signalez la mise à jour suivante comme étant violente, contenant 
 
 #: templates/web/base/report/display.html:59
 msgid "You can <a href=\"%s\">make a new report in the same location</a>."
-msgstr "Vous pouvez <a href=\"%s\"> cr&eacute;er un nouveau rapport au m&ecirc;me endroit.</a>."
+msgstr "Vous pouvez <a href=\"%s\"> créer un nouveau rapport au même endroit.</a>."
 
 #: templates/web/zurich/tokens/confirm_problem.html:5
 #: templates/web/zurich/tokens/confirm_problem.html:8
@@ -5160,7 +5160,7 @@ msgstr "Vous pouvez ajouter un courriel d'utilisateur abusif dans la liste des a
 
 #: templates/web/base/alert/_list.html:18
 msgid "You can choose to subscribe to all problems reported in an area, or reports based on their destination."
-msgstr "Vous pouvez choisir de vous abonner &agrave; tous les problèmes signalés dans une zone ou des rapports suivant leur destination."
+msgstr "Vous pouvez choisir de vous abonner à tous les problèmes signalés dans une zone ou des rapports suivant leur destination."
 
 #: templates/web/base/contact/index.html:127
 msgid "You can contact technical support on <a href='mailto:%s'>%s</a>"
@@ -5193,7 +5193,7 @@ msgstr "Vous avez refusé; merci de remplir le champ ci-dessus"
 
 #: templates/web/base/js/translation_strings.html:102
 msgid "You have <a id=\"oFN\" href=\"\"><span>%s</span> saved to submit</a>."
-msgstr "vous avez <a id=\"oFN\" href=\"\"><span>%s</span> sauvegrad&eacute; &agrave; publi&eacute;</a>."
+msgstr "vous avez <a id=\"oFN\" href=\"\"><span>%s</span> sauvegradé à publié</a>."
 
 #: perllib/FixMyStreet/App/Controller/Questionnaire.pm:39
 msgid "You have already answered this questionnaire. If you have a question, please <a href='%s'>get in touch</a>, or <a href='%s'>view your problem</a>.\n"
@@ -5220,7 +5220,7 @@ msgstr "Vous avez localisé le problème au point marqué avec une épingle vert
 
 #: perllib/FixMyStreet/App/Controller/Auth/Profile.pm:142
 msgid "You have successfully added your phone number."
-msgstr "Vous avez ajout&eacute; votre num&eacute;ro de t&eacute;l&eacute;phone avec succ&egrave;s."
+msgstr "Vous avez ajouté votre numéro de téléphone avec succès."
 
 #: perllib/FixMyStreet/App/Controller/Auth/Profile.pm:158
 #: templates/web/zurich/tokens/confirm_problem.html:5
@@ -5230,11 +5230,11 @@ msgstr "Votre adresse courriel a bien été confirmée."
 
 #: templates/web/base/auth/change_phone.html:15
 msgid "You have successfully confirmed your phone number."
-msgstr "Vous avez confirm&eacute; votre num&eacute;ro de t&eacute;l&eacute;phone."
+msgstr "Vous avez confirmé votre numéro de téléphone."
 
 #: perllib/FixMyStreet/App/Controller/Auth/Profile.pm:129
 msgid "You have successfully removed your phone number."
-msgstr "Vous avez supprim&eacute; votre num&eacute;ro de t&eacute;l&eacute;phone avec succ&egrave;s."
+msgstr "Vous avez supprimé votre numéro de téléphone avec succès."
 
 #: templates/web/base/report/display.html:25
 #: templates/web/base/report/new/login_success_form.html:3
@@ -5243,7 +5243,7 @@ msgstr "Vous avez réussi à vous connecter ; veuillez vérifier et confirmer qu
 
 #: perllib/FixMyStreet/App/Controller/Auth/Profile.pm:164
 msgid "You have successfully verified your phone number."
-msgstr "Vous avez v&eacute;rifi&eacute; votre num&eacute;ro de t&eacute;l&eacute;phone avec succ&egrave;ès."
+msgstr "Vous avez vérifié votre numéro de téléphone avec succèès."
 
 #: templates/web/base/my/my.html:79
 msgid "You haven&rsquo;t created any reports yet.  <a href=\"%s\">Report a problem now.</a>"
@@ -5307,15 +5307,15 @@ msgstr "Votre nom"
 
 #: templates/web/base/my/anonymize.html:13
 msgid "Your name has already been sent to %s, but we can hide it on this page:"
-msgstr "Votre nom a d&eacute;j&agrave; &eacutet&eacute envoy&eacute, mais nous pouvons le cacher sur cette page:"
+msgstr "Votre nom a déjà été envoyé, mais nous pouvons le cacher sur cette page:"
 
 #: perllib/FixMyStreet/App/Controller/My.pm:272
 msgid "Your name has been hidden from all your reports and updates."
-msgstr "Votre nom a &eacute;t&eacute; cach&eacute; de tous vos rapports et mises &agrave; jour."
+msgstr "Votre nom a été caché de tous vos rapports et mises à jour."
 
 #: perllib/FixMyStreet/App/Controller/My.pm:268
 msgid "Your name has been hidden."
-msgstr "Votre nom a &eacute;t&eacute; cach&eacute;."
+msgstr "Votre nom a été caché."
 
 #: templates/web/base/js/translation_strings.html:92
 msgid "Your offline reports"
@@ -5337,7 +5337,7 @@ msgstr "Votre mot de passe a été changé"
 #: templates/web/base/report/form/user_loggedout_by_email.html:63
 #: templates/web/zurich/auth/general.html:56
 msgid "Your password should include %d or more characters."
-msgstr "Votre mot de passe doit inclure %d ou plus de caract&egrave;res."
+msgstr "Votre mot de passe doit inclure %d ou plus de caractères."
 
 #: templates/web/base/auth/change_phone.html:19
 #: templates/web/base/contact/index.html:94
@@ -5359,7 +5359,7 @@ msgstr "Votre liste"
 
 #: templates/web/base/auth/generate_token.html:8
 msgid "Your token has been generated"
-msgstr "Votre jeton a &eacute;t&eacute; g&eacute;n&eacute;r&eacute;"
+msgstr "Votre jeton a été généré"
 
 #: templates/web/base/report/update/form_user.html:6
 msgid "Your update"
@@ -5367,7 +5367,7 @@ msgstr ""
 
 #: templates/web/base/js/translation_strings.html:93
 msgid "Your update has been saved offline for submission when back online."
-msgstr "Votre mise &agrave; jour a &eacute;t&eacute; sauvegard&eacute;e en mode hors connexion pour la soumission en ligne."
+msgstr "Votre mise à jour a été sauvegardée en mode hors connexion pour la soumission en ligne."
 
 #: templates/web/base/my/my.html:99
 msgid "Your updates"
@@ -5375,7 +5375,7 @@ msgstr "Vos mises à jour"
 
 #: perllib/FixMyStreet/SMS.pm:46
 msgid "Your verification code is %s"
-msgstr "Votre code de v&eacute;rification est %s"
+msgstr "Votre code de vérification est %s"
 
 #: templates/web/base/report/new/form_user_loggedin.html:20
 #: templates/web/base/report/update/form_user_loggedin.html:14
@@ -5405,7 +5405,7 @@ msgstr "un administrateur"
 
 #: perllib/FixMyStreet/DB/Result/Comment.pm:262
 msgid "and a defect raised"
-msgstr "et un d&eacute;faut soulev&eacute;"
+msgstr "et un défaut soulevé"
 
 #: templates/web/base/admin/timeline.html:4
 msgid "by %s"
@@ -5427,7 +5427,7 @@ msgstr "Par exemple '%s' ou '%s'"
 
 #: templates/web/base/report/new/form_title.html:2
 msgid "e.g. ‘10 inch pothole on Example St, near post box’"
-msgstr "par exemple. 'Nid de poule de 10cm sur la route St, pr&egrave;s de la bo&icirc;îte aux lettres'"
+msgstr "par exemple. 'Nid de poule de 10cm sur la route St, près de la boîte aux lettres'"
 
 #: templates/web/base/report/new/form_report.html:58
 msgid "e.g. ‘This pothole has been here for two months and…’"
@@ -5465,7 +5465,7 @@ msgstr "aucun"
 
 #: perllib/FixMyStreet/DB/ResultSet/State.pm:77
 msgid "not the council's responsibility"
-msgstr "pas la responsabilit&eacute; de l&apos;administration"
+msgstr "pas la responsabilité de l'administration"
 
 #: templates/web/base/auth/general.html:6
 msgid "or <a href=\"%s\">create an account</a>"
@@ -5509,7 +5509,7 @@ msgstr "déconnexion"
 
 #: templates/web/base/admin/users/import.html:71
 msgid "the database id of the body to associate that user with, e.g. <code>2217</code> for Buckinghamshire."
-msgstr "l'ID de base de données de l&rsquo;administration auquel est associer cet utilisateur, par ex.<code>2217</code> pour Versailles."
+msgstr "l'ID de base de données de l’administration auquel est associer cet utilisateur, par ex.<code>2217</code> pour Versailles."
 
 #: templates/web/base/report/new/form_report.html:16
 msgid "the local council"
@@ -5534,11 +5534,11 @@ msgstr "aujourd'hui"
 
 #: templates/web/base/js/translation_strings.html:103
 msgid "update"
-msgstr "mettre &agrave; jour"
+msgstr "mettre à jour"
 
 #: templates/web/base/js/translation_strings.html:104
 msgid "updates"
-msgstr "mises &agrave; jour"
+msgstr "mises à jour"
 
 #: templates/web/base/admin/report_edit.html:53
 msgid "used map"
@@ -5554,11 +5554,11 @@ msgstr "L'utilisateur est propriétaire du problème"
 
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:601
 msgid "user not in abuse list"
-msgstr "utilisateur ne figurant pas dans la liste d&rsquo;abus"
+msgstr "utilisateur ne figurant pas dans la liste d’abus"
 
 #: perllib/FixMyStreet/App/Controller/Admin/Users.pm:599
 msgid "user removed from abuse list"
-msgstr "utilisateur supprim&eacute; de la liste d&rsquo;abus"
+msgstr "utilisateur supprimé de la liste d’abus"
 
 #: templates/web/base/reports/body.html:0
 #: templates/web/base/reports/body.html:3
@@ -5618,8 +5618,8 @@ msgstr[1] "%d semaines"
 #, perl-format
 msgid "%d year"
 msgid_plural "%d years"
-msgstr[0] "%d ann&eacute;e "
-msgstr[1] "%d ann&eacute;e"
+msgstr[0] "%d année "
+msgstr[1] "%d année"
 
 #: templates/web/base/reports/index.html:120
 #, perl-format
@@ -5632,7 +5632,7 @@ msgstr[1] "%s jours"
 #, perl-format
 msgid "%s problem marked as fixed"
 msgid_plural "%s problems marked as fixed"
-msgstr[0] "%sprobl&egrave;me marqu&eacute; comme corrig&eacute; "
+msgstr[0] "%sproblème marqué comme corrigé "
 msgstr[1] "%s problèmes marqués comme corrigés "
 
 #: templates/web/base/reports/index.html:45
@@ -5640,7 +5640,7 @@ msgstr[1] "%s problèmes marqués comme corrigés "
 msgid "%s problem reported"
 msgid_plural "%s problems reported"
 msgstr[0] "%s problème signalé "
-msgstr[1] "%s problèmes signal&eacute;s"
+msgstr[1] "%s problèmes signalés"
 
 #: templates/web/base/reports/index.html:136
 #, perl-format

--- a/perllib/FixMyStreet/App.pm
+++ b/perllib/FixMyStreet/App.pm
@@ -371,8 +371,8 @@ sub construct_email {
         %$extra_stash_values,
         additional_template_paths => \@include_path,
     };
-    $vars->{site_name} = Utils::trim_text($c->view('Email')->render($c, 'site-name.txt', $vars));
-    $vars->{signature} = $c->view('Email')->render($c, 'signature.txt', $vars);
+    $vars->{site_name} = Utils::trim_text($c->view('EmailText')->render($c, 'site-name.txt', $vars));
+    $vars->{signature} = $c->view('EmailText')->render($c, 'signature.txt', $vars);
 
     return if FixMyStreet::Email::is_abuser($c->model('DB')->schema, $vars->{to});
 
@@ -386,7 +386,7 @@ sub construct_email {
     $c->log->debug("Error compiling HTML $template: $@") if $@;
 
     my $data = {
-        _body_ => $c->view('Email')->render( $c, $template, $vars ),
+        _body_ => $c->view('EmailText')->render( $c, $template, $vars ),
         _attachments_ => $extra_stash_values->{attachments},
         From => $vars->{from},
         To => $vars->{to},

--- a/perllib/FixMyStreet/App/Controller/Contact.pm
+++ b/perllib/FixMyStreet/App/Controller/Contact.pm
@@ -7,6 +7,7 @@ BEGIN { extends 'Catalyst::Controller'; }
 use MIME::Base64;
 use mySociety::EmailUtil;
 use FixMyStreet::Email;
+use FixMyStreet::Template::SafeString;
 
 =head1 NAME
 
@@ -253,8 +254,9 @@ generally required to stash
 sub setup_request : Private {
     my ( $self, $c ) = @_;
 
-    $c->stash->{contact_email} = $c->cobrand->contact_email;
-    $c->stash->{contact_email} =~ s/\@/&#64;/;
+    my $email = $c->cobrand->contact_email;
+    $email =~ s/\@/&#64;/;
+    $c->stash->{contact_email} = FixMyStreet::Template::SafeString->new($email);
 
     for my $param (qw/em subject message/) {
         $c->stash->{$param} = $c->get_param($param);

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -4,6 +4,7 @@ use Moose;
 use namespace::autoclean;
 BEGIN { extends 'Catalyst::Controller'; }
 
+use utf8;
 use Encode;
 use List::MoreUtils qw(uniq);
 use List::Util 'first';
@@ -895,7 +896,7 @@ sub process_user : Private {
             oauth_report => { $report->get_inflated_columns }
         };
         unless ( $c->forward( '/auth/sign_in', [ $params{username} ] ) ) {
-            $c->stash->{field_errors}->{password} = _('There was a problem with your login information. If you cannot remember your password, or do not have one, please fill in the &lsquo;No&rsquo; section of the form.');
+            $c->stash->{field_errors}->{password} = _('There was a problem with your login information. If you cannot remember your password, or do not have one, please fill in the ‘No’ section of the form.');
             return 1;
         }
         my $user = $c->user->obj;

--- a/perllib/FixMyStreet/App/Controller/Report/Update.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/Update.pm
@@ -4,6 +4,7 @@ use Moose;
 use namespace::autoclean;
 BEGIN { extends 'Catalyst::Controller'; }
 
+use utf8;
 use Path::Class;
 use List::Util 'first';
 use Utils;
@@ -143,7 +144,7 @@ sub process_user : Private {
             oauth_update => { $update->get_inflated_columns }
         };
         unless ( $c->forward( '/auth/sign_in', [ $params{username} ] ) ) {
-            $c->stash->{field_errors}->{password} = _('There was a problem with your login information. If you cannot remember your password, or do not have one, please fill in the &lsquo;No&rsquo; section of the form.');
+            $c->stash->{field_errors}->{password} = _('There was a problem with your login information. If you cannot remember your password, or do not have one, please fill in the ‘No’ section of the form.');
             return 1;
         }
         my $user = $c->user->obj;

--- a/perllib/FixMyStreet/App/View/EmailText.pm
+++ b/perllib/FixMyStreet/App/View/EmailText.pm
@@ -1,0 +1,29 @@
+package FixMyStreet::App::View::EmailText;
+use base 'Catalyst::View::TT';
+
+use strict;
+use warnings;
+
+use FixMyStreet;
+use FixMyStreet::Template;
+
+__PACKAGE__->config(
+    CLASS => 'FixMyStreet::Template',
+    TEMPLATE_EXTENSION => '.txt',
+    INCLUDE_PATH => [ FixMyStreet->path_to( 'templates', 'email', 'default' ) ],
+    render_die => 1,
+    disable_autoescape => 1,
+);
+
+=head1 NAME
+
+FixMyStreet::App::View::EmailText - TT View for FixMyStreet::App
+
+=head1 DESCRIPTION
+
+A TT view for the text part of emails - so no HTML auto-escaping
+
+=cut
+
+1;
+

--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -101,6 +101,7 @@ __PACKAGE__->load_components("+FixMyStreet::DB::RABXColumn");
 __PACKAGE__->rabx_column('extra');
 
 use Moo;
+use FixMyStreet::Template::SafeString;
 use namespace::clean -except => [ 'meta' ];
 use FixMyStreet::Template;
 
@@ -201,7 +202,7 @@ sub moderation_filter {
 =head2 meta_line
 
 Returns a string to be used on a report update, describing some of the metadata
-about an update
+about an update. Can include HTML.
 
 =cut
 
@@ -225,6 +226,7 @@ sub meta_line {
             } else {
                 $body = $self->user->body;
             }
+            $body = FixMyStreet::Template::html_filter($body);
             if ($body eq 'Bromley Council') {
                 $body = "$body <img src='/cobrands/bromley/favicon.png' alt=''>";
             } elsif ($body eq 'Royal Borough of Greenwich') {
@@ -259,7 +261,7 @@ sub meta_line {
         $meta .= ', ' . _( 'and a defect raised' );
     }
 
-    return $meta;
+    return FixMyStreet::Template::SafeString->new($meta);
 };
 
 sub problem_state_processed {

--- a/perllib/FixMyStreet/DB/Result/ModerationOriginalData.pm
+++ b/perllib/FixMyStreet/DB/Result/ModerationOriginalData.pm
@@ -74,6 +74,7 @@ __PACKAGE__->belongs_to(
 # DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:FLKiZELcfBcc9VwHU2MZYQ
 
 use Moo;
+use FixMyStreet::Template::SafeString;
 use Text::Diff;
 use Data::Dumper;
 
@@ -147,11 +148,12 @@ sub compare_photo {
         push @deleted, $diff->Items(1);
         push @added, $diff->Items(2);
     }
-    return (join ', ', map {
+    my $s = (join ', ', map {
             "<del style='background-color:#fcc'>$_</del>";
         } @deleted) . (join ', ', map {
             "<ins style='background-color:#cfc'>$_</ins>";
         } @added);
+    return FixMyStreet::Template::SafeString->new($s);
 }
 
 sub compare_extra {
@@ -212,7 +214,7 @@ sub string_diff {
             $string .= $inserted;
         }
     }
-    return $string;
+    return FixMyStreet::Template::SafeString->new($string);
 }
 
 1;

--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -449,8 +449,8 @@ sub has_permission_to {
     return 0 unless $available{$permission_type};
 
     return 1 if $self->is_superuser;
-    return 0 if !$body_ids || (ref $body_ids && !@$body_ids);
-    $body_ids = [ $body_ids ] unless ref $body_ids;
+    return 0 if !$body_ids || (ref $body_ids eq 'ARRAY' && !@$body_ids);
+    $body_ids = [ $body_ids ] unless ref $body_ids eq 'ARRAY';
     my %body_ids = map { $_ => 1 } @$body_ids;
 
     foreach (@{$self->body_permissions}) {

--- a/perllib/FixMyStreet/Email.pm
+++ b/perllib/FixMyStreet/Email.pm
@@ -169,6 +169,7 @@ sub send_cron {
     push @include_path, FixMyStreet->path_to( 'templates', 'email', 'default' );
     my $tt = FixMyStreet::Template->new({
         INCLUDE_PATH => \@include_path,
+        disable_autoescape => 1,
     });
     $vars->{signature} = _render_template($tt, 'signature.txt', $vars);
     $vars->{site_name} = Utils::trim_text(_render_template($tt, 'site-name.txt', $vars));
@@ -178,6 +179,9 @@ sub send_cron {
         my @inline_images;
         $vars->{inline_image} = sub { add_inline_image(\@inline_images, @_) };
         $vars->{file_exists} = sub { -e FixMyStreet->path_to(@_) };
+        my $tt = FixMyStreet::Template->new({
+            INCLUDE_PATH => \@include_path,
+        });
         $hdrs->{_html_} = _render_template($tt, $html_template, $vars);
         $hdrs->{_html_images_} = \@inline_images;
     }

--- a/perllib/FixMyStreet/Template.pm
+++ b/perllib/FixMyStreet/Template.pm
@@ -40,10 +40,13 @@ sub Fn : ATTR(CODE,BEGIN) {
 
 sub new {
     my ($class, $config) = @_;
+    my $disable_autoescape = delete $config->{disable_autoescape};
     $config->{FILTERS}->{$_} = $FILTERS{$_} foreach keys %FILTERS;
     $config->{ENCODING} = 'utf8';
-    $config->{STASH} = FixMyStreet::Template::Stash->new($config);
-    $config->{CONTEXT} = FixMyStreet::Template::Context->new($config);
+    if (!$disable_autoescape) {
+        $config->{STASH} = FixMyStreet::Template::Stash->new($config);
+        $config->{CONTEXT} = FixMyStreet::Template::Context->new($config);
+    }
     $class->SUPER::new($config);
 }
 

--- a/perllib/FixMyStreet/Template/Context.pm
+++ b/perllib/FixMyStreet/Template/Context.pm
@@ -1,0 +1,67 @@
+package FixMyStreet::Template::Context;
+
+use strict;
+use warnings;
+use base qw(Template::Context);
+
+sub filter {
+    my $self = shift;
+    my ($name, $args, $alias) = @_;
+
+    # If we're passing through the safe filter, then unwrap
+    # from a Template::HTML::Variable if we are one.
+    if ( $name eq 'safe' ) {
+        return sub {
+            my $value = shift;
+            return $value->plain if UNIVERSAL::isa($value, 'FixMyStreet::Template::Variable');
+            return $value;
+        };
+    }
+
+    my $filter = $self->SUPER::filter(@_);
+
+    # If we are already going to auto-encode, we don't want to do it again.
+    # This makes the html filter a no-op on auto-encoded variables.
+    if ( $name eq 'html' ) {
+        return sub {
+            my $value = shift;
+            return $value if UNIVERSAL::isa($value, 'FixMyStreet::Template::Variable');
+            return $filter->($value);
+        };
+    }
+
+    return sub {
+        my $value = shift;
+
+        if ( UNIVERSAL::isa($value, 'FixMyStreet::Template::Variable') ) {
+            my $result = $filter->($value->plain);
+            return $result if UNIVERSAL::isa($result, 'FixMyStreet::Template::SafeString');
+            return ref($value)->new($result);
+        }
+
+        return $filter->($value);
+    };
+}
+
+1;
+__END__
+
+=head1 NAME
+
+FixMyStreet::Template::Context - Similar to Template::HTML::Context but use
+'safe' rather than 'none' to be clear, also prevents html filter double-encoding,
+and doesn't rewrap a FixMyStreet::Template::SafeString.
+
+=head1 AUTHORS
+
+Martyn Smith, E<lt>msmith@cpan.orgE<gt>
+
+Matthew Somerville, E<lt>matthew@mysociety.orgE<gt>
+
+=head1 LICENSE
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself, either Perl version 5.8.8 or,
+at your option, any later version of Perl 5 you may have available.
+
+=cut

--- a/perllib/FixMyStreet/Template/SafeString.pm
+++ b/perllib/FixMyStreet/Template/SafeString.pm
@@ -1,0 +1,106 @@
+package FixMyStreet::Template::SafeString;
+
+use strict;
+use warnings;
+
+=head1 NAME
+
+FixMyStreet::Template::SafeString - a string that won't be escaped on output in a template
+
+=cut
+
+use overload
+    '""' => sub { ${$_[0]} },
+    '.'  => \&concat,
+    '.=' => \&concatequals,
+    '='  => \&clone,
+    'cmp' => \&cmp,
+;
+
+sub new {
+    my ($class, $value) = @_;
+
+    my $self = bless \$value, $class;
+
+    return $self;
+}
+
+sub cmp {
+    my ($self, $str) = @_;
+
+    if (ref $str eq __PACKAGE__) {
+        return $$self cmp $$str;
+    } else {
+        return $$self cmp $str;
+    }
+}
+
+sub concat {
+    my ($self, $str, $prefix) = @_;
+
+    return $self->clone() if not defined $str or $str eq '';
+
+    if ( $prefix ) {
+        return $str . $$self;
+    } else {
+        return $$self . $str;
+    }
+}
+
+sub concatequals {
+    my ($self, $str, $prefix) = @_;
+
+    if ( ref $str eq __PACKAGE__) {
+        $$self .= $$str;
+        return $self;
+    } else {
+        return $self->clone() if $str eq '';
+        $$self .= $str;
+        return $$self;
+    }
+}
+
+sub clone {
+    my $self = shift;
+
+    my $val = $$self;
+    my $clone = bless \$val, ref $self;
+
+    return $clone;
+}
+
+1;
+__END__
+
+=head1 SYNOPSIS
+
+  use FixMyStreet::Template;
+  use FixMyStreet::Template::SafeString;
+
+  my $s1 = "< test & stuff >";
+  my $s2 = FixMyStreet::Template::SafeString->new($s1);
+
+  my $tt = FixMyStreet::Template->new();
+  $tt->process(\"[% s1 %] * [% s2 %]\n", { s1 => $s1, s2 => $s2 });
+
+  # Produces output "&lt; test &amp; stuff &gt; * < test & stuff >"
+
+=head1 DESCRIPTION
+
+This object provides a safe string to use as part of the FixMyStreet::Template
+extension. It will not be automatically escaped when used, so can be used to
+pass HTML to a template by a function that is safely creating some.
+
+=head1 AUTHOR
+
+Matthew Somerville, E<lt>matthew@mysociety.orgE<gt>
+
+Martyn Smith, E<lt>msmith@cpan.orgE<gt>
+
+=head1 LICENSE
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself, either Perl version 5.8.8 or,
+at your option, any later version of Perl 5 you may have available.
+
+=cut

--- a/perllib/FixMyStreet/Template/Stash.pm
+++ b/perllib/FixMyStreet/Template/Stash.pm
@@ -1,0 +1,75 @@
+package FixMyStreet::Template::Stash;
+
+use strict;
+use warnings;
+use base qw(Template::Stash);
+use FixMyStreet::Template::Variable;
+use Scalar::Util qw(blessed);
+
+sub get {
+    my $self = shift;
+
+    my $value = $self->SUPER::get(@_);
+
+    $value = FixMyStreet::Template::Variable->new($value) unless ref $value;
+
+    return $value;
+}
+
+# To deal with being able to call var.upper or var.match
+sub _dotop {
+    my $self = shift;
+    my ($root, $item, $args, $lvalue) = @_;
+
+    $args ||= [ ];
+    $lvalue ||= 0;
+
+    return undef unless defined($root) and defined($item);
+    return undef if $item =~ /^[_.]/;
+
+    if (blessed($root) && $root->isa('FixMyStreet::Template::Variable')) {
+        if ((my $value = $Template::Stash::SCALAR_OPS->{ $item }) && ! $lvalue) {
+            my @result = &$value($root->{value}, @$args);
+            if (defined $result[0]) {
+                return scalar @result > 1 ? [ @result ] : $result[0];
+            }
+            return undef;
+        }
+    }
+
+    return $self->SUPER::_dotop(@_);
+}
+
+1;
+__END__
+
+=head1 NAME
+
+FixMyStreet::Template::Stash - The same as Template::HTML::Stash, but
+additionally copes with scalar operations on stash items.
+
+=head1 FUNCTIONS
+
+=head2 get()
+
+An overridden function from Template::Stash that calls the parent class's get
+method, and returns a FixMyStreet::Template::Variable instead of a raw string.
+
+=head2 _dotop()
+
+An overridden function from Template::Stash so that scalar operations on
+wrapped FixMyStreet::Template::Variable strings still function correctly.
+
+=head1 AUTHOR
+
+Martyn Smith, E<lt>msmith@cpan.orgE<gt>
+
+Matthew Somerville, E<lt>matthew@mysociety.orgE<gt>
+
+=head1 LICENSE
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself, either Perl version 5.8.8 or,
+at your option, any later version of Perl 5 you may have available.
+
+=cut

--- a/perllib/FixMyStreet/Template/Variable.pm
+++ b/perllib/FixMyStreet/Template/Variable.pm
@@ -1,0 +1,177 @@
+package FixMyStreet::Template::Variable;
+
+use strict;
+use warnings;
+use FixMyStreet::Template;
+
+sub op_factory {
+    my ($op) = @_;
+
+    return eval q|sub {
+        my ($self, $str) = @_;
+
+        if ( ref $str eq __PACKAGE__) {
+            return $self->{value} | . $op . q| $str->{value};
+        }
+        else {
+            return $self->{value} | . $op . q| $str;
+        }
+    }|;
+}
+
+use overload
+    '""'   => \&html_encoded,
+    '.'    => \&concat,
+    '.='   => \&concatequals,
+    '='    => \&clone,
+
+    'cmp' => op_factory('cmp'),
+    'eq'  => op_factory('eq'),
+    '<=>' => op_factory('<=>'),
+    '=='  => op_factory('=='),
+    '%'   => op_factory('%'),
+    '+'   => op_factory('+'),
+    '-'   => op_factory('-'),
+    '*'   => op_factory('*'),
+    '/'   => op_factory('/'),
+    '**'  => op_factory('**'),
+    '>>'  => op_factory('>>'),
+    '<<'  => op_factory('<<'),
+;
+
+sub new {
+    my ($class, $value) = @_;
+
+    my $self = bless { value => $value }, $class;
+
+    return $self;
+}
+
+sub plain {
+    my $self = shift;
+
+    return $self->{value};
+}
+
+sub html_encoded {
+    my $self = shift;
+    return FixMyStreet::Template::html_filter($self->{value});
+}
+
+sub concat {
+    my ($self, $str, $prefix) = @_;
+
+    # Special case where we're _not_ going to html_encode now now
+    return $self->clone() if not defined $str or $str eq '';
+
+    if ( $prefix ) {
+        return $str . $self->html_encoded();
+    }
+    else {
+        return $self->html_encoded() . $str;
+    }
+}
+
+sub concatequals {
+    my ($self, $str, $prefix) = @_;
+
+    if ( ref $str eq __PACKAGE__) {
+        $self->{value} .= $str->{value};
+        return $self;
+    }
+    else {
+        # Special case where we're _not_ going to html_encode now now
+        return $self->clone() if $str eq '';
+
+        # Fix Template::HTML::Variable issue with double output
+        my $ret = $self->html_encoded . $str;
+        $self->{value} .= $str;
+        return $ret;
+    }
+}
+
+sub clone {
+    my $self = shift;
+
+    my $clone = bless { %$self }, ref $self;
+
+    return $clone;
+}
+
+1;
+__END__
+
+=head1 NAME
+
+FixMyStreet::Template::Variable - A "pretend" string that auto HTML encodes;
+a copy of Template::HTML::Variable with a bugfix.
+
+=head1 SYNOPSIS
+
+  use FixMyStreet::Template::Variable;
+
+  my $string = FixMyStreet::Template::Variable->new('< test & stuff >');
+
+  print $string, "\n";
+
+  # Produces output "&lt; test &amp; stuff &gt;"
+
+=head1 DESCRIPTION
+
+This object provides a "pretend" string to use as part of the
+FixMyStreet::Template extension.
+
+It automatically stringifies to an HTML encoded version of what it was created
+with, all the while trying to keep a sane state through string concatinations
+etc.
+
+=head1 FUNCTIONS
+
+=head2 new()
+
+Takes a single argument which is the string to set this variable to
+
+=head2 plain()
+
+Returns a non HTML-encoded version of the string (i.e. exactly what was passed
+to the new() function
+
+=head2 html_encoded()
+
+Returns an HTML encoded version of the string (used by the stringify
+overloads)
+
+=head2 concat()
+
+Implementation of overloaded . operator
+
+=head2 concatequals()
+
+Implementation of overloaded .= operator.
+
+The original Template::HTML::Variable has a bug here, whereby it adds the new
+string to its internal value, then returns the HTML encoded version of the
+whole string with the new string concatenated again (unescaped).
+
+=head2 clone()
+
+Returns a clone of this variable. (used for the implementation of the
+overloaded = operator).
+
+=head2 op_factory()
+
+Factory for generating operator overloading subs
+
+=head1 AUTHOR
+
+Martyn Smith, E<lt>msmith@cpan.orgE<gt>
+
+Matthew Somerville, E<lt>matthew@mysociety.orgE<gt>
+
+=head1 LICENSE
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself, either Perl version 5.8.8 or,
+at your option, any later version of Perl 5 you may have available.
+
+=cut

--- a/t/app/controller/reports.t
+++ b/t/app/controller/reports.t
@@ -139,7 +139,7 @@ FixMyStreet::override_config {
         is $mech->uri->path, '/reports/Birmingham/Bordesley+and+Highgate';
         $mech->get_ok('/reports/Birmingham/Bordesley+and+Highgate|Birchfield');
         is $mech->uri->path, '/reports/Birmingham/Bordesley+and+Highgate%7CBirchfield';
-        $mech->content_contains('Birchfield, Bordesley & Highgate');
+        $mech->content_contains('Birchfield, Bordesley &amp; Highgate');
     };
 
     $mech->get_ok('/reports/Westminster');

--- a/t/app/helpers/send_email.t
+++ b/t/app/helpers/send_email.t
@@ -17,7 +17,7 @@ my $mech = FixMyStreet::TestMech->new;
 my $c = ctx_request("/");
 
 # set some values in the stash
-$c->stash->{foo} = 'bar';
+$c->stash->{foo} = 'bar <b>bold</b>';
 
 # clear the email queue
 $mech->clear_emails_ok;
@@ -118,6 +118,14 @@ subtest 'Inline emails!' => sub {
            \ {10}\+\ text/plain.*\n
            \ {10}\+\ text/html.*\n
         \ {5}\+\ image/gif]x;
+    $email->walk_parts(sub {
+        my ($part) = @_;
+        if ($part->content_type =~ m[text/plain]i) {
+            like $part->body_str, qr/foo: bar <b>bold<\/b>/;
+        } elsif ($part->content_type =~ m[text/html]i) {
+            like $part->body_str, qr/foo: bar &lt;b&gt;bold&lt;\/b&gt;/;
+        }
+    });
     $mech->clear_emails_ok;
 };
 

--- a/t/app/helpers/send_email_sample.txt
+++ b/t/app/helpers/send_email_sample.txt
@@ -7,7 +7,7 @@ From: CONTACT_EMAIL
 
 Hello,
 
-This is a test email where foo: bar.
+This is a test email where foo: bar <b>bold</b>.
 
 utf8: =E6=88=91=E4=BB=AC=E5=BA=94=E8=AF=A5=E8=83=BD=E5=A4=9F=E6=97=A0=E7=BC=
 =9D=E5=A4=84=E7=90=86UTF8=E7=BC=96=E7=A0=81

--- a/t/app/helpers/send_email_sample_mime.txt
+++ b/t/app/helpers/send_email_sample_mime.txt
@@ -12,7 +12,7 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello,
 
-This is a test email where foo: bar.
+This is a test email where foo: bar <b>bold</b>.
 
 utf8: =E6=88=91=E4=BB=AC=E5=BA=94=E8=AF=A5=E8=83=BD=E5=A4=9F=E6=97=A0=E7=BC=
 =9D=E5=A4=84=E7=90=86UTF8=E7=BC=96=E7=A0=81

--- a/t/cobrand/isleofwight.t
+++ b/t/cobrand/isleofwight.t
@@ -425,7 +425,7 @@ subtest "check not responsible as correct text" => sub {
         $mech->get_ok('/report/' . $p->id);
     };
 
-    $mech->content_contains("not Island Roads' responsibility", "not reponsible message contains correct text");
+    $mech->content_contains("not Island Roads&#39; responsibility", "not reponsible message contains correct text");
     $p->comments->delete;
     $p->delete;
 };

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -1,6 +1,7 @@
 # TODO
 # Overdue alerts
 
+use utf8;
 use DateTime;
 use Email::MIME;
 use File::Temp;
@@ -109,11 +110,11 @@ my @reports = $mech->create_problems_for_body( 1, $division->id, 'Test', {
 my $report = $reports[0];
 
 $mech->get_ok( '/report/' . $report->id );
-$mech->content_contains('&Uuml;berpr&uuml;fung ausstehend')
+$mech->content_contains('Überprüfung ausstehend')
     or die $mech->content;
 
 my $json = $mech->get_ok_json( '/report/ajax/' . $report->id );
-is $json->{report}->{title}, "&Uuml;berpr&uuml;fung ausstehend", "correct title";
+is $json->{report}->{title}, "Überprüfung ausstehend", "correct title";
 is $json->{report}->{state}, "submitted", "correct state";
 
 subtest "Banners are displayed correctly" => sub {
@@ -308,7 +309,7 @@ subtest "report_edit" => sub {
 
     $mech->log_in_ok( 'dm1@example.org') ;
     $mech->get_ok( '/admin/report_edit/' . $report->id );
-    $mech->content_contains( 'Unbest&auml;tigt' ); # Unconfirmed email
+    $mech->content_contains( 'Unbestätigt' ); # Unconfirmed email
     $mech->submit_form_ok( { with_fields => { state => 'confirmed' } } );
     $mech->get_ok( '/report/' . $report->id );
 
@@ -538,7 +539,7 @@ subtest 'Test publishing of final update by DM' => sub {
 
     $mech->content_contains('Admin district');
 
-    $mech->content_lacks( 'Unbest&auml;tigt' ); # Confirmed email
+    $mech->content_lacks( 'Unbestätigt' ); # Confirmed email
     $mech->submit_form_ok( { with_fields => { status_update => 'FINAL UPDATE' } } );
     $mech->form_with_fields( 'status_update' );
     $mech->submit_form_ok( { button => 'publish_response' } );
@@ -573,7 +574,7 @@ subtest "Assign feedback pending (via confirmed), don't confirm email, no email 
     $mech->content_contains('Second Test');
 
     $mech->get_ok( '/admin/report_edit/' . $report->id );
-    $mech->content_contains( 'Unbest&auml;tigt' );
+    $mech->content_contains( 'Unbestätigt' );
     $report->discard_changes;
     $mech->form_with_fields( 'status_update' );
     $mech->submit_form_ok( { button => 'publish_response', with_fields => { status_update => 'FINAL UPDATE' } } );
@@ -757,7 +758,7 @@ subtest "phone number is mandatory" => sub {
     $user = $mech->log_in_ok( 'dm1@example.org' );
     $mech->get_ok( '/report/new?lat=47.381817&lon=8.529156' );
     $mech->submit_form( with_fields => { phone => "" } );
-    $mech->content_contains( 'Diese Information wird ben&ouml;tigt' );
+    $mech->content_contains( 'Diese Information wird benötigt' );
     $mech->log_out_ok;
 };
 
@@ -774,7 +775,7 @@ subtest "phone number is not mandatory for reports from mobile apps" => sub {
     });
     my $res = $mech->response;
     ok $res->header('Content-Type') =~ m{^application/json\b}, 'response should be json';
-    unlike $res->content, qr/Diese Information wird ben&ouml;tigt/, 'response should not contain phone error';
+    unlike $res->content, qr/Diese Information wird benötigt/, 'response should not contain phone error';
     # Clear out the mailq
     $mech->clear_emails_ok;
 };
@@ -861,7 +862,7 @@ subtest "test stats" => sub {
     is $mech->res->code, 200, "superuser should be able to see stats page";
 
     $mech->content_contains('Innerhalb eines Arbeitstages moderiert: 3');
-    $mech->content_contains('Innerhalb von f&uuml;nf Arbeitstagen abgeschlossen: 3');
+    $mech->content_contains('Innerhalb von fünf Arbeitstagen abgeschlossen: 3');
     # my @data = $mech->content =~ /(?:moderiert|abgeschlossen): \d+/g;
     # diag Dumper(\@data); use Data::Dumper;
 

--- a/t/template.t
+++ b/t/template.t
@@ -1,0 +1,33 @@
+use FixMyStreet::Test;
+
+use_ok 'FixMyStreet::Template';
+
+my $tt = FixMyStreet::Template->new;
+
+my $output = '';
+$tt->process(\'[% s %] [% s | safe %] [% s | upper %] [% s | html %]', {
+    s => 'sp<i>l</i>it'
+}, \$output);
+is $output, 'sp&lt;i&gt;l&lt;/i&gt;it sp<i>l</i>it SP&lt;I&gt;L&lt;/I&gt;IT sp&lt;i&gt;l&lt;/i&gt;it';
+
+$output = '';
+$tt->process(\'[% s | html_para %]', { s => 'sp<i>l</i>it' }, \$output);
+is $output, "<p>\nsp&lt;i&gt;l&lt;/i&gt;it</p>\n";
+
+$output = '';
+$tt->process(\'[% loc("s") %] [% loc("s") | html_para %]', {}, \$output);
+is $output, "s <p>\ns</p>\n";
+
+$output = '';
+$tt->process(\'[% s.upper %] [% t = s %][% t %] [% t.upper %]', {
+    s => 'sp<i>l</i>it'
+}, \$output);
+is $output, 'SP&lt;I&gt;L&lt;/I&gt;IT sp&lt;i&gt;l&lt;/i&gt;it SP&lt;I&gt;L&lt;/I&gt;IT';
+
+$output = '';
+$tt->process(\'H: [% s.split(":").join(",") %]', {
+    s => '1:sp<i>l</i>it:3'
+}, \$output);
+is $output, 'H: 1,sp&lt;i&gt;l&lt;/i&gt;it,3';
+
+done_testing;

--- a/templates/email/bathnes/_email_top.html
+++ b/templates/email/bathnes/_email_top.html
@@ -51,7 +51,7 @@
   </style>
 </head>
 <body style="[% body_style %]">
-  <table [% wrapper_table %] style="[% wrapper_style %]">
+  <table [% wrapper_table | safe %] style="[% wrapper_style %]">
     <tr>
       <th class="spacer-cell"></th>
       <th width="[% wrapper_max_width %]" style="[% td_style %][% hint_style %]" class="hint">
@@ -60,11 +60,11 @@
       <th class="spacer-cell"></th>
     </tr>
   </table>
-  <table [% wrapper_table %] style="[% wrapper_style %]">
+  <table [% wrapper_table | safe %] style="[% wrapper_style %]">
     <tr>
       <th class="spacer-cell"></th>
       <th width="[% wrapper_max_width %]" style="[% td_style %] min-width: [% wrapper_min_width %]px;" id="main">
-        <table [% table_reset %]>
+        <table [% table_reset | safe %]>
           <tr>
             <th id="header" colspan="[% email_columns %]" style="[% td_style %][% header_style %]">
               [%~ IF file_exists("web/cobrands/${ img_dir }/images/email-logo.gif") ~%]

--- a/templates/email/buckinghamshire/alert-update.html
+++ b/templates/email/buckinghamshire/alert-update.html
@@ -12,11 +12,11 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">New updates on <a href="[% problem_url %]">[% category %] report</a></h1>
   [%~ INCLUDE '_email_comment_list.html' %]
   <p style="[% p_style %]"><a href="[% unsubscribe_url %]">Unsubscribe from alerts about this report</a></p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% title %]</h2>

--- a/templates/email/buckinghamshire/other-reported.html
+++ b/templates/email/buckinghamshire/other-reported.html
@@ -9,7 +9,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Your report has been&nbsp;logged</h1>
   <p style="[% p_style %]">Your report to [% report.body %] has been logged on [% site_name %].</p>
 [% IF cobrand.is_council && !cobrand.owns_problem( report ) %]
@@ -21,7 +21,7 @@ of report, so it will instead be sent to [% report.body %].</p>
   <p style="margin: 20px auto; text-align: center">
   <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.url %]">View my report</a>
   </p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>

--- a/templates/email/default/_email_bottom.html
+++ b/templates/email/default/_email_bottom.html
@@ -4,12 +4,12 @@
       <th class="spacer-cell"></th>
     </tr>
   </table>
-  <table [% wrapper_table %] style="[% wrapper_style %]">
+  <table [% wrapper_table | safe %] style="[% wrapper_style %]">
     <tr>
       <th class="spacer-cell"></th>
       <th width="[% wrapper_max_width %]" style="[% td_style %][% hint_style %]" class="hint">
         [%~ IF email_footer %]
-          [% email_footer %]
+          [% email_footer | safe %]
         [%~ ELSE %]
           This email was sent automatically, from an unmonitored email account. Please do not reply to it.
         [%~ END %]

--- a/templates/email/default/_email_report_list.txt
+++ b/templates/email/default/_email_report_list.txt
@@ -1,4 +1,4 @@
-[% FOR report IN data -%]
+[% FOR report IN data %]
 [% cobrand.base_url_for_report(report) %]/report/[% report.id %] - [% report.title %]
 
 [% report.nearest ~%]

--- a/templates/email/default/_email_sidebar.html
+++ b/templates/email/default/_email_sidebar.html
@@ -16,10 +16,10 @@ DEFAULT url = cobrand.base_url_for_report(report) _ report.url
   [% IF url %]
   <a href="[% url %]"><img style="[% map_image_style %]" src="[% inline_image(report.static_map, 'map.jpeg') %]" width="310" height="200" alt=""></a>
   [% END %]
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
     [%~ IF object.photo %]
       <img style="[% preview_photo_style %]" src="[% inline_image(object.get_first_image_fp) %]" alt="" align="right">
     [%~ END %]
-    [%~ content %]
-  [% end_padded_box %]
+    [%~ content | safe %]
+  [% end_padded_box | safe %]
 </th>

--- a/templates/email/default/_email_top.html
+++ b/templates/email/default/_email_top.html
@@ -47,7 +47,7 @@
   </style>
 </head>
 <body style="[% body_style %]">
-  <table [% wrapper_table %] style="[% wrapper_style %]">
+  <table [% wrapper_table | safe %] style="[% wrapper_style %]">
     <tr>
       <th class="spacer-cell"></th>
       <th width="[% wrapper_max_width %]" style="[% td_style %][% hint_style %]" class="hint">
@@ -56,11 +56,11 @@
       <th class="spacer-cell"></th>
     </tr>
   </table>
-  <table [% wrapper_table %] style="[% wrapper_style %]">
+  <table [% wrapper_table | safe %] style="[% wrapper_style %]">
     <tr>
       <th class="spacer-cell"></th>
       <th width="[% wrapper_max_width %]" style="[% td_style %] min-width: [% wrapper_min_width %]px;" id="main">
-        <table [% table_reset %]>
+        <table [% table_reset | safe %]>
           <tr>
             <th colspan="[% email_columns %]" style="[% td_style %][% header_style %]">
               [%~ IF file_exists("web/cobrands/${ img_dir }/images/${ logo_file }") ~%]

--- a/templates/email/default/alert-update.html
+++ b/templates/email/default/alert-update.html
@@ -11,11 +11,11 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">New updates on <a href="[% problem_url %]">[% title %]</a></h1>
   [%~ INCLUDE '_email_comment_list.html' %]
   <p style="[% p_style %]"><a href="[% unsubscribe_url %]">Unsubscribe from alerts about this report</a></p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% title %]</h2>

--- a/templates/email/default/contact.html
+++ b/templates/email/default/contact.html
@@ -13,7 +13,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% contact_meta_style %]">
-  <table [% table_reset %]>
+  <table [% table_reset | safe %]>
     <tr>
       <th style="[% contact_th_style %]">From</th>
       <td style="[% contact_td_style %]">

--- a/templates/email/default/other-reported.html
+++ b/templates/email/default/other-reported.html
@@ -9,7 +9,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Your report has been&nbsp;logged</h1>
   <p style="[% p_style %]">Your report to [% report.body %] has been logged on [% site_name %].</p>
 [% IF cobrand.is_council && !cobrand.owns_problem( report ) %]
@@ -21,7 +21,7 @@ of report, so it will instead be sent to [% report.body %].</p>
   <p style="margin: 20px auto; text-align: center">
   <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.url %]">View my report</a>
   </p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>

--- a/templates/email/default/other-updated.html
+++ b/templates/email/default/other-updated.html
@@ -9,14 +9,14 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Your update has been&nbsp;logged</h1>
   <p style="[% p_style %]">Your update has been logged on [% site_name %].</p>
   [% TRY %][% INCLUDE '_council_reference.html' %][% CATCH file %][% END %]
   <p style="margin: 20px auto; text-align: center">
   <a style="[% button_style %]" href="[% cobrand.base_url_for_report(problem) %][% update.url %]">View my update</a>
   </p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html'
     object = update

--- a/templates/email/default/problem-confirm-not-sending.html
+++ b/templates/email/default/problem-confirm-not-sending.html
@@ -10,7 +10,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Please confirm your&nbsp;report</h1>
   <p style="[% p_style %]">Please click on the link below to confirm that you want your report to appear
 on [% site_name %], despite not being sent to the
@@ -20,7 +20,7 @@ council.</p>
     <a style="[% button_style %]" href="[% token_url %]">Yes, publish my report</a>
   </p>
   <p style="[% p_style %]">If you no longer wish to publish this report, please take no further action.</p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report, url = token_url %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>

--- a/templates/email/default/problem-confirm.html
+++ b/templates/email/default/problem-confirm.html
@@ -10,7 +10,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Please confirm your&nbsp;report</h1>
   <p style="[% p_style %]">Please click on the link below to confirm that you want to send your report to [% report.body %].
 [% IF c.cobrand.is_council && !c.cobrand.owns_problem( report ) %]
@@ -25,7 +25,7 @@ of problem, so it will instead be sent to [% report.body %].
     <a style="[% button_style %]" href="[% token_url %]">Yes, send my report</a>
   </p>
   <p style="[% p_style %]">If you no longer wish to send this report, please take no further action.</p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report, url = token_url %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>

--- a/templates/email/default/problem-moderated.html
+++ b/templates/email/default/problem-moderated.html
@@ -10,7 +10,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Your report has been&nbsp;moderated</h1>
 [% IF types == 'hide' -%]
   <p style="[% p_style %]">The report has been hidden from the site.</p>
@@ -22,7 +22,7 @@ INCLUDE '_email_top.html';
 [% END -%]
   <p style="[% p_style %]">If you do not think that this report should have been moderated, you may contact
 the team at <a href="[% report_complain_uri %]">[% report_complain_uri %]</a></p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = problem %]
     <h2 style="[% h2_style %]">[% moderated_data.title | html %]</h2>

--- a/templates/email/default/questionnaire.html
+++ b/templates/email/default/questionnaire.html
@@ -11,7 +11,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Has your problem been&nbsp;fixed?</h1>
   <p style="[% p_style %]">[% created %] ago, you reported a problem using [% site_name %].</p>
   <p style="[% p_style %]">Help us keep [% site_name %] up to date by letting us know whether the problem has been fixed yet:</p>
@@ -23,7 +23,7 @@ INCLUDE '_email_top.html';
     <a style="[% dontknow_button_style %]" href="[% url %]?been_fixed=Unknown">Don’t know</a>
   </p>
   <p style="[% p_style %]">Thank you! Your feedback is really valuable.</p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report, url = url %]
     <h2 style="[% h2_style %]">[% title %]</h2>

--- a/templates/email/default/submit.html
+++ b/templates/email/default/submit.html
@@ -11,7 +11,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">New problem in your&nbsp;area</h1>
   <p style="[% p_style %]">[% missing %][% multiple %]A user of [% site_name %] has submitted the following report
 of a local problem that they believe might require your attention.</p>
@@ -20,7 +20,7 @@ of a local problem that they believe might require your attention.</p>
     <a style="[% button_style %]" href="[% url %]">Show full report</a>
   </p>
   <h2 style="[% h2_style %] margin: 30px 0 10px 0">Reported by:</h2>
-  <table [% table_reset %]>
+  <table [% table_reset | safe %]>
     <tr>
       <th style="[% contact_th_style %]">Name</th>
       <td style="[% contact_td_style %]">[% report.name | html %]</td>
@@ -43,7 +43,7 @@ of a local problem that they believe might require your attention.</p>
     [%~ END %]
   </table>
   <p style="[% p_style %] margin-top: 0.5em;">Replies to this message will go directly to [% report.name | html %], the user who reported the problem.</p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>

--- a/templates/email/default/update-confirm.html
+++ b/templates/email/default/update-confirm.html
@@ -10,7 +10,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Please confirm your&nbsp;update</h1>
   <p style="[% p_style %]">Please click on the link below to confirm your update on [% site_name %].</p>
   <p style="margin: 20px auto; text-align: center">
@@ -18,7 +18,7 @@ INCLUDE '_email_top.html';
   </p>
   <p style="[% p_style %]">[% INCLUDE 'update-confirm-donotsend.txt' %]</p>
   <p style="[% p_style %]">If you no longer wish to confirm this update, please take no further action.</p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html'
     object = update

--- a/templates/email/fixamingata/_email_bottom.html
+++ b/templates/email/fixamingata/_email_bottom.html
@@ -4,7 +4,7 @@
       <th></th>
     </tr>
   </table>
-  <table [% wrapper_table %] style="[% wrapper_style %]">
+  <table [% wrapper_table | safe %] style="[% wrapper_style %]">
     <tr>
       <th></th>
       <th width="[% wrapper_max_width %]" style="[% td_style %][% hint_style %]" class="hint">

--- a/templates/email/fixamingata/alert-update.html
+++ b/templates/email/fixamingata/alert-update.html
@@ -11,11 +11,11 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Ny uppdatering i <a href="[% problem_url %]">[% title %]</a></h1>
   [%~ INCLUDE '_email_comment_list.html' %]
   <p style="[% p_style %]"><a href="[% unsubscribe_url %]">Avsluta min prenumeration kring denna rapport</a></p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% title | html %]</h2>

--- a/templates/email/fixamingata/contact.html
+++ b/templates/email/fixamingata/contact.html
@@ -13,7 +13,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% contact_meta_style %]">
-  <table [% table_reset %]>
+  <table [% table_reset | safe %]>
     <tr>
       <th style="[% contact_th_style %]">Från</th>
       <td style="[% contact_td_style %]">[% name %] &lt;<a href="mailto:[% em | html %]">[% em | html %]</a>&gt;</td>

--- a/templates/email/fixamingata/other-reported.html
+++ b/templates/email/fixamingata/other-reported.html
@@ -9,7 +9,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Din rapport har&nbsp;loggats</h1>
   <p style="[% p_style %]">Din rapport till [% report.body %] har blivit loggad på [% site_name %].
 [% IF cobrand.is_council && !cobrand.owns_problem( report ) %]
@@ -20,7 +20,7 @@ rapporter, så kommer rapporten istället att skickas till [% report.body %].
   <p style="margin: 20px auto; text-align: center">
   <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.url %]">Visa min rapport</a>
   </p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>

--- a/templates/email/fixamingata/other-updated.html
+++ b/templates/email/fixamingata/other-updated.html
@@ -9,13 +9,13 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Din uppdatering har&nbsp;loggats</h1>
   <p style="[% p_style %]">Din uppdatering har blivit loggad på [% site_name %]:</p>
   <p style="margin: 20px auto; text-align: center">
   <a style="[% button_style %]" href="[% cobrand.base_url_for_report(problem) %][% problem.url %]#update_[% update.id %]">Visa min uppdatering</a>
   </p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html'
     object = update

--- a/templates/email/fixamingata/problem-confirm-not-sending.html
+++ b/templates/email/fixamingata/problem-confirm-not-sending.html
@@ -10,7 +10,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Bekräfta din&nbsp;FixaMinGata-rapport</h1>
   <p style="[% p_style %]">För att bekräfta den rapport som du nyligen lade in på FixaMinGata
 måste du klicka på nedanstående länk. Notera att din rapport inte kommer att
@@ -20,7 +20,7 @@ skickas till kommunen.</p>
     <a style="[% button_style %]" href="[% token_url %]">Skicka min rapport</a>
   </p>
   <p style="[% p_style %]">Om du inte vill skicka din rapport så behöver du inte göra något.</p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report, url = token_url %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>

--- a/templates/email/fixamingata/problem-confirm.html
+++ b/templates/email/fixamingata/problem-confirm.html
@@ -10,7 +10,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Bekräfta din&nbsp;FixaMinGata-rapport</h1>
   <p style="[% p_style %]">För att bekräfta den rapport som du nyligen lade in på FixaMinGata
 måste du klicka på nedanstående knapp.</p>
@@ -19,7 +19,7 @@ måste du klicka på nedanstående knapp.</p>
     <a style="[% button_style %]" href="[% token_url %]">Skicka min rapport</a>
   </p>
   <p style="[% p_style %]">Om du inte vill skicka din rapport så behöver du inte göra något.</p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report, url = token_url %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>

--- a/templates/email/fixamingata/problem-moderated.html
+++ b/templates/email/fixamingata/problem-moderated.html
@@ -10,7 +10,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Din rapport har blivit&nbsp;modererad</h1>
 [% IF types == 'hide' -%]
   <p style="[% p_style %]">Din rapport har dolts från sajten.</p>
@@ -22,7 +22,7 @@ INCLUDE '_email_top.html';
 [% END -%]
   <p style="[% p_style %]">Om du inte tycker att rapporten skulle ha blivit modererad kan du
 kontakta FixaMinGata:s support på <a href="[% report_complain_uri %]">[% report_complain_uri %]</a></p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = problem %]
     <h2 style="[% h2_style %]">[% problem.moderation_original_data.title | html %]</h2>

--- a/templates/email/fixamingata/questionnaire.html
+++ b/templates/email/fixamingata/questionnaire.html
@@ -11,7 +11,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Har ditt problem blivit&nbsp;fixat?</h1>
   <p style="[% p_style %]">[% created %] sedan lämnade du en rapport på FixaMinGata.</p>
   <p style="[% p_style %]">För att hålla alla rapporter uppdaterade skulle vi uppskatta om du kunde informera oss om huruvida problemet har blivit fixat än:</p>
@@ -23,7 +23,7 @@ INCLUDE '_email_top.html';
     <a style="[% dontknow_button_style %]" href="[% url %]?been_fixed=Unknown">Vet ej</a>
   </p>
   <p style="[% p_style %]">Tack! Din feedback är värdefull.</p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report, url = url %]
     <h2 style="[% h2_style %]">[% title %]</h2>

--- a/templates/email/fixamingata/submit.html
+++ b/templates/email/fixamingata/submit.html
@@ -11,7 +11,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Ny rapport för [% report.body %]</h1>
   <p style="[% p_style %]">[% missing %][% multiple %]Följande rapport
 tror medborgaren behöver er uppmärksamhet.</p>
@@ -20,7 +20,7 @@ tror medborgaren behöver er uppmärksamhet.</p>
     <a style="[% button_style %]" href="[% url %]">Visa rapporten</a>
   </p>
   <h2 style="[% h2_style %] margin: 30px 0 10px 0">Rapporterad av:</h2>
-  <table [% table_reset %]>
+  <table [% table_reset | safe %]>
     <tr>
       <th style="[% contact_th_style %]">Namn</th>
       <td style="[% contact_td_style %]">[% report.name | html %]</td>
@@ -42,7 +42,7 @@ tror medborgaren behöver er uppmärksamhet.</p>
     [%~ END %]
   </table>
   <p style="[% p_style %] margin-top: 0.5em;">Svar på det här brevet kommer att skickas till den person som lämnade rapporten.</p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>

--- a/templates/email/fixamingata/update-confirm.html
+++ b/templates/email/fixamingata/update-confirm.html
@@ -10,7 +10,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Bekräfta din uppdatering</h1>
   <p style="[% p_style %]">Vänligen klicka på knappen nedan för att bekräfta den uppdatering du just lämnade:</p>
   <p style="margin: 20px auto; text-align: center">
@@ -18,7 +18,7 @@ INCLUDE '_email_top.html';
   </p>
   <p style="[% p_style %]">[% INCLUDE 'update-confirm-donotsend.txt' %]</p>
   <p style="[% p_style %]">Om du inte vill bekräfta din uppdatering behöver du inte göra något.</p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html'
     object = update

--- a/templates/email/fixmystreet.com/_submit_footer.html
+++ b/templates/email/fixmystreet.com/_submit_footer.html
@@ -1,4 +1,4 @@
-<table [% table_reset %]>
+<table [% table_reset | safe %]>
   <tr>
     <th style="[% td_style %] padding: [% column_padding %]px; background-color: [% color_yellow %]; color: [% color_black %];">
       <h2 style="[% h2_style %] margin-bottom: 15px;">
@@ -14,7 +14,7 @@
   </tr>
 </table>
 
-<table [% table_reset %] style="table-layout: fixed;">
+<table [% table_reset | safe %] style="table-layout: fixed;">
   <tr>
     <th style="[% submit_footer_td_style %] padding: [% column_padding %]px 40px 0 0;">
       <h2 style="[% submit_footer_h2_style %]">

--- a/templates/email/fixmystreet.com/submit.html
+++ b/templates/email/fixmystreet.com/submit.html
@@ -11,7 +11,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">New problem in your&nbsp;area</h1>
   <p style="[% p_style %]">[% missing %][% multiple %]A user of [% site_name %] has submitted the following report
 of a local problem that they believe might require your attention.</p>
@@ -20,7 +20,7 @@ of a local problem that they believe might require your attention.</p>
     <a style="[% button_style %]" href="[% url %]">Show full report</a>
   </p>
   <h2 style="[% h2_style %] margin: 30px 0 10px 0">Reported by:</h2>
-  <table [% table_reset %]>
+  <table [% table_reset | safe %]>
     <tr>
       <th style="[% contact_th_style %]">Name</th>
       <td style="[% contact_td_style %]">[% report.name | html %]</td>
@@ -43,7 +43,7 @@ of a local problem that they believe might require your attention.</p>
     [%~ END %]
   </table>
   <p style="[% p_style %] margin-top: 0.5em;">Replies to this message will go directly to [% report.name | html %], the user who reported the problem.</p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>

--- a/templates/email/hounslow/other-reported.html
+++ b/templates/email/hounslow/other-reported.html
@@ -9,7 +9,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Your report has been&nbsp;logged</h1>
   <p style="[% p_style %]">Your report to [% cobrand.council_name %] has been logged on [% site_name %].</p>
 [% IF cobrand.is_council && !cobrand.owns_problem( report ) %]
@@ -21,7 +21,7 @@ of report, so it will instead be sent to [% report.body %].</p>
   <p style="margin: 20px auto; text-align: center">
   <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.url %]">View my report</a>
   </p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>

--- a/templates/email/hounslow/problem-confirm.html
+++ b/templates/email/hounslow/problem-confirm.html
@@ -10,7 +10,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Please confirm your&nbsp;report</h1>
   <p style="[% p_style %]">Please click on the link below to confirm that you want to send your report to Hounslow Highways.
 
@@ -21,7 +21,7 @@ INCLUDE '_email_top.html';
     <a style="[% button_style %]" href="[% token_url %]">Yes, send my report</a>
   </p>
   <p style="[% p_style %]">If you no longer wish to send this report, please take no further action.</p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report, url = token_url %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>

--- a/templates/email/hounslow/submit.html
+++ b/templates/email/hounslow/submit.html
@@ -11,7 +11,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">New problem in your&nbsp;area</h1>
   <p style="[% p_style %]">[% multiple %]A user of [% site_name %] has submitted the following report
 of a local problem that they believe might require your attention.</p>
@@ -20,7 +20,7 @@ of a local problem that they believe might require your attention.</p>
     <a style="[% button_style %]" href="[% url %]">Show full report</a>
   </p>
   <h2 style="[% h2_style %] margin: 30px 0 10px 0">Reported by:</h2>
-  <table [% table_reset %]>
+  <table [% table_reset | safe %]>
     <tr>
       <th style="[% contact_th_style %]">Name</th>
       <td style="[% contact_td_style %]">[% report.name | html %]</td>
@@ -43,7 +43,7 @@ of a local problem that they believe might require your attention.</p>
     [%~ END %]
   </table>
   <p style="[% p_style %] margin-top: 0.5em;">Replies to this message will go directly to [% report.name | html %], the user who reported the problem.</p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>

--- a/templates/email/isleofwight/confirm_report_sent.html
+++ b/templates/email/isleofwight/confirm_report_sent.html
@@ -9,7 +9,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Your report has been&nbsp;logged</h1>
   [% IF report.state == 'for triage' %]
   <p style="[% p_style %]">Thank you for submitting your report to FixMyStreet, it will be submitted to Island Roads for review.</p>
@@ -32,7 +32,7 @@ of report, so it will instead be sent to [% report.body %].</p>
   <p style="margin: 20px auto; text-align: center">
   <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.url %]">View my report</a>
   </p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>

--- a/templates/email/isleofwight/problem-confirm.html
+++ b/templates/email/isleofwight/problem-confirm.html
@@ -10,7 +10,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
-  [% start_padded_box %]
+  [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Please confirm your&nbsp;report</h1>
   <p style="[% p_style %]">Please click on the link below to confirm that you want to send your report to Island Roads.
 
@@ -21,7 +21,7 @@ INCLUDE '_email_top.html';
     <a style="[% button_style %]" href="[% token_url %]">Yes, send my report</a>
   </p>
   <p style="[% p_style %]">If you no longer wish to send this report, please take no further action.</p>
-  [% end_padded_box %]
+  [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report, url = token_url %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>

--- a/templates/email/lincolnshire/contact.html
+++ b/templates/email/lincolnshire/contact.html
@@ -13,7 +13,7 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% contact_meta_style %]">
-  <table [% table_reset %]>
+  <table [% table_reset | safe %]>
     <tr>
       <th style="[% contact_th_style %]">From</th>
       <td style="[% contact_td_style %]">[% name %] &lt;<a href="mailto:[% em | html %]">[% em | html %]</a>&gt;</td>

--- a/templates/web/base/admin/bodies/body.html
+++ b/templates/web/base/admin/bodies/body.html
@@ -129,7 +129,7 @@
 
   [% IF errors %]
   <div class="fms-admin-warning">
-    [% errors.values.join('<br>') %]
+    [% FOR error IN errors.values %][% error %][% IF NOT loop.last %]<br>[% END %][% END %]
   </div>
   [% INCLUDE 'admin/bodies/contact-form.html' translations=contact_translations %]
   [% ELSE  %]

--- a/templates/web/base/admin/config_page.html
+++ b/templates/web/base/admin/config_page.html
@@ -51,7 +51,12 @@ running version <strong>[% git_version || 'unknown' %]</strong>.
 [% INCLUDE just_value value="ALLOWED_COBRANDS" conf = allowed_conf %]
 <tr>
 <td>Web templates</td>
-<td colspan=2>[% c.cobrand.path_to_web_templates.join('<br>') %]</td>
+<td colspan=2>
+    [% FOR path IN c.cobrand.path_to_web_templates %]
+        [% path %]
+        [% IF NOT loop.last %]<br>[% END %]
+    [% END %]
+</td>
 </tr>
 [% INCLUDE with_cobrand value="MAP_TYPE" cob=c.cobrand.map_type %]
 [% INCLUDE with_cobrand value="EXAMPLE_PLACES"

--- a/templates/web/base/admin/reports/edit.html
+++ b/templates/web/base/admin/reports/edit.html
@@ -7,7 +7,7 @@
     PROCESS 'admin/report_blocks.html'
 -%]
 
-[% map_html %]
+[% map_html | safe %]
 </div>
 
 <div id="map_sidebar">

--- a/templates/web/base/admin/responsepriorities/edit.html
+++ b/templates/web/base/admin/responsepriorities/edit.html
@@ -4,22 +4,22 @@
 
 <form method="post" accept-charset="utf-8" class="validate">
 
-    [% form.field('name').render %]
-    [% form.field('description').render %]
+    [% form.field('name').render | safe %]
+    [% form.field('description').render | safe %]
 
     <div class="admin-hint">
       <p>
         [% loc('If this priority is passed to an external service (e.g. Exor/Confirm) enter the priority code to use with that service here.') %]
       </p>
     </div>
-    [% form.field('external_id').render %]
+    [% form.field('external_id').render | safe %]
 
     <div class="admin-hint">
       <p>
         [% loc('Select if this is the default priority') %]
       </p>
     </div>
-    [% form.field('is_default').render %]
+    [% form.field('is_default').render | safe %]
 
     <fieldset>
         <legend>
@@ -31,10 +31,10 @@
             [% loc('Categories:') %]
         </legend>
         [%# TODO Select all/none %]
-        [% form.field('contacts').render %]
+        [% form.field('contacts').render | safe %]
     </fieldset>
 
-    [% form.field('deleted').render %]
+    [% form.field('deleted').render | safe %]
 
     <p>
       <input type="hidden" name="token" value="[% csrf_token %]" >

--- a/templates/web/base/admin/roles/form.html
+++ b/templates/web/base/admin/roles/form.html
@@ -4,18 +4,18 @@
     <div class="admin-hint">
       <p>[% loc("The role's <strong>name</strong> is used to refer to this group of permissions elsewhere in the admin.") %]</p>
     </div>
-    [% form.field('name').render %]
+    [% form.field('name').render | safe %]
 
   [% IF form.field('body').is_active %]
-    [% form.field('body').render %]
+    [% form.field('body').render | safe %]
   [% END %]
 
     <div class="admin-hint">
       <p>[% loc("Users with this role can perform the following actions within their assigned body or area.") %]</p>
     </div>
-    [% form.field('permissions').render %]
+    [% form.field('permissions').render | safe %]
 
-    [% form.field('submit').render %]
+    [% form.field('submit').render | safe %]
 
     <p>
         <input class="btn" type="submit" name="submit" value="[% loc('Save changes') %]">

--- a/templates/web/base/admin/triage/_list-filters.html
+++ b/templates/web/base/admin/triage/_list-filters.html
@@ -20,7 +20,7 @@
 [% END %]
 
         <p class="report-list-filters">
-            [% tprintf(loc('<label for="statuses">Show</label> %s reports <label for="filter_categories">about</label> %s', "The first %s is a dropdown of all/fixed/etc, the second is a dropdown of categories"), 'untriaged', select_category) %]
+            [% tprintf(loc('<label for="statuses">Show</label> %s reports <label for="filter_categories">about</label> %s', "The first %s is a dropdown of all/fixed/etc, the second is a dropdown of categories"), 'untriaged', mark_safe(select_category)) %]
             <input type="submit" name="filter_update" value="[% loc('Go') %]">
         </p>
 

--- a/templates/web/base/admin/triage/index.html
+++ b/templates/web/base/admin/triage/index.html
@@ -14,7 +14,7 @@
         rss = [ tprintf(loc('Problems within %s, %s', "First %s is the body name, second %s the site name"), name, site_name), rss_url ]
 %]
 
-[% map_html %]
+[% map_html | safe %]
 
 </div>
 <div id="map_sidebar">

--- a/templates/web/base/admin/users/log.html
+++ b/templates/web/base/admin/users/log.html
@@ -44,21 +44,21 @@ action_map = {
         [%~ SET report_link = "<a href='" _ report_url _ "'>" _ item.obj.id _ "</a>" %]
         [%- SWITCH item.type -%]
             [%~ CASE 'problem' %]
-                [%- tprintf(loc('Problem %s created'), report_link) %], ‘[% item.obj.title | html %]’
+                [%- tprintf(loc('Problem %s created'), mark_safe(report_link)) %], ‘[% item.obj.title | html %]’
             [%~ CASE 'problemContributedBy' %]
-                [%- tprintf(loc('Problem %s created on behalf of %s'), report_link, item.obj.name) %], ‘[% item.obj.title | html %]’
+                [%- tprintf(loc('Problem %s created on behalf of %s'), mark_safe(report_link), item.obj.name) %], ‘[% item.obj.title | html %]’
             [%~ CASE 'update' %]
-                [% tprintf(loc("Update %s created for problem %d"), report_link, item.obj.problem_id) %]
+                [% tprintf(loc("Update %s created for problem %d"), mark_safe(report_link), item.obj.problem_id) %]
                 [% item.obj.text | add_links | markup(item.obj.user) | html_para %]
             [%~ CASE 'shortlistAdded' %]
-                [%- tprintf(loc('Problem %s added to shortlist'), report_link) %]
+                [%- tprintf(loc('Problem %s added to shortlist'), mark_safe(report_link)) %]
             [%~ CASE 'shortlistRemoved' %]
-                [%- tprintf(loc('Problem %s removed from shortlist'), report_link) %]
+                [%- tprintf(loc('Problem %s removed from shortlist'), mark_safe(report_link)) %]
             [%~ CASE 'log' %]
                 [%~ SET object_summary = item.log.object_summary %]
               [% IF object_summary %]
                 [%~ SET link = tprintf('<a href="%s">%s</a>', item.log.link, object_summary) %]
-                [%- tprintf('%s %s %s', action_map.${item.log.action}, item.log.actual_object_type, link) %]
+                [%- tprintf('%s %s %s', action_map.${item.log.action}, item.log.actual_object_type, mark_safe(link)) %]
                 [% ' – ' _ item.log.reason IF item.log.reason %]
               [% ELSE %]
                 [%- tprintf('%s %s %s', action_map.${item.log.action}, item.log.actual_object_type, item.log.object_id) %]

--- a/templates/web/base/alert/_list.html
+++ b/templates/web/base/alert/_list.html
@@ -26,7 +26,7 @@
 
   <p id="rss_local_alt">
   [% SET distance_options = '<a href="' _ rss_feed_2k _ ' ">2km</a> / <a href="' _ rss_feed_5k _ ' ">5km</a> / <a href="' _ rss_feed_10k _ '">10km</a> / <a href="' _ rss_feed_20k _ '">20km</a>' %]
-  [% tprintf(loc('(we also have RSS feeds for problems within %s)', "%s is a list of distance links, e.g. [2km] / [5km] / [10km] / [20km]"), distance_options) %]
+  [% tprintf(loc('(we also have RSS feeds for problems within %s)', "%s is a list of distance links, e.g. [2km] / [5km] / [10km] / [20km]"), mark_safe(distance_options)) %]
   </p>
 
   [% FOREACH option IN options %]

--- a/templates/web/base/around/_postcode_submit_button.html
+++ b/templates/web/base/around/_postcode_submit_button.html
@@ -1,4 +1,4 @@
-<input type="submit" [% attr %] value="[%
+<input type="submit" [% attr | safe %] value="[%
     IF c.cobrand.moniker == 'cheshireeast';
         'Search for location';
     ELSE;

--- a/templates/web/base/around/display_location.html
+++ b/templates/web/base/around/display_location.html
@@ -57,7 +57,7 @@
     [% END %]
 [% END %]
 
-    [% map_html %]
+    [% map_html | safe %]
 
     [% IF c.req.params.no_pins %]
         <a class="big-hide-pins-link" rel='nofollow' href="[% c.uri_with( { no_pins => 0 } ) %]">[% loc('Show pins') %]</a>
@@ -66,7 +66,7 @@
     [% END %]
 
         <p class="sub-map-links" id='sub_map_links'>
-            [% map_sub_links %]
+            [% map_sub_links | safe %]
             [% IF c.req.params.no_pins %]
                 <a id='hide_pins_link' rel='nofollow' href="[% c.uri_with( { no_pins => 0 } ) %]">[% loc('Show pins') %]</a>
             [% ELSE %]

--- a/templates/web/base/dashboard/heatmap.html
+++ b/templates/web/base/dashboard/heatmap.html
@@ -9,7 +9,7 @@
         title = tprintf(loc('%s - Summary reports'), body.name)
 %]
 
-[% map_html %]
+[% map_html | safe %]
 
 </div>
 <div id="map_sidebar">

--- a/templates/web/base/errors/generic.html
+++ b/templates/web/base/errors/generic.html
@@ -7,7 +7,7 @@
 
 <div class="confirmation-header confirmation-header--failure">
     <h1>[% title %]</h1>
-    <p>[% message %]</p>
+    <p>[% message | safe %]</p>
 </div>
 
 [% INCLUDE 'footer.html' %]

--- a/templates/web/base/header.html
+++ b/templates/web/base/header.html
@@ -4,9 +4,9 @@
     # SET html_att = html_att _ ' dir="rtl"';
 -%]
 <!doctype html>
-<!--[if IE 8]>   <html class="no-js ie8"[% html_att %]><![endif]-->
-<!--[if IE 9]>   <html class="no-js ie9"[% html_att %]><![endif]-->
-<!--[if gt IE 9]><!--><html class="no-js"[% html_att %]
+<!--[if IE 8]>   <html class="no-js ie8"[% html_att | safe %]><![endif]-->
+<!--[if IE 9]>   <html class="no-js ie9"[% html_att | safe %]><![endif]-->
+<!--[if gt IE 9]><!--><html class="no-js"[% html_att | safe %]
 [% IF appcache ~%]
  manifest="/offline/appcache.manifest"
 [%~ END %]><!--<![endif]-->
@@ -32,7 +32,7 @@
         <div class="table-cell">
             [% INCLUDE 'header_site.html' %]
 
-            [% pre_container_extra %]
+            [% pre_container_extra | safe %]
 
             <div class="container">
                 <div class="content[% " $mainclass" | html IF mainclass %]" role="main">

--- a/templates/web/base/header/css.html
+++ b/templates/web/base/header/css.html
@@ -8,4 +8,4 @@
 <![endif]-->
 <link rel="stylesheet" href="[% version('/vendor/OpenLayers/theme/default/style.css') %]">
 
-[% extra_css %]
+[% extra_css | safe %]

--- a/templates/web/base/header/title.html
+++ b/templates/web/base/header/title.html
@@ -1,4 +1,4 @@
 <title>
-    [% "$title :: " | html IF title %]
+    [% tprintf('%s :: ', title) IF title %]
     [% site_name -%]
 </title>

--- a/templates/web/base/header_opengraph.html
+++ b/templates/web/base/header_opengraph.html
@@ -1,5 +1,5 @@
         <meta property="og:url" content="[% c.cobrand.base_url %][% c.req.uri.path %]">
-        <meta property="og:title" content="[% title || site_name | html %]">
+        <meta property="og:title" content="[% title || site_name %]">
         <meta property="og:site_name" content="[% site_name %]">
         [% IF c.req.uri.path == '/' %]<meta property="og:description" content="[% loc('Report, view, and discuss local street-related problems.') %]">[% END %]
         <meta property="og:type" content="website">

--- a/templates/web/base/main_nav.html
+++ b/templates/web/base/main_nav.html
@@ -4,11 +4,11 @@
     SET ul_class="nav-menu nav-menu--main" UNLESS ul_class.defined;
 %]
 [% BLOCK navitem ~%]
-    <li [% liattrs %]>
+    <li [% liattrs | safe %]>
       [%~ IF c.req.uri.path == uri AND NOT always_url ~%]
-          <span [% attrs %]>[% label %]</span>
+          <span [% attrs | safe %]>[% label %]</span>
       [%~ ELSE ~%]
-          <a href="[% uri %][% suffix IF suffix %]" [% attrs %]>[% label %]</a>
+          <a href="[% uri %][% suffix IF suffix %]" [% attrs | safe %]>[% label %]</a>
       [%~ END ~%]
     </li>
 [%~ END %]

--- a/templates/web/base/maps/google-ol.html
+++ b/templates/web/base/maps/google-ol.html
@@ -6,7 +6,7 @@
 [% INCLUDE maps/openlayers.html %]
 [% UNLESS around_page %]
 <p class="sub-map-links" id="sub_map_links">
-     [% map_sub_links %]
+     [% map_sub_links | safe %]
 </p>
 [% END %]
 [% END %]

--- a/templates/web/base/maps/noscript_map.html
+++ b/templates/web/base/maps/noscript_map.html
@@ -1,23 +1,23 @@
 [% SET start = c.config.ADMIN_BASE_URL IF admin -%]
 <div class="noscript">
     <div id="[% nsm_prefix %]drag">
-        <[% map.img_type %]
+        <[% map.img_type | safe %]
             alt="NW map tile" id="[% nsm_prefix %]t2.2"
             name="tile_[% map.x_tile - 1 %].[% map.y_tile - 1 %]"
             src="[% map.tiles.0 %]"
             style="top:0; left:0;">
-        <[% map.img_type %]
+        <[% map.img_type | safe %]
             alt="NE map tile" id="[% nsm_prefix %]t2.3"
             name="tile_[% map.x_tile %].[% map.y_tile - 1 %]"
             src="[% map.tiles.1 %]"
             style="top:0px; left:256px;">
         <br>
-        <[% map.img_type %]
+        <[% map.img_type | safe %]
             alt="SW map tile" id="[% nsm_prefix %]t3.2"
             name="tile_[% map.x_tile - 1 %].[% map.y_tile %]"
             src="[% map.tiles.2 %]"
             style="top:256px; left:0;">
-        <[% map.img_type %]
+        <[% map.img_type | safe %]
             alt="SE map tile" id="[% nsm_prefix %]t3.3"
             name="tile_[% map.x_tile %].[% map.y_tile %]"
             src="[% map.tiles.3 %]"

--- a/templates/web/base/maps/noscript_map_wmts.html
+++ b/templates/web/base/maps/noscript_map_wmts.html
@@ -5,7 +5,7 @@
                 [%- FOR tile IN row -%]
                     [%- top_px = tile.row_offset * map.tile_size -%]
                     [%- left_px = tile.col_offset * map.tile_size %]
-                    <[% map.img_type %]
+                    <[% map.img_type | safe %]
                         class="square-map__tile"
                         alt="[% tile.alt %]"
                         id="[% nsm_prefix %]t[% tile.dotted_id %]"

--- a/templates/web/base/maps/openlayers.html
+++ b/templates/web/base/maps/openlayers.html
@@ -33,10 +33,13 @@
 <div id="map_box" aria-hidden="true">
     [% pre_map %]
     <div id="map">
-      [% DEFAULT noscript_map_template = 'maps/noscript_map.html' %]
-      [% INCLUDE $noscript_map_template js = 1 %]
+      [% IF noscript_map_template == 'maps/noscript_map_wmts.html' %]
+          [% INCLUDE 'maps/noscript_map_wmts.html' js = 1 %]
+      [% ELSE %]
+          [% INCLUDE 'maps/noscript_map.html' js = 1 %]
+      [% END %]
     </div>
     [% IF map.copyright %]
-    <div class="olControlAttribution" style="position: absolute;">[% map.copyright %]</div>
+    <div class="olControlAttribution" style="position: absolute;">[% map.copyright | safe %]</div>
     [% END %]
     <img id="loading-indicator" class="hidden" aria-hidden="true" src="/i/loading.svg" alt="Loading...">

--- a/templates/web/base/maps/wmts_config.html
+++ b/templates/web/base/maps/wmts_config.html
@@ -3,12 +3,12 @@
   fixmystreet.wmts_config = {
         'map_projection': '[% map.map_projection %]',
         'tile_dpi': [% map.tile_dpi %],
-        'tile_urls': [% map.tile_urls %],
+        'tile_urls': [% map.tile_urls | safe %],
         'tile_suffix': '[% map.tile_suffix %]',
-        'layer_names': [% map.layer_names %],
+        'layer_names': [% map.layer_names | safe %],
         'layer_style': '[% map.layer_style %]',
         'matrix_set': '[% map.matrix_set %]',
-        'scales': [% map.scales %],
+        'scales': [% map.scales | safe %],
         'origin_x': [% map.origin_x %],
         'origin_y': [% map.origin_y %]
   };

--- a/templates/web/base/my/my.html
+++ b/templates/web/base/my/my.html
@@ -6,7 +6,7 @@
 %]
 
 [% IF problems.size %]
-    [% map_html %]
+    [% map_html | safe %]
     </div>
     <div id="map_sidebar">
         <div id="side">

--- a/templates/web/base/my/planned.html
+++ b/templates/web/base/my/planned.html
@@ -6,7 +6,7 @@
 %]
 
 [% IF problems.size %]
-    [% map_html %]
+    [% map_html | safe %]
     </div>
     <div id="map_sidebar">
         <div id="side">

--- a/templates/web/base/pagination.html
+++ b/templates/web/base/pagination.html
@@ -1,4 +1,4 @@
-[% IF pager.total_entries > 1 %]
+[% IF pager AND pager.total_entries > 1 %]
     <p class="pagination" data-page="[% pager.current_page | html %]">
         [% IF pager.previous_page %]
             <a class="prev" href="[% c.uri_with({ $param => pager.previous_page, ajax => undefined }) %][% '#' _ hash IF hash %]">[% loc('Previous') %]</a>

--- a/templates/web/base/questionnaire/index.html
+++ b/templates/web/base/questionnaire/index.html
@@ -5,7 +5,7 @@
     INCLUDE 'header.html', title = loc('Questionnaire');
 %]
 
-[% map_html %]
+[% map_html | safe %]
 
 </div>
 
@@ -23,7 +23,9 @@
 
 [% IF errors %]
 <ul class="error questionnaire-errors">
-<li>[% errors.join("</li>\n<li>") %]</li>
+  [% FOR error IN errors %]
+    <li>[% error %]</li>
+  [% END %]
 </ul>
 [% END %]
 

--- a/templates/web/base/report/_item.html
+++ b/templates/web/base/report/_item.html
@@ -98,12 +98,12 @@
     [%# We don't want to output shortlist on report page (in duplicate list) %]
   [% ELSIF page == 'around' ~%]
     [%# The around page list is already contained within the new report form %]
-    [% item_action.replace('("shortlist-[^"]*)', '$1-' _ problem.id) %]
+    [% item_action.replace('("shortlist-[^"]*)', '$1-' _ problem.id) | safe %]
   [% ELSE ~%]
     <form method="post" action="/my/planned/change">
         <input type="hidden" name="id" value="[% problem.id %]">
         <input type="hidden" name="token" value="[% csrf_token %]">
-        [% item_action %]
+        [% item_action | safe %]
     </form>
   [% END ~%]
 [% END %]

--- a/templates/web/base/report/_main.html
+++ b/templates/web/base/report/_main.html
@@ -48,7 +48,7 @@ can_moderate_title = c.user.can_moderate_title(problem, can_moderate)
   [% END %]
 
   [% FOR error IN moderate_errors %]
-    <p class="form-error js-moderation-error">[% error %]</p>
+    <p class="form-error js-moderation-error">[% error | safe %]</p>
   [% END %]
 
   [% IF can_moderate_title %]

--- a/templates/web/base/report/display.html
+++ b/templates/web/base/report/display.html
@@ -3,14 +3,14 @@
     PROCESS "report/photo-js.html";
     PROCESS "maps/${map.type}.html";
 
-    problem_title = problem.title_safe _ ' - ' _ loc('Viewing a problem');
+    problem_title = tprintf('%s - %s', problem.title_safe, loc('Viewing a problem'));
     INCLUDE 'header.html'
         title = problem_title
         rss = [ tprintf(loc('Updates to this problem, %s', "%s is the site name"), site_name), "/rss/$problem.id" ]
         robots = 'index, nofollow';
 %]
 
-[% map_html %]
+[% map_html | safe %]
 </div>
 
 <div id="map_sidebar">
@@ -66,7 +66,7 @@
 
   </div>
 
-  [% second_column %]
+  [% second_column | safe %]
 
 [% IF two_column_sidebar %]
   </div>

--- a/templates/web/base/report/new/category_extras.html
+++ b/templates/web/base/report/new/category_extras.html
@@ -14,7 +14,7 @@
         <p class="form-section-description">
           [% tprintf(
             loc('Help <strong>%s</strong> resolve your problem quicker, by providing some extra detail. This extra information will not be published online.'),
-            list_of_names.join( '</strong>' _ loc(' or ') _ '<strong>' )
+            mark_safe(list_of_names.join( '</strong>' _ loc(' or ') _ '<strong>' ))
           ); %]
         </p>
         [% INCLUDE 'report/new/category_extras_fields.html' metas=category_extras.$category %]

--- a/templates/web/base/report/new/category_extras_fields.html
+++ b/templates/web/base/report/new/category_extras_fields.html
@@ -8,7 +8,7 @@
 
   [% ELSIF meta.variable != 'false' || NOT hide_notices %]
 
-      <label for="[% cat_prefix %]form_[% meta_name %]">[% meta.description OR meta.code %]</label>
+      <label for="[% cat_prefix %]form_[% meta_name %]">[% (meta.description OR meta.code) | safe %]</label>
       [% TRY %][% INCLUDE 'report/new/_category_extra_field_notice.html' %][% CATCH file %][% END %]
       [% IF field_errors.$x_meta_name %]
       <p class='form-error'>[% field_errors.$x_meta_name %]</p>

--- a/templates/web/base/report/new/category_wrapper.html
+++ b/templates/web/base/report/new/category_wrapper.html
@@ -21,7 +21,7 @@
 
 [% IF disable_form_message %]
 <div id="js-category-stopper" class="box-warning" role="alert" aria-live="assertive">
-    [% disable_form_message %]
+    [% disable_form_message | safe %]
 </div>
 [% ELSE %]
 <div id="js-post-category-messages" class="js-hide-if-invalid-category_extras">

--- a/templates/web/base/report/new/councils_text_all.html
+++ b/templates/web/base/report/new/councils_text_all.html
@@ -6,14 +6,14 @@
 
     tprintf(
         loc('These will be sent to <strong>%s</strong> and also published online for others to see, in accordance with our <a href="%s">privacy policy</a>.'),
-        list_of_names.join( '</strong>' _ loc(' or ') _ '<strong>' ), c.cobrand.privacy_policy_url
+        mark_safe(list_of_names.join( '</strong>' _ loc(' or ') _ '<strong>' )), c.cobrand.privacy_policy_url
     );
 
 ELSE;
 
     tprintf(
         loc('These will be sent to <strong>%s</strong> but not published online.'),
-        list_of_names.join( '</strong>' _ loc(' or ') _ '<strong>' )
+        mark_safe(list_of_names.join( '</strong>' _ loc(' or ') _ '<strong>' ))
     );
 
 END %]

--- a/templates/web/base/report/new/fill_in_details.html
+++ b/templates/web/base/report/new/fill_in_details.html
@@ -30,7 +30,7 @@
     <input type="hidden" name="longitude" id="fixmystreet.longitude" value="[% longitude | html %]">
 
   [% IF report.used_map %]
-    [% map_html %]
+    [% map_html | safe %]
     </div>
     <div id="map_sidebar">
         <div id="side-form">

--- a/templates/web/base/report/new/fill_in_details_form.html
+++ b/templates/web/base/report/new/fill_in_details_form.html
@@ -26,7 +26,7 @@
     <p class="form-error">[% loc('Sorry, we could not log you in. Please fill in the form below.') %]</p>
 [% END %]
 
-[% sidebar_html %]
+[% sidebar_html | safe %]
 
 [% INCLUDE 'errors.html' %]
 

--- a/templates/web/base/report/new/login_success_form.html
+++ b/templates/web/base/report/new/login_success_form.html
@@ -2,7 +2,7 @@
 
 <p class='form-success'>[% loc('You have successfully signed in; please check and confirm your details are accurate:') %]</p>
 
-[% sidebar_html %]
+[% sidebar_html | safe %]
 
 [% INCLUDE 'errors.html' %]
 

--- a/templates/web/base/report/new/oauth_email_form.html
+++ b/templates/web/base/report/new/oauth_email_form.html
@@ -5,7 +5,7 @@
     [% loc('We need your email address, please give it below.') %]
 </p>
 
-[% sidebar_html %]
+[% sidebar_html | safe %]
 
 [% INCLUDE 'errors.html' %]
 

--- a/templates/web/base/reports/_list-filters.html
+++ b/templates/web/base/reports/_list-filters.html
@@ -23,7 +23,7 @@
 [% END %]
 
         <p class="report-list-filters">
-            [% tprintf(loc('<label for="statuses">Show</label> %s reports <label for="filter_categories">about</label> %s', "The first %s is a dropdown of all/fixed/etc, the second is a dropdown of categories"), select_status, select_category) %]
+            [% tprintf(loc('<label for="statuses">Show</label> %s reports <label for="filter_categories">about</label> %s', "The first %s is a dropdown of all/fixed/etc, the second is a dropdown of categories"), mark_safe(select_status), mark_safe(select_category)) %]
             <input type="submit" name="filter_update" value="[% loc('Go') %]">
         </p>
 

--- a/templates/web/base/reports/body.html
+++ b/templates/web/base/reports/body.html
@@ -32,7 +32,7 @@
         rss = [ tprintf(loc('Problems within %s, %s', "First %s is the body name, second %s the site name"), name, site_name), rss_url ]
 %]
 
-[% map_html %]
+[% map_html | safe %]
 
 [% IF c.user && c.user.has_body_permission_to('planned_reports') %]
   <p class="sub-map-links" id="sub_map_links">

--- a/templates/web/base/reports/index.html
+++ b/templates/web/base/reports/index.html
@@ -25,7 +25,7 @@
         <h2>[% loc('All time') %]</h2>
         <div class="labelled-line-chart">
             <canvas id="chart-all-reports" width="600" height="300"
-                data-labels="[&quot;[% problem_periods.join('&quot;,&quot;') %]&quot;]"
+                data-labels="[[% FOR period IN problem_periods %]&quot;[% period %]&quot;[% IF NOT loop.last %],[% END %][% END %]]"
                 data-values-reports="[[% problems_reported_by_period.join(',') %]]"
                 data-values-fixed="[[% problems_fixed_by_period.join(',') %]]"
                 ></canvas>

--- a/templates/web/fiksgatami/header.html
+++ b/templates/web/fiksgatami/header.html
@@ -28,7 +28,7 @@
                 </div>
             </header>
 
-            [% pre_container_extra %]
+            [% pre_container_extra | safe %]
 
             <div class="container">
                 <div class="content[% " $mainclass" | html IF mainclass %]" role="main">

--- a/templates/web/fixmystreet.com/header/css.html
+++ b/templates/web/fixmystreet.com/header/css.html
@@ -34,4 +34,4 @@ document.getElementById('preload_base_css').onload = function(){this.onload=null
     <link rel="stylesheet" href="[% layout_css %]">
 <![endif]-->
 
-[% extra_css %]
+[% extra_css | safe %]

--- a/templates/web/hart/header.html
+++ b/templates/web/hart/header.html
@@ -34,7 +34,7 @@
                 </div>
             </header>
 
-            [% pre_container_extra %]
+            [% pre_container_extra | safe %]
 
             <div class="container">
                 <div class="content[% " $mainclass" | html IF mainclass %]" role="main">

--- a/templates/web/oxfordshire/header.html
+++ b/templates/web/oxfordshire/header.html
@@ -38,7 +38,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
             <div class="nav-spacer"></div>
 
-            [% pre_container_extra %]
+            [% pre_container_extra | safe %]
 
             <div class="container">
                 <div class="content[% " $mainclass" | html IF mainclass %]" role="main">

--- a/templates/web/oxfordshire/main_nav.html
+++ b/templates/web/oxfordshire/main_nav.html
@@ -4,8 +4,8 @@
     SET ul_class="nav-menu nav-menu--main" UNLESS ul_class.defined;
 %]
 [% BLOCK navitem ~%]
-    <li [% liattrs %]>
-        <a href="[% uri %][% suffix IF suffix %]" [% attrs %]>[% label %]</a>
+    <li [% liattrs | safe %]>
+        <a href="[% uri %][% suffix IF suffix %]" [% attrs | safe %]>[% label %]</a>
     </li>
 [%~ END %]
 

--- a/templates/web/stevenage/header.html
+++ b/templates/web/stevenage/header.html
@@ -24,7 +24,7 @@
                     <a href="#main-nav" id="nav-link">Main Navigation</a>
                 </div>
             </header>
-            [% pre_container_extra %]
+            [% pre_container_extra | safe %]
 
             <div class="container">
                 <div class="content[% " $mainclass" | html IF mainclass %]" role="main">

--- a/templates/web/zurich/admin/bodies/body.html
+++ b/templates/web/zurich/admin/bodies/body.html
@@ -35,7 +35,7 @@
 
   [% IF errors %]
     <div class="fms-admin-warning">
-        [% errors.values.join('<br>') %]
+        [% FOR error IN errors.values %][% error %][% IF NOT loop.last %]<br>[% END %][% END %]
     </div>
   [% END %]
 

--- a/templates/web/zurich/admin/report_edit-sdm.html
+++ b/templates/web/zurich/admin/report_edit-sdm.html
@@ -7,7 +7,7 @@
     PROCESS 'admin/report_blocks.html'
 -%]
 
-[% map_html %]
+[% map_html | safe %]
 </div>
 
 <div id="map_sidebar">

--- a/templates/web/zurich/admin/reports/edit.html
+++ b/templates/web/zurich/admin/reports/edit.html
@@ -7,7 +7,7 @@
     PROCESS 'admin/report_blocks.html'
 -%]
 
-[% map_html %]
+[% map_html | safe %]
 </div>
 
 <div id="map_sidebar">

--- a/templates/web/zurich/header.html
+++ b/templates/web/zurich/header.html
@@ -79,6 +79,6 @@
                   [% INCLUDE 'nav_over_content.html' %]
                 [% END %]
 
-                [% pre_container_extra %]
+                [% pre_container_extra | safe %]
 
         <!-- [% INCLUDE 'debug_header.html' %] -->

--- a/templates/web/zurich/maps/noscript_map.html
+++ b/templates/web/zurich/maps/noscript_map.html
@@ -6,7 +6,7 @@
                 [%- FOR tile IN row -%]
                     [%- top_px = tile.row_offset * map.tile_size -%]
                     [%- left_px = tile.col_offset * map.tile_size %]
-                    <[% map.img_type %]
+                    <[% map.img_type | safe %]
                         class="square-map__tile"
                         alt="[% tile.alt %]"
                         id="[% nsm_prefix %]t[% tile.dotted_id %]"
@@ -23,23 +23,23 @@
 [% ELSE %]
 <div class="noscript">
     <div id="[% nsm_prefix %]drag">
-        <[% map.img_type %]
+        <[% map.img_type | safe %]
             alt="NW map tile" id="[% nsm_prefix %]t2.2"
             name="tile_[% map.x_tile - 1 %].[% map.y_tile - 1 %]"
             src="[% map.tiles.0 %]"
             style="top:0; left:0;">
-        <[% map.img_type %]
+        <[% map.img_type | safe %]
             alt="NE map tile" id="[% nsm_prefix %]t2.3"
             name="tile_[% map.x_tile %].[% map.y_tile - 1 %]"
             src="[% map.tiles.1 %]"
             style="top:0px; left:256px;">
         <br>
-        <[% map.img_type %]
+        <[% map.img_type | safe %]
             alt="SW map tile" id="[% nsm_prefix %]t3.2"
             name="tile_[% map.x_tile - 1 %].[% map.y_tile %]"
             src="[% map.tiles.2 %]"
             style="top:256px; left:0;">
-        <[% map.img_type %]
+        <[% map.img_type | safe %]
             alt="SE map tile" id="[% nsm_prefix %]t3.3"
             name="tile_[% map.x_tile %].[% map.y_tile %]"
             src="[% map.tiles.3 %]"

--- a/templates/web/zurich/maps/zurich.html
+++ b/templates/web/zurich/maps/zurich.html
@@ -7,7 +7,7 @@
 [% INCLUDE maps/wmts_config.html %]
 [% UNLESS around_page %]
 <p class="sub-map-links" id="sub_map_links">
-     [% map_sub_links %]
+     [% map_sub_links | safe %]
 </p>
 [% END %]
 [% END %]

--- a/templates/web/zurich/report/new/fill_in_details_form.html
+++ b/templates/web/zurich/report/new/fill_in_details_form.html
@@ -1,4 +1,4 @@
-[% sidebar_html %]
+[% sidebar_html | safe %]
 
 <div id="report-a-problem-main">
     <h1>[% loc('Reporting a problem') %]</h1>

--- a/templates/web/zurich/reports/index.html
+++ b/templates/web/zurich/reports/index.html
@@ -5,7 +5,7 @@
     INCLUDE 'header.html',
         title = loc('Summary reports');
 %]
-[% map_html %]
+[% map_html | safe %]
 </div>
 
 <div id="map_sidebar">


### PR DESCRIPTION
This changes the templating code to automatically mark for escape any variable fetched from the stash, unless it is marked as safe with a filter. It is not totally perfect - if something is marked as safe, it will not go back to unsafe if you concatenate unsafe data on to it [1] - but does I feel provide a more secure model than the reverse.

My main concern is that this means that strings assigned to variables in the Perl code (error messages is the main one I can think of, but I'm sure there are others) that contain HTML entities - most likely translations, I can't see any in the base string set - will now be having those entities escaped again in the HTML (they'd be okay if fetched directly in the template as translations in the template are marked as safe). There's no need to use entities in translations, they could use UTF-8 characters directly, so a fix would be to make sure the translation files don't use entities anywhere. 

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

[1] I couldn't think of an easy way to do this - the concatenation is overloaded, so you could say that if a SafeString is concatenated with something, return an Unsafe string object - but the underlying template code uses concatenation for its actual output as well as concatenating variables within template commands, so I don't see how it can tell the difference. It didn't seem likely as something that would be done, there are no current uses in the code I could find, and it's easy to say that safe should only ever be the last/only filter used on something.