### PR TITLE
Group categories on map filters & admin

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Templates.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Templates.pm
@@ -69,8 +69,10 @@ sub edit : Path : Args(2) {
         category => $_->category_display,
         active => $active_contacts{$_->id},
         email => $_->email,
+        group => $_->get_extra_metadata('group') // '',
     } } @live_contacts;
     $c->stash->{contacts} = \@all_contacts;
+    $c->forward('/report/stash_category_groups', [ \@all_contacts, 1 ]) if $c->cobrand->enable_category_groups;
 
     # bare block to use 'last' if form is invalid.
     if ($c->req->method eq 'POST') { {

--- a/perllib/FixMyStreet/App/Controller/Admin/Users.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Users.pm
@@ -394,8 +394,10 @@ sub edit : Chained('user') : PathPart('') : Args(0) {
             id => $_->id,
             category => $_->category,
             active => $active_contacts{$_->id},
+            group => $_->get_extra_metadata('group') // '',
         } } @live_contacts;
         $c->stash->{contacts} = \@all_contacts;
+        $c->forward('/report/stash_category_groups', [ \@all_contacts, 1 ]) if $c->cobrand->enable_category_groups;
     }
 
     # this goes after in case we've delete any alerts

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -661,6 +661,33 @@ sub check_has_permission_to : Private {
     return \%permissions;
 };
 
+
+sub stash_category_groups : Private {
+    my ( $self, $c, $contacts, $combine_multiple ) = @_;
+
+    my %category_groups = ();
+    for my $category (@$contacts) {
+        my $group = $category->{group} // $category->get_extra_metadata('group') // [''];
+        # this could be an array ref or a string
+        my @groups = ref $group eq 'ARRAY' ? @$group : ($group);
+        if (scalar @groups > 1 && $combine_multiple) {
+            @groups = sort @groups;
+            $category->{group} = \@groups;
+            push( @{$category_groups{_('Multiple Groups')}}, $category );
+        } else {
+            push( @{$category_groups{$_}}, $category ) for @groups;
+        }
+    }
+
+    my @category_groups = ();
+    for my $group ( grep { $_ ne _('Other') && $_ ne _('Multiple Groups') } sort keys %category_groups ) {
+        push @category_groups, { name => $group, categories => $category_groups{$group} };
+    }
+    push @category_groups, { name => _('Other'), categories => $category_groups{_('Other')} } if ($category_groups{_('Other')});
+    push @category_groups, { name => _('Multiple Groups'), categories => $category_groups{_('Multiple Groups')} } if ($category_groups{_('Multiple Groups')});
+    $c->stash->{category_groups}  = \@category_groups;
+}
+
 __PACKAGE__->meta->make_immutable;
 
 1;

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -771,22 +771,7 @@ sub setup_categories_and_bodies : Private {
     $c->stash->{missing_details_bodies} = \@missing_details_bodies;
     $c->stash->{missing_details_body_names} = \@missing_details_body_names;
 
-    if ( $c->cobrand->enable_category_groups ) {
-        my %category_groups = ();
-        for my $category (@category_options) {
-            my $group = $category->{group} // $category->get_extra_metadata('group') // [''];
-            # this could be an array ref or a string
-            my @groups = ref $group eq 'ARRAY' ? @$group : ($group);
-            push( @{$category_groups{$_}}, $category ) for @groups;
-        }
-
-        my @category_groups = ();
-        for my $group ( grep { $_ ne _('Other') } sort keys %category_groups ) {
-            push @category_groups, { name => $group, categories => $category_groups{$group} };
-        }
-        push @category_groups, { name => _('Other'), categories => $category_groups{_('Other')} } if ($category_groups{_('Other')});
-        $c->stash->{category_groups}  = \@category_groups;
-    }
+    $c->forward('/report/stash_category_groups', [ \@category_options ]) if $c->cobrand->enable_category_groups;
 }
 
 sub setup_report_extra_fields : Private {

--- a/templates/web/base/admin/category-checkboxes.html
+++ b/templates/web/base/admin/category-checkboxes.html
@@ -1,12 +1,4 @@
-<fieldset>
-  <legend>
-  [% IF hint %]
-    <div class="admin-hint">
-      <p>[% hint %]</p>
-    </div>
-  [% END %]
-    [% loc('Categories:') %]
-  </legend>
+[% BLOCK checkboxes %]
   <ul class="no-bullets no-margin">
     <li>
       [% loc('Select:') %]
@@ -18,8 +10,31 @@
         <label class="inline" title="[% contact.email | html %]">
           <input type="checkbox" name="contacts[[% contact.id %]]" [% 'checked' IF contact.active %]/>
           [% contact.category %]
+          [% IF contact.group.size > 1 %]<small>([% contact.group.join('; ') | html %])</small>[% END %]
         </label>
       </li>
     [% END %]
   </ul>
+[% END %]
+<fieldset>
+  <legend>
+  [% IF hint %]
+    <div class="admin-hint">
+      <p>[% hint %]</p>
+    </div>
+  [% END %]
+    [% loc('Categories:') %]
+  </legend>
+
+  [% IF category_groups %]
+    [% FOR group IN category_groups %]
+      <h3>[% ( group.name OR loc('No Group') ) | html %]</h3>
+      [% IF group.name == loc("Multiple Groups") %]
+        <small>[% loc('These categories appear in more than one group:') %]</small>
+      [% END %]
+      [% INCLUDE checkboxes contacts=group.categories %]
+    [% END %]
+  [% ELSE %]
+    [% INCLUDE checkboxes contacts=contacts %]
+  [% END %]
 </fieldset>


### PR DESCRIPTION
Adds category groups to the user and template editing forms in the admin:

<img width="626" alt="image" src="https://user-images.githubusercontent.com/4776/69739938-6e02c880-1130-11ea-9f6e-80c5cf9ab3cd.png">

For https://github.com/mysociety/fixmystreet/issues/2702