### PR TITLE
[UK] Updates disallowed template work out message.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -256,10 +256,8 @@ sub about_hook {
     }
 }
 
-sub updates_disallowed {
-    my $self = shift;
-    my ($problem) = @_;
-    my $c = $self->{c};
+sub updates_disallowed_config {
+    my ($self, $problem) = @_;
 
     # This is a hash of council name to match, and what to do
     my $cfg = $self->feature('updates_allowed') || {};
@@ -273,6 +271,15 @@ sub updates_disallowed {
             last;
         }
     }
+    return ($type, $body);
+}
+
+sub updates_disallowed {
+    my $self = shift;
+    my ($problem) = @_;
+    my $c = $self->{c};
+
+    my ($type, $body) = $self->updates_disallowed_config($problem);
 
     if ($type eq 'none') {
         return 1;

--- a/t/cobrand/isleofwight.t
+++ b/t/cobrand/isleofwight.t
@@ -104,6 +104,7 @@ subtest "only original reporter can comment" => sub {
     FixMyStreet::override_config {
         MAPIT_URL => 'http://mapit.uk/',
         ALLOWED_COBRANDS => 'isleofwight',
+        COBRAND_FEATURES => { updates_allowed => { isleofwight => 'reporter' } },
     }, sub {
         $mech->get_ok('/report/' . $reports[0]->id);
         $mech->content_contains('Only the original reporter may leave updates');

--- a/templates/web/fixmystreet-uk-councils/report/_updates_disallowed_message.html
+++ b/templates/web/fixmystreet-uk-councils/report/_updates_disallowed_message.html
@@ -1,0 +1,17 @@
+[% cfg = c.cobrand.feature("updates_allowed") ~%]
+[% IF cfg.match('reporter') AND (NOT cfg.match('open') OR problem.is_open) %]
+    <p>
+        Only the original reporter may leave updates.
+        [% IF NOT c.user_exists %]
+            If you made the original report please
+            <a href="/auth?r=report/[% problem.id %]">log in</a>
+            to leave an update.
+        [% END %]
+    </p>
+[% ELSE %]
+    <p>[% loc('This report is now closed to updates.') %]
+       [% tprintf(loc('You can <a href="%s">make a new report in the same location</a>.'),
+              c.uri_for( '/report/new', { longitude = longitude, latitude = latitude } )
+          ) %]
+    </p>
+[% END %]

--- a/templates/web/fixmystreet.com/report/_updates_disallowed_message.html
+++ b/templates/web/fixmystreet.com/report/_updates_disallowed_message.html
@@ -1,0 +1,17 @@
+[% cfg = c.cobrand.updates_disallowed_config(problem).0 ~%]
+[% IF cfg.match('reporter') AND (NOT cfg.match('open') OR problem.is_open) %]
+    <p>
+        Only the original reporter may leave updates.
+        [% IF NOT c.user_exists %]
+            If you made the original report please
+            <a href="/auth?r=report/[% problem.id %]">log in</a>
+            to leave an update.
+        [% END %]
+    </p>
+[% ELSE %]
+    <p>[% loc('This report is now closed to updates.') %]
+       [% tprintf(loc('You can <a href="%s">make a new report in the same location</a>.'),
+              c.uri_for( '/report/new', { longitude = longitude, latitude = latitude } )
+          ) %]
+    </p>
+[% END %]

--- a/templates/web/isleofwight/report/_updates_disallowed_message.html
+++ b/templates/web/isleofwight/report/_updates_disallowed_message.html
@@ -1,8 +1,0 @@
-<p>
-    Only the original reporter may leave updates.
-    [% IF NOT c.user_exists %]
-        If you made the original report please
-        <a href="/auth?r=report/[% problem.id %]">log in</a>
-        to leave an update.
-    [% END %]
-</p>


### PR DESCRIPTION
This means you don't have to make a new template each time a council adds a disallowed option. [skip changelog]