### PR TITLE
[Peterborough] Add link tag referencing custom favicon.ico

### DIFF
--- a/templates/web/peterborough/header_extra.html
+++ b/templates/web/peterborough/header_extra.html
@@ -1,2 +1,3 @@
 [% INCLUDE 'tracking_code.html' %]
 <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:900,400,700,300,100">
+<link rel="shortcut icon" type="image/x-icon" href="/cobrands/peterborough/favicon.ico">


### PR DESCRIPTION
Forgot to actually reference the favicon.ico file in the original PR, oops!

Follows on from https://github.com/mysociety/fixmystreet/pull/2785.

Part of https://github.com/mysociety/fixmystreet-freshdesk/issues/103

<!-- [skip changelog] -->