### PR TITLE
[TfL] Server-side red route lookup

### DIFF
--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -86,11 +86,7 @@ sub munge_reports_categories_list {
 sub munge_report_new_category_list {
     my ($self, $options, $contacts, $extras) = @_;
 
-    # No TfL Traffic Lights category in Hounslow
     my %bodies = map { $_->body->name => $_->body } @$contacts;
-    if ( $bodies{'Hounslow Borough Council'} ) {
-        @$options = grep { ($_->{category} || $_->category) !~ /^Traffic lights$/i } @$options;
-    }
 
     if ( $bodies{'Isle of Wight Council'} ) {
         my $user = $self->{c}->user;
@@ -105,6 +101,13 @@ sub munge_report_new_category_list {
         my $seen = { map { $_->category => 1 } @$contacts };
         @$options = grep { my $c = ($_->{category} || $_->category); $c =~ 'Pick a category' || $seen->{ $c } } @$options;
     }
+
+    if ( $bodies{'TfL'} ) {
+        # Presented categories vary if we're on/off a red route
+        my $tfl = FixMyStreet::Cobrand->get_class_for_moniker( 'tfl' )->new({ c => $self->{c} });
+        $tfl->munge_red_route_categories($options, $contacts);
+    }
+
 }
 
 sub munge_load_and_group_problems {

--- a/perllib/FixMyStreet/Cobrand/Westminster.pm
+++ b/perllib/FixMyStreet/Cobrand/Westminster.pm
@@ -122,7 +122,7 @@ sub lookup_site_code_config {
 }
 
 sub _fetch_features_url {
-    my ($self, $cfg, $w, $s, $e, $n) = @_;
+    my ($self, $cfg) = @_;
 
     # Westminster's asset proxy has a slightly different calling style to
     # a standard WFS server.
@@ -132,7 +132,7 @@ sub _fetch_features_url {
         outSR => "27700",
         f => "geojson",
         outFields => $cfg->{property},
-        geometry => "$w,$s,$e,$n",
+        geometry => $cfg->{bbox},
     );
 
     return $cfg->{proxy_url} . "?" . $uri->as_string;

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -39,6 +39,7 @@ my @PLACES = (
     [ 'LE15 0GJ', 52.670447, -0.727877, 2600, 'Rutland County Council', 'CTY'],
     [ 'BR1 3UH', 51.4021, 0.01578, 2482, 'Bromley Council', 'LBO' ],
     [ 'BR1 3UH', 51.402096, 0.015784, 2482, 'Bromley Council', 'LBO' ],
+    [ 'BR1 3EF', 51.4039, 0.018697, 2482, 'Bromley Council', 'LBO' ],
     [ 'NN1 1NS', 52.236251, -0.892052, 2234, 'Northamptonshire County Council', 'CTY', 2397, 'Northampton Borough Council', 'DIS' ],
     [ 'NN1 2NS', 52.238301, -0.889992, 2234, 'Northamptonshire County Council', 'CTY', 2397, 'Northampton Borough Council', 'DIS' ],
     [ '?', 52.238827, -0.894970, 2234, 'Northamptonshire County Council', 'CTY', 2397, 'Northampton Borough Council', 'DIS' ],

--- a/t/Mock/Tilma.pm
+++ b/t/Mock/Tilma.pm
@@ -1,0 +1,39 @@
+package t::Mock::Tilma;
+
+use JSON::MaybeXS;
+use Web::Simple;
+
+has json => (
+    is => 'lazy',
+    default => sub {
+        JSON->new->utf8->pretty->allow_blessed->convert_blessed;
+    },
+);
+
+sub dispatch_request {
+    my $self = shift;
+
+    sub (GET + /mapserver/tfl + ?*) {
+        my ($self, $args) = @_;
+        my $features = [];
+        if ($args->{Filter} =~ /540512,169141/) {
+            $features = [
+                { type => "Feature", properties => { HA_ID => "19" }, geometry => { type => "Polygon", coordinates => [ [
+                    [ 539408.94, 170607.58 ],
+                    [ 539432.81, 170627.93 ],
+                    [ 539437.24, 170623.48 ],
+                    [ 539408.94, 170607.58 ],
+                ] ] } } ];
+        }
+        my $json = mySociety::Locale::in_gb_locale {
+            $self->json->encode({
+                type => "FeatureCollection",
+                crs => { type => "name", properties => { name => "urn:ogc:def:crs:EPSG::27700" } },
+                features => $features,
+            });
+        };
+        return [ 200, [ 'Content-Type' => 'application/json' ], [ $json ] ];
+    },
+}
+
+__PACKAGE__->run_if_script;

--- a/t/app/controller/admin/templates.t
+++ b/t/app/controller/admin/templates.t
@@ -347,7 +347,7 @@ subtest "TfL cobrand only shows TfL templates" => sub {
 
 subtest "Bromley cobrand only shows Bromley templates" => sub {
     FixMyStreet::override_config {
-        ALLOWED_COBRANDS => [ 'bromley' ],
+        ALLOWED_COBRANDS => [ 'bromley', 'tfl' ],
     }, sub {
         $report->update({ category => $bromleycontact->category, bodies_str => $bromley->id });
         $mech->log_in_ok( $bromleyuser->email );

--- a/t/cobrand/hounslow.t
+++ b/t/cobrand/hounslow.t
@@ -75,16 +75,6 @@ subtest "it shows the right things on an /around page" => sub {
     };
 };
 
-subtest "does not show TfL traffic lights category" => sub {
-    FixMyStreet::override_config {
-        MAPIT_URL => 'http://mapit.uk/',
-        ALLOWED_COBRANDS => 'fixmystreet',
-    }, sub {
-        my $json = $mech->get_ok_json('/report/new/ajax?latitude=51.482286&longitude=-0.328163');
-        is $json->{by_category}{"Traffic lights"}, undef;
-    };
-};
-
 subtest "Shows external ID on report page to staff users only" => sub {
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => 'hounslow',


### PR DESCRIPTION
The app can't distinguish between reports being made on red routes or not, so this PR makes the determination server side and returns the appropriate categories in the `/report/new/ajax` call. This fixes the app and also updates the website to use the same method.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1716

[skip changelog]