### PR TITLE
[TfL] Display of not responsible state

### DIFF
--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -278,7 +278,11 @@ sub problem_state_display {
     return '' unless $state;
 
     my $cobrand_name = $c->cobrand->moniker;
-    $cobrand_name = 'bromley' if $self->problem->to_body_named('Bromley');
+    my $names = join(',,', @{$self->problem->body_names});
+    if ($names =~ /(Bromley|Isle of Wight|TfL)/) {
+        ($cobrand_name = lc $1) =~ s/ //g;
+    }
+
     return FixMyStreet::DB->resultset("State")->display($state, 1, $cobrand_name);
 }
 

--- a/perllib/FixMyStreet/DB/ResultSet/State.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/State.pm
@@ -1,6 +1,7 @@
 package FixMyStreet::DB::ResultSet::State;
 use base 'DBIx::Class::ResultSet';
 
+use utf8;
 use strict;
 use warnings;
 use Memcached;
@@ -74,7 +75,8 @@ sub display {
     return $unchanging->{$label} if $unchanging->{$label};
     if ($cobrand && $label eq 'not responsible') {
         return 'third party responsibility' if $cobrand eq 'bromley';
-        return "not Island Roads' responsibility" if $cobrand eq 'isleofwight';
+        return "not Island Roads’ responsibility" if $cobrand eq 'isleofwight';
+        return "not TfL’s responsibility" if $cobrand eq 'tfl';
         return _("not the council's responsibility");
     }
     if ($cobrand && $cobrand eq 'oxfordshire' && $label eq 'unable to fix') {

--- a/t/cobrand/isleofwight.t
+++ b/t/cobrand/isleofwight.t
@@ -1,3 +1,4 @@
+use utf8;
 use CGI::Simple;
 use DateTime;
 use Test::MockModule;
@@ -425,7 +426,7 @@ subtest "check not responsible as correct text" => sub {
         $mech->get_ok('/report/' . $p->id);
     };
 
-    $mech->content_contains("not Island Roads&#39; responsibility", "not reponsible message contains correct text");
+    $mech->content_contains("not Island Roads’ responsibility", "not reponsible message contains correct text");
     $p->comments->delete;
     $p->delete;
 };

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -813,6 +813,19 @@ FixMyStreet::override_config {
         $staffuser->unset_extra_metadata('2fa_secret');
         $staffuser->update;
     };
+
+    subtest "check not responsible as correct text" => sub {
+        my ($p) = $mech->create_problems_for_body(1, $body->id, 'NotResp');
+        my $c = FixMyStreet::DB->resultset('Comment')->create({
+            problem => $p, user => $p->user, anonymous => 't', text => 'Update text',
+            problem_state => 'not responsible', state => 'confirmed', mark_fixed => 0,
+            confirmed => DateTime->now(),
+        });
+        $mech->get_ok('/report/' . $p->id);
+        $mech->content_contains("not TfL’s responsibility", "not reponsible message contains correct text");
+        $p->comments->delete;
+        $p->delete;
+    };
 };
 
 FixMyStreet::override_config {

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -813,19 +813,27 @@ FixMyStreet::override_config {
         $staffuser->unset_extra_metadata('2fa_secret');
         $staffuser->update;
     };
+};
 
-    subtest "check not responsible as correct text" => sub {
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => [ 'fixmystreet', 'tfl' ],
+    MAPIT_URL => 'http://mapit.uk/'
+}, sub {
+    foreach (qw(tfl.fixmystreet.com fixmystreet.com)) {
+        $mech->host($_);
         my ($p) = $mech->create_problems_for_body(1, $body->id, 'NotResp');
         my $c = FixMyStreet::DB->resultset('Comment')->create({
             problem => $p, user => $p->user, anonymous => 't', text => 'Update text',
             problem_state => 'not responsible', state => 'confirmed', mark_fixed => 0,
             confirmed => DateTime->now(),
         });
-        $mech->get_ok('/report/' . $p->id);
-        $mech->content_contains("not TfL’s responsibility", "not reponsible message contains correct text");
+        subtest "check not responsible as correct text on $_" => sub {
+            $mech->get_ok('/report/' . $p->id);
+            $mech->content_contains("not TfL’s responsibility", "not reponsible message contains correct text");
+        };
         $p->comments->delete;
         $p->delete;
-    };
+    }
 };
 
 FixMyStreet::override_config {


### PR DESCRIPTION
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1704
[skip changelog]

The issue remains in email alerts, but there we don't have easy access to the body names, so is harder to fix there, and has always been present, so this should at least fix the issue for TfL cobrand/.com web.