### PR TITLE
[Greenwich] Don’t show TfL categories on cobrand

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Greenwich.pm
+++ b/perllib/FixMyStreet/Cobrand/Greenwich.pm
@@ -44,6 +44,12 @@ sub reports_per_page { return 20; }
 
 sub admin_user_domain { 'royalgreenwich.gov.uk' }
 
+sub categories_restriction {
+    my ($self, $rs) = @_;
+    # Greenwich only want to display their own categories; not TfL
+    return $rs->search( { 'body.name' => 'Royal Borough of Greenwich' } );
+}
+
 sub open311_config {
     my ($self, $row, $h, $params) = @_;
 


### PR DESCRIPTION
The recent TfL launch has meant a bunch of extra categories appearing on the Greenwich site which aren't wanted.

[skip changelog]