### PR TITLE
Stored ‘contributed_by’ when staff users make anonymous reports via button

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1443,6 +1443,13 @@ sub save_user_and_report : Private {
         $report->confirm();
     } elsif ($c->stash->{contributing_as_anonymous_user}) {
         $report->set_extra_metadata( contributed_as => 'anonymous_user' );
+        if ( $c->user_exists && $c->user->from_body ) {
+            # If a staff user has clicked the 'report anonymously' button then
+            # there would be no record of who that staff member was as we've
+            # used the cobrand's anonymous_account for the report. In this case
+            # record the staff user ID in the report metadata.
+            $report->set_extra_metadata( contributed_by => $c->user->id );
+        }
         $report->confirm();
     } elsif ( !$report->user->in_storage ) {
         # User does not exist.

--- a/t/app/controller/report_new_anon.t
+++ b/t/app/controller/report_new_anon.t
@@ -202,6 +202,7 @@ subtest "test report creation anonymously by staff user" => sub {
     is $report->name, 'Anonymous Button';
     is $report->anonymous, 1;
     is $report->get_extra_metadata('contributed_as'), 'anonymous_user';
+    is $report->get_extra_metadata('contributed_by'), $staffuser->id;
 
     my $alert = FixMyStreet::DB->resultset('Alert')->find( {
         user => $report->user,


### PR DESCRIPTION
[skip changelog]