### PR TITLE
[Greenwich] [TfL] Fix TfL category display, and ignore groups

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Greenwich.pm
+++ b/perllib/FixMyStreet/Cobrand/Greenwich.pm
@@ -50,6 +50,14 @@ sub categories_restriction {
     return $rs->search( { 'body.name' => 'Royal Borough of Greenwich' } );
 }
 
+sub munge_around_category_where {
+    my ($self, $where) = @_;
+    # Hide TfL categories on the categories filter dropdown on /around
+    my $b = $self->{c}->model('DB::Body')->find({ name => 'Royal Borough of Greenwich' });
+    return unless $b;
+    return { body_id => $b->id };
+}
+
 sub open311_config {
     my ($self, $row, $h, $params) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/Greenwich.pm
+++ b/perllib/FixMyStreet/Cobrand/Greenwich.pm
@@ -44,6 +44,12 @@ sub reports_per_page { return 20; }
 
 sub admin_user_domain { 'royalgreenwich.gov.uk' }
 
+sub categories_restriction {
+    my ($self, $rs) = @_;
+    # Greenwich only want to display their own categories; not TfL
+    return $rs->search( { 'body.name' => 'Royal Borough of Greenwich' } );
+}
+
 sub open311_config {
     my ($self, $row, $h, $params) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/Greenwich.pm
+++ b/perllib/FixMyStreet/Cobrand/Greenwich.pm
@@ -44,20 +44,6 @@ sub reports_per_page { return 20; }
 
 sub admin_user_domain { 'royalgreenwich.gov.uk' }
 
-sub categories_restriction {
-    my ($self, $rs) = @_;
-    # Greenwich only want to display their own categories; not TfL
-    return $rs->search( { 'body.name' => 'Royal Borough of Greenwich' } );
-}
-
-sub munge_around_category_where {
-    my ($self, $where) = @_;
-    # Hide TfL categories on the categories filter dropdown on /around
-    my $b = $self->{c}->model('DB::Body')->find({ name => 'Royal Borough of Greenwich' });
-    return unless $b;
-    return { body_id => $b->id };
-}
-
 sub open311_config {
     my ($self, $row, $h, $params) = @_;
 
@@ -69,6 +55,9 @@ sub open311_config {
 
 sub open311_contact_meta_override {
     my ($self, $service, $contact, $meta) = @_;
+
+    # Greenwich returns groups we do not want to use
+    $service->{group} = [];
 
     my %server_set = (easting => 1, northing => 1, closest_address => 1);
     foreach (@$meta) {

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -390,7 +390,7 @@ sub munge_red_route_categories {
     my ($self, $options, $contacts) = @_;
     if ( $self->report_new_is_on_tlrn ) {
         # We're on a red route - only send TfL categories (except the disabled
-        # one that directs the user to borough for street cleaning XXX TODO: make sure this is included when on the TfL cobrand) and borough
+        # one that directs the user to borough for street cleaning) and borough
         # street cleaning categories.
         my %cleaning_cats = map { $_ => 1 } @{ $self->_cleaning_categories };
         @$contacts = grep {
@@ -400,8 +400,9 @@ sub munge_red_route_categories {
         } @$contacts;
     } else {
         # We're not on a red route - send all categories except
-        # TfL red-route-only.
+        # TfL red-route-only and the TfL street cleaning.
         my %tlrn_cats = map { $_ => 1 } @{ $self->_tlrn_categories };
+        $tlrn_cats{$self->_tfl_council_category} = 1;
         @$contacts = grep { !( $_->body->name eq 'TfL' && $tlrn_cats{$_->category } ) } @$contacts;
     }
     my $seen = { map { $_->category => 1 } @$contacts };

--- a/templates/web/tfl/about/faq-en-gb.html
+++ b/templates/web/tfl/about/faq-en-gb.html
@@ -62,7 +62,16 @@ Highways England, and the 32 London boroughs, plus the City of London.</p>
     <li>Highways England manages the national motorway network, including the M25, M1, M4 and M11</li>
 </ul>
 
-<h1>Cookie Declaration</h1>
-<script id="CookieDeclaration" src="https://consent.cookiebot.com/87b975a8-f977-4b96-9935-f5b0e33f75e6/cd.js" type="text/javascript" async></script>
+<h2>Cookies</h2>
+
+<p>A cookie is a piece of text that a website transfers to your computer's hard
+disk so it can remember who you are. Cookies are generally used to monitor how
+a website is used and improve your online experience. They do not give us
+access to the rest of your computer and are not used to identify you
+personally.</p>
+
+<p><a href="https://tfl.gov.uk/corporate/privacy-and-cookies/cookies">View a
+    list of the main cookies we set</a>, what they are used for and how to
+manage and delete them.</p>
 
 [% INCLUDE 'footer.html' pagefooter = 'yes' %]


### PR DESCRIPTION
This stops a category that should only be displayed on the TfL cobrand from displaying elsewhere (including Greenwich), and ignores groups from Greenwich as we don't want to use them but we do want to enable category groups for the TfL categories.
[skip changelog]