### PR TITLE
[East Herts] Fix z-index stacking bug in Help page sidebar

### DIFF
--- a/web/cobrands/eastherts/layout.scss
+++ b/web/cobrands/eastherts/layout.scss
@@ -146,7 +146,11 @@ body.frontpage {
 }
 
 body.twothirdswidthpage {
-    .content .sticky-sidebar aside {
-        top: 12em; // up from 7em, because of the taller header
+    .content .sticky-sidebar {
+        z-index: 1; // rather than -1, which hides it behind .container
+
+        aside {
+            top: 12em; // up from 7em, because of the taller header
+        }
     }
 }


### PR DESCRIPTION
A simple one. The `position: relative` on East Herts’ new `.container` elements was making the `position: absolute / position: fixed` sidebar unclickable, because it has a `z-index: -1` by default (so that it stacks _underneath_ the default footer).

This _does_ mean that the East Herts sidebar can now overlap on top of the footer, but it’s a very short footer (unlike FMS.com) so this will only be an issue on extremely short windows.

[skip changelog]