### PR TITLE
[Buckinghamshire] Remove ‘not responsible’ message from emails for district reports

### DIFF
--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -94,7 +94,7 @@ subtest 'flytipping off road sent to extra email' => sub {
     FixMyStreet::Script::Reports::send();
     my @email = $mech->get_email;
     is $email[0]->header('To'), 'Chiltern <flytipping@chiltern>';
-    like $mech->get_text_body_from_email($email[1]), qr/Please note that Buckinghamshire County Council is not responsible/;
+    unlike $mech->get_text_body_from_email($email[1]), qr/Please note that Buckinghamshire County Council is not responsible/;
     $report->discard_changes;
     is $report->external_id, undef, 'Report has right external ID';
 };

--- a/templates/email/buckinghamshire/other-reported.html
+++ b/templates/email/buckinghamshire/other-reported.html
@@ -12,10 +12,7 @@ INCLUDE '_email_top.html';
   [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Your report has been&nbsp;logged</h1>
   <p style="[% p_style %]">Your report to [% report.body %] has been logged on [% site_name %].</p>
-[% IF cobrand.is_council && !cobrand.owns_problem( report ) %]
-<p style="[% p_style %]">Please note that [% cobrand.council_name %] is not responsible for this type
-of report, so it will instead be sent to [% report.body %].</p>
-[% ELSE %]
+[% IF cobrand.owns_problem( report ) %]
 [% TRY %][% INCLUDE '_council_reference.html' problem=report %][% CATCH file %][% END %]
 [% END %]
   <p style="margin: 20px auto; text-align: center">

--- a/templates/email/buckinghamshire/other-reported.txt
+++ b/templates/email/buckinghamshire/other-reported.txt
@@ -4,10 +4,7 @@ Hello [% report.name %],
 
 Your report to [% report.body %] has been logged on [% site_name %].
 
-[% IF cobrand.is_council && !cobrand.owns_problem( report ) %]
-Please note that [% cobrand.council_name %] is not responsible for this type
-of report, so it will instead be sent to [% report.body %].
-[% ELSE %]
+[% IF cobrand.owns_problem( report ) %]
 [% TRY %][% INCLUDE '_council_reference.txt' problem=report %][% CATCH file %][% END %]
 [% END %]
 


### PR DESCRIPTION
Fixes https://github.com/mysociety/fixmystreet-freshdesk/issues/104

[skip changelog]