### PR TITLE
Fix 'all reports' link for users with categories but no from_body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
         - Fix removal of cached photos on moderation. #2696
         - Checking of cached front page details against database. #2696
         - Inconsistent display of mark private checkbox for staff users
+        - Clear user categories when staff access is removed. #2815
     - Development improvements:
         - Upgrade the underlying framework and a number of other packages. #2473
         - Add feature cobrand helper function.

--- a/perllib/FixMyStreet/App/Controller/Admin/Users.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Users.pm
@@ -373,6 +373,8 @@ sub edit : Chained('user') : PathPart('') : Args(0) {
             my @live_contact_ids = map { $_->id } @live_contacts;
             my @new_contact_ids = grep { $c->get_param("contacts[$_]") } @live_contact_ids;
             $user->set_extra_metadata('categories', \@new_contact_ids);
+        } else {
+            $user->unset_extra_metadata('categories');
         }
 
         $user->update;

--- a/t/app/controller/report_inspect.t
+++ b/t/app/controller/report_inspect.t
@@ -119,12 +119,23 @@ FixMyStreet::override_config {
             good_link => "/reports",
             bad_link => "/my/inspector_redirect",
         },
+        {
+            name => "categories but no from_body",
+            area_ids => undef,
+            categories => [ $contact->id ],
+            destination => "/my",
+            query_form => {},
+            good_link => "/reports",
+            bad_link => "/my/inspector_redirect",
+            unset_from_body => 1,
+        },
     ) {
         subtest "login destination and top-level nav for inspectors with " . $test->{name} => sub {
             $mech->log_out_ok;
 
             $user->area_ids($test->{area_ids});
             $user->set_extra_metadata('categories', $test->{categories});
+            $user->from_body(undef) if $test->{unset_from_body};
             $user->update;
 
             # Can't use log_in_ok, as the call to logged_in_ok clobbers our post-login
@@ -144,6 +155,8 @@ FixMyStreet::override_config {
             $mech->get_ok("/");
             ok $mech->find_link( text => 'All reports', url => $test->{good_link} );
             ok !$mech->find_link( text => 'All reports', url => $test->{bad_link} );
+
+            $user->update( { from_body => $oxon } ) if $test->{unset_from_body};
         };
     }
 

--- a/templates/web/base/navigation/_all_reports.html
+++ b/templates/web/base/navigation/_all_reports.html
@@ -1,5 +1,5 @@
 [%~
-    IF c.user_exists AND ( c.user.categories.size OR c.user.area_ids.size );
+    IF c.user_exists AND c.user.from_body AND ( c.user.categories.size OR c.user.area_ids.size );
       reports_uri = '/my/inspector_redirect';
     ELSE;
       reports_uri = '/reports';


### PR DESCRIPTION
In the rare situation that a user has no from_body set but does have categories set in their extra metadata, the 'All reports' link would point to /my/inspector_redirect but this URL would 404 if the user did not have a from_body. This PR updates the template to use the same logic when generating the 'all reports' link, so users without from_body will never be sent to /my/inspector_redirect.
Also clears any categories from the user record when its from_body is unset.

Fixes #2815.