### PR TITLE
Issues/freshdesk/105 peterborough cookies link

### DIFF
--- a/templates/web/fixmystreet-uk-councils/about/privacy.html
+++ b/templates/web/fixmystreet-uk-councils/about/privacy.html
@@ -354,7 +354,7 @@ United Kingdom<br>
 </p>
 
 
-<h2>Cookies</h2>
+<h2 id="cookies">Cookies</h2>
 
 <p>To make our service easier or more useful, we sometimes place small data
 files on your computer or mobile phone, known as cookies; many websites do

--- a/templates/web/peterborough/footer_extra.html
+++ b/templates/web/peterborough/footer_extra.html
@@ -3,10 +3,10 @@
         <li><a href="https://www.peterborough.gov.uk/accessibility/">
             Accessibility
         </a></li>
-        <li><a href="https://www.peterborough.gov.uk/privacy/">
+        <li><a href="/about/privacy">
             Privacy policy
         </a></li>
-        <li><a href="https://www.peterborough.gov.uk/cookies/">
+        <li><a href="/about/privacy#cookies">
             Cookies
         </a></li>
         <li><a href="https://www.peterborough.gov.uk/disclaimer/">


### PR DESCRIPTION
Small tweaks to privacy/cookies links on peterborough

For freshdesk: https://mysocietysupport.freshdesk.com/a/tickets/357

[skip changelog]