### PR TITLE
STAGING_FLAGS option to hide the staging site banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
         - Make contact edit note optional on staging sites.
         - Store email addresses report sent to on the report.
         - Add configuration for setting Content-Security-Policy header.
-        - Add banner on staging website/emails.
+        - Add banner on staging website/emails, and STAGING_FLAGS option to hide it.
         - Do not hard code site name in database fixture.
     - Open311 improvements:
         - Support use of 'private' service definition <keywords> to mark

--- a/conf/general.yml-docker
+++ b/conf/general.yml-docker
@@ -57,6 +57,7 @@ STAGING_SITE: 1
 STAGING_FLAGS:
   send_reports: 0
   skip_checks: 0
+  hide_staging_banner: 0
   enable_appcache: 0
 
 # What to use as front page/alert example places placeholder

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -57,6 +57,7 @@ STAGING_SITE: 1
 STAGING_FLAGS:
   send_reports: 0
   skip_checks: 0
+  hide_staging_banner: 0
   enable_appcache: 0
 
 # What to use as front page/alert example places placeholder

--- a/docs/customising/config.md
+++ b/docs/customising/config.md
@@ -311,12 +311,23 @@ The following are all the configuration settings that you can change in `conf/ge
     <p>
       A variety of flags that change the behaviour of a site when
       <code><a href="#staging_site">STAGING_SITE</a></code> is <code>1</code>.
-      <code>send_reports</code> being set to 0 will
+    </p>
+    <p>
+      Setting <code>send_reports</code> to <code>0</code> will
       <a href="{{ "/customising/send_reports" | relative_url }}">send
       reports</a> to the reporter <em>instead of</em> the relevant body's
-      contact address; <code>skip_checks</code> will stop cobrands from
+      contact address.
+    </p>
+    <p>
+      Setting <code>skip_checks</code> to <code>1</code> will stop cobrands from
       performing some checks such as the map pin location being within their
-      covered area, which makes testing multiple cobrands much easier;
+      covered area, which makes testing multiple cobrands much easier.
+    </p>
+    <p>
+      Setting <code>hide_staging_banner</code> to <code>1</code> will hide the
+      red “Staging site” banner in the top left corner of the site.
+    </p>
+    <p>
       <code>enable_appcache</code> lets you say whether the appcache should be
       active or not.
     </p>
@@ -336,6 +347,7 @@ The following are all the configuration settings that you can change in `conf/ge
 STAGING_FLAGS:
   send_reports: 0
   skip_checks: 1
+  hide_staging_banner: 1
   enable_appcache: 0
 </pre>
     </div>

--- a/t/cobrand/staging.t
+++ b/t/cobrand/staging.t
@@ -1,0 +1,18 @@
+use FixMyStreet::TestMech;
+my $mech = FixMyStreet::TestMech->new;
+
+subtest 'staging banner is visible by default on staging sites' => sub {
+    $mech->get_ok('/');
+    $mech->content_contains('<div class="dev-site-notice">');
+};
+
+FixMyStreet::override_config {
+    STAGING_FLAGS => { hide_staging_banner => 1 },
+}, sub {
+    subtest 'staging banner can be hidden through STAGING_FLAGS config' => sub {
+        $mech->get_ok('/');
+        $mech->content_lacks('<div class="dev-site-notice">');
+    };
+};
+
+done_testing();

--- a/templates/web/base/debug_header.html
+++ b/templates/web/base/debug_header.html
@@ -1,4 +1,4 @@
-[% IF c.config.STAGING_SITE ~%]
+[% IF c.config.STAGING_SITE and !c.config.STAGING_FLAGS.hide_staging_banner ~%]
     <div class="dev-site-notice">
         [% loc("Staging site") %]
     </div>


### PR DESCRIPTION
Allows you to hide the banner introduced in 1f43fc9.

Useful when you’re making front-end changes—especially on small screens—and don’t want the banner getting in the way.

I can see why the banner’s useful, but it’s just been annoying me ever since it arrived last month ;-)

I’ve added a new test in `t/cobrand/staging.t` – not sure whether that’s the best place! Couldn’t find any other front-end tests for staging/development options. Maybe this is the first one?

The new flag is documented on the `/customising/config` docs page, alongside the other STAGING_FLAGS.

Changlelog updated.