### PR TITLE
[TfL] Switch to OSM geocoder; add ‘London’ to disambiguation

### DIFF
--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -25,6 +25,18 @@ sub is_council { 0 }
 sub abuse_reports_only { 1 }
 sub send_questionnaires { 0 }
 
+sub disambiguate_location {
+    my $self    = shift;
+    my $string  = shift;
+
+    return {
+        %{ $self->SUPER::disambiguate_location() },
+        town   => "London",
+    };
+}
+
+sub get_geocoder { 'OSM' }
+
 sub category_change_force_resend { 1 }
 
 sub do_not_reply_email { shift->feature('do_not_reply_email') }


### PR DESCRIPTION
 - Adds disambiguation to try and get results that are actually within London.
 - OSM includes more of the address in each result to help the user identify where each identically-named road actually is within London.

[skip changelog]