### PR TITLE
[TfL] Remove old reports after specified time periods

### DIFF
--- a/bin/process-inactive-reports
+++ b/bin/process-inactive-reports
@@ -15,7 +15,7 @@ use FixMyStreet::Script::Inactive;
 use Pod::Usage;
 
 my %h;
-GetOptions(\%h, 'anonymize=i', 'close=i', 'delete=i', 'verbose|v', 'help|h', 'dry-run|n');
+GetOptions(\%h, 'anonymize=i', 'close=i', 'delete=i', 'cobrand=s', 'verbose|v', 'help|h', 'dry-run|n');
 pod2usage(0) if $h{help};
 pod2usage(1) unless $h{anonymize} || $h{close} || $h{delete};
 
@@ -29,12 +29,13 @@ process-inactive-reports - deal with anonymizing inactive non-open reports
 
 =head1 SYNOPSIS
 
-process-inactive-reports [--anonymize N] [--close N] [--delete N]
+process-inactive-reports [--anonymize N] [--close N] [--delete N] [--cobrand COBRAND]
 
  Options:
    --anonymize   Anonymize non-open reports (and related) inactive longer than this time (months)
    --close       Close comments on non-open reports inactive longer than this time (months)
    --delete      Delete non-open reports inactive longer than this time (months)
+   --cobrand     Only act upon reports made on this cobrand
    --dry-run     Don't actually anonymize anything or send any emails
    --verbose     Output as to which reports are being affected
    --help        This help message

--- a/bin/process-inactive-reports
+++ b/bin/process-inactive-reports
@@ -15,9 +15,9 @@ use FixMyStreet::Script::Inactive;
 use Pod::Usage;
 
 my %h;
-GetOptions(\%h, 'anonymize=i', 'close=i', 'verbose|v', 'help|h', 'dry-run|n');
+GetOptions(\%h, 'anonymize=i', 'close=i', 'delete=i', 'verbose|v', 'help|h', 'dry-run|n');
 pod2usage(0) if $h{help};
-pod2usage(1) unless $h{anonymize} || $h{close};
+pod2usage(1) unless $h{anonymize} || $h{close} || $h{delete};
 
 FixMyStreet::Script::Inactive->new(%h)->reports;
 
@@ -29,11 +29,12 @@ process-inactive-reports - deal with anonymizing inactive non-open reports
 
 =head1 SYNOPSIS
 
-process-inactive-reports [--anonymize N] [--close N]
+process-inactive-reports [--anonymize N] [--close N] [--delete N]
 
  Options:
    --anonymize   Anonymize non-open reports (and related) inactive longer than this time (months)
    --close       Close comments on non-open reports inactive longer than this time (months)
+   --delete      Delete non-open reports inactive longer than this time (months)
    --dry-run     Don't actually anonymize anything or send any emails
    --verbose     Output as to which reports are being affected
    --help        This help message

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -127,6 +127,16 @@ sub problems_sql_restriction {
     return $q;
 }
 
+sub inactive_reports_filter {
+    my ($self, $time, $rs) = @_;
+    if ($time < 7*12) {
+        $rs = $rs->search({ extra => { like => '%safety_critical,T5:value,T2:no%' } });
+    } else {
+        $rs = $rs->search({ extra => { like => '%safety_critical,T5:value,T3:yes%' } });
+    }
+    return $rs;
+}
+
 sub password_expiry {
     return if FixMyStreet->test_mode;
     # uncoverable statement

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -1187,4 +1187,15 @@ has inspection_log_entry => (
     },
 );
 
+has alerts => (
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        return $self->result_source->schema->resultset('Alert')->search({
+            alert_type => 'new_updates', parameter => $self->id
+        });
+    },
+);
+
 1;

--- a/perllib/FixMyStreet/Script/Inactive.pm
+++ b/perllib/FixMyStreet/Script/Inactive.pm
@@ -126,6 +126,7 @@ sub anonymize_users {
 
     my $users = FixMyStreet::DB->resultset("User")->search({
         last_active => { '<', interval($self->anonymize) },
+        email => { -not_like => 'removed-%@' . FixMyStreet->config('EMAIL_DOMAIN') },
     });
 
     while (my $user = $users->next) {

--- a/perllib/FixMyStreet/Script/Inactive.pm
+++ b/perllib/FixMyStreet/Script/Inactive.pm
@@ -95,6 +95,7 @@ sub _relevant_reports {
     });
     if ($self->cobrand) {
         $problems = $problems->search({ cobrand => $self->cobrand->moniker });
+        $problems = $self->cobrand->call_hook(inactive_reports_filter => $time, $problems) || $problems;
     }
     return $problems;
 }

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -556,6 +556,16 @@ subtest 'check report age on /around' => sub {
     });
 };
 
+subtest 'check report age in general' => sub {
+    my $report = FixMyStreet::DB->resultset("Problem")->find({ title => 'Test Report 1'});
+    $report->update({ state => 'confirmed' });
+    $mech->get_ok('/report/' . $report->id);
+    $report->update({ lastupdate => \"current_timestamp-'4 years'::interval" });
+    $mech->get('/report/' . $report->id);
+    is $mech->res->code, 404;
+    $report->update({ lastupdate => \"current_timestamp" });
+};
+
 subtest 'TfL admin allows inspectors to be assigned to borough areas' => sub {
     $mech->log_in_ok($superuser->email);
 

--- a/t/script/inactive.t
+++ b/t/script/inactive.t
@@ -60,6 +60,17 @@ subtest 'Closing updates on inactive fixed/closed reports' => sub {
     $mech->content_contains('now closed to updates');
 };
 
+subtest 'Deleting reports' => sub {
+    my $in = FixMyStreet::Script::Inactive->new( delete => 6 );
+    $in->reports;
+
+    my $count = FixMyStreet::DB->resultset("Problem")->count;
+    is $count, 6, 'Six left';
+
+    $mech->get("/report/" . $problems[2]->id);
+    is $mech->res->code, 404;
+};
+
 subtest 'Anonymization of inactive users' => sub {
     my $in = FixMyStreet::Script::Inactive->new( anonymize => 6, email => 3, verbose => 1 );
     stdout_is { $in->users } "Anonymizing user #" . $user->id . "\nEmailing user #" . $user_inactive->id . "\n", 'users dealt with first time';


### PR DESCRIPTION
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1608
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1669
Fixes https://github.com/mysociety/fixmystreet/issues/2376

Will be run as `process-inactive-reports --delete 36 --cobrand tfl` and `process-inactive-reports --delete 84 --cobrand tfl` with the code picking the right ones to delete based upon the time period.

[skip changelog]
