### PR TITLE
[Zürich] Fix admin CSV exports and front page double-escaped text

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -80,7 +80,7 @@ sub find_closest {
 
 sub enter_postcode_text {
     my ( $self ) = @_;
-    return _('Enter a Z&uuml;rich street name');
+    return _('Enter a Zürich street name');
 }
 
 sub example_places {

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -1153,7 +1153,7 @@ sub admin_stats {
     if ($y && $m) {
         $c->stash->{start_date} = DateTime->new( year => $y, month => $m, day => 1 );
         $c->stash->{end_date} = $c->stash->{start_date} + DateTime::Duration->new( months => 1 );
-        $optional_params{created} = {
+        $optional_params{'me.created'} = {
             '>=', DateTime::Format::Pg->format_datetime($c->stash->{start_date}), 
             '<',  DateTime::Format::Pg->format_datetime($c->stash->{end_date}),
         };

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -81,7 +81,8 @@ my $external_body2 = $mech->create_body_ok( 4, 'Another Body External',
 
 sub get_export_rows_count {
     my $mech = shift;
-    $mech->get_ok( '/admin/stats?export=1' );
+    my $extra = shift || '';
+    $mech->get_ok( '/admin/stats?export=1' . $extra);
     is $mech->res->code, 200, 'csv retrieved ok';
     is $mech->content_type, 'text/csv', 'content_type correct' and do {
         my @lines = split /\n/, $mech->content;
@@ -871,6 +872,8 @@ subtest "test stats" => sub {
         is $export_count - $EXISTING_REPORT_COUNT, 3, 'Correct number of reports';
         $mech->content_contains('fixed - council');
     }
+    $export_count =  get_export_rows_count($mech, '&ym=' . DateTime->now->strftime("%m.%Y"));
+    is $export_count - $EXISTING_REPORT_COUNT, 3, 'Correct number of reports when filtering by month';
 };
 
 subtest "test admin_log" => sub {


### PR DESCRIPTION
 - Fixes an ambiguous column name when attempting to download CSV stats for a specific month
 - Fixes front page double escaping of postcode text. That appears to be the only place it was happening.

[skip changelog]