### PR TITLE
Cope with swapped operands in template operators

### DIFF
--- a/perllib/FixMyStreet/Template/Variable.pm
+++ b/perllib/FixMyStreet/Template/Variable.pm
@@ -8,13 +8,15 @@ sub op_factory {
     my ($op) = @_;
 
     return eval q|sub {
-        my ($self, $str) = @_;
+        my ($self, $str, $swapped) = @_;
 
         if ( ref $str eq __PACKAGE__) {
-            return $self->{value} | . $op . q| $str->{value};
+            return $self->{value} | . $op . q| $str->{value} unless $swapped;
+            return $str->{value} | . $op . q| $self->{value};
         }
         else {
-            return $self->{value} | . $op . q| $str;
+            return $self->{value} | . $op . q| $str unless $swapped;
+            return $str | . $op . q| $self->{value};
         }
     }|;
 }

--- a/t/template.t
+++ b/t/template.t
@@ -30,4 +30,10 @@ $tt->process(\'H: [% s.split(":").join(",") %]', {
 }, \$output);
 is $output, 'H: 1,sp&lt;i&gt;l&lt;/i&gt;it,3';
 
+$output = '';
+$tt->process(\'[% size %] [% 100 / size %] [% size / 100 %]', {
+    size => 4
+}, \$output);
+is $output, '4 25 0.04';
+
 done_testing;


### PR DESCRIPTION
Perl may pass swapped operands to ensure the first one is always an object that implements the relevant operator.

[skip changelog]