### PR TITLE
[open311] always update problem state if no comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
         - Add support for account_id parameter to POST Service Request calls.
         - Do not overwrite/remove protected meta data. #2598
         - Spot multiple groups inside a <groups> element.
+        - Always update problem state from first comment #2832
     - Backwards incompatible changes:
         - The FixMyStreet templating code will now escape all variables by
           default. If you need to output HTML in a variable directly, you will


### PR DESCRIPTION
To avoid issues with autogenerated updates in the bodies back-end
happening quicker that the back-end returns the external_id to us ignore
the check for comment being earlier than the last update if it's the
first comment.