### PR TITLE
Reduce saturation of basemap when heatmap is active

### DIFF
--- a/web/cobrands/fixmystreet/density-map.js
+++ b/web/cobrands/fixmystreet/density-map.js
@@ -55,9 +55,11 @@ $(function(){
     $('#heatmap_yes').on('click', function() {
         fixmystreet.markers.setVisibility(false);
         heat_layer.setVisibility(true);
+        $(fixmystreet.map.div).addClass("heatmap-active");
     });
 
     $('#heatmap_no').on('click', function() {
+        $(fixmystreet.map.div).removeClass("heatmap-active");
         heat_layer.setVisibility(false);
         fixmystreet.markers.setVisibility(true);
     });
@@ -65,6 +67,7 @@ $(function(){
     if (heatmap_on) {
         fixmystreet.markers.setVisibility(false);
         heat_layer.setVisibility(true);
+        $(fixmystreet.map.div).addClass("heatmap-active");
     }
 
     $('#sort').closest('.report-list-filters').hide();

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1683,6 +1683,12 @@ input.final-submit {
     height: 100%;
     // Needs to be position:absolute for the mobile banners to show on top
     position: absolute;
+
+    &.heatmap-active {
+      .olLayerGrid, .olBackBuffer {
+        filter: grayscale(0.75);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This helps distinguish between the heatmap and underlying features.

Old | New
--- | ---
![Screen Shot 2020-01-20 at 19 23 26](https://user-images.githubusercontent.com/4776/72752702-d31bed00-3bba-11ea-86f9-723e6eb5de94.png) | ![Screen Shot 2020-01-20 at 19 22 53](https://user-images.githubusercontent.com/4776/72752724-e0d17280-3bba-11ea-9307-8ba6b5e4a8f5.png)
![Screen Shot 2020-01-20 at 19 25 39](https://user-images.githubusercontent.com/4776/72752795-08283f80-3bbb-11ea-8ae7-33964f81ae30.png) | ![Screen Shot 2020-01-20 at 19 25 29](https://user-images.githubusercontent.com/4776/72752804-0eb6b700-3bbb-11ea-915b-5afde5235014.png)



[skip changelog]