### PR TITLE
[Peterborough] Changes for ezytreev integration

### DIFF
--- a/bin/fixmystreet.com/add_emergency_message
+++ b/bin/fixmystreet.com/add_emergency_message
@@ -32,6 +32,7 @@ my ($opts, $usage) = describe_options(
     ['no=s', 'no answer to question'],
     ['message=s', 'message to be shown if form disabled', { required => 1 } ],
     ['send_method=s', 'send method to restrict categories to' ],
+    ['group=s', 'group to restrict categories to' ],
     ['help|h', "print usage message and exit" ],
 );
 $usage->die if $opts->help;
@@ -87,6 +88,10 @@ unless ($body) {
 my $contacts = $body->contacts->not_deleted;
 $contacts = $contacts->search({ send_method => $opts->send_method }) if $opts->send_method;
 foreach my $category ($contacts->all) {
+    # Check if we're just adding the message to a certain group
+    if ($opts->group) {
+        next unless grep { $_ eq $opts->group } @{$category->groups};
+    }
     my $found = $category->get_extra_field(code => $field->{code});
     if ($found) {
         say colored("Updating ", 'red') . $field->{code} . " message disable form on " . $category->category . ", " . $opts->body;

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -70,6 +70,9 @@ sub open311_munge_update_params {
 
     # Send the FMS problem ID with the update.
     $params->{service_request_id_ext} = $comment->problem->id;
+
+    my $contact = $comment->problem->category_row;
+    $params->{service_code} = $contact->email;
 }
 
 1;

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -67,6 +67,9 @@ sub open311_munge_update_params {
     # Peterborough want to make it clear in Confirm when an update has come
     # from FMS.
     $params->{description} = "[Customer FMS update] " . $params->{description};
+
+    # Send the FMS problem ID with the update.
+    $params->{service_request_id_ext} = $comment->problem->id;
 }
 
 1;

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -43,9 +43,10 @@ sub admin_user_domain { "peterborough.gov.uk" }
 around 'open311_config' => sub {
     my ($orig, $self, $row, $h, $params) = @_;
 
-    # remove the emergency category which is informational only
+    # remove categories which are informational only
     my $extra = $row->get_extra_fields;
     @$extra = grep { $_->{name} ne 'emergency' } @$extra;
+    @$extra = grep { $_->{name} ne 'private_land' } @$extra;
     $row->set_extra_fields(@$extra);
 
     $self->$orig($row, $h, $params);

--- a/t/cobrand/peterborough.t
+++ b/t/cobrand/peterborough.t
@@ -1,0 +1,79 @@
+use FixMyStreet::TestMech;
+use FixMyStreet::Script::Reports;
+use CGI::Simple;
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $params = {
+    send_method => 'Open311',
+    send_comments => 1,
+    api_key => 'KEY',
+    endpoint => 'endpoint',
+    jurisdiction => 'home',
+    can_be_devolved => 1,
+};
+my $peterborough = $mech->create_body_ok(2566, 'Peterborough City Council', $params);
+
+subtest 'open311 request handling', sub {
+    FixMyStreet::override_config {
+        STAGING_FLAGS => { send_reports => 1 },
+        ALLOWED_COBRANDS => ['peterborough' ],
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        my $contact = $mech->create_contact_ok(body_id => $peterborough->id, category => 'Trees', email => 'TREES');
+        my ($p) = $mech->create_problems_for_body(1, $peterborough->id, 'Title', { category => 'Trees', latitude => 52.5608, longitude => 0.2405, cobrand => 'peterborough' });
+        $p->set_extra_fields({ name => 'emergency', value => 'no'});
+        $p->set_extra_fields({ name => 'private_land', value => 'no'});
+        $p->set_extra_fields({ name => 'tree_code', value => 'tree-42'});
+        $p->update;
+
+        my $test_data = FixMyStreet::Script::Reports::send();
+
+        $p->discard_changes;
+        ok $p->whensent, 'Report marked as sent';
+        is $p->send_method_used, 'Open311', 'Report sent via Open311';
+        is $p->external_id, 248, 'Report has correct external ID';
+
+        my $req = $test_data->{test_req_used};
+        my $c = CGI::Simple->new($req->content);
+        is $c->param('attribute[emergency]'), undef, 'no emergency param sent';
+        is $c->param('attribute[private_land]'), undef, 'no private_land param sent';
+        is $c->param('attribute[tree_code]'), 'tree-42', 'tree_code param sent';
+    };
+};
+
+subtest "extra update params are sent to open311" => sub {
+    FixMyStreet::override_config {
+        MAPIT_URL => 'http://mapit.uk/',
+        ALLOWED_COBRANDS => 'peterborough',
+    }, sub {
+        my $contact = $mech->create_contact_ok(body_id => $peterborough->id, category => 'Trees', email => 'TREES');
+        my $test_res = HTTP::Response->new();
+        $test_res->code(200);
+        $test_res->message('OK');
+        $test_res->content('<?xml version="1.0" encoding="utf-8"?><service_request_updates><request_update><update_id>ezytreev-248</update_id></request_update></service_request_updates>');
+
+        my $o = Open311->new(
+            fixmystreet_body => $peterborough,
+            test_mode => 1,
+            test_get_returns => { 'servicerequestupdates.xml' => $test_res },
+        );
+
+        my ($p) = $mech->create_problems_for_body(1, $peterborough->id, 'Title', { external_id => 1, category => 'Trees' });
+
+        my $c = FixMyStreet::DB->resultset('Comment')->create({
+            problem => $p, user => $p->user, anonymous => 't', text => 'Update text',
+            problem_state => 'fixed - council', state => 'confirmed', mark_fixed => 0,
+            confirmed => DateTime->now(),
+        });
+
+        my $id = $o->post_service_request_update($c);
+        is $id, "ezytreev-248", 'correct update ID returned';
+        my $cgi = CGI::Simple->new($o->test_req_used->content);
+        is $cgi->param('description'), '[Customer FMS update] Update text', 'FMS update prefix included';
+        is $cgi->param('service_request_id_ext'), $p->id, 'Service request ID included';
+        is $cgi->param('service_code'), $contact->email, 'Service code included';
+    };
+};
+
+done_testing;

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -31,7 +31,9 @@ OpenLayers.Layer.VectorAsset = OpenLayers.Class(OpenLayers.Layer.Vector, {
           group = $('select#category_group').val(),
           layer = this.fixmystreet,
           relevant;
-      if (layer.asset_group) {
+      if (layer.relevant) {
+          relevant = layer.relevant({category: category, group: group});
+      } else if (layer.asset_group) {
           relevant = (layer.asset_group === group);
       } else {
           relevant = (OpenLayers.Util.indexOf(layer.asset_category, category) != -1);

--- a/web/cobrands/peterborough/js.js
+++ b/web/cobrands/peterborough/js.js
@@ -54,6 +54,8 @@ fixmystreet.assets.add(defaults, {
     asset_item: 'tree group'
 });
 
+var NEW_TREE_CATEGORY_NAME = 'Request for tree to be planted';
+
 fixmystreet.assets.add(defaults, {
     http_options: {
         url: "https://tilma.staging.mysociety.org/mapserver/peterborough",
@@ -67,7 +69,27 @@ fixmystreet.assets.add(defaults, {
     },
     asset_type: 'spot',
     asset_group: 'Trees',
-    asset_item: 'tree'
+    asset_item: 'tree',
+    relevant: function(options) {
+        return options.group === 'Trees' && options.category !== NEW_TREE_CATEGORY_NAME;
+    }
+});
+
+// We don't want to plant trees where the existing trees are, so add a
+// separate layer with pin-snapping disabled for new tree requests.
+// The new tree request category is disabled in the other tree point layer.
+fixmystreet.assets.add(defaults, {
+    http_options: {
+        url: "https://tilma.staging.mysociety.org/mapserver/peterborough",
+        params: {
+            TYPENAME: "tree_points"
+        }
+    },
+    asset_id_field: 'TREE_CODE',
+    asset_type: 'spot',
+    asset_category: NEW_TREE_CATEGORY_NAME,
+    asset_item: 'tree',
+    disable_pin_snapping: true
 });
 
 })();

--- a/web/cobrands/peterborough/js.js
+++ b/web/cobrands/peterborough/js.js
@@ -38,4 +38,36 @@ fixmystreet.assets.add(defaults, {
     name: "Adopted Highways"
 });
 
+fixmystreet.assets.add(defaults, {
+    http_options: {
+        url: "https://tilma.staging.mysociety.org/mapserver/peterborough",
+        params: {
+            TYPENAME: "tree_groups"
+        }
+    },
+    asset_id_field: 'TREE_CODE',
+    attributes: {
+        tree_code: 'TREE_CODE'
+    },
+    asset_type: 'area',
+    asset_group: 'Trees',
+    asset_item: 'tree group'
+});
+
+fixmystreet.assets.add(defaults, {
+    http_options: {
+        url: "https://tilma.staging.mysociety.org/mapserver/peterborough",
+        params: {
+            TYPENAME: "tree_points"
+        }
+    },
+    asset_id_field: 'TREE_CODE',
+    attributes: {
+        tree_code: 'TREE_CODE'
+    },
+    asset_type: 'spot',
+    asset_group: 'Trees',
+    asset_item: 'tree'
+});
+
 })();

--- a/web/cobrands/peterborough/js.js
+++ b/web/cobrands/peterborough/js.js
@@ -15,7 +15,7 @@ var defaults = {
         }
     },
     max_resolution: 4.777314267158508,
-    min_resolution: 0.5971642833948135,
+    min_resolution: 0.00001,
     geometryName: 'msGeometry',
     srsName: "EPSG:3857",
     body: "Peterborough City Council",


### PR DESCRIPTION
Changes for the ezytreev integration. Mostly adding and removing fields in the open311_config around hook. Also adding the javascript to display the tree layers on the map when the "Trees" category i selected.

Part of [Peterborough Phase 2 - EzyTreev](https://github.com/mysociety/fixmystreet-commercial/milestone/37).

Related open311-adapter PRs: https://github.com/mysociety/open311-adapter/pull/85 and https://github.com/mysociety/open311-adapter/pull/87

<!-- [skip changelog] -->