### PR TITLE
Sort My Sign

### DIFF
--- a/perllib/FixMyStreet/TestMech.pm
+++ b/perllib/FixMyStreet/TestMech.pm
@@ -68,7 +68,7 @@ sub uniquify_email {
     my ($self, $email, $file) = @_;
 
     $file = (caller)[1] unless $file;
-    (my $pkg = $file) =~ s{/}{}g;
+    (my $pkg = $file) =~ s{[/\.]}{}g;
 
     if ($email =~ /@/ && $email !~ /^pkg-/) {
         $email = "pkg-$pkg-$email";

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -55,6 +55,7 @@ my @PLACES = (
     [ 'PE1 1HF', 52.57146, -0.24201, 2566, 'Peterborough City Council', 'UTA' ],
     [ 'OX28 4DS', 51.784721, -1.494453 ],
     [ 'E14 2DN', 51.508536, '0.000001' ],
+    [ '?', 52.51093, -1.86514, 11809, 'West Midlands', 'EUR' ],
     # Norway
     [ '3290', 59, 10, 709, 'Larvik', 'NKO', 7, 'Vestfold', 'NFY' ],
     [ '0045', "59.9", "10.9", 301, 'Oslo', 'NKO', 3, 'Oslo', 'NFY' ],

--- a/t/Mock/OpenIDConnect.pm
+++ b/t/Mock/OpenIDConnect.pm
@@ -55,7 +55,7 @@ sub dispatch_request {
             extension_CrmContactId => "1c304134-ef12-c128-9212-123908123901",
             nonce => 'MyAwesomeRandomValue',
         };
-        $payload->{emails} = ['pkg-tappcontrollerauth_social.t-oidc@example.org'] if $self->returns_email;
+        $payload->{emails} = ['pkg-tappcontrollerauth_socialt-oidc@example.org'] if $self->returns_email;
         my $signature = "dummy";
         my $id_token = join(".", (
             encode_base64($self->json->encode($header), ''),

--- a/templates/web/base/report/new/category.html
+++ b/templates/web/base/report/new/category.html
@@ -1,3 +1,4 @@
+[% TRY %][% PROCESS 'report/new/_form_labels.html' %][% CATCH file %][% END ~%]
 [%
 # If only one option, pre-select that as if it were already selected. This
 # carries through to the category_extras template because this template is
@@ -19,7 +20,7 @@ END
         category_lc = category | lower;
        END; ~%]
     <label for='form_category' id="form_category_label">
-        [%~ loc('Category') ~%]
+        [%~ form_category_label OR loc('Category') ~%]
     </label>[% =%]
     <select required class="validCategory form-control[% IF category_groups.size %] js-grouped-select[% END %]" name="category" id="form_category"
     [%~ IF c.user.from_body =%]

--- a/templates/web/base/report/new/category_wrapper.html
+++ b/templates/web/base/report/new/category_wrapper.html
@@ -1,6 +1,6 @@
 <div id="form_category_row">
 [% IF js %]
-    <label for="form_category">[% loc('Category') %]</label>
+    <label for="form_category">[% form_category_label OR loc('Category') %]</label>
     <select class="validCategory form-control" name="category" id="form_category"
     [%~ IF c.user.from_body =%]
       [%~ prefill_report = c.cobrand.prefill_report_fields_for_inspector || c.user.has_body_permission_to('report_prefill') %]

--- a/templates/web/base/report/new/form_report.html
+++ b/templates/web/base/report/new/form_report.html
@@ -1,4 +1,5 @@
 [% SET form_show_category_only = NOT category || field_errors.category || disable_form_message || have_disable_qn_to_answer %]
+[% TRY %][% PROCESS 'report/new/_form_labels.html' %][% CATCH file %][% END %]
 
 <!-- report/new/form_report.html -->
 [% INCLUDE 'report/new/form_after_heading.html' %]
@@ -25,7 +26,6 @@
 [% END %]
 
 <div class="js-hide-if-invalid-category[% ' hidden-nojs' IF form_show_category_only %]">
-[% TRY %][% PROCESS 'report/new/_form_labels.html' %][% CATCH file %][% END %]
 
   [% UNLESS public_councils_text_at_top %]
     [% INCLUDE public_councils_text %]

--- a/templates/web/base/reports/_list-filters-sort.html
+++ b/templates/web/base/reports/_list-filters-sort.html
@@ -1,0 +1,14 @@
+<p class="report-list-filters">
+    <label for="sort">[% loc('Sort by') %]</label>
+    <select class="form-control" name="sort" id="sort">
+      [% IF shortlist %]
+        <option value="shortlist"[% ' selected' IF sort_key == 'shortlist' %]>[% loc('Manual order') %]</option>
+      [% END %]
+        <option value="created-desc"[% ' selected' IF sort_key == 'created-desc' %]>[% loc('Newest') %]</option>
+        <option value="created-asc"[% ' selected' IF sort_key == 'created-asc' %]>[% loc('Oldest') %]</option>
+        <option value="updated-desc"[% ' selected' IF sort_key == 'updated-desc' %]>[% loc('Recently updated') %]</option>
+        <option value="updated-asc"[% ' selected' IF sort_key == 'updated-asc' %]>[% loc('Least recently updated') %]</option>
+        <option value="comments-desc"[% ' selected' IF sort_key == 'comments-desc' %]>[% loc('Most commented') %]</option>
+    </select>
+    <input type="submit" name="filter_update" value="[% loc('Go') %]">
+</p>

--- a/templates/web/base/reports/_list-filters.html
+++ b/templates/web/base/reports/_list-filters.html
@@ -27,20 +27,8 @@
             <input type="submit" name="filter_update" value="[% loc('Go') %]">
         </p>
 
-        <p class="report-list-filters">
-            <label for="sort">[% loc('Sort by') %]</label>
-            <select class="form-control" name="sort" id="sort">
-              [% IF shortlist %]
-                <option value="shortlist"[% ' selected' IF sort_key == 'shortlist' %]>[% loc('Manual order') %]</option>
-              [% END %]
-                <option value="created-desc"[% ' selected' IF sort_key == 'created-desc' %]>[% loc('Newest') %]</option>
-                <option value="created-asc"[% ' selected' IF sort_key == 'created-asc' %]>[% loc('Oldest') %]</option>
-                <option value="updated-desc"[% ' selected' IF sort_key == 'updated-desc' %]>[% loc('Recently updated') %]</option>
-                <option value="updated-asc"[% ' selected' IF sort_key == 'updated-asc' %]>[% loc('Least recently updated') %]</option>
-                <option value="comments-desc"[% ' selected' IF sort_key == 'comments-desc' %]>[% loc('Most commented') %]</option>
-            </select>
-            <input type="submit" name="filter_update" value="[% loc('Go') %]">
-        </p>
+        [% PROCESS 'reports/_list-filters-sort.html' %]
+
         [% IF page == 'around' %]
         <p id="show_old_reports_wrapper" class="report-list-filters[% ' hidden' UNLESS num_old_reports > 0 %]">
             <label for="show_old_reports">[% loc('Show older reports') %]</label>


### PR DESCRIPTION
Tweaks needed in core for the Sort My Sign project:
* Labels template included earlier so we can override the category label;
* Allow running of its own tests;
* Factor out the list filter sort section to its own template;
* Let the heatmap be viewable when not logged in (if cobrand allows it).

[skip changelog]