### PR TITLE
Skip admin contact email validation check if address hasn’t changed

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
@@ -248,7 +248,8 @@ sub update_contact : Private {
     my $email = $c->get_param('email');
     $email =~ s/\s+//g;
     my $send_method = $c->get_param('send_method') || $contact->body->send_method || "";
-    unless ( $send_method eq 'Open311' ) {
+    my $email_unchanged = $contact->email && $email && $contact->email eq $email;
+    unless ( $send_method eq 'Open311' || $email_unchanged ) {
         $errors{email} = _('Please enter a valid email') unless is_valid_email_list($email) || $email eq 'REFUSED';
     }
 


### PR DESCRIPTION
Some contacts (e.g. TfL) don’t have a valid email address but aren’t Open311
categories - the email destination is managed via the borough_email_addresses
feature. This prevents any changes to the contact being made via the admin
due to the email validation error message.

This commit updates the logic to only check that the email address is valid
if it’s been changed from the existing value (which may be blank if a it’s a
new contact).

Fixes https://github.com/mysociety/fixmystreet-freshdesk/issues/108

[skip changelog]