### PR TITLE
[TfL] Always use TfL branding on shortlist email.

### DIFF
--- a/perllib/FixMyStreet/App.pm
+++ b/perllib/FixMyStreet/App.pm
@@ -368,8 +368,8 @@ sub construct_email {
     my $vars = {
         from => [ $sender, _($sender_name) ],
         %{ $c->stash },
-        %$extra_stash_values,
         additional_template_paths => \@include_path,
+        %$extra_stash_values,
     };
     $vars->{site_name} = Utils::trim_text($c->view('EmailText')->render($c, 'site-name.txt', $vars));
     $vars->{signature} = $c->view('EmailText')->render($c, 'signature.txt', $vars);

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -313,12 +313,18 @@ sub must_have_2fa {
 sub update_email_shortlisted_user {
     my ($self, $update) = @_;
     my $c = $self->{c};
+    my $cobrand = FixMyStreet::Cobrand::TfL->new; # $self may be FMS
     my $shortlisted_by = $update->problem->shortlisted_user;
     if ($shortlisted_by && $shortlisted_by->from_body && $shortlisted_by->from_body->name eq 'TfL' && $shortlisted_by->id ne $update->user_id) {
         $c->send_email('alert-update.txt', {
+            additional_template_paths => [
+                FixMyStreet->path_to( 'templates', 'email', 'tfl' ),
+                FixMyStreet->path_to( 'templates', 'email', 'fixmystreet.com'),
+            ],
             to => [ [ $shortlisted_by->email, $shortlisted_by->name ] ],
             report => $update->problem,
-            problem_url => $c->cobrand->base_url_for_report($update->problem) . $update->problem->url,
+            cobrand => $cobrand,
+            problem_url => $cobrand->base_url . $update->problem->url,
             data => [ {
                 item_photo => $update->photo,
                 item_text => $update->text,

--- a/templates/email/tfl/signature.txt
+++ b/templates/email/tfl/signature.txt
@@ -1,0 +1,1 @@
+Street Care


### PR DESCRIPTION
It was using the branding/URL of the site the update was left on.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1741 [skip changelog]
