### PR TITLE
Allow update signup even if updates disallowed.

### DIFF
--- a/templates/web/base/report/display_tools.html
+++ b/templates/web/base/report/display_tools.html
@@ -10,7 +10,7 @@
             c.cobrand.moniker == 'fixmystreet' ? 'Unsuitable?' : loc('Report abuse')
         %]</a></li>
         [% END %]
-        [% IF NOT c.cobrand.updates_disallowed(problem) AND c.cobrand.moniker != 'zurich' %]
+        [% IF c.cobrand.moniker != 'zurich' %]
         <li><a rel="nofollow" id="key-tool-report-updates" class="feed js-feed" href="[% c.uri_for( '/alert/subscribe', { id => problem.id } ) %]">[% loc('Get updates' ) %]</a></li>
         [% END %]
         [% IF c.cobrand.moniker == 'fixmystreet' %]


### PR DESCRIPTION
It is possible for a report to be closed to public updates, but it still
could receive updates (eg updates only from problem reporter, or updates
only by staff), so we should still allow people to sign up.
[skip changelog]
