### PR TITLE
Fix bug in add_emergency_message script

### DIFF
--- a/bin/fixmystreet.com/add_emergency_message
+++ b/bin/fixmystreet.com/add_emergency_message
@@ -43,8 +43,8 @@ if (!$opts->commit) {
 my $field;
 
 if ( $opts->mode eq 'questions' ) {
-    die "questions, code, yes and no required"
-        unless $opts->questions && $opts->code && $opts->yes && $opts->no;
+    die "question, code, yes and no required"
+        unless $opts->question && $opts->code && $opts->yes && $opts->no;
 
     $field = {
         order => 0,


### PR DESCRIPTION
There was a typo in the error message and the related conditional which meant it was checking for `$opts->questions` (which doesn't exist) rather than `$opts->question`, which prevented the script from being used to add a question.

Related to https://github.com/mysociety/fixmystreet/pull/2699, where the bug was originally introduced.

<!-- [skip changelog] -->