### PR TITLE
Allow multiple question to disable the new report form

### DIFF
--- a/.cypress/cypress/integration/peterborough.js
+++ b/.cypress/cypress/integration/peterborough.js
@@ -1,0 +1,34 @@
+describe('new report form', function() {
+
+  beforeEach(function() {
+    cy.server();
+    cy.route('/report/new/ajax*').as('report-ajax');
+    cy.visit('http://peterborough.localhost:3001/');
+    cy.contains('Peterborough');
+    cy.get('[name=pc]').type('PE1 1HF');
+    cy.get('[name=pc]').parents('form').submit();
+    cy.get('#map_box').click();
+    cy.wait('@report-ajax');
+  });
+
+  it('is hidden when emergency option is yes', function() {
+    cy.get('select:eq(4)').select('Fallen branch');
+    cy.get('#form_emergency').select('yes');
+    cy.get('#js-category-stopper').should('contain', 'Please phone customer services to report this problem.');
+    cy.get('.js-hide-if-invalid-category').should('be.hidden');
+    cy.get('#form_emergency').select('no');
+    cy.get('#js-category-stopper').should('not.contain', 'Please phone customer services to report this problem.');
+    cy.get('.js-hide-if-invalid-category').should('be.visible');
+  });
+
+  it('is hidden when private land option is yes', function() {
+    cy.get('select:eq(4)').select('Fallen branch');
+    cy.get('#form_private_land').select('yes');
+    cy.get('#js-category-stopper').should('contain', 'The council do not have powers to address issues on private land.');
+    cy.get('.js-hide-if-invalid-category').should('be.hidden');
+    cy.get('#form_private_land').select('no');
+    cy.get('#js-category-stopper').should('not.contain', 'The council do not have powers to address issues on private land.');
+    cy.get('.js-hide-if-invalid-category').should('be.visible');
+  });
+
+});

--- a/bin/browser-tests
+++ b/bin/browser-tests
@@ -11,7 +11,7 @@ my ($cobrand, $coords, $area_id, $name, $mapit_url);
 
 BEGIN {
     $config_file = 'conf/general.yml-example';
-    $cobrand = [ 'borsetshire', 'fixmystreet', 'northamptonshire', 'bathnes', 'buckinghamshire', 'hounslow', 'isleofwight' ];
+    $cobrand = [ 'borsetshire', 'fixmystreet', 'northamptonshire', 'bathnes', 'buckinghamshire', 'hounslow', 'isleofwight', 'peterborough' ];
     $coords = '51.532851,-2.284277';
     $area_id = 2608;
     $name = 'Borsetshire';
@@ -150,7 +150,7 @@ browser-tests [running options] [fixture options] [cypress options]
    --help           this help message
 
  Fixture option:
-   --cobrand        Cobrand(s) to use, default is fixmystreet,northamptonshire,bathnes,buckinghamshire,isleofwight
+   --cobrand        Cobrand(s) to use, default is fixmystreet,northamptonshire,bathnes,buckinghamshire,isleofwight,peterborough
    --coords         Default co-ordinates for created reports
    --area_id        Area ID to use for created body
    --name           Name to use for created body

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -100,6 +100,7 @@ if ($opt->test_fixtures) {
         { area_id => 2397, categories => [ 'Graffiti' ], name => 'Northampton Borough Council' },
         { area_id => 2483, categories => [ 'Potholes', 'Other' ], name => 'Hounslow Borough Council' },
         { area_id => 2636, categories => [ 'Potholes', 'Private', 'Extra' ], name => 'Isle of Wight Council' },
+        { area_id => 2566, categories => [ 'Fallen branch' ], name => 'Peterborough City Council' },
     ) {
         $bodies->{$_->{area_id}} = FixMyStreet::DB::Factory::Body->find_or_create($_);
         my $cats = join(', ', @{$_->{categories}});
@@ -189,6 +190,38 @@ if ($opt->test_fixtures) {
         order => 1,
         variable => 'true',
     });
+    $child_cat->update;
+
+    $child_cat = FixMyStreet::DB->resultset("Contact")->find({
+        body => $bodies->{2566},
+        category => 'Fallen branch',
+    });
+    $child_cat->set_extra_fields(
+        {
+            code => 'emergency',
+            datatype => 'singlevaluelist',
+            description => 'Is it blocking a footpath or a highway?',
+            order => 0,
+            variable => 'true',
+            required => 'true',
+            values => [
+                { key => 'yes', name => 'Yes', disable => 1, disable_message => 'Please phone customer services to report this problem.' },
+                { key => 'no', name => 'No' },
+            ]
+        },
+        {
+            code => 'private_land',
+            datatype => 'singlevaluelist',
+            description => 'Is this problem on private land?',
+            order => 0,
+            variable => 'true',
+            required => 'true',
+            values => [
+                { key => 'yes', name => 'Yes', disable => 1, disable_message => 'The council do not have powers to address issues on private land.' },
+                { key => 'no', name => 'No' },
+            ]
+        }
+    );
     $child_cat->update;
 }
 

--- a/t/app/controller/report_new_open311.t
+++ b/t/app/controller/report_new_open311.t
@@ -378,9 +378,13 @@ subtest "Category extras includes form disabling string" => sub {
             my $output = $json->{by_category} ? $json->{by_category}{Pothole}{disable_form} : $json->{disable_form};
             is_deeply $output, {
                 all => 'Please ring us!',
-                message => 'Please please ring',
-                code => 'dangerous',
-                answers => [ 'yes' ],
+                questions => [
+                    {
+                        message => 'Please please ring',
+                        code => 'dangerous',
+                        answers => [ 'yes' ],
+                    },
+                ],
             };
         }
 

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -459,9 +459,13 @@ $.extend(fixmystreet.set_up, {
             $(".js-hide-if-public-category").hide();
         }
 
-        if (fixmystreet.message_controller && data && data.disable_form && data.disable_form.answers) {
-            $('#form_' + data.disable_form.code).on('change.category', function() {
-                $(fixmystreet).trigger('report_new:category_change');
+        if (fixmystreet.message_controller && data && data.disable_form && data.disable_form.questions) {
+            $.each(data.disable_form.questions, function(_, question) {
+                if (question.message && question.code) {
+                    $('#form_' + question.code).on('change.category', function() {
+                        $(fixmystreet).trigger('report_new:category_change');
+                    });
+                }
             });
         }
 
@@ -1334,10 +1338,14 @@ fixmystreet.fetch_reporting_data = function() {
                         message: details.disable_form.all
                     });
                 }
-                if (details.disable_form.answers) {
-                    details.disable_form.category = category;
-                    details.disable_form.keep_category_extras = true;
-                    fixmystreet.message_controller.register_category(details.disable_form);
+                if (details.disable_form.questions) {
+                    $.each(details.disable_form.questions, function(_, question) {
+                        if (question.message && question.code) {
+                            question.category = category;
+                            question.keep_category_extras = true;
+                            fixmystreet.message_controller.register_category(question);
+                        }
+                    });
                 }
             });
         }


### PR DESCRIPTION
This changes the existing logic to account for the fact that multiple questions might have the disable form checkbox ticked for one of their options. Previously it only worked for one question which disabled the form.

At the moment this just displays one of the messages at a time, with the first one taking priority. So if you have a "Is this an emergency" question and a "Is this on private land" question which both disable the
form, and the user has selected "Yes" to both, then only the message for the first question is displayed. This can potentially be improved in the future, but seemed out of scope for this change.

Fixes https://github.com/mysociety/fixmystreet/issues/2853

Original PR which added the disable for option for question: https://github.com/mysociety/fixmystreet/pull/2599

<!-- [skip changelog] -->