### PR TITLE
[Northamptonshire] Customise homepage index steps

### DIFF
--- a/templates/web/northamptonshire/index-steps.html
+++ b/templates/web/northamptonshire/index-steps.html
@@ -1,0 +1,18 @@
+<h2>[% loc('How to report a problem') %]</h2>
+
+<ol class="big-numbers">
+    <li>[% question %]</li>
+    <li>[% loc('Locate the problem on a map of the area') %]</li>
+    <li>[% loc('Enter details of the problem') %]</li>
+    <li>Confirm the report and [% c.cobrand.council_name %] will investigate</li>
+    <li>
+      Please enter a single problem per enquiry.<br>
+      The first item described will be taken as the enquiry
+    </li>
+</ol>
+
+<section class="full-width">
+[% INCLUDE "front/stats.html" %]
+[% TRY %][% INCLUDE "front/tips.html" %][% CATCH file %][% END %]
+</section>
+


### PR DESCRIPTION
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;

[skip changelog]

This is as requested on https://mysocietysupport.freshdesk.com/a/tickets/389 but perhaps there is a better solution to this, thoughts? 
