### PR TITLE
Only trigger one change event on initial popstate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
         - Checking of cached front page details against database. #2696
         - Inconsistent display of mark private checkbox for staff users
         - Clear user categories when staff access is removed. #2815
+        - Only trigger one change event on initial popstate.
     - Development improvements:
         - Upgrade the underlying framework and a number of other packages. #2473
         - Add feature cobrand helper function.

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1716,9 +1716,9 @@ $(function() {
                     // location.href is something like foo.com/around?pc=abc-123,
                     // which we pass into fixmystreet.display.reports_list() as a fallback
                     // in case the list isn't already in the DOM.
-                    $('#filter_categories').add('#statuses').add('#sort').find('option')
-                        .prop('selected', function() { return this.defaultSelected; })
-                        .trigger('change.multiselect');
+                    var filters = $('#filter_categories').add('#statuses').add('#sort');
+                    filters.find('option').prop('selected', function() { return this.defaultSelected; });
+                    filters.trigger('change.multiselect');
                     if (fixmystreet.utils && fixmystreet.utils.parse_query_string) {
                         var qs = fixmystreet.utils.parse_query_string();
                         var page = qs.p || 1;


### PR DESCRIPTION
When going back to the initial state with popstate, a change event was
being triggered on every single option of the filter selects. This led
to a lot of change events running on the category/status multi-selects
which then needlessly repeated the same activities over and over. This
locked up the browser for seconds in locations with many categories.

Performance chart before:
![image](https://user-images.githubusercontent.com/154364/73260403-bcc8ef00-41c1-11ea-87be-96a135f89453.png)

After:
![image](https://user-images.githubusercontent.com/154364/73260623-32cd5600-41c2-11ea-9fa4-8122e9710440.png)
