### PR TITLE
Tweak to report updates link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
         - Add XSL to RSS feeds so they look nicer in browsers.
         - Add per-report OpenGraph images. #2394
         - Display GPS marker on /around map. #2359
+        - Use nicer default photo upload message. #2358
     - Admin improvements:
         - Add new roles system, to group permissions and apply to users. #2483
         - Contact form emails now include user admin links.

--- a/templates/web/base/js/translation_strings.html
+++ b/templates/web/base/js/translation_strings.html
@@ -74,7 +74,8 @@ fixmystreet.password_minimum_length = [% c.cobrand.password_minimum_length %];
         hide_pins: '[% loc('Hide pins') | replace("'", "\\'") %]',
 
         upload_max_files_exceeded: '[% loc ('Sorry! You’ve hit the limit of images that can be attached to one report.') | replace("'", "\\'") %]',
-        upload_default_message: '[% loc ('Drag and drop photos here or <u>click to upload</u>') | replace("'", "\\'") %]',
+        upload_default_message: '[% loc('Drag photos here or <u>browse photos</u>') | replace("'", "\\'") %]',
+        upload_default_message_mobile: '[% loc('<u>Take or choose existing photo</u>') | replace("'", "\\'") %]',
         upload_cancel_confirmation: '[% loc ('Are you sure you want to cancel this upload?') | replace("'", "\\'") %]',
         upload_invalid_file_type: '[% loc ('Please upload an image only') | replace("'", "\\'") %]',
 

--- a/templates/web/base/report/display_tools.html
+++ b/templates/web/base/report/display_tools.html
@@ -11,7 +11,7 @@
         %]</a></li>
         [% END %]
         [% IF c.cobrand.moniker != 'zurich' %]
-        <li><a rel="nofollow" id="key-tool-report-updates" class="feed js-feed" href="[% c.uri_for( '/alert/subscribe', { id => problem.id } ) %]">[% loc('Get updates' ) %]</a></li>
+        <li><a rel="nofollow" id="key-tool-report-updates" class="feed" href="[% c.uri_for( '/alert/subscribe', { id => problem.id } ) %]">[% loc('Get updates' ) %]</a></li>
         [% END %]
         [% IF c.cobrand.moniker == 'fixmystreet' %]
         <li><a rel="nofollow" id="key-tool-report-share" class="share" href="#report-share">[% loc('Share') %]</a></li>

--- a/templates/web/base/report/update-form.html
+++ b/templates/web/base/report/update-form.html
@@ -24,6 +24,7 @@
           [% IF login_success %]
             [% PROCESS "report/update/form_user_loggedin.html" %]
             [% INCLUDE 'report/update/form_update.html' %]
+            <hr>
           [% ELSIF oauth_need_email %]
             <div id="form_sign_in">
                 [% PROCESS "report/form/user_loggedout_by_email.html" object=update type='update' valid_class='validNameU' email_required=1 %]

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -684,6 +684,10 @@ $.extend(fixmystreet.set_up, {
       $originalInput.hide();
 
       $dropzone.insertAfter($originalInput);
+      var default_message = translation_strings.upload_default_message;
+      if ($("html").hasClass("mobile")) {
+        default_message = translation_strings.upload_default_message_mobile;
+      }
       var photodrop = new Dropzone($dropzone[0], {
         url: '/photo/upload',
         paramName: 'photo',
@@ -695,7 +699,7 @@ $.extend(fixmystreet.set_up, {
         resizeHeight: 2048,
         resizeQuality: 0.6,
         acceptedFiles: 'image/jpeg,image/pjpeg,image/gif,image/tiff,image/png',
-        dictDefaultMessage: translation_strings.upload_default_message,
+        dictDefaultMessage: default_message,
         dictCancelUploadConfirmation: translation_strings.upload_cancel_confirmation,
         dictInvalidFileType: translation_strings.upload_invalid_file_type,
         dictMaxFilesExceeded: translation_strings.upload_max_files_exceeded,

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -837,10 +837,8 @@ $.extend(fixmystreet.set_up, {
 
   map_controls: function() {
     //add links container (if its not there)
-    if (fixmystreet.cobrand != 'zurich') {
-        if ($('#sub_map_links').length === 0) {
-            $('<p class="sub-map-links" id="sub_map_links" />').insertAfter($('#map'));
-        }
+    if ($('#sub_map_links').length === 0) {
+        $('<p class="sub-map-links" id="sub_map_links" />').insertAfter($('#map'));
     }
 
     if ($('.mobile').length) {

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -810,7 +810,6 @@ ul.error {
     background-repeat: no-repeat;
     color: #333 !important;
     padding: 1em;
-    text-transform: uppercase;
     font-size: 0.6875em;
     font-family: $meta-font;
     font-weight: normal;

--- a/web/cobrands/tfl/js.js
+++ b/web/cobrands/tfl/js.js
@@ -1,7 +1,6 @@
 (function(){
 
 translation_strings.name.validName = 'Please enter your full name, Transport for London needs this information – if you do not wish your name to be shown on the site, untick the box below';
-translation_strings.upload_default_message = 'Drag photo here to upload or <u>browse files</u>';
 translation_strings.incident_date = { date: 'Enter a date in the format dd/mm/yyyy' };
 translation_strings.time = 'Enter a time in the format hh:mm';
 


### PR DESCRIPTION
A bit of #2013 and/or #2494.
It stops the updates link on a mobile-width report page moving to be part of the map, and keeps it where it would be at larger widths. And stops capitalising those key tools links.