### PR TITLE
Remove pan control from mobile widths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
         - Add XSL to RSS feeds so they look nicer in browsers.
         - Add per-report OpenGraph images. #2394
         - Display GPS marker on /around map. #2359
+        - Remove pan control from mobile widths. #2865
     - Admin improvements:
         - Add new roles system, to group permissions and apply to users. #2483
         - Contact form emails now include user admin links.

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1699,15 +1699,18 @@ html.js #map .noscript {
   display: none;
 }
 
-// OpenLayers fix for navigation being top right
-// Left and right so that zoom can be left, pan right.
 #fms_pan_zoom {
-  top: 0.5em; // This will be overridden in JS if there's a full screen map with banner
-  #{$left}: 0.5em;
+  top: 0.5em;
   #{$right}: 0.5em;
 }
 
-// Openlayers map controls (overrides)
+#fms_pan_zoom_panup,
+#fms_pan_zoom_pandown,
+#fms_pan_zoom_panleft,
+#fms_pan_zoom_panright {
+    display: none;
+}
+
 #fms_pan_zoom_panup,
 #fms_pan_zoom_pandown,
 #fms_pan_zoom_panleft,
@@ -1755,13 +1758,13 @@ html.js #map .noscript {
 #fms_pan_zoom_zoomin {
   background-position: -84px 0;
   padding-top: 44px;
-  #{$left}: 0;
+  #{$right}: 0;
   top: 0;
 }
 #fms_pan_zoom_zoomout {
   background-position: -120px 100%;
   padding-top: 44px;
-  #{$left}: 0;
+  #{$right}: 0;
   top: 44px;
 }
 
@@ -2071,10 +2074,9 @@ img.pin {
   background-color: #333;
   border-radius: 0.25em;
   padding: 0.25em;
-  // Offset from top same as fms_pan_zoom, from left so as not
-  // to appear on top of zoom buttons (0.5em, 36px, 0.5em)
+  // Offset from top and left same as fms_pan_zoom
   top: 0.5em;
-  #{$left}: 3.25em;
+  #{$left}: 0.5em;
   .map-reporting & {
     // Same as fms_pan_zoom above, leaving space for the top bar when reporting
     top: 2.75em;

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -553,6 +553,13 @@ body.authpage {
 #fms_pan_zoom_panup,
 #fms_pan_zoom_pandown,
 #fms_pan_zoom_panleft,
+#fms_pan_zoom_panright {
+    display: block;
+}
+
+#fms_pan_zoom_panup,
+#fms_pan_zoom_pandown,
+#fms_pan_zoom_panleft,
 #fms_pan_zoom_panright,
 #fms_pan_zoom_zoomin,
 #fms_pan_zoom_zoomout,
@@ -563,14 +570,12 @@ body.authpage {
   }
 }
 
-// push zoom back over to right
+// indent zoom to line up with pan
 #fms_pan_zoom_zoomin {
-  #{$left}: auto;
   #{$right}: 30px;
   top: 130px;
 }
 #fms_pan_zoom_zoomout {
-  #{$left}: auto;
   #{$right}: 30px;
   top: 174px;
 }
@@ -724,8 +729,6 @@ body.authpage {
   height: 64px;
   width: 64px;
   background-color: rgba(0, 0, 0, 0.7);
-  // Reset the base left, as zoom buttons now elsewhere
-  #{$left}: 0.5em;
 }
 
 .big-green-banner {


### PR DESCRIPTION
For #2013. I've left the zoom control there for now, easy to remove also if desired.

![Screen Shot 2020-01-30 at 11 53 31](https://user-images.githubusercontent.com/739624/73447676-28909080-4357-11ea-907a-7391637d38c2.png)

![Screen Shot 2020-01-30 at 11 54 12](https://user-images.githubusercontent.com/739624/73447764-5544a800-4357-11ea-833d-15ecfa9190d1.png)
