### PR TITLE
Add cobrand-specific manifest customisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
         - Allow report as another user with only name.
         - Allow staff users to sign other people up for alerts.
         - Group categories on body page. #2850
+        - Add admin UI for managing web manifest themes. #2792
     - New features:
         - Categories can be listed under more than one group #2475
         - OpenID Connect login support. #2523

--- a/perllib/FixMyStreet/App/Controller/Admin/ManifestTheme.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/ManifestTheme.pm
@@ -67,6 +67,7 @@ sub form {
 
     if ($c->get_param('delete_theme')) {
         $c->forward('_delete_all_manifest_icons');
+        $c->forward('/offline/_clear_manifest_icons_cache', [ $theme->cobrand ]);
         $theme->delete;
         $c->forward('/admin/log_edit', [ $theme->id, 'manifesttheme', 'delete' ]);
         $c->response->redirect($c->uri_for($self->action_for('index')));
@@ -82,6 +83,7 @@ sub form {
     return unless $form->validated;
 
     $c->forward('/admin/log_edit', [ $theme->id, 'manifesttheme', $action ]);
+    $c->forward('/offline/_clear_manifest_icons_cache', [ $theme->cobrand ]);
     $c->response->redirect($c->uri_for($self->action_for('index')));
 }
 

--- a/perllib/FixMyStreet/App/Controller/Admin/ManifestTheme.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/ManifestTheme.pm
@@ -1,0 +1,80 @@
+package FixMyStreet::App::Controller::Admin::ManifestTheme;
+use Moose;
+use namespace::autoclean;
+
+BEGIN { extends 'Catalyst::Controller'; }
+
+use FixMyStreet::App::Form::ManifestTheme;
+
+sub auto :Private {
+    my ($self, $c) = @_;
+
+    if ( $c->cobrand->moniker eq 'fixmystreet' ) {
+        $c->stash(rs => $c->model('DB::ManifestTheme')->search_rs({}), show_all => 1);
+    } else {
+        $c->stash(rs => $c->model('DB::ManifestTheme')->search_rs({ cobrand => $c->cobrand->moniker }));
+    }
+}
+
+sub index :Path :Args(0) {
+    my ( $self, $c ) = @_;
+
+    unless ( $c->stash->{show_all} ) {
+        if ( $c->stash->{rs}->count ) {
+            $c->res->redirect($c->uri_for($self->action_for('edit'), [ $c->stash->{rs}->first->cobrand ]));
+        } else {
+            $c->res->redirect($c->uri_for($self->action_for('create')));
+        }
+        $c->detach;
+    }
+}
+
+sub item :PathPart('admin/manifesttheme') :Chained :CaptureArgs(1) {
+    my ($self, $c, $cobrand) = @_;
+
+    my $obj = $c->stash->{rs}->find({ cobrand =>  $cobrand })
+        or $c->detach('/page_error_404_not_found', []);
+    $c->stash(obj => $obj);
+}
+
+sub edit :PathPart('') :Chained('item') :Args(0) {
+    my ($self, $c) = @_;
+    return $self->form($c, $c->stash->{obj});
+}
+
+
+sub create :Local :Args(0) {
+    my ($self, $c) = @_;
+
+    unless ( $c->stash->{show_all} || $c->stash->{rs}->count == 0) {
+        $c->res->redirect($c->uri_for($self->action_for('edit'), [ $c->stash->{rs}->first->cobrand ]));
+        $c->detach;
+    }
+
+    my $theme = $c->stash->{rs}->new_result({});
+    return $self->form($c, $theme);
+}
+
+sub form {
+    my ($self, $c, $theme) = @_;
+
+    if ($c->get_param('delete_theme')) {
+        $theme->delete;
+        $c->forward('/admin/log_edit', [ $theme->id, 'manifesttheme', 'delete' ]);
+        $c->response->redirect($c->uri_for($self->action_for('index')));
+        $c->detach;
+    }
+
+    my $action = $theme->in_storage ? 'edit' : 'add';
+    my $form = FixMyStreet::App::Form::ManifestTheme->new( cobrand => $c->cobrand->moniker );
+    $c->stash(template => 'admin/manifesttheme/form.html', form => $form);
+    $form->process(item => $theme, params => $c->req->params);
+    return unless $form->validated;
+
+    $c->forward('/admin/log_edit', [ $theme->id, 'manifesttheme', $action ]);
+    $c->response->redirect($c->uri_for($self->action_for('index')));
+}
+
+
+
+1;

--- a/perllib/FixMyStreet/App/Controller/Offline.pm
+++ b/perllib/FixMyStreet/App/Controller/Offline.pm
@@ -33,24 +33,12 @@ sub manifest: Path("/.well-known/manifest.webmanifest") {
     my ($self, $c) = @_;
     $c->res->content_type('application/manifest+json');
 
-    my $theme = $c->model('DB::ManifestTheme')->find({ cobrand => $c->cobrand->moniker });
-    unless ( $theme ) {
-        $theme = $c->model('DB::ManifestTheme')->new({
-            name => $c->stash->{site_name},
-            short_name => $c->stash->{site_name},
-            background_colour => '#ffffff',
-            theme_colour => '#ffd000',
-        });
-    }
-
-    $c->forward("_stash_manifest_icons", [ $c->cobrand->moniker ]);
-
     my $data = {
-        name => $theme->name,
-        short_name => $theme->short_name,
-        background_color => $theme->background_colour,
-        theme_color => $theme->theme_colour,
-        icons => $c->stash->{manifest_icons},
+        name => $c->stash->{manifest_theme}->{name},
+        short_name => $c->stash->{manifest_theme}->{short_name},
+        background_color => $c->stash->{manifest_theme}->{background_colour},
+        theme_color => $c->stash->{manifest_theme}->{theme_colour},
+        icons => $c->stash->{manifest_theme}->{icons},
         lang => $c->stash->{lang_code},
         display => "minimal-ui",
         start_url => "/?pwa",
@@ -64,14 +52,30 @@ sub manifest: Path("/.well-known/manifest.webmanifest") {
     $c->res->body($json);
 }
 
-sub _stash_manifest_icons : Private {
+sub _stash_manifest_theme : Private {
+    my ($self, $c, $cobrand) = @_;
+
+    $c->stash->{manifest_theme} = $c->forward('_find_manifest_theme', [ $cobrand ]);
+}
+
+sub _find_manifest_theme : Private {
     my ($self, $c, $cobrand, $ignore_cache_and_defaults) = @_;
 
-    my $key = "manifest_icons:$cobrand";
+    my $key = "manifest_theme:$cobrand";
     # ignore_cache_and_defaults is only used in the admin, so no harm bypassing cache
-    my $icons = $ignore_cache_and_defaults ? undef : Memcached::get($key);
+    my $manifest_theme = $ignore_cache_and_defaults ? undef : Memcached::get($key);
 
-    unless ( $icons ) {
+    unless ( $manifest_theme ) {
+        my $theme = $c->model('DB::ManifestTheme')->find({ cobrand => $cobrand });
+        unless ( $theme ) {
+            $theme = $c->model('DB::ManifestTheme')->new({
+                name => $c->stash->{site_name},
+                short_name => $c->stash->{site_name},
+                background_colour => '#ffffff',
+                theme_colour => '#ffd000',
+            });
+        }
+
         my @icons;
         my $uri = '/theme/' . $cobrand;
         my $theme_path = path(FixMyStreet->path_to('web' . $uri));
@@ -92,20 +96,26 @@ sub _stash_manifest_icons : Private {
                 { src => "/cobrands/fixmystreet/images/512.png", sizes => "512x512", type => "image/png" };
         }
 
-        $icons = \@icons;
+        $manifest_theme = {
+            icons => \@icons,
+            background_colour => $theme->background_colour,
+            theme_colour => $theme->theme_colour,
+            name => $theme->name,
+            short_name => $theme->short_name,
+        };
 
         unless ($ignore_cache_and_defaults) {
-            Memcached::set($key, $icons);
+            Memcached::set($key, $manifest_theme);
         }
     }
 
-    $c->stash->{manifest_icons} = $icons;
+    return $manifest_theme;
 }
 
-sub _clear_manifest_icons_cache : Private {
+sub _clear_manifest_theme_cache : Private {
     my ($self, $c, $cobrand ) = @_;
 
-    Memcached::set("manifest_icons:$cobrand", "");
+    Memcached::delete("manifest_theme:$cobrand");
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/perllib/FixMyStreet/App/Controller/Root.pm
+++ b/perllib/FixMyStreet/App/Controller/Root.pm
@@ -77,6 +77,10 @@ sub index : Path : Args(0) {
         $c->detach;
     }
 
+    # TODO: Not sure we want to hammer the FS for every front page request,
+    # might need a smarter way to tell iOS about the icons
+    $c->forward('/offline/_stash_manifest_icons', [ $c->cobrand->moniker ]);
+
     $c->forward('/auth/get_csrf_token');
 }
 

--- a/perllib/FixMyStreet/App/Controller/Root.pm
+++ b/perllib/FixMyStreet/App/Controller/Root.pm
@@ -77,8 +77,6 @@ sub index : Path : Args(0) {
         $c->detach;
     }
 
-    # TODO: Not sure we want to hammer the FS for every front page request,
-    # might need a smarter way to tell iOS about the icons
     $c->forward('/offline/_stash_manifest_icons', [ $c->cobrand->moniker ]);
 
     $c->forward('/auth/get_csrf_token');

--- a/perllib/FixMyStreet/App/Controller/Root.pm
+++ b/perllib/FixMyStreet/App/Controller/Root.pm
@@ -42,6 +42,8 @@ sub auto : Private {
     $c->forward('check_password_expiry');
     $c->detach('/auth/redirect') if $c->cobrand->call_hook('check_login_disallowed');
 
+    $c->forward('/offline/_stash_manifest_theme', [ $c->cobrand->moniker ]);
+
     return 1;
 }
 
@@ -76,8 +78,6 @@ sub index : Path : Args(0) {
         $c->stash->{template} = $c->stash->{homepage_template};
         $c->detach;
     }
-
-    $c->forward('/offline/_stash_manifest_icons', [ $c->cobrand->moniker ]);
 
     $c->forward('/auth/get_csrf_token');
 }

--- a/perllib/FixMyStreet/App/Form/ManifestTheme.pm
+++ b/perllib/FixMyStreet/App/Form/ManifestTheme.pm
@@ -1,0 +1,28 @@
+package FixMyStreet::App::Form::ManifestTheme;
+
+use HTML::FormHandler::Moose;
+use FixMyStreet::App::Form::I18N;
+extends 'HTML::FormHandler::Model::DBIC';
+use namespace::autoclean;
+
+has 'cobrand' => ( isa => 'Str', is => 'ro' );
+
+has '+widget_name_space' => ( default => sub { ['FixMyStreet::App::Form::Widget'] } );
+has '+widget_tags' => ( default => sub { { wrapper_tag => 'p' } } );
+has '+item_class' => ( default => 'ManifestTheme' );
+has_field 'cobrand' => ( required => 0 );
+has_field 'name' => ( required => 1 );
+has_field 'short_name' => ( required => 1 );
+has_field 'background_colour' => ( required => 0 );
+has_field 'theme_colour' => ( required => 0 );
+
+before 'update_model' => sub {
+    my $self = shift;
+    $self->item->cobrand($self->cobrand) if $self->cobrand && !$self->item->cobrand;
+};
+
+sub _build_language_handle { FixMyStreet::App::Form::I18N->new }
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/perllib/FixMyStreet/App/Form/ManifestTheme.pm
+++ b/perllib/FixMyStreet/App/Form/ManifestTheme.pm
@@ -6,6 +6,7 @@ use Digest::SHA qw(sha1_hex);
 use File::Basename;
 use HTML::FormHandler::Moose;
 use FixMyStreet::App::Form::I18N;
+use List::MoreUtils qw(uniq);
 extends 'HTML::FormHandler::Model::DBIC';
 use namespace::autoclean;
 
@@ -14,7 +15,7 @@ has 'cobrand' => ( isa => 'Str', is => 'ro' );
 has '+widget_name_space' => ( default => sub { ['FixMyStreet::App::Form::Widget'] } );
 has '+widget_tags' => ( default => sub { { wrapper_tag => 'p' } } );
 has '+item_class' => ( default => 'ManifestTheme' );
-has_field 'cobrand' => ( required => 0 );
+has_field 'cobrand' => ( type => 'Select', empty_select => 'Select a cobrand', required => 1 );
 has_field 'name' => ( required => 1 );
 has_field 'short_name' => ( required => 1 );
 has_field 'background_colour' => ( required => 0 );
@@ -22,12 +23,12 @@ has_field 'theme_colour' => ( required => 0 );
 has_field 'icon' => ( required => 0, type => 'Upload', label => "Add icon" );
 has_field 'delete_icon' => ( type => 'Multiple' );
 
-before 'update_model' => sub {
-    my $self = shift;
-    $self->item->cobrand($self->cobrand) if $self->cobrand && !$self->item->cobrand;
-};
-
 sub _build_language_handle { FixMyStreet::App::Form::I18N->new }
+
+sub options_cobrand {
+    my @cobrands = uniq sort map { $_->{moniker} } FixMyStreet::Cobrand->available_cobrand_classes;
+    return map { $_ => $_ } @cobrands;
+}
 
 sub validate {
     my $self = shift;

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -685,6 +685,7 @@ sub admin_pages {
         $pages->{flagged} = [ _('Flagged'), 7 ];
         $pages->{states} = [ _('States'), 8 ];
         $pages->{config} = [ _('Configuration'), 9];
+        $pages->{manifesttheme} = [ _('Manifest Theme'), 11];
         $pages->{user_import} = [ undef, undef ];
     };
     # And some that need special permissions

--- a/perllib/FixMyStreet/DB/Result/AdminLog.pm
+++ b/perllib/FixMyStreet/DB/Result/AdminLog.pm
@@ -91,6 +91,10 @@ sub link {
         my $category = $self->object;
         return "/admin/body/" . $category->body_id . '/' . $category->category;
     }
+    if ($type eq 'manifesttheme') {
+        my $theme = $self->object;
+        return "/admin/manifesttheme/" . $theme->cobrand;
+    }
     return '';
 }
 
@@ -114,6 +118,7 @@ sub object_summary {
         role => 'name',
         template => 'title',
         category => 'category',
+        manifesttheme => 'cobrand',
     };
     my $thing = $type_to_thing->{$self->object_type} || 'id';
 
@@ -130,6 +135,7 @@ sub object {
         template => 'ResponseTemplate',
         category => 'Contact',
         update => 'Comment',
+        manifesttheme => 'ManifestTheme',
     };
     $type = $type_to_object->{$type} || ucfirst $type;
     my $object = $self->result_source->schema->resultset($type)->find($id);

--- a/perllib/FixMyStreet/PhotoStorage.pm
+++ b/perllib/FixMyStreet/PhotoStorage.pm
@@ -58,8 +58,10 @@ sub base64_decode_upload {
             print $fh $decoded;
             close $fh
         } else {
-            $c->log->info('Couldn\'t open temp file to save base64 decoded image: ' . $!);
-            $c->stash->{photo_error} = _("Sorry, we couldn't save your file(s), please try again.");
+            if ($c) {
+                $c->log->info('Couldn\'t open temp file to save base64 decoded image: ' . $!);
+                $c->stash->{photo_error} = _("Sorry, we couldn't save your file(s), please try again.");
+            }
             return ();
         }
     }

--- a/perllib/Memcached.pm
+++ b/perllib/Memcached.pm
@@ -29,4 +29,8 @@ sub set {
     instance->set(@_);
 }
 
+sub delete {
+    instance->delete(@_);
+}
+
 1;

--- a/t/app/controller/admin/manifesttheme.t
+++ b/t/app/controller/admin/manifesttheme.t
@@ -9,7 +9,7 @@ my $superuser = $mech->create_user_ok('superuser@example.com', name => 'Super Us
 $mech->log_in_ok( $superuser->email );
 
 FixMyStreet::override_config {
-    ALLOWED_COBRANDS => [ 'lincolnshire', 'fixmystreet' ],
+    ALLOWED_COBRANDS => [ 'lincolnshire', 'tfl', 'fixmystreet' ],
 }, sub {
 
 ok $mech->host('lincolnshire.fixmystreet.com');
@@ -107,6 +107,7 @@ subtest "cobrand admin lets you add an icon to an existing theme" => sub {
             short_name => "Lincs FMS",
             background_colour => "#663399",
             theme_colour => "rgb(102, 51, 153)",
+            cobrand => 'lincolnshire',
             icon => [ $sample_jpeg, undef, Content_Type => 'image/jpeg' ],
         },
     );
@@ -149,6 +150,7 @@ subtest "cobrand admin rejects non-images" => sub {
             short_name => "Lincs FMS",
             background_colour => "#663399",
             theme_colour => "rgb(102, 51, 153)",
+            cobrand => 'lincolnshire',
             icon => [ $sample_pdf, undef, Content_Type => 'application/pdf' ],
         },
     );
@@ -196,6 +198,7 @@ subtest "can delete theme" => sub {
             short_name => "Lincs FMS",
             background_colour => "#663399",
             theme_colour => "rgb(102, 51, 153)",
+            cobrand => "lincolnshire",
             icon => [ $sample_jpeg, undef, Content_Type => 'image/jpeg' ],
         },
     );

--- a/t/app/controller/admin/manifesttheme.t
+++ b/t/app/controller/admin/manifesttheme.t
@@ -114,8 +114,8 @@ subtest "cobrand admin lets you add an icon to an existing theme" => sub {
     ok $mech->success, 'Posted request successfully';
 
     is $mech->uri->path, '/admin/manifesttheme/lincolnshire', "redirected back to edit page";
-    $mech->content_contains($icon_filename);
-    $mech->content_contains("133x100");
+    $mech->content_contains("<img src=\"/theme/lincolnshire/" . $icon_filename);
+    $mech->content_contains("<td class=\"icon-size\">133x100</td>");
     my $icon_dest = path(FixMyStreet->path_to('web/theme/lincolnshire/', $icon_filename));
     ok $icon_dest->exists, "Icon stored on disk";
 };
@@ -132,8 +132,8 @@ subtest "cobrand admin lets you delete an icon from an existing theme" => sub {
     $mech->submit_form_ok( { with_fields => $fields } );
 
     is $mech->uri->path, '/admin/manifesttheme/lincolnshire', "redirected back to edit page";
-    $mech->content_lacks($icon_filename);
-    $mech->content_lacks("133x100");
+    $mech->content_lacks("<img src=\"/theme/lincolnshire/" . $icon_filename);
+    $mech->content_lacks("<td class=\"icon-size\">133x100</td>");
     ok !$icon_dest->exists, "Icon removed from disk";
 };
 

--- a/t/app/controller/admin/manifesttheme.t
+++ b/t/app/controller/admin/manifesttheme.t
@@ -1,0 +1,244 @@
+use FixMyStreet::TestMech;
+use FixMyStreet::DB;
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $superuser = $mech->create_user_ok('superuser@example.com', name => 'Super User', is_superuser => 1);
+
+$mech->log_in_ok( $superuser->email );
+
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => [ 'lincolnshire', 'fixmystreet' ],
+}, sub {
+
+ok $mech->host('lincolnshire.fixmystreet.com');
+
+subtest "theme link on cobrand admin goes to create form if no theme exists" => sub {
+    is( FixMyStreet::DB->resultset('ManifestTheme')->count, 0, "no themes yet" );
+
+    $mech->get_ok("/admin");
+    $mech->follow_link_ok({ text => "Manifest Theme" });
+
+    is $mech->res->previous->code, 302, "got 302 for redirect";
+    is $mech->res->previous->base->path, "/admin/manifesttheme", "redirected from index";
+    is $mech->uri->path, '/admin/manifesttheme/create', "redirected to create page";
+};
+
+subtest "name and short_name are required fields" => sub {
+    is( FixMyStreet::DB->resultset('ManifestTheme')->count, 0, "no themes yet" );
+
+    $mech->get_ok("/admin/manifesttheme/create");
+    $mech->content_lacks("Delete theme");
+
+    $mech->submit_form_ok({});
+    is $mech->uri->path, '/admin/manifesttheme/create', "stayed on create page";
+    $mech->content_contains("field is required");
+    is( FixMyStreet::DB->resultset('ManifestTheme')->count, 0, "theme not created" );
+
+    $mech->get_ok("/admin/manifesttheme/create");
+    $mech->submit_form_ok({ with_fields => { short_name => "Lincs FMS" } });
+    is $mech->uri->path, '/admin/manifesttheme/create', "stayed on create page";
+    $mech->content_contains("field is required", "name is required");
+    is( FixMyStreet::DB->resultset('ManifestTheme')->count, 0, "theme not created" );
+
+    $mech->get_ok("/admin/manifesttheme/create");
+    $mech->submit_form_ok({ with_fields => { name => "Lincolnshire FixMyStreet" } });
+    is $mech->uri->path, '/admin/manifesttheme/create', "stayed on create page";
+    $mech->content_contains("field is required", "short_name is required");
+    is( FixMyStreet::DB->resultset('ManifestTheme')->count, 0, "theme not created" );
+};
+
+subtest "cobrand admin lets you create a new theme" => sub {
+    is( FixMyStreet::DB->resultset('ManifestTheme')->count, 0, "no themes yet" );
+
+    $mech->get_ok("/admin/manifesttheme/create");
+    $mech->content_lacks("Delete theme");
+
+    my $fields = {
+        name => "Lincolnshire FixMyStreet",
+        short_name => "Lincs FMS",
+    };
+    $mech->submit_form_ok( { with_fields => $fields } );
+    is $mech->uri->path, '/admin/manifesttheme/lincolnshire', "redirected to edit page";
+    is( FixMyStreet::DB->resultset('ManifestTheme')->count, 1, "theme was created" );
+
+    my $theme = FixMyStreet::DB->resultset('ManifestTheme')->find({ cobrand => 'lincolnshire' });
+    is $theme->name, "Lincolnshire FixMyStreet";
+    is $theme->short_name, "Lincs FMS";
+    is $theme->background_colour, undef;
+
+    my $log = $superuser->admin_logs->search({}, { order_by => { -desc => 'id' } })->first;
+    is $log->object_id, $theme->id;
+    is $log->action, "add";
+    is $log->object_summary, "lincolnshire";
+    is $log->link, "/admin/manifesttheme/lincolnshire";
+
+    $fields = {
+        background_colour => "#663399",
+        theme_colour => "rgb(102, 51, 153)",
+    };
+    $mech->submit_form_ok( { with_fields => $fields } );
+    $theme->discard_changes;
+    is $theme->background_colour, "#663399";
+    is $theme->theme_colour, "rgb(102, 51, 153)";
+
+    $log = $superuser->admin_logs->search({}, { order_by => { -desc => 'id' } })->first;
+    is $log->object_id, $theme->id;
+    is $log->action, "edit";
+};
+
+subtest "theme link on cobrand admin goes to edit form when theme exists" => sub {
+    is( FixMyStreet::DB->resultset('ManifestTheme')->count, 1, "theme exists" );
+
+    $mech->get_ok("/admin");
+    $mech->follow_link_ok({ text => "Manifest Theme" });
+
+    is $mech->res->previous->code, 302, "got 302 for redirect";
+    is $mech->res->previous->base->path, "/admin/manifesttheme", "redirected from index";
+    is $mech->uri->path, '/admin/manifesttheme/lincolnshire', "redirected to edit page";
+};
+
+subtest "create page on cobrand admin redirects to edit form when theme exists" => sub {
+    is( FixMyStreet::DB->resultset('ManifestTheme')->count, 1, "theme exists" );
+
+    $mech->get_ok("/admin/manifesttheme/create");
+
+    is $mech->res->previous->code, 302, "got 302 for redirect";
+    is $mech->uri->path, '/admin/manifesttheme/lincolnshire', "redirected to edit page";
+};
+
+subtest "can delete theme" => sub {
+    is( FixMyStreet::DB->resultset('ManifestTheme')->count, 1, "theme exists" );
+
+    $mech->get_ok("/admin/manifesttheme/lincolnshire");
+    my $theme_id = FixMyStreet::DB->resultset('ManifestTheme')->find({ cobrand => 'lincolnshire' })->id;
+
+    $mech->submit_form_ok({ button => 'delete_theme' });
+    is $mech->uri->path, '/admin/manifesttheme/create', "redirected to create page";
+
+    is( FixMyStreet::DB->resultset('ManifestTheme')->count, 0, "theme deleted" );
+
+    my $log = $superuser->admin_logs->search({}, { order_by => { -desc => 'id' } })->first;
+    is $log->object_id, $theme_id;
+    is $log->action, "delete";
+};
+
+subtest "can't edit another cobrand's theme" => sub {
+    FixMyStreet::DB->resultset('ManifestTheme')->create({
+        cobrand => "tfl",
+        name => "Transport for London Street Care",
+        short_name => "TfL Street Care",
+    });
+
+    $mech->get("/admin/manifesttheme/tfl");
+    ok !$mech->res->is_success(), "want a bad response";
+    is $mech->res->code, 404, "got 404";
+};
+
+ok $mech->host('www.fixmystreet.com');
+
+subtest "fms cobrand lets you view all manifest themes" => sub {
+    is( FixMyStreet::DB->resultset('ManifestTheme')->count, 1, "theme already exists" );
+
+    $mech->get_ok("/admin");
+    $mech->follow_link_ok({ text => "Manifest Theme" });
+
+    is $mech->uri->path, '/admin/manifesttheme', "taken to list page";
+
+    $mech->content_contains("Transport for London Street Care");
+    $mech->content_contains("TfL Street Care");
+
+};
+
+subtest "fms cobrand lets you edit a cobrand's manifest theme" => sub {
+    $mech->get_ok("/admin/manifesttheme");
+    $mech->follow_link_ok({ url => "manifesttheme/tfl" }) or diag $mech->content;
+
+    my $fields = {
+        name => "Transport for London Report It",
+    };
+    $mech->submit_form_ok( { with_fields => $fields } );
+    is $mech->uri->path, '/admin/manifesttheme', "redirected back to list page";
+
+    my $theme = FixMyStreet::DB->resultset('ManifestTheme')->find({ cobrand => 'tfl' });
+    is $theme->name, "Transport for London Report It";
+
+};
+
+subtest "fms cobrand lets you create a new manifest theme" => sub {
+    $mech->get_ok("/admin/manifesttheme");
+    $mech->follow_link_ok({ text => "Create" });
+
+    my $fields = {
+        name => "FixMyStreet Pro",
+        short_name => "FMS Pro",
+        cobrand => "fixmystreet",
+    };
+    $mech->submit_form_ok( { with_fields => $fields } );
+    is $mech->uri->path, '/admin/manifesttheme', "redirected to list page";
+
+    is( FixMyStreet::DB->resultset('ManifestTheme')->count, 2, "theme added" );
+    my $theme = FixMyStreet::DB->resultset('ManifestTheme')->find({ cobrand => 'fixmystreet' });
+    is $theme->name, "FixMyStreet Pro";
+};
+
+subtest "fms cobrand prevents you creating a duplicate theme" => sub {
+    $mech->get_ok("/admin/manifesttheme");
+    $mech->follow_link_ok({ text => "Create" });
+
+    my $fields = {
+        name => "FixMyStreet Pro",
+        short_name => "FMS Pro",
+        cobrand => "fixmystreet",
+    };
+    $mech->submit_form_ok( { with_fields => $fields } );
+    is $mech->uri->path, '/admin/manifesttheme/create', "stayed on create form";
+
+    is( FixMyStreet::DB->resultset('ManifestTheme')->count, 2, "theme not added" );
+};
+
+subtest "fms cobrand prevents creating a duplicate by editing" => sub {
+    $mech->get_ok("/admin/manifesttheme");
+    $mech->follow_link_ok({ url => "manifesttheme/tfl" });
+
+    my $fields = {
+        cobrand => "fixmystreet",
+    };
+    $mech->submit_form_ok( { with_fields => $fields } );
+    is $mech->uri->path, '/admin/manifesttheme/tfl', "stayed on edit page";
+};
+
+};
+
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => [ 'fixamingata' ],
+}, sub {
+
+ok $mech->host("www.fixamingata.se"), "change host to FixaMinGata";
+
+subtest "single cobrand behaves correctly" => sub {
+    FixMyStreet::DB->resultset('ManifestTheme')->delete_all;
+    is( FixMyStreet::DB->resultset('ManifestTheme')->count, 0, "themes all deleted" );
+
+    $mech->get_ok("/admin/manifesttheme");
+    is $mech->uri->path, '/admin/manifesttheme/create', "redirected to create page";
+
+    my $fields = {
+        name => "FixaMinGata Theme Test",
+        short_name => "FixaMinGata Short Name",
+        cobrand => "fixamingata",
+    };
+    $mech->submit_form_ok( { with_fields => $fields } );
+    is $mech->uri->path, '/admin/manifesttheme/fixamingata', "redirected to edit form page";
+    $mech->content_contains("FixaMinGata Theme Test");
+    $mech->content_contains("FixaMinGata Short Name");
+
+    is( FixMyStreet::DB->resultset('ManifestTheme')->count, 1, "theme added" );
+    my $theme = FixMyStreet::DB->resultset('ManifestTheme')->find({ cobrand => 'fixamingata' });
+    is $theme->name, "FixaMinGata Theme Test";
+};
+
+
+};
+
+done_testing();

--- a/t/app/controller/offline.t
+++ b/t/app/controller/offline.t
@@ -1,4 +1,5 @@
 use FixMyStreet::TestMech;
+use FixMyStreet::DB;
 use Path::Tiny;
 
 my $mech = FixMyStreet::TestMech->new;
@@ -19,6 +20,21 @@ FixMyStreet::override_config {
             src => '/theme/test/sample.jpg',
             sizes => '133x100'
         }, 'correct icon';
+    };
+    subtest 'themed manifest' => sub {
+        FixMyStreet::DB->resultset('ManifestTheme')->create({
+            cobrand => "test",
+            name => "My Test Cobrand FMS",
+            short_name => "Test FMS",
+            background_colour => "#ff00ff",
+            theme_colour => "#ffffff",
+        });
+
+        my $j = $mech->get_ok_json('/.well-known/manifest.webmanifest');
+        is $j->{name}, 'My Test Cobrand FMS', 'correctly overridden name';
+        is $j->{short_name}, 'Test FMS', 'correctly overridden short_name';
+        is $j->{background_color}, '#ff00ff', 'correctly overridden background colour';
+        is $j->{theme_color}, '#ffffff', 'correctly overridden theme colour';
     };
     $theme_dir->remove_tree;
 };

--- a/t/app/controller/offline.t
+++ b/t/app/controller/offline.t
@@ -1,6 +1,7 @@
 use FixMyStreet::TestMech;
 use FixMyStreet::DB;
 use Path::Tiny;
+use Memcached;
 
 my $mech = FixMyStreet::TestMech->new;
 
@@ -12,6 +13,7 @@ FixMyStreet::override_config {
     my $image_path = path('t/app/controller/sample.jpg');
     $image_path->copy($theme_dir->child('sample.jpg'));
     subtest 'manifest' => sub {
+        Memcached::delete("manifest_theme:test");
         my $j = $mech->get_ok_json('/.well-known/manifest.webmanifest');
         is $j->{name}, 'FixMyStreet', 'correct name';
         is $j->{theme_color}, '#ffd000', 'correct theme colour';
@@ -22,6 +24,7 @@ FixMyStreet::override_config {
         }, 'correct icon';
     };
     subtest 'themed manifest' => sub {
+        Memcached::delete("manifest_theme:test");
         FixMyStreet::DB->resultset('ManifestTheme')->create({
             cobrand => "test",
             name => "My Test Cobrand FMS",

--- a/templates/web/base/admin/manifesttheme/form.html
+++ b/templates/web/base/admin/manifesttheme/form.html
@@ -23,6 +23,8 @@
 
     [% IF show_all %]
       [% form.field('cobrand').render | safe %]
+    [% ELSE %]
+      <input type=hidden name=cobrand value='[% c.cobrand.moniker %]' />
     [% END %]
 
     <table>

--- a/templates/web/base/admin/manifesttheme/form.html
+++ b/templates/web/base/admin/manifesttheme/form.html
@@ -1,0 +1,42 @@
+[% INCLUDE 'admin/header.html' title=loc('Theme') -%]
+
+<form method="post">
+    <div class="admin-hint">
+      <p>[% loc("The <strong>name</strong> is a string that represents the name of the web application as it is usually displayed to the user (e.g., amongst a list of other applications, or as a label for an icon).") %]</p>
+    </div>
+    [% form.field('name').render | safe %]
+
+    <div class="admin-hint">
+      <p>[% loc("The <strong>short name</strong> is a string that represents the name of the web application displayed to the user if there is not enough space to display name (e.g., as a label for an icon on the phone home screen).") %]</p>
+    </div>
+    [% form.field('short_name').render | safe %]
+
+    <div class="admin-hint">
+      <p>[% loc("The <strong>theme colour</strong> defines the default theme colour for the application. This sometimes affects how the OS displays the site (e.g., on Android's task switcher, the theme colour surrounds the site). Colours should be specified with CSS syntax, e.g. <strong><code>#ff00ff</code></strong> or <strong><code>rgb(255, 0, 255)</code></strong> or a named colour like <strong><code>fuchsia</code></strong>.") %]</p>
+    </div>
+    [% form.field('theme_colour').render | safe %]
+
+    <div class="admin-hint">
+      <p>[% loc("The <strong>background colour</strong> defines a placeholder background colour for the application splash screen before it has loaded.  Colours should be specified with CSS syntax, e.g. <strong><code>#ff00ff</code></strong> or <strong><code>rgb(255, 0, 255)</code></strong> or a named colour like <strong><code>fuchsia</code></strong>.") %]</p>
+    </div>
+    [% form.field('background_colour').render | safe %]
+
+    [% IF show_all %]
+      [% form.field('cobrand').render | safe %]
+    [% END %]
+
+    <p>
+        <input class="btn" type="submit" name="submit" value="[% loc('Save changes') %]">
+    </p>
+  [% IF form.item.id %]
+    <p>
+        <input class="btn-danger" type="submit" name="delete_theme" value="[% loc('Delete theme') %]" data-confirm="[% loc('Are you sure?') %]">
+    </p>
+  [% END %]
+</form>
+
+[% IF show_all %]
+  <p><a href="[% c.uri_for(c.controller.action_for('list')) %]">Return to themes list</a></p>
+[% END %]
+
+[% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/admin/manifesttheme/form.html
+++ b/templates/web/base/admin/manifesttheme/form.html
@@ -1,6 +1,6 @@
 [% INCLUDE 'admin/header.html' title=loc('Theme') -%]
 
-<form method="post">
+<form method="post" enctype="multipart/form-data">
     <div class="admin-hint">
       <p>[% loc("The <strong>name</strong> is a string that represents the name of the web application as it is usually displayed to the user (e.g., amongst a list of other applications, or as a label for an icon).") %]</p>
     </div>
@@ -24,6 +24,33 @@
     [% IF show_all %]
       [% form.field('cobrand').render | safe %]
     [% END %]
+
+    <table>
+      <thead>
+        <tr>
+          <th>Icon</th>
+          <th>Size</th>
+          <th>Delete?</th>
+        </tr>
+      </thead>
+      <tbody>
+        [% FOREACH icon IN manifest_icons %]
+          <tr>
+            <td><img src="[% icon.src %]" /></td>
+            <td class="icon-size">[% icon.sizes %]</td>
+            <td><input type=checkbox name=delete_icon value='[% icon.src %]' /></td>
+          </tr>
+        [% END %]
+        <tr>
+          <td colspan=3>
+            <div class="admin-hint">
+              <p>[% loc("The <strong>icons</strong> are used when the application is installed to the user's home screen. Icons must be <strong>square</strong>, with <strong>512x512</strong>px and <strong>192x192</strong>px being the most common sizes.") %]</p>
+            </div>
+            [% form.field('icon').render | safe %]
+          </td>
+        </tr>
+      </tbody>
+    </table>
 
     <p>
         <input class="btn" type="submit" name="submit" value="[% loc('Save changes') %]">

--- a/templates/web/base/admin/manifesttheme/form.html
+++ b/templates/web/base/admin/manifesttheme/form.html
@@ -36,7 +36,7 @@
         </tr>
       </thead>
       <tbody>
-        [% FOREACH icon IN manifest_icons %]
+        [% FOREACH icon IN editing_manifest_theme.icons %]
           <tr>
             <td><img src="[% icon.src %]" /></td>
             <td class="icon-size">[% icon.sizes %]</td>

--- a/templates/web/base/admin/manifesttheme/index.html
+++ b/templates/web/base/admin/manifesttheme/index.html
@@ -1,0 +1,35 @@
+[% INCLUDE 'admin/header.html' title=loc('Themes') %]
+
+<table>
+  <thead>
+  <tr>
+      <th>  [% loc('Cobrand') %] </th>
+      <th>  [% loc('Name') %] </th>
+      <th>  [% loc('Short Name') %] </th>
+      <th>  [% loc('Background Colour') %] </th>
+      <th>  [% loc('Theme Colour') %] </th>
+      <th>  &nbsp; </th>
+  </tr>
+  </thead>
+  <tbody>
+    [% FOR theme IN rs.all %]
+      <tr>
+        <td>[% theme.cobrand %]</td>
+        <td>[% theme.name %]</td>
+        <td>[% theme.short_name %]</td>
+        <td>[% theme.background_colour %]</td>
+        <td>[% theme.theme_colour %]</td>
+        <td> <a href="[% c.uri_for(c.controller.action_for('edit'), [theme.cobrand]) %]" class="btn">[% loc('Edit') %]</a> </td>
+      </tr>
+    [% END %]
+  </tbody>
+</table>
+
+
+
+<p>
+    <a href="[% c.uri_for(c.controller.action_for('create')) %]">[% loc('Create') %]</a>
+  </p>
+  
+
+[% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/common_header_tags.html
+++ b/templates/web/base/common_header_tags.html
@@ -2,8 +2,11 @@
 
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
 <link rel="manifest" href="/.well-known/manifest.webmanifest">
-[% FOREACH icon IN manifest_icons %]
-    <link rel="apple-touch-icon" sizes="[% icon.sizes %]" href="[% icon.src %]">
+[% IF manifest_theme %]
+    <meta name='theme-color' content='[% manifest_theme.theme_colour %]'>
+    [% FOREACH icon IN manifest_theme.icons %]
+        <link rel="apple-touch-icon" sizes="[% icon.sizes %]" href="[% icon.src %]">
+    [% END %]
 [% END %]
 
 [% IF csrf_token %]

--- a/templates/web/base/common_header_tags.html
+++ b/templates/web/base/common_header_tags.html
@@ -2,6 +2,9 @@
 
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
 <link rel="manifest" href="/.well-known/manifest.webmanifest">
+[% FOREACH icon IN manifest_icons %]
+    <link rel="apple-touch-icon" sizes="[% icon.sizes %]" href="[% icon.src %]">
+[% END %]
 
 [% IF csrf_token %]
   <meta content="[% csrf_token %]" name="csrf-token" />

--- a/templates/web/fixmystreet.com/header_extra.html
+++ b/templates/web/fixmystreet.com/header_extra.html
@@ -10,7 +10,6 @@
     <link rel="canonical" href="https://www.fixmystreet.com[% c.req.uri.path_query %]">
 [% END %]
 
-<meta name='theme-color' content='#ffd000'>
 <link rel="Shortcut Icon" type="image/x-icon" href="/cobrands/fixmystreet.com/favicon.ico">
 
 [% INCLUDE 'tracking_code.html' %]

--- a/web/cobrands/fixmystreet/admin.js
+++ b/web/cobrands/fixmystreet/admin.js
@@ -190,5 +190,12 @@ $(function(){
     $('.js-metadata-items').on('click', '.js-metadata-option-remove', function(){
         $(this).parents('.js-metadata-option').remove();
     });
+
+    // On the manifest theme editing page we have tickboxes for deleting individual
+    // icons - ticking one of these should grey out that row to indicate it will be
+    // deleted upon form submission.
+    $("input[name=delete_icon]").change(function() {
+        $(this).closest("tr").toggleClass("is-deleted", this.checked);
+    });
 });
 

--- a/web/cobrands/sass/_admin.scss
+++ b/web/cobrands/sass/_admin.scss
@@ -61,7 +61,10 @@ $button_bg_col: #a1a1a1;  // also search bar (tables)
         }
         tr.is-deleted {
           background-color: #ffdddd;
-          td.contact-category {
+          img {
+              filter: grayscale(1);
+          }
+          td.contact-category, td.icon-size {
             text-decoration: line-through;
           }
         }


### PR DESCRIPTION
Adds admin UI for superusers to manage the `ManifestTheme` model for each cobrand. Allows the names/icon/colours to be customised.

## Desktop Chrome PWA theming:
<img width="391" alt="Screenshot 2020-01-30 at 15 48 36" src="https://user-images.githubusercontent.com/4776/73465238-00fdf000-4378-11ea-9333-9599ae7b284b.png">

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/4776/73465162-e0359a80-4377-11ea-8cc1-b0b00e950ba0.png">

## Installing on iOS:
Installing | Icon
---------- | ----
![IMG_1640](https://user-images.githubusercontent.com/4776/73465331-25f26300-4378-11ea-8196-1e05cf6a4bc5.PNG) | ![IMG_D33429854842-1](https://user-images.githubusercontent.com/4776/73465348-2c80da80-4378-11ea-9ece-cff1aaf91748.jpeg)


## Managing via cobrand admin
![lincolnshire fms davea me_admin_manifesttheme_lincolnshire (2)](https://user-images.githubusercontent.com/4776/73465660-99947000-4378-11ea-8321-d1d94d1b2a1b.png)

## fixmystreet.com can edit all cobrand themes
<img width="1050" alt="image" src="https://user-images.githubusercontent.com/4776/73465719-b3ce4e00-4378-11ea-8197-93a5b491b50c.png">

## Guidance tooltips
![fms davea me_admin_manifesttheme_tfl](https://user-images.githubusercontent.com/4776/73465823-d95b5780-4378-11ea-94ef-0a0e9fbc3ede.png)

### Possible future improvements
 - Colour picker UI in form
 - Live preview of app/home screen UI alongside form fields

Please check the following:

- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

Fixes #2792.