### PR TITLE
Display inline map for duplicate suggestions on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
         - Use nicer default photo upload message. #2358
         - Remove pan control from mobile widths. #2865
         - Use category groups whenever category lists are shown. #2702
+        - Display map inline with duplicate suggestions on mobile. #2668
     - Admin improvements:
         - Add new roles system, to group permissions and apply to users. #2483
         - Contact form emails now include user admin links.

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -590,7 +590,13 @@ sub inspect : Private {
 sub map :Chained('id') :Args(0) {
     my ($self, $c) = @_;
 
-    my $image = $c->stash->{problem}->static_map;
+    my %params;
+    if ( $c->get_param('inline_duplicate') ) {
+        $params{full_size} = 1;
+        $params{zoom} = 5;
+    }
+
+    my $image = $c->stash->{problem}->static_map(%params);
     $c->res->content_type($image->{content_type});
     $c->res->body($image->{data});
 }
@@ -639,7 +645,7 @@ sub _nearby_json :Private {
 
     my $list_html = $c->render_fragment(
         'report/nearby.html',
-        { reports => $nearby }
+        { reports => $nearby, inline_maps => $c->get_param("inline_maps") ? 1 : 0 }
     );
 
     my $json = { pins => \@pins };

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -1045,7 +1045,7 @@ sub pin_data {
 };
 
 sub static_map {
-    my ($self) = @_;
+    my ($self, %params) = @_;
 
     return unless $IM;
 
@@ -1053,7 +1053,11 @@ sub static_map {
         unless $FixMyStreet::Map::map_class->isa("FixMyStreet::Map::OSM");
 
     my $map_data = $FixMyStreet::Map::map_class->generate_map_data(
-        { cobrand => $self->get_cobrand_logged },
+        {
+            cobrand => $self->get_cobrand_logged,
+            distance => 1, # prevents the call to Gaze which isn't necessary
+            $params{zoom} ? ( zoom => $params{zoom} ) : (),
+        },
         latitude  => $self->latitude,
         longitude => $self->longitude,
         pins      => $self->used_map
@@ -1110,7 +1114,7 @@ sub static_map {
     $image->Extent( geometry => '512x384', gravity => 'NorthWest');
     $image->Extent( geometry => '512x320', gravity => 'SouthWest');
 
-    $image->Scale( geometry => "310x200>" );
+    $image->Scale( geometry => "310x200>" ) unless $params{full_size};
 
     my @blobs = $image->ImageToBlob(magick => 'jpeg');
     undef $image;

--- a/templates/web/base/report/_item_expandable.html
+++ b/templates/web/base/report/_item_expandable.html
@@ -44,6 +44,11 @@
         [% INCLUDE 'report/_main_sent_info.html' %]
         [% INCLUDE 'report/photo.html' object=problem %]
         [% full_detail %]
+        [% IF inline_maps %]
+          <div class="duplicate-map">
+            <img src="/report/[% problem.id %]/map?inline_duplicate=1" alt="" />
+          </div>
+        [% END %]
     </div>
 
     <div class="item-list__item--expandable__actions">

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1489,6 +1489,12 @@ input.final-submit {
   }
 }
 
+.item-list__item .duplicate-map {
+  padding: 1em;
+  clear: both;
+  text-align: center;
+}
+
 .problem-header .update-img,
 .item-list .update-img {
     float: $right;

--- a/web/js/duplicates.js
+++ b/web/js/duplicates.js
@@ -42,6 +42,10 @@
             url_params.pin_size = 'normal';
         }
 
+        if ($('html').hasClass('mobile')) {
+            url_params.inline_maps = 1;
+        }
+
         if (category && params && params.check_duplicates_dismissal ) {
             dismissed = category === dismissed_category;
             dismissed_category = category;

--- a/web/js/duplicates.js
+++ b/web/js/duplicates.js
@@ -93,15 +93,21 @@
             $('.js-hide-if-invalid-category_extras').slideUp();
         }
 
-        // Highlight map pin when hovering associated list item.
-        var timeout;
-        $reports.on('mouseenter', function(){
-            var id = parseInt( $(this).data('reportId'), 10 );
-            clearTimeout( timeout );
-            fixmystreet.maps.markers_highlight( id );
-        }).on('mouseleave', function(){
-            timeout = setTimeout( fixmystreet.maps.markers_highlight, 50 );
-        });
+        if (!fixmystreet.map.events.extensions.buttonclick.isDeviceTouchCapable) {
+            // Highlight map pin when hovering associated list item.
+            // (not on touchscreens though because a) the 'mouseenter' handler means
+            // two taps are required on the 'read more' button - one to highlight
+            // the list item and another to activate the button- and b) the pins
+            // might be scrolled off the top of the screen anyway e.g. on phones)
+            var timeout;
+            $reports.on('mouseenter', function(){
+                var id = parseInt( $(this).data('reportId'), 10 );
+                clearTimeout( timeout );
+                fixmystreet.maps.markers_highlight( id );
+            }).on('mouseleave', function(){
+                timeout = setTimeout( fixmystreet.maps.markers_highlight, 50 );
+            });
+        }
 
         // Add a "select this report" button, when on the report inspect form.
         if ( $('#report_inspect_form').length ) {


### PR DESCRIPTION
When making a new report on mobile devices the main map has scrolled off the top of the page when the duplicate suggestions are shown. This PR adds an inline image for each one that gives a bit more context about where the suggested report:

![westminster fms davea me_report_new_longitude=-0 15226302250671653 latitude=51 509851245708994(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/4776/73468806-45d85580-437d-11ea-81f2-d37d01e0f8e0.png)


Fixes #2668.