### PR TITLE
Default logging to logged in user.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -369,8 +369,8 @@ sub set_allowed_pages : Private {
 sub get_user : Private {
     my ( $self, $c ) = @_;
 
-    my $user = $c->req->remote_user();
-    $user ||= ($c->user && $c->user->name);
+    my $user = ($c->user && $c->user->name);
+    $user ||= $c->req->remote_user();
     $user ||= '';
 
     return $user;


### PR DESCRIPTION
Historically, the FixMyStreet admin was accessed via HTTP Basic Auth and
a secure proxy, so the auth user was used for logging purposes. Nowadays
all admin use is by FixMyStreet user, and any Basic Auth is used for the
purpose of hiding staging sites from bots. This configuration means that
on those staging sites, all admin is logged by the one staging user, not
the actual user, so let's swap that round.

[skip changelog]
