### PR TITLE
[UK] Use feature flag for send_questionnaire.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -278,22 +278,22 @@ sub about_hook {
     }
 }
 
-sub updates_disallowed_config {
-    my ($self, $problem) = @_;
+sub per_body_config {
+    my ($self, $feature, $problem) = @_;
 
     # This is a hash of council name to match, and what to do
-    my $cfg = $self->feature('updates_allowed') || {};
+    my $cfg = $self->feature($feature) || {};
 
-    my $type = '';
+    my $value;
     my $body;
     foreach (keys %$cfg) {
         if ($problem->to_body_named($_)) {
-            $type = $cfg->{$_};
+            $value = $cfg->{$_};
             $body = $_;
             last;
         }
     }
-    return ($type, $body);
+    return ($value, $body);
 }
 
 sub updates_disallowed {
@@ -301,7 +301,8 @@ sub updates_disallowed {
     my ($problem) = @_;
     my $c = $self->{c};
 
-    my ($type, $body) = $self->updates_disallowed_config($problem);
+    my ($type, $body) = $self->per_body_config('updates_allowed', $problem);
+    $type //= '';
 
     if ($type eq 'none') {
         return 1;
@@ -341,10 +342,8 @@ sub must_have_2fa {
 
 sub send_questionnaire {
     my ($self, $problem) = @_;
-    my $cobrand = $problem->get_cobrand_logged;
-    return 0 if $cobrand->moniker eq 'tfl';
-    return 0 if $problem->to_body_named('TfL');
-    return 1;
+    my ($send, $body) = $self->per_body_config('send_questionnaire', $problem);
+    return $send // 1;
 }
 
 sub update_email_shortlisted_user {

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -1,6 +1,7 @@
 use FixMyStreet::TestMech;
 use FixMyStreet::App;
 use FixMyStreet::Script::Reports;
+use FixMyStreet::Script::Questionnaires;
 
 # disable info logs for this test run
 FixMyStreet::App->log->disable('info');
@@ -207,6 +208,11 @@ FixMyStreet::override_config {
         },
         do_not_reply_email => {
             tfl => 'fms-tfl-DO-NOT-REPLY@example.com',
+        },
+        send_questionnaire => {
+            fixmystreet => {
+                TfL => 0,
+            }
         },
     },
 }, sub {
@@ -690,6 +696,12 @@ subtest 'Test public reports are visible on cobrands appropriately' => sub {
     $mech->content_contains('Test Bromley report');
     $mech->content_contains('https://street.tfl/report/' . $tfl_report->id);
     $mech->content_contains('Other problem');
+};
+
+subtest 'Test no questionnaire sending' => sub {
+    $report->update({ send_questionnaire => 1, whensent => \"current_timestamp-'7 weeks'::interval" });
+    FixMyStreet::Script::Questionnaires::send();
+    $mech->email_count_is(0);
 };
 
 };


### PR DESCRIPTION
Will need a feature adding to match current behaviour of:
```
send_questionnaire:
  fixmystreet:
    TfL: 0
```
[skip changelog] Connects with https://github.com/mysociety/fixmystreet-freshdesk/issues/111