### PR TITLE
[Zürich] Fix crash on certain /report/ajax/<id> URLs

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -299,7 +299,8 @@ sub format_problem_for_display : Private {
         delete $report_hashref->{created};
         delete $report_hashref->{confirmed};
 
-        my $content = encode_json(
+        my $json = JSON::MaybeXS->new( convert_blessed => 1, utf8 => 1 );
+        my $content = $json->encode(
             {
                 report => $report_hashref,
                 updates => $c->cobrand->updates_as_hashref( $problem, $c ),

--- a/perllib/FixMyStreet/Template/SafeString.pm
+++ b/perllib/FixMyStreet/Template/SafeString.pm
@@ -69,6 +69,12 @@ sub clone {
     return $clone;
 }
 
+sub TO_JSON {
+    my $self = shift;
+
+    return $$self;
+}
+
 1;
 __END__
 

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -118,6 +118,15 @@ my $json = $mech->get_ok_json( '/report/ajax/' . $report->id );
 is $json->{report}->{title}, "Überprüfung ausstehend", "correct title";
 is $json->{report}->{state}, "submitted", "correct state";
 
+$report->state('fixed - council');
+$report->set_extra_metadata(public_response => 'Freundliche Grüsse');
+$report->update;
+$json = $mech->get_ok_json( '/report/ajax/' . $report->id );
+is $json->{report}->{state}, "closed", "correct state";
+is $json->{updates}->{details}, "Freundliche Grüsse", "correct public response";
+
+$report->update({ state => 'submitted' });
+
 subtest "Banners are displayed correctly" => sub {
     for my $test (
         {


### PR DESCRIPTION
Attempting to load the `/report/ajax/<id>` URL for a problem that had a public response and wasn't in the ‘external’ state was causing a crash because the call to `FixMyStreet::App::View::Web::add_links` in `updates_as_hashref` was returning a `FixMyStreet::Template::SafeString` that the JSON module didn't know how to serialise.

This commit adds a `TO_JSON` method to `SafeString`, and ensures the output
of `/report/ajax/<id>` is JSON-encoded with `convert_blessed` turned on so the
`TO_JSON` method is called.

[skip changelog]