### PR TITLE
[TfL] Bus stops outside London

### DIFF
--- a/.cypress/cypress/fixtures/tfl-bus-stops.xml
+++ b/.cypress/cypress/fixtures/tfl-bus-stops.xml
@@ -1,0 +1,176 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver https://tilma.mysociety.org:80/mapserver/tfl?SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=busstops&amp;OUTPUTFORMAT=text/xml;%20subtype=gml/3.1.1  http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+      <gml:boundedBy>
+      	<gml:Envelope srsName="EPSG:3857">
+      		<gml:lowerCorner>-26966.052548 6682557.933485</gml:lowerCorner>
+      		<gml:upperCorner>-24818.713303 6683455.672461</gml:upperCorner>
+      	</gml:Envelope>
+      </gml:boundedBy>
+<!-- WARNING: FeatureId item 'fid' not found in typename 'busstops'. -->
+    <gml:featureMember>
+      <ms:busstops>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-26739.919949 6682734.390283</gml:lowerCorner>
+        		<gml:upperCorner>-26739.919949 6682734.390283</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point srsName="EPSG:3857">
+            <gml:pos>-26739.919949 6682734.390283</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:STOP_CODE>BP3936</ms:STOP_CODE>
+      </ms:busstops>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:busstops>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-24974.257309 6683105.238970</gml:lowerCorner>
+        		<gml:upperCorner>-24974.257309 6683105.238970</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point srsName="EPSG:3857">
+            <gml:pos>-24974.257309 6683105.238970</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:STOP_CODE>BP3931</ms:STOP_CODE>
+      </ms:busstops>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:busstops>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-24826.301974 6683406.167649</gml:lowerCorner>
+        		<gml:upperCorner>-24826.301974 6683406.167649</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point srsName="EPSG:3857">
+            <gml:pos>-24826.301974 6683406.167649</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:STOP_CODE>BP3929</ms:STOP_CODE>
+      </ms:busstops>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:busstops>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-26021.414677 6682568.040132</gml:lowerCorner>
+        		<gml:upperCorner>-26021.414677 6682568.040132</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point srsName="EPSG:3857">
+            <gml:pos>-26021.414677 6682568.040132</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:STOP_CODE>BP3939</ms:STOP_CODE>
+      </ms:busstops>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:busstops>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-24818.713303 6683455.672461</gml:lowerCorner>
+        		<gml:upperCorner>-24818.713303 6683455.672461</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point srsName="EPSG:3857">
+            <gml:pos>-24818.713303 6683455.672461</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:STOP_CODE>BP3930</ms:STOP_CODE>
+      </ms:busstops>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:busstops>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-25376.237114 6682675.840759</gml:lowerCorner>
+        		<gml:upperCorner>-25376.237114 6682675.840759</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point srsName="EPSG:3857">
+            <gml:pos>-25376.237114 6682675.840759</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:STOP_CODE>BP3934</ms:STOP_CODE>
+      </ms:busstops>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:busstops>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-26966.052548 6682770.284294</gml:lowerCorner>
+        		<gml:upperCorner>-26966.052548 6682770.284294</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point srsName="EPSG:3857">
+            <gml:pos>-26966.052548 6682770.284294</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:STOP_CODE>BP3935</ms:STOP_CODE>
+      </ms:busstops>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:busstops>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-26068.008727 6682557.933485</gml:lowerCorner>
+        		<gml:upperCorner>-26068.008727 6682557.933485</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point srsName="EPSG:3857">
+            <gml:pos>-26068.008727 6682557.933485</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:STOP_CODE>BP3938</ms:STOP_CODE>
+      </ms:busstops>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:busstops>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-25333.074328 6682676.397427</gml:lowerCorner>
+        		<gml:upperCorner>-25333.074328 6682676.397427</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point srsName="EPSG:3857">
+            <gml:pos>-25333.074328 6682676.397427</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:STOP_CODE>BP3933</ms:STOP_CODE>
+      </ms:busstops>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:busstops>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-24959.726550 6683177.005692</gml:lowerCorner>
+        		<gml:upperCorner>-24959.726550 6683177.005692</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point srsName="EPSG:3857">
+            <gml:pos>-24959.726550 6683177.005692</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:STOP_CODE>BP3932</ms:STOP_CODE>
+      </ms:busstops>
+    </gml:featureMember>
+</wfs:FeatureCollection>

--- a/.cypress/cypress/fixtures/tfl-tlrn.xml
+++ b/.cypress/cypress/fixtures/tfl-tlrn.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver https://tilma.mysociety.org:80/mapserver/highways?SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=Highways&amp;OUTPUTFORMAT=text/xml;%20subtype=gml/3.1.1  http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+   <gml:boundedBy>
+      <gml:Null>missing</gml:Null>
+   </gml:boundedBy>
+</wfs:FeatureCollection>
+

--- a/.cypress/cypress/integration/tfl.js
+++ b/.cypress/cypress/integration/tfl.js
@@ -1,0 +1,37 @@
+it('allows bus stop clicking outside London', function() {
+    cy.server();
+    cy.route('/report/new/ajax*').as('report-ajax');
+    cy.fixture('tfl-bus-stops.xml');
+    cy.route('**/mapserver/tfl*busstops*', 'fixture:tfl-bus-stops.xml').as('tfl-bus-stops');
+    cy.route('**/mapserver/tfl*RedRoutes*', 'fixture:tfl-tlrn.xml').as('tfl-tlrn');
+
+    // Click on a bus stop outside London...
+    cy.visit('http://tfl.localhost:3001/report/new?latitude=51.345714&longitude=-0.227959');
+    cy.wait('@report-ajax');
+    cy.contains('Transport for London');
+    cy.get('[id=category_group]').select('Bus Stops and Shelters');
+    cy.wait('@tfl-bus-stops');
+    cy.get('.js-subcategory').select('Incorrect timetable');
+
+    // Also check a category not on a red route
+    cy.get('[id=category_group]').select('Mobile Crane Operation');
+    cy.contains('does not maintain this road');
+});
+
+it('does not show TfL categories outside London on .com', function() {
+    cy.visit('http://fixmystreet.localhost:3001/report/new?latitude=51.345714&longitude=-0.227959');
+    cy.contains('We do not yet have details');
+});
+
+it('shows TfL categories inside London on .com', function() {
+    cy.server();
+    cy.route('/report/new/ajax*').as('report-ajax');
+
+    cy.visit('http://fixmystreet.localhost:3001/');
+    cy.get('[name=pc]').type('TW7 5JN');
+    cy.get('[name=pc]').parents('form').submit();
+    cy.get('#map_box').click(290, 307);
+    cy.wait('@report-ajax');
+    cy.get('[id=category_group]').select('Bus Stops and Shelters');
+    cy.get('[id=category_group]').select('Potholes');
+});

--- a/bin/browser-tests
+++ b/bin/browser-tests
@@ -11,7 +11,7 @@ my ($cobrand, $coords, $area_id, $name, $mapit_url);
 
 BEGIN {
     $config_file = 'conf/general.yml-example';
-    $cobrand = [ 'borsetshire', 'fixmystreet', 'northamptonshire', 'bathnes', 'buckinghamshire', 'hounslow', 'isleofwight', 'peterborough' ];
+    $cobrand = [ 'borsetshire', 'fixmystreet', 'northamptonshire', 'bathnes', 'buckinghamshire', 'hounslow', 'isleofwight', 'peterborough', 'tfl' ];
     $coords = '51.532851,-2.284277';
     $area_id = 2608;
     $name = 'Borsetshire';
@@ -150,7 +150,7 @@ browser-tests [running options] [fixture options] [cypress options]
    --help           this help message
 
  Fixture option:
-   --cobrand        Cobrand(s) to use, default is fixmystreet,northamptonshire,bathnes,buckinghamshire,isleofwight,peterborough
+   --cobrand        Cobrand(s) to use, default is fixmystreet,northamptonshire,bathnes,buckinghamshire,isleofwight,peterborough,tfl
    --coords         Default co-ordinates for created reports
    --area_id        Area ID to use for created body
    --name           Name to use for created body

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -101,6 +101,7 @@ if ($opt->test_fixtures) {
         { area_id => 2483, categories => [ 'Potholes', 'Other' ], name => 'Hounslow Borough Council' },
         { area_id => 2636, categories => [ 'Potholes', 'Private', 'Extra' ], name => 'Isle of Wight Council' },
         { area_id => 2566, categories => [ 'Fallen branch' ], name => 'Peterborough City Council' },
+        { area_id => 2498, categories => [ 'Incorrect timetable', 'Glass broken', 'Mobile Crane Operation' ], name => 'TfL' },
     ) {
         $bodies->{$_->{area_id}} = FixMyStreet::DB::Factory::Body->find_or_create($_);
         my $cats = join(', ', @{$_->{categories}});
@@ -222,6 +223,15 @@ if ($opt->test_fixtures) {
             ]
         }
     );
+    $child_cat->update;
+
+    FixMyStreet::DB->resultset('BodyArea')->create({ body_id => $bodies->{2498}->id, area_id => 2457 });
+    FixMyStreet::DB->resultset('BodyArea')->create({ body_id => $bodies->{2498}->id, area_id => 2483 });
+    $child_cat = FixMyStreet::DB->resultset("Contact")->find({ body => $bodies->{2498}, category => 'Incorrect timetable' });
+    $child_cat->set_extra_metadata(group => ['Bus Stops and Shelters']);
+    $child_cat->update;
+    $child_cat = FixMyStreet::DB->resultset("Contact")->find({ body => $bodies->{2498}, category => 'Glass broken' });
+    $child_cat->set_extra_metadata(group => ['Bus Stops and Shelters']);
     $child_cat->update;
 }
 

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -688,6 +688,8 @@ sub setup_categories_and_bodies : Private {
     my @bodies = $c->model('DB::Body')->active->for_areas(keys %$all_areas)->all;
     my %bodies = map { $_->id => $_ } @bodies;
 
+    $c->cobrand->call_hook(munge_report_new_bodies => \%bodies);
+
     my $contacts                #
       = $c                      #
       ->model('DB::Contact')    #
@@ -774,7 +776,7 @@ sub setup_categories_and_bodies : Private {
     $c->stash->{bodies} = \%bodies;
     $c->stash->{contacts} = \@contacts;
     $c->stash->{bodies_to_list} = \%bodies_to_list;
-    $c->stash->{bodies_ids} = [ map { $_->id } @bodies];
+    $c->stash->{bodies_ids} = [ map { $_ } keys %bodies ];
     $c->stash->{category_options} = \@category_options;
     $c->stash->{category_extras}  = \%category_extras;
     $c->stash->{category_extras_hidden}  = \%category_extras_hidden;

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -197,10 +197,12 @@ sub setup_categories_and_map :Private {
 
     my $pins = $c->stash->{pins} || [];
 
+    my $areas = [ $c->stash->{wards} ? map { $_->{id} } @{$c->stash->{wards}} : keys %{$c->stash->{body}->areas} ];
+    $c->cobrand->call_hook(munge_reports_area_list => $areas);
     my %map_params = (
         latitude  => @$pins ? $pins->[0]{latitude} : 0,
         longitude => @$pins ? $pins->[0]{longitude} : 0,
-        area      => [ $c->stash->{wards} ? map { $_->{id} } @{$c->stash->{wards}} : keys %{$c->stash->{body}->areas} ],
+        area      => $areas,
         any_zoom  => 1,
     );
     FixMyStreet::Map::display_map(

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -83,6 +83,17 @@ sub munge_reports_categories_list {
     }
 }
 
+sub munge_report_new_bodies {
+    my ($self, $bodies) = @_;
+
+    my %bodies = map { $_->name => 1 } values %$bodies;
+    if ( $bodies{'TfL'} ) {
+        # Presented categories vary if we're on/off a red route
+        my $tfl = FixMyStreet::Cobrand->get_class_for_moniker( 'tfl' )->new({ c => $self->{c} });
+        $tfl->munge_surrounding_london($bodies);
+    }
+}
+
 sub munge_report_new_contacts {
     my ($self, $contacts) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -83,6 +83,15 @@ sub munge_reports_categories_list {
     }
 }
 
+sub munge_reports_area_list {
+    my ($self, $areas) = @_;
+    my $c = $self->{c};
+    if ($c->stash->{body}->name eq 'TfL') {
+        my %london_hash = map { $_ => 1 } FixMyStreet::Cobrand::TfL->london_boroughs;
+        @$areas = grep { $london_hash{$_} } @$areas;
+    }
+}
+
 sub munge_report_new_bodies {
     my ($self, $bodies) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -468,6 +468,12 @@ sub report_new_is_on_tlrn {
     return scalar @$features ? 1 : 0;
 }
 
+sub munge_reports_area_list {
+    my ($self, $areas) = @_;
+    my %london_hash = map { $_ => 1 } $self->london_boroughs;
+    @$areas = grep { $london_hash{$_} } @$areas;
+}
+
 sub munge_report_new_contacts { }
 sub munge_report_new_bodies { }
 

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -291,6 +291,17 @@ sub prefill_report_fields_for_inspector { 1 }
 
 sub social_auth_disabled { 1 }
 
+sub munge_report_new_bodies {
+    my ($self, $bodies) = @_;
+
+    my %bodies = map { $_->name => 1 } values %$bodies;
+    if ( $bodies{'TfL'} ) {
+        # Presented categories vary if we're on/off a red route
+        my $tfl = FixMyStreet::Cobrand->get_class_for_moniker( 'tfl' )->new({ c => $self->{c} });
+        $tfl->munge_surrounding_london($bodies);
+    }
+}
+
 sub munge_report_new_contacts {
     my ($self, $contacts) = @_;
 

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -46,6 +46,7 @@ my @PLACES = (
     [ 'TW7 5JN', 51.482286, -0.328163, 2483, 'Hounslow Borough Council', 'LBO' ],
     [ '?', 51.48111, -0.327219, 2483, 'Hounslow Borough Council', 'LBO' ],
     [ '?', 51.482045, -0.327219, 2483, 'Hounslow Borough Council', 'LBO' ],
+    [ '?', 51.345714, -0.227959, 2457, 'Epsom and Ewell Borough Council', 'DIS' ],
     [ 'CW11 1HZ', 53.145324, -2.370437, 21069, 'Cheshire East Council', 'UTA', 135301, 'Sandbach Town', 'UTW' ],
     [ '?', 50.78301, -0.646929 ],
     [ 'TA1 1QP', 51.023569, -3.099055, 2239, 'Somerset County Council', 'CTY', 2429, 'Taunton Deane Borough Council', 'DIS' ],


### PR DESCRIPTION
After this change, you can safely add the TfL body to other councils (namely the ones surrounding London that include TfL bus stops); clicking in those councils on other cobrands will have no change, as the TfL body will be fully ignored on a non-London council, but on the TfL cobrand it will allow it for e.g. the selection of bus stops outside London.

It removes the body rather than just all its categories to prevent a "We do not have details of the other body covering this area" message appearing.

Fixes https://github.com/mysociety/fixmystreet-freshdesk/issues/116 [skip changelog]
