### PR TITLE
[TfL] Include borough flytipping categories on red routes

### DIFF
--- a/perllib/FixMyStreet/Template.pm
+++ b/perllib/FixMyStreet/Template.pm
@@ -155,7 +155,7 @@ sub sanitize {
     my $scrubber = HTML::Scrubber->new(
         rules => [
             %allowed_tags,
-            a => { href => qr{^(http|/|tel)}i, style => 1, target => qr/^_blank$/, title => 1 },
+            a => { href => qr{^(http|/|tel)}i, style => 1, target => qr/^_blank$/, title => 1, class => qr/^js-/ },
             img => { src => 1, alt => 1, width => 1, height => 1, hspace => 1, vspace => 1, align => 1, sizes => 1, srcset => 1 },
             font => { color => 1 },
             span => { style => 1 },

--- a/web/cobrands/tfl/assets.js
+++ b/web/cobrands/tfl/assets.js
@@ -51,7 +51,6 @@ var tlrn_categories = [
     "Debris in the carriageway",
     "Fallen Tree",
     "Flooding",
-    "Flytipping (TfL)",
     "Graffiti / Flyposting (non-offensive)",
     "Graffiti / Flyposting (offensive)",
     "Graffiti / Flyposting on street light (non-offensive)",


### PR DESCRIPTION
On the TfL cobrand, this treats the 'Flytipping (TfL)' category
the same as the existing 'General Litter' and redirects users to
fixmystreet.com.

On fixmystreet.com, borough flytipping categories are included in
those available on red routes.

This PR also includes a commit to allow the `class` attribute on `a` elements in HTML-scrubbed inputs, which is required for the "form disabled" message of the to-be-disabled TfL flytipping category.

For mysociety/fixmystreet-freshdesk#120

[skip changelog]