### PR TITLE
Add libpng-dev to package lists (generic and for Docker)

### DIFF
--- a/conf/packages.docker
+++ b/conf/packages.docker
@@ -2,6 +2,7 @@ make
 g++
 jhead
 liblocale-gettext-perl
+libpng-dev
 perl
 perlmagick
 libmath-bigint-gmp-perl

--- a/conf/packages.generic
+++ b/conf/packages.generic
@@ -2,6 +2,7 @@ make
 g++
 jhead
 liblocale-gettext-perl
+libpng-dev
 memcached
 perl
 perlmagick


### PR DESCRIPTION
I tried installing the latest master on Debian Buster and ran into this missing dependency.