### PR TITLE
[Buckinghamshire] Change "Name" to "Full name" on forms

### DIFF
--- a/.cypress/cypress/integration/buckinghamshire.js
+++ b/.cypress/cypress/integration/buckinghamshire.js
@@ -5,6 +5,7 @@ describe('flytipping', function() {
     cy.fixture('roads.xml');
     cy.route('**mapserver/bucks*Whole_Street*', 'fixture:roads.xml').as('roads-layer');
     cy.route('/report/new/ajax*').as('report-ajax');
+    cy.route('/around/nearby*').as('around-ajax');
     cy.visit('http://buckinghamshire.localhost:3001/');
     cy.contains('Buckinghamshire');
     cy.get('[name=pc]').type('SL9 0NX');
@@ -49,6 +50,19 @@ describe('flytipping', function() {
     cy.wait('@report-ajax');
     cy.get('select:eq(4)').select('Parks');
     cy.get('[name=site_code]').should('have.value', '7300268');
+  });
+
+  it('uses the label "Full name" for the name field', function() {
+    cy.get('#map_box').click(290, 307);
+    cy.wait('@report-ajax');
+    cy.get('select:eq(4)').select('Flytipping');
+    cy.wait('@around-ajax');
+    cy.get('.js-hide-duplicate-suggestions:first').should('be.visible').click();
+
+    cy.get('[name=title]').type('Title');
+    cy.get('[name=detail]').type('Detail');
+    cy.get('.js-new-report-user-show').click();
+    cy.get('label[for=form_name]').should('contain', 'Full name');
   });
 
 });

--- a/templates/web/buckinghamshire/report/form/user_name.html
+++ b/templates/web/buckinghamshire/report/form/user_name.html
@@ -1,0 +1,13 @@
+<!-- user_name.html -->
+<label for="form_name">Full name
+[% TRY %]
+    [% INCLUDE 'report/form/after_name.html' %]
+    [% CATCH file %]
+[% END %]
+</label>
+[% IF field_errors.name %]
+    <p class='form-error'>[% field_errors.name %]</p>
+[% END %]
+<input type="text" class="form-control [% valid_class OR 'validName' %] js-form-name [% extra_class %]"
+    value="[% object.name || c.user.name | html %]" name="name" id="form_name">
+<!-- /user_name.html -->


### PR DESCRIPTION
Since we require the user to enter their full name Buckinghamshire have asked us to change the text to "Full name" to make it clearer that the full name is required to complete the form.

Fixes https://github.com/mysociety/fixmystreet-freshdesk/issues/122

There is the wider issue of doing this for all cobrands that have the validation for full name on them, but that will be done separately, as part of https://github.com/mysociety/fixmystreet/pull/2868.

<!-- [skip changelog] -->