### PR TITLE
Fix category extra AJAX call for categories with ampersands

### DIFF
--- a/templates/web/base/report/new/category_extras.html
+++ b/templates/web/base/report/new/category_extras.html
@@ -1,5 +1,6 @@
 [% SET default_list = [] %][% FOR b IN bodies_to_list.values %][% default_list.push(b.cobrand_name) %][% END %]
 [% DEFAULT list_of_names = default_list %]
+[% category = mark_safe(category) %]
 
 <div id="category_meta">
   [%- IF unresponsive.$category %]

--- a/templates/web/base/report/new/councils_text.html
+++ b/templates/web/base/report/new/councils_text.html
@@ -1,4 +1,5 @@
 [% FILTER collapse %]
+[% category = mark_safe(category) %]
 [% IF unresponsive.$category OR unresponsive.ALL OR bodies_to_list.size == 0 %]
     [% tprintf(
         loc('These will be published online for others to see, in accordance with our <a href="%s">privacy policy</a>.'),

--- a/templates/web/base/report/new/councils_text_all.html
+++ b/templates/web/base/report/new/councils_text_all.html
@@ -1,5 +1,6 @@
 [% SET default_list = [] %][% FOR b IN bodies_to_list.values %][% default_list.push(b.cobrand_name) %][% END %]
 [% DEFAULT list_of_names = default_list %]
+[% category = mark_safe(category) %]
 
 <p>
 [% UNLESS non_public_categories.$category;

--- a/templates/web/base/report/new/councils_text_private.html
+++ b/templates/web/base/report/new/councils_text_private.html
@@ -1,4 +1,5 @@
 [% FILTER collapse %]
+[% category = mark_safe(category) %]
 [% IF unresponsive.$category OR unresponsive.ALL OR bodies_to_list.size == 0 %]
     [% loc('These details will never be shown online without your permission.') %]
 [% ELSE %]

--- a/templates/web/oxfordshire/report/new/councils_text_all.html
+++ b/templates/web/oxfordshire/report/new/councils_text_all.html
@@ -1,3 +1,4 @@
+[% category = mark_safe(category) %]
 <p>
     All the information you provide here will be sent to the
     [% # NB this empty class attribute is so fixmystreet.update_public_councils_text

--- a/templates/web/tfl/report/new/councils_text_all.html
+++ b/templates/web/tfl/report/new/councils_text_all.html
@@ -1,4 +1,5 @@
 <p>
+[% category = mark_safe(category) %]
 [% UNLESS non_public_categories.$category;
 
     tprintf(

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -453,7 +453,7 @@ $.extend(fixmystreet.set_up, {
         }
         if (data && data.non_public) {
             $(".js-hide-if-private-category").hide();
-            $(".js-hide-if-public-category").show();
+            $(".js-hide-if-public-category").removeClass("hidden-js").show();
         } else {
             $(".js-hide-if-private-category").show();
             $(".js-hide-if-public-category").hide();


### PR DESCRIPTION
The `IF category_extras.$category.size` condition in category_extras.html was using an escaped string for `$category`, meaning the lookup would always fail for categories that had an ampersand in their name. The result of this was an empty `<div id="category_meta">`, and no extra fields shown to the user. This caused issues when one or more of the fields were required, as they were always empty and the error message wasn't being rendered and shown to the user. This meant the user would see their report form over and over again when submitting instead of useful feedback.

Fixes https://github.com/mysociety/fixmystreet-freshdesk/issues/126

[skip changelog]