### PR TITLE
Include explanation of private reports in other-reported email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
         - Use category groups whenever category lists are shown. #2702
         - Display map inline with duplicate suggestions on mobile. #2668
         - Improved try again process on mobile. #2863
+        - Improve messaging/display of private reports.
     - Admin improvements:
         - Add new roles system, to group permissions and apply to users. #2483
         - Contact form emails now include user admin links.

--- a/perllib/FixMyStreet/App/Controller/Tokens.pm
+++ b/perllib/FixMyStreet/App/Controller/Tokens.pm
@@ -185,9 +185,7 @@ sub alert_to_reporter : Path('/R') {
     my $problem = $c->model('DB::Problem')->find( { id => $problem_id } )
       || $c->detach('token_error');
 
-    $c->detach('token_too_old') if $auth_token->created < DateTime->now->subtract( months => 1 );
-
-    $c->flash->{alert_to_reporter} = 1;
+    $c->flash->{alert_to_reporter} = $problem->id;
     my $report_uri = $c->cobrand->base_url_for_report( $problem ) . $problem->url;
     $c->res->redirect($report_uri);
 }

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -525,6 +525,31 @@ sub tokenised_url {
     return "/M/". $token->token;
 }
 
+has view_token => (
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my $token = FixMyStreet::App->model('DB::Token')->create({
+            scope => 'alert_to_reporter',
+            data => { id => $self->id }
+        });
+    },
+);
+
+=head2 view_url
+
+Return a url for this problem report that will always show it
+(even if e.g. a private report) but does not log the user in.
+
+=cut
+
+sub view_url {
+    my $self = shift;
+    return $self->url unless $self->non_public;
+    return "/R/" . $self->view_token->token;
+}
+
 =head2 is_hidden
 
 Returns 1 if the problem is in an hidden state otherwise 0.

--- a/t/app/controller/report_display.t
+++ b/t/app/controller/report_display.t
@@ -73,38 +73,6 @@ subtest "change report to hidden and check for 410 status" => sub {
     ok $report->update( { state => 'confirmed' } ), 'confirm report again';
 };
 
-subtest "change report to non_public and check for 403 status" => sub {
-    ok $report->update( { non_public => 1 } ), 'make report non public';
-    ok $mech->get("/report/$report_id"), "get '/report/$report_id'";
-    is $mech->res->code, 403, "access denied";
-    is $mech->uri->path, "/report/$report_id", "at /report/$report_id";
-    $mech->content_contains('permission to do that. If you are the problem reporter');
-    $mech->content_lacks('Report another problem here');
-    $mech->content_lacks($report->latitude);
-    $mech->content_lacks($report->longitude);
-    ok $report->update( { non_public => 0 } ), 'make report public';
-};
-
-subtest "check owner of report can view non public reports" => sub {
-    ok $report->update( { non_public => 1 } ), 'make report non public';
-    $mech->log_in_ok( $report->user->email );
-    ok $mech->get("/report/$report_id"), "get '/report/$report_id'";
-    is $mech->res->code, 200, "report can be viewed";
-    is $mech->uri->path, "/report/$report_id", "at /report/$report_id";
-    $mech->log_out_ok;
-
-    $mech->log_in_ok( $user2->email );
-    ok $mech->get("/report/$report_id"), "get '/report/$report_id'";
-    is $mech->res->code, 403, "access denied to user who is not report creator";
-    is $mech->uri->path, "/report/$report_id", "at /report/$report_id";
-    $mech->content_contains('permission to do that. If you are the problem reporter');
-    $mech->content_lacks('Report another problem here');
-    $mech->content_lacks($report->latitude);
-    $mech->content_lacks($report->longitude);
-    $mech->log_out_ok;
-    ok $report->update( { non_public => 0 } ), 'make report public';
-};
-
 subtest "duplicate reports are signposted correctly" => sub {
     $report2->set_extra_metadata(duplicate_of => $report->id);
     $report2->state('duplicate');

--- a/t/app/controller/report_non_public.t
+++ b/t/app/controller/report_non_public.t
@@ -1,0 +1,85 @@
+use FixMyStreet::TestMech;
+
+# disable info logs for this test run
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $body = $mech->create_body_ok(2237, 'Oxfordshire County Council');
+$mech->create_contact_ok( body_id => $body->id, category => 'Potholes', email => 'potholes@example.com' );
+
+my $staffuser = $mech->create_user_ok('body-user@example.net', name => 'Body User', from_body => $body->id);
+$staffuser->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_another_user' });
+$staffuser->user_body_permissions->create({ body => $body, permission_type => 'report_mark_private' });
+
+my $user = $mech->create_user_ok('test@example.com', name => 'Test User');
+my $user2 = $mech->create_user_ok('test2@example.com', name => 'Other User');
+
+my ($report) = $mech->create_problems_for_body(1, $body->id, "Example", {
+    user => $user,
+    non_public => 1,
+});
+my $report_id = $report->id;
+
+subtest "check cannot view non_public report by default" => sub {
+    ok $mech->get("/report/$report_id"), "get '/report/$report_id'";
+    is $mech->res->code, 403, "access denied";
+    is $mech->uri->path, "/report/$report_id", "at /report/$report_id";
+    $mech->content_contains('permission to do that. If you are the problem reporter');
+    $mech->content_lacks('Report another problem here');
+    $mech->content_lacks($report->latitude);
+    $mech->content_lacks($report->longitude);
+};
+
+subtest "check owner of report can view non public reports" => sub {
+    $mech->log_in_ok( $report->user->email );
+    ok $mech->get("/report/$report_id"), "get '/report/$report_id'";
+    is $mech->res->code, 200, "report can be viewed";
+    is $mech->uri->path, "/report/$report_id", "at /report/$report_id";
+    $mech->log_out_ok;
+
+    $mech->log_in_ok( $user2->email );
+    ok $mech->get("/report/$report_id"), "get '/report/$report_id'";
+    is $mech->res->code, 403, "access denied to user who is not report creator";
+    is $mech->uri->path, "/report/$report_id", "at /report/$report_id";
+    $mech->content_contains('permission to do that. If you are the problem reporter');
+    $mech->content_lacks('Report another problem here');
+    $mech->content_lacks($report->latitude);
+    $mech->content_lacks($report->longitude);
+    $mech->log_out_ok;
+};
+
+subtest "Logged email working on private report" => sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'fixmystreet',
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $mech->log_in_ok($staffuser->email);
+        $mech->get_ok('/report/new?latitude=51.7549262252&longitude=-1.25617899435');
+        $mech->submit_form_ok({
+            with_fields => {
+                form_as => 'another_user',
+                title => "Test Report",
+                detail => 'Test report details.',
+                category => 'Potholes',
+                name => 'Another User',
+                username => 'another@example.net',
+                non_public => 1,
+            }
+        }, "submit details");
+    };
+    $mech->content_contains('Thank you for reporting this issue');
+    my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+    ok $report, "Found the report";
+    is $report->state, 'confirmed', "report is now confirmed";
+    is $report->non_public, 1;
+
+    my $email = $mech->get_email;
+    my $body = $mech->get_text_body_from_email($email);
+    my $url = $mech->get_link_from_email($email);
+    like $body, qr/Your report to Oxfordshire County Council has been logged/;
+    $mech->get_ok($url);
+};
+
+done_testing();

--- a/t/app/controller/report_non_public.t
+++ b/t/app/controller/report_non_public.t
@@ -80,6 +80,8 @@ subtest "Logged email working on private report" => sub {
     my $url = $mech->get_link_from_email($email);
     like $body, qr/Your report to Oxfordshire County Council has been logged/;
     $mech->get_ok($url);
+    $mech->content_lacks('Get updates');
+    $mech->content_contains('To provide an update, please');
 };
 
 done_testing();

--- a/templates/email/buckinghamshire/other-reported.html
+++ b/templates/email/buckinghamshire/other-reported.html
@@ -23,7 +23,7 @@ using the email address associated with the report.</p>
 [% TRY %][% INCLUDE '_council_reference.html' problem=report %][% CATCH file %][% END %]
 [% END %]
   <p style="margin: 20px auto; text-align: center">
-  <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.url %]">View my report</a>
+  <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.view_url %]">View my report</a>
   </p>
   [% end_padded_box | safe %]
 </th>

--- a/templates/email/buckinghamshire/other-reported.html
+++ b/templates/email/buckinghamshire/other-reported.html
@@ -12,6 +12,13 @@ INCLUDE '_email_top.html';
   [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Your report has been&nbsp;logged</h1>
   <p style="[% p_style %]">Your report to [% report.body %] has been logged on [% site_name %].</p>
+
+[% IF report.non_public %]
+<p style="[% p_style %]">It has been marked as private and will not be visible
+to the general public; you may view it using the link below, or if you sign in
+using the email address associated with the report.</p>
+[% END %]
+
 [% IF cobrand.owns_problem( report ) %]
 [% TRY %][% INCLUDE '_council_reference.html' problem=report %][% CATCH file %][% END %]
 [% END %]

--- a/templates/email/buckinghamshire/other-reported.txt
+++ b/templates/email/buckinghamshire/other-reported.txt
@@ -4,6 +4,13 @@ Hello [% report.name %],
 
 Your report to [% report.body %] has been logged on [% site_name %].
 
+[% IF report.non_public ~%]
+It has been marked as private and will not be visible to the general public;
+you may view it using the link below, or if you sign in using the email address
+associated with the report.
+
+[% END ~%]
+
 [% IF cobrand.owns_problem( report ) %]
 [% TRY %][% INCLUDE '_council_reference.txt' problem=report %][% CATCH file %][% END %]
 [% END %]

--- a/templates/email/buckinghamshire/other-reported.txt
+++ b/templates/email/buckinghamshire/other-reported.txt
@@ -17,7 +17,7 @@ associated with the report.
 
 It is available to view at:
 
-[% cobrand.base_url_for_report(report) %][% report.url %]
+[% cobrand.base_url_for_report(report) %][% report.view_url %]
 
 Your report is at the following location:
 

--- a/templates/email/default/other-reported.html
+++ b/templates/email/default/other-reported.html
@@ -12,12 +12,20 @@ INCLUDE '_email_top.html';
   [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Your report has been&nbsp;logged</h1>
   <p style="[% p_style %]">Your report to [% report.body %] has been logged on [% site_name %].</p>
+
+[% IF report.non_public %]
+<p style="[% p_style %]">It has been marked as private and will not be visible
+to the general public; you may view it using the link below, or if you sign in
+using the email address associated with the report.</p>
+[% END %]
+
 [% IF cobrand.is_council && !cobrand.owns_problem( report ) %]
 <p style="[% p_style %]">Please note that [% cobrand.council_name %] is not responsible for this type
 of report, so it will instead be sent to [% report.body %].</p>
 [% ELSE %]
 [% TRY %][% INCLUDE '_council_reference.html' problem=report %][% CATCH file %][% END %]
 [% END %]
+
   <p style="margin: 20px auto; text-align: center">
   <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.url %]">View my report</a>
   </p>

--- a/templates/email/default/other-reported.html
+++ b/templates/email/default/other-reported.html
@@ -27,7 +27,7 @@ of report, so it will instead be sent to [% report.body %].</p>
 [% END %]
 
   <p style="margin: 20px auto; text-align: center">
-  <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.url %]">View my report</a>
+  <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.view_url %]">View my report</a>
   </p>
   [% end_padded_box | safe %]
 </th>

--- a/templates/email/default/other-reported.txt
+++ b/templates/email/default/other-reported.txt
@@ -20,7 +20,7 @@ of report, so it will instead be sent to [% report.body %].
 
 It is available to view at:
 
-[% cobrand.base_url_for_report(report) %][% report.url %]
+[% cobrand.base_url_for_report(report) %][% report.view_url %]
 
 Your report has the title:
 

--- a/templates/email/default/other-reported.txt
+++ b/templates/email/default/other-reported.txt
@@ -4,6 +4,13 @@ Hello [% report.name %],
 
 Your report to [% report.body %] has been logged on [% site_name %].
 
+[% IF report.non_public ~%]
+It has been marked as private and will not be visible to the general public;
+you may view it using the link below, or if you sign in using the email address
+associated with the report.
+
+[% END ~%]
+
 [% IF cobrand.is_council && !cobrand.owns_problem( report ) %]
 Please note that [% cobrand.council_name %] is not responsible for this type
 of report, so it will instead be sent to [% report.body %].

--- a/templates/email/fixamingata/other-reported.html
+++ b/templates/email/fixamingata/other-reported.html
@@ -25,7 +25,7 @@ rapporter, så kommer rapporten istället att skickas till [% report.body %].
 [% END %]
   </p>
   <p style="margin: 20px auto; text-align: center">
-  <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.url %]">Visa min rapport</a>
+  <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.view_url %]">Visa min rapport</a>
   </p>
   [% end_padded_box | safe %]
 </th>

--- a/templates/email/fixamingata/other-reported.html
+++ b/templates/email/fixamingata/other-reported.html
@@ -12,6 +12,13 @@ INCLUDE '_email_top.html';
   [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Din rapport har&nbsp;loggats</h1>
   <p style="[% p_style %]">Din rapport till [% report.body %] har blivit loggad på [% site_name %].
+
+[% IF report.non_public %]
+<p style="[% p_style %]">It has been marked as private and will not be visible
+to the general public; you may view it using the link below, or if you sign in
+using the email address associated with the report.</p>
+[% END %]
+
 [% IF cobrand.is_council && !cobrand.owns_problem( report ) %]
 Eftersom [% cobrand.council_name %] inte är ansvarig för den här typen av
 rapporter, så kommer rapporten istället att skickas till [% report.body %].

--- a/templates/email/fixamingata/other-reported.txt
+++ b/templates/email/fixamingata/other-reported.txt
@@ -18,7 +18,7 @@ rapporter, så kommer rapporten istället att skickas till [% report.body %].
 
 Du kan se din rapport på:
 
-[% cobrand.base_url_for_report(report) %][% report.url %]
+[% cobrand.base_url_for_report(report) %][% report.view_url %]
 
 Din rapport har titeln:
 

--- a/templates/email/fixamingata/other-reported.txt
+++ b/templates/email/fixamingata/other-reported.txt
@@ -4,6 +4,13 @@ Hej [% report.name %],
 
 Din rapport till [% report.body %] har blivit loggad på [% site_name %].
 
+[% IF report.non_public ~%]
+It has been marked as private and will not be visible to the general public;
+you may view it using the link below, or if you sign in using the email address
+associated with the report.
+
+[% END ~%]
+
 [% IF cobrand.is_council && !cobrand.owns_problem( report ) %]
 Eftersom [% cobrand.council_name %] inte är ansvarig för den här typen av
 rapporter, så kommer rapporten istället att skickas till [% report.body %].

--- a/templates/email/hounslow/other-reported.html
+++ b/templates/email/hounslow/other-reported.html
@@ -12,6 +12,13 @@ INCLUDE '_email_top.html';
   [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Your report has been&nbsp;logged</h1>
   <p style="[% p_style %]">Your report to [% cobrand.council_name %] has been logged on [% site_name %].</p>
+
+[% IF report.non_public %]
+<p style="[% p_style %]">It has been marked as private and will not be visible
+to the general public; you may view it using the link below, or if you sign in
+using the email address associated with the report.</p>
+[% END %]
+
 [% IF cobrand.is_council && !cobrand.owns_problem( report ) %]
 <p style="[% p_style %]">Please note that [% cobrand.council_name %] is not responsible for this type
 of report, so it will instead be sent to [% report.body %].</p>

--- a/templates/email/hounslow/other-reported.html
+++ b/templates/email/hounslow/other-reported.html
@@ -26,7 +26,7 @@ of report, so it will instead be sent to [% report.body %].</p>
 [% TRY %][% INCLUDE '_council_reference.html' problem=report %][% CATCH file %][% END %]
 [% END %]
   <p style="margin: 20px auto; text-align: center">
-  <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.url %]">View my report</a>
+  <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.view_url %]">View my report</a>
   </p>
   [% end_padded_box | safe %]
 </th>

--- a/templates/email/hounslow/other-reported.txt
+++ b/templates/email/hounslow/other-reported.txt
@@ -20,7 +20,7 @@ of report, so it will instead be sent to [% report.body %].
 
 It is available to view at:
 
-[% cobrand.base_url_for_report(report) %][% report.url %]
+[% cobrand.base_url_for_report(report) %][% report.view_url %]
 
 Your report has the title:
 

--- a/templates/email/hounslow/other-reported.txt
+++ b/templates/email/hounslow/other-reported.txt
@@ -4,6 +4,13 @@ Hello [% report.name %],
 
 Your report to [% cobrand.council_name %] has been logged on [% site_name %].
 
+[% IF report.non_public ~%]
+It has been marked as private and will not be visible to the general public;
+you may view it using the link below, or if you sign in using the email address
+associated with the report.
+
+[% END ~%]
+
 [% IF cobrand.is_council && !cobrand.owns_problem( report ) %]
 Please note that [% cobrand.council_name %] is not responsible for this type
 of report, so it will instead be sent to [% report.body %].

--- a/templates/email/tfl/other-reported.html
+++ b/templates/email/tfl/other-reported.html
@@ -12,6 +12,13 @@ INCLUDE '_email_top.html';
   [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">Your report has been&nbsp;logged</h1>
   <p style="[% p_style %]">Your report to Transport for London has been logged on [% site_name %].</p>
+
+[% IF report.non_public %]
+<p style="[% p_style %]">It has been marked as private and will not be visible
+to the general public; you may view it using the link below, or if you sign in
+using the email address associated with the report.</p>
+[% END %]
+
 [% TRY %][% INCLUDE '_council_reference.html' problem=report %][% CATCH file %][% END %]
   <p style="margin: 20px auto; text-align: center">
   <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.url %]">View my report</a>

--- a/templates/email/tfl/other-reported.html
+++ b/templates/email/tfl/other-reported.html
@@ -21,7 +21,7 @@ using the email address associated with the report.</p>
 
 [% TRY %][% INCLUDE '_council_reference.html' problem=report %][% CATCH file %][% END %]
   <p style="margin: 20px auto; text-align: center">
-  <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.url %]">View my report</a>
+  <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.view_url %]">View my report</a>
   </p>
   [% end_padded_box | safe %]
 </th>

--- a/templates/email/tfl/other-reported.txt
+++ b/templates/email/tfl/other-reported.txt
@@ -4,6 +4,13 @@ Hello [% report.name %],
 
 Your report to Transport for London has been logged on [% site_name %].
 
+[% IF report.non_public ~%]
+It has been marked as private and will not be visible to the general public;
+you may view it using the link below, or if you sign in using the email address
+associated with the report.
+
+[% END ~%]
+
 [% TRY %][% INCLUDE '_council_reference.txt' problem=report %][% CATCH file %][% END %]
 
 It is available to view at:

--- a/templates/email/tfl/other-reported.txt
+++ b/templates/email/tfl/other-reported.txt
@@ -15,7 +15,7 @@ associated with the report.
 
 It is available to view at:
 
-[% cobrand.base_url_for_report(report) %][% report.url %]
+[% cobrand.base_url_for_report(report) %][% report.view_url %]
 
 Your report has the title:
 

--- a/templates/web/base/report/display_tools.html
+++ b/templates/web/base/report/display_tools.html
@@ -1,5 +1,6 @@
 <div class="shadow-wrap">
     <ul id="key-tools">
+      [% IF c.user_exists OR NOT problem.non_public %]
         [% IF c.user_exists AND c.cobrand.users_can_hide AND c.user.belongs_to_body( problem.bodies_str ) %]
         <li><form method="post" action="/report/[% problem.id %]/delete" id="remove-from-site-form">
             <input type="hidden" name="token" value="[% csrf_token %]">
@@ -16,6 +17,7 @@
         [% IF c.cobrand.moniker == 'fixmystreet' %]
         <li><a rel="nofollow" id="key-tool-report-share" class="share" href="#report-share">[% loc('Share') %]</a></li>
         [% END %]
+      [% END %]
       [% IF c.cobrand.moniker == 'zurich' %]
         <li><a class="chevron" id="key-tool-problems-nearby" href="[% c.uri_for( '/around', { lat => latitude, lon => longitude } ) %]">[% loc( 'Problems on the map' ) %]</a></li>
       [% ELSE %]

--- a/templates/web/base/report/update-form-wrapper.html
+++ b/templates/web/base/report/update-form-wrapper.html
@@ -1,4 +1,10 @@
 [% UNLESS c.cobrand.updates_disallowed(problem) %]
+
+  [% IF NOT c.user_exists AND problem.non_public # Came via other-reported token or similar %]
+    <p>[% tprintf(loc('To provide an update, please <a href="%s">sign in</a>.'), '/auth?r=report/' _ problem.id) %]</p>
+
+  [% ELSE %]
+
     [% IF two_column_sidebar %]
         <button type="button" class="btn btn--provide-update js-provide-update hidden-nojs">[% loc('Provide an update') %]</button>
         <div class="hidden-js">
@@ -7,6 +13,9 @@
     [% IF two_column_sidebar %]
         </div>
     [% END %]
+
+  [% END %]
+
 [% ELSE %]
     [% TRY %][% INCLUDE 'report/_updates_disallowed_message.html' %][% CATCH file %][% END %]
 [% END %]


### PR DESCRIPTION
If a report is made using "Report as other" and marked as private, the email that gets sent to the user telling them this should explain that it's a private report. We also make the link in that email work (even if not logged in) but don't log them in, in case they forward the email on (could change that easily enough). Fixes https://github.com/mysociety/fixmystreet-freshdesk/issues/125
