### PR TITLE
Ensure that Vagrant box packages are kept updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
         - Add configuration for setting Content-Security-Policy header.
         - Add banner on staging website/emails, and STAGING_FLAGS option to hide it.
         - Do not hard code site name in database fixture.
+        - Ensure OS dependencies are kept updated in development environments.
     - Open311 improvements:
         - Support use of 'private' service definition <keywords> to mark
           reports made in that category private. #2488

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -105,7 +105,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # When using the mySociety box, just mount the local perl modules and run `script/update`
   # For any other box, just run the full setup process.
-  if "#{baseBox}" == "mysociety/fixmystreet"
+  if "#{baseBox}" == "mysociety/fixmystreet" || "#{baseBox}" == "fms-local"
     config.vm.provision "shell", run: "always", inline: $mount_modules
     config.vm.provision "shell", run: "always", inline: $update
   else

--- a/bin/install_packages
+++ b/bin/install_packages
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+PACKAGE_FILE=conf/packages
+
+[ -n "$1" ] && PACKAGE_FILE="conf/packages.${1}"
+
+apt-get update
+
+grep -v ^# $PACKAGE_FILE | grep -v ^$ | xargs apt-get install -qq -y
+

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -4,4 +4,14 @@ set -e
 cd "$(dirname "$0")/.."
 
 git submodule --quiet update --init --recursive --rebase
+
+# Let's see if we can't work out where we might be running.
+if cut -d/ -f2 /proc/self/cgroup | sort -u | grep -q docker ; then
+    # Docker
+    sudo bin/install_packages docker
+else
+    # Fallback
+    sudo bin/install_packages generic
+fi
+
 bin/install_perl_modules


### PR DESCRIPTION
This adds a script, `bin/install_packages`, that will install packages
listed in versions of `conf/packages*` and calls it from the bootstrap
script in a way appropriate to the environment it is being run under.

This should ensure that, for example, changes to dependencies will be
applied to Vagrant machines in-between tagged releases.

Please check the following:

- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
