### PR TITLE
Allow anonymous reporting on per-category basis

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -272,9 +272,11 @@ sub by_category_ajax_data : Private {
     }
 
     my $non_public = $c->stash->{non_public_categories}->{$category};
+    my $anon_button = ($c->cobrand->allow_anonymous_reports($category) eq 'button');
     my $body = {
         bodies => [ map { $_->name } @bodies ],
         $non_public ? ( non_public => JSON->true ) : (),
+        $anon_button ? ( allow_anonymous => JSON->true ) : (),
     };
 
     if ( $c->stash->{category_extras}->{$category} && @{ $c->stash->{category_extras}->{$category} } >= 1 ) {
@@ -984,7 +986,7 @@ sub process_report : Private {
         $c->stash->{contributing_as_anonymous_user} = $user->contributing_as('anonymous_user', $c, $c->stash->{bodies});
     }
     # This is also done in process_user, but is needed here for anonymous() just below
-    my $anon_button = $c->cobrand->allow_anonymous_reports eq 'button' && $c->get_param('report_anonymously');
+    my $anon_button = $c->cobrand->allow_anonymous_reports($params{category}) eq 'button' && $c->get_param('report_anonymously');
     if ($anon_button) {
         $c->stash->{contributing_as_anonymous_user} = 1;
         $c->stash->{contributing_as_body} = undef;

--- a/perllib/FixMyStreet/Script/Reports.pm
+++ b/perllib/FixMyStreet/Script/Reports.pm
@@ -107,7 +107,7 @@ sub send(;$) {
             $h{osm_url} .= '?m';
         }
 
-        if ( $cobrand->allow_anonymous_reports &&
+        if ( $cobrand->allow_anonymous_reports($row->category) &&
              $row->user->email eq $cobrand->anonymous_account->{'email'}
          ) {
             $h{anonymous_report} = 1;

--- a/templates/web/base/report/form/user.html
+++ b/templates/web/base/report/form/user.html
@@ -26,11 +26,12 @@
   [% END %]
     <button type="button" class="btn btn--block hidden-nojs js-new-report-user-show">[% loc('Log in with email') %]</button>
 [% END %]
-[% IF type == 'report' AND c.cobrand.allow_anonymous_reports == 'button' %]
+  <div class="js-show-if-anonymous
+    [%~ ' hidden-js' UNLESS type == 'report' AND c.cobrand.allow_anonymous_reports == 'button' %]">
     <small id="or">[% loc('or') %]</small>
     <button name="report_anonymously" value="yes" class="btn btn--block js-new-report-submit">[% loc('Report anonymously') %]</button>
     <small>[% loc('No personal details will be stored, and you will not receive updates about this report.') %]</small>
-[% END %]
+  </div>
 </div>
 
 [% IF (c.user_exists OR NOT c.cobrand.social_auth_enabled) AND type == 'report' AND c.cobrand.allow_anonymous_reports == 'button' %]

--- a/templates/web/base/report/form/user.html
+++ b/templates/web/base/report/form/user.html
@@ -32,4 +32,13 @@
     <small>[% loc('No personal details will be stored, and you will not receive updates about this report.') %]</small>
 [% END %]
 </div>
+
+[% IF (c.user_exists OR NOT c.cobrand.social_auth_enabled) AND type == 'report' AND c.cobrand.allow_anonymous_reports == 'button' %]
+<div class="form-section-preview form-section-preview--next hidden-js">
+    <button name="report_anonymously" value="yes" class="btn btn--block">[% loc('Report anonymously') %]</button>
+    <small>[% loc('No personal details will be stored, and you will not receive updates about this report.') %]</small>
+    <small id="or">[% loc('or') %]</small>
+</div>
+[% END %]
+
 <!-- /report/form/user.html -->

--- a/templates/web/westminster/report/form/user_loggedout.html
+++ b/templates/web/westminster/report/form/user_loggedout.html
@@ -1,0 +1,2 @@
+<!-- user_loggedout.html -->
+<!-- /user_loggedout.html -->

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -458,6 +458,11 @@ $.extend(fixmystreet.set_up, {
             $(".js-hide-if-private-category").show();
             $(".js-hide-if-public-category").hide();
         }
+        if (data && data.allow_anonymous) {
+            $('.js-show-if-anonymous').removeClass('hidden-js');
+        } else {
+            $('.js-show-if-anonymous').addClass('hidden-js');
+        }
 
         if (fixmystreet.message_controller && data && data.disable_form && data.disable_form.questions) {
             $.each(data.disable_form.questions, function(_, question) {


### PR DESCRIPTION
This passes in the category to `allow_anonymous_reports` function so it can change its answer on a per-category basis should it wish to. It also passes the result to the client JS so it can show/hide the button as appropriate. In a cobrand where it is always allowed for all categories, this does mean it's adding `"allow_anonymous": true` to every category of the output, but with gzip that shouldn't make much difference.

Also fixes a bug where the report anonymously button wasn't being shown in non-JS scenario.