### PR TITLE
Fix assets disappearing at maximum zoom

### DIFF
--- a/web/cobrands/bathnes/assets.js
+++ b/web/cobrands/bathnes/assets.js
@@ -24,7 +24,6 @@ fixmystreet.maps.banes_defaults = {
     asset_item: "asset",
     asset_type: 'spot',
     max_resolution: 4.777314267158508,
-    min_resolution: 0.5971642833948135,
     asset_id_field: 'feature_no',
     attributes: null,
     geometryName: 'msGeometry',

--- a/web/cobrands/bexley/assets.js
+++ b/web/cobrands/bexley/assets.js
@@ -15,7 +15,6 @@ var defaults = {
         }
     },
     max_resolution: 4.777314267158508,
-    min_resolution: 0.5971642833948135,
     geometryName: 'msGeometry',
     srsName: "EPSG:3857",
     body: "London Borough of Bexley",

--- a/web/cobrands/bristol/assets.js
+++ b/web/cobrands/bristol/assets.js
@@ -11,7 +11,6 @@ var options = {
         'bristol': 0.33072982812632296,
         'fixmystreet': 4.777314267158508
     },
-    min_resolution: 0.00001,
     asset_type: 'spot',
     body: "Bristol City Council",
     srsName: "EPSG:27700",

--- a/web/cobrands/bromley/assets.js
+++ b/web/cobrands/bromley/assets.js
@@ -16,7 +16,6 @@ var defaults = {
     },
     asset_type: 'spot',
     max_resolution: 4.777314267158508,
-    min_resolution: 0.5971642833948135,
     asset_id_field: 'CENTRAL_AS',
     geometryName: 'msGeometry',
     srsName: "EPSG:3857",

--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -19,7 +19,6 @@ var defaults = {
       'buckinghamshire': 2.116670900008467,
       'fixmystreet': 4.777314267158508
     },
-    min_resolution: 0.00001,
     asset_id_field: 'central_as',
     attributes: {
         central_asset_id: 'central_as',

--- a/web/cobrands/cheshireeast/assets.js
+++ b/web/cobrands/cheshireeast/assets.js
@@ -10,7 +10,6 @@ var defaults = {
         fixmystreet: 4.777314267158508,
         cheshireeast: 1.4000028000056002
     },
-    min_resolution: 0.00001,
     attributes: {
         central_asset_id: 'central_as',
         site_code: 'site_code'

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -590,7 +590,10 @@ function construct_layer_options(options, protocol) {
         protocol: protocol,
         visibility: false,
         maxResolution: max_resolution,
-        minResolution: options.min_resolution,
+        // If minimum resolution not specified, we only want to set a default
+        // if max_resolution is specified, otherwise the default minimum will
+        // be used to construct all the resolutions and it won't work
+        minResolution: options.min_resolution || (max_resolution ? 0.00001 : undefined),
         styleMap: options.stylemap || get_asset_stylemap(),
         assets: true
     };

--- a/web/cobrands/highways/assets.js
+++ b/web/cobrands/highways/assets.js
@@ -18,7 +18,6 @@ var defaults = {
     // this covers zoomed right out on Cumbrian sections of
     // the M6
     max_resolution: 20,
-    min_resolution: 0.5971642833948135,
     srsName: "EPSG:900913",
     strategy_class: OpenLayers.Strategy.FixMyStreet
 };

--- a/web/cobrands/hounslow/assets.js
+++ b/web/cobrands/hounslow/assets.js
@@ -19,7 +19,6 @@ var defaults = {
         'hounslow': 0.5291677250021167,
         'fixmystreet': 1.194328566789627
     },
-    min_resolution: 0.00001,
     asset_id_field: 'CentralAssetId',
     attributes: {
         central_asset_id: 'CentralAssetId',

--- a/web/cobrands/isleofwight/assets.js
+++ b/web/cobrands/isleofwight/assets.js
@@ -27,7 +27,6 @@ var defaults = {
         central_asset_id: 'central_asset_id',
         site_code: 'site_code'
     },
-    min_resolution: 0.00001,
     asset_id_field: 'asset_id',
     geometryName: 'msGeometry',
     srsName: "EPSG:27700",

--- a/web/cobrands/lincolnshire/assets.js
+++ b/web/cobrands/lincolnshire/assets.js
@@ -8,7 +8,6 @@ var defaults = {
     wfs_url: "https://tilma.mysociety.org/mapserver/lincs",
     asset_type: 'spot',
     max_resolution: 2.388657133579254,
-    min_resolution: 0.5971642833948135,
     asset_id_field: 'Confirm_CA',
     attributes: {
         central_asset_id: 'Confirm_CA',

--- a/web/cobrands/peterborough/assets.js
+++ b/web/cobrands/peterborough/assets.js
@@ -15,7 +15,6 @@ var defaults = {
         }
     },
     max_resolution: 4.777314267158508,
-    min_resolution: 0.5971642833948135,
     geometryName: 'msGeometry',
     srsName: "EPSG:3857",
     body: "Peterborough City Council",

--- a/web/cobrands/tfl/assets.js
+++ b/web/cobrands/tfl/assets.js
@@ -16,7 +16,6 @@ var defaults = {
     },
     asset_type: 'spot',
     max_resolution: 2.388657133579254,
-    min_resolution: 0.5971642833948135,
     geometryName: 'msGeometry',
     srsName: "EPSG:3857",
     strategy_class: OpenLayers.Strategy.FixMyStreet

--- a/web/cobrands/westminster/assets.js
+++ b/web/cobrands/westminster/assets.js
@@ -60,7 +60,6 @@ var defaults = {
     },
     asset_type: 'spot',
     max_resolution: 4.777314267158508,
-    min_resolution: 0.5971642833948135,
     asset_id_field: 'central_asset_id',
     srsName: "EPSG:4326",
     body: "Westminster City Council",


### PR DESCRIPTION
Rather than setting a min_resolution on all of the cobrands just set a
default in web/cobrands/fixmystreet/assets.js. This means that assets
will appear at all zoom levels, which seems like what we want to happen
most of the time.

Fixes #2835.  Same as #2843 with additional change to only set the default min_resolution if a max_resolution has been specified (otherwise OpenLayers tries to construct all the resolutions solely from the min_resolution and gets confused). [skip changelog]