### PR TITLE
[HighwaysEngland] road number attribute now lower case

### DIFF
--- a/web/cobrands/highways/assets.js
+++ b/web/cobrands/highways/assets.js
@@ -53,7 +53,7 @@ fixmystreet.assets.add(defaults, {
             $('#highways').remove();
             if ( !fixmystreet.assets.selectedFeature() ) {
                 fixmystreet.body_overrides.only_send('Highways England');
-                add_highways_warning(feature.attributes.ROA_NUMBER);
+                add_highways_warning(feature.attributes.roa_number);
                 $('#category_meta').empty();
             }
         },


### PR DESCRIPTION
The data has been updated and it seems the case of the attributes has
changed.

[skip changelog]