### PR TITLE
[Bromley] Fix shortlist button styling for inspectors

### DIFF
--- a/web/cobrands/bromley/_colours.scss
+++ b/web/cobrands/bromley/_colours.scss
@@ -2,7 +2,7 @@
 
 $menu-image: 'menu-black';
 
-$bromley_blue: rgb(91,120,147);
+$bromley_blue: #647890;
 $bromley_green: #235e1c;
 $bromley_dark_green: #505050;
 

--- a/web/cobrands/bromley/base.scss
+++ b/web/cobrands/bromley/base.scss
@@ -218,37 +218,12 @@ input.field, input.text,
   font-family: Arial,'Helvetica Neue',Helvetica,sans-serif;
 }
 
-// Bromley's button definitions
-.button__primary, .button, input[type=submit], .doc-main-content .byEditor .basketitem a.button {
-  background: #647890;
-  color: white;
-  border: none;
-}
-.button, input[type=submit] {
-  border-style: solid;
-  border-width: 1px;
-  display: inline-block;
-  text-decoration: none;
-  font-weight: 400;
-  cursor: pointer;
-  font-size: 1em;
-  line-height: 2em;
-  height: 2em;
-  padding: 0 1em;
-  margin: 0.5em 0;
-  opacity: 1;
-  transition: opacity .25s ease-in-out;
-  -moz-transition: opacity .25s ease-in-out;
-  -webkit-transition: opacity .25s ease-in-out;
-  -webkit-border-radius: 5px;
-  -moz-border-radius: 5px;
-  border-radius: 5px;
-
-  #postcodeForm & {
-    margin: 0;
-    height: auto;
-    line-height: 1;
-  }
+.btn-primary,
+.green-btn,
+.btn--primary {
+  $bg: $bromley_blue;
+  $hover-bg: darken($bromley_blue, 10%);
+  @include button-variant($bg, $bg, false, #fff, $hover-bg, $hover-bg, false, #fff);
 }
 
 // Bromley's silly A-Z menu

--- a/web/cobrands/sass/_mixins.scss
+++ b/web/cobrands/sass/_mixins.scss
@@ -42,21 +42,37 @@ $direction: 'left' !default;
 @mixin button-variant($bg-top: #fff, $bg-bottom: #eee, $border: #ccc, $text: inherit, $hover-bg-bottom: #e9e9e9, $hover-bg-top: #f9f9f9, $hover-border: #ccc, $hover-text: inherit) {
     color: $text !important; // !important to override more specific selectors like `a:link`
     background: $bg-bottom;
-    @include linear-gradient($bg-top, $bg-bottom);
-    border: 1px solid $border;
+    @if $bg-top != $bg-bottom {
+        @include linear-gradient($bg-top, $bg-bottom);
+    }
+    @if $border {
+        border: 1px solid $border;
+    } @else {
+        border: none;
+    }
 
     &:hover,
     &:focus {
         color: $hover-text !important;
         background: $hover-bg-bottom;
-        @include linear-gradient($hover-bg-top, $hover-bg-bottom);
-        border-color: $hover-border;
+        @if $hover-bg-top != $hover-bg-bottom {
+            @include linear-gradient($hover-bg-top, $hover-bg-bottom);
+        }
+        @if $hover-border {
+            border-color: $hover-border;
+        } @else {
+            border: none;
+        }
     }
 
     &:disabled {
         color: desaturate(darken($bg-bottom, 50%), 50%) !important;
         background: $bg-bottom;
-        border-color: $border;
+        @if $border {
+            border-color: $border;
+        } @else {
+            border: none;
+        }
     }
 }
 


### PR DESCRIPTION
The shortlist "star" icons were losing their styling, because Bromley’s default button styling was more specific.

Bromley’s existing styles only affected "primary" buttons anyway (ie: elements with `.btn-primary` rather than just regular `.btn`) so buttons at the bottom of the first stage of the reporting form, for example, were still showing the default FMS white/grey gradient. I’ve not added any `.btn` styling in this pull request, so that’s not changed.

### Before

![Screenshot_2020-02-24 Viewing a location](https://user-images.githubusercontent.com/739624/75145698-5a480d80-56f1-11ea-8f67-e37804a3bc95.png)

### After

![Screenshot_2020-02-24 Viewing a location(1)](https://user-images.githubusercontent.com/739624/75145701-5e742b00-56f1-11ea-8ea9-296363082fe8.png)

Fixes mysociety/fixmystreet-commercial#1659.

[skip changelog]