### PR TITLE
Also check filter_category for category choice.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
         - Improved try again process on mobile. #2863
         - Improve messaging/display of private reports.
         - Add a web manifest and service worker. #2220
+        - Also check filter_category for category choice. #2893
     - Admin improvements:
         - Add new roles system, to group permissions and apply to users. #2483
         - Contact form emails now include user admin links.

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1554,6 +1554,8 @@ sub check_for_category : Private {
 
     my $category = $c->get_param('category') || $c->stash->{report}->category || '';
     $category = '' if $category eq _('Loading...') || $category eq _('-- Pick a category --');
+    # Just check to see if the filter had an option
+    $category ||= $c->get_param('filter_category') || '';
     $c->stash->{category} = $category;
 
     # Bit of a copy of set_report_extras, because we need the results here, but


### PR DESCRIPTION
If you submit the non-JS image map from an around page with a particular
category selected, that is sent to the server in filter_category and
should be checked to see if we can pre-fill the category dropdown on new
report.