### PR TITLE
Optional server-side tracking for unsuccessful location searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@
         - Make front page cache time configurable.
         - Better working of /fakemapit/ under https.
         - Improve Open311 error output on failing GET requests.
+        - Optionally log failed geocoder searches.
     - Backwards incompatible changes:
         - If you wish the default for the showname checkbox to be checked,
           add `sub default_show_name { 1 }` to your cobrand file.

--- a/perllib/FixMyStreet/Geocode/Bexley.pm
+++ b/perllib/FixMyStreet/Geocode/Bexley.pm
@@ -23,6 +23,8 @@ sub string {
     my $js = query_layer($s);
     return $osm unless $js && @{$js->{features}};
 
+    $c->stash->{geocoder_url} = $s;
+
     my ( $error, @valid_locations, $latitude, $longitude, $address );
     foreach (sort { $a->{properties}{ADDRESS} cmp $b->{properties}{ADDRESS} } @{$js->{features}}) {
         my @lines = @{$_->{geometry}{coordinates}};

--- a/perllib/FixMyStreet/Geocode/Bing.pm
+++ b/perllib/FixMyStreet/Geocode/Bing.pm
@@ -38,6 +38,7 @@ sub string {
     $url .= '&userLocation=' . $params->{centre} if $params->{centre};
     $url .= '&c=' . $params->{bing_culture} if $params->{bing_culture};
 
+    $c->stash->{geocoder_url} = $url;
     my $js = FixMyStreet::Geocode::cache('bing', $url, 'key=' . FixMyStreet->config('BING_MAPS_API_KEY'));
     if (!$js) {
         return { error => _('Sorry, we could not parse that location. Please try again.') };

--- a/perllib/FixMyStreet/Geocode/Google.pm
+++ b/perllib/FixMyStreet/Geocode/Google.pm
@@ -49,6 +49,7 @@ sub string {
 
     $url .= '&components=' . $components if $components;
 
+    $c->stash->{geocoder_url} = $url;
     my $args = 'key=' . FixMyStreet->config('GOOGLE_MAPS_API_KEY');
     my $js = FixMyStreet::Geocode::cache('google', $url, $args, qr/"status"\s*:\s*"(OVER_QUERY_LIMIT|REQUEST_DENIED|INVALID_REQUEST|UNKNOWN_ERROR)"/);
     if (!$js) {

--- a/perllib/FixMyStreet/Geocode/OSM.pm
+++ b/perllib/FixMyStreet/Geocode/OSM.pm
@@ -47,6 +47,7 @@ sub string {
         if $params->{country};
     $url .= join('&', map { "$_=$query_params{$_}" } sort keys %query_params);
 
+    $c->stash->{geocoder_url} = $url;
     my $js = FixMyStreet::Geocode::cache('osm', $url);
     if (!$js) {
         return { error => _('Sorry, we could not find that location.') };

--- a/perllib/FixMyStreet/Geocode/Zurich.pm
+++ b/perllib/FixMyStreet/Geocode/Zurich.pm
@@ -97,6 +97,7 @@ sub string {
     my $cache_dir = path(FixMyStreet->config('GEO_CACHE'), 'zurich')->absolute(FixMyStreet->path_to());
     my $cache_file = $cache_dir->child(md5_hex($s));
     my $result;
+    $c->stash->{geocoder_url} = $s;
     if (-s $cache_file && -M $cache_file <= 7 && !FixMyStreet->config('STAGING_SITE')) {
         $result = retrieve($cache_file);
     } else {


### PR DESCRIPTION
If a SQLite file exists at `../data/analytics.sqlite` with a table named `location_searches_with_no_results`, then a row will be created for each `/around` search that returns no results.

Assuming a search for "heath field close" on fixmystreet.com, that returned no results, it would log:

| datetime | cobrand | geocoder | url | user_input |
| --- | --- | --- | --- | --- |
| 2020-02-25 14:57:48 | fixmystreet | OSM | https://nominatim.openstreetmap.org/search?countrycodes=gb&format=json&q=heath+field+close | heath field close |

Part of mysociety/fixmystreet-commercial#1663.

@dracos I attempted to make the whole thing "optional" by wrapping it in a `try catch` block – not sure whether that’s a good idea or not?

Also, do you think it’s worth adding tests for this? Maybe not worth testing the actual analytics.sqlite logging behaviour, but I’m wondering whether we should have a test that checks the extra bit we added doesn’t break the site if you, say, don’t have an `analytics.sqlite` file in place?