### PR TITLE
Use staging sites on staging hosts

### DIFF
--- a/perllib/FixMyStreet/Map/MasterMap.pm
+++ b/perllib/FixMyStreet/Map/MasterMap.pm
@@ -23,7 +23,8 @@ sub map_tiles {
     my ( $self, %params ) = @_;
     my ( $x, $y, $z ) = ( $params{x_tile}, $params{y_tile}, $params{zoom_act} );
     if ($z >= 17) {
-        my $base = "//%stilma.mysociety.org/mastermap/%d/%d/%d.png";
+        my $layer = FixMyStreet->config('STAGING_SITE') ? 'mastermap-staging' : 'mastermap';
+        my $base = "//%stilma.mysociety.org/$layer/%d/%d/%d.png";
         return [
             sprintf($base, 'a.', $z, $x-1, $y-1),
             sprintf($base, 'b.', $z, $x, $y-1),

--- a/t/map/mastermap.t
+++ b/t/map/mastermap.t
@@ -5,7 +5,7 @@ use FixMyStreet::Map::MasterMap;
 subtest 'correct map tiles used' => sub {
     my %test = (
         16 => [ '-', 'oml' ],
-        20 => [ '.', 'mastermap' ]
+        20 => [ '.', 'mastermap-staging' ]
     );
     foreach my $zoom (qw(16 20)) {
         my $tiles = FixMyStreet::Map::MasterMap->map_tiles(x_tile => 123, y_tile => 456, zoom_act => $zoom);

--- a/templates/web/base/maps/openlayers.html
+++ b/templates/web/base/maps/openlayers.html
@@ -6,6 +6,9 @@
 
 <input type="hidden" name="zoom" value="[% map.zoom %]">
 <div id="js-map-data"
+[%- IF c.config.STAGING_SITE %]
+    data-staging=1
+[%- END %]
 [%- UNLESS c.cobrand.call_hook('hide_areas_on_reports') %]
     data-area="[% map.area.join(',') %]"
 [%- END %]

--- a/web/cobrands/bexley/assets.js
+++ b/web/cobrands/bexley/assets.js
@@ -91,7 +91,7 @@ fixmystreet.assets.add(road_defaults, {
 
 fixmystreet.assets.add(defaults, {
     http_options: {
-        url: "https://tilma.staging.mysociety.org/mapserver/bexley",
+        url: "https://tilma.mysociety.org/mapserver/bexley",
         params: {
             TYPENAME: "Trees"
         }

--- a/web/cobrands/fixmystreet/map.js
+++ b/web/cobrands/fixmystreet/map.js
@@ -3,7 +3,7 @@ var fixmystreet = fixmystreet || {};
 (function(){
 
     var map_data = document.getElementById('js-map-data'),
-        map_keys = [ 'area', 'latitude', 'longitude', 'zoomToBounds', 'zoom', 'pin_prefix', 'pin_new_report_colour', 'numZoomLevels', 'zoomOffset', 'map_type', 'key', 'bodies' ],
+        map_keys = [ 'area', 'latitude', 'longitude', 'zoomToBounds', 'zoom', 'pin_prefix', 'pin_new_report_colour', 'numZoomLevels', 'zoomOffset', 'map_type', 'key', 'bodies', 'staging' ],
         numeric = { zoom: 1, numZoomLevels: 1, zoomOffset: 1, id: 1 },
         bool = { draggable: 1 },
         pin_keys = [ 'lat', 'lon', 'colour', 'id', 'title', 'type', 'draggable' ];

--- a/web/cobrands/isleofwight/assets.js
+++ b/web/cobrands/isleofwight/assets.js
@@ -4,14 +4,9 @@ if (!fixmystreet.maps) {
     return;
 }
 
-var is_live = false;
-if ( location.hostname === 'www.fixmystreet.com' || location.hostname === 'fms.islandroads.com' ) {
-    is_live = true;
-}
-
 var defaults = {
     http_options: {
-        url: is_live ? "https://tilma.mysociety.org/mapserver/iow": "https://staging.tilma.mysociety.org/mapserver/iow",
+        url: fixmystreet.staging ? "https://tilma.staging.mysociety.org/mapserver/iow": "https://tilma.mysociety.org/mapserver/iow",
         params: {
             SERVICE: "WFS",
             VERSION: "1.1.0",

--- a/web/cobrands/northamptonshire/assets.js
+++ b/web/cobrands/northamptonshire/assets.js
@@ -4,10 +4,7 @@ if (!fixmystreet.maps) {
     return;
 }
 
-var is_live = false;
-if ( location.hostname === 'www.fixmystreet.com' || location.hostname == 'fixmystreet.northamptonshire.gov.uk' ) {
-    is_live = true;
-}
+var is_live = !fixmystreet.staging;
 
 var layers = [
   /*

--- a/web/cobrands/peterborough/assets.js
+++ b/web/cobrands/peterborough/assets.js
@@ -4,9 +4,10 @@ if (!fixmystreet.maps) {
     return;
 }
 
+
 var defaults = {
     http_options: {
-        url: "https://tilma.mysociety.org/mapserver/peterborough",
+        url: fixmystreet.staging ? "https://tilma.staging.mysociety.org/mapserver/peterborough" : "https://tilma.mysociety.org/mapserver/peterborough",
         params: {
             SERVICE: "WFS",
             VERSION: "1.1.0",
@@ -58,9 +59,6 @@ var trees_defaults = $.extend(true, {}, defaults, {
         asset_found: fixmystreet.message_controller.asset_found,
         asset_not_found: fixmystreet.message_controller.asset_not_found
     },
-    http_options: {
-        url: "https://tilma.mysociety.org/mapserver/peterborough"
-    },
     attributes: {
         tree_code: 'TREE_CODE'
     },
@@ -96,7 +94,6 @@ fixmystreet.assets.add(trees_defaults, {
 // The new tree request category is disabled in the other tree point layer.
 fixmystreet.assets.add(defaults, {
     http_options: {
-        url: "https://tilma.mysociety.org/mapserver/peterborough",
         params: {
             TYPENAME: "tree_points"
         }

--- a/web/js/map-mastermap.js
+++ b/web/js/map-mastermap.js
@@ -13,7 +13,8 @@ OpenLayers.Layer.MasterMap = OpenLayers.Class(OpenLayers.Layer.BingUK, {
 
         var urls = [];
         var servers = [ '', 'a.', 'b.', 'c.' ];
-        var base = "//{S}tilma.mysociety.org/mastermap/${z}/${x}/${y}.png";
+        var layer = fixmystreet.staging ? 'mastermap-staging' : 'mastermap';
+        var base = "//{S}tilma.mysociety.org/" + layer + "/${z}/${x}/${y}.png";
         for (var i=0; i < servers.length; i++) {
             urls.push( base.replace('{S}', servers[i]) );
         }


### PR DESCRIPTION
This passes a flag from server to client rather than rely upon hostnames.
It switches existing (IoW/Northants) to use this var, and adds Peterborough assets/MasterMap to things that use it.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1785 [skip changelog]