### PR TITLE
Fix error hiding user's updates with no confirmed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
         - Inconsistent display of mark private checkbox for staff users
         - Clear user categories when staff access is removed. #2815
         - Only trigger one change event on initial popstate.
+        - Fix error when hiding a user's updates with no confirmed updates. #2898
     - Development improvements:
         - Upgrade the underlying framework and a number of other packages. #2473
         - Add feature cobrand helper function.

--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -292,6 +292,7 @@ sub is_latest {
         { problem_id => $self->problem_id, state => 'confirmed' },
         { order_by => [ { -desc => 'confirmed' }, { -desc => 'id' } ] }
     )->first;
+    return unless $latest_update;
     return $latest_update->id == $self->id;
 }
 


### PR DESCRIPTION
If a user had no confirmed updates, but did have e.g. an unconfirmed update that had mark_fixed set, you would get an error when trying to hide the user's reports/updates.

Fixes #2898.

- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog