### PR TITLE
[UK Councils] Superusers cannot be edited by staff

### DIFF
--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -130,7 +130,11 @@ sub users_restriction {
         push @$or_query, email => @domains;
     }
 
-    return $rs->search($or_query);
+    my $query = {
+        is_superuser => 0,
+        -or => $or_query
+    };
+    return $rs->search($query);
 }
 
 sub base_url {

--- a/t/app/controller/admin/users.t
+++ b/t/app/controller/admin/users.t
@@ -103,9 +103,12 @@ subtest 'search does not show user from another council' => sub {
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => [ 'oxfordshire' ],
     }, sub {
+        $superuser->update({ from_body => $oxfordshire->id });
         $mech->get_ok('/admin/users');
-        $mech->get_ok('/admin/users?search=' . $user->name);
+        $mech->content_lacks('Super User');
+        $superuser->update({ from_body => undef });
 
+        $mech->get_ok('/admin/users?search=' . $user->name);
         $mech->content_contains( "Searching found no users." );
 
         $mech->get_ok('/admin/users?search=' . $user->email);


### PR DESCRIPTION
[skip changelog]