### PR TITLE
Allow Docker app user to install packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Unreleased
     - Admin improvements:
         - order unsent reports by confirmed date
+    - Bugfixes
+	- Application user in Docker container can't install packages. #2914
 
 * v3.0 (4th March 2020)
     - Security:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM jgoerzen/debian-base-standard:stretch
 MAINTAINER sysadmin@mysociety.org
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG VERSION_OVERRIDE
 
 RUN apt-get -qq update \
       && apt-get -qq -y install ca-certificates sudo \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,12 @@ MAINTAINER sysadmin@mysociety.org
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -qq update \
-      && apt-get -qq -y install ca-certificates \
+      && apt-get -qq -y install ca-certificates sudo \
       && wget -O install-site.sh --no-verbose https://raw.githubusercontent.com/mysociety/commonlib/master/bin/install-site.sh \
-      && chmod +x /install-site.sh
+      && chmod +x /install-site.sh \
+      && echo 'fms ALL=(ALL) NOPASSWD: /var/www/fixmystreet/fixmystreet/bin/install_packages' \
+         >/etc/sudoers.d/10_fms_install_packages \
+      && chmod 0440 /etc/sudoers.d/10_fms_install_packages
 
 RUN /install-site.sh --docker fixmystreet fms 127.0.0.1.xip.io \
       && apt-get purge -y --auto-remove \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       FMS_ROOT: '/var/www/fixmystreet/fixmystreet'
       SUPERUSER_EMAIL: 'superuser@example.org'
       SUPERUSER_PASSWORD: '5up3r53cr3t'
+      SKIP_PACKAGES_INSTALL:
     networks:
       default:
         aliases:

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -7,10 +7,13 @@ git submodule --quiet update --init --recursive --rebase
 
 # Let's see if we can't work out where we might be running.
 if cut -d/ -f2 /proc/self/cgroup | sort -u | grep -q docker ; then
-    # Docker
-    sudo bin/install_packages docker
+    if [ -z ${SKIP_PACKAGES_INSTALL:+x} ] ; then
+        echo "==> Installing Docker packages..."
+        sudo bin/install_packages docker
+    fi
 else
     # Fallback
+    echo "==> Installing generic packages..."
     sudo bin/install_packages generic
 fi
 


### PR DESCRIPTION
This adds a `sudo` rule to the Docker image to ensure the application user can install packages.

It also adds support for skipping this if desired by setting `SKIP_PACKAGES_INSTALL` in the Docker Compose environment and, when building, enables `--build-arg VERSION_OVERRIDE=<foo>` to build arbitrary git commits instead of the most recent tagged release.

Fixes #2914 
