### PR TITLE
[UK] Norwich/Norfolk highways agreement now ended.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -93,15 +93,6 @@ sub geocode_postcode {
     return {};
 }
 
-sub remove_redundant_areas {
-  my $self = shift;
-  my $all_areas = shift;
-
-  # Norwich is responsible for everything in its areas, not Norfolk
-  delete $all_areas->{2233}    #
-    if $all_areas->{2391};
-}
-
 sub short_name {
     my $self = shift;
     my ($area) = @_;


### PR DESCRIPTION
[skip changelog]
Email from Norwich: "The Highways Agency Agreement covering Norwich is coming to an end this month. As of 1st March all new highways enquiries for the Norwich City Council district will need to be directed to Norfolk County Council."