### PR TITLE
Staff only cats in admin 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
     - Admin improvements:
         - order unsent reports by confirmed date
     - Bugfixes
-	- Application user in Docker container can't install packages. #2914
+        - Application user in Docker container can't install packages. #2914
+        - Look at all categories when sending reports.
     - UK:
         - Added junction lookup, so you can search for things like "M60, Junction 2"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     - Bugfixes
         - Application user in Docker container can't install packages. #2914
         - Look at all categories when sending reports.
+        - Provide access to staff-only categories in admin.
     - UK:
         - Added junction lookup, so you can search for things like "M60, Junction 2"
 

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -180,7 +180,7 @@ sub fetch_contacts : Private {
 
     my $contacts = $c->stash->{body}->contacts->search(undef, { order_by => [ 'category' ] } );
     $c->stash->{contacts} = $contacts;
-    $c->stash->{live_contacts} = $contacts->not_deleted;
+    $c->stash->{live_contacts} = $contacts->not_deleted_admin;
     $c->stash->{any_not_confirmed} = $contacts->search({ state => 'unconfirmed' })->count;
 
     if ( $c->get_param('text') && $c->get_param('text') eq '1' ) {

--- a/perllib/FixMyStreet/DB/ResultSet/Contact.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Contact.pm
@@ -20,6 +20,11 @@ sub not_deleted {
     return $rs->search( { $rs->me('state') => { -not_in => [ 'deleted', 'staff' ] } } );
 }
 
+sub not_deleted_admin {
+    my $rs = shift;
+    return $rs->search( { $rs->me('state') => { -not_in => [ 'deleted' ] } } );
+}
+
 sub active {
     my $rs = shift;
     $rs->search( { $rs->me('state') => [ 'unconfirmed', 'confirmed' ] } );

--- a/perllib/FixMyStreet/SendReport.pm
+++ b/perllib/FixMyStreet/SendReport.pm
@@ -63,7 +63,7 @@ sub add_body {
 sub fetch_category {
     my ($self, $body, $row, $category_override) = @_;
 
-    my $contact = $row->result_source->schema->resultset("Contact")->not_deleted->find( {
+    my $contact = $row->result_source->schema->resultset("Contact")->find( {
         body_id => $body->id,
         category => $category_override || $row->category,
     } );

--- a/t/app/controller/report_new_staff.t
+++ b/t/app/controller/report_new_staff.t
@@ -237,6 +237,9 @@ subtest 'staff-only categories when reporting' => sub {
         $edin_trees->discard_changes;
         is $edin_trees->state, 'staff', 'category is staff only';
 
+        $mech->get_ok('/admin/templates/' . $body_ids{2651} . '/new');
+        $mech->content_contains('Trees');
+
         my $extra_details = $mech->get_ok_json( '/report/new/ajax?latitude=55.952055&longitude=-3.189579' );
         is_deeply [ sort keys %{$extra_details->{by_category}} ], [ 'Street lighting', 'Trees' ], 'Superuser can see staff-only category';
 


### PR DESCRIPTION
Staff-only categories were added previously, but only in terms of them being there when making a new report. Turns out you couldn't *send* those reports, whoops, or e.g. set up admin templates for them or anything.