### PR TITLE
Refactor send reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
         - Application user in Docker container can't install packages. #2914
         - Look at all categories when sending reports.
         - Provide access to staff-only categories in admin.
+    - Development improvements:
+        - Refactor Script::Report into an object.
     - UK:
         - Added junction lookup, so you can search for things like "M60, Junction 2"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
         - Provide access to staff-only categories in admin.
     - Development improvements:
         - Refactor Script::Report into an object.
+        - Move summary failures to a separate script.
     - UK:
         - Added junction lookup, so you can search for things like "M60, Junction 2"
 

--- a/bin/send-reports-failure-summary
+++ b/bin/send-reports-failure-summary
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+
+# send-reports-failure-summary:
+# Prints a summary of report sending failures
+
+use strict;
+use warnings;
+use v5.14;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../setenv.pl";
+}
+
+use FixMyStreet::Script::Reports;
+
+my $manager = FixMyStreet::Script::Reports->new;
+$manager->end_summary_failures;

--- a/perllib/FixMyStreet/Cobrand/Bexley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley.pm
@@ -83,14 +83,17 @@ sub lookup_site_code_config {
 }
 
 sub open311_config {
-    my ($self, $row, $h, $params, $contact) = @_;
+    my ($self, $row, $h, $params) = @_;
 
     $params->{multi_photos} = 1;
+}
 
-    my $extra = $row->get_extra_fields;
+sub open311_extra_data {
+    my ($self, $row, $h, $extra, $contact) = @_;
 
+    my $open311_only;
     if ($contact->email =~ /^Confirm/) {
-        push @$extra,
+        push @$open311_only,
             { name => 'report_url', description => 'Report URL',
               value => $h->{url} },
             { name => 'title', description => 'Title',
@@ -123,7 +126,7 @@ sub open311_config {
         }
     }
 
-    $row->set_extra_fields(@$extra);
+    return $open311_only;
 }
 
 sub admin_user_domain { 'bexley.gov.uk' }

--- a/perllib/FixMyStreet/Cobrand/CheshireEast.pm
+++ b/perllib/FixMyStreet/Cobrand/CheshireEast.pm
@@ -60,15 +60,19 @@ sub open311_config {
     my ($self, $row, $h, $params) = @_;
 
     $params->{multi_photos} = 1;
+}
 
-    my $extra = $row->get_extra_fields;
-    push @$extra,
+sub open311_extra_data {
+    my ($self, $row, $h, $extra) = @_;
+
+    my $open311_only = [
         { name => 'report_url',
           value => $h->{url} },
         { name => 'title',
           value => $row->title },
         { name => 'description',
-          value => $row->detail };
+          value => $row->detail },
+    ];
 
     # Reports made via FMS.com or the app probably won't have a site code
     # value because we don't display the adopted highways layer on those
@@ -82,7 +86,7 @@ sub open311_config {
         }
     }
 
-    $row->set_extra_fields(@$extra);
+    return $open311_only;
 }
 
 # TODO These values may not be accurate

--- a/perllib/FixMyStreet/Cobrand/Greenwich.pm
+++ b/perllib/FixMyStreet/Cobrand/Greenwich.pm
@@ -44,13 +44,13 @@ sub reports_per_page { return 20; }
 
 sub admin_user_domain { 'royalgreenwich.gov.uk' }
 
-sub open311_config {
-    my ($self, $row, $h, $params) = @_;
+sub open311_extra_data {
+    my ($self, $row, $h, $extra) = @_;
 
-    my $extra = $row->get_extra_fields;
     # Greenwich doesn't have category metadata to fill this
-    push @$extra, { name => 'external_id', value => $row->id };
-    $row->set_extra_fields( @$extra );
+    return [
+        { name => 'external_id', value => $row->id },
+    ];
 }
 
 sub open311_contact_meta_override {

--- a/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
@@ -88,12 +88,13 @@ sub map_type { 'Northamptonshire' }
 sub open311_config {
     my ($self, $row, $h, $params) = @_;
 
-    my $extra = $row->get_extra_fields;
+    $params->{multi_photos} = 1;
+}
 
-    # remove the emergency category which is informational only
-    @$extra = grep { $_->{name} ne 'emergency' } @$extra;
+sub open311_extra_data {
+    my ($self, $row, $h, $extra) = @_;
 
-    push @$extra,
+    return ([
         { name => 'report_url',
           value => $h->{url} },
         { name => 'title',
@@ -101,11 +102,10 @@ sub open311_config {
         { name => 'description',
           value => $row->detail },
         { name => 'category',
-          value => $row->category };
-
-    $row->set_extra_fields(@$extra);
-
-    $params->{multi_photos} = 1;
+          value => $row->category },
+    ], [
+        'emergency'
+    ]);
 }
 
 sub open311_get_update_munging {

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -118,18 +118,19 @@ sub state_groups_inspect {
 sub open311_config {
     my ($self, $row, $h, $params) = @_;
 
-    my $extra = $row->get_extra_fields;
-    push @$extra, { name => 'external_id', value => $row->id };
-    push @$extra, { name => 'northing', value => $h->{northing} };
-    push @$extra, { name => 'easting', value => $h->{easting} };
-
-    if ($h->{closest_address}) {
-        push @$extra, { name => 'closest_address', value => "$h->{closest_address}" }
-    }
-    $row->set_extra_fields( @$extra );
-
     $params->{multi_photos} = 1;
     $params->{extended_description} = 'oxfordshire';
+}
+
+sub open311_extra_data {
+    my ($self, $row, $h, $extra) = @_;
+
+    return [
+        { name => 'external_id', value => $row->id },
+        { name => 'northing', value => $h->{northing} },
+        { name => 'easting', value => $h->{easting} },
+        $h->{closest_address} ? { name => 'closest_address', value => "$h->{closest_address}" } : (),
+    ];
 }
 
 sub open311_config_updates {

--- a/perllib/FixMyStreet/Cobrand/Rutland.pm
+++ b/perllib/FixMyStreet/Cobrand/Rutland.pm
@@ -26,17 +26,18 @@ sub report_validation {
 sub open311_config {
     my ($self, $row, $h, $params) = @_;
 
-    my $extra = $row->get_extra_fields;
-    push @$extra, { name => 'external_id', value => $row->id };
-    push @$extra, { name => 'title', value => $row->title };
-    push @$extra, { name => 'description', value => $row->detail };
-
-    if ($h->{closest_address}) {
-        push @$extra, { name => 'closest_address', value => "$h->{closest_address}" }
-    }
-    $row->set_extra_fields( @$extra );
-
     $params->{multi_photos} = 1;
+}
+
+sub open311_extra_data {
+    my ($self, $row, $h, $extra) = @_;
+
+    return [
+        { name => 'external_id', value => $row->id },
+        { name => 'title', value => $row->title },
+        { name => 'description', value => $row->detail },
+        $h->{closest_address} ? { name => 'closest_address', value => "$h->{closest_address}" } : (),
+    ];
 }
 
 sub disambiguate_location {

--- a/perllib/FixMyStreet/Cobrand/Westminster.pm
+++ b/perllib/FixMyStreet/Cobrand/Westminster.pm
@@ -76,8 +76,10 @@ sub open311_config {
     my $id = $row->user->get_extra_metadata('westminster_account_id');
     # Westminster require 0 as the account ID if there's no MyWestminster ID.
     $h->{account_id} = $id || '0';
+}
 
-    my $extra = $row->get_extra_fields;
+sub open311_extra_data {
+    my ($self, $row, $h, $extra) = @_;
 
     # Reports made via the app probably won't have a USRN because we don't
     # display the road layer. Instead we'll look up the closest asset from the
@@ -97,8 +99,6 @@ sub open311_config {
             push @$extra, { name => 'UPRN', value => $ref };
         }
     }
-
-    $row->set_extra_fields(@$extra);
 }
 
 sub lookup_site_code_config {

--- a/perllib/FixMyStreet/Queue/Item/Report.pm
+++ b/perllib/FixMyStreet/Queue/Item/Report.pm
@@ -1,0 +1,305 @@
+package FixMyStreet::Queue::Item::Report;
+
+use Moo;
+use DateTime::Format::Pg;
+
+use Utils::OpenStreetMap;
+
+use FixMyStreet;
+use FixMyStreet::Cobrand;
+use FixMyStreet::DB;
+use FixMyStreet::Email;
+use FixMyStreet::Map;
+use FixMyStreet::SendReport;
+
+# The row from the database being processed
+has report => ( is => 'ro' );
+# The thing dealing with the reports (for feeding back debug/test data)
+has manager => ( is => 'ro' );
+
+# The possible ways of sending reports
+has senders => ( is => 'lazy', default => sub {
+    my $send_report = FixMyStreet::SendReport->new();
+    $send_report->get_senders;
+});
+
+# The cobrand the report was logged *on*
+has cobrand => ( is => 'lazy', default => sub {
+    $_[0]->report->get_cobrand_logged;
+});
+
+# A cobrand that handles the body to which this report is being sent, or logged cobrand if none
+has cobrand_handler => ( is => 'lazy', default => sub {
+    my $self = shift;
+    $self->cobrand->call_hook(get_body_handler_for_problem => $self->report) || $self->cobrand;
+});
+
+# Data to be used in email templates / Open311 sending
+has h => ( is => 'rwp' );
+
+# SendReport subclasses to be used to send this report
+has reporters => ( is => 'rwp' );
+
+# Run parameters
+has nomail => ( is => 'ro' );
+has debug_mode => ( is => 'ro' );
+
+sub process {
+    my $self = shift;
+
+    FixMyStreet::DB->schema->cobrand($self->cobrand);
+
+    if ($self->debug_mode) {
+        $self->manager->debug_unsent_count++;
+        print "\n";
+        my $row = $self->report;
+        $self->debug_print("state=" . $row->state . ", bodies_str=" . $row->bodies_str . ($row->cobrand? ", cobrand=" . $row->cobrand : ""), $row->id);
+    }
+
+    # Cobranded and non-cobranded messages can share a database. In this case, the conf file
+    # should specify a vhost to send the reports for each cobrand, so that they don't get sent
+    # more than once if there are multiple vhosts running off the same database. The email_host
+    # call checks if this is the host that sends mail for this cobrand.
+    if (! $self->cobrand->email_host()) {
+        $self->debug_print("skipping because this host does not send reports for cobrand " . $self->cobrand->moniker, $self->report->id);
+        return;
+    }
+
+    $self->cobrand->set_lang_and_domain($self->report->lang, 1);
+    FixMyStreet::Map::set_map_class($self->cobrand_handler->map_type);
+
+    return unless $self->_check_abuse;
+    $self->_create_vars;
+    $self->_create_reporters or return;
+    my $result = $self->_send;
+    $self->_post_send($result);
+}
+
+sub _check_abuse {
+    my $self = shift;
+    if ( $self->report->is_from_abuser) {
+        $self->report->update( { state => 'hidden' } );
+        $self->debug_print("hiding because its sender is flagged as an abuser", $self->report->id);
+        return;
+    } elsif ( $self->report->title =~ /app store test/i ) {
+        $self->report->update( { state => 'hidden' } );
+        $self->debug_print("hiding because it is an app store test message", $self->report->id);
+        return;
+    }
+    return 1;
+}
+
+sub _create_vars {
+    my $self = shift;
+
+    my $row = $self->report;
+
+    # Template variables for the email
+    my $email_base_url = $self->cobrand_handler->base_url_for_report($row);
+    my %h = map { $_ => $row->$_ } qw/id title detail name category latitude longitude used_map/;
+    $h{report} = $row;
+    $h{cobrand} = $self->cobrand;
+    map { $h{$_} = $row->user->$_ || '' } qw/email phone/;
+    $h{confirmed} = DateTime::Format::Pg->format_datetime( $row->confirmed->truncate (to => 'second' ) )
+        if $row->confirmed;
+
+    $h{query} = $row->postcode;
+    $h{url} = $email_base_url . $row->url;
+    $h{admin_url} = $row->admin_url($self->cobrand_handler);
+    if ($row->photo) {
+        $h{has_photo} = _("This web page also contains a photo of the problem, provided by the user.") . "\n\n";
+        $h{image_url} = $email_base_url . $row->photos->[0]->{url_full};
+        my @all_images = map { $email_base_url . $_->{url_full} } @{ $row->photos };
+        $h{all_image_urls} = \@all_images;
+    } else {
+        $h{has_photo} = '';
+        $h{image_url} = '';
+    }
+    $h{fuzzy} = $row->used_map ? _('To view a map of the precise location of this issue')
+        : _('The user could not locate the problem on a map, but to see the area around the location they entered');
+    $h{closest_address} = '';
+
+    $h{osm_url} = Utils::OpenStreetMap::short_url($h{latitude}, $h{longitude});
+    if ( $row->used_map ) {
+        $h{closest_address} = $self->cobrand->find_closest($row);
+        $h{osm_url} .= '?m';
+    }
+
+    if ( $self->cobrand->allow_anonymous_reports($row->category) &&
+         $row->user->email eq $self->cobrand->anonymous_account->{'email'}
+     ) {
+        $h{anonymous_report} = 1;
+    }
+
+    if ($h{category} eq _('Other')) {
+        $h{category_footer} = _('this type of local problem');
+    } else {
+        $h{category_footer} = "'" . $h{category} . "'";
+    }
+
+    my $missing;
+    if ($row->bodies_missing) {
+        my @missing = FixMyStreet::DB->resultset("Body")->search(
+            { id => [ split /,/, $row->bodies_missing ] },
+            { order_by => 'name' }
+        )->get_column('name')->all;
+        $missing = join(' / ', @missing) if @missing;
+    }
+    $h{missing} = '';
+    if ($missing) {
+        $h{missing} = '[ '
+          . sprintf(_('We realise this problem might be the responsibility of %s; however, we don\'t currently have any contact details for them. If you know of an appropriate contact address, please do get in touch.'), $missing)
+          . " ]\n\n";
+    }
+
+    # If we are in the UK include eastings and northings
+    if ( $self->cobrand->country eq 'GB' && !$h{easting} ) {
+        ( $h{easting}, $h{northing}, $h{coordsyst} ) = $row->local_coords;
+    }
+
+    $self->cobrand->call_hook(process_additional_metadata_for_email => $row, \%h);
+
+    $self->_set_h(\%h);
+}
+
+sub _create_reporters {
+    my $self = shift;
+
+    my $row = $self->report;
+    my $bodies = FixMyStreet::DB->resultset('Body')->search(
+        { id => $row->bodies_str_ids },
+        { order_by => 'name' },
+    );
+
+    my @dear;
+    my %reporters = ();
+    my $skip = 0;
+    while (my $body = $bodies->next) {
+        my $sender_info = $self->cobrand->get_body_sender( $body, $row->category );
+        my $sender = "FixMyStreet::SendReport::" . $sender_info->{method};
+
+        if ( ! exists $self->senders->{ $sender } ) {
+            warn sprintf "No such sender [ $sender ] for body %s ( %d )", $body->name, $body->id;
+            next;
+        }
+        $reporters{ $sender } ||= $sender->new();
+
+        if ( $reporters{ $sender }->should_skip( $row, $self->debug_mode ) ) {
+            $skip = 1;
+            $self->debug_print("skipped by sender " . $sender_info->{method} . " (might be due to previous failed attempts?)", $row->id);
+        } else {
+            $self->debug_print("OK, adding recipient body " . $body->id . ":" . $body->name . ", " . $sender_info->{method}, $row->id);
+            push @dear, $body->name;
+            $reporters{ $sender }->add_body( $body, $sender_info->{config} );
+        }
+    }
+
+    unless ( keys %reporters ) {
+        die 'Report not going anywhere for ID ' . $row->id . '!';
+    }
+
+    return if $skip;
+
+    my $h = $self->h;
+    $h->{bodies_name} = join(_(' and '), @dear);
+    if ($h->{category} eq _('Other')) {
+        $h->{multiple} = @dear>1 ? "[ " . _("This email has been sent to both councils covering the location of the problem, as the user did not categorise it; please ignore it if you're not the correct council to deal with the issue, or let us know what category of problem this is so we can add it to our system.") . " ]\n\n"
+            : '';
+    } else {
+        $h->{multiple} = @dear>1 ? "[ " . _("This email has been sent to several councils covering the location of the problem, as the category selected is provided for all of them; please ignore it if you're not the correct council to deal with the issue.") . " ]\n\n"
+            : '';
+    }
+
+    if (FixMyStreet->staging_flag('send_reports', 0)) {
+        # on a staging server send emails to ourselves rather than the bodies
+        %reporters = map { $_ => $reporters{$_} } grep { /FixMyStreet::SendReport::Email/ } keys %reporters;
+        unless (%reporters) {
+            %reporters = ( 'FixMyStreet::SendReport::Email' => FixMyStreet::SendReport::Email->new() );
+        }
+    }
+
+    $self->_set_reporters(\%reporters);
+}
+
+sub _send {
+    my $self = shift;
+
+    # Multiply results together, so one success counts as a success.
+    my $result = -1;
+
+    for my $sender ( keys %{$self->reporters} ) {
+        $self->debug_print("sending using " . $sender, $self->report->id);
+        $sender = $self->reporters->{$sender};
+        my $res = $sender->send( $self->report, $self->h );
+        $result *= $res;
+        $self->report->add_send_method($sender) if !$res;
+        if ( $sender->unconfirmed_data) {
+            foreach my $e (keys %{ $sender->unconfirmed_data } ) {
+                foreach my $c (keys %{ $sender->unconfirmed_data->{$e} }) {
+                    $self->manager->unconfirmed_data->{$e}{$c}{count} += $sender->unconfirmed_data->{$e}{$c}{count};
+                    $self->manager->unconfirmed_data->{$e}{$c}{note} = $sender->unconfirmed_data->{$e}{$c}{note};
+                }
+            }
+        }
+        $self->manager->test_data->{test_req_used} = $sender->open311_test_req_used
+            if FixMyStreet->test_mode && $sender->can('open311_test_req_used');
+    }
+
+    return $result;
+}
+
+sub _post_send {
+    my ($self, $result) = @_;
+
+    my $send_confirmation_email = $self->cobrand_handler->report_sent_confirmation_email;
+    unless ($result) {
+        $self->report->update( {
+            whensent => \'current_timestamp',
+            lastupdate => \'current_timestamp',
+        } );
+        if ($send_confirmation_email && !$self->h->{anonymous_report}) {
+            $self->h->{sent_confirm_id_ref} = $self->report->$send_confirmation_email;
+            $self->_send_report_sent_email;
+        }
+        $self->debug_print("send successful: OK", $self->report->id);
+    } else {
+        my @errors;
+        for my $sender ( keys %{$self->reporters} ) {
+            unless ( $self->reporters->{ $sender }->success ) {
+                push @errors, $self->reporters->{ $sender }->error;
+            }
+        }
+        $self->report->update_send_failed( join( '|', @errors ) );
+        $self->debug_print("send FAILED: " . join( '|', @errors ), $self->report->id);
+    }
+}
+
+sub _send_report_sent_email {
+    my $self = shift;
+
+    # Don't send 'report sent' text
+    return unless $self->report->user->email_verified;
+
+    my $contributed_as = $self->report->get_extra_metadata('contributed_as') || '';
+    return if $contributed_as eq 'body' || $contributed_as eq 'anonymous_user';
+
+    FixMyStreet::Email::send_cron(
+        $self->report->result_source->schema,
+        'confirm_report_sent.txt',
+        $self->h,
+        {
+            To => $self->report->user->email,
+        },
+        undef,
+        $self->nomail,
+        $self->cobrand,
+        $self->report->lang,
+    );
+}
+
+sub debug_print {
+    my $self = shift;
+    $self->manager->debug_print(@_);
+}
+
+1;

--- a/perllib/FixMyStreet/Roles/ConfirmOpen311.pm
+++ b/perllib/FixMyStreet/Roles/ConfirmOpen311.pm
@@ -11,15 +11,19 @@ sub open311_config {
     my ($self, $row, $h, $params) = @_;
 
     $params->{multi_photos} = 1;
+}
 
-    my $extra = $row->get_extra_fields;
-    push @$extra,
+sub open311_extra_data {
+    my ($self, $row, $h, $extra) = @_;
+
+    my $open311_only = [
         { name => 'report_url',
           value => $h->{url} },
         { name => 'title',
           value => $row->title },
         { name => 'description',
-          value => $row->detail };
+          value => $row->detail },
+    ];
 
     # Reports made via FMS.com or the app probably won't have a USRN
     # value because we don't display the adopted highways layer on those
@@ -33,7 +37,7 @@ sub open311_config {
         }
     }
 
-    $row->set_extra_fields(@$extra);
+    return $open311_only;
 }
 
 1;

--- a/perllib/FixMyStreet/Script/Reports.pm
+++ b/perllib/FixMyStreet/Script/Reports.pm
@@ -197,13 +197,12 @@ sub send(;$) {
         # Multiply results together, so one success counts as a success.
         my $result = -1;
 
-        my @methods;
         for my $sender ( keys %reporters ) {
             debug_print("sending using " . $sender, $row->id) if $debug_mode;
             $sender = $reporters{$sender};
             my $res = $sender->send( $row, \%h );
             $result *= $res;
-            push @methods, $sender if !$res;
+            $row->add_send_method($sender) if !$res;
             if ( $sender->unconfirmed_counts) {
                 foreach my $e (keys %{ $sender->unconfirmed_counts } ) {
                     foreach my $c (keys %{ $sender->unconfirmed_counts->{$e} }) {
@@ -214,12 +213,6 @@ sub send(;$) {
             }
             $test_data->{test_req_used} = $sender->open311_test_req_used
                 if FixMyStreet->test_mode && $sender->can('open311_test_req_used');
-        }
-
-        # Add the send methods now because e.g. Open311
-        # send() calls $row->discard_changes
-        foreach (@methods) {
-            $row->add_send_method($_);
         }
 
         unless ($result) {

--- a/perllib/FixMyStreet/Script/Reports.pm
+++ b/perllib/FixMyStreet/Script/Reports.pm
@@ -51,7 +51,6 @@ sub send(;$) {
 
     $manager->end_debug_line;
     $manager->end_summary_unconfirmed;
-    $manager->end_summary_failures;
 
     return $manager->test_data;
 }
@@ -84,7 +83,6 @@ sub end_summary_unconfirmed {
 
 sub end_summary_failures {
     my $self = shift;
-    return unless $self->verbose || $self->debug_mode;
 
     my $sending_errors = '';
     my $unsent = FixMyStreet::DB->resultset('Problem')->search( {

--- a/perllib/FixMyStreet/Script/Reports.pm
+++ b/perllib/FixMyStreet/Script/Reports.pm
@@ -1,30 +1,13 @@
 package FixMyStreet::Script::Reports;
 
-use strict;
-use warnings;
-
-use CronFns;
-use DateTime::Format::Pg;
 use Moo;
-
-use Utils;
-use Utils::OpenStreetMap;
-
+use CronFns;
 use FixMyStreet;
-use FixMyStreet::Cobrand;
 use FixMyStreet::DB;
-use FixMyStreet::Email;
-use FixMyStreet::Map;
-use FixMyStreet::SendReport;
+use FixMyStreet::Queue::Item::Report;
 
 has verbose => ( is => 'ro' );
-has nomail => ( is => 'ro' );
 has debug_mode => ( is => 'ro' );
-
-has senders => ( is => 'lazy', default => sub {
-    my $send_report = FixMyStreet::SendReport->new();
-    $send_report->get_senders;
-});
 
 has debug_unsent_count => ( is => 'rw', default => 0 );
 has unconfirmed_data => ( is => 'ro', default => sub { {} } );
@@ -41,7 +24,6 @@ sub send(;$) {
 
     my $manager = __PACKAGE__->new(
         verbose => $verbose,
-        nomail => $nomail,
         debug_mode => $debug_mode,
     );
 
@@ -58,7 +40,13 @@ sub send(;$) {
 
     $manager->debug_print("starting to loop through unsent problem reports...");
     while (my $row = $unsent->next) {
-        $manager->process($row);
+        my $item = FixMyStreet::Queue::Item::Report->new(
+            report => $row,
+            manager => $manager,
+            nomail => $nomail,
+            debug_mode => $debug_mode,
+        );
+        $item->process;
     }
 
     $manager->end_debug_line;
@@ -66,230 +54,6 @@ sub send(;$) {
     $manager->end_summary_failures;
 
     return $manager->test_data;
-}
-
-sub process {
-    my $self = shift;
-    my $row = shift;
-
-    my $cobrand = $row->get_cobrand_logged;
-    FixMyStreet::DB->schema->cobrand($cobrand);
-
-    # Also get a cobrand that handles where a report is going
-    my $cobrand_handler = $cobrand->call_hook(get_body_handler_for_problem => $row) || $cobrand;
-
-    if ($self->debug_mode) {
-        $self->debug_unsent_count++;
-        print "\n";
-        $self->debug_print("state=" . $row->state . ", bodies_str=" . $row->bodies_str . ($row->cobrand? ", cobrand=" . $row->cobrand : ""), $row->id);
-    }
-
-    # Cobranded and non-cobranded messages can share a database. In this case, the conf file
-    # should specify a vhost to send the reports for each cobrand, so that they don't get sent
-    # more than once if there are multiple vhosts running off the same database. The email_host
-    # call checks if this is the host that sends mail for this cobrand.
-    if (! $cobrand->email_host()) {
-        $self->debug_print("skipping because this host does not send reports for cobrand " . $cobrand->moniker, $row->id);
-        return;
-    }
-
-    $cobrand->set_lang_and_domain($row->lang, 1);
-    FixMyStreet::Map::set_map_class($cobrand_handler->map_type);
-    if ( $row->is_from_abuser) {
-        $row->update( { state => 'hidden' } );
-        $self->debug_print("hiding because its sender is flagged as an abuser", $row->id);
-        return;
-    } elsif ( $row->title =~ /app store test/i ) {
-        $row->update( { state => 'hidden' } );
-        $self->debug_print("hiding because it is an app store test message", $row->id);
-        return;
-    }
-
-    my $h = $self->_create_vars($row, $cobrand_handler, $cobrand);
-    my $reporters = $self->_create_reporters($row, $cobrand, $h) or return;
-    my $result = $self->_send($reporters, $row, $h);
-    $self->_post_send($result, $row, $h, $cobrand_handler, $cobrand, $reporters);
-}
-
-sub _create_vars {
-    my ($self, $row, $cobrand_handler, $cobrand) = @_;
-
-    # Template variables for the email
-    my $email_base_url = $cobrand_handler->base_url_for_report($row);
-    my %h = map { $_ => $row->$_ } qw/id title detail name category latitude longitude used_map/;
-    $h{report} = $row;
-    $h{cobrand} = $cobrand;
-    map { $h{$_} = $row->user->$_ || '' } qw/email phone/;
-    $h{confirmed} = DateTime::Format::Pg->format_datetime( $row->confirmed->truncate (to => 'second' ) )
-        if $row->confirmed;
-
-    $h{query} = $row->postcode;
-    $h{url} = $email_base_url . $row->url;
-    $h{admin_url} = $row->admin_url($cobrand_handler);
-    if ($row->photo) {
-        $h{has_photo} = _("This web page also contains a photo of the problem, provided by the user.") . "\n\n";
-        $h{image_url} = $email_base_url . $row->photos->[0]->{url_full};
-        my @all_images = map { $email_base_url . $_->{url_full} } @{ $row->photos };
-        $h{all_image_urls} = \@all_images;
-    } else {
-        $h{has_photo} = '';
-        $h{image_url} = '';
-    }
-    $h{fuzzy} = $row->used_map ? _('To view a map of the precise location of this issue')
-        : _('The user could not locate the problem on a map, but to see the area around the location they entered');
-    $h{closest_address} = '';
-
-    $h{osm_url} = Utils::OpenStreetMap::short_url($h{latitude}, $h{longitude});
-    if ( $row->used_map ) {
-        $h{closest_address} = $cobrand->find_closest($row);
-        $h{osm_url} .= '?m';
-    }
-
-    if ( $cobrand->allow_anonymous_reports($row->category) &&
-         $row->user->email eq $cobrand->anonymous_account->{'email'}
-     ) {
-        $h{anonymous_report} = 1;
-    }
-
-    if ($h{category} eq _('Other')) {
-        $h{category_footer} = _('this type of local problem');
-    } else {
-        $h{category_footer} = "'" . $h{category} . "'";
-    }
-
-    my $missing;
-    if ($row->bodies_missing) {
-        my @missing = FixMyStreet::DB->resultset("Body")->search(
-            { id => [ split /,/, $row->bodies_missing ] },
-            { order_by => 'name' }
-        )->get_column('name')->all;
-        $missing = join(' / ', @missing) if @missing;
-    }
-    $h{missing} = '';
-    if ($missing) {
-        $h{missing} = '[ '
-          . sprintf(_('We realise this problem might be the responsibility of %s; however, we don\'t currently have any contact details for them. If you know of an appropriate contact address, please do get in touch.'), $missing)
-          . " ]\n\n";
-    }
-
-    # If we are in the UK include eastings and northings
-    if ( $cobrand->country eq 'GB' && !$h{easting} ) {
-        ( $h{easting}, $h{northing}, $h{coordsyst} ) = $row->local_coords;
-    }
-
-    $cobrand->call_hook(process_additional_metadata_for_email => $row, \%h);
-
-    return \%h;
-}
-
-sub _create_reporters {
-    my ($self, $row, $cobrand, $h) = @_;
-
-    my $bodies = FixMyStreet::DB->resultset('Body')->search(
-        { id => $row->bodies_str_ids },
-        { order_by => 'name' },
-    );
-
-    my @dear;
-    my %reporters = ();
-    my $skip = 0;
-    while (my $body = $bodies->next) {
-        my $sender_info = $cobrand->get_body_sender( $body, $row->category );
-        my $sender = "FixMyStreet::SendReport::" . $sender_info->{method};
-
-        if ( ! exists $self->senders->{ $sender } ) {
-            warn sprintf "No such sender [ $sender ] for body %s ( %d )", $body->name, $body->id;
-            next;
-        }
-        $reporters{ $sender } ||= $sender->new();
-
-        if ( $reporters{ $sender }->should_skip( $row, $self->debug_mode ) ) {
-            $skip = 1;
-            $self->debug_print("skipped by sender " . $sender_info->{method} . " (might be due to previous failed attempts?)", $row->id);
-        } else {
-            $self->debug_print("OK, adding recipient body " . $body->id . ":" . $body->name . ", " . $sender_info->{method}, $row->id);
-            push @dear, $body->name;
-            $reporters{ $sender }->add_body( $body, $sender_info->{config} );
-        }
-    }
-
-    unless ( keys %reporters ) {
-        die 'Report not going anywhere for ID ' . $row->id . '!';
-    }
-
-    return if $skip;
-
-    $h->{bodies_name} = join(_(' and '), @dear);
-    if ($h->{category} eq _('Other')) {
-        $h->{multiple} = @dear>1 ? "[ " . _("This email has been sent to both councils covering the location of the problem, as the user did not categorise it; please ignore it if you're not the correct council to deal with the issue, or let us know what category of problem this is so we can add it to our system.") . " ]\n\n"
-            : '';
-    } else {
-        $h->{multiple} = @dear>1 ? "[ " . _("This email has been sent to several councils covering the location of the problem, as the category selected is provided for all of them; please ignore it if you're not the correct council to deal with the issue.") . " ]\n\n"
-            : '';
-    }
-
-    if (FixMyStreet->staging_flag('send_reports', 0)) {
-        # on a staging server send emails to ourselves rather than the bodies
-        %reporters = map { $_ => $reporters{$_} } grep { /FixMyStreet::SendReport::Email/ } keys %reporters;
-        unless (%reporters) {
-            %reporters = ( 'FixMyStreet::SendReport::Email' => FixMyStreet::SendReport::Email->new() );
-        }
-    }
-
-    return \%reporters;
-}
-
-sub _send {
-    my ($self, $reporters, $row, $h) = @_;
-
-    # Multiply results together, so one success counts as a success.
-    my $result = -1;
-
-    for my $sender ( keys %$reporters ) {
-        $self->debug_print("sending using " . $sender, $row->id);
-        $sender = $reporters->{$sender};
-        my $res = $sender->send( $row, $h );
-        $result *= $res;
-        $row->add_send_method($sender) if !$res;
-        if ( $sender->unconfirmed_data) {
-            foreach my $e (keys %{ $sender->unconfirmed_data } ) {
-                foreach my $c (keys %{ $sender->unconfirmed_data->{$e} }) {
-                    $self->unconfirmed_data->{$e}{$c}{count} += $sender->unconfirmed_data->{$e}{$c}{count};
-                    $self->unconfirmed_data->{$e}{$c}{note} = $sender->unconfirmed_data->{$e}{$c}{note};
-                }
-            }
-        }
-        $self->test_data->{test_req_used} = $sender->open311_test_req_used
-            if FixMyStreet->test_mode && $sender->can('open311_test_req_used');
-    }
-
-    return $result;
-}
-
-sub _post_send {
-    my ($self, $result, $row, $h, $cobrand_handler, $cobrand, $reporters) = @_;
-
-    my $send_confirmation_email = $cobrand_handler->report_sent_confirmation_email;
-    unless ($result) {
-        $row->update( {
-            whensent => \'current_timestamp',
-            lastupdate => \'current_timestamp',
-        } );
-        if ($send_confirmation_email && !$h->{anonymous_report}) {
-            $h->{sent_confirm_id_ref} = $row->$send_confirmation_email;
-            $self->_send_report_sent_email( $row, $h, $cobrand );
-        }
-        $self->debug_print("send successful: OK", $row->id);
-    } else {
-        my @errors;
-        for my $sender ( keys %$reporters ) {
-            unless ( $reporters->{ $sender }->success ) {
-                push @errors, $reporters->{ $sender }->error;
-            }
-        }
-        $row->update_send_failed( join( '|', @errors ) );
-        $self->debug_print("send FAILED: " . join( '|', @errors ), $row->id);
-    }
 }
 
 sub end_debug_line {
@@ -338,32 +102,6 @@ sub end_summary_failures {
     if ($sending_errors) {
         print "The following reports had problems sending:\n$sending_errors";
     }
-}
-
-sub _send_report_sent_email {
-    my $self = shift;
-    my $row = shift;
-    my $h = shift;
-    my $cobrand = shift;
-
-    # Don't send 'report sent' text
-    return unless $row->user->email_verified;
-
-    my $contributed_as = $row->get_extra_metadata('contributed_as') || '';
-    return if $contributed_as eq 'body' || $contributed_as eq 'anonymous_user';
-
-    FixMyStreet::Email::send_cron(
-        $row->result_source->schema,
-        'confirm_report_sent.txt',
-        $h,
-        {
-            To => $row->user->email,
-        },
-        undef,
-        $self->nomail,
-        $cobrand,
-        $row->lang,
-    );
 }
 
 sub debug_print {

--- a/perllib/FixMyStreet/Script/Reports.pm
+++ b/perllib/FixMyStreet/Script/Reports.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use CronFns;
 use DateTime::Format::Pg;
+use Moo;
 
 use Utils;
 use Utils::OpenStreetMap;
@@ -16,13 +17,33 @@ use FixMyStreet::Email;
 use FixMyStreet::Map;
 use FixMyStreet::SendReport;
 
+has verbose => ( is => 'ro' );
+has nomail => ( is => 'ro' );
+has debug_mode => ( is => 'ro' );
+
+has senders => ( is => 'lazy', default => sub {
+    my $send_report = FixMyStreet::SendReport->new();
+    $send_report->get_senders;
+});
+
+has debug_unsent_count => ( is => 'rw', default => 0 );
+has unconfirmed_data => ( is => 'ro', default => sub { {} } );
+has test_data => ( is => 'ro', default => sub { {} } );
+
+# Static method, used by send-reports cron script and tests.
+# Creates a manager object from provided data and processes it.
 sub send(;$) {
     my ($site_override) = @_;
     my $rs = FixMyStreet::DB->resultset('Problem');
 
     # Set up site, language etc.
     my ($verbose, $nomail, $debug_mode) = CronFns::options();
-    my $test_data;
+
+    my $manager = __PACKAGE__->new(
+        verbose => $verbose,
+        nomail => $nomail,
+        debug_mode => $debug_mode,
+    );
 
     my $base_url = FixMyStreet->config('BASE_URL');
     my $site = $site_override || CronFns::site($base_url);
@@ -34,249 +55,295 @@ sub send(;$) {
         whensent => undef,
         bodies_str => { '!=', undef },
     } );
-    my (%notgot, %note);
 
-    my $send_report = FixMyStreet::SendReport->new();
-    my $senders = $send_report->get_senders;
-
-    my $debug_unsent_count = 0;
-    debug_print("starting to loop through unsent problem reports...") if $debug_mode;
+    $manager->debug_print("starting to loop through unsent problem reports...");
     while (my $row = $unsent->next) {
-
-        my $cobrand = $row->get_cobrand_logged;
-        FixMyStreet::DB->schema->cobrand($cobrand);
-
-        # Also get a cobrand that handles where a report is going
-        my $cobrand_handler = $cobrand->call_hook(get_body_handler_for_problem => $row) || $cobrand;
-
-        if ($debug_mode) {
-            $debug_unsent_count++;
-            print "\n";
-            debug_print("state=" . $row->state . ", bodies_str=" . $row->bodies_str . ($row->cobrand? ", cobrand=" . $row->cobrand : ""), $row->id);
-        }
-
-        # Cobranded and non-cobranded messages can share a database. In this case, the conf file
-        # should specify a vhost to send the reports for each cobrand, so that they don't get sent
-        # more than once if there are multiple vhosts running off the same database. The email_host
-        # call checks if this is the host that sends mail for this cobrand.
-        if (! $cobrand->email_host()) {
-            debug_print("skipping because this host does not send reports for cobrand " . $cobrand->moniker, $row->id) if $debug_mode;
-            next;
-        }
-
-        $cobrand->set_lang_and_domain($row->lang, 1);
-        FixMyStreet::Map::set_map_class($cobrand_handler->map_type);
-        if ( $row->is_from_abuser) {
-            $row->update( { state => 'hidden' } );
-            debug_print("hiding because its sender is flagged as an abuser", $row->id) if $debug_mode;
-            next;
-        } elsif ( $row->title =~ /app store test/i ) {
-            $row->update( { state => 'hidden' } );
-            debug_print("hiding because it is an app store test message", $row->id) if $debug_mode;
-            next;
-        }
-
-        # Template variables for the email
-        my $email_base_url = $cobrand_handler->base_url_for_report($row);
-        my %h = map { $_ => $row->$_ } qw/id title detail name category latitude longitude used_map/;
-        $h{report} = $row;
-        $h{cobrand} = $cobrand;
-        map { $h{$_} = $row->user->$_ || '' } qw/email phone/;
-        $h{confirmed} = DateTime::Format::Pg->format_datetime( $row->confirmed->truncate (to => 'second' ) )
-            if $row->confirmed;
-
-        $h{query} = $row->postcode;
-        $h{url} = $email_base_url . $row->url;
-        $h{admin_url} = $row->admin_url($cobrand_handler);
-        if ($row->photo) {
-            $h{has_photo} = _("This web page also contains a photo of the problem, provided by the user.") . "\n\n";
-            $h{image_url} = $email_base_url . $row->photos->[0]->{url_full};
-            my @all_images = map { $email_base_url . $_->{url_full} } @{ $row->photos };
-            $h{all_image_urls} = \@all_images;
-        } else {
-            $h{has_photo} = '';
-            $h{image_url} = '';
-        }
-        $h{fuzzy} = $row->used_map ? _('To view a map of the precise location of this issue')
-            : _('The user could not locate the problem on a map, but to see the area around the location they entered');
-        $h{closest_address} = '';
-
-        $h{osm_url} = Utils::OpenStreetMap::short_url($h{latitude}, $h{longitude});
-        if ( $row->used_map ) {
-            $h{closest_address} = $cobrand->find_closest($row);
-            $h{osm_url} .= '?m';
-        }
-
-        if ( $cobrand->allow_anonymous_reports($row->category) &&
-             $row->user->email eq $cobrand->anonymous_account->{'email'}
-         ) {
-            $h{anonymous_report} = 1;
-        }
-
-        $cobrand->call_hook(process_additional_metadata_for_email => $row, \%h);
-
-        my $bodies = FixMyStreet::DB->resultset('Body')->search(
-            { id => $row->bodies_str_ids },
-            { order_by => 'name' },
-        );
-
-        my $missing;
-        if ($row->bodies_missing) {
-            my @missing = FixMyStreet::DB->resultset("Body")->search(
-                { id => [ split /,/, $row->bodies_missing ] },
-                { order_by => 'name' }
-            )->get_column('name')->all;
-            $missing = join(' / ', @missing) if @missing;
-        }
-
-        my $send_confirmation_email = $cobrand_handler->report_sent_confirmation_email;
-
-        my @dear;
-        my %reporters = ();
-        my $skip = 0;
-        while (my $body = $bodies->next) {
-            my $sender_info = $cobrand->get_body_sender( $body, $row->category );
-            my $sender = "FixMyStreet::SendReport::" . $sender_info->{method};
-
-            if ( ! exists $senders->{ $sender } ) {
-                warn sprintf "No such sender [ $sender ] for body %s ( %d )", $body->name, $body->id;
-                next;
-            }
-            $reporters{ $sender } ||= $sender->new();
-
-            if ( $reporters{ $sender }->should_skip( $row, $debug_mode ) ) {
-                $skip = 1;
-                debug_print("skipped by sender " . $sender_info->{method} . " (might be due to previous failed attempts?)", $row->id) if $debug_mode;
-            } else {
-                debug_print("OK, adding recipient body " . $body->id . ":" . $body->name . ", " . $sender_info->{method}, $row->id) if $debug_mode;
-                push @dear, $body->name;
-                $reporters{ $sender }->add_body( $body, $sender_info->{config} );
-            }
-
-            # If we are in the UK include eastings and northings
-            if ( $cobrand->country eq 'GB' && !$h{easting} ) {
-                ( $h{easting}, $h{northing}, $h{coordsyst} ) = $row->local_coords;
-            }
-        }
-
-        unless ( keys %reporters ) {
-            die 'Report not going anywhere for ID ' . $row->id . '!';
-        }
-
-        next if $skip;
-
-        if ($h{category} eq _('Other')) {
-            $h{category_footer} = _('this type of local problem');
-        } else {
-            $h{category_footer} = "'" . $h{category} . "'";
-        }
-
-        $h{bodies_name} = join(_(' and '), @dear);
-        if ($h{category} eq _('Other')) {
-            $h{multiple} = @dear>1 ? "[ " . _("This email has been sent to both councils covering the location of the problem, as the user did not categorise it; please ignore it if you're not the correct council to deal with the issue, or let us know what category of problem this is so we can add it to our system.") . " ]\n\n"
-                : '';
-        } else {
-            $h{multiple} = @dear>1 ? "[ " . _("This email has been sent to several councils covering the location of the problem, as the category selected is provided for all of them; please ignore it if you're not the correct council to deal with the issue.") . " ]\n\n"
-                : '';
-        }
-        $h{missing} = '';
-        if ($missing) {
-            $h{missing} = '[ '
-              . sprintf(_('We realise this problem might be the responsibility of %s; however, we don\'t currently have any contact details for them. If you know of an appropriate contact address, please do get in touch.'), $missing)
-              . " ]\n\n";
-        }
-
-        if (FixMyStreet->staging_flag('send_reports', 0)) {
-            # on a staging server send emails to ourselves rather than the bodies
-            %reporters = map { $_ => $reporters{$_} } grep { /FixMyStreet::SendReport::Email/ } keys %reporters;
-            unless (%reporters) {
-                %reporters = ( 'FixMyStreet::SendReport::Email' => FixMyStreet::SendReport::Email->new() );
-            }
-        }
-
-        # Multiply results together, so one success counts as a success.
-        my $result = -1;
-
-        for my $sender ( keys %reporters ) {
-            debug_print("sending using " . $sender, $row->id) if $debug_mode;
-            $sender = $reporters{$sender};
-            my $res = $sender->send( $row, \%h );
-            $result *= $res;
-            $row->add_send_method($sender) if !$res;
-            if ( $sender->unconfirmed_counts) {
-                foreach my $e (keys %{ $sender->unconfirmed_counts } ) {
-                    foreach my $c (keys %{ $sender->unconfirmed_counts->{$e} }) {
-                        $notgot{$e}{$c} += $sender->unconfirmed_counts->{$e}{$c};
-                    }
-                }
-                %note = (%note, %{ $sender->unconfirmed_notes });
-            }
-            $test_data->{test_req_used} = $sender->open311_test_req_used
-                if FixMyStreet->test_mode && $sender->can('open311_test_req_used');
-        }
-
-        unless ($result) {
-            $row->update( {
-                whensent => \'current_timestamp',
-                lastupdate => \'current_timestamp',
-            } );
-            if ($send_confirmation_email && !$h{anonymous_report}) {
-                $h{sent_confirm_id_ref} = $row->$send_confirmation_email;
-                _send_report_sent_email( $row, \%h, $nomail, $cobrand );
-            }
-            debug_print("send successful: OK", $row->id) if $debug_mode;
-        } else {
-            my @errors;
-            for my $sender ( keys %reporters ) {
-                unless ( $reporters{ $sender }->success ) {
-                    push @errors, $reporters{ $sender }->error;
-                }
-            }
-            $row->update_send_failed( join( '|', @errors ) );
-            debug_print("send FAILED: " . join( '|', @errors ), $row->id) if $debug_mode;
-        }
+        $manager->process($row);
     }
-    if ($debug_mode) {
+
+    $manager->end_debug_line;
+    $manager->end_summary_unconfirmed;
+    $manager->end_summary_failures;
+
+    return $manager->test_data;
+}
+
+sub process {
+    my $self = shift;
+    my $row = shift;
+
+    my $cobrand = $row->get_cobrand_logged;
+    FixMyStreet::DB->schema->cobrand($cobrand);
+
+    # Also get a cobrand that handles where a report is going
+    my $cobrand_handler = $cobrand->call_hook(get_body_handler_for_problem => $row) || $cobrand;
+
+    if ($self->debug_mode) {
+        $self->debug_unsent_count++;
         print "\n";
-        if ($debug_unsent_count) {
-            debug_print("processed all unsent reports (total: $debug_unsent_count)");
+        $self->debug_print("state=" . $row->state . ", bodies_str=" . $row->bodies_str . ($row->cobrand? ", cobrand=" . $row->cobrand : ""), $row->id);
+    }
+
+    # Cobranded and non-cobranded messages can share a database. In this case, the conf file
+    # should specify a vhost to send the reports for each cobrand, so that they don't get sent
+    # more than once if there are multiple vhosts running off the same database. The email_host
+    # call checks if this is the host that sends mail for this cobrand.
+    if (! $cobrand->email_host()) {
+        $self->debug_print("skipping because this host does not send reports for cobrand " . $cobrand->moniker, $row->id);
+        return;
+    }
+
+    $cobrand->set_lang_and_domain($row->lang, 1);
+    FixMyStreet::Map::set_map_class($cobrand_handler->map_type);
+    if ( $row->is_from_abuser) {
+        $row->update( { state => 'hidden' } );
+        $self->debug_print("hiding because its sender is flagged as an abuser", $row->id);
+        return;
+    } elsif ( $row->title =~ /app store test/i ) {
+        $row->update( { state => 'hidden' } );
+        $self->debug_print("hiding because it is an app store test message", $row->id);
+        return;
+    }
+
+    my $h = $self->_create_vars($row, $cobrand_handler, $cobrand);
+    my $reporters = $self->_create_reporters($row, $cobrand, $h) or return;
+    my $result = $self->_send($reporters, $row, $h);
+    $self->_post_send($result, $row, $h, $cobrand_handler, $cobrand, $reporters);
+}
+
+sub _create_vars {
+    my ($self, $row, $cobrand_handler, $cobrand) = @_;
+
+    # Template variables for the email
+    my $email_base_url = $cobrand_handler->base_url_for_report($row);
+    my %h = map { $_ => $row->$_ } qw/id title detail name category latitude longitude used_map/;
+    $h{report} = $row;
+    $h{cobrand} = $cobrand;
+    map { $h{$_} = $row->user->$_ || '' } qw/email phone/;
+    $h{confirmed} = DateTime::Format::Pg->format_datetime( $row->confirmed->truncate (to => 'second' ) )
+        if $row->confirmed;
+
+    $h{query} = $row->postcode;
+    $h{url} = $email_base_url . $row->url;
+    $h{admin_url} = $row->admin_url($cobrand_handler);
+    if ($row->photo) {
+        $h{has_photo} = _("This web page also contains a photo of the problem, provided by the user.") . "\n\n";
+        $h{image_url} = $email_base_url . $row->photos->[0]->{url_full};
+        my @all_images = map { $email_base_url . $_->{url_full} } @{ $row->photos };
+        $h{all_image_urls} = \@all_images;
+    } else {
+        $h{has_photo} = '';
+        $h{image_url} = '';
+    }
+    $h{fuzzy} = $row->used_map ? _('To view a map of the precise location of this issue')
+        : _('The user could not locate the problem on a map, but to see the area around the location they entered');
+    $h{closest_address} = '';
+
+    $h{osm_url} = Utils::OpenStreetMap::short_url($h{latitude}, $h{longitude});
+    if ( $row->used_map ) {
+        $h{closest_address} = $cobrand->find_closest($row);
+        $h{osm_url} .= '?m';
+    }
+
+    if ( $cobrand->allow_anonymous_reports($row->category) &&
+         $row->user->email eq $cobrand->anonymous_account->{'email'}
+     ) {
+        $h{anonymous_report} = 1;
+    }
+
+    if ($h{category} eq _('Other')) {
+        $h{category_footer} = _('this type of local problem');
+    } else {
+        $h{category_footer} = "'" . $h{category} . "'";
+    }
+
+    my $missing;
+    if ($row->bodies_missing) {
+        my @missing = FixMyStreet::DB->resultset("Body")->search(
+            { id => [ split /,/, $row->bodies_missing ] },
+            { order_by => 'name' }
+        )->get_column('name')->all;
+        $missing = join(' / ', @missing) if @missing;
+    }
+    $h{missing} = '';
+    if ($missing) {
+        $h{missing} = '[ '
+          . sprintf(_('We realise this problem might be the responsibility of %s; however, we don\'t currently have any contact details for them. If you know of an appropriate contact address, please do get in touch.'), $missing)
+          . " ]\n\n";
+    }
+
+    # If we are in the UK include eastings and northings
+    if ( $cobrand->country eq 'GB' && !$h{easting} ) {
+        ( $h{easting}, $h{northing}, $h{coordsyst} ) = $row->local_coords;
+    }
+
+    $cobrand->call_hook(process_additional_metadata_for_email => $row, \%h);
+
+    return \%h;
+}
+
+sub _create_reporters {
+    my ($self, $row, $cobrand, $h) = @_;
+
+    my $bodies = FixMyStreet::DB->resultset('Body')->search(
+        { id => $row->bodies_str_ids },
+        { order_by => 'name' },
+    );
+
+    my @dear;
+    my %reporters = ();
+    my $skip = 0;
+    while (my $body = $bodies->next) {
+        my $sender_info = $cobrand->get_body_sender( $body, $row->category );
+        my $sender = "FixMyStreet::SendReport::" . $sender_info->{method};
+
+        if ( ! exists $self->senders->{ $sender } ) {
+            warn sprintf "No such sender [ $sender ] for body %s ( %d )", $body->name, $body->id;
+            next;
+        }
+        $reporters{ $sender } ||= $sender->new();
+
+        if ( $reporters{ $sender }->should_skip( $row, $self->debug_mode ) ) {
+            $skip = 1;
+            $self->debug_print("skipped by sender " . $sender_info->{method} . " (might be due to previous failed attempts?)", $row->id);
         } else {
-            debug_print("no unsent reports were found (must have whensent=null and suitable bodies_str & state) -- nothing to send");
+            $self->debug_print("OK, adding recipient body " . $body->id . ":" . $body->name . ", " . $sender_info->{method}, $row->id);
+            push @dear, $body->name;
+            $reporters{ $sender }->add_body( $body, $sender_info->{config} );
         }
     }
 
-    if ($verbose || $debug_mode) {
-        print "Council email addresses that need checking:\n" if keys %notgot;
-        foreach my $e (keys %notgot) {
-            foreach my $c (keys %{$notgot{$e}}) {
-                print "    " . $notgot{$e}{$c} . " problem, to $e category $c (" . $note{$e}{$c}. ")\n";
+    unless ( keys %reporters ) {
+        die 'Report not going anywhere for ID ' . $row->id . '!';
+    }
+
+    return if $skip;
+
+    $h->{bodies_name} = join(_(' and '), @dear);
+    if ($h->{category} eq _('Other')) {
+        $h->{multiple} = @dear>1 ? "[ " . _("This email has been sent to both councils covering the location of the problem, as the user did not categorise it; please ignore it if you're not the correct council to deal with the issue, or let us know what category of problem this is so we can add it to our system.") . " ]\n\n"
+            : '';
+    } else {
+        $h->{multiple} = @dear>1 ? "[ " . _("This email has been sent to several councils covering the location of the problem, as the category selected is provided for all of them; please ignore it if you're not the correct council to deal with the issue.") . " ]\n\n"
+            : '';
+    }
+
+    if (FixMyStreet->staging_flag('send_reports', 0)) {
+        # on a staging server send emails to ourselves rather than the bodies
+        %reporters = map { $_ => $reporters{$_} } grep { /FixMyStreet::SendReport::Email/ } keys %reporters;
+        unless (%reporters) {
+            %reporters = ( 'FixMyStreet::SendReport::Email' => FixMyStreet::SendReport::Email->new() );
+        }
+    }
+
+    return \%reporters;
+}
+
+sub _send {
+    my ($self, $reporters, $row, $h) = @_;
+
+    # Multiply results together, so one success counts as a success.
+    my $result = -1;
+
+    for my $sender ( keys %$reporters ) {
+        $self->debug_print("sending using " . $sender, $row->id);
+        $sender = $reporters->{$sender};
+        my $res = $sender->send( $row, $h );
+        $result *= $res;
+        $row->add_send_method($sender) if !$res;
+        if ( $sender->unconfirmed_data) {
+            foreach my $e (keys %{ $sender->unconfirmed_data } ) {
+                foreach my $c (keys %{ $sender->unconfirmed_data->{$e} }) {
+                    $self->unconfirmed_data->{$e}{$c}{count} += $sender->unconfirmed_data->{$e}{$c}{count};
+                    $self->unconfirmed_data->{$e}{$c}{note} = $sender->unconfirmed_data->{$e}{$c}{note};
+                }
             }
         }
-        my $sending_errors = '';
-        my $unsent = $rs->search( {
-            state => [ FixMyStreet::DB::Result::Problem::open_states() ],
-            whensent => undef,
-            bodies_str => { '!=', undef },
-            send_fail_count => { '>', 0 }
-        } );
-        while (my $row = $unsent->next) {
-            my $base_url = FixMyStreet->config('BASE_URL');
-            $sending_errors .= "\n" . '=' x 80 . "\n\n" . "* " . $base_url . "/report/" . $row->id . ", failed "
-                . $row->send_fail_count . " times, last at " . $row->send_fail_timestamp
-                . ", reason " . $row->send_fail_reason . "\n";
-        }
-        if ($sending_errors) {
-            print "The following reports had problems sending:\n$sending_errors";
-        }
+        $self->test_data->{test_req_used} = $sender->open311_test_req_used
+            if FixMyStreet->test_mode && $sender->can('open311_test_req_used');
     }
 
-    return $test_data;
+    return $result;
+}
+
+sub _post_send {
+    my ($self, $result, $row, $h, $cobrand_handler, $cobrand, $reporters) = @_;
+
+    my $send_confirmation_email = $cobrand_handler->report_sent_confirmation_email;
+    unless ($result) {
+        $row->update( {
+            whensent => \'current_timestamp',
+            lastupdate => \'current_timestamp',
+        } );
+        if ($send_confirmation_email && !$h->{anonymous_report}) {
+            $h->{sent_confirm_id_ref} = $row->$send_confirmation_email;
+            $self->_send_report_sent_email( $row, $h, $cobrand );
+        }
+        $self->debug_print("send successful: OK", $row->id);
+    } else {
+        my @errors;
+        for my $sender ( keys %$reporters ) {
+            unless ( $reporters->{ $sender }->success ) {
+                push @errors, $reporters->{ $sender }->error;
+            }
+        }
+        $row->update_send_failed( join( '|', @errors ) );
+        $self->debug_print("send FAILED: " . join( '|', @errors ), $row->id);
+    }
+}
+
+sub end_debug_line {
+    my $self = shift;
+    return unless $self->debug_mode;
+
+    print "\n";
+    if ($self->debug_unsent_count) {
+        $self->debug_print("processed all unsent reports (total: " . $self->debug_unsent_count . ")");
+    } else {
+        $self->debug_print("no unsent reports were found (must have whensent=null and suitable bodies_str & state) -- nothing to send");
+    }
+}
+
+sub end_summary_unconfirmed {
+    my $self = shift;
+    return unless $self->verbose || $self->debug_mode;
+
+    my %unconfirmed_data = %{$self->unconfirmed_data};
+    print "Council email addresses that need checking:\n" if keys %unconfirmed_data;
+    foreach my $e (keys %unconfirmed_data) {
+        foreach my $c (keys %{$unconfirmed_data{$e}}) {
+            my $data = $unconfirmed_data{$e}{$c};
+            print "    " . $data->{count} . " problem, to $e category $c (" . $data->{note} . ")\n";
+        }
+    }
+}
+
+sub end_summary_failures {
+    my $self = shift;
+    return unless $self->verbose || $self->debug_mode;
+
+    my $sending_errors = '';
+    my $unsent = FixMyStreet::DB->resultset('Problem')->search( {
+        state => [ FixMyStreet::DB::Result::Problem::open_states() ],
+        whensent => undef,
+        bodies_str => { '!=', undef },
+        send_fail_count => { '>', 0 }
+    } );
+    while (my $row = $unsent->next) {
+        my $base_url = FixMyStreet->config('BASE_URL');
+        $sending_errors .= "\n" . '=' x 80 . "\n\n" . "* " . $base_url . "/report/" . $row->id . ", failed "
+            . $row->send_fail_count . " times, last at " . $row->send_fail_timestamp
+            . ", reason " . $row->send_fail_reason . "\n";
+    }
+    if ($sending_errors) {
+        print "The following reports had problems sending:\n$sending_errors";
+    }
 }
 
 sub _send_report_sent_email {
+    my $self = shift;
     my $row = shift;
     my $h = shift;
-    my $nomail = shift;
     my $cobrand = shift;
 
     # Don't send 'report sent' text
@@ -293,13 +360,16 @@ sub _send_report_sent_email {
             To => $row->user->email,
         },
         undef,
-        $nomail,
+        $self->nomail,
         $cobrand,
         $row->lang,
     );
 }
 
 sub debug_print {
+    my $self = shift;
+    return unless $self->debug_mode;
+
     my $msg = shift;
     my $id = shift || '';
     $id = "report $id: " if $id;

--- a/perllib/FixMyStreet/SendReport.pm
+++ b/perllib/FixMyStreet/SendReport.pm
@@ -15,8 +15,7 @@ has 'to' => ( is => 'rw', isa => ArrayRef, default => sub { [] } );
 has 'bcc' => ( is => 'rw', isa => ArrayRef, default => sub { [] } );
 has 'success' => ( is => 'rw', isa => Bool, default => 0 );
 has 'error' => ( is => 'rw', isa => Str, default => '' );
-has 'unconfirmed_counts' => ( 'is' => 'rw', isa => HashRef, default => sub { {} } );
-has 'unconfirmed_notes' => ( 'is' => 'rw', isa => HashRef, default => sub { {} } );
+has 'unconfirmed_data' => ( 'is' => 'rw', isa => HashRef, default => sub { {} } );
 
 
 sub should_skip {

--- a/perllib/FixMyStreet/SendReport/Email.pm
+++ b/perllib/FixMyStreet/SendReport/Email.pm
@@ -24,8 +24,8 @@ sub build_recipient_list {
             $note = 'Body ' . $row->bodies_str . ' deleted'
                 unless $note;
             $body_email = 'N/A' unless $body_email;
-            $self->unconfirmed_counts->{$body_email}{$row->category}++;
-            $self->unconfirmed_notes->{$body_email}{$row->category} = $note;
+            $self->unconfirmed_data->{$body_email}{$row->category}{count}++;
+            $self->unconfirmed_data->{$body_email}{$row->category}{note} = $note;
         }
 
         my @emails;

--- a/t/app/sendreport/email.t
+++ b/t/app/sendreport/email.t
@@ -63,8 +63,9 @@ foreach my $test ( {
         is $e->build_recipient_list( $row, {} ), $test->{count}, 'correct recipient list count';
 
         if ( $test->{unconfirmed} ) {
-            is_deeply $e->unconfirmed_counts, { 'council@example.com' => { 'category' => 1 } }, 'correct unconfirmed_counts count';
-            is_deeply $e->unconfirmed_notes, { 'council@example.com' => { 'category' => $test->{expected_note} } }, 'correct note used';
+            is_deeply $e->unconfirmed_data, { 'council@example.com' => {
+                'category' => { 'count' => 1, 'note' => $test->{expected_note} }
+            } }, 'correct unconfirmed_data';
         }
     };
 }

--- a/t/cobrand/bexley.t
+++ b/t/cobrand/bexley.t
@@ -156,7 +156,7 @@ FixMyStreet::override_config {
 
         $mech->submit_form_ok({ with_fields => { category => 'Gulley covers' } });
         $test_data = FixMyStreet::Script::Reports::send();
-        is $test_data, undef, 'Report not resent';
+        is_deeply $test_data, {}, 'Report not resent';
 
         $mech->submit_form_ok({ with_fields => { category => 'Lamp post' } });
         $test_data = FixMyStreet::Script::Reports::send();


### PR DESCRIPTION
This refactors send reports to not be one monolithic function, and moves the per-row processing to its own package for future use elsewhere. It also takes the 'verbose' end summary of failures out to its own script.
<!-- [skip changelog] -->