### PR TITLE
[fixmystreet.com] Survey banner

### DIFF
--- a/templates/web/fixmystreet.com/before_wrapper.html
+++ b/templates/web/fixmystreet.com/before_wrapper.html
@@ -1,0 +1,26 @@
+<div class="survey-banner">
+    <p>
+        <span class="survey-banner__text">Share your views and help us improve FixMyStreet for&nbsp;everyone</span>
+        <a class="survey-banner__cta" href="https://www.surveygizmo.com/s3/5506345/46e9932d0fbf" target="_blank">Take our short survey</a>
+    </p>
+    <button class="survey-banner__close">Close</button>
+</div>
+<script nonce="[% csp_nonce %]">
+(function(){
+    var live_site = location.hostname === 'www.fixmystreet.com';
+    var hasnt_opted_out = document.cookie.indexOf('__has_closed_march_2020_survey') === -1;
+    var randomly_chosen = Math.random() > 0.6;
+    if ( live_site && hasnt_opted_out && randomly_chosen ) {
+        document.body.className = ((document.body.className) ? document.body.className + ' has-survey-banner' : 'has-survey-banner');
+        document.querySelector('.survey-banner').style.display = 'block';
+    }
+    function hide_survey(){
+        document.querySelector('.survey-banner').style.display = 'none';
+        document.body.className = document.body.className.replace('has-survey-banner', '');
+        var t = new Date(); t.setFullYear(t.getFullYear() + 1);
+        document.cookie = '__has_closed_march_2020_survey=1; path=/; expires=' + t.toUTCString();
+    }
+    document.querySelector('.survey-banner__close').onclick = hide_survey;
+    document.querySelector('.survey-banner__cta').onclick = hide_survey;
+})();
+</script>

--- a/web/cobrands/fixmystreet.com/_survey-banner.scss
+++ b/web/cobrands/fixmystreet.com/_survey-banner.scss
@@ -1,0 +1,124 @@
+.survey-banner {
+    display: none; // will get shown by javascript
+    background: #A94CA6;
+    color: #fff;
+    position: relative;
+    z-index: 1; // stack in front of the page top border
+    text-align: center;
+    padding: 0 2.5em; // make space for the close button
+
+    .map-reporting & {
+        display: none !important;
+    }
+
+    p {
+        margin: 0;
+        padding: 12px 0; // 12px vertical padding, plus 4px margin on childen = 16px = 1em
+        line-height: 1.3;
+    }
+}
+
+.survey-banner__text,
+.survey-banner__cta {
+    display: inline-block;
+    margin: 4px 8px;
+}
+
+.survey-banner__text {
+    font-size: 0.9em;
+}
+
+.survey-banner__cta {
+    font-size: 0.8em;
+    font-weight: bold;
+    background: #fff;
+    color: #000;
+    padding: 0.4em 1em;
+    border-radius: 3em;
+    text-decoration: none;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.4);
+
+    &:visited {
+        color: #000;
+    }
+
+    &:focus {
+        outline: none;
+        box-shadow: 0 0 0 4px $primary;
+    }
+
+    &:hover,
+    &:active {
+        background: mix(#A94CA6, #fff, 10%);
+        color: #000;
+        text-decoration: none;
+    }
+}
+
+.survey-banner__close {
+    display: block;
+    position: absolute;
+    top: 0.5em;
+    right: 0.5em;
+
+    width: 2em;
+    height: 0;
+    padding-top: 2em;
+    overflow: hidden;
+
+    color: #fff;
+    background: transparent;
+    border: none;
+
+    &:before {
+        display: block;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        content: "\00d7";
+        font-size: 2em;
+    }
+
+    @media screen and (min-width: 48em) {
+        top: 50%;
+        right: 0.75em;
+        transform: translate(0, -50%);
+    }
+}
+
+
+@media screen and (min-width: 48em) {
+    .mappage.has-survey-banner {
+        $mappage-header-height: 4em !default;
+        $banner-height: 3.5em;
+
+        .survey-banner {
+            p {
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                height: $banner-height;
+                padding-top: 0;
+                padding-bottom: 0;
+            }
+        }
+
+        #site-header {
+            top: 0 + $banner-height;
+        }
+
+        #map_box,
+        #map_sidebar {
+            top: $mappage-header-height + $banner-height;
+        }
+
+        .nav-wrapper {
+            @if ($header-top-border) {
+                top: $header-top-border-width + $banner-height;
+            } @else {
+                top: 0 + $banner-height;
+            }
+        }
+    }
+}

--- a/web/cobrands/fixmystreet.com/base.scss
+++ b/web/cobrands/fixmystreet.com/base.scss
@@ -176,6 +176,7 @@ svg|g.site-logo__svg {
   border-bottom: none;
 }
 
+@import "survey-banner";
 
 $mysoc-footer-background-color: #222;
 $mysoc-footer-text-color: #acacac;


### PR DESCRIPTION
Big purple survey banner, which is hidden by default, and shown on 40% of pageloads, by JavaScript.

CTA button opens the surveygizmo survey in a new window/tab.

Banner can be hidden using the cross in the top right corner.

If the user clicks either the main CTA button, or the close button, a cookie is set that prevents the banner ever showing again.

Works on both the static pages, and the map pages. Here’s how it looks:

![Screenshot_2020-03-20 FixMyStreet](https://user-images.githubusercontent.com/739624/77173798-fcbc9c00-6ab7-11ea-87a7-309704abf0c6.png)

![Screenshot_2020-03-20 Pothole in cycle lane - Viewing a problem](https://user-images.githubusercontent.com/739624/77173807-ffb78c80-6ab7-11ea-8c59-d020e6f854cc.png)

![Screen Shot 2020-03-20 at 14 33 15](https://user-images.githubusercontent.com/739624/77173814-01815000-6ab8-11ea-892b-39b153633047.png)

Fixes #2928.

[skip changelog]