### PR TITLE
Fixes the To header when sending emails about inactive accounts.

### DIFF
--- a/perllib/FixMyStreet/Script/Inactive.pm
+++ b/perllib/FixMyStreet/Script/Inactive.pm
@@ -191,7 +191,7 @@ sub email_inactive_users {
                 user => $user,
                 url => $self->base_cobrand->base_url_with_lang . '/my',
             },
-            { To => [ $user->email, $user->name ] },
+            { To => [ [ $user->email, $user->name ] ] },
             undef, 0, $self->base_cobrand,
         );
 


### PR DESCRIPTION
Without the brackets the user's name was interpreted as a separate
recipient.

Fixes #2935
