### PR TITLE
[Buckinghamshire] Handle ex-district categories correctly

### DIFF
--- a/.cypress/cypress/integration/buckinghamshire.js
+++ b/.cypress/cypress/integration/buckinghamshire.js
@@ -1,4 +1,4 @@
-describe('flytipping', function() {
+describe('buckinghamshire cobrand', function() {
 
   beforeEach(function() {
     cy.server();
@@ -10,37 +10,6 @@ describe('flytipping', function() {
     cy.contains('Buckinghamshire');
     cy.get('[name=pc]').type('SL9 0NX');
     cy.get('[name=pc]').parents('form').submit();
-  });
-
-  it('handles flytipping on a road correctly', function() {
-    cy.get('.olMapViewport #fms_pan_zoom_zoomin').click();
-    cy.wait('@roads-layer');
-    cy.get('#map_box').click(290, 307);
-    cy.wait('@report-ajax');
-    cy.get('select:eq(4)').select('Flytipping');
-    cy.get('#form_road-placement').select('off-road');
-    cy.contains('sent to Chiltern District Council and also');
-    cy.get('#form_road-placement').select('road');
-    cy.contains('sent to Buckinghamshire Council and also');
-  });
-
-  it('handles flytipping off a road correctly', function() {
-    cy.get('#map_box').click(200, 307);
-    cy.wait('@report-ajax');
-    cy.get('select:eq(4)').select('Flytipping');
-    cy.contains('sent to Chiltern District Council and also');
-
-    cy.get('[name=title]').type('Title');
-    cy.get('[name=detail]').type('Detail');
-    cy.get('.js-new-report-user-show').click();
-    cy.get('.js-new-report-show-sign-in').should('be.visible').click();
-    cy.get('#form_username_sign_in').type('user@example.org');
-    cy.get('[name=password_sign_in]').type('password');
-    cy.get('[name=password_sign_in]').parents('form').submit();
-    cy.get('#map_sidebar').should('contain', 'check and confirm your details');
-    cy.wait('@report-ajax');
-    cy.get('#map_sidebar').parents('form').submit();
-    cy.get('body').should('contain', 'Thank you for your report');
   });
 
   it('sets the site_code correctly', function() {
@@ -57,7 +26,6 @@ describe('flytipping', function() {
     cy.wait('@report-ajax');
     cy.get('select:eq(4)').select('Flytipping');
     cy.wait('@around-ajax');
-    cy.get('.js-hide-duplicate-suggestions:first').should('be.visible').click();
 
     cy.get('[name=title]').type('Title');
     cy.get('[name=detail]').type('Detail');

--- a/bin/fixmystreet.com/buckinghamshire-flytipping
+++ b/bin/fixmystreet.com/buckinghamshire-flytipping
@@ -57,12 +57,22 @@ sub find_problems {
         $time_param = { '<', \$to };
     }
 
-    # Fetch all Flytipping problems sent only to districts, between $from and $to
-    my $q = FixMyStreet::DB->resultset("Problem")->search(
-        \[ "? @> regexp_split_to_array(bodies_str, ',')", [ {} => \@district_ids ] ]
-    )->search({
+    # Fetch all Flytipping problems made off-road (i.e. those that previously
+    # would been sent only to districts) any any older ones which actually were
+    # sent to districts, between $from and $to
+    my $q = FixMyStreet::DB->resultset("Problem")->search([
+        # Reports sent to district, made before the unitary switchover
+        -and => [
+            \[ "? @> regexp_split_to_array(bodies_str, ',')", [ {} => \@district_ids ] ],
+            category => 'Flytipping'
+        ],
+        # Reports sent to Bucks Council after unitary switchover
+        {
+            bodies_str => $body->id,
+            category => 'Flytipping (off-road)'
+        }
+    ])->search({
         state => [ FixMyStreet::DB::Result::Problem->open_states() ],
-        category => 'Flytipping',
         confirmed => $time_param,
     });
 

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -4,6 +4,9 @@ use parent 'FixMyStreet::Cobrand::Whitelabel';
 use strict;
 use warnings;
 
+use Moo;
+with 'FixMyStreet::Roles::BoroughEmails';
+
 use POSIX qw(strcoll);
 
 use FixMyStreet::MapIt;
@@ -389,63 +392,6 @@ sub report_new_munge_before_insert {
     @$extra = grep { $_->{name} ne 'safety_critical' } @$extra;
     push @$extra, { name => 'safety_critical', value => $safety_critical ? 'yes' : 'no' };
     $report->set_extra_fields(@$extra);
-}
-
-=head2 munge_sendreport_params
-
-TfL want reports made in certain categories sent to different email addresses
-depending on what London Borough they were made in. To achieve this we have
-some config in COBRAND_FEATURES that specifies what address to direct reports
-to based on the MapIt area IDs it's in.
-
-Contacts that use this technique have a short code in their email field,
-which is looked up in the `borough_email_addresses` hash.
-
-For example, if you wanted Pothole reports in Bromley and Barnet to be sent to
-one email address, and Pothole reports in Hounslow to be sent to another,
-create a contact with category = "Potholes" and email = "BOROUGHPOTHOLES" and
-use the following config in general.yml:
-
-COBRAND_FEATURES:
-  borough_email_addresses:
-    tfl:
-      BOROUGHPOTHOLES:
-        - email: bromleybarnetpotholes@example.org
-          areas:
-            - 2482 # Bromley
-            - 2489 # Barnet
-        - email: hounslowpotholes@example.org
-          areas:
-            - 2483 # Hounslow
-
-=cut
-
-sub munge_sendreport_params {
-    my ($self, $row, $h, $params) = @_;
-
-    my $addresses = $self->feature('borough_email_addresses');
-    return unless $addresses;
-
-    my @report_areas = grep { $_ } split ',', $row->areas;
-
-    my $to = $params->{To};
-    my @munged_to = ();
-    for my $recip ( @$to ) {
-        my ($email, $name) = @$recip;
-        if (my $teams = $addresses->{$email}) {
-            for my $team (@$teams) {
-                my %team_area_ids = map { $_ => 1 } @{ $team->{areas} };
-                if ( grep { $team_area_ids{$_} } @report_areas ) {
-                    $recip = [
-                        $team->{email},
-                        $name
-                    ];
-                }
-            }
-        }
-        push @munged_to, $recip;
-    }
-    $params->{To} = \@munged_to;
 }
 
 sub report_new_is_on_tlrn {

--- a/perllib/FixMyStreet/Roles/BoroughEmails.pm
+++ b/perllib/FixMyStreet/Roles/BoroughEmails.pm
@@ -1,0 +1,68 @@
+package FixMyStreet::Roles::BoroughEmails;
+use Moo::Role;
+
+=head1 NAME
+
+FixMyStreet::Roles::BoroughEmails - role for directing reports according to the
+borough_email_addresses COBRAND_FEATURE
+
+=cut
+
+=head2 munge_sendreport_params
+
+TfL want reports made in certain categories sent to different email addresses
+depending on what London Borough they were made in. To achieve this we have
+some config in COBRAND_FEATURES that specifies what address to direct reports
+to based on the MapIt area IDs it's in.
+
+Contacts that use this technique have a short code in their email field,
+which is looked up in the `borough_email_addresses` hash.
+
+For example, if you wanted Pothole reports in Bromley and Barnet to be sent to
+one email address, and Pothole reports in Hounslow to be sent to another,
+create a contact with category = "Potholes" and email = "BOROUGHPOTHOLES" and
+use the following config in general.yml:
+
+COBRAND_FEATURES:
+  borough_email_addresses:
+    tfl:
+      BOROUGHPOTHOLES:
+        - email: bromleybarnetpotholes@example.org
+          areas:
+            - 2482 # Bromley
+            - 2489 # Barnet
+        - email: hounslowpotholes@example.org
+          areas:
+            - 2483 # Hounslow
+
+=cut
+
+sub munge_sendreport_params {
+    my ($self, $row, $h, $params) = @_;
+
+    my $addresses = $self->feature('borough_email_addresses');
+    return unless $addresses;
+
+    my @report_areas = grep { $_ } split ',', $row->areas;
+
+    my $to = $params->{To};
+    my @munged_to = ();
+    for my $recip ( @$to ) {
+        my ($email, $name) = @$recip;
+        if (my $teams = $addresses->{$email}) {
+            for my $team (@$teams) {
+                my %team_area_ids = map { $_ => 1 } @{ $team->{areas} };
+                if ( grep { $team_area_ids{$_} } @report_areas ) {
+                    $recip = [
+                        $team->{email},
+                        $name
+                    ];
+                }
+            }
+        }
+        push @munged_to, $recip;
+    }
+    $params->{To} = \@munged_to;
+}
+
+1;

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -4,18 +4,34 @@ use FixMyStreet::Script::Reports;
 
 my $mech = FixMyStreet::TestMech->new;
 
-my $body = $mech->create_body_ok(2217, 'Buckinghamshire', {
-    send_method => 'Open311', api_key => 'key', endpoint => 'endpoint', jurisdiction => 'fms' });
-my $counciluser = $mech->create_user_ok('counciluser@example.com', name => 'Council User', from_body => $body);
+# disable info logs for this test run
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
 
-$mech->create_contact_ok(body_id => $body->id, category => 'Flytipping', email => "FLY");
+my $body = $mech->create_body_ok(2217, 'Buckinghamshire', {
+    send_method => 'Open311', api_key => 'key', endpoint => 'endpoint', jurisdiction => 'fms', can_be_devolved => 1 });
+my $counciluser = $mech->create_user_ok('counciluser@example.com', name => 'Council User', from_body => $body);
+my $publicuser = $mech->create_user_ok('fmsuser@example.org', name => 'Simon Neil');
+
+my $contact = $mech->create_contact_ok(body_id => $body->id, category => 'Flytipping', email => "FLY");
+$contact->set_extra_fields({
+    code => 'road-placement',
+    datatype => 'singlevaluelist',
+    description => 'Is the fly-tip located on',
+    order => 100,
+    required => 'true',
+    variable => 'true',
+    values => [
+        { key => 'road', name => 'The road' },
+        { key => 'off-road', name => 'Off the road/on a verge' },
+    ],
+});
+$contact->update;
 $mech->create_contact_ok(body_id => $body->id, category => 'Potholes', email => "POT");
 $mech->create_contact_ok(body_id => $body->id, category => 'Blocked drain', email => "DRA");
-
-my $district = $mech->create_body_ok(2257, 'Chiltern');
-$mech->create_contact_ok(body_id => $district->id, category => 'Car Parks', email => "car\@chiltern");
-$mech->create_contact_ok(body_id => $district->id, category => 'Flytipping', email => "flytipping\@chiltern");
-$mech->create_contact_ok(body_id => $district->id, category => 'Graffiti', email => "graffiti\@chiltern");
+$mech->create_contact_ok(body_id => $body->id, category => 'Car Parks', email => "car\@chiltern", send_method => 'Email');
+$mech->create_contact_ok(body_id => $body->id, category => 'Graffiti', email => "graffiti\@chiltern", send_method => 'Email');
+$mech->create_contact_ok(body_id => $body->id, category => 'Flytipping (off-road)', email => "districts_flytipping", send_method => 'Email');
 
 my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Buckinghamshire');
 $cobrand->mock('lookup_site_code', sub {
@@ -33,6 +49,13 @@ FixMyStreet::override_config {
                 flytipping => 'flytipping@example.org',
                 flood => 'floods@example.org',
             }
+        },
+        borough_email_addresses => {
+            buckinghamshire => {
+                districts_flytipping => [
+                    { email => "flytipping\@chiltern", areas => [ 2257 ] },
+                ]
+            }
         }
     }
 }, sub {
@@ -45,18 +68,20 @@ subtest 'cobrand displays council name' => sub {
 
 subtest 'cobrand displays correct categories' => sub {
     my $json = $mech->get_ok_json('/report/new/ajax?latitude=51.615559&longitude=-0.556903');
-    is @{$json->{bodies}}, 2, 'Both Chiltern and Bucks returned';
+    is @{$json->{bodies}}, 1, 'Bucks returned';
     like $json->{category}, qr/Car Parks/, 'Car Parks displayed';
     like $json->{category}, qr/Flytipping/, 'Flytipping displayed';
     like $json->{category}, qr/Blocked drain/, 'Blocked drain displayed';
-    unlike $json->{category}, qr/Graffiti/, 'Graffiti not displayed';
+    like $json->{category}, qr/Graffiti/, 'Graffiti displayed';
+    unlike $json->{category}, qr/Flytipping \(off-road\)/, 'Flytipping (off-road) not displayed';
     $json = $mech->get_ok_json('/report/new/category_extras?latitude=51.615559&longitude=-0.556903');
-    is @{$json->{bodies}}, 2, 'Still both Chiltern and Bucks returned';
+    is @{$json->{bodies}}, 1, 'Still Bucks returned';
 };
 
 my ($report) = $mech->create_problems_for_body(1, $body->id, 'On Road', {
     category => 'Flytipping', cobrand => 'fixmystreet',
     latitude => 51.812244, longitude => -0.827363,
+    dt => DateTime->now()->subtract(minutes => 10),
 });
 
 subtest 'flytipping on road sent to extra email' => sub {
@@ -75,6 +100,7 @@ subtest 'flytipping on road sent to extra email' => sub {
         contributed_as => 'another_user',
         contributed_by => $counciluser->id,
     },
+    dt => DateTime->now()->subtract(minutes => 9),
 });
 
 subtest 'pothole on road not sent to extra email, only confirm sent' => sub {
@@ -86,22 +112,38 @@ subtest 'pothole on road not sent to extra email, only confirm sent' => sub {
     is $report->external_id, 248, 'Report has right external ID';
 };
 
-($report) = $mech->create_problems_for_body(1, $district->id, 'Off Road', {
-    category => 'Flytipping', cobrand => 'buckinghamshire',
-    latitude => 51.813173, longitude => -0.826741,
-});
-subtest 'flytipping off road sent to extra email' => sub {
+
+# report made in Flytipping category off road should get moved to other category
+subtest 'Flytipping not on a road gets recategorised' => sub {
+    $mech->log_in_ok($publicuser->email);
+    $mech->get_ok('/report/new?latitude=51.615559&longitude=-0.556903&category=Flytipping');
+    $mech->submit_form_ok({
+        with_fields => {
+            title => "Test Report",
+            detail => 'Test report details.',
+            category => 'Flytipping',
+            'road-placement' => 'off-road',
+        }
+    }, "submit details");
+    $mech->content_contains('Your issue is on its way to the council.');
+    my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+    ok $report, "Found the report";
+    is $report->category, "Flytipping (off-road)", 'Report was recategorised correctly';
+
+    $mech->log_out_ok;
+};
+
+subtest 'Ex-district reports are sent to correct emails' => sub {
     FixMyStreet::Script::Reports::send();
+    $mech->email_count_is(2); # one for council, one confirmation for user
     my @email = $mech->get_email;
-    is $email[0]->header('To'), 'Chiltern <flytipping@chiltern>';
-    unlike $mech->get_text_body_from_email($email[1]), qr/Please note that Buckinghamshire Council is not responsible/;
-    $report->discard_changes;
-    is $report->external_id, undef, 'Report has right external ID';
+    is $email[0]->header('To'), 'Buckinghamshire <flytipping@chiltern>';
 };
 
 my ($report2) = $mech->create_problems_for_body(1, $body->id, 'Drainage problem', {
     category => 'Blocked drain', cobrand => 'fixmystreet',
     latitude => 51.812244, longitude => -0.827363,
+    dt => DateTime->now()->subtract(minutes => 8),
 });
 
 subtest 'blocked drain sent to extra email' => sub {
@@ -113,29 +155,6 @@ subtest 'blocked drain sent to extra email' => sub {
 };
 
 $cobrand = FixMyStreet::Cobrand::Buckinghamshire->new();
-
-subtest 'Flytipping extra question used if necessary' => sub {
-    my $errors = { 'xroad-placement' => 'This field is required' };
-
-    $report->update({ bodies_str => $body->id });
-    $cobrand->flytipping_body_fix($report, 'road', $errors);
-    is $errors->{'xroad-placement'}, 'This field is required', 'Error stays if sent to county';
-
-    $report->update({ bodies_str => $district->id });
-    $report->discard_changes; # As e.g. ->bodies has been remembered.
-    $cobrand->flytipping_body_fix($report, 'road', $errors);
-    is $errors->{'xroad-placement'}, undef, 'Error removed if sent to district';
-
-    $report->update({ bodies_str => $body->id . ',' . $district->id });
-    $report->discard_changes; # As e.g. ->bodies has been remembered.
-    $cobrand->flytipping_body_fix($report, 'road', $errors);
-    is $report->bodies_str, $body->id, 'Sent to both becomes sent to county on-road';
-
-    $report->update({ bodies_str => $district->id . ',' . $body->id });
-    $report->discard_changes; # As e.g. ->bodies has been remembered.
-    $cobrand->flytipping_body_fix($report, 'off-road', $errors);
-    is $report->bodies_str, $district->id, 'Sent to both becomes sent to district off-road';
-};
 
 for my $test (
     {

--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -203,6 +203,22 @@ var non_bucks_types = [
     "P", // HW: PRIVATE
 ];
 
+// Since Buckinghamshire went unitary, if the user selects an ex-district
+// category we shouldn't enforce the road asset selection.
+var ex_district_categories = [
+    "Abandoned vehicles",
+    "Car Parks",
+    "Dog fouling",
+    "Flyposting",
+    "Flytipping",
+    "Graffiti",
+    "Parks/landscapes",
+    "Public toilets",
+    "Rubbish (refuse and recycling)",
+    "Street cleaning",
+    "Street nameplates"
+];
+
 // We show roads that Bucks are and aren't responsible for, and display a
 // message to the user if they click something Bucks don't maintain.
 var types_to_show = bucks_types.concat(non_bucks_types);
@@ -287,6 +303,12 @@ fixmystreet.assets.add(defaults, {
             fixmystreet.body_overrides.allow_send(layer.fixmystreet.body);
             fixmystreet.body_overrides.remove_only_send();
             fixmystreet.message_controller.road_found(layer, feature, function(feature) {
+                // If an ex-district category is selected, always allow report
+                // regardless of road ownership.
+                var cat = $('select#form_category').val();
+                if (cat === "-- Pick a category --" || OpenLayers.Util.indexOf(ex_district_categories, cat) != -1) {
+                    return true;
+                }
                 if (OpenLayers.Util.indexOf(bucks_types, feature.attributes.feature_ty) != -1) {
                     return true;
                 } else {
@@ -296,9 +318,16 @@ fixmystreet.assets.add(defaults, {
         },
 
         not_found: function(layer) {
-            fixmystreet.body_overrides.do_not_send(layer.fixmystreet.body);
-            fixmystreet.body_overrides.remove_only_send();
-            fixmystreet.message_controller.road_not_found(layer);
+            // If an ex-district category is selected, always allow report.
+            var cat = $('select#form_category').val();
+            if (cat === "-- Pick a category --" || OpenLayers.Util.indexOf(ex_district_categories, cat) != -1) {
+                fixmystreet.body_overrides.allow_send(layer.fixmystreet.body);
+                fixmystreet.body_overrides.remove_only_send();
+            } else {
+                fixmystreet.body_overrides.do_not_send(layer.fixmystreet.body);
+                fixmystreet.body_overrides.remove_only_send();
+                fixmystreet.message_controller.road_not_found(layer);
+            }
         }
     },
     no_asset_msg_id: '#js-not-a-road',

--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -288,34 +288,17 @@ fixmystreet.assets.add(defaults, {
             fixmystreet.body_overrides.remove_only_send();
             fixmystreet.message_controller.road_found(layer, feature, function(feature) {
                 if (OpenLayers.Util.indexOf(bucks_types, feature.attributes.feature_ty) != -1) {
-                    var cat = $('select#form_category').val();
-                    if (cat === 'Flytipping') {
-                        fixmystreet.body_overrides.only_send(layer.fixmystreet.body);
-                    }
                     return true;
                 } else {
                     return false;
                 }
             }, msg_id);
-
-            // Make sure Flytipping related things reset
-            $('#category_meta').show();
-            $('#form_road-placement').attr('required', '');
         },
 
         not_found: function(layer) {
             fixmystreet.body_overrides.do_not_send(layer.fixmystreet.body);
             fixmystreet.body_overrides.remove_only_send();
             fixmystreet.message_controller.road_not_found(layer);
-
-            // If flytipping is picked, we don't want to ask the extra question
-            var cat = $('select#form_category').val();
-            if (cat === 'Flytipping') {
-                $('#category_meta').hide();
-                $('#form_road-placement').removeAttr('required');
-            } else {
-                $('#category_meta').show();
-            }
         }
     },
     no_asset_msg_id: '#js-not-a-road',
@@ -325,18 +308,6 @@ fixmystreet.assets.add(defaults, {
     },
     filter_key: 'feature_ty',
     filter_value: types_to_show,
-});
-
-// As with the road found/not_found above, we want to change the destination
-// depending upon the answer to the extra question shown when on a road
-$("#problem_form").on("change", "#form_road-placement", function() {
-    if (this.value == 'road') {
-        fixmystreet.body_overrides.allow_send(defaults.body);
-        fixmystreet.body_overrides.only_send(defaults.body);
-    } else if (this.value == 'off-road') {
-        fixmystreet.body_overrides.do_not_send(defaults.body);
-        fixmystreet.body_overrides.remove_only_send();
-    }
 });
 
 fixmystreet.assets.add(defaults, {


### PR DESCRIPTION
 - Sends district categories to old district email addresses using the `borough_email_addresses` cobrand feature from TfL
 - Updates cobrand JS to allow reports in specific ex-district categories to be made off the road assets
 - Uses the answer to the 'road placement' question on the Flytipping category to recategorise into a new ex-district category which is sent via email.

To test, add something like the following to your `COBRAND_FEATURES` setting:

```
  borough_email_addresses:
    buckinghamshire:
      districts:
        - email: district-a@example.org
          areas:
            - 2255
        - email: district-b@example.org
          areas:
            - 2256
        - email: district-c@example.org
          areas:
            - 2257
        - email: district-d@example.org
          areas:
            - 2258
```

and then create a new devolved `Flytipping (off-road)` category which sends email to `districts`, as well as a few more from this list:

 - `Abandoned vehicles`
 - `Car Parks`
 - `Dog fouling`
 - `Flyposting`
 - `Flytipping`
 - `Graffiti`
 - `Parks/landscapes`
 - `Public toilets`
 - `Rubbish (refuse and recycling)`
 - `Street cleaning`
 - `Street nameplates`


For https://github.com/mysociety/fixmystreet-freshdesk/issues/131


[skip changelog]