### PR TITLE
[Bexley] Add COVID-19 messages

### DIFF
--- a/templates/email/bexley/_problem-confirm_footer.html
+++ b/templates/email/bexley/_problem-confirm_footer.html
@@ -1,0 +1,12 @@
+<p style="border: 0.1em solid rgb(252, 13, 27); padding: 0.5em; background-color: rgb(237, 207, 206);">
+    <strong>While we find ourselves in these unprecedented times.</strong>
+    All issues reported on Bexley’s FixMyStreet system will continue to be
+    actioned to keep our roads safe for critical workers to be able to continue
+    to support the London Borough of Bexley and its residents. We may take
+    longer to respond to you while we concentrate on getting issues resolved in
+    priority order and within available resources. Non-urgent defects may also
+    take longer than normal to fix. We will continue to serve you the best that
+    we can but urge everyone not to make journeys unless absolutely necessary
+    and not report to anything that is not urgent. Thank you for
+    your&nbsp;understanding.
+</p>

--- a/templates/email/default/problem-confirm.html
+++ b/templates/email/default/problem-confirm.html
@@ -25,6 +25,7 @@ of problem, so it will instead be sent to [% report.body %].
     <a style="[% button_style %]" href="[% token_url %]">Yes, send my report</a>
   </p>
   <p style="[% p_style %]">If you no longer wish to send this report, please take no further action.</p>
+  [% TRY %][% INCLUDE '_problem-confirm_footer.html' %][% CATCH file %][% END %]
   [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report, url = token_url %]

--- a/templates/web/bexley/email_sent.html
+++ b/templates/web/bexley/email_sent.html
@@ -1,0 +1,38 @@
+[% INCLUDE 'header.html', bodyclass = 'fullwidthpage', title = loc('Create a report') %]
+
+<div class="confirmation-header confirmation-header--inbox">
+
+    <h1>[% loc("Nearly done! Now check your email&hellip;") %]</h1>
+
+    <p>
+    [% IF email_type == 'problem' %]
+        [% loc("Click the link in our confirmation email to publish your problem.") %]
+    [% ELSIF email_type == 'update' %]
+        [% loc("Click the link in our confirmation email to publish your update.") %]
+    [% ELSIF email_type == 'alert' %]
+        [% loc("Click the link in our confirmation email to activate your alert.") %]
+    [% END %]
+    </p>
+
+    [% TRY %][% INCLUDE '_email_sent_extra.html' %][% CATCH file %][% END %]
+
+    <p>
+        [% loc("Can&rsquo;t find our email? Check your spam folder&nbsp;&ndash; that&rsquo;s the solution 99% of the time.") %]
+    </p>
+
+    <p style="border: 0.1em solid rgb(252, 13, 27); padding: 0.5em; background-color: rgb(237, 207, 206);">
+        <strong>While we find ourselves in these unprecedented times.</strong>
+        All issues reported on Bexley’s FixMyStreet system will continue to be
+        actioned to keep our roads safe for critical workers to be able to continue
+        to support the London Borough of Bexley and its residents. We may take
+        longer to respond to you while we concentrate on getting issues resolved in
+        priority order and within available resources. Non-urgent defects may also
+        take longer than normal to fix. We will continue to serve you the best that
+        we can but urge everyone not to make journeys unless absolutely necessary
+        and not report to anything that is not urgent. Thank you for
+        your&nbsp;understanding.
+    </p>
+
+</div>
+
+[% INCLUDE 'footer.html' %]

--- a/templates/web/bexley/front/pre-steps.html
+++ b/templates/web/bexley/front/pre-steps.html
@@ -1,0 +1,12 @@
+<p style="border: 0.3em solid rgb(252, 13, 27); padding: 2em; background-color: rgb(237, 207, 206); font-size: 1.2em;">
+<strong>While we find ourselves in these unprecedented times.</strong>
+    All issues reported on Bexley’s FixMyStreet system will continue to be
+    actioned to keep our roads safe for critical workers to be able to continue
+    to support the London Borough of Bexley and its residents. We may take
+    longer to respond to you while we concentrate on getting issues resolved in
+    priority order and within available resources. Non-urgent defects may also
+    take longer than normal to fix. We will continue to serve you the best that
+    we can but urge everyone not to make journeys unless absolutely necessary
+    and not report to anything that is not urgent. Thank you for your
+    understanding.
+</p>

--- a/templates/web/bexley/tokens/_extras_confirm.html
+++ b/templates/web/bexley/tokens/_extras_confirm.html
@@ -1,0 +1,12 @@
+<p style="border: 0.1em solid rgb(252, 13, 27); padding: 0.5em; background-color: rgb(237, 207, 206);">
+    <strong>While we find ourselves in these unprecedented times.</strong>
+    All issues reported on Bexley’s FixMyStreet system will continue to be
+    actioned to keep our roads safe for critical workers to be able to continue
+    to support the London Borough of Bexley and its residents. We may take
+    longer to respond to you while we concentrate on getting issues resolved in
+    priority order and within available resources. Non-urgent defects may also
+    take longer than normal to fix. We will continue to serve you the best that
+    we can but urge everyone not to make journeys unless absolutely necessary
+    and not report to anything that is not urgent. Thank you for
+    your&nbsp;understanding.
+</p>


### PR DESCRIPTION
This adds a COVID-19 informational banner to the following places:

- The homepage
- Problem confirm email
- Page when you create a problem as an unregistered user
- Page when you create a problem as a registered user

Fixes https://github.com/mysociety/fixmystreet-freshdesk/issues/139

<!-- [skip changelog] -->

---

<img width="1154" alt="Screenshot 2020-03-27 at 14 36 13" src="https://user-images.githubusercontent.com/22996/77772414-03ab5780-7040-11ea-8ab7-13b81f5853ac.png">

---

<img width="726" alt="Screenshot 2020-03-27 at 14 13 21" src="https://user-images.githubusercontent.com/22996/77772419-04dc8480-7040-11ea-8d45-9d43dda4e656.png">

---

<img width="680" alt="Screenshot 2020-03-27 at 14 26 56" src="https://user-images.githubusercontent.com/22996/77772418-0443ee00-7040-11ea-9e92-f934581970ac.png">

---

<img width="648" alt="Screenshot 2020-03-27 at 14 36 33" src="https://user-images.githubusercontent.com/22996/77772407-0017d080-7040-11ea-9009-615119cdaab8.png">
