### PR TITLE
Sending reports tidying

### DIFF
--- a/bin/send-reports
+++ b/bin/send-reports
@@ -17,6 +17,7 @@ BEGIN {
     require "$d/../setenv.pl";
 }
 
+use Getopt::Long::Descriptive;
 use CronFns;
 
 use FixMyStreet;
@@ -25,4 +26,13 @@ use FixMyStreet::Script::Reports;
 my $site = CronFns::site(FixMyStreet->config('BASE_URL'));
 CronFns::language($site);
 
-FixMyStreet::Script::Reports::send();
+my ($opts, $usage) = describe_options(
+    '%c %o',
+    ['verbose|v', 'more verbose output'],
+    ['nomail', 'do not send any email, print instead'],
+    ['debug', 'always try and send reports (no back-off skipping)'],
+    ['help|h', "print usage message and exit" ],
+);
+$usage->die if $opts->help;
+
+FixMyStreet::Script::Reports::send($opts->verbose, $opts->nomail, $opts->debug);

--- a/perllib/FixMyStreet/SendReport.pm
+++ b/perllib/FixMyStreet/SendReport.pm
@@ -18,21 +18,6 @@ has 'error' => ( is => 'rw', isa => Str, default => '' );
 has 'unconfirmed_data' => ( 'is' => 'rw', isa => HashRef, default => sub { {} } );
 
 
-sub should_skip {
-    my $self  = shift;
-    my $row   = shift;
-    my $debug = shift;
-
-    return 0 unless $row->send_fail_count;
-    return 0 if $debug;
-
-    my $now = DateTime->now( time_zone => FixMyStreet->local_time_zone );
-    my $diff = $now - $row->send_fail_timestamp;
-
-    my $backoff = $row->send_fail_count > 1 ? 30 : 5;
-    return $diff->in_units( 'minutes' ) < $backoff;
-}
-
 sub get_senders {
     my $self = shift;
 

--- a/perllib/FixMyStreet/SendReport/Noop.pm
+++ b/perllib/FixMyStreet/SendReport/Noop.pm
@@ -4,9 +4,4 @@ use Moo;
 
 BEGIN { extends 'FixMyStreet::SendReport'; }
 
-# Always skip when using this method
-sub should_skip {
-    return 1;
-}
-
 1;

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -31,7 +31,7 @@ my $sample_file = path(__FILE__)->parent->parent->child("app/controller/sample.j
 ok $sample_file->exists, "sample file $sample_file exists";
 
 sub send_reports_for_zurich {
-    FixMyStreet::Script::Reports::send('zurich');
+    FixMyStreet::Script::Reports::send();
 }
 sub reset_report_state {
     my ($report, $created) = @_;
@@ -50,6 +50,7 @@ sub reset_report_state {
 my $UPLOAD_DIR = File::Temp->newdir();
 FixMyStreet::override_config {
     STAGING_FLAGS => { send_reports => 1 },
+    BASE_URL => 'https://www.zurich',
     ALLOWED_COBRANDS => 'zurich',
     MAPIT_URL => 'http://mapit.zurich/',
     MAPIT_TYPES => [ 'O08' ],

--- a/t/cobrand/zurich_attachments.txt
+++ b/t/cobrand/zurich_attachments.txt
@@ -12,7 +12,7 @@ Content-Transfer-Encoding: quoted-printable
 
 Gr=C3=BCezi External Body,
 
-=C3=96ffentliche URL: http://www.example.org/report/REPORT_ID
+=C3=96ffentliche URL: https://www.zurich/report/REPORT_ID
 
 Bei Fragen zu "Z=C3=BCri wie neu" wenden Sie sich bitte an =
 gis-zentrum@zuerich.ch.=


### PR DESCRIPTION
This PR does two things - firstly tidies up the command parameters so verbose/debug are clear as to what they're doing, they've always confused me. Then it moves the code-based "should we skip this report" behaviour to the DB query, so that the sending daemon can then use the same query and not look at reports it will then go on to skip, iyswim. [skip changelog]
So #2924 will need rewriting on top of this, but that's easier if it's merged and agreed a good thing to do!