### PR TITLE
[Bexley] P1 updates

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley.pm
@@ -172,6 +172,12 @@ sub open311_post_send {
             $p1_email = 1;
             $outofhours_email = 1;
         }
+    } elsif ($row->category eq 'Street cleaning and litter') {
+        my $reportType = $row->get_extra_field_value('reportType') || '';
+        if ($reportType eq 'Oil spillage' || $dangerous eq 'Yes') {
+            $p1_email = 1;
+            $outofhours_email = 1;
+        }
     } elsif ($row->category eq 'Damage to kerb' || $row->category eq 'Damaged road' || $row->category eq 'Damaged pavement') {
         $p1_email = 1;
         $outofhours_email = 1;

--- a/perllib/FixMyStreet/Cobrand/Bexley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley.pm
@@ -181,7 +181,8 @@ sub open311_post_send {
     }
 
     my @to;
-    push @to, email_list($emails->{p1}, 'Bexley P1 email') if $p1_email;
+    my $p1_email_to_use = ($contact->email =~ /^Confirm/) ? $emails->{p1confirm} : $emails->{p1};
+    push @to, email_list($p1_email_to_use, 'Bexley P1 email') if $p1_email;
     push @to, email_list($emails->{lighting}, 'FixMyStreet Bexley Street Lighting') if $lighting{$row->category};
     push @to, email_list($emails->{flooding}, 'FixMyStreet Bexley Flooding') if $flooding{$row->category};
     push @to, email_list($emails->{outofhours}, 'Bexley out of hours') if $outofhours_email && _is_out_of_hours();

--- a/t/cobrand/bexley.t
+++ b/t/cobrand/bexley.t
@@ -41,6 +41,7 @@ $mech->create_contact_ok(body_id => $body->id, category => 'Damaged road', email
 $mech->create_contact_ok(body_id => $body->id, category => 'Flooding in the road', email => "ConfirmFLOD");
 $mech->create_contact_ok(body_id => $body->id, category => 'Flytipping', email => "UniformFLY");
 $mech->create_contact_ok(body_id => $body->id, category => 'Dead animal', email => "ANIM");
+$mech->create_contact_ok(body_id => $body->id, category => 'Street cleaning and litter', email => "STREET");
 my $category = $mech->create_contact_ok(body_id => $body->id, category => 'Something dangerous', email => "DANG");
 $category->set_extra_metadata(group => 'Danger things');
 $category->update;
@@ -81,6 +82,8 @@ FixMyStreet::override_config {
             extra => { 'name' => 'dangerous', description => 'Was it dangerous?', 'value' => 'Yes' } },
         { category => 'Something dangerous', code => 'DANG',
             extra => { 'name' => 'dangerous', description => 'Was it dangerous?', 'value' => 'No' } },
+        { category => 'Street cleaning and litter', email => ['p1', 'outofhours', 'ooh2'], code => 'STREET',
+            extra => { 'name' => 'reportType', description => 'Type of report', 'value' => 'Oil spillage' } },
         { category => 'Gulley covers', email => ['p1', 'outofhours', 'ooh2'], code => 'GULL',
             extra => { 'name' => 'reportType', description => 'Type of report', 'value' => 'Cover missing' } },
         { category => 'Gulley covers', code => 'GULL',

--- a/t/cobrand/bexley.t
+++ b/t/cobrand/bexley.t
@@ -34,7 +34,7 @@ my $mech = FixMyStreet::TestMech->new;
 
 my $body = $mech->create_body_ok(2494, 'London Borough of Bexley', {
     send_method => 'Open311', api_key => 'key', 'endpoint' => 'e', 'jurisdiction' => 'j' });
-$mech->create_contact_ok(body_id => $body->id, category => 'Abandoned and untaxed vehicles', email => "ABAN");
+$mech->create_contact_ok(body_id => $body->id, category => 'Abandoned and untaxed vehicles', email => "ConfirmABAN");
 $mech->create_contact_ok(body_id => $body->id, category => 'Lamp post', email => "StreetLightingLAMP");
 $mech->create_contact_ok(body_id => $body->id, category => 'Gulley covers', email => "GULL");
 $mech->create_contact_ok(body_id => $body->id, category => 'Damaged road', email => "ROAD");
@@ -51,6 +51,7 @@ FixMyStreet::override_config {
     STAGING_FLAGS => { send_reports => 1, skip_checks => 0 },
     COBRAND_FEATURES => { open311_email => { bexley => {
         p1 => 'p1@bexley',
+        p1confirm => 'p1confirm@bexley',
         lighting => 'thirdparty@notbexley.example.com,another@notbexley.example.com',
         outofhours => 'outofhours@bexley,ooh2@bexley',
         flooding => 'flooding@bexley',
@@ -71,9 +72,9 @@ FixMyStreet::override_config {
 
     my $report;
     foreach my $test (
-        { category => 'Abandoned and untaxed vehicles', email => ['p1'], code => 'ABAN',
+        { category => 'Abandoned and untaxed vehicles', email => ['p1confirm'], code => 'ConfirmABAN',
             extra => { 'name' => 'burnt', description => 'Was it burnt?', 'value' => 'Yes' } },
-        { category => 'Abandoned and untaxed vehicles', code => 'ABAN',
+        { category => 'Abandoned and untaxed vehicles', code => 'ConfirmABAN',
             extra => { 'name' => 'burnt', description => 'Was it burnt?', 'value' => 'No' } },
         { category => 'Dead animal', email => ['p1', 'outofhours', 'ooh2'], code => 'ANIM' },
         { category => 'Something dangerous', email => ['p1', 'outofhours', 'ooh2'], code => 'DANG',


### PR DESCRIPTION
Bexley wish to send Confirm reports to a different P1 email address than other reports, and want to treat any Oil spillage report as a P1.

This goes alongside /data/servers commit 92332bdb for the Open311 part.

Please check the following:
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]