### PR TITLE
[UK] Show Highways England categories on cobrands.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/BathNES.pm
+++ b/perllib/FixMyStreet/Cobrand/BathNES.pm
@@ -161,7 +161,7 @@ sub categories_restriction {
     # send_method set to 'Email::BathNES' (to use a custom template) which must
     # be show on the cobrand.
     return $rs->search( { -or => [
-        'me.send_method' => undef, # Open311 categories
+        'me.send_method' => undef, # Open311 categories, or Highways England
         'me.send_method' => '', # Open311 categories that have been edited in the admin
         'me.send_method' => 'Email::BathNES', # Street Light Fault
         'me.send_method' => 'Blackhole', # Parks categories

--- a/perllib/FixMyStreet/Cobrand/Bristol.pm
+++ b/perllib/FixMyStreet/Cobrand/Bristol.pm
@@ -51,6 +51,7 @@ sub categories_restriction {
     # cobrand, not the email categories from FMS.com. We've set up the
     # Email categories with a devolved send_method, so can identify Open311
     # categories as those which have a blank send_method.
+    # Also Highways England categories have a blank send_method.
     return $rs->search( { 'me.send_method' => undef } );
 }
 

--- a/perllib/FixMyStreet/Cobrand/Hounslow.pm
+++ b/perllib/FixMyStreet/Cobrand/Hounslow.pm
@@ -64,7 +64,10 @@ sub categories_restriction {
     # cobrand, not the email categories from FMS.com. We've set up the
     # Email categories with a devolved send_method, so can identify Open311
     # categories as those which have a blank send_method.
-    return $rs->search( { 'me.send_method' => undef, 'body.name' => 'Hounslow Borough Council' } );
+    return $rs->search({
+        'me.send_method' => undef,
+        'body.name' => [ 'Hounslow Borough Council', 'Highways England' ],
+    });
 }
 
 sub report_sent_confirmation_email { 'external_id' }

--- a/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
@@ -57,7 +57,7 @@ sub categories_restriction {
     # Lincolnshire is a two-tier council, but don't want to display
     # all district-level categories on their cobrand - just a couple.
     return $rs->search( { -or => [
-        'body.name' => "Lincolnshire County Council",
+        'body.name' => [ "Lincolnshire County Council", 'Highways England' ],
 
         # District categories:
         'me.category' => { -in => [

--- a/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
@@ -27,7 +27,7 @@ sub disambiguate_location {
 
 sub categories_restriction {
     my ($self, $rs) = @_;
-    return $rs->search( { 'body.name' => 'Northamptonshire County Council' }, { join => 'body' });
+    return $rs->search( { 'body.name' => [ 'Northamptonshire County Council', 'Highways England' ] } );
 }
 
 sub send_questionnaires { 0 }

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -112,7 +112,7 @@ sub base_url_for_report {
 
 sub categories_restriction {
     my ($self, $rs) = @_;
-    $rs = $rs->search( { 'body.name' => 'TfL' } );
+    $rs = $rs->search( { 'body.name' => [ 'TfL', 'Highways England' ] } );
     return $rs unless $self->{c}->stash->{categories_for_point}; # Admin page
     return $rs->search( { category => { -not_in => $self->_tfl_no_resend_categories } } );
 }


### PR DESCRIPTION
Without allowing through the Highways England body, clicking on a
Highways England road in these cobrands would leave no categories
to be selected.
[skip changelog]