### PR TITLE
[TfL] Couple of bug fixes

### DIFF
--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -421,7 +421,19 @@ sub munge_reports_area_list {
 }
 
 sub munge_report_new_contacts { }
-sub munge_report_new_bodies { }
+
+sub munge_report_new_bodies {
+    my ($self, $bodies) = @_;
+
+    # Highways England handling
+    my $c = $self->{c};
+    my $he = FixMyStreet::Cobrand::HighwaysEngland->new({ c => $c });
+    my $on_he_road = $c->stash->{on_he_road} = $he->report_new_is_on_he_road;
+
+    if (!$on_he_road) {
+        %$bodies = map { $_->id => $_ } grep { $_->name ne 'Highways England' } values %$bodies;
+    }
+}
 
 sub munge_surrounding_london {
     my ($self, $bodies) = @_;

--- a/t/Mock/Tilma.pm
+++ b/t/Mock/Tilma.pm
@@ -10,6 +10,18 @@ has json => (
     },
 );
 
+sub as_json {
+    my ($self, $features) = @_;
+    my $json = mySociety::Locale::in_gb_locale {
+        $self->json->encode({
+            type => "FeatureCollection",
+            crs => { type => "name", properties => { name => "urn:ogc:def:crs:EPSG::27700" } },
+            features => $features,
+        });
+    };
+    return $json;
+}
+
 sub dispatch_request {
     my $self = shift;
 
@@ -25,15 +37,16 @@ sub dispatch_request {
                     [ 539408.94, 170607.58 ],
                 ] ] } } ];
         }
-        my $json = mySociety::Locale::in_gb_locale {
-            $self->json->encode({
-                type => "FeatureCollection",
-                crs => { type => "name", properties => { name => "urn:ogc:def:crs:EPSG::27700" } },
-                features => $features,
-            });
-        };
+        my $json = $self->as_json($features);
         return [ 200, [ 'Content-Type' => 'application/json' ], [ $json ] ];
     },
+
+    sub (GET + /mapserver/highways + ?*) {
+        my ($self, $args) = @_;
+        my $json = $self->as_json([]);
+        return [ 200, [ 'Content-Type' => 'application/json' ], [ $json ] ];
+    },
+
 }
 
 __PACKAGE__->run_if_script;

--- a/web/cobrands/tfl/assets.js
+++ b/web/cobrands/tfl/assets.js
@@ -35,7 +35,7 @@ var tlrn_stylemap = new OpenLayers.StyleMap({
         fillColor: "#ff0000",
         fillOpacity: 0.3,
         strokeColor: "#ff0000",
-        strokeOpacity: 0.6,
+        strokeOpacity: 1,
         strokeWidth: 2
     })
 });


### PR DESCRIPTION
Two small things:
* Increase stroke opacity of red routes - in Firefox/Edge on Windows, having a translucent stroke causes a large slowdown in page painting - see animation when I drag the red route into view:

![tfl-slow-stroke](https://user-images.githubusercontent.com/154364/78774218-4c420980-798c-11ea-9c33-bc2015842da1.gif)

* Restrict HE categories to HE roads - The checks added in 285e183 missed the TfL cobrand, and so the Highways England categories are currently appearing everywhere.

[skip changelog]
