### PR TITLE
[UK] Make it clearer that full name is required.

### DIFF
--- a/templates/web/fixmystreet-uk-councils/report/form/user_name.html
+++ b/templates/web/fixmystreet-uk-councils/report/form/user_name.html
@@ -1,10 +1,5 @@
 <!-- user_name.html -->
-<label for="form_name">Full name
-[% TRY %]
-    [% INCLUDE 'report/form/after_name.html' %]
-    [% CATCH file %]
-[% END %]
-</label>
+<label for="form_name">Full name</label>
 [% IF field_errors.name %]
     <p class='form-error'>[% field_errors.name %]</p>
 [% END %]


### PR DESCRIPTION
Requested by the folks at Bucks. I figure it makes sense to change it across the board though [for all UK councils that include the checking code.]

It’s annoying that we even have to mandate a "full name" (who says everyone’s "full name" has a space in it!?) but it’s a requirement of most councils’ case management systems.

At least this way, users get an up-front hint that they need to enter a full name (ie: with at least two words) before they submit the form and the validation runs.

[skip changelog]