### PR TITLE
[Peterborough] Improve extra question handling.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -40,17 +40,17 @@ sub geocoder_munge_results {
 
 sub admin_user_domain { "peterborough.gov.uk" }
 
-around 'open311_config' => sub {
-    my ($orig, $self, $row, $h, $params) = @_;
+# remove categories which are informational only
+sub open311_pre_send {
+    my ($self, $row, $open311) = @_;
 
-    # remove categories which are informational only
+    return unless $row->extra;
     my $extra = $row->get_extra_fields;
-    @$extra = grep { $_->{name} ne 'emergency' } @$extra;
-    @$extra = grep { $_->{name} ne 'private_land' } @$extra;
-    $row->set_extra_fields(@$extra);
-
-    $self->$orig($row, $h, $params);
-};
+    if (@$extra) {
+        @$extra = grep { $_->{name} !~ /^(PCC-|emergency$|private_land$)/i } @$extra;
+        $row->set_extra_fields(@$extra);
+    }
+}
 
 sub lookup_site_code_config { {
     buffer => 50, # metres

--- a/t/cobrand/peterborough.t
+++ b/t/cobrand/peterborough.t
@@ -22,9 +22,10 @@ subtest 'open311 request handling', sub {
     }, sub {
         my $contact = $mech->create_contact_ok(body_id => $peterborough->id, category => 'Trees', email => 'TREES');
         my ($p) = $mech->create_problems_for_body(1, $peterborough->id, 'Title', { category => 'Trees', latitude => 52.5608, longitude => 0.2405, cobrand => 'peterborough' });
-        $p->set_extra_fields({ name => 'emergency', value => 'no'});
-        $p->set_extra_fields({ name => 'private_land', value => 'no'});
-        $p->set_extra_fields({ name => 'tree_code', value => 'tree-42'});
+        $p->push_extra_fields({ name => 'emergency', value => 'no'});
+        $p->push_extra_fields({ name => 'private_land', value => 'no'});
+        $p->push_extra_fields({ name => 'PCC-light', value => 'whatever'});
+        $p->push_extra_fields({ name => 'tree_code', value => 'tree-42'});
         $p->update;
 
         my $test_data = FixMyStreet::Script::Reports::send();
@@ -33,11 +34,13 @@ subtest 'open311 request handling', sub {
         ok $p->whensent, 'Report marked as sent';
         is $p->send_method_used, 'Open311', 'Report sent via Open311';
         is $p->external_id, 248, 'Report has correct external ID';
+        is $p->get_extra_field_value('emergency'), 'no';
 
         my $req = $test_data->{test_req_used};
         my $c = CGI::Simple->new($req->content);
         is $c->param('attribute[emergency]'), undef, 'no emergency param sent';
         is $c->param('attribute[private_land]'), undef, 'no private_land param sent';
+        is $c->param('attribute[PCC-light]'), undef, 'no pcc- param sent';
         is $c->param('attribute[tree_code]'), 'tree-42', 'tree_code param sent';
     };
 };


### PR DESCRIPTION
Ignore (for Open311-sending purposes) any questions whose code starts
"PCC-", so that it is easier to use the admin to add extra questions,
and move the removal of the extra questions to a more normal location
so answers are not lost when extra fields is reset post-send.

For freshdesk 544 and 545.

[skip changelog]