### PR TITLE
Allow a template to be an initial update on reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
         - Disable staff private tickbox on new reports if category is private. #2961
         - Move stats from main admin index to stats index.
         - Speed up dashboard export and report search.
+        - Allow a template to be an initial update on reports. #2973
     - Bugfixes
         - Application user in Docker container can't install packages. #2914
         - Look at all categories when sending reports.

--- a/docs/_includes/admin-tasks-content.md
+++ b/docs/_includes/admin-tasks-content.md
@@ -748,6 +748,12 @@ process. In this instance, if your Open311 server returns extra text as part of
 the update, you may put the placeholder `{% raw %}{{description}}{% endraw %}` in the template here,
 and that placeholder will be replaced by the text from the Open311 server.
 
+If you don’t have an Open311 connection, or your Open311 connection does not
+provide an immediate initial update, there is a special case where if a
+template is assigned to the Open state, and marked as ‘auto-response’, then it
+will automatically be added as a first update to any new report created that
+matches the template (ie. in the relevant category if assigned). This lets
+you give e.g. estimated timescales or other useful information up front.
 
 #### Editing or deleting a template
 

--- a/t/app/controller/report_new_update.t
+++ b/t/app/controller/report_new_update.t
@@ -1,0 +1,71 @@
+use FixMyStreet::TestMech;
+
+# disable info logs for this test run
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $comment_user = $mech->create_user_ok('systemuser@example.org', name => 'Glos Council');
+my $body = $mech->create_body_ok(2226, 'Gloucestershire County Council', {
+    comment_user => $comment_user,
+});
+
+$mech->create_contact_ok(
+    body_id => $body->id,
+    category => 'Potholes',
+    email => 'potholes@example.com',
+);
+
+my $user = $mech->log_in_ok('test-2@example.com');
+
+subtest "test report creation with no initial auto-update" => sub {
+    my $report = make_report();
+    my $comment = FixMyStreet::DB->resultset('Comment')->count;
+    is $comment, 0, 'No comments left';
+    $report->delete;
+};
+
+my $template = FixMyStreet::DB->resultset("ResponseTemplate")->create({
+    body => $body,
+    state => 'confirmed',
+    title => 'Initial email response',
+    text => 'Thanks for your report. We will investigate within 5 working days.',
+    auto_response => 1,
+});
+ok $template, 'Template created';
+
+subtest "test report creation with initial auto-update" => sub {
+    my $report = make_report();
+    my $comment = FixMyStreet::DB->resultset('Comment')->single;
+    is $comment->text, 'Thanks for your report. We will investigate within 5 working days.';
+    is $comment->problem->id, $report->id;
+    is $comment->user->id, $comment_user->id;
+    is $comment->external_id, 'auto-internal';
+    is $comment->name, 'Glos Council';
+};
+
+done_testing;
+
+sub make_report {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'fixmystreet',
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $mech->get_ok('/around?pc=GL50+2PR');
+        $mech->follow_link_ok({ text_regex => qr/skip this step/i, }, "follow 'skip this step' link" );
+        $mech->submit_form_ok({
+            with_fields => {
+                title => "Test Report",
+                detail => 'Test report details.',
+                name => 'Joe Bloggs',
+                category => 'Potholes',
+            }
+        }, "submit good details");
+    };
+
+    my $report = $user->problems->first;
+    ok $report, "Found the report";
+
+    return $report;
+}


### PR DESCRIPTION
Upon report confirmation, we look to see if there is an auto-response response template in the database for the Open (confirmed) state. If there is, we add that immediately to the new report as its first update (as if it had just come in via Open311).

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1832

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog