### PR TITLE
[Bristol] Remove Open311 groups.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bristol.pm
+++ b/perllib/FixMyStreet/Cobrand/Bristol.pm
@@ -64,6 +64,9 @@ sub open311_config {
 sub open311_contact_meta_override {
     my ($self, $service, $contact, $meta) = @_;
 
+    # Bristol returns groups we do not want to use
+    $service->{group} = [];
+
     my %server_set = (easting => 1, northing => 1);
     foreach (@$meta) {
         $_->{automated} = 'server_set' if $server_set{$_->{code}};


### PR DESCRIPTION
Category groups were turned on for Bristol due to Highways England using groups, turns out all Bristol categories are in a "Highways" group which we should remove because it wasn't used/displayed previously. [skip changelog]