### PR TITLE
Disable staff private tickbox if category private.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Unreleased
     - Admin improvements:
         - order unsent reports by confirmed date
+        - Disable staff private tickbox on new reports if category is private. #2961
     - Bugfixes
         - Application user in Docker container can't install packages. #2914
         - Look at all categories when sending reports.

--- a/t/app/controller/report_new_staff.t
+++ b/t/app/controller/report_new_staff.t
@@ -45,6 +45,14 @@ subtest "report_mark_private allows users to mark reports as private" => sub {
             "follow 'skip this step' link"
         );
 
+        my $edin_cats = $mech->create_contact_ok( body_id => $body_ids{2651}, category => 'Cats', email => 'cats@example.com', non_public => 1 );
+        $mech->submit_form_ok({
+            button => 'submit_category_part_only',
+            with_fields => { category => 'Cats' }
+        });
+        $mech->content_contains('id="form_non_public" value="1" checked disabled');
+        $edin_cats->delete;
+
         $mech->submit_form_ok(
             {
                 with_fields => {

--- a/templates/web/base/report/new/form_user_loggedin.html
+++ b/templates/web/base/report/new/form_user_loggedin.html
@@ -63,7 +63,9 @@
 
 [% IF c.user.has_permission_to("report_inspect", bodies_ids) OR c.user.has_permission_to("report_mark_private", bodies_ids) %]
     <div class="checkbox-group">
-        <input type="checkbox" name="non_public" id="form_non_public" value="1"[% ' checked' IF report.non_public %]>
+        <input type="checkbox" name="non_public" id="form_non_public" value="1"
+            [%~ ' checked' IF report.non_public OR non_public_categories.$category %]
+            [%~ ' disabled' IF non_public_categories.$category %]>
         <label class="inline" for="form_non_public">[% loc('Private') %] </label>
     </div>
 [% END %]

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -454,9 +454,11 @@ $.extend(fixmystreet.set_up, {
         if (data && data.non_public) {
             $(".js-hide-if-private-category").hide();
             $(".js-hide-if-public-category").removeClass("hidden-js").show();
+            $('#form_non_public').prop('checked', true).prop('disabled', true);
         } else {
             $(".js-hide-if-private-category").show();
             $(".js-hide-if-public-category").hide();
+            $('#form_non_public').prop('checked', false).prop('disabled', false);
         }
         if (data && data.allow_anonymous) {
             $('.js-show-if-anonymous').removeClass('hidden-js');


### PR DESCRIPTION
If a category is marked private, new reports are always marked private regardless of the setting of the private checkbox shown to relevant staff when making a new report. So tick/disable this box in that situation to prevent any confusion. Fixes #2961