### PR TITLE
Disable category rename on Open311 categories.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
         - Allow a template to be an initial update on reports. #2973
         - Interface for disabling updates/reopening for certain categories. #2991 #2992
         - Include group in CSV export if enabled. #2994
+        - Disable category rename on Open311 categories when unprotected. #2957
     - Bugfixes:
         - Application user in Docker container can't install packages. #2914
         - Look at all categories when sending reports.

--- a/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
@@ -241,10 +241,14 @@ sub update_contact : Private {
     if ($current_contact && $contact->id && $contact->id != $current_contact->id) {
         $errors{category} = _('You cannot rename a category to an existing category');
     } elsif ($current_contact && !$contact->id) {
-        # Changed name
         $contact = $current_contact;
-        $c->model('DB::Problem')->to_body($c->stash->{body_id})->search({ category => $current_category })->update({ category => $category });
-        $contact->category($category);
+        # Set the flag here so we can run the editable test on it
+        $contact->set_extra_metadata(open311_protect => $c->get_param('open311_protect'));
+        if (!$contact->category_uneditable) {
+            # Changed name
+            $c->model('DB::Problem')->to_body($c->stash->{body_id})->search({ category => $current_category })->update({ category => $category });
+            $contact->category($category);
+        }
     }
 
     my $email = $c->get_param('email');

--- a/perllib/FixMyStreet/DB/Result/Contact.pm
+++ b/perllib/FixMyStreet/DB/Result/Contact.pm
@@ -175,4 +175,25 @@ sub disable_form_field {
     return $field;
 }
 
+sub sent_by_open311 {
+    my $self = shift;
+    my $body = $self->body;
+    return 1 if
+        (!$body->can_be_devolved && $body->send_method eq 'Open311')
+        || ($body->can_be_devolved && $body->send_method eq 'Open311' && !$self->send_method)
+        || ($body->can_be_devolved && $self->send_method eq 'Open311');
+    return 0;
+}
+
+# We do not want to allow editing of a category's name
+# if it's Open311, unless it's marked as protected
+sub category_uneditable {
+    my $self = shift;
+    return 1 if
+        $self->in_storage
+        && !$self->get_extra_metadata('open311_protect')
+        && $self->sent_by_open311;
+    return 0;
+}
+
 1;

--- a/t/app/controller/admin/bodies.t
+++ b/t/app/controller/admin/bodies.t
@@ -210,6 +210,7 @@ subtest 'check open311 configuring' => sub {
 
 subtest 'check open311 devolved editing' => sub {
     $mech->get_ok('/admin/body/' . $body->id . '/test%20category');
+    $mech->content_contains("name=\"category\"\n    size=\"30\" value=\"test category\"\n    readonly>", 'Cannot edit Open311 category name');
     $mech->submit_form_ok( { with_fields => {
         send_method => 'Email',
         email => 'testing@example.org',
@@ -217,6 +218,7 @@ subtest 'check open311 devolved editing' => sub {
     } } );
     $mech->content_contains('Values updated');
     $mech->get_ok('/admin/body/' . $body->id . '/test%20category');
+    $mech->content_contains("name=\"category\"\n    size=\"30\" value=\"test category\"\n    required>", 'Can edit as now devolved');
     $mech->submit_form_ok( { with_fields => {
         send_method => '',
         email => 'open311-code',

--- a/templates/web/base/admin/bodies/_category_field.html
+++ b/templates/web/base/admin/bodies/_category_field.html
@@ -9,7 +9,10 @@
 </div>
 
 <p>
-  <strong>[% loc('Category') %] </strong><input type="text" class="form-control" name="category" size="30" value="[% contact.category | html %]" required>
+  <label for="category">[% loc('Category') %]</label>
+  <input type="text" class="form-control" id="category" name="category"
+    size="30" value="[% contact.category %]"
+    [% contact.category_uneditable ? 'readonly' : 'required' %]>
 </p>
 
 [% IF contact.in_storage %]

--- a/templates/web/base/admin/bodies/contact-form.html
+++ b/templates/web/base/admin/bodies/contact-form.html
@@ -74,7 +74,8 @@
         <span class='form-hint'>[% loc('Use this where you do not want problem reporters to be able to reopen their fixed or closed reports when leaving an update.') %]</span>
     </p>
 
-    [% IF body.send_method == 'Open311' %]
+    [% IF contact.sent_by_open311 %]
+
       <p class="form-check">
           <input type="checkbox" name="open311_protect" value="1" id="open311_protect"[% ' checked' IF contact.get_extra_metadata('open311_protect') %]>
           <label for="open311_protect">[% loc("Protect this category's name and group(s) from Open311 changes") %]</label>

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -335,6 +335,21 @@ fixmystreet.staff_set_up = {
     });
   },
 
+  open311_category_edit: function() {
+    var protect_input = document.getElementById('open311_protect');
+    if (!protect_input) {
+        return;
+    }
+    protect_input.addEventListener('change', function() {
+        var cat = document.getElementById('category');
+        cat.readOnly = !this.checked;
+        cat.required = this.checked;
+        if (!this.checked) {
+            cat.value = cat.getAttribute('value');
+        }
+    });
+  },
+
   shortlist_listener: function() {
     $('#fms_shortlist_all').on('click', function() {
       var features = [];


### PR DESCRIPTION
If you rename an Open311 category, it will only get reinstated/deleted
by the Open311 populate script shortly after, and can cause issues due
to the problem category renaming that occurs. Fixes #2957.