### PR TITLE
Maintain category group on pin move.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
         - Application user in Docker container can't install packages. #2914
         - Look at all categories when sending reports.
         - Provide access to staff-only categories in admin.
+        - Maintain group on pin move with same category in multiple groups. #2962
     - Development improvements:
         - Refactor Script::Report into an object.
         - Move summary failures to a separate script.

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1362,7 +1362,10 @@ fixmystreet.fetch_reporting_data = function() {
         }
 
         $('#form_category_row').html(data.category);
-        if ($("#form_category option[value=\"" + old_category + "\"]").length) {
+        var cat_in_group = $("#form_category optgroup[label=\"" + old_category_group + "\"] option[value=\"" + old_category + "\"]");
+        if (cat_in_group.length) {
+            cat_in_group.prop({selected:true});
+        } else if ($("#form_category option[value=\"" + old_category + "\"]").length) {
             $("#form_category").val(old_category);
         } else if (filter_category !== undefined && $("#form_category option[value='" + filter_category + "']").length) {
             // If the category filter appears on the map and the user has selected


### PR DESCRIPTION
If the same category is in multiple groups, upon moving the pin and fetching new categories from the server it would then pick the last instance of that category in the list. Instead of using val(), pick the correct entry in the previously selected optgroup. Fixes #2962.