### PR TITLE
Add contact flag to protect category/group names from Open311 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
         - Add fetch script that does combined job of fetch-comments and fetch-reports.
     - Open311 improvements:
         - match response templates on external status code over state
+        - Add flag to protect category/group names from Open311 overwrite.
     - UK:
         - Added junction lookup, so you can search for things like "M60, Junction 2"
 

--- a/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
@@ -272,6 +272,11 @@ sub update_contact : Private {
     } else {
         $contact->unset_extra_metadata( 'photo_required' );
     }
+    if ( $c->get_param('open311_protect') ) {
+        $contact->set_extra_metadata( open311_protect => 1 );
+    } else {
+        $contact->unset_extra_metadata( 'open311_protect' );
+    }
     if ( my @group = $c->get_param_list('group') ) {
         @group = grep { $_ } @group;
         if (scalar @group == 0) {

--- a/perllib/Open311/PopulateServiceList.pm
+++ b/perllib/Open311/PopulateServiceList.pm
@@ -143,6 +143,7 @@ sub _handle_existing_contact {
     my ( $self, $contact ) = @_;
 
     my $service_name = $self->_normalize_service_name;
+    my $protected = $contact->get_extra_metadata("open311_protect");
 
     print $self->_current_body->id . " already has a contact for service code " . $self->_current_service->{service_code} . "\n" if $self->verbose >= 2;
 
@@ -150,7 +151,7 @@ sub _handle_existing_contact {
         eval {
             $contact->update(
                 {
-                    category => $service_name,
+                    $protected ? () : (category => $service_name),
                     email => $self->_current_service->{service_code},
                     state => 'confirmed',
                     %{ $self->_action_params("undeleted") },
@@ -178,7 +179,7 @@ sub _handle_existing_contact {
         $contact->update;
     }
 
-    $self->_set_contact_group($contact);
+    $self->_set_contact_group($contact) unless $protected;
     $self->_set_contact_non_public($contact);
 
     push @{ $self->found_contacts }, $self->_current_service->{service_code};

--- a/t/app/controller/admin/bodies.t
+++ b/t/app/controller/admin/bodies.t
@@ -250,6 +250,17 @@ subtest 'disable form message editing' => sub {
     }], 'right message added';
 };
 
+subtest 'open311 protection editing' => sub {
+    $mech->get_ok('/admin/body/' . $body->id . '/test%20category');
+    $mech->submit_form_ok( { with_fields => {
+        open311_protect => 1,
+        note => 'Protected from Open311 changes',
+    } } );
+    $mech->content_contains('Values updated');
+    my $contact = $body->contacts->find({ category => 'test category' });
+    is $contact->get_extra_metadata('open311_protect'), 1, 'Open311 protect flag set';
+};
+
 
 }; # END of override wrap
 

--- a/templates/web/base/admin/bodies/contact-form.html
+++ b/templates/web/base/admin/bodies/contact-form.html
@@ -63,6 +63,13 @@
         <textarea id="disabled-message" name="disable_message" class="form-control">[% contact.disable_form_field.description %]</textarea>
     </p>
 
+    [% IF body.send_method == 'Open311' %]
+      <p class="form-check">
+          <input type="checkbox" name="open311_protect" value="1" id="open311_protect"[% ' checked' IF contact.get_extra_metadata('open311_protect') %]>
+          <label for="open311_protect">[% loc("Protect this category's name and group(s) from Open311 changes") %]</label>
+      </p>
+    [% END %]
+
   [% IF body.can_be_devolved %]
     <div class="admin-hint">
       <p>


### PR DESCRIPTION
Adds a new tickbox to the contact editing form that protects the category
and group names from being changed by Open311.

<img width="612" alt="image" src="https://user-images.githubusercontent.com/4776/80368875-4f426280-8885-11ea-9688-dc68532f66e7.png">


For mysociety/fixmystreet-commercial#1776