### PR TITLE
[East Sussex] FIx issue sending notices, tidy up detail reset.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/EastSussex.pm
+++ b/perllib/FixMyStreet/Cobrand/EastSussex.pm
@@ -6,36 +6,28 @@ use warnings;
 
 sub council_area_id { return 2224; }
 
-sub open311_pre_send {
-    my ($self, $row, $open311) = @_;
+sub open311_extra_data {
+    my ($self, $row, $h, $extra, $contact) = @_;
 
-    my $contact = $row->category_row;
+    $h->{es_original_detail} = $row->detail;
+
+    $contact = $row->category_row;
     my $fields = $contact->get_extra_fields;
+    my $text = '';
     for my $field ( @$fields ) {
-        if ($field->{variable} && !$field->{automated}) {
-            my $text = $row->detail;
+        if (($field->{variable} || '') eq 'true' && !$field->{automated}) {
             my $q = $row->get_extra_field_value( $field->{code} ) || '';
             $text .= "\n\n" . $field->{description} . "\n" . $q;
-            $row->detail($text);
         }
     }
+    $row->detail($row->detail . $text);
+    return ();
 }
 
 sub open311_post_send {
     my ($self, $row, $h, $contact) = @_;
 
-    my $fields = $contact->get_extra_fields;
-    my $text = $row->detail;
-    my $added = '';
-    for my $field ( @$fields ) {
-        if ($field->{variable} && !$field->{automated}) {
-            my $q = $row->get_extra_field_value( $field->{code} ) || '';
-            $added .= "\n\n" . $field->{description} . "\n" . $q;
-        }
-    }
-
-    $text =~ s/\Q$added\E//;
-    $row->detail($text);
+    $row->detail($h->{es_original_detail});
 }
 
 1;

--- a/t/cobrand/eastsussex.t
+++ b/t/cobrand/eastsussex.t
@@ -1,0 +1,42 @@
+use FixMyStreet::TestMech;
+use FixMyStreet::Script::Reports;
+use CGI::Simple;
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $body = $mech->create_body_ok(2224, 'East Sussex Council',
+    { send_method => 'Open311', api_key => 'KEY', endpoint => 'endpoint', jurisdiction => 'eastsussex' });
+my $contact = $mech->create_contact_ok(body => $body, category => 'Pothole', email => 'POTHOLE');
+$contact->set_extra_fields(
+    { code => 'urgent', description => 'Is it urgent?', variable => 'true' },
+    { code => 'notice', description => 'This is a notice', variable => 'false' });
+$contact->update;
+my ($p) = $mech->create_problems_for_body(1, $body->id, 'East Sussex report', { category => 'Pothole' });
+$p->set_extra_fields({ name => 'urgent', value => 'no'});
+$p->update;
+
+subtest 'Check special Open311 request handling', sub {
+    my $orig_detail = $p->detail;
+    my $test_data;
+    FixMyStreet::override_config {
+        STAGING_FLAGS => { send_reports => 1 },
+        ALLOWED_COBRANDS => 'eastsussex',
+        BASE_URL => 'https://www.fixmystreet.com',
+    }, sub {
+        $test_data = FixMyStreet::Script::Reports::send();
+    };
+
+    $p->discard_changes;
+    ok $p->whensent, 'Report marked as sent';
+    is $p->send_method_used, 'Open311', 'Report sent via Open311';
+    is $p->external_id, 248, 'Report has right external ID';
+    is $p->detail, $orig_detail, 'Detail in database not changed';
+
+    my $req = $test_data->{test_req_used};
+    my $c = CGI::Simple->new($req->content);
+    my $expected = join "\r\n", $p->title, '', $p->detail, '',
+        'Is it urgent?', 'no', '', "https://www.fixmystreet.com" . $p->url, '';
+    is $c->param('description'), $expected, 'Correct description, with extra question and no notice text';
+};
+
+done_testing;


### PR DESCRIPTION
Fix issue sending notices. Store the original detail so we can reset back to it easily. (Also use a function not also used by update sending, in case that's used in future and it would break.) [skip changelog]