### PR TITLE
Simplify #geolocate_link styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
     - Admin improvements:
         - Display user name/email for contributed as reports. #2990
         - Interface for enabling anonymous reports for certain categories. #2989
+    - Development improvements:
+        - `#geolocate_link` is now easier to re-style. #3006
+        - Links inside `#front-main` can be customised using `$primary_link_*` Sass variables. #3007
 
 * v3.0.1 (6th May 2020)
     - New features:

--- a/templates/web/buckinghamshire/front/pre-steps.html
+++ b/templates/web/buckinghamshire/front/pre-steps.html
@@ -1,4 +1,4 @@
-<p style="margin: -1em -1em 1em; padding: 20px 30px; background-color: #f79f73; color: #000;">
+<p style="margin: 1em -20px; padding: 20px; background-color: #f79f73; color: #000;">
 In light of the ongoing COVID 19 crisis an element of TfB workforce has reduced
 by the need for self-isolation. This regrettably means that for the immediate
 future some work will have to be delayed. We apologise for any possible delay

--- a/web/cobrands/bathnes/_colours.scss
+++ b/web/cobrands/bathnes/_colours.scss
@@ -18,9 +18,11 @@ $site-width: 60em;
 
 @import "pattern-lib/colours";
 
-$primary: #00728F;
+$primary: $bathnes-primary;
 $primary_b: #0b0b0c;
-$primary_text: #0b0c0c;
+$primary_text: #fff;
+$primary_link_color: $primary_text;
+$primary_link_hover_color: rgba($primary_text, 0.8);
 
 $base_bg: white;
 $base_fg: #0b0c0c;

--- a/web/cobrands/bexley/base.scss
+++ b/web/cobrands/bexley/base.scss
@@ -39,7 +39,7 @@ small {
 .mobile-map-banner {
     font-size: 0.89em;
 }
-#front-main a#geolocate_link {
+a#geolocate_link {
     font-size: 0.89em;
 }
 #front_stats div {

--- a/web/cobrands/bristol/base.scss
+++ b/web/cobrands/bristol/base.scss
@@ -109,10 +109,6 @@ dl dt {
   }
 }
 
-a#geolocate_link {
-  color: $b3;
-}
-
 label {
   @extend %bold-font;
 }

--- a/web/cobrands/bristol/layout.scss
+++ b/web/cobrands/bristol/layout.scss
@@ -54,10 +54,6 @@ body.frontpage, body.twothirdswidthpage, body.fullwidthpage, body.authpage {
       }
     }
 
-    a#geolocate_link {
-      color: $b3;
-    }
-
     h1 {
       font-size: 3em;
     }
@@ -97,6 +93,10 @@ body.frontpage, body.twothirdswidthpage, body.fullwidthpage, body.authpage {
   .content .sticky-sidebar aside {
     top: 12.5em;
   }
+}
+
+a#geolocate_link {
+  color: $b3; // override default `#front-main a`
 }
 
 body.mappage {

--- a/web/cobrands/bristol/layout.scss
+++ b/web/cobrands/bristol/layout.scss
@@ -95,10 +95,6 @@ body.frontpage, body.twothirdswidthpage, body.fullwidthpage, body.authpage {
   }
 }
 
-a#geolocate_link {
-  color: $b3; // override default `#front-main a`
-}
-
 body.mappage {
   // Add a red border-bottom *inside* the header
   #site-header {

--- a/web/cobrands/bromley/_colours.scss
+++ b/web/cobrands/bromley/_colours.scss
@@ -9,6 +9,8 @@ $bromley_dark_green: #505050;
 $primary: $bromley_blue;
 $primary_b: #ffffff;
 $primary_text: #ffffff;
+$primary_link_color: $primary_text;
+$primary_link_hover_color: rgba($primary_text, 0.8);
 
 $link-color: $bromley_green;
 $link-hover-color: $bromley_green;

--- a/web/cobrands/buckinghamshire/base.scss
+++ b/web/cobrands/buckinghamshire/base.scss
@@ -102,24 +102,13 @@ dl dt {
   }
 
   #postcodeForm {
-    margin-top: 1em;
+    margin: 1em 0 0 0;
+    padding: 0;
     background: #fff;
+
     div input#sub {
       @include bucks-button();
       box-shadow: 0;
-    }
-  }
-  a#geolocate_link {
-    background: transparent;
-    color: $bucks_links;
-    padding: 0;
-    font-size: 1em;
-    &:hover,
-    &:active,
-    &:focus { 
-      background: transparent;
-      color: $link-hover-color;
-      text-decoration: underline;
     }
   }
 }
@@ -137,7 +126,13 @@ dl dt {
 }
 
 a#geolocate_link {
-  color: $b3;
+  color: $bucks_links;
+
+  &:hover,
+  &:active,
+  &:focus {
+    color: $link-hover-color;
+  }
 }
 
 label {

--- a/web/cobrands/buckinghamshire/layout.scss
+++ b/web/cobrands/buckinghamshire/layout.scss
@@ -90,17 +90,12 @@ body.twothirdswidthpage .content .sticky-sidebar aside {
     background-color: white;
     text-align: left;
     padding-top: 40px;
+    padding-bottom: 0;
 
     #postcodeForm {
-      margin-top: 0;
-
       div {
         margin: 0;
       }
-    }
-
-    a#geolocate_link {
-      color: $b3;
     }
 
     h1 {

--- a/web/cobrands/cheshireeast/_colours.scss
+++ b/web/cobrands/cheshireeast/_colours.scss
@@ -27,6 +27,7 @@ $col_button_hover: $green;
 $primary: $white;
 $primary_b: $green;
 $primary_text: $text_black;
+$primary_link_decoration: none;
 
 $base_bg: $white;
 $base_fg: $text_black;

--- a/web/cobrands/cheshireeast/base.scss
+++ b/web/cobrands/cheshireeast/base.scss
@@ -90,15 +90,12 @@ a,
     background-color: #ecf3ec;
 }
 
-#front-main a#geolocate_link {
-    color: #2e3191;
-    background: transparent;
+a#geolocate_link {
     border-bottom: 1px solid #a6a7da;
-    padding: 0;
-    margin-top: 0.5em;
-    font-size: inherit;
+    padding: 0; // remove padding so that border-bottom looks like an underline
+    margin: 0 0 1em 0;
+
     &:hover {
-        background: transparent;
         border-bottom: 1px solid #2e3191;
         transition: border-color 0.5s;
     }

--- a/web/cobrands/cheshireeast/layout.scss
+++ b/web/cobrands/cheshireeast/layout.scss
@@ -31,12 +31,7 @@ body.frontpage .content {
 }
 
 a#geolocate_link {
-    color: #2e3191; // override default `#front-main a`
     margin-top: 1em;
-
-    &:hover {
-        text-decoration: none;
-    }
 }
 
 .ce-footer {

--- a/web/cobrands/cheshireeast/layout.scss
+++ b/web/cobrands/cheshireeast/layout.scss
@@ -29,8 +29,11 @@ body.frontpage .content {
     margin: 0;
     width: 30em;
 }
-#front-main a#geolocate_link {
-    color: #2e3191;
+
+a#geolocate_link {
+    color: #2e3191; // override default `#front-main a`
+    margin-top: 1em;
+
     &:hover {
         text-decoration: none;
     }

--- a/web/cobrands/eastherts/layout.scss
+++ b/web/cobrands/eastherts/layout.scss
@@ -116,10 +116,6 @@
         }
     }
 
-    a#geolocate_link {
-        color: $eh_green;
-    }
-
     h1 {
         font-size: 2.5em;
     }
@@ -129,6 +125,10 @@
         line-height: 1.25em;
         max-width: 640px;
     }
+}
+
+a#geolocate_link {
+    color: $eh_green; // override default `#front-main a`
 }
 
 body.mappage {

--- a/web/cobrands/eastherts/layout.scss
+++ b/web/cobrands/eastherts/layout.scss
@@ -127,10 +127,6 @@
     }
 }
 
-a#geolocate_link {
-    color: $eh_green; // override default `#front-main a`
-}
-
 body.mappage {
     .eh-footer {
         display: none;

--- a/web/cobrands/fiksgatami/_colours.scss
+++ b/web/cobrands/fiksgatami/_colours.scss
@@ -7,6 +7,8 @@ $bg: #1a4f7f;
 $primary: #99bfe1;
 $primary_b: #000000;
 $primary_text: #222222;
+$primary_link_color: $primary_text;
+$primary_link_hover_color: rgba($primary_text, 0.8);
 
 $base_bg: $bg;
 $base_fg: #fff;

--- a/web/cobrands/fixamingata/_colours.scss
+++ b/web/cobrands/fixamingata/_colours.scss
@@ -5,6 +5,8 @@ $menu-image: 'menu-black';
 $primary: #00b1da;
 $primary_b: #0087a6;
 $primary_text: #222;
+$primary_link_color: $primary_text;
+$primary_link_hover_color: rgba($primary_text, 0.8);
 
 $base_bg: #eee url(images/tile.jpg) 0 0 repeat;
 $base_fg: $primary_text;

--- a/web/cobrands/fixamingata/layout.scss
+++ b/web/cobrands/fixamingata/layout.scss
@@ -122,25 +122,22 @@ body.mappage {
 
 .content footer .tablewrapper { background: #fff; }
 
-#front-main {
-    a#geolocate_link {
+a#geolocate_link {
+    background: url(images/locate-me.png) $left 0 no-repeat;
+    height: 34px;
+    padding-#{$left}: 24px;
+    margin-top: 0.25em;
+    @media ($high-dpi-screen) {
+        background-image: url(images/locate-me@2.png);
+        background-size: 22px 34px;
+    }
+    &:hover {
+        text-decoration:underline;
         background: url(images/locate-me.png) $left 0 no-repeat;
-        height: 34px;
-        padding-#{$left}: 24px;
-        margin-top: 0.25em;
-        font-size: 1em;
+
         @media ($high-dpi-screen) {
             background-image: url(images/locate-me@2.png);
             background-size: 22px 34px;
-        }
-        &:hover {
-            text-decoration:underline;
-            background: url(images/locate-me.png) $left 0 no-repeat;
-
-            @media ($high-dpi-screen) {
-                background-image: url(images/locate-me@2.png);
-                background-size: 22px 34px;
-            }
         }
     }
 }

--- a/web/cobrands/fixmystreet.com/_colours.scss
+++ b/web/cobrands/fixmystreet.com/_colours.scss
@@ -3,6 +3,8 @@
 $primary: #FFD000;
 $primary_b: #F3B11E; // For the box around the front page postcode form only
 $primary_text: #222;
+$primary_link_color: $primary_text;
+$primary_link_hover_color: rgba($primary_text, 0.8);
 
 // Tiled main body background
 $base_bg: #272727 url(images/tile.jpg) 0 0 repeat;

--- a/web/cobrands/fixmystreet.com/layout.scss
+++ b/web/cobrands/fixmystreet.com/layout.scss
@@ -152,20 +152,23 @@ body.fullwidthpage {
                 }
             }
         }
-        a#geolocate_link {
-            font-family: $body-font;
-            background: url(images/locate-me.png) $left 0 no-repeat;
-            height: 34px;
-            padding-#{$left}: 24px;
-            margin-top: 0.25em;
-            @media ($high-dpi-screen) {
-                background-image: url(images/locate-me@2.png);
-                background-size: 22px 34px;
-            }
-        }
-        a#geolocate_link.loading {
-            background: url("/cobrands/fixmystreet/images/spinner-yellow.gif") 100% 33% no-repeat
-        }
+    }
+}
+
+a#geolocate_link {
+    font-family: $body-font;
+    background: url(images/locate-me.png) $left 0 no-repeat;
+    height: 34px;
+    padding-#{$left}: 24px;
+    margin-top: 0.25em;
+
+    @media ($high-dpi-screen) {
+        background-image: url(images/locate-me@2.png);
+        background-size: 22px 34px;
+    }
+
+    &.loading {
+        background: url("/cobrands/fixmystreet/images/spinner-yellow.gif") 100% 33% no-repeat
     }
 }
 

--- a/web/cobrands/greenwich/base.scss
+++ b/web/cobrands/greenwich/base.scss
@@ -28,6 +28,10 @@
     background-color: $greenwich_light_grey;
 }
 
+#front-main #postcodeForm {
+    margin-top: 1em;
+}
+
 label[for=pc] {
     color: $greenwich_dark_red;
 }

--- a/web/cobrands/hart/_colours.scss
+++ b/web/cobrands/hart/_colours.scss
@@ -8,6 +8,8 @@ $col_fixed_label: $hart_primary;
 
 $primary_b: #000000;
 $primary_text: #ffffff;
+$primary_link_color: $primary_text;
+$primary_link_hover_color: rgba($primary_text, 0.8);
 
 $link-color: #369;
 $link-hover-color: #369;

--- a/web/cobrands/hounslow/_colours.scss
+++ b/web/cobrands/hounslow/_colours.scss
@@ -21,6 +21,8 @@ $primary: $purple;
 //$primary: #dce6f2; // From bexley.gov.uk/services
 $primary_b: #222;
 $primary_text: $white;
+$primary_link_color: $primary_text;
+$primary_link_hover_color: rgba($primary_text, 0.8);
 
 $base_bg: $white;
 $base_fg: #222;

--- a/web/cobrands/isleofwight/_colours.scss
+++ b/web/cobrands/isleofwight/_colours.scss
@@ -11,9 +11,11 @@ $green: #75c044;
 
 //Any 20% tint of the above
 
-$primary_text: #fff;
 $primary: $cyan;
 $primary_b: #222;
+$primary_text: #fff;
+$primary_link_color: $primary_text;
+$primary_link_hover_color: rgba($primary_text, 0.8);
 
 $base_bg: #fff;
 $base_fg: #222;

--- a/web/cobrands/oxfordshire/_colours.scss
+++ b/web/cobrands/oxfordshire/_colours.scss
@@ -14,6 +14,7 @@ $color-oxfordshire-link-blue: #0a549d;
 $primary: $color-oxfordshire-bright-green;
 $primary_b: $color-oxfordshire-dark-green;
 $primary_text: #fff;
+$primary_link_decoration: none;
 
 $link-color: $color-oxfordshire-link-blue;
 $link-hover-color: $color-oxfordshire-bright-yellow;

--- a/web/cobrands/oxfordshire/base.scss
+++ b/web/cobrands/oxfordshire/base.scss
@@ -99,29 +99,15 @@ a:not([class]):focus {
             }
         }
     }
+}
 
-    a#geolocate_link {
-        padding: 0;
-        background: transparent;
-        font-size: inherit;
-        color: $link-color;
-        margin-top: 0.5em;
+a#geolocate_link {
+    padding: 0;
+    margin-top: 0.5em;
 
-        &:hover {
-            background-color: transparent;
-            color: $link-hover-color;
-        }
-
-        &:focus {
-            background-color: $color-oxfordshire-bright-yellow;
-            outline: 2px solid $color-oxfordshire-bright-yellow;
-        }
-
-        &.loading {
-            background: transparent url("/cobrands/fixmystreet/images/spinner-white.gif") 100% 50% no-repeat;
-            padding: 0 1.5em 0 0;
-            border: none;
-        }
+    &.loading {
+        background: transparent url("/cobrands/fixmystreet/images/spinner-white.gif") 100% 50% no-repeat;
+        padding: 0 1.5em 0 0;
     }
 }
 

--- a/web/cobrands/oxfordshire/layout.scss
+++ b/web/cobrands/oxfordshire/layout.scss
@@ -130,18 +130,13 @@ $mappage-header-height: 10em;
             }
         }
     }
+}
 
-    a#geolocate_link {
-        color: $color-oxfordshire-link-blue;
+a#geolocate_link {
+    color: $color-oxfordshire-link-blue; // override default `#front-main a`
 
-        &:hover {
-            color: $color-oxfordshire-bright-yellow;
-        }
-
-        &:focus {
-            background-color: $color-oxfordshire-bright-yellow;
-            outline: 2px solid $color-oxfordshire-bright-yellow;
-        }
+    &:hover {
+        color: $color-oxfordshire-bright-yellow; // override default `#front-main a`
     }
 }
 

--- a/web/cobrands/oxfordshire/layout.scss
+++ b/web/cobrands/oxfordshire/layout.scss
@@ -132,14 +132,6 @@ $mappage-header-height: 10em;
     }
 }
 
-a#geolocate_link {
-    color: $color-oxfordshire-link-blue; // override default `#front-main a`
-
-    &:hover {
-        color: $color-oxfordshire-bright-yellow; // override default `#front-main a`
-    }
-}
-
 .frontpage {
     .content h2 {
         font-size: 2em;

--- a/web/cobrands/peterborough/base.scss
+++ b/web/cobrands/peterborough/base.scss
@@ -45,6 +45,7 @@ h1, h2 {
     }
     #postcodeForm {
         background-color: #fff;
+        padding-bottom: 0;
         div input#sub {
             background-color: $link-color;
         }
@@ -52,17 +53,6 @@ h1, h2 {
     label,
     .form-hint {
         color: $primary_b;
-    }
-    a#geolocate_link {
-        background-color: transparent;
-        padding: 0;
-        color: $link-color;
-        &:hover,
-        &:active,
-        &:focus {
-            background-color: transparent;
-            text-decoration: underline
-        }
     }
 }
 

--- a/web/cobrands/peterborough/layout.scss
+++ b/web/cobrands/peterborough/layout.scss
@@ -29,13 +29,14 @@ body.frontpage #front-main {
         font-weight: normal;
         font-size: 1.5em;
     }
-    a#geolocate_link {
-        color: $link-color;
-        &:hover,
-        &:active,
-        &:focus {
-            color: $link-hover-color;
-        }
+}
+
+a#geolocate_link {
+    color: $link-color; // override default `#front-main a`
+    &:hover,
+    &:active,
+    &:focus {
+        color: $link-hover-color; // override default `#front-main a`
     }
 }
 

--- a/web/cobrands/peterborough/layout.scss
+++ b/web/cobrands/peterborough/layout.scss
@@ -31,15 +31,6 @@ body.frontpage #front-main {
     }
 }
 
-a#geolocate_link {
-    color: $link-color; // override default `#front-main a`
-    &:hover,
-    &:active,
-    &:focus {
-        color: $link-hover-color; // override default `#front-main a`
-    }
-}
-
 #postcodeForm .form-hint {
     color: $grey;
 }

--- a/web/cobrands/rutland/_colours.scss
+++ b/web/cobrands/rutland/_colours.scss
@@ -14,6 +14,8 @@ $RCCbg: #F1F1F1;
 $primary: $RCCGreen;
 $primary_b: #000000;
 $primary_text: #222222;
+$primary_link_color: $primary_text;
+$primary_link_hover_color: rgba($primary_text, 0.8);
 
 $base_bg: $RCCbg;
 $base_fg: #000;

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -11,6 +11,9 @@ $link-visited-color: $link-color !default;
 $link-text-decoration: none !default;
 $link-hover-text-decoration: underline !default;
 
+$primary_link_decoration: underline !default;
+$primary_link_hover_decoration: $primary_link_decoration !default;
+
 $itemlist_item_background: #f6f6f6 !default;
 $itemlist_item_background_hover: #e6e6e6 !default;
 $col_big_numbers: #666 !default;
@@ -2371,6 +2374,12 @@ label .muted {
           background:#333;
         }
       }
+    }
+  }
+  a {
+    text-decoration: $primary_link_decoration;
+    &:hover {
+      text-decoration: $primary_link_hover_decoration;
     }
   }
 }

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2373,26 +2373,13 @@ label .muted {
       }
     }
   }
-  a#geolocate_link {
-    @include inline-block;
-    vertical-align:top;
-    background:#1a1a1a;
-    color:#C8C8C8;
-    padding:0.5em;
-    font-family: $meta-font;
-    font-size: 0.8125em;
-    @include border-radius(0 0 0.25em 0.25em);
-    &:hover {
-      text-decoration:none;
-      background:#2a2a2a;
-    }
-  }
-  a#geolocate_link.loading {
-      background: #1a1a1a url("/cobrands/fixmystreet/images/spinner-black.gif") flip(100%,0) 50% no-repeat;
-      border-#{$right}: solid 0.5em #1a1a1a;
-      padding-#{$right}: 1.5em;
-  }
 }
+
+a#geolocate_link {
+  display: inline-block;
+  padding: 0.5em;
+}
+
 .no-js #geolocate_link {
     display: none !important;
 }

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -13,6 +13,9 @@ $header-top-border: $header-top-border-width solid $primary !default;
 
 $container-max-width: 60em !default;
 
+$primary_link_color: null !default;
+$primary_link_hover_color: null !default;
+
 .internal-link-fixed-header {
     display: block;
     position: relative;
@@ -854,18 +857,10 @@ textarea.form-error {
     }
   }
   a {
-    color: inherit;
-    text-decoration: underline;
+    color: $primary_link_color;
     &:hover {
-      text-decoration: none;
+      color: $primary_link_hover_color;
     }
-  }
-}
-
-a#geolocate_link {
-  text-decoration: none; // override `#front-main a`
-  &:hover {
-    text-decoration: underline;
   }
 }
 

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -860,18 +860,12 @@ textarea.form-error {
       text-decoration: none;
     }
   }
-  a#geolocate_link {
-    color: inherit;
-    background:none;
-    text-decoration: none;
-    padding-bottom: 0;
-    &:hover {
-      text-decoration:underline;
-      background:none;
-    }
-  }
-  a#geolocate_link.loading {
-      border-#{$right}: none;
+}
+
+a#geolocate_link {
+  text-decoration: none; // override `#front-main a`
+  &:hover {
+    text-decoration: underline;
   }
 }
 

--- a/web/cobrands/tfl/base.scss
+++ b/web/cobrands/tfl/base.scss
@@ -138,24 +138,17 @@ input.form-error, textarea.form-error {
             }
         } 
     }
-    a#geolocate_link {
-        color: $beck-blue;
-        font-family: $heading-font;
-        text-decoration: underline;
-        font-size: 1.125em;
-        background: transparent;
-        &:hover,
-        &:active,
-        &:focus {
-            background: transparent;
-        }
-    }
     h2 {
         font-style: normal;
         font-family: $body-font;
         font-size: 1.625em;
         max-width: 29em;
     }
+}
+
+a#geolocate_link {
+    font-family: $heading-font;
+    font-size: 1.125em;
 }
 
 .item-list__heading {

--- a/web/cobrands/tfl/layout.scss
+++ b/web/cobrands/tfl/layout.scss
@@ -66,12 +66,11 @@ h1 {
   #postcodeForm div {
     margin: 0;
   }
-  a#geolocate_link {
-    color: $beck-blue;
-    font-family: $heading-font;
-    text-decoration: underline;
-    font-size: 1.125em;
-  }
+}
+
+a#geolocate_link {
+  color: $beck-blue; // override default `#front-main a`
+  text-decoration: underline;
 }
 
 .frontpage .content {

--- a/web/cobrands/tfl/layout.scss
+++ b/web/cobrands/tfl/layout.scss
@@ -68,11 +68,6 @@ h1 {
   }
 }
 
-a#geolocate_link {
-  color: $beck-blue; // override default `#front-main a`
-  text-decoration: underline;
-}
-
 .frontpage .content {
   padding: 2em 0;
 }

--- a/web/cobrands/warwickshire/base.scss
+++ b/web/cobrands/warwickshire/base.scss
@@ -79,31 +79,21 @@
             }
         }
     }
+}
 
-    a#geolocate_link {
-        padding: 0;
-        background: transparent;
-        font-size: 1em;
-        color: $link-color;
-        margin-top: 0.5em;
+a#geolocate_link {
+    padding: 0;
+    margin-top: 0.5em;
 
-        &:hover {
-            background-color: transparent;
-            color: $link-hover-color;
-        }
-
-        &:focus {
-            outline: 3px solid $warwickshire-yellow;
-        }
-
-        &.loading,
-        &.loading:hover {
-            background: transparent url("/cobrands/warwickshire/images/spinner-f6f6f6-333333.gif") 100% 50% no-repeat;
-            padding: 0 1.5em 0 0;
-            border: none;
-        }
+    &:focus {
+        outline: 3px solid $warwickshire-yellow;
     }
 
+    &.loading,
+    &.loading:hover {
+        background: transparent url("/cobrands/warwickshire/images/spinner-f6f6f6-333333.gif") 100% 50% no-repeat;
+        padding: 0 1.5em 0 0;
+    }
 }
 
 .box-warning {

--- a/web/cobrands/warwickshire/layout.scss
+++ b/web/cobrands/warwickshire/layout.scss
@@ -45,14 +45,6 @@
     }
 }
 
-a#geolocate_link {
-    color: $link-color; // override default `#front-main a`
-
-    &:hover {
-        color: $link-hover-color; // override default `#front-main a`
-    }
-}
-
 .site-footer__section {
     @include box-sizing(border-box);
     float: left;

--- a/web/cobrands/warwickshire/layout.scss
+++ b/web/cobrands/warwickshire/layout.scss
@@ -43,17 +43,13 @@
             margin: 1.5em 0 0.5em 0;
         }
     }
+}
 
-    a#geolocate_link {
-        color: $link-color;
+a#geolocate_link {
+    color: $link-color; // override default `#front-main a`
 
-        &:hover {
-            color: $link-hover-color;
-        }
-
-        &:focus {
-            outline: 3px solid $warwickshire-yellow;
-        }
+    &:hover {
+        color: $link-hover-color; // override default `#front-main a`
     }
 }
 

--- a/web/cobrands/westminster/base.scss
+++ b/web/cobrands/westminster/base.scss
@@ -82,25 +82,14 @@ body.frontpage {
         }
     }
 
-    a#geolocate_link {
-        background: transparent;
-        display: block;
-        padding: 0;
-        margin-top: 0.5em;
-        font-family: inherit;
-        font-size: 1em;
-        border-radius: 0;
-        color: $westminster_blue;
-
-        &:hover {
-            background: transparent;
-            text-decoration: underline;
-        }
-    }
-
     .form-hint {
         color: inherit;
     }
+}
+
+a#geolocate_link {
+    padding: 0;
+    margin-top: 0.5em;
 }
 
 #front-howto h2,

--- a/web/cobrands/westminster/layout.scss
+++ b/web/cobrands/westminster/layout.scss
@@ -36,10 +36,6 @@
     }
 }
 
-a#geolocate_link {
-    color: $westminster-blue; // override default `#front-main a`
-}
-
 body.mappage {
     #site-header {
         box-sizing: border-box; // count padding as part of height, so border-bottom is visible

--- a/web/cobrands/westminster/layout.scss
+++ b/web/cobrands/westminster/layout.scss
@@ -36,8 +36,8 @@
     }
 }
 
-#front-main a#geolocate_link {
-    color: $westminster-blue;
+a#geolocate_link {
+    color: $westminster-blue; // override default `#front-main a`
 }
 
 body.mappage {


### PR DESCRIPTION
Fixes mysociety/fixmystreet-commercial#1835.

Reduces the amount of styling on the `#geolocate_link` in core, because we’re seeing more cobrands now (eg: bexley, bristol, bucks, lincs) where the very opinionated "dark grey button with rounded bottom corners" styling just didn’t fit and had to be overwritten, separately, again and again.

Rather than keep the grey button styling in just a few cobrands, I‘ve removed it everywhere. Also took the opportunity to increase the font size, so it’s a bit more tappable on touchscreens.

Before, and after, at narrow widths:

![fmscom](https://user-images.githubusercontent.com/739624/80810491-dd875300-8bbb-11ea-92f1-5f25a953b60d.png)

![island-roads](https://user-images.githubusercontent.com/739624/80810495-de1fe980-8bbb-11ea-85b3-c9c4d0e20dd3.png)

![highways](https://user-images.githubusercontent.com/739624/80810812-7d44e100-8bbc-11ea-860f-fd27bbf11f08.png)

While I was at it, I also reduced the specificity of all the `#geolocate` selectors (in core and the cobrands). No need for them to be as specific as they were.
