### PR TITLE
Remove unnecessary margin-right on #postcodeForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
         - Look at all categories when sending reports.
         - Provide access to staff-only categories in admin.
         - Maintain group on pin move with same category in multiple groups. #2962
+        - Remove unnecessary margin-right on #postcodeForm. #3010
     - Development improvements:
         - Refactor Script::Report into an object.
         - Move summary failures to a separate script.

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -842,7 +842,6 @@ textarea.form-error {
     background:none;
     overflow:hidden;
     padding-bottom: 0;
-    margin-#{$right}: 0.5em;
     label {
       margin:0.5em 0;
     }


### PR DESCRIPTION
Not sure why this margin was even here. Appears to have been present since the original FMS redesign in 2012.

![Screen Shot 2020-05-01 at 12 17 45](https://user-images.githubusercontent.com/739624/80808979-a6637280-8bb8-11ea-866d-c19ba15fa6cb.png)

It certainly isn’t required, and actually causes weird off-centre alignment, which is especially noticeable on cobrands with a narrower homepage search box form.