### PR TITLE
Interface for disabling updates for certain categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
         - Move stats from main admin index to stats index.
         - Speed up dashboard export and report search.
         - Allow a template to be an initial update on reports. #2973
+        - Interface for disabling updates for certain categories. #2991
     - Bugfixes
         - Application user in Docker container can't install packages. #2914
         - Look at all categories when sending reports.

--- a/docs/_includes/admin-tasks-content.md
+++ b/docs/_includes/admin-tasks-content.md
@@ -560,14 +560,14 @@ and staff users — can filter reports when viewing them on the site.
 From the Admin menu, click on ‘Categories’. You’ll see a table of existing categories, and below
 that, a form by which you can create new ones.
 
-
 Input a title for the category, and the email address to which reports in that category should be
 forwarded. When creating a category, these are the only fields required.
 
 You can also choose a variety of options – whether to automatically hide any
 reports made in this category, whether to prevent form submission when this
-category is selected, or what parent category or categories a particular
-category is in. See below for information on <a
+category is selected, whether updates are allowed on reports in this category,
+or what parent category or categories a particular category is in. See below
+for information on <a
 href="#creating-editing-notices">creating/editing extra notices and
 questions</a> for a category.
 

--- a/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
@@ -267,15 +267,12 @@ sub update_contact : Private {
     $contact->send_method( $c->get_param('send_method') );
 
     # Set flags in extra to the appropriate values
-    if ( $c->get_param('photo_required') ) {
-        $contact->set_extra_metadata_if_undefined(  photo_required => 1 );
-    } else {
-        $contact->unset_extra_metadata( 'photo_required' );
-    }
-    if ( $c->get_param('open311_protect') ) {
-        $contact->set_extra_metadata( open311_protect => 1 );
-    } else {
-        $contact->unset_extra_metadata( 'open311_protect' );
+    foreach (qw(photo_required open311_protect updates_disallowed)) {
+        if ( $c->get_param($_) ) {
+            $contact->set_extra_metadata( $_ => 1 );
+        } else {
+            $contact->unset_extra_metadata($_);
+        }
     }
     if ( my @group = $c->get_param_list('group') ) {
         @group = grep { $_ } @group;

--- a/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
@@ -110,6 +110,7 @@ sub index : Path {
             {
                 join => 'user',
                 '+columns' => 'user.email',
+                prefetch => 'contact',
                 rows => 50,
                 order_by => $order,
             }
@@ -166,7 +167,13 @@ sub index : Path {
 
         my $problems = $c->cobrand->problems->search(
             $query,
-            { order_by => $order, rows => 50 }
+            {
+                '+columns' => ['user.email'],
+                join => 'user',
+                prefetch => 'contact',
+                order_by => $order,
+                rows => 50
+            }
         )->page( $p_page );
         $c->stash->{problems} = [ $problems->all ];
         $c->stash->{problems_pager} = $problems->pager;

--- a/perllib/FixMyStreet/App/Controller/Dashboard.pm
+++ b/perllib/FixMyStreet/App/Controller/Dashboard.pm
@@ -591,7 +591,15 @@ sub heatmap_sidebar :Private {
         order_by => 'lastupdate',
     })->all ];
 
-    my $params = { map { my $n = $_; s/me\./problem\./; $_ => $where->{$n} } keys %$where };
+    my $params = { map {
+        my $v = $where->{$_};
+        if (ref $v eq 'HASH') {
+            $v = { map { my $vv = $v->{$_}; s/me\./problem\./; $_ => $vv } keys %$v };
+        } else {
+            s/me\./problem\./;
+        }
+        $_ => $v;
+    } keys %$where };
     my $body = $c->stash->{body};
 
     my @user;

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -133,11 +133,13 @@ sub support :Chained('id') :Args(0) {
 sub load_problem_or_display_error : Private {
     my ( $self, $c, $id ) = @_;
 
+    my $attrs = { prefetch => 'contact' };
+
     # try to load a report if the id is a number
     my $problem
       = ( !$id || $id =~ m{\D} ) # is id non-numeric?
       ? undef                    # ...don't even search
-      : $c->cobrand->problems->find( { id => $id } )
+      : $c->cobrand->problems->find( { id => $id }, $attrs )
           or $c->detach( '/page_error_404_not_found', [ _('Unknown problem ID') ] );
 
     # check that the problem is suitable to show.

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -620,6 +620,9 @@ sub load_problems_parameters : Private {
     };
     if ($c->user_exists && $body) {
         my $prefetch = [];
+        if ($c->user->from_body || $c->user->is_superuser) {
+            push @$prefetch, 'contact';
+        }
         if ($c->user->has_permission_to('planned_reports', $body->id)) {
             push @$prefetch, 'user_planned_reports';
         }
@@ -646,7 +649,7 @@ sub load_problems_parameters : Private {
     }
 
     if (@$category) {
-        $where->{category} = $category;
+        $where->{'me.category'} = $category;
     }
 
     if ($c->stash->{wards}) {
@@ -687,12 +690,12 @@ sub check_non_public_reports_permission : Private {
         }
 
         if ( $user_has_permission ) {
-            $where->{non_public} = 1 if $c->stash->{only_non_public};
+            $where->{'me.non_public'} = 1 if $c->stash->{only_non_public};
         } else {
-            $where->{non_public} = 0;
+            $where->{'me.non_public'} = 0;
         }
     } else {
-        $where->{non_public} = 0;
+        $where->{'me.non_public'} = 0;
     }
 }
 

--- a/perllib/FixMyStreet/Cobrand/Bexley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley.pm
@@ -54,7 +54,7 @@ sub open311_munge_update_params {
 
     $params->{service_request_id_ext} = $comment->problem->id;
 
-    my $contact = $comment->problem->category_row;
+    my $contact = $comment->problem->contact;
     $params->{service_code} = $contact->email;
 }
 

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -344,23 +344,23 @@ sub munge_load_and_group_problems {
     return unless $c->action eq 'dashboard/heatmap';
 
     # Bromley subcategory stuff
-    if (!$where->{category}) {
+    if (!$where->{'me.category'}) {
         my $cats = $c->user->categories;
         my $subcats = $c->user->get_extra_metadata('subcategories') || [];
-        $where->{category} = [ @$cats, @$subcats ] if @$cats || @$subcats;
+        $where->{'me.category'} = [ @$cats, @$subcats ] if @$cats || @$subcats;
     }
 
     my %subcats = $self->subcategories;
     my $subcat;
-    my %chosen = map { $_ => 1 } @{$where->{category} || []};
+    my %chosen = map { $_ => 1 } @{$where->{'me.category'} || []};
     my @subcat = grep { $chosen{$_} } map { $_->{key} } map { @$_ } values %subcats;
     if (@subcat) {
         my %chosen = map { $_ => 1 } @subcat;
         $where->{'-or'} = {
-            category => [ grep { !$chosen{$_} } @{$where->{category}} ],
-            subcategory => \@subcat,
+            'me.category' => [ grep { !$chosen{$_} } @{$where->{'me.category'}} ],
+            'me.subcategory' => \@subcat,
         };
-        delete $where->{category};
+        delete $where->{'me.category'};
     }
 }
 

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -530,6 +530,7 @@ or not. Default behaviour is disallowed if "closed_updates" metadata is set.
 sub updates_disallowed {
     my ($self, $problem) = @_;
     return 1 if $problem->get_extra_metadata('closed_updates');
+    return 1 if $problem->contact && $problem->contact->get_extra_metadata('updates_disallowed');
     return 0;
 }
 

--- a/perllib/FixMyStreet/Cobrand/EastSussex.pm
+++ b/perllib/FixMyStreet/Cobrand/EastSussex.pm
@@ -11,7 +11,6 @@ sub open311_extra_data {
 
     $h->{es_original_detail} = $row->detail;
 
-    $contact = $row->category_row;
     my $fields = $contact->get_extra_fields;
     my $text = '';
     for my $field ( @$fields ) {

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -139,10 +139,10 @@ sub munge_report_new_contacts {
 sub munge_load_and_group_problems {
     my ($self, $where, $filter) = @_;
 
-    return unless $where->{category} && $self->{c}->stash->{body}->name eq 'Isle of Wight Council';
+    return unless $where->{'me.category'} && $self->{c}->stash->{body}->name eq 'Isle of Wight Council';
 
     my $iow = FixMyStreet::Cobrand->get_class_for_moniker( 'isleofwight' )->new({ c => $self->{c} });
-    $where->{category} = $iow->expand_triage_cat_list($where->{category}, $self->{c}->stash->{body});
+    $where->{'me.category'} = $iow->expand_triage_cat_list($where->{'me.category'}, $self->{c}->stash->{body});
 }
 
 sub title_list {

--- a/perllib/FixMyStreet/Cobrand/IsleOfWight.pm
+++ b/perllib/FixMyStreet/Cobrand/IsleOfWight.pm
@@ -140,9 +140,9 @@ sub munge_around_category_where {
 sub munge_load_and_group_problems {
     my ($self, $where, $filter) = @_;
 
-    return unless $where->{category};
+    return unless $where->{'me.category'};
 
-    $where->{category} = $self->_expand_triage_cat_list($where->{category});
+    $where->{'me.category'} = $self->_expand_triage_cat_list($where->{'me.category'});
 }
 
 sub munge_around_filter_category_list {

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -85,7 +85,7 @@ sub open311_munge_update_params {
     # Send the FMS problem ID with the update.
     $params->{service_request_id_ext} = $comment->problem->id;
 
-    my $contact = $comment->problem->category_row;
+    my $contact = $comment->problem->contact;
     $params->{service_code} = $contact->email;
 }
 

--- a/t/app/controller/admin/bodies.t
+++ b/t/app/controller/admin/bodies.t
@@ -261,6 +261,17 @@ subtest 'open311 protection editing' => sub {
     is $contact->get_extra_metadata('open311_protect'), 1, 'Open311 protect flag set';
 };
 
+subtest 'updates disabling' => sub {
+    $mech->get_ok('/admin/body/' . $body->id . '/test%20category');
+    $mech->submit_form_ok( { with_fields => {
+        updates_disallowed => 1,
+        note => 'Disabling updates',
+    } } );
+    $mech->content_contains('Values updated');
+    my $contact = $body->contacts->find({ category => 'test category' });
+    is $contact->get_extra_metadata('updates_disallowed'), 1, 'Updates disallowed flag set';
+};
+
 
 }; # END of override wrap
 

--- a/t/app/controller/report_updates.t
+++ b/t/app/controller/report_updates.t
@@ -22,6 +22,8 @@ my $user2 = $mech->create_user_ok('commenter@example.com', name => 'Commenter');
 
 my $body = $mech->create_body_ok(2504, 'Westminster City Council');
 
+my $contact = $mech->create_contact_ok( body_id => $body->id, category => 'Other', email => 'other' );
+
 my $dt = DateTime->new(
     year   => 2011,
     month  => 04,
@@ -1893,6 +1895,18 @@ for my $test (
     };
 }
 
+$mech->log_in_ok( $report->user->email );
+
+my %standard_fields = (
+    name => $report->user->name,
+    update => 'update text',
+    photo1 => '',
+    photo2 => '',
+    photo3 => '',
+    may_show_name => 1,
+    add_alert => 1,
+);
+
 for my $test (
     {
         desc => 'update confirmed without marking as fixed leaves state unchanged',
@@ -2094,18 +2108,6 @@ for my $test (
     },
 ) {
     subtest $test->{desc} => sub {
-        $mech->log_in_ok( $report->user->email );
-
-        my %standard_fields = (
-            name => $report->user->name,
-            update => 'update text',
-            photo1 => '',
-            photo2 => '',
-            photo3 => '',
-            may_show_name => 1,
-            add_alert => 1,
-        );
-
         my %expected_fields = (
             %standard_fields,
             %{ $test->{expected_form_fields} },
@@ -2176,6 +2178,13 @@ FixMyStreet::override_config {
         $mech->get( "/report/$report_id" );
         $mech->content_lacks("Provide an update");
     };
+};
+
+subtest 'check disabling of updates per category' => sub {
+    $contact->set_extra_metadata( updates_disallowed => 1 );
+    $contact->update;
+    $mech->get_ok("/report/$report_id");
+    $mech->content_lacks('Provide an update');
 };
 
 done_testing();

--- a/t/roles/translatable.t
+++ b/t/roles/translatable.t
@@ -77,8 +77,9 @@ FixMyStreet::override_config {
 subtest 'Check display_name override' => sub {
     $contact->set_extra_metadata( display_name => 'Override name' );
     $contact->update;
-    is $contact->category_display, "Override name";
-    is $problem->category_display, "Override name";
+    is $contact->category_display, "Override name", 'Contact uses display_name';
+    $problem->discard_changes;
+    is $problem->category_display, "Override name", 'Problem uses display_name';
 };
 
 done_testing;

--- a/templates/web/base/admin/bodies/contact-form.html
+++ b/templates/web/base/admin/bodies/contact-form.html
@@ -63,6 +63,11 @@
         <textarea id="disabled-message" name="disable_message" class="form-control">[% contact.disable_form_field.description %]</textarea>
     </p>
 
+    <p class="form-check">
+        <input type="checkbox" name="updates_disallowed" value="1" id="updates_disallowed" [% ' checked' IF contact.get_extra_metadata('updates_disallowed') %]>
+        <label for="updates_disallowed">[% loc('Disable updates on reports in this category') %]</label>
+    </p>
+
     [% IF body.send_method == 'Open311' %]
       <p class="form-check">
           <input type="checkbox" name="open311_protect" value="1" id="open311_protect"[% ' checked' IF contact.get_extra_metadata('open311_protect') %]>

--- a/templates/web/isleofwight/report/_item_heading.html
+++ b/templates/web/isleofwight/report/_item_heading.html
@@ -1,7 +1,7 @@
 [%
     SET title = problem.title;
     IF c.req.uri.path == '/';
-        title = problem.category_display;
+        title = problem.category; # Not category_display to prevent unneeded DM lookup
     END;
 %]
 <h3 class="item-list__heading">[% title %]</h3>


### PR DESCRIPTION
Add a tickbox to the category admin, and do not allow updates on reports made in those selected categories.

- [x] Whether this PR should include changes to any documentation - will do same time as others that affect same part
- [x] Is new functionality tested?
- [x] Have you updated the changelog?

Fixes #2991.
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1871

Before that, it also moves the "category_row" functionality to a database relationship, so that it could use that in its feature, and also fix the issue I had spotted that e.g. admin report list was doing a db lookup once per row. Sadly, due to quite a few shared-column names this was trickier than it looked (and some places it's aliased differently, and there appears to be an issue whereby if you try and save an update whose associated problem is an object on which the contact has been looked up, it fails, I gave up tracking that one down :-/ ). But hopefully is okay now, at least all the places the tests look at!