### PR TITLE
Add way to disallow report reopening on reports in a category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
         - Move stats from main admin index to stats index. #2982
         - Speed up dashboard export and report search. #2988
         - Allow a template to be an initial update on reports. #2973
-        - Interface for disabling updates for certain categories. #2991
+        - Interface for disabling updates/reopening for certain categories. #2991 #2992
     - Bugfixes:
         - Application user in Docker container can't install packages. #2914
         - Look at all categories when sending reports.

--- a/docs/_includes/admin-tasks-content.md
+++ b/docs/_includes/admin-tasks-content.md
@@ -566,6 +566,7 @@ forwarded. When creating a category, these are the only fields required.
 You can also choose a variety of options – whether to automatically hide any
 reports made in this category, whether to prevent form submission when this
 category is selected, whether updates are allowed on reports in this category,
+whether members of the public can reopen fixed/closed reports in this category,
 or what parent category or categories a particular category is in. See below
 for information on <a
 href="#creating-editing-notices">creating/editing extra notices and

--- a/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
@@ -267,7 +267,7 @@ sub update_contact : Private {
     $contact->send_method( $c->get_param('send_method') );
 
     # Set flags in extra to the appropriate values
-    foreach (qw(photo_required open311_protect updates_disallowed)) {
+    foreach (qw(photo_required open311_protect updates_disallowed reopening_disallowed)) {
         if ( $c->get_param($_) ) {
             $contact->set_extra_metadata( $_ => 1 );
         } else {

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -523,7 +523,8 @@ sub allow_update_reporting { return 0; }
 =item updates_disallowed
 
 Returns a boolean indicating whether updates on a particular report are allowed
-or not. Default behaviour is disallowed if "closed_updates" metadata is set.
+or not. Default behaviour is disallowed if "closed_updates" metadata is set, or
+if the report's category has its "updates_disallowed" flag set.
 
 =cut
 
@@ -531,6 +532,20 @@ sub updates_disallowed {
     my ($self, $problem) = @_;
     return 1 if $problem->get_extra_metadata('closed_updates');
     return 1 if $problem->contact && $problem->contact->get_extra_metadata('updates_disallowed');
+    return 0;
+}
+
+=item reopening_disallowed
+
+Returns a boolean indicating whether reopening of a particular report is
+allowed or not. Default behaviour is allowed unless the report's category
+has its reopening_disallowed flag set.
+
+=cut
+
+sub reopening_disallowed {
+    my ($self, $problem) = @_;
+    return 1 if $problem->contact && $problem->contact->get_extra_metadata('reopening_disallowed');
     return 0;
 }
 

--- a/t/app/controller/admin/bodies.t
+++ b/t/app/controller/admin/bodies.t
@@ -272,6 +272,17 @@ subtest 'updates disabling' => sub {
     is $contact->get_extra_metadata('updates_disallowed'), 1, 'Updates disallowed flag set';
 };
 
+subtest 'reopen disabling' => sub {
+    $mech->get_ok('/admin/body/' . $body->id . '/test%20category');
+    $mech->submit_form_ok( { with_fields => {
+        reopening_disallowed => 1,
+        note => 'Disabling reopening',
+    } } );
+    $mech->content_contains('Values updated');
+    my $contact = $body->contacts->find({ category => 'test category' });
+    is $contact->get_extra_metadata('reopening_disallowed'), 1, 'Reopening disallowed flag set';
+};
+
 
 }; # END of override wrap
 

--- a/t/app/controller/report_updates.t
+++ b/t/app/controller/report_updates.t
@@ -2145,6 +2145,17 @@ for my $test (
     };
 }
 
+subtest 'check disabling of reopening' => sub {
+    $report->state('fixed - council');
+    $report->update;
+    $mech->get_ok("/report/$report_id");
+    $mech->content_contains('This problem has not been fixed');
+    $contact->set_extra_metadata( reopening_disallowed => 1 );
+    $contact->update;
+    $mech->get_ok("/report/$report_id");
+    $mech->content_lacks('This problem has not been fixed');
+};
+
 subtest 'check have to be logged in for creator fixed questionnaire' => sub {
     $mech->log_out_ok();
 

--- a/templates/web/base/admin/bodies/contact-form.html
+++ b/templates/web/base/admin/bodies/contact-form.html
@@ -68,6 +68,12 @@
         <label for="updates_disallowed">[% loc('Disable updates on reports in this category') %]</label>
     </p>
 
+    <p class="form-check">
+        <input type="checkbox" name="reopening_disallowed" value="1" id="reopening_disallowed" [% ' checked' IF contact.get_extra_metadata('reopening_disallowed') %]>
+        <label for="reopening_disallowed">[% loc('Disable reopening of reports in this category') %]</label>
+        <span class='form-hint'>[% loc('Use this where you do not want problem reporters to be able to reopen their fixed or closed reports when leaving an update.') %]</span>
+    </p>
+
     [% IF body.send_method == 'Open311' %]
       <p class="form-check">
           <input type="checkbox" name="open311_protect" value="1" id="open311_protect"[% ' checked' IF contact.get_extra_metadata('open311_protect') %]>

--- a/templates/web/base/report/update/form_state_checkbox.html
+++ b/templates/web/base/report/update/form_state_checkbox.html
@@ -1,5 +1,7 @@
 [% IF (problem.is_fixed OR problem.is_closed) AND ((c.user_exists AND c.user.id == problem.user_id) OR alert_to_reporter) %]
 
+    [% RETURN IF c.cobrand.reopening_disallowed(problem) ~%]
+
     <input type="checkbox" name="reopen" id="form_reopen" value="1"[% ' checked' IF (update.mark_open || c.req.params.reopen) %]>
     [% IF problem.is_closed %]
       <label class="inline" for="form_reopen">[% loc('This problem is still ongoing') %]</label>

--- a/templates/web/fixmystreet.com/report/update/form_state_checkbox.html
+++ b/templates/web/fixmystreet.com/report/update/form_state_checkbox.html
@@ -2,6 +2,8 @@
 
 [% IF (problem.is_fixed OR problem.is_closed) AND ((c.user_exists AND c.user.id == problem.user_id) OR alert_to_reporter) %]
 
+    [% RETURN IF c.cobrand.reopening_disallowed(problem) ~%]
+
     <input type="checkbox" name="reopen" id="form_reopen" value="1"[% ' checked' IF (update.mark_open || c.req.params.reopen) %]>
     [% IF problem.is_closed %]
       <label class="inline" for="form_reopen">[% loc('This problem is still ongoing') %]</label>


### PR DESCRIPTION
Fixes #2992. Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1872.
Does need a doc update but I will do that at same time as #2991 doc given it'll be same screenshot, same place. In fact, might as well wait for #2989 to only do the screenshot once!

Includes same first commit as mentioned in #3011