### PR TITLE
Pass class argument to council_area_id in fixture script

### DIFF
--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -302,7 +302,7 @@ if ($opt->coords) {
 my $cobrand = 'default';
 foreach (FixMyStreet::Cobrand->available_cobrand_classes) {
     my $sub = $_->{class} && $_->{class}->can('council_area_id');
-    if ($sub && &$sub == $opt->area_id) {
+    if ($sub && &$sub($_->{class}) == $opt->area_id) {
         $cobrand = $_->{class}->moniker;
         last;
     }


### PR DESCRIPTION
The TfL `council_area_id` sub uses the `$_[0]` argument to call other cobrand methods, but that argument wasn't being passed in correctly in the `bin/fixmystreet.com/fixture` script.

Fixes #3018 

<!-- [skip changelog] -->