### PR TITLE
[Bristol] Add admin_user_domain

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bristol.pm
+++ b/perllib/FixMyStreet/Cobrand/Bristol.pm
@@ -73,4 +73,6 @@ sub open311_contact_meta_override {
     }
 }
 
+sub admin_user_domain { 'bristol.gov.uk' }
+
 1;


### PR DESCRIPTION
Not sure how we've managed to go this long without this. PRd despite being a small change because I couldn't remember if there was a good reason it wasn't there.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1882

[skip changelog]