### PR TITLE
Blocks /mapit from web crawlers

### DIFF
--- a/web/robots.txt
+++ b/web/robots.txt
@@ -3,3 +3,6 @@ Crawl-delay: 3
 
 User-agent: bingbot
 Crawl-delay: 3
+
+User-agent: *
+Disallow: /mapit


### PR DESCRIPTION
I noticed that https://global.mapit.mysociety.org/ disallows all web crawling, but I guess bots will still go through fixmystreet.com/mapit?

Perhaps there's a good reason to allow that?

