### PR TITLE
admin interface for per category anonymous reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - Fix issue with dashboard report CSV export. #3026
     - Admin improvements:
         - Display user name/email for contributed as reports. #2990
+        - Interface for enabling anonymous reports for certain categories. #2989
 
 * v3.0.1 (6th May 2020)
     - New features:

--- a/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
@@ -271,7 +271,7 @@ sub update_contact : Private {
     $contact->send_method( $c->get_param('send_method') );
 
     # Set flags in extra to the appropriate values
-    foreach (qw(photo_required open311_protect updates_disallowed reopening_disallowed assigned_users_only)) {
+    foreach (qw(photo_required open311_protect updates_disallowed reopening_disallowed assigned_users_only anonymous_allowed)) {
         if ( $c->get_param($_) ) {
             $contact->set_extra_metadata( $_ => 1 );
         } else {

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -1123,7 +1123,22 @@ pressed in the front end, rather than whenever a username is not provided.
 
 =cut
 
-sub allow_anonymous_reports { 0; }
+sub allow_anonymous_reports {
+    my ($self, $category_name) = @_;
+
+    $category_name ||= $self->{c}->stash->{category};
+    if ( $category_name && $self->can('body') and $self->body ) {
+        my $category_rs = FixMyStreet::DB->resultset("Contact")->search({
+            body_id => $self->body->id,
+            category => $category_name
+        });
+        if ( my $category = $category_rs->first ) {
+            return 'button' if $category->get_extra_metadata('anonymous_allowed');
+        }
+    }
+
+    return 0;
+}
 
 =item anonymous_account
 

--- a/templates/web/base/admin/bodies/contact-form.html
+++ b/templates/web/base/admin/bodies/contact-form.html
@@ -74,8 +74,14 @@
         <span class='form-hint'>[% loc('Use this where you do not want problem reporters to be able to reopen their fixed or closed reports when leaving an update.') %]</span>
     </p>
 
-    [% IF contact.sent_by_open311 %]
+    [% IF body.get_cobrand_handler.anonymous_account %]
+    <p class="form-check">
+        <input type="checkbox" name="anonymous_allowed" value="1" id="anonymous_allowed" [% ' checked' IF contact.get_extra_metadata('anonymous_allowed') %]>
+        <label for="anonymous_allowed">[% loc('Allow anonymous reports on this category') %]</label>
+    </p>
+    [% END %]
 
+    [% IF contact.sent_by_open311 %]
       <p class="form-check">
           <input type="checkbox" name="open311_protect" value="1" id="open311_protect"[% ' checked' IF contact.get_extra_metadata('open311_protect') %]>
           <label for="open311_protect">[% loc("Protect this category's name and group(s) from Open311 changes") %]</label>


### PR DESCRIPTION
Add an interface to enable a category to accept anonymous reports, plus
the code to handle permitting this.

It's only available on single body cobrand sites in the default
configuration.