### PR TITLE
Make year in map copyright notices dynamic

### DIFF
--- a/web/js/map-fms.js
+++ b/web/js/map-fms.js
@@ -38,14 +38,15 @@ OpenLayers.Layer.BingUK = OpenLayers.Class(OpenLayers.Layer.Bing, {
         var logo = '';
         var c = this.map.getCenter();
         var in_uk = c ? this.in_uk(c) : true;
+        var year = (new Date()).getFullYear();
         if (z >= 16 && in_uk) {
-            copyrights = 'Contains Highways England and Ordnance Survey data &copy; Crown copyright and database right 2016';
+            copyrights = 'Contains Highways England and Ordnance Survey data &copy; Crown copyright and database right ' + year;
         } else {
             logo = '<a href="https://www.bing.com/maps/"><img border=0 src="//dev.virtualearth.net/Branding/logo_powered_by.png"></a>';
             if (in_uk) {
-                copyrights = '&copy; 2016 <a href="https://www.bing.com/maps/">Microsoft</a>. &copy; AND, Navteq, Highways England, Ordnance Survey';
+                copyrights = '&copy; ' + year + ' <a href="https://www.bing.com/maps/">Microsoft</a>. &copy; AND, Navteq, Highways England, Ordnance Survey';
             } else {
-                copyrights = '&copy; 2016 <a href="https://www.bing.com/maps/">Microsoft</a>. &copy; AND, Navteq, Ordnance Survey';
+                copyrights = '&copy; ' + year + ' <a href="https://www.bing.com/maps/">Microsoft</a>. &copy; AND, Navteq, Ordnance Survey';
             }
         }
         this._updateAttribution(copyrights, logo);


### PR DESCRIPTION
Display the current year, rather than hard-coding a year, in the map copyright notices.

![image](https://user-images.githubusercontent.com/22996/81696756-442e2b80-945c-11ea-91dc-ccbce42a21bb.png)


Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1879

<!-- [skip changelog] -->