### PR TITLE
Include updates in failure summary report

### DIFF
--- a/bin/send-failure-summary
+++ b/bin/send-failure-summary
@@ -1,9 +1,8 @@
 #!/usr/bin/env perl
 
-# send-reports-failure-summary:
-# Prints a summary of report sending failures
+# send-failure-summary:
+# Prints a summary of report/update sending failures
 
-use strict;
 use warnings;
 use v5.14;
 
@@ -15,6 +14,12 @@ BEGIN {
 }
 
 use FixMyStreet::Script::Reports;
+use Open311::PostServiceRequestUpdates;
 
+# report summary
 my $manager = FixMyStreet::Script::Reports->new;
 $manager->end_summary_failures;
+
+# updates summary
+my $updates = Open311::PostServiceRequestUpdates->new;
+$updates->summary_failures;

--- a/conf/crontab-example
+++ b/conf/crontab-example
@@ -12,7 +12,7 @@ PATH=/usr/local/bin:/usr/bin:/bin
 
 # send-reports has three rows so that its 8am entry can be run with --verbose to send a morning summary of anything that's gone wrong
 */5 * * * * "$FMS/commonlib/bin/run-with-lockfile.sh" -n "$LOCK_DIR/send-reports.lock" "$FMS/bin/send-reports" || echo "stalled?"
-0 8 * * * "$FMS/bin/send-reports-failure-summary"
+0 8 * * * "$FMS/bin/send-failure-summary"
 
 2 * * * * "$FMS/commonlib/bin/run-with-lockfile.sh" -n "$LOCK_DIR/send-alerts.lock" "$FMS/bin/send-alerts" || echo "stalled?"
 22,52 * * * * "$FMS/commonlib/bin/run-with-lockfile.sh" -n "$LOCK_DIR/send-questionnaires.lock" "$FMS/bin/send-questionnaires" || echo "stalled?"

--- a/t/open311/post-service-request-updates.t
+++ b/t/open311/post-service-request-updates.t
@@ -1,12 +1,13 @@
 #!/usr/bin/env perl
 
 use FixMyStreet::TestMech;
+use Test::Output;
 
 my $mech = FixMyStreet::TestMech->new;
 
 use_ok( 'Open311::PostServiceRequestUpdates' );
 
-my $o = Open311::PostServiceRequestUpdates->new( site => 'fixmystreet.com' );
+my $o = Open311::PostServiceRequestUpdates->new;
 
 my $params = {
     send_method => 'Open311',
@@ -130,6 +131,7 @@ subtest 'Oxfordshire gets an ID' => sub {
     $o->send;
     $c2->discard_changes;
     is $c2->send_fail_count, 1, 'Oxfordshire update tried to send, failed';
+    stdout_like { $o->summary_failures } qr/The following updates failed sending/;
   };
 };
 


### PR DESCRIPTION
This will include details of failed updates along with reports.

We may want to change the name of the script to reflect this, `send-failure-summary`, perhaps.

[skip changelog]