### PR TITLE
reset asset select message by id when asset unselected

### DIFF
--- a/.cypress/cypress/integration/peterborough.js
+++ b/.cypress/cypress/integration/peterborough.js
@@ -31,4 +31,11 @@ describe('new report form', function() {
     cy.get('.js-hide-if-invalid-category').should('be.visible');
   });
 
+  it('correctly changes the asset select message', function() {
+    cy.get('select:eq(4)').select('Street lighting');
+    cy.get('.category_meta_message').should('contain', 'You can pick a street light from the map');
+    cy.get('select:eq(4)').select('Trees');
+    cy.get('.category_meta_message').should('contain', 'You can pick a tree from the map');
+  });
+
 });

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -100,12 +100,30 @@ if ($opt->test_fixtures) {
         { area_id => 2397, categories => [ 'Graffiti' ], name => 'Northampton Borough Council' },
         { area_id => 2483, categories => [ 'Potholes', 'Other' ], name => 'Hounslow Borough Council' },
         { area_id => 2636, categories => [ 'Potholes', 'Private', 'Extra' ], name => 'Isle of Wight Council' },
-        { area_id => 2566, categories => [ 'Fallen branch' ], name => 'Peterborough City Council' },
+        { area_id => 2566, categories => [ 'Fallen branch', 'Light Out', 'Light Dim', 'Fallen Tree', 'Damaged Tree' ], name => 'Peterborough City Council' },
         { area_id => 2498, categories => [ 'Incorrect timetable', 'Glass broken', 'Mobile Crane Operation' ], name => 'TfL' },
     ) {
         $bodies->{$_->{area_id}} = FixMyStreet::DB::Factory::Body->find_or_create($_);
         my $cats = join(', ', @{$_->{categories}});
         say "Created body $_->{name} for MapIt area ID $_->{area_id}, categories $cats";
+    }
+
+    for my $cat_name ('Fallen Tree', 'Damaged Tree') {
+        my $cat = FixMyStreet::DB->resultset('Contact')->find({
+            body => $bodies->{2566},
+            category => $cat_name,
+        });
+        $cat->set_extra_metadata( group => 'Trees' );
+        $cat->update;
+    }
+
+    for my $cat_name ('Light Out', 'Light Dim') {
+        my $cat = FixMyStreet::DB->resultset('Contact')->find({
+            body => $bodies->{2566},
+            category => $cat_name,
+        });
+        $cat->set_extra_metadata( group => 'Street lighting' );
+        $cat->update;
     }
 
     my $child_cat = FixMyStreet::DB->resultset("Contact")->find({

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -833,7 +833,19 @@ fixmystreet.assets = {
     named_select_action_not_found: function() {
         var message = this.fixmystreet.asset_item_message;
         message = message.replace('ITEM', this.fixmystreet.asset_item);
-        $('.category_meta_message').html(message);
+        if (this.fixmystreet.asset_group) {
+            var prefix = this.fixmystreet.asset_group.replace(/[^a-z]/gi, '');
+            var id = "category_meta_message_" + prefix;
+            var $p = $('#' + id);
+            $p.html(message);
+        } else {
+            $.each(this.fixmystreet.asset_category, function(i, c) {
+                var prefix = c.replace(/[^a-z]/gi, ''),
+                    id = "category_meta_message_" + prefix,
+                    $p = $('#' + id);
+                $p.html(message);
+            });
+        }
     },
 
     selectedFeature: function() {


### PR DESCRIPTION
Resetting using the class could cause an incorrect "you can pick an
$item from the map" message to be display when asset_groups were being
used. This was happening when the unselect event was firing after the
category change event and then updating the new message using the
message from the unselected layer.

Fixes mysociety/fixmystreet-commercial#1888

[skip changelog]