### PR TITLE
[Oxfordshire] Add instruct defect functionality back in

### DIFF
--- a/.cypress/cypress/integration/oxfordshire.js
+++ b/.cypress/cypress/integration/oxfordshire.js
@@ -1,0 +1,25 @@
+describe("Oxfordshire cobrand", function() {
+  it("allows inspectors to instruct defects", function() {
+    cy.server();
+    cy.request({
+      method: 'POST',
+      url: 'http://oxfordshire.localhost:3001/auth',
+      form: true,
+      body: { username: 'inspector-instructor@example.org', password_sign_in: 'password' }
+    });
+    cy.visit('http://oxfordshire.localhost:3001/report/1');
+    cy.contains('Oxfordshire');
+
+    cy.get('#report_inspect_form').should('be.visible');
+    cy.get('#js-inspect-action-scheduled').should('not.be.visible');
+    cy.get('#raise_defect_yes').should('not.have.attr', 'required');
+
+    cy.get('#report_inspect_form select[name=state]').select('Action scheduled');
+    cy.get('#js-inspect-action-scheduled').should('be.visible');
+    cy.get('#raise_defect_yes').should('have.attr', 'required', 'required');
+
+    cy.get('#report_inspect_form select[name=state]').select('No further action');
+    cy.get('#js-inspect-action-scheduled').should('not.be.visible');
+    cy.get('#raise_defect_yes').should('not.have.attr', 'required');
+  });
+});

--- a/bin/browser-tests
+++ b/bin/browser-tests
@@ -11,7 +11,19 @@ my ($cobrand, $coords, $area_id, $name, $mapit_url, $coverage);
 
 BEGIN {
     $config_file = 'conf/general.yml-example';
-    $cobrand = [ 'borsetshire', 'fixmystreet', 'northamptonshire', 'bathnes', 'buckinghamshire', 'hounslow', 'isleofwight', 'peterborough', 'tfl', 'hackney' ];
+    $cobrand = [qw(
+        bathnes
+        borsetshire
+        buckinghamshire
+        fixmystreet
+        hackney
+        hounslow
+        isleofwight
+        northamptonshire
+        oxfordshire
+        peterborough
+        tfl
+    )];
     $coords = '51.532851,-2.284277';
     $area_id = 2608;
     $name = 'Borsetshire';
@@ -190,7 +202,7 @@ browser-tests [running options] [fixture options] [cypress options]
    --help           this help message
 
  Fixture option:
-   --cobrand        Cobrand(s) to use, default is fixmystreet,northamptonshire,bathnes,buckinghamshire,isleofwight,peterborough,tfl,hackney
+   --cobrand        Cobrand(s) to use, default is fixmystreet,northamptonshire,bathnes,buckinghamshire,isleofwight,peterborough,tfl,hackney,oxfordshire
    --coords         Default co-ordinates for created reports
    --area_id        Area ID to use for created body
    --name           Name to use for created body

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -103,6 +103,7 @@ if ($opt->test_fixtures) {
         { area_id => 2636, categories => [ 'Potholes', 'Private', 'Extra' ], name => 'Isle of Wight Council' },
         { area_id => 2566, categories => [ 'Fallen branch', 'Light Out', 'Light Dim', 'Fallen Tree', 'Damaged Tree' ], name => 'Peterborough City Council' },
         { area_id => 2498, categories => [ 'Incorrect timetable', 'Glass broken', 'Mobile Crane Operation' ], name => 'TfL' },
+        { area_id => 2237, categories => [ 'Flytipping', 'Roads', 'Parks' ], name => 'Oxfordshire County Council' },
     ) {
         $bodies->{$_->{area_id}} = FixMyStreet::DB::Factory::Body->find_or_create($_);
         my $cats = join(', ', @{$_->{categories}});
@@ -279,6 +280,7 @@ $priority->add_to_contacts($body->contacts->first);
 say "Created users, all with password 'password':";
 my %users;
 my $perms_inspector = ['report_inspect', 'planned_reports'];
+my $perms_inspector_with_instruct = [@$perms_inspector, 'report_instruct'];
 my $perms_cs = [
     'contribute_as_body', 'contribute_as_another_user',
     'moderate', 'view_body_contribute_details',
@@ -290,6 +292,7 @@ my $perms_cs_full = [
 ];
 foreach (
     { name => 'Inspector Gadget', email => 'inspector@example.org', email_verified => 1, body => $body, permissions => $perms_inspector },
+    { name => 'Inspector Instructor', email => 'inspector-instructor@example.org', email_verified => 1, body => $body, permissions => $perms_inspector_with_instruct },
     { name => 'Harriet Helpful', email_verified => 1, email => 'cs@example.org', body => $body, permissions => $perms_cs },
     { name => 'Andrew Agreeable', email_verified => 1, email => 'cs_full@example.org', body => $body, permissions => $perms_cs_full },
     { name => 'Super User', email_verified => 1, email => 'super@example.org', body => $body, permissions => [

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -466,7 +466,7 @@ sub inspect : Private {
                 }
             }
 
-            if ( $c->get_param('include_update') ) {
+            if ( $c->get_param('include_update') or $c->get_param('raise_defect') ) {
                 $update_text = Utils::cleanup_text( $c->get_param('public_update'), { allow_multiline => 1 } );
                 if (!$update_text) {
                     $valid = 0;
@@ -510,6 +510,14 @@ sub inspect : Private {
                     lang         => $problem->lang,
                 };
                 $c->user->create_alert($problem->id, $options);
+            }
+
+            # If the state has been changed to action scheduled and they've said
+            # they want to raise a defect, consider the report to be inspected.
+            if ($problem->state eq 'action scheduled' && $c->get_param('raise_defect') && !$problem->get_extra_metadata('inspected')) {
+                $update_params{extra} = { 'defect_raised' => 1 };
+                $problem->set_extra_metadata( inspected => 1 );
+                $c->forward( '/admin/log_edit', [ $problem->id, 'problem', 'inspected' ] );
             }
         }
 

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -232,6 +232,11 @@ sub open311_pre_send {
     }
 }
 
+sub open311_pre_send_updates {
+    my ($self, $row) = @_;
+    return $self->open311_pre_send($row);
+}
+
 sub open311_munge_update_params {
     my ($self, $params, $comment, $body) = @_;
     delete $params->{update_id};

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -147,6 +147,11 @@ sub open311_pre_send {
         my $text = $row->detail . "\n\nAsset Id: $fid\n";
         $row->detail($text);
     }
+
+    if (my $usrn = $row->get_extra_field_value('usrn')) {
+        my $text = $row->detail . "\n\nUSRN: $usrn\n";
+        $row->detail($text);
+    }
 }
 
 sub open311_post_send {

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -138,6 +138,23 @@ sub open311_config_updates {
     $params->{use_customer_reference} = 1;
 }
 
+sub open311_pre_send {
+    my ($self, $row, $open311) = @_;
+
+    $self->{ox_original_detail} = $row->detail;
+
+    if (my $fid = $row->get_extra_field_value('feature_id')) {
+        my $text = $row->detail . "\n\nAsset Id: $fid\n";
+        $row->detail($text);
+    }
+}
+
+sub open311_post_send {
+    my ($self, $row, $h, $contact) = @_;
+
+    $row->detail($self->{ox_original_detail});
+}
+
 sub should_skip_sending_update {
     my ($self, $update ) = @_;
 

--- a/perllib/Open311/PostServiceRequestUpdates.pm
+++ b/perllib/Open311/PostServiceRequestUpdates.pm
@@ -126,7 +126,7 @@ sub process_update {
 
     my $o = $self->construct_open311($body, $comment);
 
-    $cobrand->call_hook(open311_pre_send => $comment, $o);
+    $cobrand->call_hook(open311_pre_send_updates => $comment);
 
     my $id = $o->post_service_request_update( $comment );
 

--- a/t/app/controller/report_inspect.t
+++ b/t/app/controller/report_inspect.t
@@ -233,7 +233,7 @@ FixMyStreet::override_config {
         $user->update;
     };
 
-    subtest "test update is required when instructing" => sub {
+    subtest "test public update is required if include_update is checked" => sub {
         $report->update;
         $report->comments->delete_all;
         $mech->get_ok("/report/$report_id");
@@ -869,6 +869,41 @@ FixMyStreet::override_config {
         $mech->content_lacks('shortlist');
         $contact2->unset_extra_metadata('assigned_users_only');
         $contact2->update;
+    };
+
+    subtest 'instruct defect' => sub {
+        $user->user_body_permissions->create({ body => $oxon, permission_type => 'report_instruct' });
+        $mech->get_ok("/report/$report2_id");
+        $mech->submit_form_ok({ button => 'save', with_fields => {
+            public_update => "This is a public update.", include_update => "1",
+            state => 'action scheduled', raise_defect => 1,
+        } });
+        $report2->discard_changes;
+        is $report2->get_extra_metadata('inspected'), 1, 'report marked as inspected';
+        $mech->get_ok("/report/$report2_id");
+        my $meta = $mech->extract_update_metas;
+        like $meta->[0], qr/State changed to: Action scheduled/, 'First update mentions action scheduled';
+        like $meta->[1], qr/Posted by .*defect raised/, 'Update mentions defect raised';
+        my $log_entry = $report2->inspection_log_entry;
+        is $log_entry->object_id, $report2_id, 'Log entry has correct ID';
+        is $log_entry->object_type, 'problem', 'Log entry has correct type';
+        is $log_entry->action, 'inspected', 'Log entry has correct action';
+    };
+
+    subtest "test update is required when instructing defect" => sub {
+        $report2->unset_extra_metadata('inspected');
+        $report2->update;
+        $report2->inspection_log_entry->delete;
+        $report2->comments->delete_all;
+        $mech->get_ok("/report/$report2_id");
+        $mech->submit_form_ok({ button => 'save', with_fields => {
+            public_update => "", include_update => "0",
+            state => 'action scheduled', raise_defect => 1,
+        } });
+        is_deeply $mech->page_errors, [ "Please provide a public update for this report." ], 'errors match';
+        $report2->discard_changes;
+        is $report2->comments->count, 0, "Update wasn't created";
+        is $report2->get_extra_metadata('inspected'), undef, 'report not marked as inspected';
     };
 };
 

--- a/t/cobrand/oxfordshire.t
+++ b/t/cobrand/oxfordshire.t
@@ -141,33 +141,47 @@ FixMyStreet::override_config {
     my $contact = $mech->create_contact_ok( body_id => $oxon->id, category => 'Gullies and Catchpits', email => 'GC' );
     $contact->set_extra_fields( (
         { code => 'feature_id', datatype => 'hidden', variable => 'true' },
+        { code => 'usrn', datatype => 'hidden', variable => 'true' },
     ) );
     $contact->update;
     FixMyStreet::Script::Reports::send(); # Make sure no waiting reports
 
-    subtest 'Check special Open311 request handling', sub {
-        my ($p) = $mech->create_problems_for_body( 1, $oxon->id, 'Test', {
-            cobrand => 'oxfordshire',
-            category => 'Gullies and Catchpits',
-            user => $user,
-            latitude => 51.754926,
-            longitude => -1.256179,
-        });
-        $p->set_extra_fields({ name => 'feature_id', value => 9875432});
-        $p->update;
+    for my $test (
+        {
+            field => 'usrn',
+            value => '12345',
+            text => 'USRN',
+        },
+        {
+            field => 'feature_id',
+            value => '12345',
+            text => 'Asset Id',
+        },
+    ) {
+        subtest 'Check special Open311 request handling of ' . $test->{text}, sub {
+            my ($p) = $mech->create_problems_for_body( 1, $oxon->id, 'Test', {
+                cobrand => 'oxfordshire',
+                category => 'Gullies and Catchpits',
+                user => $user,
+                latitude => 51.754926,
+                longitude => -1.256179,
+            });
+            $p->set_extra_fields({ name => $test->{field}, value => $test->{value}});
+            $p->update;
 
-        my $test_data = FixMyStreet::Script::Reports::send();
+            my $test_data = FixMyStreet::Script::Reports::send();
 
-        $p->discard_changes;
-        ok $p->whensent, 'Report marked as sent';
-        is $p->send_method_used, 'Open311', 'Report sent via Open311';
-        is $p->external_id, 248, 'Report has right external ID';
-        unlike $p->detail, qr/Asset Id:/, 'asset id not saved to report detail';
+            $p->discard_changes;
+            ok $p->whensent, 'Report marked as sent';
+            is $p->send_method_used, 'Open311', 'Report sent via Open311';
+            is $p->external_id, 248, 'Report has right external ID';
+            unlike $p->detail, qr/$test->{text}:/, $test->{text} . ' not saved to report detail';
 
-        my $req = $test_data->{test_req_used};
-        my $c = CGI::Simple->new($req->content);
-        like $c->param('description'), qr/Asset Id: 9875432/, 'asset id included in body';
-    };
+            my $req = $test_data->{test_req_used};
+            my $c = CGI::Simple->new($req->content);
+            like $c->param('description'), qr/$test->{text}: $test->{value}/, $test->{text} . ' included in body';
+        };
+    }
 
 };
 

--- a/templates/email/oxfordshire/submit.html
+++ b/templates/email/oxfordshire/submit.html
@@ -1,0 +1,77 @@
+[%
+
+PROCESS '_email_settings.html';
+
+email_summary = "A new problem in your area has been reported by a " _ site_name _ " user.";
+email_footer = PROCESS '_submit_footer.html';
+email_columns = 2;
+
+INCLUDE '_email_top.html';
+
+%]
+
+<th style="[% td_style %][% primary_column_style %]" id="primary_column">
+  [% start_padded_box | safe %]
+  <h1 style="[% h1_style %]">New problem in your&nbsp;area</h1>
+  <p style="[% p_style %]">[% missing %][% multiple %]A user of [% site_name %] has submitted the following report
+of a local problem that they believe might require your attention.</p>
+
+  <p style="margin: 20px auto; text-align: center">
+    <a style="[% button_style %]" href="[% url %]">Show full report</a>
+  </p>
+  <h2 style="[% h2_style %] margin: 30px 0 10px 0">Reported by:</h2>
+  <table [% table_reset | safe %]>
+    <tr>
+      <th style="[% contact_th_style %]">Name</th>
+      <td style="[% contact_td_style %]">[% report.name | html %]</td>
+    </tr>
+    <tr>
+      <th style="[% contact_th_style %]">Email</th>
+      <td style="[% contact_td_style %]">
+        [%~ IF report.user.email ~%]
+          <a href="mailto:[% report.user.email | html %]">[% report.user.email | html %]</a>
+        [%~ ELSE ~%]
+          <strong>No email address provided, only phone number</strong>
+        [%~ END ~%]
+      </td>
+    </tr>
+    [%~ IF report.user.phone %]
+      <tr>
+        <th style="[% contact_th_style %]">Phone</th>
+        <td style="[% contact_td_style %]"><a href="tel:[% report.user.phone | html %]">[% report.user.phone | html %]</a></td>
+      </tr>
+    [%~ END %]
+  </table>
+  <p style="[% p_style %] margin-top: 0.5em;">Replies to this message will go directly to [% report.name | html %], the user who reported the problem.</p>
+  [% end_padded_box | safe %]
+</th>
+[% WRAPPER '_email_sidebar.html' object = report %]
+    <h2 style="[% h2_style %]">[% report.title | html %]</h2>
+    <p style="[% secondary_p_style %]"><strong>Category:</strong> [% report.category | html %]</p>
+    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [%~ IF additional_information %]
+    <p style="[% secondary_p_style %]">[% additional_information %]</p>
+    [%~ END %]
+    <p style="[% secondary_p_style %]">
+      <strong>Location:</strong>
+      <br>Easting/Northing
+      [%~ " (IE)" IF coordsyst == "I" ~%]
+      : [% easting %]/[% northing %]
+      (<a href="[% osm_url %]" title="View OpenStreetMap of this location">
+        [%~ report.latitude %], [% report.longitude ~%]
+      </a>)
+      [% IF closest_address %]<br>[% closest_address | trim | replace("\n\n", "<br>") %][% END %]
+    </p>
+    [% IF report.get_extra_field_value('feature_id') %]
+    <p style="[% secondary_p_style %]">
+        <strong>Asset id:</strong> [% report.get_extra_field_value('feature_id') %]
+    </p>
+    [% END %]
+    [% IF report.get_extra_field_value('column_no') %]
+    <p style="[% secondary_p_style %]">
+        <strong>Column Number:</strong> [% report.get_extra_field_value('column_no') %]
+    </p>
+    [% END %]
+[% END %]
+
+[% INCLUDE '_email_bottom.html' %]

--- a/templates/email/oxfordshire/submit.txt
+++ b/templates/email/oxfordshire/submit.txt
@@ -1,0 +1,52 @@
+Subject: Problem Report: [% report.title %]
+
+Dear [% bodies_name %],
+
+[% missing %][% multiple %]A user of
+[% site_name %] has submitted the following report
+of a local problem that they believe might require your attention.
+
+[% fuzzy %], or to provide an update on the problem,
+please visit the following link:
+
+    [% url %]
+
+[% has_photo %]----------
+
+Name: [% report.name %]
+
+Email: [% report.user.email OR 'None provided' %]
+
+Phone: [% report.user.phone OR 'None provided' %]
+
+Category: [% report.category %]
+
+Subject: [% report.title %]
+
+Details: [% report.detail %]
+
+[% additional_information %]
+
+[%- IF report.get_extra_field_value('feature_id') %]
+Asset id: [% report.get_extra_field_value('feature_id') %]
+[%- END %]
+
+[%- IF report.get_extra_field_value('column_no') %]
+Column number: [% report.get_extra_field_value('column_no') %]
+[%- END %]
+
+Easting/Northing
+[%- " (IE)" IF coordsyst == "I" -%]
+: [% easting %]/[% northing %]
+
+Latitude: [% report.latitude %]
+
+Longitude: [% report.longitude %]
+
+View OpenStreetMap of this location: [% osm_url %]
+
+[% closest_address %]----------
+
+Replies to this email will go to the user who submitted the problem.
+
+[% signature %]

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -34,6 +34,7 @@
             <label for="state">[% loc('State') %]</label>
             [% INCLUDE 'report/inspect/state_groups_select.html' %]
           </p>
+          [% TRY %][% INCLUDE 'report/inspect/_raise_defect.html' %][% CATCH file %][% END %]
           <div id="js-duplicate-reports" class="[% "hidden" UNLESS problem.duplicate_of %]">
             <input type="hidden" name="duplicate_of" value="[% problem.duplicate_of.id %]">
             <p class="[% "hidden" UNLESS problem.duplicate_of %]"><strong>[% loc('Duplicate of') %]</strong></p>
@@ -69,6 +70,8 @@
         [% IF permissions.report_inspect %]
           [% INCLUDE 'report/inspect/public_update.html' %]
         [% END %]
+
+        [% TRY %][% INCLUDE 'report/inspect/_inspected.html' %][% CATCH file %][% END %]
 
         <p>
           <input type="hidden" name="token" value="[% csrf_token %]" />

--- a/templates/web/oxfordshire/footer_extra_js.html
+++ b/templates/web/oxfordshire/footer_extra_js.html
@@ -1,1 +1,1 @@
-[% PROCESS 'footer_extra_js_base.html' highways=1 validation=1 roadworks=1 %]
+[% PROCESS 'footer_extra_js_base.html' highways=1 validation=1 roadworks=1 cobrand_js=1 %]

--- a/templates/web/oxfordshire/report/inspect/_inspected.html
+++ b/templates/web/oxfordshire/report/inspect/_inspected.html
@@ -1,0 +1,7 @@
+[% IF problem.get_extra_metadata('inspected') %]
+[% IF problem.whensent %]
+  <p>[% loc("<strong>Note:</strong> This report has been sent onwards for action. Any changes made won't be passed on.") %]</p>
+[% ELSE %]
+  <p>[% loc("<strong>Note:</strong> This report hasn't yet been sent onwards for action. Any changes made may not be passed on.") %]</p>
+[% END %]
+[% END %]

--- a/templates/web/oxfordshire/report/inspect/_raise_defect.html
+++ b/templates/web/oxfordshire/report/inspect/_raise_defect.html
@@ -1,0 +1,11 @@
+[% IF permissions.report_instruct AND NOT problem.get_extra_metadata('inspected') %]
+<div id="js-inspect-action-scheduled" class="[% "hidden" UNLESS problem.state == 'action scheduled' %]">
+  <p>[% loc('Do you want to automatically raise a defect?') %]</p>
+  <p class="segmented-control segmented-control--radio">
+      <input type="radio" name="raise_defect" id="raise_defect_yes" value="1">
+      <label class="btn" for="raise_defect_yes">[% loc('Yes') %]</label>
+      <input type="radio" name="raise_defect" id="raise_defect_no" value="0">
+      <label class="btn" for="raise_defect_no">[% loc('No') %]</label>
+  </p>
+</div>
+[% END %]

--- a/templates/web/oxfordshire/report/new/roads_message.html
+++ b/templates/web/oxfordshire/report/new/roads_message.html
@@ -1,0 +1,7 @@
+<div id="js-roads-responsibility" class="box-warning hidden">
+    <div id="js-not-a-road" class="hidden js-responsibility-message">
+        <p>This area is not under the responsibility of Oxfordshire
+        County Council and therefore we are unable to accept reports in
+        this area / street.</p>
+    </div>
+</div>

--- a/templates/web/oxfordshire/report/new/roads_message.html
+++ b/templates/web/oxfordshire/report/new/roads_message.html
@@ -4,4 +4,10 @@
         County Council and therefore we are unable to accept reports in
         this area / street.</p>
     </div>
+    <div id="js-not-local-authority-asset" class="hidden js-responsibility-message">
+        <p>This item is not maintained by Oxfordshire
+            County Council and therefore we are unable to accept reports about it. Please
+            Contact your Parish or District Council.
+        </p>
+    </div>
 </div>

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -549,15 +549,7 @@ function get_asset_stylemap() {
     return new OpenLayers.StyleMap({
         'default': fixmystreet.assets.style_default,
         'select': fixmystreet.assets.style_default_select,
-        'hover': new OpenLayers.Style({
-            fillColor: "#55BB00",
-            fillOpacity: 0.8,
-            strokeColor: "#000000",
-            strokeOpacity: 1,
-            strokeWidth: 2,
-            pointRadius: 8,
-            cursor: 'pointer'
-        })
+        'hover': fixmystreet.assets.style_default_hover
     });
 }
 
@@ -822,6 +814,16 @@ fixmystreet.assets = {
         strokeOpacity: 0.8,
         strokeWidth: 2,
         pointRadius: 6
+    }),
+
+    style_default_hover: new OpenLayers.Style({
+        fillColor: "#55BB00",
+        fillOpacity: 0.8,
+        strokeColor: "#000000",
+        strokeOpacity: 1,
+        strokeWidth: 2,
+        pointRadius: 8,
+        cursor: 'pointer'
     }),
 
     style_default_select: new OpenLayers.Style({

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -1,4 +1,16 @@
 fixmystreet.staff_set_up = {
+  action_scheduled_raise_defect: function() {
+    $("#report_inspect_form").find('[name=state]').on('change', function() {
+        if ($(this).val() !== "action scheduled") {
+            $("#js-inspect-action-scheduled").addClass("hidden");
+            $('#raise_defect_yes').prop('required', false);
+        } else {
+            $("#js-inspect-action-scheduled").removeClass("hidden");
+            $('#raise_defect_yes').prop('required', true);
+        }
+    });
+  },
+
   list_item_actions: function() {
     $('#js-reports-list').on('click', ':submit', function(e) {
       e.preventDefault();
@@ -379,6 +391,7 @@ $(fixmystreet).on('display:report', function() {
     fixmystreet.staff_set_up.response_templates();
     if ($("#report_inspect_form").length) {
         fixmystreet.staff_set_up.report_page_inspect();
+        fixmystreet.staff_set_up.action_scheduled_raise_defect();
     }
 });
 

--- a/web/cobrands/oxfordshire/assets.js
+++ b/web/cobrands/oxfordshire/assets.js
@@ -151,4 +151,35 @@ fixmystreet.assets.add(defaults, {
     asset_item: 'grit bin'
 });
 
+var highways_style = new OpenLayers.Style({
+    fill: false,
+    strokeColor: "#5555FF",
+    strokeOpacity: 0.1,
+    strokeWidth: 7
+});
+
+fixmystreet.assets.add(defaults, {
+    stylemap: new OpenLayers.StyleMap({
+        'default': highways_style
+    }),
+    wfs_url: proxy_base_url + 'nsg/',
+    wfs_feature: "WFS_LIST_OF_STREETS",
+    srsName: "EPSG:27700",
+    geometryName: null,
+    usrn: {
+        attribute: 'USRN',
+        field: 'usrn'
+    },
+    non_interactive: true,
+    road: true,
+    no_asset_msg_id: '#js-not-a-road',
+    asset_item: 'road',
+    asset_type: 'road',
+    actions: {
+        found: fixmystreet.message_controller.road_found,
+        not_found: fixmystreet.message_controller.road_not_found
+    },
+    asset_category: ["Carriageway Defect", "Pavements", "Pothole"],
+});
+
 })();

--- a/web/cobrands/oxfordshire/assets.js
+++ b/web/cobrands/oxfordshire/assets.js
@@ -1,0 +1,154 @@
+(function(){
+
+if (!fixmystreet.maps) {
+    return;
+}
+
+var wfs_host = fixmystreet.staging ? 'tilma.staging.mysociety.org' : 'tilma.mysociety.org';
+var tilma_url = "https://" + wfs_host + "/mapserver/oxfordshire";
+var proxy_base_url = "https://" + wfs_host + "/proxy/occ/";
+
+var defaults = {
+    wfs_url: tilma_url,
+    asset_type: 'spot',
+    max_resolution: 4.777314267158508,
+    geometryName: 'msGeometry',
+    srsName: "EPSG:3857",
+    body: "Oxfordshire County Council",
+    strategy_class: OpenLayers.Strategy.FixMyStreet
+};
+
+var occ_default = $.extend({}, fixmystreet.assets.style_default.defaultStyle, {
+    fillColor: "#007258"
+});
+
+var occ_hover = new OpenLayers.Style({
+    pointRadius: 8,
+    cursor: 'pointer'
+});
+
+var occ_stylemap = new OpenLayers.StyleMap({
+    'default': occ_default,
+    'select': fixmystreet.assets.style_default_select,
+    'hover': occ_hover
+});
+
+fixmystreet.assets.add(defaults, {
+    stylemap: occ_stylemap,
+    wfs_feature: "Trees",
+    asset_id_field: 'Ref',
+    attributes: {
+        feature_id: 'Ref'
+    },
+    asset_category: ["Trees"],
+    asset_item: 'tree'
+});
+
+fixmystreet.assets.add(defaults, {
+    stylemap: occ_stylemap,
+    wfs_feature: "Traffic_Lights",
+    asset_id_field: 'Site',
+    attributes: {
+        feature_id: 'Site'
+    },
+    asset_category: ["Traffic Lights (permanent only)"],
+    asset_item: 'traffic light'
+});
+
+var streetlight_select = $.extend({
+    label: "${UNITNO}",
+    fontColor: "#FFD800",
+    labelOutlineColor: "black",
+    labelOutlineWidth: 3,
+    labelYOffset: 69,
+    fontSize: '18px',
+    fontWeight: 'bold'
+}, fixmystreet.assets.style_default_select.defaultStyle);
+
+var streetlight_stylemap = new OpenLayers.StyleMap({
+  'default': occ_default,
+  'select': new OpenLayers.Style(streetlight_select),
+  'hover': occ_hover
+});
+
+fixmystreet.assets.add(defaults, {
+    select_action: true,
+    stylemap: streetlight_stylemap,
+    wfs_feature: "Street_Lights",
+    asset_id_field: 'OBJECTID',
+    attributes: {
+        feature_id: 'OBJECTID',
+        column_no: 'UNITNO'
+    },
+    asset_category: ["Street lighting"],
+    asset_item: 'street light',
+    actions: {
+        asset_found: function(asset) {
+          var id = asset.attributes.UNITNO || '';
+          if (id !== '') {
+              $('.category_meta_message').html('You have selected ' + this.fixmystreet.asset_item + ' <b>' + id + '</b>');
+          } else {
+              $('.category_meta_message').html('You can pick a <b class="asset-spot">' + this.fixmystreet.asset_item + '</b> from the map &raquo;');
+          }
+        },
+        asset_not_found: function() {
+           $('.category_meta_message').html('You can pick a <b class="asset-spot">' + this.fixmystreet.asset_item + '</b> from the map &raquo;');
+        }
+    }
+});
+
+fixmystreet.assets.add(defaults, {
+    stylemap: occ_stylemap,
+    // have to do this by hand rather than using wfs_* options
+    // as the server does not like being POSTed xml with application/xml
+    // as the Content-Type which is what using those options results in.
+    http_options: {
+        headers: {
+            'Content-Type': 'text/plain'
+        },
+        url: proxy_base_url + 'drains/wfs',
+        params: {
+            SERVICE: "WFS",
+            VERSION: "1.1.0",
+            REQUEST: "GetFeature",
+            SRSNAME: "urn:ogc:def:crs:EPSG::27700",
+            TYPENAME: "junctions"
+        }
+    },
+    srsName: "EPSG:27700",
+    asset_id_field: 'id',
+    attributes: {
+        feature_id: 'id'
+    },
+    asset_category: ["Gully and Catchpits"],
+    asset_item: 'drain'
+});
+
+fixmystreet.assets.add(defaults, {
+    stylemap: occ_stylemap,
+    // have to do this by hand rather than using wfs_* options
+    // as the server does not like being POSTed xml with application/xml
+    // as the Content-Type which is what using those options results in.
+    http_options: {
+        headers: {
+            'Content-Type': 'text/plain',
+        },
+        url: proxy_base_url + 'grit/wfs',
+        params: {
+            SERVICE: "WFS",
+            VERSION: "1.1.0",
+            REQUEST: "GetFeature",
+            SRSNAME: "urn:ogc:def:crs:EPSG::27700",
+            TYPENAME: "Gritbins"
+        }
+    },
+    srsName: "EPSG:27700",
+    asset_id_field: 'id',
+    attributes: {
+        feature_id: 'id'
+    },
+    asset_category: ["Ice/Snow"],
+    asset_item: 'grit bin'
+});
+
+})();

--- a/web/cobrands/oxfordshire/base.scss
+++ b/web/cobrands/oxfordshire/base.scss
@@ -279,6 +279,10 @@ textarea {
     color: $color-oxfordshire-link-blue;
 }
 
+.asset-spot:before {
+    background-color: #007258;
+}
+
 @media print {
     body {
         background-color: #fff !important;


### PR DESCRIPTION
In the past Oxfordshire had a way for inspectors to "instruct a defect", which generated a CSV which got emailed to Oxfordshire with a list of defects.

They now want to bring this functionality back, but instead of emailing a CSV they want it to call an API.

As a first step towards that goal, this adds back some of the instruct defect functionality that was removed in 68e18ff.

Part of https://github.com/mysociety/fixmystreet-commercial/issues/1846

<!-- [skip changelog] -->

![image](https://user-images.githubusercontent.com/22996/82075735-9e392600-96d4-11ea-91f5-377690810fe1.png)

