### PR TITLE
Fix update-schema constraint check on Postgres 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Unreleased
     - Bugfixes:
         - Fix issue with dashboard report CSV export. #3026
+        - bin/update-schema PostgreSQL 12 compatibility. #3043
     - Admin improvements:
         - Display user name/email for contributed as reports. #2990
         - Interface for enabling anonymous reports for certain categories. #2989

--- a/bin/update-schema
+++ b/bin/update-schema
@@ -319,7 +319,7 @@ sub constraint_exists {
 # Returns true if a check constraint contains a certain string
 sub constraint_contains {
     my ( $constraint, $check ) = @_;
-    my ($consrc) = $db->dbh->selectrow_array('select consrc from pg_constraint where conname = ?', {}, $constraint);
+    my ($consrc) = $db->dbh->selectrow_array('select pg_get_expr(conbin, conrelid) from pg_constraint where conname = ?', {}, $constraint);
     return unless $consrc;
     return $consrc =~ /$check/;
 }


### PR DESCRIPTION
`pg_constraint.consrc` has [been removed in Postgres 12](https://www.postgresql.org/docs/12/release-12.html), and this is the recommended replacement.
 