### PR TITLE
Mark user as active when sent an email alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Releases
 
 * Unreleased
+    - Changes:
+        - Mark user as active when sent an email alert.
     - Bugfixes:
         - Fix issue with dashboard report CSV export. #3026
         - bin/update-schema PostgreSQL 12 compatibility. #3043

--- a/perllib/FixMyStreet/App/Controller/Report/Update.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/Update.pm
@@ -484,6 +484,13 @@ sub save_update : Private {
         $update->confirm();
     } elsif ($c->stash->{contributing_as_anonymous_user}) {
         $update->set_extra_metadata( contributed_as => 'anonymous_user' );
+        if ( $c->user_exists && $c->user->from_body ) {
+            # If a staff user has clicked the 'report anonymously' button then
+            # there would be no record of who that staff member was as we've
+            # used the cobrand's anonymous_account for the report. In this case
+            # record the staff user ID in the report metadata.
+            $update->set_extra_metadata( contributed_by => $c->user->id );
+        }
         $update->confirm();
     } elsif ( !$update->user->in_storage ) {
         # User does not exist.

--- a/perllib/FixMyStreet/Script/Alerts.pm
+++ b/perllib/FixMyStreet/Script/Alerts.pm
@@ -307,6 +307,10 @@ sub _send_aggregated_alert_email(%) {
     # Ignore phone-only users
     return unless $data{alert_user}->email_verified;
 
+    # Mark user as active as they're being sent an alert
+    $data{alert_user}->set_last_active;
+    $data{alert_user}->update;
+
     my $email = $data{alert_user}->email;
     my ($domain) = $email =~ m{ @ (.*) \z }x;
     return if $data{schema}->resultset('Abuse')->search( {

--- a/perllib/FixMyStreet/Script/Inactive.pm
+++ b/perllib/FixMyStreet/Script/Inactive.pm
@@ -158,8 +158,14 @@ sub delete_reports {
 sub anonymize_users {
     my $self = shift;
 
+    my $body_users = FixMyStreet::DB->resultset("Body")->search({
+        comment_user_id => { '!=' => undef },
+    }, {
+        columns => 'comment_user_id',
+    });
     my $users = FixMyStreet::DB->resultset("User")->search({
         last_active => { '<', interval($self->anonymize) },
+        id => { -not_in => $body_users->as_query },
         email => { -not_like => 'removed-%@' . FixMyStreet->config('EMAIL_DOMAIN') },
     });
 

--- a/t/app/controller/alert_new.t
+++ b/t/app/controller/alert_new.t
@@ -523,6 +523,8 @@ subtest "Test alerts are not sent for no-text updates" => sub {
     };
 
     $mech->email_count_is(1);
+    $user2->discard_changes;
+    isnt $user2->last_active, undef, 'Last active has been set';
 
     $mech->delete_user($user1);
     $mech->delete_user($user2);

--- a/templates/web/fixmystreet.com/about/privacy.html
+++ b/templates/web/fixmystreet.com/about/privacy.html
@@ -287,8 +287,10 @@ When you make a report
 </p>
 
 <p>
+    Personal details will automatically be removed from our database after two
+    years of inactivity of the associated account.
     Please <a href="/contact">contact us</a> if you would like your details to be removed from our admin
-    database.
+    database sooner than that.
 </p>
 
 <h3>
@@ -297,7 +299,7 @@ When you make a report
 
 <p>
     If you contact FixMyStreet via our support email address we keep your message for two
-    years at which point they will be automatically deleted.. This is to aid continuity
+    years at which point it will be automatically deleted. This is to aid continuity
     and so that we can view any historic context which may have bearing on subsequent
     support mail, even if members of the support staff change. Support staff adhere to
     internal privacy policies which may be viewed on request.


### PR DESCRIPTION
If a user is sent email alerts they've signed up for, but otherwise doesn't log in to the site, we probably don't want to delete their account as 'inactive'. We could/would send them the "about to be deleted" warning email, but that could be confusing because their account isn't "inactive", as dur, they're getting email alerts. (If an email alert bounces, they'll be unsubscribed and then not get emails and account will get deleted as normal.) So when an alert is sent, take that as activity on the user's account and update the last active time.

Also update .com privacy page to say that is what we are doing. Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1661