### PR TITLE
[UK] Remove Somerset West and Taunton special destination handling

### DIFF
--- a/perllib/FixMyStreet/SendReport/Email.pm
+++ b/perllib/FixMyStreet/SendReport/Email.pm
@@ -16,9 +16,6 @@ sub build_recipient_list {
 
         my ($body_email, $state, $note) = ( $contact->email, $contact->state, $contact->note );
 
-        $body_email = swandt_contact($row->latitude, $row->longitude)
-            if $body->name eq 'Somerset West and Taunton Council' && $body_email eq 'SPECIAL';
-
         unless ($state eq 'confirmed') {
             $all_confirmed = 0;
             $note = 'Body ' . $row->bodies_str . ' deleted'
@@ -126,23 +123,6 @@ sub email_list {
     my $list = shift;
     my @list = map { ref $_ ? $_->[0] : $_ } @$list;
     return \@list;
-}
-
-# SW&T has different contact addresses depending upon the old district
-sub swandt_contact {
-    my $district = _get_district_for_contact(@_);
-    my $email;
-    $email = ['customerservices', 'westsomerset'] if $district == 2427;
-    $email = ['enquiries', 'tauntondeane'] if $district == 2429;
-    return join('@', $email->[0], $email->[1] . '.gov.uk');
-}
-
-sub _get_district_for_contact {
-    my ( $lat, $lon ) = @_;
-    my $district =
-      FixMyStreet::MapIt::call( 'point', "4326/$lon,$lat", type => 'DIS', generation => 34 );
-    ($district) = keys %$district;
-    return $district;
 }
 
 1;

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -50,7 +50,6 @@ my @PLACES = (
     [ '?', 51.345714, -0.227959, 2457, 'Epsom and Ewell Borough Council', 'DIS' ],
     [ 'CW11 1HZ', 53.145324, -2.370437, 21069, 'Cheshire East Council', 'UTA', 135301, 'Sandbach Town', 'UTW' ],
     [ '?', 50.78301, -0.646929 ],
-    [ 'TA1 1QP', 51.023569, -3.099055, 2239, 'Somerset County Council', 'CTY', 2429, 'Taunton Deane Borough Council', 'DIS' ],
     [ 'GU51 4AE', 51.279456, -0.846216, 2333, 'Hart District Council', 'DIS', 2227, 'Hampshire County Council', 'CTY' ],
     [ 'WS1 4NH', 52.563074, -1.991032, 2535, 'Sandwell Borough Council', 'MTD' ],
     [ 'PO30 5XJ', 50.71086, -1.29573, 2636, 'Isle of Wight Council', 'UTA' ],

--- a/t/app/sendreport/email.t
+++ b/t/app/sendreport/email.t
@@ -20,8 +20,6 @@ my $contact = $mech->create_contact_ok(
 );
 
 my $row = FixMyStreet::DB->resultset('Problem')->new( {
-    latitude => 51.023569,
-    longitude => -3.099055,
     bodies_str => '1000',
     category => 'category',
     cobrand => '',
@@ -69,19 +67,5 @@ foreach my $test ( {
         }
     };
 }
-
-$body->update({ name => 'Somerset West and Taunton Council' });
-
-subtest 'Test special behaviour' => sub {
-    my $e = FixMyStreet::SendReport::Email->new;
-    $contact->update( { state => 'confirmed', email => 'SPECIAL' } );
-    $e->add_body( $body );
-    FixMyStreet::override_config {
-        MAPIT_URL => 'http://mapit.uk/'
-    }, sub {
-        my ($e) = $e->build_recipient_list( $row, {} );
-        like $e->[0], qr/tauntondeane/, 'correct recipient';
-    };
-};
 
 done_testing();


### PR DESCRIPTION
No longer required since we have a single email address for the council now.

[skip changelog]