### PR TITLE
[Bexley] Show report ID in report confirmation email

### DIFF
--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -42,6 +42,7 @@ my @PLACES = (
     [ 'BR1 3UH', 51.402096, 0.015784, 2482, 'Bromley Council', 'LBO' ],
     [ 'BR1 3EF', 51.4039, 0.018697, 2482, 'Bromley Council', 'LBO' ],
     [ '?', 51.466707, 0.181108, 2494, 'London Borough of Bexley', 'LBO' ],
+    [ 'DA6 7AT', 51.45556, 0.15356, 2494, 'London Borough of Bexley', 'LBO' ],
     [ 'NN1 1NS', 52.236251, -0.892052, 2234, 'Northamptonshire County Council', 'CTY', 2397, 'Northampton Borough Council', 'DIS' ],
     [ 'NN1 2NS', 52.238301, -0.889992, 2234, 'Northamptonshire County Council', 'CTY', 2397, 'Northampton Borough Council', 'DIS' ],
     [ '?', 52.238827, -0.894970, 2234, 'Northamptonshire County Council', 'CTY', 2397, 'Northampton Borough Council', 'DIS' ],

--- a/templates/email/bexley/_problem-confirm_extra.html
+++ b/templates/email/bexley/_problem-confirm_extra.html
@@ -1,0 +1,4 @@
+</p>
+<p style="[% p_style %]">
+  The report's reference number is <strong>[% report.id %]</strong>.
+  Please quote this if you need to contact us about this report.

--- a/templates/email/bexley/_problem-confirm_extra.txt
+++ b/templates/email/bexley/_problem-confirm_extra.txt
@@ -1,0 +1,2 @@
+  The report's reference number is [% report.id %].
+  Please quote this if you need to contact us about this report.


### PR DESCRIPTION
As requested by the client, this adds the report ID to the report confirmation email that is sent when an unregistered user creates a report.
<!-- [skip changelog] -->

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1892

![image](https://user-images.githubusercontent.com/22996/83501187-b1f7d100-a4b7-11ea-8b54-3a507b1bdaf9.png)
