### PR TITLE
[Open311] Do not remove any devolved contacts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - Fix issue with dashboard report CSV export. #3026
         - bin/update-schema PostgreSQL 12 compatibility. #3043
         - Make sure category shown in all its groups when reporting.
+        - Do not remove any devolved contacts.
     - Admin improvements:
         - Display user name/email for contributed as reports. #2990
         - Interface for enabling anonymous reports for certain categories. #2989

--- a/perllib/Open311/PopulateServiceList.pm
+++ b/perllib/Open311/PopulateServiceList.pm
@@ -350,10 +350,10 @@ sub _delete_contacts_not_in_service_list {
     );
 
     if ($self->_current_body->can_be_devolved) {
-        # If the body has can_be_devolved switched on, it's most likely a
-        # combination of Open311/email, so ignore any email addresses.
+        # If the body has can_be_devolved switched on, ignore any
+        # contact with its own send method
         $found_contacts = $found_contacts->search(
-            { email => { -not_like => '%@%' } }
+            { send_method => [ "", undef ] },
         );
     }
 


### PR DESCRIPTION
What I'll be doing on Bromley will have a devolved Open311 contact, and this script keeps deleting it as it only spots email addresses.