### PR TITLE
[Oxfordshire] display asset layers on map

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -232,6 +232,11 @@ sub open311_pre_send {
     }
 }
 
+sub open311_pre_send_updates {
+    my ($self, $row) = @_;
+    return $self->open311_pre_send($row);
+}
+
 sub open311_munge_update_params {
     my ($self, $params, $comment, $body) = @_;
     delete $params->{update_id};

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -147,6 +147,11 @@ sub open311_pre_send {
         my $text = $row->detail . "\n\nAsset Id: $fid\n";
         $row->detail($text);
     }
+
+    if (my $usrn = $row->get_extra_field_value('usrn')) {
+        my $text = $row->detail . "\n\nUSRN: $usrn\n";
+        $row->detail($text);
+    }
 }
 
 sub open311_post_send {

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -138,6 +138,23 @@ sub open311_config_updates {
     $params->{use_customer_reference} = 1;
 }
 
+sub open311_pre_send {
+    my ($self, $row, $open311) = @_;
+
+    $self->{ox_original_detail} = $row->detail;
+
+    if (my $fid = $row->get_extra_field_value('feature_id')) {
+        my $text = $row->detail . "\n\nAsset Id: $fid\n";
+        $row->detail($text);
+    }
+}
+
+sub open311_post_send {
+    my ($self, $row, $h, $contact) = @_;
+
+    $row->detail($self->{ox_original_detail});
+}
+
 sub should_skip_sending_update {
     my ($self, $update ) = @_;
 

--- a/perllib/Open311/PostServiceRequestUpdates.pm
+++ b/perllib/Open311/PostServiceRequestUpdates.pm
@@ -126,7 +126,7 @@ sub process_update {
 
     my $o = $self->construct_open311($body, $comment);
 
-    $cobrand->call_hook(open311_pre_send => $comment, $o);
+    $cobrand->call_hook(open311_pre_send_updates => $comment);
 
     my $id = $o->post_service_request_update( $comment );
 

--- a/t/cobrand/oxfordshire.t
+++ b/t/cobrand/oxfordshire.t
@@ -141,33 +141,47 @@ FixMyStreet::override_config {
     my $contact = $mech->create_contact_ok( body_id => $oxon->id, category => 'Gullies and Catchpits', email => 'GC' );
     $contact->set_extra_fields( (
         { code => 'feature_id', datatype => 'hidden', variable => 'true' },
+        { code => 'usrn', datatype => 'hidden', variable => 'true' },
     ) );
     $contact->update;
     FixMyStreet::Script::Reports::send(); # Make sure no waiting reports
 
-    subtest 'Check special Open311 request handling', sub {
-        my ($p) = $mech->create_problems_for_body( 1, $oxon->id, 'Test', {
-            cobrand => 'oxfordshire',
-            category => 'Gullies and Catchpits',
-            user => $user,
-            latitude => 51.754926,
-            longitude => -1.256179,
-        });
-        $p->set_extra_fields({ name => 'feature_id', value => 9875432});
-        $p->update;
+    for my $test (
+        {
+            field => 'usrn',
+            value => '12345',
+            text => 'USRN',
+        },
+        {
+            field => 'feature_id',
+            value => '12345',
+            text => 'Asset Id',
+        },
+    ) {
+        subtest 'Check special Open311 request handling of ' . $test->{text}, sub {
+            my ($p) = $mech->create_problems_for_body( 1, $oxon->id, 'Test', {
+                cobrand => 'oxfordshire',
+                category => 'Gullies and Catchpits',
+                user => $user,
+                latitude => 51.754926,
+                longitude => -1.256179,
+            });
+            $p->set_extra_fields({ name => $test->{field}, value => $test->{value}});
+            $p->update;
 
-        my $test_data = FixMyStreet::Script::Reports::send();
+            my $test_data = FixMyStreet::Script::Reports::send();
 
-        $p->discard_changes;
-        ok $p->whensent, 'Report marked as sent';
-        is $p->send_method_used, 'Open311', 'Report sent via Open311';
-        is $p->external_id, 248, 'Report has right external ID';
-        unlike $p->detail, qr/Asset Id:/, 'asset id not saved to report detail';
+            $p->discard_changes;
+            ok $p->whensent, 'Report marked as sent';
+            is $p->send_method_used, 'Open311', 'Report sent via Open311';
+            is $p->external_id, 248, 'Report has right external ID';
+            unlike $p->detail, qr/$test->{text}:/, $test->{text} . ' not saved to report detail';
 
-        my $req = $test_data->{test_req_used};
-        my $c = CGI::Simple->new($req->content);
-        like $c->param('description'), qr/Asset Id: 9875432/, 'asset id included in body';
-    };
+            my $req = $test_data->{test_req_used};
+            my $c = CGI::Simple->new($req->content);
+            like $c->param('description'), qr/$test->{text}: $test->{value}/, $test->{text} . ' included in body';
+        };
+    }
 
 };
 

--- a/templates/email/oxfordshire/submit.html
+++ b/templates/email/oxfordshire/submit.html
@@ -1,0 +1,77 @@
+[%
+
+PROCESS '_email_settings.html';
+
+email_summary = "A new problem in your area has been reported by a " _ site_name _ " user.";
+email_footer = PROCESS '_submit_footer.html';
+email_columns = 2;
+
+INCLUDE '_email_top.html';
+
+%]
+
+<th style="[% td_style %][% primary_column_style %]" id="primary_column">
+  [% start_padded_box | safe %]
+  <h1 style="[% h1_style %]">New problem in your&nbsp;area</h1>
+  <p style="[% p_style %]">[% missing %][% multiple %]A user of [% site_name %] has submitted the following report
+of a local problem that they believe might require your attention.</p>
+
+  <p style="margin: 20px auto; text-align: center">
+    <a style="[% button_style %]" href="[% url %]">Show full report</a>
+  </p>
+  <h2 style="[% h2_style %] margin: 30px 0 10px 0">Reported by:</h2>
+  <table [% table_reset | safe %]>
+    <tr>
+      <th style="[% contact_th_style %]">Name</th>
+      <td style="[% contact_td_style %]">[% report.name | html %]</td>
+    </tr>
+    <tr>
+      <th style="[% contact_th_style %]">Email</th>
+      <td style="[% contact_td_style %]">
+        [%~ IF report.user.email ~%]
+          <a href="mailto:[% report.user.email | html %]">[% report.user.email | html %]</a>
+        [%~ ELSE ~%]
+          <strong>No email address provided, only phone number</strong>
+        [%~ END ~%]
+      </td>
+    </tr>
+    [%~ IF report.user.phone %]
+      <tr>
+        <th style="[% contact_th_style %]">Phone</th>
+        <td style="[% contact_td_style %]"><a href="tel:[% report.user.phone | html %]">[% report.user.phone | html %]</a></td>
+      </tr>
+    [%~ END %]
+  </table>
+  <p style="[% p_style %] margin-top: 0.5em;">Replies to this message will go directly to [% report.name | html %], the user who reported the problem.</p>
+  [% end_padded_box | safe %]
+</th>
+[% WRAPPER '_email_sidebar.html' object = report %]
+    <h2 style="[% h2_style %]">[% report.title | html %]</h2>
+    <p style="[% secondary_p_style %]"><strong>Category:</strong> [% report.category | html %]</p>
+    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [%~ IF additional_information %]
+    <p style="[% secondary_p_style %]">[% additional_information %]</p>
+    [%~ END %]
+    <p style="[% secondary_p_style %]">
+      <strong>Location:</strong>
+      <br>Easting/Northing
+      [%~ " (IE)" IF coordsyst == "I" ~%]
+      : [% easting %]/[% northing %]
+      (<a href="[% osm_url %]" title="View OpenStreetMap of this location">
+        [%~ report.latitude %], [% report.longitude ~%]
+      </a>)
+      [% IF closest_address %]<br>[% closest_address | trim | replace("\n\n", "<br>") %][% END %]
+    </p>
+    [% IF report.get_extra_field_value('feature_id') %]
+    <p style="[% secondary_p_style %]">
+        <strong>Asset id:</strong> [% report.get_extra_field_value('feature_id') %]
+    </p>
+    [% END %]
+    [% IF report.get_extra_field_value('column_no') %]
+    <p style="[% secondary_p_style %]">
+        <strong>Column Number:</strong> [% report.get_extra_field_value('column_no') %]
+    </p>
+    [% END %]
+[% END %]
+
+[% INCLUDE '_email_bottom.html' %]

--- a/templates/email/oxfordshire/submit.txt
+++ b/templates/email/oxfordshire/submit.txt
@@ -1,0 +1,52 @@
+Subject: Problem Report: [% report.title %]
+
+Dear [% bodies_name %],
+
+[% missing %][% multiple %]A user of
+[% site_name %] has submitted the following report
+of a local problem that they believe might require your attention.
+
+[% fuzzy %], or to provide an update on the problem,
+please visit the following link:
+
+    [% url %]
+
+[% has_photo %]----------
+
+Name: [% report.name %]
+
+Email: [% report.user.email OR 'None provided' %]
+
+Phone: [% report.user.phone OR 'None provided' %]
+
+Category: [% report.category %]
+
+Subject: [% report.title %]
+
+Details: [% report.detail %]
+
+[% additional_information %]
+
+[%- IF report.get_extra_field_value('feature_id') %]
+Asset id: [% report.get_extra_field_value('feature_id') %]
+[%- END %]
+
+[%- IF report.get_extra_field_value('column_no') %]
+Column number: [% report.get_extra_field_value('column_no') %]
+[%- END %]
+
+Easting/Northing
+[%- " (IE)" IF coordsyst == "I" -%]
+: [% easting %]/[% northing %]
+
+Latitude: [% report.latitude %]
+
+Longitude: [% report.longitude %]
+
+View OpenStreetMap of this location: [% osm_url %]
+
+[% closest_address %]----------
+
+Replies to this email will go to the user who submitted the problem.
+
+[% signature %]

--- a/templates/web/oxfordshire/footer_extra_js.html
+++ b/templates/web/oxfordshire/footer_extra_js.html
@@ -1,1 +1,1 @@
-[% PROCESS 'footer_extra_js_base.html' highways=1 validation=1 roadworks=1 %]
+[% PROCESS 'footer_extra_js_base.html' highways=1 validation=1 roadworks=1 cobrand_js=1 %]

--- a/templates/web/oxfordshire/report/new/roads_message.html
+++ b/templates/web/oxfordshire/report/new/roads_message.html
@@ -1,0 +1,7 @@
+<div id="js-roads-responsibility" class="box-warning hidden">
+    <div id="js-not-a-road" class="hidden js-responsibility-message">
+        <p>This area is not under the responsibility of Oxfordshire
+        County Council and therefore we are unable to accept reports in
+        this area / street.</p>
+    </div>
+</div>

--- a/templates/web/oxfordshire/report/new/roads_message.html
+++ b/templates/web/oxfordshire/report/new/roads_message.html
@@ -4,4 +4,10 @@
         County Council and therefore we are unable to accept reports in
         this area / street.</p>
     </div>
+    <div id="js-not-local-authority-asset" class="hidden js-responsibility-message">
+        <p>This item is not maintained by Oxfordshire
+            County Council and therefore we are unable to accept reports about it. Please
+            Contact your Parish or District Council.
+        </p>
+    </div>
 </div>

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -549,15 +549,7 @@ function get_asset_stylemap() {
     return new OpenLayers.StyleMap({
         'default': fixmystreet.assets.style_default,
         'select': fixmystreet.assets.style_default_select,
-        'hover': new OpenLayers.Style({
-            fillColor: "#55BB00",
-            fillOpacity: 0.8,
-            strokeColor: "#000000",
-            strokeOpacity: 1,
-            strokeWidth: 2,
-            pointRadius: 8,
-            cursor: 'pointer'
-        })
+        'hover': fixmystreet.assets.style_default_hover
     });
 }
 
@@ -822,6 +814,16 @@ fixmystreet.assets = {
         strokeOpacity: 0.8,
         strokeWidth: 2,
         pointRadius: 6
+    }),
+
+    style_default_hover: new OpenLayers.Style({
+        fillColor: "#55BB00",
+        fillOpacity: 0.8,
+        strokeColor: "#000000",
+        strokeOpacity: 1,
+        strokeWidth: 2,
+        pointRadius: 8,
+        cursor: 'pointer'
     }),
 
     style_default_select: new OpenLayers.Style({

--- a/web/cobrands/oxfordshire/assets.js
+++ b/web/cobrands/oxfordshire/assets.js
@@ -151,4 +151,35 @@ fixmystreet.assets.add(defaults, {
     asset_item: 'grit bin'
 });
 
+var highways_style = new OpenLayers.Style({
+    fill: false,
+    strokeColor: "#5555FF",
+    strokeOpacity: 0.1,
+    strokeWidth: 7
+});
+
+fixmystreet.assets.add(defaults, {
+    stylemap: new OpenLayers.StyleMap({
+        'default': highways_style
+    }),
+    wfs_url: proxy_base_url + 'nsg/',
+    wfs_feature: "WFS_LIST_OF_STREETS",
+    srsName: "EPSG:27700",
+    geometryName: null,
+    usrn: {
+        attribute: 'USRN',
+        field: 'usrn'
+    },
+    non_interactive: true,
+    road: true,
+    no_asset_msg_id: '#js-not-a-road',
+    asset_item: 'road',
+    asset_type: 'road',
+    actions: {
+        found: fixmystreet.message_controller.road_found,
+        not_found: fixmystreet.message_controller.road_not_found
+    },
+    asset_category: ["Carriageway Defect", "Pavements", "Pothole"],
+});
+
 })();

--- a/web/cobrands/oxfordshire/assets.js
+++ b/web/cobrands/oxfordshire/assets.js
@@ -1,0 +1,154 @@
+(function(){
+
+if (!fixmystreet.maps) {
+    return;
+}
+
+var wfs_host = fixmystreet.staging ? 'tilma.staging.mysociety.org' : 'tilma.mysociety.org';
+var tilma_url = "https://" + wfs_host + "/mapserver/oxfordshire";
+var proxy_base_url = "https://" + wfs_host + "/proxy/occ/";
+
+var defaults = {
+    wfs_url: tilma_url,
+    asset_type: 'spot',
+    max_resolution: 4.777314267158508,
+    geometryName: 'msGeometry',
+    srsName: "EPSG:3857",
+    body: "Oxfordshire County Council",
+    strategy_class: OpenLayers.Strategy.FixMyStreet
+};
+
+var occ_default = $.extend({}, fixmystreet.assets.style_default.defaultStyle, {
+    fillColor: "#007258"
+});
+
+var occ_hover = new OpenLayers.Style({
+    pointRadius: 8,
+    cursor: 'pointer'
+});
+
+var occ_stylemap = new OpenLayers.StyleMap({
+    'default': occ_default,
+    'select': fixmystreet.assets.style_default_select,
+    'hover': occ_hover
+});
+
+fixmystreet.assets.add(defaults, {
+    stylemap: occ_stylemap,
+    wfs_feature: "Trees",
+    asset_id_field: 'Ref',
+    attributes: {
+        feature_id: 'Ref'
+    },
+    asset_category: ["Trees"],
+    asset_item: 'tree'
+});
+
+fixmystreet.assets.add(defaults, {
+    stylemap: occ_stylemap,
+    wfs_feature: "Traffic_Lights",
+    asset_id_field: 'Site',
+    attributes: {
+        feature_id: 'Site'
+    },
+    asset_category: ["Traffic Lights (permanent only)"],
+    asset_item: 'traffic light'
+});
+
+var streetlight_select = $.extend({
+    label: "${UNITNO}",
+    fontColor: "#FFD800",
+    labelOutlineColor: "black",
+    labelOutlineWidth: 3,
+    labelYOffset: 69,
+    fontSize: '18px',
+    fontWeight: 'bold'
+}, fixmystreet.assets.style_default_select.defaultStyle);
+
+var streetlight_stylemap = new OpenLayers.StyleMap({
+  'default': occ_default,
+  'select': new OpenLayers.Style(streetlight_select),
+  'hover': occ_hover
+});
+
+fixmystreet.assets.add(defaults, {
+    select_action: true,
+    stylemap: streetlight_stylemap,
+    wfs_feature: "Street_Lights",
+    asset_id_field: 'OBJECTID',
+    attributes: {
+        feature_id: 'OBJECTID',
+        column_no: 'UNITNO'
+    },
+    asset_category: ["Street lighting"],
+    asset_item: 'street light',
+    actions: {
+        asset_found: function(asset) {
+          var id = asset.attributes.UNITNO || '';
+          if (id !== '') {
+              $('.category_meta_message').html('You have selected ' + this.fixmystreet.asset_item + ' <b>' + id + '</b>');
+          } else {
+              $('.category_meta_message').html('You can pick a <b class="asset-spot">' + this.fixmystreet.asset_item + '</b> from the map &raquo;');
+          }
+        },
+        asset_not_found: function() {
+           $('.category_meta_message').html('You can pick a <b class="asset-spot">' + this.fixmystreet.asset_item + '</b> from the map &raquo;');
+        }
+    }
+});
+
+fixmystreet.assets.add(defaults, {
+    stylemap: occ_stylemap,
+    // have to do this by hand rather than using wfs_* options
+    // as the server does not like being POSTed xml with application/xml
+    // as the Content-Type which is what using those options results in.
+    http_options: {
+        headers: {
+            'Content-Type': 'text/plain'
+        },
+        url: proxy_base_url + 'drains/wfs',
+        params: {
+            SERVICE: "WFS",
+            VERSION: "1.1.0",
+            REQUEST: "GetFeature",
+            SRSNAME: "urn:ogc:def:crs:EPSG::27700",
+            TYPENAME: "junctions"
+        }
+    },
+    srsName: "EPSG:27700",
+    asset_id_field: 'id',
+    attributes: {
+        feature_id: 'id'
+    },
+    asset_category: ["Gully and Catchpits"],
+    asset_item: 'drain'
+});
+
+fixmystreet.assets.add(defaults, {
+    stylemap: occ_stylemap,
+    // have to do this by hand rather than using wfs_* options
+    // as the server does not like being POSTed xml with application/xml
+    // as the Content-Type which is what using those options results in.
+    http_options: {
+        headers: {
+            'Content-Type': 'text/plain',
+        },
+        url: proxy_base_url + 'grit/wfs',
+        params: {
+            SERVICE: "WFS",
+            VERSION: "1.1.0",
+            REQUEST: "GetFeature",
+            SRSNAME: "urn:ogc:def:crs:EPSG::27700",
+            TYPENAME: "Gritbins"
+        }
+    },
+    srsName: "EPSG:27700",
+    asset_id_field: 'id',
+    attributes: {
+        feature_id: 'id'
+    },
+    asset_category: ["Ice/Snow"],
+    asset_item: 'grit bin'
+});
+
+})();

--- a/web/cobrands/oxfordshire/base.scss
+++ b/web/cobrands/oxfordshire/base.scss
@@ -279,6 +279,10 @@ textarea {
     color: $color-oxfordshire-link-blue;
 }
 
+.asset-spot:before {
+    background-color: #007258;
+}
+
 @media print {
     body {
         background-color: #fff !important;


### PR DESCRIPTION
This adds asset layers to the map for OCC for:
 - drains
 - grit bins
 - streetlights
 - traffic lights
 - trees

It also adds a roads layer for access to the USRN.

It includes the asset id and USRN in the description sent over Open311.

[skip changelog]