### PR TITLE
[Oxfordshire] Send raise_defect flag to open311 for inspected reports

### DIFF
--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -412,7 +412,7 @@ sub _nearest_feature {
 
     # We have a list of features, and we want to find the one closest to the
     # report location.
-    my $site_code = '';
+    my $chosen = '';
     my $nearest;
 
     # We shouldn't receive anything aside from these geometry types, but belt and braces.
@@ -439,14 +439,14 @@ sub _nearest_feature {
             for (my $i=0; $i<@$coordinates-1; $i++) {
                 my $distance = $self->_distanceToLine($x, $y, $coordinates->[$i], $coordinates->[$i+1]);
                 if ( !defined $nearest || $distance < $nearest ) {
-                    $site_code = $feature->{properties}->{$cfg->{property}};
+                    $chosen = $feature;
                     $nearest = $distance;
                 }
             }
         }
     }
 
-    return $site_code;
+    return $cfg->{property} && $chosen ? $chosen->{properties}->{$cfg->{property}} : $chosen;
 }
 
 sub contact_name {

--- a/t/cobrand/oxfordshire.t
+++ b/t/cobrand/oxfordshire.t
@@ -4,6 +4,7 @@ use CGI::Simple;
 use FixMyStreet::TestMech;
 use FixMyStreet::Script::Alerts;
 use FixMyStreet::Script::Reports;
+use Open311;
 my $mech = FixMyStreet::TestMech->new;
 
 my $oxon = $mech->create_body_ok(2237, 'Oxfordshire County Council');
@@ -182,6 +183,58 @@ FixMyStreet::override_config {
             like $c->param('description'), qr/$test->{text}: $test->{value}/, $test->{text} . ' included in body';
         };
     }
+
+    subtest 'extra data sent with defect update' => sub {
+        my $comment = FixMyStreet::DB->resultset('Comment')->first;
+        $comment->set_extra_metadata(defect_raised => 1);
+        $comment->update;
+        $comment->problem->external_id('hey');
+        $comment->problem->update;
+
+        my $cbr = Test::MockModule->new('FixMyStreet::Cobrand::Oxfordshire');
+        $cbr->mock('_fetch_features', sub {
+            my ($self, $cfg, $x, $y) = @_;
+            if ($cfg->{filter} =~ /<PropertyIsEqualTo><PropertyName>USRN<\/PropertyName><Literal>(.*?)</) {
+                [ {
+                    type => 'Feature',
+                    geometry => { type => 'LineString', coordinates => [ [ 1, 2 ], [ 3, 4 ] ] },
+                    properties => { USRN => $1, STREET => 'Street Avenue', TOWN_NAME => 'Town' },
+                } ]
+            } else {
+                [ {
+                    type => 'Feature',
+                    geometry => { type => 'LineString', coordinates => [ [ 1, 2 ], [ 3, 4 ] ] },
+                    properties => { USRN => 13579, STREET => 'Street Avenue', TOWN_NAME => 'Town' },
+                } ]
+            }
+        });
+        my $test_res = HTTP::Response->new();
+        $test_res->code(200);
+        $test_res->message('OK');
+        $test_res->content('<?xml version="1.0" encoding="utf-8"?><service_request_updates><request_update><update_id>248</update_id></request_update></service_request_updates>');
+
+        my $o = Open311->new(
+            fixmystreet_body => $oxon,
+            test_mode => 1,
+            test_get_returns => { 'servicerequestupdates.xml' => $test_res },
+        );
+
+        $o->post_service_request_update($comment);
+        my $cgi = CGI::Simple->new($o->test_req_used->content);
+        is $cgi->param('attribute[usrn]'), 13579, 'USRN sent with update';
+        is $cgi->param('attribute[raise_defect]'), 1, 'Defect flag sent with update';
+        is $cgi->param('attribute[street_descriptor]'), '13579 - Street Avenue, Town', 'Street description sent';
+
+        # Now set a USRN on the problem (found at submission)
+        $comment->problem->push_extra_fields({ name => 'usrn', value => '12345' });
+        $comment->problem->update;
+
+        $o->post_service_request_update($comment);
+        $cgi = CGI::Simple->new($o->test_req_used->content);
+        is $cgi->param('attribute[usrn]'), 12345, 'USRN sent with update';
+        is $cgi->param('attribute[raise_defect]'), 1, 'Defect flag sent with update';
+        is $cgi->param('attribute[street_descriptor]'), '12345 - Street Avenue, Town', 'Street description sent';
+    };
 
 };
 


### PR DESCRIPTION
Part of https://github.com/mysociety/fixmystreet-commercial/issues/1847

This deals with the USRN aspect of the data to be sent for a defect, but not the various item type codes.

<!-- [skip changelog] -->