### PR TITLE
[UK Councils] Enable private photo uploading on cobrands whose backend supports it

### DIFF
--- a/perllib/FixMyStreet/Cobrand/IsleOfWight.pm
+++ b/perllib/FixMyStreet/Cobrand/IsleOfWight.pm
@@ -77,6 +77,13 @@ sub open311_pre_send {
 # Make sure fetched report description isn't shown.
 sub filter_report_description { "" }
 
+around 'open311_config' => sub {
+    my ($orig, $self, $row, $h, $params) = @_;
+
+    $params->{upload_files} = 1;
+    $self->$orig($row, $h, $params);
+};
+
 sub open311_munge_update_params {
     my ($self, $params, $comment, $body) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
@@ -77,4 +77,11 @@ sub pin_colour {
     return 'yellow';
 }
 
+around 'open311_config' => sub {
+    my ($orig, $self, $row, $h, $params) = @_;
+
+    $params->{upload_files} = 1;
+    $self->$orig($row, $h, $params);
+};
+
 1;

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -89,4 +89,11 @@ sub open311_munge_update_params {
     $params->{service_code} = $contact->email;
 }
 
+around 'open311_config' => sub {
+    my ($orig, $self, $row, $h, $params) = @_;
+
+    $params->{upload_files} = 1;
+    $self->$orig($row, $h, $params);
+};
+
 1;


### PR DESCRIPTION
For https://github.com/mysociety/fixmystreet-commercial/issues/1778
Already reviewed at #2903. [skip changelog]