### PR TITLE
 [TfL] Hide unassigned categories from filters.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -240,12 +240,8 @@ sub check_and_stash_category : Private {
     $c->stash->{bodies_ids} = [ map { $_->id } @bodies];
     $c->{stash}->{list_of_names_as_string} = $csv->string;
 
-    my $where  = { body_id => [ keys %bodies ], };
-
-    my $cobrand_where = $c->cobrand->call_hook('munge_around_category_where', $where );
-    if ( $cobrand_where ) {
-       $where = $cobrand_where;
-    }
+    my $where = { body_id => [ keys %bodies ], };
+    $c->cobrand->call_hook('munge_around_category_where', $where);
 
     my @categories = $c->model('DB::Contact')->not_deleted->search(
         $where,

--- a/perllib/FixMyStreet/Cobrand/IsleOfWight.pm
+++ b/perllib/FixMyStreet/Cobrand/IsleOfWight.pm
@@ -128,11 +128,10 @@ sub munge_around_category_where {
     my $b = $self->{c}->model('DB::Body')->for_areas( $self->council_area_id )->first;
     if ( $user && ( $user->is_superuser || $user->belongs_to_body( $b->id ) ) ) {
         $where->{send_method} = [ { '!=' => 'Triage' }, undef ];
-        return $where;
+        return;
     }
 
     $where->{'send_method'} = 'Triage';
-    return $where;
 }
 
 sub munge_load_and_group_problems {

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -117,6 +117,35 @@ sub categories_restriction {
     return $rs->search( { category => { -not_in => $self->_tfl_no_resend_categories } } );
 }
 
+sub munge_reports_category_list {
+    my ($self, $categories) = @_;
+    my $c = $self->{c};
+    return unless $c->user_exists && $c->user->from_body;
+
+    my $assigned_categories_only = $c->user->get_extra_metadata('assigned_categories_only');
+    my %user_categories = map { $_ => 1 } @{$c->user->categories};
+
+    @$categories = grep {
+        my $assigned_users_only = $_->get_extra_metadata('assigned_users_only');
+        $user_categories{$_->category} || (!$assigned_categories_only && !$assigned_users_only);
+    } @$categories;
+}
+
+sub munge_around_filter_category_list {
+    my $self = shift;
+    my $c = $self->{c};
+    # This function is called by around and its ajax call, we only care about the actual one
+    return unless $c->stash->{filter_categories};
+    # This hook is called after category groupings, so we'll
+    # need to see if it's changed and regenerate them if so
+    my $num_categories = scalar @{$c->stash->{filter_categories}};
+    $self->munge_reports_category_list($c->stash->{filter_categories});
+    my $num_categories_after = scalar @{$c->stash->{filter_categories}};
+    if ($num_categories != $num_categories_after) {
+        $c->forward('/report/stash_category_groups', [ $c->stash->{filter_categories} ]);
+    }
+}
+
 sub admin_user_domain { 'tfl.gov.uk' }
 
 sub allow_anonymous_reports { 'button' }

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -642,12 +642,23 @@ subtest 'TfL admin allows inspectors to be assigned to borough areas' => sub {
 
     $mech->submit_form_ok( { with_fields => {
         area_ids => [2482],
+        'contacts[' . $contact1->id . ']' => 1,
+        'contacts[' . $contact2->id . ']' => 1,
+        assigned_categories_only => 1,
     } } );
 
     $staffuser->discard_changes;
     is_deeply $staffuser->area_ids, [2482], "User assigned to Bromley LBO area";
 
     $staffuser->update({ area_ids => undef}); # so login below doesn't break
+};
+
+subtest 'Check TfL assigned only sees only their categories in filter' => sub {
+    $mech->log_in_ok($staffuser->email);
+    $mech->get_ok('/around?pc=BR1+3UH');
+    $mech->content_contains('Bus stops');
+    $mech->content_lacks('Pothole');
+    $staffuser->unset_extra_metadata('categories'); # so login below doesn't break
 };
 
 my $report = FixMyStreet::DB->resultset("Problem")->find({ title => 'Test Report 1'});


### PR DESCRIPTION
If a staff user has assigned categories only, or categories have assigned users only, only show those categories in the map filter for the appropriate staff. [skip changelog]
Would hopefully fix https://github.com/mysociety/fixmystreet-commercial/issues/1891