### PR TITLE
[Hackney] A few bug fixes that have shaken out of testing

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Hackney.pm
+++ b/perllib/FixMyStreet/Cobrand/Hackney.pm
@@ -15,9 +15,17 @@ sub disambiguate_location {
     my $self    = shift;
     my $string  = shift;
 
+    my $town = 'Hackney';
+
+    # Teale Street is on the boundary with Tower Hamlets and
+    # shows the 'please use fixmystreet.com' message, but Hackney
+    # do provide services on that road.
+    ($string, $town) = ('E2 9AA', '') if $string =~ /^teale\s+st/i;
+
     return {
         %{ $self->SUPER::disambiguate_location() },
-        town   => 'Hackney',
+        string => $string,
+        town   => $town,
         centre => '51.552267,-0.063316',
         bounds => [ 51.519814, -0.104511, 51.577784, -0.016527 ],
     };

--- a/perllib/FixMyStreet/Cobrand/Hackney.pm
+++ b/perllib/FixMyStreet/Cobrand/Hackney.pm
@@ -27,6 +27,27 @@ sub get_geocoder {
     return 'OSM'; # default of Bing gives poor results, let's try overriding.
 }
 
+sub geocoder_munge_query_params {
+    my ($self, $params) = @_;
+
+    $params->{addressdetails} = 1;
+}
+
+sub geocoder_munge_results {
+    my ($self, $result) = @_;
+    if (my $a = $result->{address}) {
+        if ($a->{road} && $a->{suburb} && $a->{postcode}) {
+            $result->{display_name} = "$a->{road}, $a->{suburb}, $a->{postcode}";
+            return;
+        }
+    }
+    $result->{display_name} = '' unless $result->{display_name} =~ /Hackney/;
+    $result->{display_name} =~ s/, United Kingdom$//;
+    $result->{display_name} =~ s/, London, Greater London, England//;
+    $result->{display_name} =~ s/, London Borough of Hackney//;
+}
+
+
 sub open311_config {
     my ($self, $row, $h, $params) = @_;
 

--- a/perllib/FixMyStreet/Geocode/OSM.pm
+++ b/perllib/FixMyStreet/Geocode/OSM.pm
@@ -45,6 +45,7 @@ sub string {
         if $params->{bounds};
     $query_params{countrycodes} = $params->{country}
         if $params->{country};
+    $c->cobrand->call_hook(geocoder_munge_query_params => \%query_params);
     $url .= join('&', map { "$_=$query_params{$_}" } sort keys %query_params);
 
     $c->stash->{geocoder_url} = $url;

--- a/t/app/controller/admin/report_edit.t
+++ b/t/app/controller/admin/report_edit.t
@@ -686,16 +686,28 @@ subtest "Test display of fields extra data" => sub {
     $mech->get_ok("/admin/report_edit/$report_id");
     $mech->content_contains('Extra data: No');
 
-    $report->push_extra_fields( {
-        name => 'report_url',
-        value => 'http://example.com',
-    });
+    $report->push_extra_fields(
+        {
+            name => 'report_url',
+            value => 'http://example.com',
+        },
+        {
+            name => 'sent_to',
+            value => [ 'onerecipient@example.org' ],
+        },
+        {
+            name => 'sent_too',
+            value => [ 'onemorerecipient@example.org', 'another@example.org' ],
+        },
+    );
     $report->update;
 
     $report->discard_changes;
 
     $mech->get_ok("/admin/report_edit/$report_id");
     $mech->content_contains('report_url</strong>: http://example.com');
+    $mech->content_contains('sent_to</strong>: onerecipient@example.org');
+    $mech->content_contains('sent_too</strong>: onemorerecipient@example.org, another@example.org');
 
     $report->set_extra_fields( {
         description => 'Report URL',

--- a/templates/web/base/admin/reports/edit.html
+++ b/templates/web/base/admin/reports/edit.html
@@ -131,7 +131,20 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
 <li><label class="inline-text" for="category">[% loc('Category:') %]</label>
     [% INCLUDE 'admin/report-category.html' %]
 </li>
-<li>[% loc('Extra data:') %] [% IF extra_fields.size %]<ul>[% FOREACH field IN extra_fields %]<li><strong>[% field.name %]</strong>: [% field.val %]</li>[% END %]</ul>[% ELSE %]No[% END %]</li>
+<li>[% loc('Extra data:') ~%]
+    [%~ IF extra_fields.size ~%]
+        <ul>
+        [%~ FOREACH field IN extra_fields ~%]
+            <li><strong>[%~ field.name ~%]</strong>: [% IF field.val.0.defined ~%]
+                    [%~ field.val.list.join(", ") ~%]
+                [%~ ELSE ~%]
+                    [%~ field.val ~%]
+                [%~ END ~%]
+            </li>
+        [%~ END ~%]
+        </ul>
+    [%~ ELSE %] No[% END ~%]
+</li>
 <li><label class="inline-text" for="anonymous">[% loc('Anonymous:') %]</label>
 <select class="form-control" name="anonymous"  id="anonymous">
 <option [% 'selected ' IF problem.anonymous %]value="1">[% loc('Yes') %]</option>

--- a/web/cobrands/hackney/assets.js
+++ b/web/cobrands/hackney/assets.js
@@ -127,6 +127,50 @@ fixmystreet.assets.add(wfs_defaults, {
   attributes: {}
 });
 
+fixmystreet.hackney = {};
+fixmystreet.hackney.debug_parks = function() {
+  fixmystreet.assets.add(wfs_defaults, {
+    http_options: {
+        params: {
+            TYPENAME: "greenspaces:hackney_park",
+        }
+    },
+    non_interactive: true,
+    always_visible: true,
+    stylemap: new OpenLayers.StyleMap({
+        'default': new OpenLayers.Style({
+            fillColor: "#88ff88",
+            fillOpacity: 0.4,
+            strokeColor: "#008800",
+            strokeOpacity: 1,
+            strokeWidth: 4,
+        })
+    }),
+    attributes: {}
+  });
+  fixmystreet.assets.add(wfs_defaults, {
+    http_options: {
+        params: {
+            TYPENAME: "housing:lbh_estate",
+        }
+    },
+    non_interactive: true,
+    always_visible: true,
+    stylemap: new OpenLayers.StyleMap({
+      'default': new OpenLayers.Style({
+          fillColor: "#C3A963",
+          fillOpacity: 0.4,
+          strokeColor: "#C3A963",
+          strokeOpacity: 1,
+          strokeWidth: 4,
+      })
+    }),
+    attributes: {}
+  });
+};
+if (window.URLSearchParams && new URLSearchParams(location.search).has("debuglbr")) {
+  fixmystreet.hackney.debug_parks();
+}
 
 /** These layers are served directly from Alloy: */
 


### PR DESCRIPTION
 - Allow more cobrand control over geocoder parameters
 - Some Hackney-specific geocoder tweaks
 - Work around an issue with Hackney WFS server returning features outside of the BBOX param
 - Show array contents instead of `ARRAY(0x5587da81ffb0)` in report admin extra data

[skip changelog]