### PR TITLE
Change company name

### DIFF
--- a/templates/email/default/submit-example.txt
+++ b/templates/email/default/submit-example.txt
@@ -46,7 +46,7 @@ Replies to this email will go to the user who submitted the problem.
 Yours,  
 The FixMyStreet team
 
-This message was sent via FixMyStreet, a project of UKCOD,
+This message was sent via FixMyStreet, a project of mySociety,
 registered charity number 1076346. If there is a more appropriate
 email address for messages about 'Potholes', please let us know by
 visiting <https://www.fixmystreet.com/contact>. This will help

--- a/templates/web/bromley/about/faq-en-gb.html
+++ b/templates/web/bromley/about/faq-en-gb.html
@@ -70,11 +70,10 @@ the problem.</dd>
 
     <dt>The site is powered by FixMyStreet, who are they?</dt>
         <dd>FixMyStreet was built by <a href="http://www.mysociety.org/">mySociety</a>, in conjunction with the <a href="http://www.youngfoundation.org.uk/">Young Foundation</a>.
-mySociety is the project of a registered charity which has grown out of the community of
+mySociety is a registered charity, number 1076346, which has grown out of the community of
 volunteers who built sites like <a href="http://www.theyworkforyou.com/">TheyWorkForYou</a>.
 mySociety&rsquo;s primary mission is to build Internet projects which give people simple, tangible
-benefits in the civic and community aspects of their lives.
-The charity is called UK Citizens Online Democracy and is charity number 1076346. mySociety
+benefits in the civic and community aspects of their lives. mySociety
 can be contacted by email at <a href="mailto:hello&#64;mysociety.org">hello&#64;mysociety.org</a>,
 or by post at mySociety, 483 Green Lanes, London, N13 4BS.</dd>
 

--- a/templates/web/eastherts/about/faq-en-gb.html
+++ b/templates/web/eastherts/about/faq-en-gb.html
@@ -79,7 +79,7 @@ by a user of the site.</dd>
 
     <dt>The site is powered by FixMyStreet, who are they?</dt>
         <dd>FixMyStreet was built by <a href="http://www.mysociety.org/">mySociety</a>, in conjunction with the <a href="http://www.youngfoundation.org.uk/">Young Foundation</a>. 
-mySociety is the project of a registered charity which has grown out of the community of
+mySociety is a registered charity, number 1076346, which has grown out of the community of
 volunteers who built sites like <a href="http://www.theyworkforyou.com/">TheyWorkForYou</a>. 
 mySociety&rsquo;s primary mission is to build Internet projects which give people simple, tangible
 benefits in the civic and community aspects of their lives.

--- a/templates/web/fixmystreet.com/contact/address.html
+++ b/templates/web/fixmystreet.com/contact/address.html
@@ -1,7 +1,7 @@
 <hr>
 
-<p>FixMyStreet is a service provided by mySociety, which is the project of a
-registered charity, UK Citizens Online Democracy, charity number 1076346.</p>
+<p>FixMyStreet is a service provided by mySociety, which is a
+registered charity, charity number 1076346.</p>
 
 <p>If you wish to contact us by post, our address is
 <address>mySociety, 483 Green Lanes, London, N13 4BS, UK.</address></p>

--- a/templates/web/greenwich/about/faq-en-gb.html
+++ b/templates/web/greenwich/about/faq-en-gb.html
@@ -72,11 +72,10 @@ by a user of the site.</dd>
 
     <dt>The site is powered by FixMyStreet, who are they?</dt>
         <dd>FixMyStreet was built by <a href="http://www.mysociety.org/">mySociety</a>, in conjunction with the <a href="http://www.youngfoundation.org.uk/">Young Foundation</a>. 
-mySociety is the project of a registered charity which has grown out of the community of
+mySociety is a registered charity, number 1076346, which has grown out of the community of
 volunteers who built sites like <a href="http://www.theyworkforyou.com/">TheyWorkForYou</a>. 
 mySociety&rsquo;s primary mission is to build Internet projects which give people simple, tangible
-benefits in the civic and community aspects of their lives.
-The charity is called UK Citizens Online Democracy and is charity number 1076346. mySociety
+benefits in the civic and community aspects of their lives. mySociety
 can be contacted by email at <a href="mailto:hello&#64;mysociety.org">hello&#64;mysociety.org</a>,
 or by post at mySociety, 483 Green Lanes, London, N13 4BS.</dd>
 

--- a/templates/web/hart/about/faq-en-gb.html
+++ b/templates/web/hart/about/faq-en-gb.html
@@ -70,11 +70,10 @@ by a user of the site.</dd>
 
     <dt>The site is powered by FixMyStreet, who are they?</dt>
         <dd>FixMyStreet was built by <a href="http://www.mysociety.org/">mySociety</a>, in conjunction with the <a href="http://www.youngfoundation.org.uk/">Young Foundation</a>. 
-mySociety is the project of a registered charity which has grown out of the community of
+mySociety is a registered charity, number 1076346, which has grown out of the community of
 volunteers who built sites like <a href="http://www.theyworkforyou.com/">TheyWorkForYou</a>. 
 mySociety&rsquo;s primary mission is to build Internet projects which give people simple, tangible
-benefits in the civic and community aspects of their lives.
-The charity is called UK Citizens Online Democracy and is charity number 1076346. mySociety
+benefits in the civic and community aspects of their lives. mySociety
 can be contacted by email at <a href="mailto:hello&#64;mysociety.org">hello&#64;mysociety.org</a>,
 or by post at mySociety, 483 Green Lanes, London, N13 4BS.</dd>
 

--- a/templates/web/stevenage/about/faq-en-gb.html
+++ b/templates/web/stevenage/about/faq-en-gb.html
@@ -64,11 +64,10 @@ by a user of the site.</dd>
 
     <dt>The site is powered by FixMyStreet, who are they?</dt>
         <dd>FixMyStreet was built by <a href="http://www.mysociety.org/">mySociety</a>, in conjunction with the <a href="http://www.youngfoundation.org.uk/">Young Foundation</a>.
-mySociety is the project of a registered charity which has grown out of the community of
+mySociety is a registered charity, number 1076346, which has grown out of the community of
 volunteers who built sites like <a href="http://www.theyworkforyou.com/">TheyWorkForYou</a>.
 mySociety&rsquo;s primary mission is to build Internet projects which give people simple, tangible
-benefits in the civic and community aspects of their lives.
-The charity is called UK Citizens Online Democracy and is charity number 1076346. mySociety
+benefits in the civic and community aspects of their lives. mySociety
 can be contacted by email at <a href="mailto:hello&#64;mysociety.org">hello&#64;mysociety.org</a>,
 or by post at mySociety, 483 Green Lanes, London, N13 4BS.</dd>
 


### PR DESCRIPTION
[skip changelog]

UKCOD is now formally known as mySociety, this PR hopefully sweeps up all the existing mentions of the old name.

Sidenote: some of these cobrands (and they are the older ones) are using very old FAQ text and should maybe be prompted to review/update?