### PR TITLE
[Hounslow] Allow two email categories to be shown.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Hounslow.pm
+++ b/perllib/FixMyStreet/Cobrand/Hounslow.pm
@@ -65,8 +65,14 @@ sub categories_restriction {
     # Email categories with a devolved send_method, so can identify Open311
     # categories as those which have a blank send_method.
     return $rs->search({
-        'me.send_method' => undef,
         'body.name' => [ 'Hounslow Borough Council', 'Highways England' ],
+        -or => [
+            'me.send_method' => undef,
+            'me.category' => { -in => [
+                'Pavement Overcrowding',
+                'Streetspace Suggestions and Feedback',
+            ] },
+        ],
     });
 }
 


### PR DESCRIPTION
[skip changelog]
Requested in ticket 659 on Freshdesk.