### PR TITLE
Improve Bing geocoder results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - Add Open Location Codes support to search box. #3047
     - Front end improvements:
         - Add lazy image loading on list items.
+        - Improve Bing geocoder results.
     - Changes:
         - Mark user as active when sent an email alert.
     - Bugfixes:

--- a/perllib/FixMyStreet/Geocode/Bing.pm
+++ b/perllib/FixMyStreet/Geocode/Bing.pm
@@ -36,6 +36,8 @@ sub string {
     $url .= '&userMapView=' . join(',', @{$params->{bounds}})
         if $params->{bounds};
     $url .= '&userLocation=' . $params->{centre} if $params->{centre};
+    $url .= '&userIp=127.0.0.1'; # So server location does not affect results
+    $url .= '&maxResults=10'; # Match what is said in the front end
     $url .= '&c=' . $params->{bing_culture} if $params->{bing_culture};
 
     $c->stash->{geocoder_url} = $url;
@@ -52,7 +54,13 @@ sub string {
 
     foreach (@$results) {
         my $address = $_->{name};
-        next if $params->{bing_country} && $_->{address}->{countryRegion} ne $params->{bing_country};
+        if ($params->{bing_country}) {
+            next if $_->{address}->{countryRegion} ne $params->{bing_country};
+            $address =~ s/, $params->{bing_country}$//;
+        }
+        if ($address !~ /$_->{address}->{locality}/) {
+            $address .= ", $_->{address}->{locality}";
+        }
 
         # Getting duplicate, yet different, results from Bing sometimes
         next if @valid_locations

--- a/t/Mock/Bing.pm
+++ b/t/Mock/Bing.pm
@@ -14,6 +14,36 @@ has json => (
 sub dispatch_request {
     my $self = shift;
 
+    sub (GET + /REST/v1/Locations + ?*) {
+        my ($self, $query) = @_;
+        my $results = [ {
+            point => { coordinates => [ 51, -1 ] },
+            name => 'Constitution Hill, London, SW1A',
+            address => {
+                addressLine => 'Constitution Hill',
+                locality => 'London',
+                countryRegion => 'United Kingdom',
+            }
+        } ];
+        if ($query->{q} =~ /two results/) {
+            push @$results, {
+                point => { coordinates => [ 51, -1 ] },
+                name => 'Constitution Hill again, United Kingdom',
+                address => {
+                    addressLine => 'Constitution Hill again',
+                    locality => 'London',
+                    countryRegion => 'United Kingdom',
+                }
+            };
+        }
+        my $data = {
+            statusCode => 200,
+            resourceSets => [ { resources => $results } ],
+        };
+        my $json = $self->json->encode($data);
+        return [ 200, [ 'Content-Type' => 'application/json' ], [ $json ] ];
+    },
+
     sub (GET + /REST/v1/Locations/* + ?*) {
         my ($self, $location, $query) = @_;
         my $data = {

--- a/t/geocode/bing.t
+++ b/t/geocode/bing.t
@@ -1,0 +1,24 @@
+use FixMyStreet::Test;
+use FixMyStreet::Geocode::Bing;
+use Catalyst::Test 'FixMyStreet::App';
+use t::Mock::Bing;
+
+my $c = ctx_request('/');
+
+FixMyStreet::override_config {
+    GEOCODING_DISAMBIGUATION => { bing_culture => 'en-GB' }
+}, sub {
+    my $r = FixMyStreet::Geocode::Bing->string('a result', $c);
+    ok $r->{latitude};
+    ok $r->{longitude};
+};
+
+FixMyStreet::override_config {
+    GEOCODING_DISAMBIGUATION => { bing_country => 'United Kingdom' }
+}, sub {
+    my $r = FixMyStreet::Geocode::Bing->string('two results', $c);
+    is scalar @{$r->{error}}, 2;
+    is $r->{error}[1]{address}, 'Constitution Hill again, London';
+};
+
+done_testing;


### PR DESCRIPTION
Add a couple of parameters to hopefully improve results, and make sure the returned locality is included in the summary address.

Sometimes (I think with results with less information?), Bing is including no information beyond the country in the result string. Make sure the locality is included if not already present. Also ignore our server IP, and ask for 10 results (default was changed to 5 at some point).

Helps with this example query, at least, and I don't think it could harm any other.

Before:
![image](https://user-images.githubusercontent.com/154364/85410152-a18ac180-b55e-11ea-81a1-9ee15226c10e.png)

After:
![image](https://user-images.githubusercontent.com/154364/85410163-a6e80c00-b55e-11ea-999c-6326f15f3bbc.png)
