### PR TITLE
Upgrades the Mozilla::CA module to 20200520.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -185,6 +185,9 @@ requires 'Test::WWW::Mechanize::Catalyst', '0.62';
 requires 'Web::Scraper';
 requires 'Web::Simple';
 
+# Default root certificates used by LWP::UserAgent
+requires 'Mozilla::CA', '20200520';
+
 #################################################################
 # [1] Params::Classify 0.13 installs XS, but 0.15 will only do so
 # if ParseXS >= 3.30 is installed. If we don't do that, and are

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -3691,6 +3691,7 @@ DISTRIBUTIONS
       IO::Socket::SSL::Utils 2.014
     requirements:
       ExtUtils::MakeMaker 0
+      Mozilla::CA 0
       Net::SSLeay 1.46
       Scalar::Util 0
   IO-String-1.08
@@ -5108,10 +5109,10 @@ DISTRIBUTIONS
       MooseX::Types 0.04
       Path::Class 0.16
       Test::More 0.88
-  Mozilla-CA-20130114
-    pathname: A/AB/ABH/Mozilla-CA-20130114.tar.gz
+  Mozilla-CA-20200520
+    pathname: A/AB/ABH/Mozilla-CA-20200520.tar.gz
     provides:
-      Mozilla::CA 20130114
+      Mozilla::CA 20200520
     requirements:
       ExtUtils::MakeMaker 0
       Test 0


### PR DESCRIPTION
LWP::UserAgent (used by MapIt and Open311 integrations) uses this
cert bundle by default to verify peers.

Fixes #3088
