### PR TITLE
[Bromley] waste update tweaks

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -222,7 +222,7 @@ sub open311_config_updates {
     $params->{endpoints} = {
         service_request_updates => 'update.xml',
         update => 'update.xml'
-    };
+    } if $params->{endpoint} =~ /bromley.gov.uk/;
 }
 
 sub open311_pre_send {

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -515,13 +515,13 @@ sub bin_services_for_address {
     my $echo = $self->feature('echo');
     $echo = Integrations::Echo->new(%$echo);
     my $result = $echo->GetServiceUnitsForObject($property->{uprn});
-    return [] unless $result;
+    return [] unless @$result;
 
     my $events = $echo->GetEventsForObject($property->{id});
     my $open = _parse_events($events);
 
     my @out;
-    foreach (@{$result->{ServiceUnit}}) {
+    foreach (@$result) {
         next unless $_->{ServiceTasks};
 
         my $servicetask = $_->{ServiceTasks}{ServiceTask};
@@ -648,7 +648,8 @@ sub bin_future_collections {
     my $events = [];
     foreach (@$result) {
         my $task_id = $_->{ServiceTaskRef}{Value}{anyType};
-        foreach (@{$_->{Instances}{ScheduledTaskInfo}}) {
+        my $tasks = Integrations::Echo::force_arrayref($_->{Instances}, 'ScheduledTaskInfo');
+        foreach (@$tasks) {
             my $dt = construct_bin_date($_->{CurrentScheduledDate});
             my $summary = $names{$task_id} . ' collection';
             my $desc = '';

--- a/perllib/Integrations/Echo.pm
+++ b/perllib/Integrations/Echo.pm
@@ -142,92 +142,93 @@ sub GetServiceUnitsForObject {
     my $self = shift;
     my $uprn = shift;
     my $obj = _uprn_ref($uprn);
-    return {
-        ServiceUnit => [ {
-            Id => 1001,
-            ServiceId => 101,
-            ServiceName => 'Refuse collection',
-            ServiceTasks => { ServiceTask => {
-                Id => 401,
-                ScheduleDescription => 'every Wednesday',
-                ServiceTaskSchedules => { ServiceTaskSchedule => {
-                    EndDate => { DateTime => '2050-01-01T00:00:00Z' },
-                    NextInstance => {
-                        CurrentScheduledDate => { DateTime => '2020-06-03T00:00:00Z' },
-                        OriginalScheduledDate => { DateTime => '2020-06-03T00:00:00Z' },
-                    },
-                    LastInstance => {
-                        CurrentScheduledDate => { DateTime => '2020-05-27T00:00:00Z' },
-                    },
-                } },
+    return [ {
+        Id => 1001,
+        ServiceId => 101,
+        ServiceName => 'Refuse collection',
+        ServiceTasks => { ServiceTask => {
+            Id => 401,
+            ScheduleDescription => 'every Wednesday',
+            ServiceTaskSchedules => { ServiceTaskSchedule => {
+                EndDate => { DateTime => '2050-01-01T00:00:00Z' },
+                NextInstance => {
+                    CurrentScheduledDate => { DateTime => '2020-06-03T00:00:00Z' },
+                    OriginalScheduledDate => { DateTime => '2020-06-03T00:00:00Z' },
+                },
+                LastInstance => {
+                    CurrentScheduledDate => { DateTime => '2020-05-27T00:00:00Z' },
+                },
             } },
-        }, {
-            Id => 1002,
-            ServiceId => 537,
-            ServiceName => 'Paper recycling collection',
-            ServiceTasks => { ServiceTask => {
-                Id => 402,
-                ScheduleDescription => 'every other Wednesday',
-                ServiceTaskSchedules => { ServiceTaskSchedule => {
-                    EndDate => { DateTime => '2050-01-01T00:00:00Z' },
-                    NextInstance => {
-                        CurrentScheduledDate => { DateTime => '2020-06-10T00:00:00Z' },
-                        OriginalScheduledDate => { DateTime => '2020-06-10T00:00:00Z' },
-                    },
-                    LastInstance => {
-                        CurrentScheduledDate => { DateTime => '2020-05-27T00:00:00Z' },
-                    },
-                } },
+        } },
+    }, {
+        Id => 1002,
+        ServiceId => 537,
+        ServiceName => 'Paper recycling collection',
+        ServiceTasks => { ServiceTask => {
+            Id => 402,
+            ScheduleDescription => 'every other Wednesday',
+            ServiceTaskSchedules => { ServiceTaskSchedule => {
+                EndDate => { DateTime => '2050-01-01T00:00:00Z' },
+                NextInstance => {
+                    CurrentScheduledDate => { DateTime => '2020-06-10T00:00:00Z' },
+                    OriginalScheduledDate => { DateTime => '2020-06-10T00:00:00Z' },
+                },
+                LastInstance => {
+                    CurrentScheduledDate => { DateTime => '2020-05-27T00:00:00Z' },
+                },
             } },
-        }, {
-            Id => 1003,
-            ServiceId => 535,
-            ServiceName => 'Domestic Container Mix Collection',
-            ServiceTasks => { ServiceTask => {
-                Id => 403,
-                ScheduleDescription => 'every other Wednesday',
-                ServiceTaskSchedules => { ServiceTaskSchedule => {
-                    EndDate => { DateTime => '2050-01-01T00:00:00Z' },
-                    NextInstance => {
-                        CurrentScheduledDate => { DateTime => '2020-06-03T00:00:00Z' },
-                        OriginalScheduledDate => { DateTime => '2020-06-03T00:00:00Z' },
-                    },
-                    LastInstance => {
-                        CurrentScheduledDate => { DateTime => '2020-05-20T00:00:00Z' },
-                    },
-                } },
+        } },
+    }, {
+        Id => 1003,
+        ServiceId => 535,
+        ServiceName => 'Domestic Container Mix Collection',
+        ServiceTasks => { ServiceTask => {
+            Id => 403,
+            ScheduleDescription => 'every other Wednesday',
+            ServiceTaskSchedules => { ServiceTaskSchedule => {
+                EndDate => { DateTime => '2050-01-01T00:00:00Z' },
+                NextInstance => {
+                    CurrentScheduledDate => { DateTime => '2020-06-03T00:00:00Z' },
+                    OriginalScheduledDate => { DateTime => '2020-06-03T00:00:00Z' },
+                },
+                LastInstance => {
+                    CurrentScheduledDate => { DateTime => '2020-05-20T00:00:00Z' },
+                },
             } },
-        }, {
-            Id => 1004,
-            ServiceId => 542,
-            ServiceName => 'Food waste collection',
-            ServiceTasks => { ServiceTask => {
-                Id => 404,
-                ScheduleDescription => 'every other Monday',
-                ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                    EndDate => { DateTime => '2020-01-01T00:00:00Z' },
-                    LastInstance => {
-                        CurrentScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
-                    },
-                }, {
-                    EndDate => { DateTime => '2050-01-01T00:00:00Z' },
-                    NextInstance => {
-                        CurrentScheduledDate => { DateTime => '2020-06-02T00:00:00Z' },
-                        OriginalScheduledDate => { DateTime => '2020-06-01T00:00:00Z' },
-                    },
-                    LastInstance => {
-                        CurrentScheduledDate => { DateTime => '2020-05-18T00:00:00Z' },
-                    },
-                } ] },
-            } },
-        } ],
-    } if $self->sample_data;
-    $self->call('GetServiceUnitsForObject',
+        } },
+    }, {
+        Id => 1004,
+        ServiceId => 542,
+        ServiceName => 'Food waste collection',
+        ServiceTasks => { ServiceTask => {
+            Id => 404,
+            ScheduleDescription => 'every other Monday',
+            ServiceTaskSchedules => { ServiceTaskSchedule => [ {
+                EndDate => { DateTime => '2020-01-01T00:00:00Z' },
+                LastInstance => {
+                    CurrentScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
+                },
+            }, {
+                EndDate => { DateTime => '2050-01-01T00:00:00Z' },
+                NextInstance => {
+                    CurrentScheduledDate => { DateTime => '2020-06-02T00:00:00Z' },
+                    OriginalScheduledDate => { DateTime => '2020-06-01T00:00:00Z' },
+                },
+                LastInstance => {
+                    CurrentScheduledDate => { DateTime => '2020-05-18T00:00:00Z' },
+                },
+            } ] },
+        } },
+    } ] if $self->sample_data;
+    # uncoverable statement
+    my $res = $self->call('GetServiceUnitsForObject',
         objectRef => $obj,
         query => {
             IncludeTaskInstances => 'true',
         }
     );
+    # uncoverable statement
+    return force_arrayref($res, 'ServiceUnit');
 }
 
 sub GetServiceTaskInstances {

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -1,8 +1,13 @@
 use CGI::Simple;
+use Test::MockModule;
 use Test::MockTime qw(:all);
 use FixMyStreet::TestMech;
 use FixMyStreet::Script::Reports;
 my $mech = FixMyStreet::TestMech->new;
+
+# Mock fetching bank holidays
+my $uk = Test::MockModule->new('FixMyStreet::Cobrand::UK');
+$uk->mock('_fetch_url', sub { '{}' });
 
 # Create test data
 my $user = $mech->create_user_ok( 'bromley@example.com', name => 'Bromley' );

--- a/t/open311/post-service-request-updates.t
+++ b/t/open311/post-service-request-updates.t
@@ -16,7 +16,10 @@ my $params = {
     endpoint => 'endpoint',
     jurisdiction => 'home',
 };
-my $bromley = $mech->create_body_ok(2482, 'Bromley', { %$params, send_extended_statuses => 1, can_be_devolved => 1 });
+my $bromley = $mech->create_body_ok(2482, 'Bromley', { %$params,
+    endpoint => 'www.bromley.gov.uk',
+    send_extended_statuses => 1,
+    can_be_devolved => 1 });
 my $oxon = $mech->create_body_ok(2237, 'Oxfordshire', { %$params, id => "5" . $bromley->id });
 my $bucks = $mech->create_body_ok(2217, 'Buckinghamshire', $params);
 my $lewisham = $mech->create_body_ok(2492, 'Lewisham', $params);
@@ -34,6 +37,7 @@ subtest 'Check Open311 params' => sub {
     my %conf = $o->open311_params($bromley);
     is_deeply \%conf, {
         %$result,
+        endpoint => 'www.bromley.gov.uk',
         extended_statuses => 1,
         endpoints => { service_request_updates => 'update.xml', update => 'update.xml' },
         fixmystreet_body => $bromley,

--- a/templates/web/bromley/report/update/form_state_checkbox.html
+++ b/templates/web/bromley/report/update/form_state_checkbox.html
@@ -1,0 +1,22 @@
+[% RETURN IF problem.cobrand_data == 'waste' %]
+
+[% IF (problem.is_fixed OR problem.is_closed) AND ((c.user_exists AND c.user.id == problem.user_id) OR alert_to_reporter) %]
+
+    [% RETURN IF c.cobrand.reopening_disallowed(problem) ~%]
+
+    <input type="checkbox" name="reopen" id="form_reopen" value="1"[% ' checked' IF (update.mark_open || c.req.params.reopen) %]>
+    [% IF problem.is_closed %]
+      <label class="inline" for="form_reopen">[% loc('This problem is still ongoing') %]</label>
+    [% ELSE %]
+      <label class="inline" for="form_reopen">[% loc('This problem has not been fixed') %]</label>
+    [% END %]
+
+[% ELSIF !problem.is_fixed AND has_fixed_state %]
+
+    <div class="checkbox-group">
+        <input type="checkbox" name="fixed" id="form_fixed" value="1"[% ' checked' IF update.mark_fixed %]>
+        <label class="inline" for="form_fixed">[% loc('This problem has been fixed') %]</label>
+    </div>
+
+[% END %]
+


### PR DESCRIPTION
First fixup is to stop the bromley tests requesting gov.uk bank holiday live, whoops. Second is because if one entry in a list is returned to SOAP, it's auto-promoted to the single entry directly, which we don't want, we want to always loop.

Then the other two are to only change the Bromley endpoint for the main endpoint, so waste updates will be posted correctly to the right endpoint, and hide the fixed checkbox because users can leave updates but can't do that.

[skip changelog]
