### PR TITLE
[Docker] Specify MAPIT_URL.

### DIFF
--- a/conf/general.yml-docker
+++ b/conf/general.yml-docker
@@ -110,7 +110,7 @@ PHOTO_STORAGE_OPTIONS:
 #   MAPIT_URL: 'http://global.mapit.mysociety.org/'
 # And then specify whichever type code have the boundaries you want:
 #   MAPIT_TYPES: [ 'O06' ]
-MAPIT_URL: ''
+MAPIT_URL: 'http://localhost:9000/fakemapit/'
 MAPIT_TYPES: [ 'ZZZ' ]
 
 # If the MapIt you're using in MAPIT_URL requires an API key


### PR DESCRIPTION
Letting the code pick a default MAPIT_URL means it picks port 8000,
which will not work with the current Docker container setup.
Fixes https://github.com/mysociety/fixmystreet/issues/3090