### PR TITLE
Add option to check password on Have I Been Pwned.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - Front end improvements:
         - Add lazy image loading on list items.
         - Improve Bing geocoder results.
+        - Add option of checking passwords against Have I Been Pwned.
     - Changes:
         - Mark user as active when sent an email alert.
     - Bugfixes:

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -223,6 +223,10 @@ SMTP_PORT: ''
 SMTP_USERNAME: ''
 SMTP_PASSWORD: ''
 
+# Set if you want password setting to be checked (securely) against the
+# Have I Been Pwned dataset
+CHECK_HAVEIBEENPWNED: 0
+
 # Gaze is a world-wide service for population density lookups. You can leave
 # this as is.
 GAZE_URL: 'https://gaze.mysociety.org/gaze'


### PR DESCRIPTION
If switched on, sends first five letters of the SHA1 hash of the entered
password to HIBP's API, which then returns all matching hashes in their
database of breached passwords. If we find a match, tell the user they
need to pick a different password.

Questions to answer - leave it like this, or if the count is very low, allow it to go through anyway? (Read the count section of https://www.troyhunt.com/ive-just-launched-pwned-passwords-version-2/ for background)
Future work - could on login check password against this and alert the user to change it if present?