### PR TITLE
[Hackney] Custom domain for email envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
         - Links inside `#front-main` can be customised using `$primary_link_*` Sass variables. #3007
         - Add option to show front end testing code coverage. #3036
         - Add function to fetch user's country from Gaze.
+        - Add cobrand hook to specify custom domain for VERP emails.
     - Open311 improvements:
         - Use devolved data on update sending.
     - UK:

--- a/perllib/FixMyStreet/Cobrand/Hackney.pm
+++ b/perllib/FixMyStreet/Cobrand/Hackney.pm
@@ -31,6 +31,10 @@ sub disambiguate_location {
     };
 }
 
+sub do_not_reply_email { shift->feature('do_not_reply_email') }
+
+sub verp_email_domain { shift->feature('verp_email_domain') }
+
 sub get_geocoder {
     return 'OSM'; # default of Bing gives poor results, let's try overriding.
 }

--- a/perllib/FixMyStreet/Email.pm
+++ b/perllib/FixMyStreet/Email.pm
@@ -79,7 +79,9 @@ sub _render_template {
 }
 
 sub unique_verp_id {
-    sprintf('fms-%s@%s', generate_verp_token(@_), FixMyStreet->config('EMAIL_DOMAIN'));
+    my $parts = shift;
+    my $domain = shift || FixMyStreet->config('EMAIL_DOMAIN');
+    sprintf('fms-%s@%s', generate_verp_token(@$parts), $domain);
 }
 
 sub _unique_id {

--- a/perllib/FixMyStreet/Script/Alerts.pm
+++ b/perllib/FixMyStreet/Script/Alerts.pm
@@ -327,7 +327,7 @@ sub _send_aggregated_alert_email(%) {
     } );
     $data{unsubscribe_url} = $cobrand->base_url( $data{cobrand_data} ) . '/A/' . $token->token;
 
-    my $sender = FixMyStreet::Email::unique_verp_id('alert', $data{alert_id});
+    my $sender = FixMyStreet::Email::unique_verp_id([ 'alert', $data{alert_id} ], $cobrand->call_hook('verp_email_domain'));
     my $result = FixMyStreet::Email::send_cron(
         $data{schema},
         "$data{template}.txt",

--- a/perllib/FixMyStreet/SendReport/Email.pm
+++ b/perllib/FixMyStreet/SendReport/Email.pm
@@ -53,10 +53,11 @@ sub send_from {
 sub envelope_sender {
     my ($self, $row) = @_;
 
+    my $cobrand = $row->get_cobrand_logged;
     if ($row->user->email && $row->user->email_verified) {
-        return FixMyStreet::Email::unique_verp_id('report', $row->id);
+        return FixMyStreet::Email::unique_verp_id([ 'report', $row->id ], $cobrand->call_hook('verp_email_domain'));
     }
-    return $row->get_cobrand_logged->do_not_reply_email;
+    return $cobrand->do_not_reply_email;
 }
 
 sub send {

--- a/t/app/controller/auth_social.t
+++ b/t/app/controller/auth_social.t
@@ -118,7 +118,13 @@ for my $test (
                     token_uri => 'http://oidc.example.org/oauth2/v2.0/token_google',
                     allowed_domains => [ 'example.org' ],
                 }
-            }
+            },
+            do_not_reply_email => {
+                hackney => 'fms-hackney-DO-NOT-REPLY@hackney-example.com',
+            },
+            verp_email_domain => {
+                hackney => 'hackney-example.com',
+            },
         }
     },
     email => $mech->uniquify_email('oidc_google@example.org'),

--- a/t/cobrand/hackney.t
+++ b/t/cobrand/hackney.t
@@ -85,6 +85,14 @@ subtest "check moderation label uses correct name" => sub {
     FixMyStreet::override_config {
         MAPIT_URL => 'http://mapit.uk/',
         ALLOWED_COBRANDS => ['hackney'],
+        COBRAND_FEATURES => {
+            do_not_reply_email => {
+                hackney => 'fms-hackney-DO-NOT-REPLY@hackney-example.com',
+            },
+            verp_email_domain => {
+                hackney => 'hackney-example.com',
+            },
+        },
     }, sub {
         $mech->log_out_ok;
         $mech->log_in_ok( $hackney_user->email );
@@ -139,6 +147,14 @@ subtest "sends branded confirmation emails" => sub {
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => [ 'hackney' ],
         MAPIT_URL => 'http://mapit.uk/',
+        COBRAND_FEATURES => {
+            do_not_reply_email => {
+                hackney => 'fms-hackney-DO-NOT-REPLY@hackney-example.com',
+            },
+            verp_email_domain => {
+                hackney => 'hackney-example.com',
+            },
+        },
     }, sub {
         $mech->submit_form_ok( { with_fields => { pc => 'E8 1DY', } },
             "submit location" );

--- a/t/email.t
+++ b/t/email.t
@@ -14,4 +14,10 @@ my ($type, $id) = FixMyStreet::Email::check_verp_token($token);
 is $type, "report", 'Correct type from token';
 is $id, 123, 'Correct ID from token';
 
+my $verpid = FixMyStreet::Email::unique_verp_id([ "report", 123 ]);
+is $verpid, 'fms-report-123-8fb274c6@example.org', 'VERP id okay';
+
+$verpid = FixMyStreet::Email::unique_verp_id([ "report", 123 ], "example.net");
+is $verpid, 'fms-report-123-8fb274c6@example.net', 'VERP id okay with custom domain';
+
 done_testing();


### PR DESCRIPTION
Adds cobrand hook for setting domain of VERP emails, enables this for Hackney using a cobrand feature.