### PR TITLE
[Zurich] Internal reports

### DIFF
--- a/bin/zurich/overdue-alert
+++ b/bin/zurich/overdue-alert
@@ -45,6 +45,7 @@ sub loop_through {
         state => $states,
         created => { '<',  $date_threshold },
         bodies_str => { '!=', undef },
+        non_public => 0,
     } );
 
     my %to_send = ();

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -468,6 +468,7 @@ sub admin {
     my $self = shift;
     my $c = $self->{c};
     my $type = $c->stash->{admin_type};
+    my $internal = $c->get_param('internal');
 
     if ($type eq 'dm') {
         $c->stash->{template} = 'admin/index-dm.html';
@@ -482,12 +483,14 @@ sub admin {
         $c->stash->{submitted} = $c->cobrand->problems->search({
             state => [ 'submitted', 'confirmed' ],
             bodies_str => $c->stash->{body}->id,
+            non_public => $internal ? 1 : 0,
         }, {
             order_by => $order,
         });
         $c->stash->{approval} = $c->cobrand->problems->search({
             state => 'feedback pending',
             bodies_str => $c->stash->{body}->id,
+            non_public => $internal ? 1 : 0,
         }, {
             order_by => $order,
         });
@@ -496,6 +499,7 @@ sub admin {
         $c->stash->{other} = $c->cobrand->problems->search({
             state => { -not_in => [ 'submitted', 'confirmed', 'feedback pending' ] },
             bodies_str => \@all,
+            non_public => $internal ? 1 : 0,
         }, {
             order_by => $order,
         })->page( $page );
@@ -511,12 +515,14 @@ sub admin {
         $c->stash->{reports_new} = $c->cobrand->problems->search( {
             state => 'in progress',
             bodies_str => $body->id,
+            non_public => $internal ? 1 : 0,
         }, {
             order_by => $order
         } );
         $c->stash->{reports_unpublished} = $c->cobrand->problems->search( {
             state => 'feedback pending',
             bodies_str => $body->parent->id,
+            non_public => $internal ? 1 : 0,
         }, {
             order_by => $order
         } );
@@ -525,6 +531,7 @@ sub admin {
         $c->stash->{reports_published} = $c->cobrand->problems->search( {
             state => 'fixed - council',
             bodies_str => $body->parent->id,
+            non_public => $internal ? 1 : 0,
         }, {
             order_by => $order
         } )->page( $page );

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -957,10 +957,15 @@ sub admin_report_edit {
 
             # If they clicked the no more updates button, we're done.
             if ($c->get_param('no_more_updates')) {
-                $problem->set_extra_metadata( subdiv_overdue => $self->overdue( $problem ) );
-                $problem->bodies_str( $body->parent->id );
-                $problem->whensent( undef );
-                $self->set_problem_state($c, $problem, 'feedback pending');
+                if ($problem->non_public) {
+                    $problem->bodies_str( $body->parent->id );
+                    $self->set_problem_state($c, $problem, 'fixed - council');
+                } else {
+                    $problem->set_extra_metadata( subdiv_overdue => $self->overdue( $problem ) );
+                    $problem->bodies_str( $body->parent->id );
+                    $problem->whensent( undef );
+                    $self->set_problem_state($c, $problem, 'feedback pending');
+                }
                 $problem->update;
                 $c->res->redirect( '/admin/summary' );
             }

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -1061,6 +1061,7 @@ sub _admin_send_email {
     my ( $c, $template, $problem ) = @_;
 
     return unless $problem->get_extra_metadata('email_confirmed');
+    return if $problem->non_public;
 
     my $to = $problem->name
         ? [ $problem->user->email, $problem->name ]

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -892,8 +892,7 @@ sub admin_report_edit {
 
     if ($type eq 'sdm') {
 
-        my $editable = $type eq 'sdm' && $body->id eq $problem->bodies_str;
-        $c->stash->{sdm_disabled} = $editable ? '' : 'disabled';
+        my $editable = $body->id eq $problem->bodies_str;
 
         # Has cut-down edit template for adding update and sending back up only
         $c->stash->{template} = 'admin/report_edit-sdm.html';
@@ -970,6 +969,10 @@ sub admin_report_edit {
                 $c->res->redirect( '/admin/summary' );
             }
         }
+
+        $c->stash->{sdm_disabled} = $editable ? '' : 'disabled';
+        $c->stash->{sdm_disabled_internal} = $problem->non_public ? 'disabled' : '';
+        $c->stash->{sdm_disabled_fixed} = $problem->is_fixed ? 'disabled' : '';
 
         return $self->admin_report_edit_done;
     }

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -454,6 +454,16 @@ sub admin_type {
     return $type;
 }
 
+sub _admin_index_order {
+    my $self = shift;
+    my $c = $self->{c};
+    my $order = $c->get_param('o') || 'created';
+    my $dir = defined $c->get_param('d') ? $c->get_param('d') : 1;
+    $c->stash->{order} = $order;
+    $c->stash->{dir} = $dir;
+    return $dir ? { -desc => $order } : $order;
+}
+
 sub admin {
     my $self = shift;
     my $c = $self->{c};
@@ -466,13 +476,9 @@ sub admin {
         my @children = map { $_->id } $body->bodies->all;
         my @all = (@children, $body->id);
 
-        my $order = $c->get_param('o') || 'created';
-        my $dir = defined $c->get_param('d') ? $c->get_param('d') : 1;
-        $c->stash->{order} = $order;
-        $c->stash->{dir} = $dir;
-        $order = { -desc => $order } if $dir;
+        my $order = $self->_admin_index_order;
 
-        # XXX No multiples or missing bodies
+        # No multiples or missing bodies
         $c->stash->{submitted} = $c->cobrand->problems->search({
             state => [ 'submitted', 'confirmed' ],
             bodies_str => $c->stash->{body}->id,
@@ -499,14 +505,9 @@ sub admin {
         $c->stash->{template} = 'admin/index-sdm.html';
 
         my $body = $c->stash->{body};
+        my $order = $self->_admin_index_order;
 
-        my $order = $c->get_param('o') || 'created';
-        my $dir = defined $c->get_param('d') ? $c->get_param('d') : 1;
-        $c->stash->{order} = $order;
-        $c->stash->{dir} = $dir;
-        $order = { -desc => $order } if $dir;
-
-        # XXX No multiples or missing bodies
+        # No multiples or missing bodies
         $c->stash->{reports_new} = $c->cobrand->problems->search( {
             state => 'in progress',
             bodies_str => $body->id,

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -1390,4 +1390,13 @@ sub hook_report_filter_status {
     } @$status;
 }
 
+# If report is made by a flagged user, mark as non-public
+sub report_new_munge_before_insert {
+    my ($self, $report) = @_;
+
+    if ($report->user->flagged) {
+        $report->non_public(1);
+    }
+}
+
 1;

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -800,7 +800,12 @@ subtest 'test no email sent if closed' => sub {
     $internal->discard_changes;
     is $internal->state, 'fixed - council';
     $mech->email_count_is(0);
+};
 
+subtest 'remove internal flag' => sub {
+    $mech->submit_form_ok( { form_number => 2, button => 'stop_internal' } );
+    $internal->discard_changes;
+    is $internal->non_public, 0;
     $internal->delete;
     $mech->log_out_ok;
 };

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -98,7 +98,7 @@ my $superuser;
 subtest "set up superuser" => sub {
     $superuser = $mech->log_in_ok( 'super@example.org' );
     # a user from body $zurich is a superuser, as $zurich has no parent id!
-    $superuser->update({ from_body => $zurich->id });
+    $superuser->update({ name => 'Superuser', from_body => $zurich->id });
     $EXISTING_REPORT_COUNT = get_export_rows_count($mech);
     $mech->log_out_ok;
 };
@@ -989,6 +989,15 @@ $mech->log_out_ok;
 subtest 'users at the top level can be edited' => sub {
     $mech->log_in_ok( $superuser->email );
     $mech->get_ok('/admin/users/' . $superuser->id );
+    $mech->content_contains('name="flagged">');
+    $mech->submit_form_ok({ with_fields => { flagged => 1 } });
+    $superuser->discard_changes;
+    is $superuser->flagged, 1, 'Marked as flagged';
+    $mech->get_ok('/admin/users/' . $superuser->id );
+    $mech->content_contains('name="flagged" checked');
+    $mech->submit_form_ok({ with_fields => { flagged => 0 } });
+    $superuser->discard_changes;
+    is $superuser->flagged, 0, 'Unmarked';
 };
 
 subtest 'A visit to /reports is okay' => sub {

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -747,26 +747,20 @@ subtest "superuser and dm can see stats" => sub {
     $user = $mech->log_in_ok( 'dm1@example.org' );
     $mech->get( '/admin/stats' );
     is $mech->res->code, 200, "dm can now also see stats page";
-    $mech->log_out_ok;
 };
 
 subtest "only superuser can edit bodies" => sub {
-    $user = $mech->log_in_ok( 'dm1@example.org' );
     $mech->get( '/admin/body/' . $zurich->id );
     is $mech->res->code, 403, "only superuser should be able to edit bodies";
-    $mech->log_out_ok;
 };
 
 subtest "only superuser can see 'Add body' form" => sub {
-    $user = $mech->log_in_ok( 'dm1@example.org' );
     $mech->get_ok( '/admin/bodies' );
     $mech->content_contains('External Body');
     $mech->content_lacks( '<form method="post" action="bodies"' );
-    $mech->log_out_ok;
 };
 
 subtest "phone number is mandatory" => sub {
-    $user = $mech->log_in_ok( 'dm1@example.org' );
     $mech->get_ok( '/report/new?lat=47.381817&lon=8.529156' );
     $mech->submit_form( with_fields => { phone => "" } );
     $mech->content_contains( 'Diese Information wird benötigt' );

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -802,7 +802,18 @@ subtest 'test no email sent if closed' => sub {
     $mech->email_count_is(0);
 };
 
+subtest 'SDM closing internal report' => sub {
+    $mech->log_in_ok('sdm1@example.org');
+    $internal->update({ bodies_str => $subdivision->id, state => 'confirmed' });
+    $mech->get_ok('/admin/report_edit/' . $internal->id);
+    $mech->submit_form_ok( { form_number => 2, button => 'no_more_updates' } );
+    $internal->discard_changes;
+    is $internal->state, 'fixed - council', 'State updated';
+};
+
 subtest 'remove internal flag' => sub {
+    $internal->update({ bodies_str => $subdivision->id, state => 'confirmed' });
+    $mech->get_ok('/admin/report_edit/' . $internal->id);
     $mech->submit_form_ok( { form_number => 2, button => 'stop_internal' } );
     $internal->discard_changes;
     is $internal->non_public, 0;

--- a/templates/web/base/admin/users/_form_details.html
+++ b/templates/web/base/admin/users/_form_details.html
@@ -1,0 +1,33 @@
+<li>
+  <div class="admin-hint">
+    <p>
+      [% loc(
+        "The user's <strong>name</strong> is displayed publicly on reports that have not been marked <em>anonymous</em>.
+        Names are not necessarily unique.")
+      %]
+    </p>
+  </div>
+  <label for="name">[% loc('Name:') %]</label>
+  <input type='text' class="form-control" name='name' id='name' value='[% user.name | html %]'>
+</li>
+
+<li><label for="email">[% loc('Email:') %]</label>
+<input type='text' class="form-control" id='email' name='email' value='[% user.email | html %]'>
+[% IF user %]
+    <input class="btn" type="submit" name="send_login_email" value="[% loc('Send login email') %]">
+[% END %]
+</li>
+
+<li><label class="inline-text" for="email_verified">[% loc('Email verified:') %]</label>
+<input type="checkbox" id="email_verified" name="email_verified" value="1" [% user.email_verified ? ' checked' : '' %]>
+
+<li><label for="phone">[% loc('Phone:') %]</label>
+<input type='text' class="form-control" id='phone' name='phone' value='[% user.phone | html %]'></li>
+<li><label class="inline-text" for="phone_verified">[% loc('Phone verified:') %]</label>
+<input type="checkbox" id="phone_verified" name="phone_verified" value="1" [% user.phone_verified ? ' checked' : '' %]>
+
+[% IF username_in_abuse %]
+<li>
+    <p class="error">[% loc('User in abuse table') %] <input name="unban" type="submit" value="[% loc('Unban') %]"></p>
+</li>
+[% END %]

--- a/templates/web/base/admin/users/form.html
+++ b/templates/web/base/admin/users/form.html
@@ -7,38 +7,9 @@
 
     [% INCLUDE 'errors.html' errors = field_errors.values %]
     <ul class="no-bullets">
-        <li>
-          <div class="admin-hint">
-            <p>
-              [% loc(
-                "The user's <strong>name</strong> is displayed publicly on reports that have not been marked <em>anonymous</em>.
-                Names are not necessarily unique.")
-              %]
-            </p>
-          </div>
-          <label for="name">[% loc('Name:') %]</label>
-          <input type='text' class="form-control" name='name' id='name' value='[% user.name | html %]'>
-        </li>
-        <li><label for="email">[% loc('Email:') %]</label>
-        <input type='text' class="form-control" id='email' name='email' value='[% user.email | html %]'>
-        [% IF user %]
-            <input class="btn" type="submit" name="send_login_email" value="[% loc('Send login email') %]">
-        [% END %]
-        </li>
-        <li><label class="inline-text" for="email_verified">[% loc('Email verified:') %]</label>
-        <input type="checkbox" id="email_verified" name="email_verified" value="1" [% user.email_verified ? ' checked' : '' %]>
-        <li><label for="phone">[% loc('Phone:') %]</label>
-        <input type='text' class="form-control" id='phone' name='phone' value='[% user.phone | html %]'></li>
-        <li><label class="inline-text" for="phone_verified">[% loc('Phone verified:') %]</label>
-        <input type="checkbox" id="phone_verified" name="phone_verified" value="1" [% user.phone_verified ? ' checked' : '' %]>
+        [% PROCESS 'admin/users/_form_details.html' %]
 
-      [% IF username_in_abuse %]
-      <li>
-            <p class="error">[% loc('User in abuse table') %] <input name="unban" type="submit" value="[% loc('Unban') %]"></p>
-      </li>
-      [% END %]
-
-      [% IF c.user.is_superuser || c.cobrand.moniker == 'zurich' %]
+      [% IF c.user.is_superuser %]
         <li>
           <div class="admin-hint">
             <p>
@@ -72,7 +43,7 @@
           </li>
       [% END %]
 
-        [% IF areas AND c.cobrand.moniker != 'zurich' %]
+        [% IF areas %]
           <li>
             <div class="admin-hint">
               <p>
@@ -94,14 +65,14 @@
           </li>
         [% END %]
 
-        [% IF contacts AND c.cobrand.moniker != 'zurich'%]
+        [% IF contacts %]
           <li class="js-user-categories">
             [% INCLUDE 'admin/category-checkboxes.html' hint=loc("Authorised staff users can be associated with the categories in which they operate.") %]
           </li>
         [% END %]
 
 
-      [% IF user.from_body AND c.cobrand.moniker != 'zurich' %]
+      [% IF user.from_body %]
         <li>
           <div class="admin-hint">
             <p>
@@ -116,7 +87,6 @@
         </li>
       [% END %]
 
-      [% IF c.cobrand.moniker != 'zurich' %]
         <li>
           <div class="admin-hint">
             <p>
@@ -197,7 +167,7 @@
             </fieldset>
           </li>
         [% END %]
-      [% END %]
+
       [% TRY %][% INCLUDE 'admin/users/form-extra-fields.html' %][% CATCH file %][% END %]
     </ul>
     <p>

--- a/templates/web/zurich/admin/_index_table.html
+++ b/templates/web/zurich/admin/_index_table.html
@@ -13,8 +13,5 @@
         <th class='edit'>*</th>
         [% END %]
     </tr>
-    <tr class="filter-row">
-        <td colspan="8"><input type="text" placeholder="[%= loc('Filter report list') %]" /></td>
-    </tr>
 [% INCLUDE 'admin/problem_row.html' %]
 </table>

--- a/templates/web/zurich/admin/_index_table.html
+++ b/templates/web/zurich/admin/_index_table.html
@@ -1,0 +1,20 @@
+<table cellspacing="0" cellpadding="2" border="1">
+    <tr>
+        <th>[% loc('ID') %]</th>
+        <th>[% loc('Description') %]</th>
+      [% FOREACH col IN [ [ 'category', loc('Category') ], [ 'created', loc('Submitted') ], [ 'lastupdate', loc('Updated') ], [ 'state', loc('Status') ] ] %]
+        <th><a href="[% INCLUDE sort_link choice = col.0 %]#[% hash %]">[% col.1 %] [% INCLUDE sort_arrow choice = col.0 %]</a></th>
+      [% END %]
+    [% IF include_subdiv %]
+        <th>[% loc('Subdivision/Body') %]</th>
+    [% END %]
+        <th>[% loc('Photo') %]</th>
+        [% IF NOT no_edit %]
+        <th class='edit'>*</th>
+        [% END %]
+    </tr>
+    <tr class="filter-row">
+        <td colspan="8"><input type="text" placeholder="[%= loc('Filter report list') %]" /></td>
+    </tr>
+[% INCLUDE 'admin/problem_row.html' %]
+</table>

--- a/templates/web/zurich/admin/index-dm.html
+++ b/templates/web/zurich/admin/index-dm.html
@@ -6,34 +6,13 @@
 </div>
 
 <h2 id="submitted">[% loc('Submitted') %]</h2>
-[% INCLUDE list, problems = submitted.all, hash = 'submitted' %]
+[% INCLUDE 'admin/_index_table.html' problems=submitted.all hash='submitted' %]
 
 <h2 id="feedback_pending">Rückmeldung ausstehend</h2>
-[% INCLUDE list, problems = approval.all, hash = 'feedback_pending' %]
+[% INCLUDE 'admin/_index_table.html' problems=approval.all hash='feedback_pending' %]
 
 <h2 id="alle">[% loc('All reports') %]</h2>
-[% INCLUDE list, problems = other.all, include_subdiv = 1, hash = 'alle' %]
+[% INCLUDE 'admin/_index_table.html' problems=other.all include_subdiv=1 hash='alle' %]
 [% INCLUDE 'pagination.html', admin = 1, param = 'p', hash = 'alle' %]
 
 [% INCLUDE 'admin/footer.html' %]
-
-[% BLOCK list %]
-<table cellspacing="0" cellpadding="2" border="1">
-    <tr>
-        <th>[% loc('ID') %]</th>
-        <th>[% loc('Description') %]</th>
-      [% FOREACH col IN [ [ 'category', loc('Category') ], [ 'created', loc('Submitted') ], [ 'lastupdate', loc('Updated') ], [ 'state', loc('Status') ] ] %]
-        <th><a href="[% INCLUDE sort_link choice = col.0 %]#[% hash %]">[% col.1 %] [% INCLUDE sort_arrow choice = col.0 %]</a></th>
-      [% END %]
-    [% IF include_subdiv %]
-        <th>[% loc('Subdivision/Body') %]</th>
-    [% END %]
-        <th>[% loc('Photo') %]</th>
-        <th class='edit'>*</th>
-    </tr>
-    <tr class="filter-row">
-        <td colspan="8"><input type="text" placeholder="[%= loc('Filter report list') %]" /></td>
-    </tr>
-[% INCLUDE 'admin/problem_row.html' %]
-</table>
-[% END %]

--- a/templates/web/zurich/admin/index-sdm.html
+++ b/templates/web/zurich/admin/index-sdm.html
@@ -2,33 +2,13 @@
 [% PROCESS 'admin/report_blocks.html' %]
 
 <h2 id="new">[% loc('New reports') %]</h2>
-[% INCLUDE list, problems = reports_new.all, hash = 'new' %]
+[% INCLUDE 'admin/_index_table.html' problems=reports_new.all hash='new' %]
 
 <h2 id="wait">[% loc('Reports awaiting approval') %]</h2>
-[% INCLUDE list, problems = reports_unpublished.all, hash = 'wait' %]
+[% INCLUDE 'admin/_index_table.html' problems=reports_unpublished.all hash='wait' %]
 
 <h2 id="alle">[% loc('Reports published') %]</h2>
-[% INCLUDE list, problems = reports_published.all, no_edit = 1, hash = 'alle' %]
+[% INCLUDE 'admin/_index_table.html' problems=reports_published.all no_edit=1 hash='alle' %]
 [% INCLUDE 'pagination.html', admin = 1, param = 'p', hash = 'alle' %]
 
 [% INCLUDE 'admin/footer.html' %]
-
-[% BLOCK list %]
-<table cellspacing="0" cellpadding="2" border="1">
-    <tr>
-        <th>[% loc('ID') %]</th>
-        <th>[% loc('Description') %]</th>
-      [% FOREACH col IN [ [ 'category', loc('Category') ], [ 'created', loc('Submitted') ], [ 'lastupdate', loc('Updated') ], [ 'state', loc('Status') ] ] %]
-        <th><a href="[% INCLUDE sort_link choice = col.0 %]#[% hash %]">[% col.1 %] [% INCLUDE sort_arrow choice = col.0 %]</a></th>
-      [% END %]
-        <th>[% loc('Photo') %]</th>
-        [% IF NOT no_edit %]
-        <th class='edit'>*</th>
-        [% END %]
-    </tr>
-    <tr class="filter-row">
-        <td colspan="8"><input type="text" placeholder="[%= loc('Filter report list') %]" /></td>
-    </tr>
-[% INCLUDE 'admin/problem_row.html' %]
-</table>
-[% END %]

--- a/templates/web/zurich/admin/problem_row.html
+++ b/templates/web/zurich/admin/problem_row.html
@@ -21,7 +21,8 @@
         <td>[% prettify_state(problem.state) %]
             [% IF problem.state == 'feedback pending';
             SET cs=problem.get_extra_metadata('closure_status');
-            IF cs %] ([% prettify_state(cs) %]) [% END; END %]</td>
+            IF cs %] ([% prettify_state(cs) %]) [% END; END %]
+            [% IF problem.non_public %]<br><i>Interne Meldung</i>[% END %]</td>
 
         [% IF include_subdiv %]
             <td>

--- a/templates/web/zurich/admin/problem_row.html
+++ b/templates/web/zurich/admin/problem_row.html
@@ -1,3 +1,5 @@
+[% no_edit = no_edit AND NOT c.req.params.internal ~%]
+
 [%- FOR problem IN problems %]
     [% SET p_body = problem.bodies.values.0 %]
     <tr[%

--- a/templates/web/zurich/admin/report_edit-sdm.html
+++ b/templates/web/zurich/admin/report_edit-sdm.html
@@ -85,6 +85,12 @@
 
 <div class="admin-report-edit admin-report-edit--interact">
 
+[% IF problem.non_public %]
+<p align="right" class="screen-only">
+    <input [% sdm_disabled %] type="submit" class="btn" name="stop_internal" value="Keine interne Meldung">
+</p>
+[% END %]
+
 <p align="right" class="screen-only"><input [% sdm_disabled %] type="submit" class="btn" name="send_back" value="[% loc('Not for my subdivision') %]"></p>
 
 [% status_message | safe %]

--- a/templates/web/zurich/admin/report_edit-sdm.html
+++ b/templates/web/zurich/admin/report_edit-sdm.html
@@ -87,15 +87,15 @@
 
 [% IF problem.non_public %]
 <p align="right" class="screen-only">
-    <input [% sdm_disabled %] type="submit" class="btn" name="stop_internal" value="Keine interne Meldung">
+    <input [% sdm_disabled %] [% sdm_disabled_fixed %] type="submit" class="btn" name="stop_internal" value="Keine interne Meldung">
 </p>
 [% END %]
 
-<p align="right" class="screen-only"><input [% sdm_disabled %] type="submit" class="btn" name="send_back" value="[% loc('Not for my subdivision') %]"></p>
+<p align="right" class="screen-only"><input [% sdm_disabled %] [% sdm_disabled_fixed %] type="submit" class="btn" name="send_back" value="[% loc('Not for my subdivision') %]"></p>
 
 [% status_message | safe %]
 
-<p align="right" class="screen-only"><input [% sdm_disabled %] type="submit" class="btn" name="not_contactable" value="[% loc('Customer not contactable') %]"></p>
+<p align="right" class="screen-only"><input [% sdm_disabled %] [% sdm_disabled_internal %] [% sdm_disabled_fixed %] type="submit" class="btn" name="not_contactable" value="[% loc('Customer not contactable') %]"></p>
 
 <ul class="no-bullets screen-only">
     <li>
@@ -104,7 +104,7 @@
     </li>
     <li>
         <label for="status_update">[% loc('New note to DM:') %]</label>
-        <textarea [% sdm_disabled %] class="form-control" name='status_update' id='status_update' cols=60 rows=4></textarea>
+        <textarea [% sdm_disabled %] [% sdm_disabled_internal %] [% sdm_disabled_fixed %] class="form-control" name='status_update' id='status_update' cols=60 rows=4></textarea>
     </li>
 </ul>
 
@@ -115,7 +115,7 @@
 
 <p class="clearfix screen-only">
     <input [% sdm_disabled %] style="float:left" type="submit" class="btn" name="Submit changes" value="[% loc('Submit changes') %]" >
-    <input [% sdm_disabled %] style="float:right" type="submit" class="btn" name="no_more_updates" value="[% loc('No further updates') %]">
+    <input [% sdm_disabled %] [% sdm_disabled_fixed %] style="float:right" type="submit" class="btn" name="no_more_updates" value="[% loc('No further updates') %]">
 </p>
 
 [% INCLUDE 'admin/list_updates.html' %]

--- a/templates/web/zurich/admin/reports/edit.html
+++ b/templates/web/zurich/admin/reports/edit.html
@@ -119,6 +119,10 @@
 
 [% status_message | safe %]
 
+[% IF problem.non_public %]
+<p align="right" class="screen-only"><input type="submit" class="btn" name="stop_internal" value="Keine interne Meldung"></p>
+[% END %]
+
 <dl [% IF status_message %]class="with-message"[% END %]>
 
     <dt class="screen-only">

--- a/templates/web/zurich/admin/reports/index.html
+++ b/templates/web/zurich/admin/reports/index.html
@@ -6,21 +6,8 @@
 </form>
 
 [% IF problems.size %]
-<table cellspacing="0" cellpadding="2" border="1">
-    <tr>
-        <th>[% loc('ID') %]</th>
-        <th>[% loc('Description') %]</th>
-      [% FOREACH col IN [ [ 'category', loc('Category') ], [ 'created', loc('Submitted') ], [ 'lastupdate', loc('Updated') ], [ 'state', loc('Status') ] ] %]
-        <th><a href="[% INCLUDE sort_link choice = col.0 %]">[% col.1 %] [% INCLUDE sort_arrow choice = col.0 %]</a></th>
-      [% END %]
-        <th>[% loc('Photo') %]</th>
-        <th class='edit'>*</th>
-    </tr>
-    [% INCLUDE 'admin/problem_row.html' %]
-</table>
-
-[% INCLUDE 'pagination.html', admin = 1, param = 'p', pager = problems_pager %]
-
+    [% PROCESS 'admin/_index_table.html' %]
+    [% INCLUDE 'pagination.html', admin = 1, param = 'p', pager = problems_pager %]
 [% END %]
 
 [% INCLUDE 'admin/list_updates.html' %]

--- a/templates/web/zurich/admin/reports/index.html
+++ b/templates/web/zurich/admin/reports/index.html
@@ -1,4 +1,4 @@
-[% PROCESS 'admin/header.html' title=loc('Search Reports') %]
+[% PROCESS 'admin/header.html' title=loc('All Reports') %]
 [% PROCESS 'admin/report_blocks.html' %]
 
 <form method="get" action="[% c.uri_for_action('admin/reports/index') %]" enctype="application/x-www-form-urlencoded" accept-charset="utf-8">

--- a/templates/web/zurich/admin/users/form.html
+++ b/templates/web/zurich/admin/users/form.html
@@ -19,6 +19,13 @@
           </select>
         </li>
 
+        <li>
+          <label>
+            [% loc('government-internal') %]
+            <input type="checkbox" id="flagged" name="flagged"[% user.flagged ? ' checked' : '' %]>
+          </label>
+        </li>
+
     </ul>
     <p>
       <input type="submit" class="btn" name="Submit changes" value="[% loc('Submit changes') %]" >

--- a/templates/web/zurich/admin/users/form.html
+++ b/templates/web/zurich/admin/users/form.html
@@ -1,0 +1,36 @@
+<form method="post" id="user_edit" action="[%
+    SET action_end = user.id || 'add';
+    c.uri_for_action( 'admin/users/edit', [ action_end ] )
+    %]" enctype="application/x-www-form-urlencoded" accept-charset="utf-8">
+    <input type="hidden" name="token" value="[% csrf_token %]" >
+    <input type="hidden" name="submit" value="1" >
+
+    [% INCLUDE 'errors.html' errors = field_errors.values %]
+    <ul class="no-bullets">
+        [% PROCESS 'admin/users/_form_details.html' %]
+
+        <li>
+          <label for="body">[% loc('Body:') %]</label>
+          <select class="form-control" id='body' name='body'>
+            <option value=''>[% loc('No body') %]</option>
+          [% FOR body IN bodies %]
+            <option value="[% body.id %]"[% ' selected data-originally-selected' IF body.id == user.from_body.id %]>[% body.name %]</option>
+          [% END %]
+          </select>
+        </li>
+
+    </ul>
+    <p>
+      <input type="submit" class="btn" name="Submit changes" value="[% loc('Submit changes') %]" >
+    </p>
+
+  [% IF user AND NOT user.from_body %]
+    <ul class="no-bullets danger-zone">
+      <li><input class="btn-danger" type="submit" name="logout_everywhere" value="[% loc('Log out of all sessions') %]">
+      <li><input class="btn-danger" type="submit" name="anon_everywhere" value="[% loc('Make anonymous on all reports and updates') %]">
+      <li><input class="btn-danger" type="submit" name="hide_everywhere" value="[% loc('Hide all reports and updates') %]">
+      <li><input class="btn-danger" type="submit" name="remove_account" value="[% loc('Remove account details') %]">
+    </ul>
+  [% END %]
+
+</form>

--- a/templates/web/zurich/header.html
+++ b/templates/web/zurich/header.html
@@ -66,7 +66,7 @@
             </li>
             [% END %]
             <li class="search-box">
-                <form method="get" action="[% c.uri_for('reports') %]" enctype="application/x-www-form-urlencoded" accept-charset="utf-8">
+                <form method="get" action="[% c.uri_for_action('/admin/reports/index') %]" enctype="application/x-www-form-urlencoded" accept-charset="utf-8">
                     <input type="text" name="search" size="20" id="search" placeholder="[% loc('Search reports') %]">
                 </form>
 

--- a/templates/web/zurich/header.html
+++ b/templates/web/zurich/header.html
@@ -41,11 +41,20 @@
             [% pagename = c.req.uri.path %]
             [% pagename = pagename.replace('/admin/?(\w*).*', '$1') %]
 
+            [% IF admin_type == 'super' %]
             <li [% IF pagename == 'summary' OR pagename == '' %]class="current"[% END %]>
                 <a href="/admin/summary">[% loc('Summary') %]</a>
             </li>
+            [% ELSE %]
+            <li [% IF NOT c.get_param('internal') AND (pagename == 'summary' OR pagename == '') %]class="current"[% END %]>
+                <a href="/admin/summary">Öffentliche</a>
+            </li>
+            <li [% IF c.get_param('internal') AND (pagename == 'summary' OR pagename == '') %]class="current"[% END %]>
+                <a href="/admin/summary?internal=1">Interne</a>
+            </li>
+            [% END %]
             <li [% IF pagename == 'reports' OR pagename == 'report_edit' %]class="current"[% END %]>
-                <a href="/admin/reports">[% loc('Reports') %]</a>
+                <a href="/admin/reports">[% loc('All') %]</a>
             </li>
             [% IF admin_type == 'dm' OR admin_type == 'super' %]
             <li [% IF pagename == 'bodies' OR pagename == 'body' %]class="current"[% END %]>

--- a/web/cobrands/sass/_admin.scss
+++ b/web/cobrands/sass/_admin.scss
@@ -43,22 +43,6 @@ $button_bg_col: #a1a1a1;  // also search bar (tables)
             text-align: center;
             font-weight: bold;
         }
-        tr.filter-row td {
-            display: none; /* TODO: reveal when filtering is implemented */
-            padding: flip(4px 4px 4px 40px, 4px 40px 4px 4px);
-            background-color: $button_bg_col;
-            background-image: url('/cobrands/zurich/search-icon-white.png');
-            background-position: flip(14px, right) center;
-            background-repeat: no-repeat;
-            border-bottom: 2px solid $table_border_color;
-        }
-        tr.filter-row td input[type=text] {
-            background-color: #e1e1e1;
-            width: 16em;
-            @include border-radius(4px);
-            border: none;
-            padding: 3px 0.5em;
-        }
         tr.is-deleted {
           background-color: #ffdddd;
           img {

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -313,6 +313,9 @@ legend,
         box-shadow: none;
         color: #888888;
     }
+    &[disabled] {
+        background-color: #eee;
+    }
 }
 
 select.form-control {


### PR DESCRIPTION
Adds the bits of functionality required. Starts off doing some refactoring that makes no actual changes to some templates and code (oh, and one small bug fix). Then sets up marking users/reports as internal, and the various bits.

This is a replacement PR for https://github.com/mysociety/fixmystreet/pull/2855 where almost all this was already reviewed - only bits to be reviewed are https://github.com/mysociety/fixmystreet/commit/fde6fcf77f3dffc9d9abef8a8711ad980e55ce17, https://github.com/mysociety/fixmystreet/commit/2025cbf1175f469178db7ab72e9bba6115fe20d7, and the base https://github.com/mysociety/fixmystreet/commit/99996e1c8f96e6eaf6b2f2643937c75e5627b47f.

Fixes mysociety/fixmystreet-commercial#1698
Fixes mysociety/fixmystreet-commercial#1699
Fixes mysociety/fixmystreet-commercial#1700
Fixes mysociety/fixmystreet-commercial#1701
Fixes mysociety/fixmystreet-commercial#1702
Fixes mysociety/fixmystreet-commercial#1703
[skip changelog]