### PR TITLE
[Hackney] skip hackney categories for TfL red routes

### DIFF
--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -437,6 +437,13 @@ sub munge_surrounding_london {
         # Don't send any TfL categories
         %$bodies = map { $_->id => $_ } grep { $_->name ne 'TfL' } values %$bodies;
     }
+
+    # Hackney doesn't have any of the council TfL categories so don't show
+    # any Hackney categories on red routes
+    my %bodies = map { $_->name => $_->id } values %$bodies;
+    if ( $bodies{'Hackney Council'} && $self->report_new_is_on_tlrn ) {
+        delete $bodies->{ $bodies{'Hackney Council'} };
+    }
 }
 
 sub munge_red_route_categories {

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -45,6 +45,7 @@ my @PLACES = (
     [ '?', 52.238827, -0.894970, 2234, 'Northamptonshire County Council', 'CTY', 2397, 'Northampton Borough Council', 'DIS' ],
     [ '?', 52.23025, -1.015826, 2234, 'Northamptonshire County Council', 'CTY', 2397, 'Northampton Borough Council', 'DIS' ],
     [ 'E8 1DY', 51.552267, -0.063316, 2508, 'Hackney Borough Council', 'LBO' ],
+    [ 'E8 2DY', 51.552287, -0.063326, 2508, 'Hackney Council', 'LBO' ],
     [ 'TW7 5JN', 51.482286, -0.328163, 2483, 'Hounslow Borough Council', 'LBO' ],
     [ '?', 51.48111, -0.327219, 2483, 'Hounslow Borough Council', 'LBO' ],
     [ '?', 51.482045, -0.327219, 2483, 'Hounslow Borough Council', 'LBO' ],

--- a/t/Mock/Tilma.pm
+++ b/t/Mock/Tilma.pm
@@ -28,7 +28,7 @@ sub dispatch_request {
     sub (GET + /mapserver/tfl + ?*) {
         my ($self, $args) = @_;
         my $features = [];
-        if ($args->{Filter} =~ /540512,169141/) {
+        if ($args->{Filter} =~ /540512,169141|534371,185488/) {
             $features = [
                 { type => "Feature", properties => { HA_ID => "19" }, geometry => { type => "Polygon", coordinates => [ [
                     [ 539408.94, 170607.58 ],

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -23,6 +23,10 @@ FixMyStreet::DB->resultset('BodyArea')->find_or_create({
     area_id => 2457, # Epsom Ewell, outside London, for bus stop test
     body_id => $body->id,
 });
+FixMyStreet::DB->resultset('BodyArea')->find_or_create({
+    area_id => 2508, # Hackney
+    body_id => $body->id,
+});
 my $superuser = $mech->create_user_ok('superuser@example.com', name => 'Super User', is_superuser => 1);
 my $staffuser = $mech->create_user_ok('counciluser@example.com', name => 'Council User', from_body => $body, password => 'password');
 $staffuser->user_body_permissions->create({
@@ -57,6 +61,13 @@ my $bromley_flytipping = $mech->create_contact_ok(
 );
 $bromley_flytipping->set_extra_metadata(group => [ 'Street cleaning' ]);
 $bromley_flytipping->update;
+
+my $hackney = $mech->create_body_ok(2508, 'Hackney Council');
+$mech->create_contact_ok(
+    body_id => $hackney->id,
+    category => 'Abandoned Vehicle',
+    email => 'av-hackney@example.com',
+);
 
 my $contact1 = $mech->create_contact_ok(
     body_id => $body->id,
@@ -748,7 +759,7 @@ subtest 'Test no questionnaire sending' => sub {
 };
 
 FixMyStreet::override_config {
-    ALLOWED_COBRANDS => [ 'tfl', 'bromley', 'fixmystreet' ],
+    ALLOWED_COBRANDS => [ 'tfl', 'bromley', 'fixmystreet', 'hackney' ],
     MAPIT_URL => 'http://mapit.uk/',
     COBRAND_FEATURES => {
         internal_ips => { tfl => [ '127.0.0.1' ] },
@@ -859,6 +870,21 @@ for my $test (
             'Flooding (Bromley)',
             'Flytipping (Bromley)',
             'Grit bins',
+            'Timings',
+            'Traffic lights',
+            'Trees'
+        ],
+    },
+    {
+        host => 'hackney.fixmystreet.com',
+        name => "test no hackney categories on red route",
+        lat => 51.552287,
+        lon => -0.063326,
+        expected => [
+            'Bus stops',
+            'Flooding',
+            'Grit bins',
+            'Pothole',
             'Timings',
             'Traffic lights',
             'Trees'


### PR DESCRIPTION
Because Hackney doesn't have any matching categories for TfL red routes
skip sending the body, otherwise you get a "no contact details" message
when you click on a red route in Hackney

[skip changelog]