### PR TITLE
Better sort admin user table.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
     - Admin improvements:
         - Display user name/email for contributed as reports. #2990
         - Interface for enabling anonymous reports for certain categories. #2989
+        - Better sort admin user table.
     - Development improvements:
         - `#geolocate_link` is now easier to re-style. #3006
         - Links inside `#front-main` can be customised using `$primary_link_*` Sass variables. #3007


### PR DESCRIPTION
Sort the table when showing search results, and show users without name at the bottom, rather than at the top.
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1925