### PR TITLE
[Peterborough,TfL] Remove unneeded CSS.

### DIFF
--- a/web/cobrands/peterborough/base.scss
+++ b/web/cobrands/peterborough/base.scss
@@ -78,20 +78,6 @@ h1, h2 {
     font-weight: 700;
 }
 
-a,
-.fake-link   {
-  color: $link-color;
-
-  &:visited {
-    color: $link-visited-color;
-  }
-
-  &:hover,
-  &:active {
-    color: $link-hover-color;
-  }
-}
-
 .dz-clickable .dz-message u {
     color: $link-color;
 }

--- a/web/cobrands/tfl/_colours.scss
+++ b/web/cobrands/tfl/_colours.scss
@@ -33,6 +33,7 @@ $primary_b: $johnston-black;
 $primary_text: $johnston-black;
 
 $link-color: $beck-blue;
+$link-text-decoration: 'underline';
 $link-hover-color: $blue-dark;
 
 $base_bg: $white;

--- a/web/cobrands/tfl/base.scss
+++ b/web/cobrands/tfl/base.scss
@@ -55,10 +55,6 @@ h3 {
     line-height: 1.238095238em; //26px
 }
 
-a, .fake-link {
-    text-decoration: underline;
-}
-
 .btn--primary,
 .btn,
 .green-btn {


### PR DESCRIPTION
[skip changelog]

In Peterborough's case, having them repeated meant they took precedence over the sub map links overrides. TfL's just didn't seem needed.