### PR TITLE
Do not have bootstrap run sudo commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
         - Improve compatibility with G Suite OpenID Connect authentication. #3032
         - Fix duplicate asset message after dismissing duplicate suggestions.
         - Improve moderation diff display in a few small ways. #3105
+        - Do not have bootstrap run sudo commands. #2930
     - Admin improvements:
         - Display user name/email for contributed as reports. #2990
         - Interface for enabling anonymous reports for certain categories. #2989

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,6 +60,9 @@ EOS
 # This just runs our update script, used on our offical box.
 $update = <<-EOS
     chown -R vagrant:vagrant /home/vagrant/.cpanm
+    # Ensure any new packages are installed
+    /home/vagrant/fixmystreet/bin/install_packages
+    # Run setup script
     su vagrant -c '/home/vagrant/fixmystreet/script/setup ; exit $?'
     if [ $? -eq 0 ]; then
       touch /tmp/success

--- a/bin/docker.preinit
+++ b/bin/docker.preinit
@@ -34,6 +34,7 @@ fi
 su $FMS_DB_USER -c "${FMS_ROOT}/bin/docker-cobrand"
 
 # Ensure things are up to date - schema, CSS, etc
+${FMS_ROOT}/bin/install_packages docker
 su $FMS_DB_USER -c "${FMS_ROOT}/script/update"
 
 # Update reports

--- a/bin/install_packages
+++ b/bin/install_packages
@@ -3,7 +3,7 @@ set -e
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-PACKAGE_FILE=conf/packages
+PACKAGE_FILE=conf/packages.generic
 
 [ -n "$1" ] && PACKAGE_FILE="conf/packages.${1}"
 

--- a/bin/site-specific-install.sh
+++ b/bin/site-specific-install.sh
@@ -54,8 +54,6 @@ fi
 
 install_website_packages
 
-su -l -c "touch '$DIRECTORY/admin-htpasswd'" "$UNIX_USER"
-
 if [ $INSTALL_DB = true ]; then
     add_postgresql_user
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
       FMS_ROOT: '/var/www/fixmystreet/fixmystreet'
       SUPERUSER_EMAIL: 'superuser@example.org'
       SUPERUSER_PASSWORD: '5up3r53cr3t'
-      SKIP_PACKAGES_INSTALL:
     networks:
       default:
         aliases:

--- a/docs/install/manual-install.md
+++ b/docs/install/manual-install.md
@@ -40,7 +40,7 @@ dependencies are listed in `conf/packages.generic`. To install all of them you
 can run e.g.:
 
 {% highlight bash %}
-$ sudo xargs -a conf/packages.generic apt-get install
+$ sudo bin/install_packages
 {% endhighlight %}
 
 A similar list of packages should work for other Debian-based distributions.

--- a/docs/updating/ami.md
+++ b/docs/updating/ami.md
@@ -41,9 +41,11 @@ make sure they are all committed to your local branch and fork first, see
 to try checking out your repository elsewhere and trying the merge there first,
 to see if it there are any problems.
 
-After updating the code, you should run the following command to update any
+After updating the code, you should run the following commands to update any
 needed dependencies and any schema changes to your database. It's a good idea
 to take a backup of your database first.
+
+    admin@ip-10-58-191-98:/var/www/fixmystreet/fixmystreet$ sudo bin/install_packages
 
     fms@ip-10-58-191-98:~/fixmystreet$ script/update
 

--- a/docs/updating/index.md
+++ b/docs/updating/index.md
@@ -53,12 +53,13 @@ you are too worried to merge in case it breaks something.
 
 ## Subsequent dependency updates
 
-After updating the code, you should run the following command to update any
+After updating the code, you should run the following commands to update any
 needed dependencies and any schema changes to your database. It's a good idea
 to take a backup of your database first.
 
 {% highlight bash %}
-script/update
+sudo bin/install_packages # (as your admin user)
+script/update # (as the fms user)
 {% endhighlight %}
 
 Of course, if you have made changes to the database schema yourself, this may

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -4,17 +4,4 @@ set -e
 cd "$(dirname "$0")/.."
 
 git submodule --quiet update --init --recursive --rebase
-
-if [ -z ${SKIP_PACKAGES_INSTALL:+x} ] ; then
-    # Let's see if we can't work out where we might be running.
-    if cut -d/ -f2 /proc/self/cgroup | sort -u | grep -q docker ; then
-        echo "==> Installing Docker packages..."
-        sudo bin/install_packages docker
-    else
-        # Fallback
-        echo "==> Installing generic packages..."
-        sudo bin/install_packages generic
-    fi
-fi
-
 bin/install_perl_modules


### PR DESCRIPTION
Your site user may not have access to sudo, and your admin user may cause permission issues if used to do the git checkout, or the Perl module installation. Document the separate script to install system packages instead.

Fixes #2930. I think it causes too much confusion to have it run sudo-level commands, when it's a user-level script. I realise this was introduced because a new Perl module needed a new library package, I've added some documentation about updating.

I've left in the Docker fms user being able to run bin/install_packages, don't see why not, and have changed the preinit to run this as well. I'm not sure if that's everything.