### PR TITLE
[UK] Show message if site-wide update disallowed.

### DIFF
--- a/t/app/controller/admin/bodies.t
+++ b/t/app/controller/admin/bodies.t
@@ -413,4 +413,31 @@ subtest 'check log of the above' => sub {
     $mech->content_contains('Edited body <a href="/admin/body/' . $body->id . '">Aberdeen City Council</a>');
 };
 
+subtest 'check update disallowed message' => sub {
+    FixMyStreet::override_config {
+        MAPIT_URL => 'http://mapit.uk/',
+        ALLOWED_COBRANDS => 'bathnes',
+        COBRAND_FEATURES => { updates_allowed => { bathnes => 'open' } }
+    }, sub {
+        $mech->get_ok('/admin/body/' . $body->id .'/test%20category');
+        $mech->content_contains('even if this is unticked, only open reports can have updates left on them.');
+    };
+    FixMyStreet::override_config {
+        MAPIT_URL => 'http://mapit.uk/',
+        ALLOWED_COBRANDS => 'bathnes',
+        COBRAND_FEATURES => { updates_allowed => { bathnes => 'staff' } }
+    }, sub {
+        $mech->get_ok('/admin/body/' . $body->id .'/test%20category');
+        $mech->content_contains('even if this is unticked, only staff will be able to leave updates.');
+    };
+    FixMyStreet::override_config {
+        MAPIT_URL => 'http://mapit.uk/',
+        ALLOWED_COBRANDS => 'bathnes',
+        COBRAND_FEATURES => { updates_allowed => { bathnes => 'reporter' } }
+    }, sub {
+        $mech->get_ok('/admin/body/' . $body->id .'/test%20category');
+        $mech->content_contains('even if this is unticked, only the problem reporter will be able to leave updates');
+    };
+};
+
 done_testing();

--- a/t/cobrand/isleofwight.t
+++ b/t/cobrand/isleofwight.t
@@ -116,13 +116,24 @@ subtest "only original reporter can comment" => sub {
     };
 };
 
+subtest "only original reporter can comment" => sub {
+    FixMyStreet::override_config {
+        MAPIT_URL => 'http://mapit.uk/',
+        ALLOWED_COBRANDS => 'fixmystreet',
+        COBRAND_FEATURES => { updates_allowed => { fixmystreet => { 'Isle of Wight' => 'reporter' } } },
+    }, sub {
+        $mech->log_out_ok;
+        $mech->get_ok('/report/' . $reports[0]->id);
+        $mech->content_contains('Only the original reporter may leave updates');
+    };
+};
+
 subtest "check moderation label uses correct name" => sub {
     my $REPORT_URL = '/report/' . $reports[0]->id;
     FixMyStreet::override_config {
         MAPIT_URL => 'http://mapit.uk/',
         ALLOWED_COBRANDS => ['isleofwight'],
     }, sub {
-        $mech->log_out_ok;
         $mech->log_in_ok( $iow_user->email );
         $mech->get_ok($REPORT_URL);
         $mech->content_lacks('show-moderation');

--- a/templates/web/base/admin/bodies/contact-form.html
+++ b/templates/web/base/admin/bodies/contact-form.html
@@ -66,6 +66,7 @@
     <p class="form-check">
         <input type="checkbox" name="updates_disallowed" value="1" id="updates_disallowed" [% ' checked' IF contact.get_extra_metadata('updates_disallowed') %]>
         <label for="updates_disallowed">[% loc('Disable updates on reports in this category') %]</label>
+        [% TRY %][% INCLUDE admin/bodies/_updates_disallowed_hint.html %][% CATCH file %][% END %]
     </p>
 
     <p class="form-check">

--- a/templates/web/fixmystreet-uk-councils/admin/bodies/_updates_disallowed_hint.html
+++ b/templates/web/fixmystreet-uk-councils/admin/bodies/_updates_disallowed_hint.html
@@ -1,0 +1,9 @@
+[% cfg = c.cobrand.feature('updates_allowed') ~%]
+<span class="form-hint">
+    This site’s configuration means even if this is unticked, only
+  [%~ IF cfg == 'staff' %] staff will be able to leave updates.
+  [%~ ELSIF cfg == 'reporter' %] the problem reporter will be able to leave updates.
+  [%~ ELSIF cfg == 'reporter-open' %] the problem reporter will be able to leave updates on open reports.
+  [%~ ELSIF cfg == 'open' %] open reports can have updates left on them.
+  [%~ END %]
+</span>

--- a/templates/web/fixmystreet.com/report/_updates_disallowed_message.html
+++ b/templates/web/fixmystreet.com/report/_updates_disallowed_message.html
@@ -1,4 +1,4 @@
-[% cfg = c.cobrand.updates_disallowed_config(problem).0 ~%]
+[% cfg = c.cobrand.per_body_config('updates_allowed', problem).0 ~%]
 [% IF cfg.match('reporter') AND (NOT cfg.match('open') OR problem.is_open) %]
     <p>
         Only the original reporter may leave updates.


### PR DESCRIPTION
And fix bug in .com showing of original reporter only message I just spotted.
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1886 [skip changelog]
