### PR TITLE
Spot user set on update not at object creation.

### DIFF
--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -145,6 +145,26 @@ sub FOREIGNBUILDARGS {
     return $opts;
 };
 
+=head2 around user
+
+Also make sure we catch the setting of a user on an object at a time other than
+object creation, to set the extra field needed.
+
+=cut
+
+around user => sub {
+    my ( $orig, $self ) = ( shift, shift );
+    my $res = $self->$orig(@_);
+    if (@_) {
+        if ($_[0]->is_superuser) {
+            $self->set_extra_metadata( is_superuser => 1 );
+        } elsif (my $body = $_[0]->from_body) {
+            $self->set_extra_metadata( is_body_user => $body->id );
+        }
+    }
+    return $res;
+};
+
 =head2 get_cobrand_logged
 
 Get a cobrand object for the cobrand the update was made on.

--- a/t/app/controller/report_updates.t
+++ b/t/app/controller/report_updates.t
@@ -907,6 +907,7 @@ subtest "check comment with no status change has not status in meta" => sub {
 
         is $report->state, 'investigating', 'correct report state';
         is $update->problem_state, 'investigating', 'correct update state';
+        is $update->get_extra_metadata('is_body_user'), $body->id, 'correct metadata';
         $update_meta = $mech->extract_update_metas;
         like $update_meta->[0], qr/fixed/i, 'first update meta says fixed';
         unlike $update_meta->[2], qr/State changed to/, 'second update meta does not include state change';


### PR DESCRIPTION
The changes in 67823bc78 create the necessary metadata at the creation
of a Comment object, but if the user is not included at that point but
later (as is done by the normal public update flow), then it would not
be created. Wrap the user accessor so we can make sure it is set.
[skip changelog]
