### PR TITLE
Lowercase contact email when looking for user.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Contact.pm
+++ b/perllib/FixMyStreet/App/Controller/Contact.pm
@@ -199,7 +199,7 @@ sub prepare_params_for_email : Private {
     my $base_url = $c->cobrand->base_url();
     my $admin_url = $c->cobrand->admin_base_url;
 
-    my $user = $c->cobrand->users->find( { email => $c->stash->{em} } );
+    my $user = $c->cobrand->users->find( { email => lc $c->stash->{em} } );
     if ( $user ) {
         $c->stash->{user_admin_url} = $admin_url . '/users/' . $user->id;
         $c->stash->{user_reports_admin_url} = $admin_url . '/reports?search=' . $user->email;

--- a/t/app/controller/contact.t
+++ b/t/app/controller/contact.t
@@ -382,7 +382,7 @@ for my $test (
 
         $mech->clear_emails_ok;
         $mech->get_ok('/contact');
-        $test->{fields}{em} = $user->email;
+        $test->{fields}{em} = ucfirst $user->email; # Check case
         $mech->submit_form_ok( { with_fields => $test->{fields} } );
 
         my $email = $mech->get_email;


### PR DESCRIPTION
Tiny change I just noticed when I wondered why someone didn't have the links added [skip changelog] 