### PR TITLE
[Open311] use staff categories when fetching reports

### DIFF
--- a/perllib/Open311/GetServiceRequests.pm
+++ b/perllib/Open311/GetServiceRequests.pm
@@ -81,7 +81,7 @@ sub create_problems {
     }
 
     my $contacts = $self->schema->resultset('Contact')
-        ->active
+        ->not_deleted_admin
         ->search( { body_id => $body->id } );
 
     for my $request (@$requests) {

--- a/t/open311/getservicerequests.t
+++ b/t/open311/getservicerequests.t
@@ -534,6 +534,46 @@ subtest "non_public contacts result in non_public reports" => sub {
 
 };
 
+subtest "staff and non_public contacts result in non_public reports" => sub {
+
+    $contact->update({
+        non_public => 1,
+        state => 'staff'
+    });
+    my $o = Open311->new(
+        jurisdiction => 'mysociety',
+        endpoint => 'http://example.com',
+        test_mode => 1,
+        test_get_returns => { 'requests.xml' => prepare_xml( {} ) }
+    );
+
+    my $update = Open311::GetServiceRequests->new(
+        system_user => $user,
+        start_date => $start_date,
+        end_date => $end_date
+    );
+
+    FixMyStreet::override_config {
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $update->create_problems( $o, $body );
+    };
+
+    my $p = FixMyStreet::DB->resultset('Problem')->search(
+        { external_id => 123456, category => $contact->category }
+    )->first;
+
+    ok $p, 'problem created';
+    is $p->non_public, 1, "report non_public is set correctly";
+
+    $p->delete;
+    $contact->update({
+        non_public => 0,
+        state => 'confirmed'
+    });
+
+};
+
 for my $test (
   {
       test_desc => 'filters out phone numbers',


### PR DESCRIPTION
At the moment if you fetch a report in a staff category it will still be
created but will be in the Other category. Given that some staff
categories are marked as private this can allow reports that should be
private to be put in a public category.

[skip changelog]