### PR TITLE
[fixmystreet.org] Update "pro" layout to latest SocietyWorks content

### DIFF
--- a/docs/_layouts/pro.html
+++ b/docs/_layouts/pro.html
@@ -2,21 +2,22 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>{{ page.title }} | FixMyStreet Platform | mySociety</title>
+    <meta name="viewport" content="initial-scale=1">
+    <title>{{ page.title }} – SocietyWorks</title>
+    <link rel="dns-prefetch" href="//fonts.googleapis.com" />
+    <link rel="stylesheet" id="google-fonts-css"  href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Lora:wght@700&display=swap" type="text/css" media="all" />
     <link rel="stylesheet" href="{{ "/assets/css/fixmystreet-org.css" | absolute_url }}">
     <link rel="stylesheet" href="{{ "/assets/css/fixmystreet-pro.css" | absolute_url }}">
     <link rel="stylesheet" href="{{ "/assets/css/fixmystreet-pro-print.css" | absolute_url }}" media="print">
-    <link rel="stylesheet" href="https://www.fixmystreet.com/pro/wp-content/themes/fixmystreet-pro/assets/css/main.css" />
+    <link rel="stylesheet" href="https://www.societyworks.org/wp-content/themes/fixmystreet-pro/assets/css/main.css" />
     <link href="{{ "/atom.xml" | absolute_url }}" rel="alternate" title="FixMyStreet Platform" type="application/atom+xml">
-    <meta name="viewport" content="initial-scale=1">
-    <link rel="stylesheet" id="google-fonts-css" href="https://fonts.googleapis.com/css?family=Rubik%3A400%2C500%2C700&amp;ver=4.9.4" type="text/css" media="all">
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script type="text/javascript" src="{{ "/assets/vendor/jquery.min.js" | absolute_url }}"></script>
     <script type="text/javascript" src="{{ "/assets/vendor/jquery-migrate.min.js" | absolute_url }}"></script>
-    <script type="text/javascript" src="https://www.fixmystreet.com/pro/wp-content/themes/fixmystreet-pro/assets/javascript/bootstrap.min.js"></script>
-    <script type="text/javascript" src="https://www.fixmystreet.com/pro/wp-content/themes/fixmystreet-pro/assets/javascript/main.js"></script>
+    <script type="text/javascript" src="https://www.societyworks.org/wp-content/themes/fixmystreet-pro/assets/javascript/bootstrap.min.js"></script>
+    <script type="text/javascript" src="https://www.societyworks.org/wp-content/themes/fixmystreet-pro/assets/javascript/main.js"></script>
   </head>
   <body{% if page.bodyclass %} class="{{ page.bodyclass }}"{% endif %}>
 
@@ -36,36 +37,50 @@
 
     <header class="site-header">
       <div class="container">
-          <a href="https://www.fixmystreet.com/pro/" class="site-logo" aria-label="FixMyStreet Pro home">
-              FixMyStreet Pro            </a>
-          <a href="#main-nav" role="button" data-toggle="collapse" aria-expanded="false" aria-controls="main-nav">
-              Menu
-          </a>
-          <nav id="main-nav" class="site-nav collapse">
-            <ul id="menu-main-menu" class="menu js-dropdown-sub-menus">
-              <li id="menu-item-29" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-29"><a href="https://www.fixmystreet.com/pro/take-a-tour/">Take a tour</a></li>
-              <li id="menu-item-537" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-537"><a href="https://www.fixmystreet.com/pro/case-studies/">Case Studies</a>
+        <a href="https://www.societyworks.org/" class="site-logo" aria-label="SocietyWorks home">SocietyWorks</a>
+        <a href="#main-nav" role="button" data-toggle="collapse" aria-expanded="false" aria-controls="main-nav">Menu</a>
+        <nav id="main-nav" class="site-nav collapse">
+          <ul id="menu-main-menu" class="menu js-dropdown-sub-menus">
+            <li id="menu-item-1801" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1801"><a href="https://www.societyworks.org/services/">Services</a>
               <ul class="sub-menu">
-                <li id="menu-item-615" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-615"><a href="https://www.fixmystreet.com/pro/take-a-tour/banes/">Bath &amp; North East Somerset Council</a></li>
-                <li id="menu-item-538" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-538"><a href="https://www.fixmystreet.com/pro/take-a-tour/bristol/">Bristol Council</a></li>
-                <li id="menu-item-630" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-630"><a href="https://www.fixmystreet.com/pro/take-a-tour/east-herts/">East Herts District Council</a></li>
-                <li id="menu-item-588" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-588"><a href="https://www.fixmystreet.com/pro/take-a-tour/ground-control/">Ground Control</a></li>
-                <li id="menu-item-539" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-539"><a href="https://www.fixmystreet.com/pro/take-a-tour/oxfordshire/">Oxfordshire County Council</a></li>
-              </ul>
-              </li>
-              <li id="menu-item-30" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-30"><a href="https://www.fixmystreet.com/pro/features/">Features</a>
-              <ul class="sub-menu">
-                <li id="menu-item-32" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-32"><a href="https://www.fixmystreet.com/pro/features/fully-integrated/">Fully integrated</a></li>
-                <li id="menu-item-34" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-34"><a href="https://www.fixmystreet.com/pro/features/open-standards/">Open standards</a></li>
-                <li id="menu-item-28" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-28"><a href="https://www.fixmystreet.com/pro/training/">Training</a></li>
-                <li id="menu-item-33" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-33"><a href="https://www.fixmystreet.com/pro/features/hosted-secure/">Hosted &amp; Secure</a></li>
-                <li id="menu-item-752" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-752"><a href="https://www.fixmystreet.com/pro/features/gdpr-and-fixmystreet-pro/">GDPR and FixMyStreet Pro</a></li>
-                <li id="menu-item-35" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-35"><a href="https://www.fixmystreet.com/pro/features/accessible/">Accessible</a></li>
-                <li id="menu-item-31" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-31"><a href="https://www.fixmystreet.com/pro/features/privacy/">Privacy</a></li>
+                <li id="menu-item-1803" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1803"><a href="https://www.societyworks.org/services/highways/">Streets and highways</a></li>
+                <li id="menu-item-1805" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1805"><a href="https://www.societyworks.org/services/waste/">Bins and waste</a></li>
+                <li id="menu-item-1804" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1804"><a href="https://www.societyworks.org/services/noise/">Noise and social complaints</a></li>
+                <li id="menu-item-1808" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1808"><a href="https://www.societyworks.org/services/green-spaces/">Parks, trees and green spaces</a></li>
+                <li id="menu-item-1802" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1802"><a href="https://www.societyworks.org/services/licensing/">Licence applications</a></li>
+                <li id="menu-item-1817" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1817"><a href="https://www.societyworks.org/features/housing/">Estate maintenance</a></li>
+                <li id="menu-item-1806" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1806"><a href="https://www.societyworks.org/services/foi/">FOI</a></li>
+                <li id="menu-item-1807" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1807"><a href="https://www.societyworks.org/services/discovery/">Service transformation</a></li>
               </ul>
             </li>
-            <li id="menu-item-36" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-36"><a href="https://www.fixmystreet.com/pro/how-to-buy/">How to buy</a></li>
-            <li id="menu-item-800" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-800"><a href="https://www.fixmystreet.com/pro/blog/">Blog</a></li>
+            <li id="menu-item-537" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-537"><a href="https://www.societyworks.org/case-studies/">Case Studies</a>
+              <ul class="sub-menu">
+                <li id="menu-item-1065" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1065"><a href="https://www.societyworks.org/case-studies/banes/">Bath &#038; North East Somerset District Council</a></li>
+                <li id="menu-item-538" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-538"><a href="https://www.societyworks.org/case-studies/bristol/">Bristol Council</a></li>
+                <li id="menu-item-1272" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1272"><a href="https://www.societyworks.org/case-studies/bromley-borough-council/">Bromley Borough Council</a></li>
+                <li id="menu-item-588" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-588"><a href="https://www.societyworks.org/case-studies/ground-control/">Ground Control</a></li>
+                <li id="menu-item-1077" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1077"><a href="https://www.societyworks.org/case-studies/lincolnshire-county-council/">Lincolnshire County Council</a></li>
+                <li id="menu-item-539" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-539"><a href="https://www.societyworks.org/case-studies/oxfordshire/">Oxfordshire County Council</a></li>
+                <li id="menu-item-947" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-947"><a href="https://www.societyworks.org/case-studies/rutland-county-council/">Rutland County Council</a></li>
+                <li id="menu-item-1080" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1080"><a href="https://www.societyworks.org/case-studies/buckinghamshire/">Buckinghamshire Council</a></li>
+              </ul>
+            </li>
+            <li id="menu-item-30" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-30"><a href="https://www.societyworks.org/features/">Features</a>
+              <ul class="sub-menu">
+                <li id="menu-item-1813" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1813"><a href="https://www.societyworks.org/features/reporting/">Reporting</a></li>
+                <li id="menu-item-1812" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1812"><a href="https://www.societyworks.org/features/customer-contact/">Customer contact</a></li>
+                <li id="menu-item-1816" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1816"><a href="https://www.societyworks.org/features/inspections/">Inspections</a></li>
+                <li id="menu-item-1815" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1815"><a href="https://www.societyworks.org/features/case-management/">Case management</a></li>
+                <li id="menu-item-32" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-32"><a href="https://www.societyworks.org/features/fully-integrated/">Integrations</a></li>
+                <li id="menu-item-1814" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1814"><a href="https://www.societyworks.org/features/data-assets/">Data and assets</a></li>
+                <li id="menu-item-33" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-33"><a href="https://www.societyworks.org/features/hosted-secure/">Secure hosting</a></li>
+                <li id="menu-item-34" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-34"><a href="https://www.societyworks.org/features/open-standards/">Open standards</a></li>
+                <li id="menu-item-28" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-28"><a href="https://www.societyworks.org/training/">Training and onboarding</a></li>
+                <li id="menu-item-35" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-35"><a href="https://www.societyworks.org/features/accessible/">Accessibilty</a></li>
+              </ul>
+            </li>
+            <li id="menu-item-36" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-36"><a href="https://www.societyworks.org/how-to-buy/">How to buy</a></li>
+            <li id="menu-item-1800" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1800"><a href="https://www.societyworks.org/blog/">Blog</a></li>
           </ul>
         </nav>
       </div>
@@ -117,48 +132,52 @@
         </div>
       </div>
     </div>
-<div class="site-footer mysoc-footer">
-    <div class="container">
-              <div class="site-footer__primary">
-                      <div class="footer-widget-area">
-                <span class="hidden">Footer Contact Details</span><div class="textwidget custom-html-widget"><ul class="list-inline">
-<li><a href="mailto:enquiries@fixmystreet.com">enquiries@fixmystreet.com</a></li>
-<li><a href="tel:+442032879859">020 3287 9859</a></li>
-</ul></div>            </div>
-                                <nav class="menu-footer-menu-container">
-                                  <ul id="menu-footer-menu" class="footer-nav-menu list-inline">
-                                    <li id="" class="menu-item menu-item-type-post_type menu-item-object-page"><a href="/pro-manual/">User guide</a></li>
-                                    <li id="menu-item-261" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-261"><a href="https://www.fixmystreet.com/pro/contact/">Contact</a></li>
-                                    <li id="menu-item-51" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-51"><a href="https://www.mysociety.org/subscribe/">Newsletter</a></li>
-                                    <li id="menu-item-282" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-282"><a href="https://www.fixmystreet.com/pro/features/privacy/">Privacy</a></li>
-                                    </ul>
-                                  </nav>                  
-                                </div>
-        <hr class="mysoc-footer__divider" role="presentation">
-              <div class="row">
-            <div class="col-sm-4">
-                <a href="https://www.mysociety.org?utm_source=fixmystreet.com%2Fpro&amp;utm_content=footer+logo&amp;utm_medium=link&amp;utm_campaign=mysoc_footer" class="mysoc-footer__org__logo mysoc-footer__org__logo--mysociety">mySociety</a>
-            </div>
-            <div class="col-sm-6">
-                <div class="mysoc-footer__legal">
-                    <p>
-                        <a href="https://www.societyworks.org?utm_source=fixmystreet.com%2Fpro&amp;utm_content=footer+full+legal+details&amp;utm_medium=link&amp;utm_campaign=mysoc_footer">SocietyWorks</a>
-                        is a limited company (05798215). It is a trading subsidiary of
-                        <a href="https://www.mysociety.org?utm_source=fixmystreet.com%2Fpro&amp;utm_content=footer+full+legal+details&amp;utm_medium=link&amp;utm_campaign=mysoc_footer">mySociety</a>,
-                        a registered charity in England and Wales (1076346).
-                    </p>
-                </div>
-            </div>
-            <div class="col-sm-2">
-                <ul class="mysoc-footer__badges">
-                    <li role="presentation"><a href="https://github.com/mysociety/" class="mysoc-footer__badge mysoc-footer__badge--github">Github</a></li>
-                    <li role="presentation"><a href="https://twitter.com/fixmystreet/" class="mysoc-footer__badge mysoc-footer__badge--twitter">Twitter</a></li>
-                    <li role="presentation"><a href="https://www.facebook.com/fixmystreet" class="mysoc-footer__badge mysoc-footer__badge--facebook">Facebook</a></li>
-                </ul>
-            </div>
-        </div>
-    </div>
-</div>
 
-</body>
+    <div class="site-footer mysoc-footer">
+      <div class="container">
+        <div class="site-footer__primary">
+          <div class="footer-widget-area">
+            <span class="hidden">Footer Contact Details</span>
+            <div class="textwidget custom-html-widget">
+              <ul class="list-inline">
+                <li><a href="mailto:enquiries@fixmystreet.com">enquiries@fixmystreet.com</a></li>
+                <li><a href="tel:+442032879859">020 3287 9859</a></li>
+              </ul>
+            </div>
+          </div>
+          <nav class="menu-footer-menu-container">
+            <ul id="menu-footer-menu" class="footer-nav-menu list-inline">
+              <li id="menu-item-261" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-261"><a href="https://www.societyworks.org/contact/">Contact</a></li>
+              <li id="menu-item-51" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-51"><a href="https://www.mysociety.org/subscribe/">Newsletter</a></li>
+              <li id="menu-item-282" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-282"><a href="https://www.societyworks.org/features/privacy/">Privacy</a></li>
+            </ul>
+          </nav>
+        </div>
+        <hr class="mysoc-footer__divider" role="presentation">
+        <div class="row">
+          <div class="col-sm-4">
+            <a href="https://www.mysociety.org?utm_source=fixmystreet.com/pro&amp;utm_content=footer+logo&amp;utm_medium=link&amp;utm_campaign=mysoc_footer" class="mysoc-footer__org__logo mysoc-footer__org__logo--mysociety">mySociety</a>
+          </div>
+          <div class="col-sm-6">
+            <div class="mysoc-footer__legal">
+              <p>
+                <a href="https://www.societyworks.org?utm_source=fixmystreet.com/pro&amp;utm_content=footer+full+legal+details&amp;utm_medium=link&amp;utm_campaign=mysoc_footer">SocietyWorks Ltd</a>
+                (05798215) is a wholly owned subsidiary of
+                <a href="https://www.mysociety.org?utm_source=fixmystreet.com/pro&amp;utm_content=footer+full+legal+details&amp;utm_medium=link&amp;utm_campaign=mysoc_footer">mySociety</a>,
+                a registered charity in England and Wales (1076346) and limited company (03277032).
+              </p>
+            </div>
+          </div>
+          <div class="col-sm-2">
+            <ul class="mysoc-footer__badges">
+              <li role="presentation"><a href="https://github.com/mysociety/" class="mysoc-footer__badge mysoc-footer__badge--github">Github</a></li>
+              <li role="presentation"><a href="https://twitter.com/fixmystreet/" class="mysoc-footer__badge mysoc-footer__badge--twitter">Twitter</a></li>
+              <li role="presentation"><a href="https://www.facebook.com/fixmystreet" class="mysoc-footer__badge mysoc-footer__badge--facebook">Facebook</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </body>
 </html>


### PR DESCRIPTION
The Pro manual at `/pro-manual` uses a separate jekyll layout that mimics the output of the WordPress site at societyworks.org.

Our copy had fallen out of date. This commit:

* Updates the Google Fonts requested (was Rubik, now Lato and Lora).
* Updates the header nav menu content to match the live site.
* Replaces fixmystreet.com/pro URLs with societyworks.org URLs.
* Updates the footer legal text to match the live site.

Part of https://github.com/mysociety/fixmystreet-commercial/issues/1949

[skip changelog]