### PR TITLE
Allow HTML in response templates and updates from staff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
         - Add full text index to speed up admin search.
         - Offline process for CSV generation.
         - Allow inspectors to change report asset.
+        - Staff users can use HTML tags in updates. #3143
+        - Response templates can include HTML tags. #3143
     - Development improvements:
         - `#geolocate_link` is now easier to re-style. #3006
         - Links inside `#front-main` can be customised using `$primary_link_*` Sass variables. #3007

--- a/docs/_includes/admin-tasks-content.md
+++ b/docs/_includes/admin-tasks-content.md
@@ -829,7 +829,11 @@ above, ‘Creating a template’. Additionally you can delete the template from 
 #### HTML content in templates
 
 HTML tags are permitted in response templates, which makes it possible to include
-images or rich text formatting in the updates which are added to reports.
+hyperlinks or rich text formatting in the updates which are added to reports.
+
+Be aware that response templates are emailed to users as well as being shown on
+the site, so it's best to keep any HTML formatting quite light-touch due to the
+quirks of email clients' rendering of HTML message.
 
 Refer to the section ["HTML Content in notices"](#html-content-in-notices) above for details of
 what tags and attributes are allowed.

--- a/docs/_includes/admin-tasks-content.md
+++ b/docs/_includes/admin-tasks-content.md
@@ -825,6 +825,15 @@ Click on ‘Templates’ in the admin menu. You will see a table of existing tem
 beside the status you wish to change. You may alter any of the fields as described in the section
 above, ‘Creating a template’. Additionally you can delete the template from this page.
 
+
+#### HTML content in templates
+
+HTML tags are permitted in response templates, which makes it possible to include
+images or rich text formatting in the updates which are added to reports.
+
+Refer to the section ["HTML Content in notices"](#html-content-in-notices) above for details of
+what tags and attributes are allowed.
+
 </div>
 
 <div class="admin-task" markdown="1" id="view-statistics">

--- a/perllib/FixMyStreet/App/View/Web.pm
+++ b/perllib/FixMyStreet/App/View/Web.pm
@@ -126,29 +126,34 @@ sub staff_html_markup_factory {
 
     return sub {
         my $text = shift;
-        unless ($staff) {
-            return FixMyStreet::Template::html_paragraph(add_links($text));
-        }
-
-        $text = FixMyStreet::Template::sanitize($text);
-
-        # Apply Markdown-style italics
-        $text =~ s{\*(\S.*?\S)\*}{<i>$1</i>};
-
-        # Mark safe so add_links doesn't escape everything.
-        $text = FixMyStreet::Template::SafeString->new($text);
-
-        $text = add_links($text);
-
-        # If the update already has block-level elements then don't wrap
-        # individual lines in <p> elements, as we assume the user knows what
-        # they're doing.
-        unless ($text =~ /<(p|ol|ul)>/) {
-            $text = FixMyStreet::Template::html_paragraph($text);
-        }
-
-        return $text;
+        return _staff_html_markup($text, $staff);
     }
+}
+
+sub _staff_html_markup {
+    my ( $text, $staff ) = @_;
+    unless ($staff) {
+        return FixMyStreet::Template::html_paragraph(add_links($text));
+    }
+
+    $text = FixMyStreet::Template::sanitize($text);
+
+    # Apply Markdown-style italics
+    $text =~ s{\*(\S.*?\S)\*}{<i>$1</i>};
+
+    # Mark safe so add_links doesn't escape everything.
+    $text = FixMyStreet::Template::SafeString->new($text);
+
+    $text = add_links($text);
+
+    # If the update already has block-level elements then don't wrap
+    # individual lines in <p> elements, as we assume the user knows what
+    # they're doing.
+    unless ($text =~ /<(p|ol|ul)>/) {
+        $text = FixMyStreet::Template::html_paragraph($text);
+    }
+
+    return $text;
 }
 
 =head2 escape_js

--- a/perllib/FixMyStreet/App/View/Web.pm
+++ b/perllib/FixMyStreet/App/View/Web.pm
@@ -25,7 +25,7 @@ __PACKAGE__->config(
     FILTERS => {
         add_links => \&add_links,
         escape_js => \&escape_js,
-        markup => [ \&markup_factory, 1 ],
+        staff_html_markup => [ \&staff_html_markup_factory, 1 ],
     },
     COMPILE_EXT => '.ttc',
     STAT_TTL    => FixMyStreet->config('STAGING_SITE') ? 1 : 86400,
@@ -100,7 +100,7 @@ sub add_links {
     my $text = shift;
     $text = FixMyStreet::Template::conditional_escape($text);
     $text =~ s/\r//g;
-    $text =~ s{(https?://)([^\s]+)}{"<a href=\"$1$2\">$1" . _space_slash($2) . '</a>'}ge;
+    $text =~ s{(?<!["'])(https?://)([^\s]+)}{"<a href=\"$1$2\">$1" . _space_slash($2) . '</a>'}ge;
     return FixMyStreet::Template::SafeString->new($text);
 }
 
@@ -110,20 +110,44 @@ sub _space_slash {
     return $t;
 }
 
-=head2 markup_factory
+=head2 staff_html_markup_factory
 
-This returns a function that will allow updates to have markdown-style italics.
-Pass in the user that wrote the text, so we know whether it can be privileged.
+This returns a function that processes the text body of an update, applying
+HTML sanitization and markdown-style italics if it was made by a staff user.
+
+Pass in the update extra, so we can determine if it was made by a staff user.
 
 =cut
 
-sub markup_factory {
-    my ($c, $user) = @_;
+sub staff_html_markup_factory {
+    my ($c, $extra) = @_;
+
+    my $staff = $extra->{is_superuser} || $extra->{is_body_user};
+
     return sub {
         my $text = shift;
-        return $text unless $user && ($user->from_body || $user->is_superuser);
+        unless ($staff) {
+            return FixMyStreet::Template::html_paragraph(add_links($text));
+        }
+
+        $text = FixMyStreet::Template::sanitize($text);
+
+        # Apply Markdown-style italics
         $text =~ s{\*(\S.*?\S)\*}{<i>$1</i>};
-        FixMyStreet::Template::SafeString->new($text);
+
+        # Mark safe so add_links doesn't escape everything.
+        $text = FixMyStreet::Template::SafeString->new($text);
+
+        $text = add_links($text);
+
+        # If the update already has block-level elements then don't wrap
+        # individual lines in <p> elements, as we assume the user knows what
+        # they're doing.
+        unless ($text =~ /<(p|ol|ul)>/) {
+            $text = FixMyStreet::Template::html_paragraph($text);
+        }
+
+        return $text;
     }
 }
 

--- a/perllib/FixMyStreet/Script/Alerts.pm
+++ b/perllib/FixMyStreet/Script/Alerts.pm
@@ -41,6 +41,7 @@ sub send() {
                    $item_table.photo as item_photo,
                    $item_table.problem_state as item_problem_state,
                    $item_table.cobrand as item_cobrand,
+                   $item_table.extra as item_extra,
                    $head_table.*
             from alert, $item_table, $head_table
                 where alert.parameter::integer = $head_table.id

--- a/perllib/FixMyStreet/Template.pm
+++ b/perllib/FixMyStreet/Template.pm
@@ -141,6 +141,8 @@ sub html_paragraph : Filter('html_para') {
 sub sanitize {
     my $text = shift;
 
+    $text = $$text if UNIVERSAL::isa($text, 'FixMyStreet::Template::SafeString');
+ 
     my %allowed_tags = map { $_ => 1 } qw( p ul ol li br b i strong em );
     my $scrubber = HTML::Scrubber->new(
         rules => [

--- a/perllib/FixMyStreet/Template.pm
+++ b/perllib/FixMyStreet/Template.pm
@@ -7,6 +7,7 @@ use FixMyStreet;
 use mySociety::Locale;
 use Attribute::Handlers;
 use HTML::Scrubber;
+use HTML::TreeBuilder;
 use FixMyStreet::Template::SafeString;
 use FixMyStreet::Template::Context;
 use FixMyStreet::Template::Stash;
@@ -160,6 +161,66 @@ sub sanitize {
     return $text;
 }
 
+
+=head2 email_sanitize_text
+
+Intended for use in the _email_comment_list.txt template to allow HTML
+in updates from staff/superusers. Sanitizes the HTML and then converts
+it all to text.
+
+=cut
+
+sub email_sanitize_text : Fn('email_sanitize_text') {
+    my $update = shift;
+
+    my $text = $update->{item_text};
+    my $extra = $update->{item_extra};
+    $extra = $extra ? RABX::wire_rd(new IO::String($extra)) : {};
+
+    my $staff = $extra->{is_superuser} || $extra->{is_body_user};
+
+    return $text unless $staff;
+
+    $text = FixMyStreet::Template::sanitize($text);
+
+    my $tree = HTML::TreeBuilder->new_from_content($text);
+    _sanitize_elt($tree);
+
+    return $tree->as_text;
+}
+
+my $list_type;
+my $list_num;
+my $sanitize_text_subs = {
+    b => [ '*', '*' ],
+    strong => [ '*', '*' ],
+    i => [ '_', '_' ],
+    em => [ '_', '_' ],
+    p => [ '', "\n\n" ],
+    li => [ '', "\n\n" ],
+};
+sub _sanitize_elt {
+    my $elt = shift;
+    foreach ($elt->content_list) {
+        next unless ref $_;
+        $list_type = $_->tag, $list_num = 1 if $_->tag eq 'ol' || $_->tag eq 'ul';
+        _sanitize_elt($_);
+        $_->replace_with("\n") if $_->tag eq 'br';
+        $_->replace_with('[image: ', $_->attr('alt'), ']') if $_->tag eq 'img';
+        $_->replace_with($_->as_text, ' [', $_->attr('href'), ']') if $_->tag eq 'a';
+        $_->replace_with_content if $_->tag eq 'span' || $_->tag eq 'font';
+        $_->replace_with_content if $_->tag eq 'ul' || $_->tag eq 'ol';
+        if ($_->tag eq 'li') {
+            $sanitize_text_subs->{li}[0] = $list_type eq 'ol' ? "$list_num. " : '* ';
+            $list_num++;
+        }
+        if (my $sub = $sanitize_text_subs->{$_->tag}) {
+            $_->preinsert($sub->[0]);
+            $_->postinsert($sub->[1]);
+            $_->replace_with_content;
+        }
+    }
+}
 
 =head2 email_sanitize_html
 

--- a/perllib/FixMyStreet/Template.pm
+++ b/perllib/FixMyStreet/Template.pm
@@ -11,6 +11,9 @@ use FixMyStreet::Template::SafeString;
 use FixMyStreet::Template::Context;
 use FixMyStreet::Template::Stash;
 
+use RABX;
+use IO::String;
+
 my %FILTERS;
 my %SUBS;
 
@@ -155,6 +158,26 @@ sub sanitize {
     );
     $text = $scrubber->scrub($text);
     return $text;
+}
+
+
+=head2 email_sanitize_html
+
+Intended for use in the _email_comment_list.html template to allow HTML
+in updates from staff/superusers.
+
+=cut
+
+sub email_sanitize_html : Fn('email_sanitize_html') {
+    my $update = shift;
+
+    my $text = $update->{item_text};
+    my $extra = $update->{item_extra};
+    $extra = $extra ? RABX::wire_rd(new IO::String($extra)) : {};
+
+    my $staff = $extra->{is_superuser} || $extra->{is_body_user};
+
+    return FixMyStreet::App::View::Web::_staff_html_markup($text, $staff);
 }
 
 1;

--- a/perllib/FixMyStreet/TestMech.pm
+++ b/perllib/FixMyStreet/TestMech.pm
@@ -276,6 +276,24 @@ sub get_text_body_from_email {
     return $body;
 }
 
+sub get_html_body_from_email {
+    my ($mech, $email, $obj) = @_;
+    unless ($email) {
+        $email = $mech->get_email;
+        $mech->clear_emails_ok;
+    }
+
+    my $body;
+    $email->walk_parts(sub {
+        my $part = shift;
+        return if $part->subparts;
+        return if $part->content_type !~ m{text/html};
+        $body = $obj ? $part : $part->body_str;
+        ok $body, "Found HTML body";
+    });
+    return $body;
+}
+
 sub get_link_from_email {
     my ($mech, $email, $multiple, $mismatch) = @_;
     unless ($email) {

--- a/t/app/controller/alert_new.t
+++ b/t/app/controller/alert_new.t
@@ -878,7 +878,7 @@ subtest 'check staff updates can include sanitized HTML' => sub {
         user => $user1,
     });
 
-    my $update1 = $mech->create_comment_for_problem($report, $user2, 'Staff User', 'This is some update text with <strong>HTML</strong> and *italics*. <script>not allowed</script>', 't', 'confirmed', undef, { confirmed  => $r_dt->clone->add( minutes => 8 ) });
+    my $update1 = $mech->create_comment_for_problem($report, $user2, 'Staff User', '<p>This is some update text with <strong>HTML</strong> and *italics*.</p> <ul><li>Even a list</li><li>Which might work</li><li>In the <a href="https://www.fixmystreet.com/">text</a> part</li></ul> <script>not allowed</script>', 't', 'confirmed', undef, { confirmed  => $r_dt->clone->add( minutes => 8 ) });
     $update1->set_extra_metadata(is_body_user => $user2->from_body->id);
     $update1->update;
 
@@ -896,7 +896,7 @@ subtest 'check staff updates can include sanitized HTML' => sub {
     FixMyStreet::DB->resultset('AlertType')->email_alerts();
     my $email = $mech->get_email;
     my $plain = $mech->get_text_body_from_email($email);
-    like $plain, qr/This is some update text with <strong>HTML<\/strong> and \*italics\*\./, 'plain text part contains exactly what was entered';
+    like $plain, qr/This is some update text with \*HTML\* and \*italics\*\.\r\n\r\n\* Even a list\r\n\r\n\* Which might work\r\n\r\n\* In the text \[https:\/\/www.fixmystreet.com\/\] part/, 'plain text part contains no HTML tags from staff update';
     like $plain, qr/Public users <i>cannot<\/i> use HTML\./, 'plain text part contains exactly what was entered';
 
     my $html = $mech->get_html_body_from_email($email);

--- a/t/app/controller/alert_new.t
+++ b/t/app/controller/alert_new.t
@@ -866,4 +866,47 @@ subtest 'check setting include dates in new updates cobrand option' => sub {
     $include_date_in_alert_override->restore();
 };
 
+subtest 'check staff updates can include sanitized HTML' => sub {
+    my $user1 = $mech->create_user_ok('reporter@example.com', name => 'Reporter User');
+    my $user2 = $mech->create_user_ok('staff@example.com', name => 'Staff User', from_body => $body);
+    my $user3 = $mech->create_user_ok('updater@example.com', name => 'Another User');
+
+    my $dt = DateTime->now->add( minutes => -30 );
+    my $r_dt = $dt->clone->add( minutes => 20 );
+
+    my ($report) = $mech->create_problems_for_body(1, $body->id, 'Testing', {
+        user => $user1,
+    });
+
+    my $update1 = $mech->create_comment_for_problem($report, $user2, 'Staff User', 'This is some update text with <strong>HTML</strong> and *italics*. <script>not allowed</script>', 't', 'confirmed', undef, { confirmed  => $r_dt->clone->add( minutes => 8 ) });
+    $update1->set_extra_metadata(is_body_user => $user2->from_body->id);
+    $update1->update;
+
+    $mech->create_comment_for_problem($report, $user3, 'Updater User', 'Public users <i>cannot</i> use HTML. <script>not allowed</script>', 't', 'confirmed', undef, { confirmed  => $r_dt->clone->add( minutes => 9 ) });
+
+    my $alert_user1 = FixMyStreet::DB->resultset('Alert')->create( {
+            user       => $user1,
+            alert_type => 'new_updates',
+            parameter  => $report->id,
+            confirmed  => 1,
+            whensubscribed => $dt,
+    } );
+    ok $alert_user1, "alert created";
+
+    FixMyStreet::DB->resultset('AlertType')->email_alerts();
+    my $email = $mech->get_email;
+    my $plain = $mech->get_text_body_from_email($email);
+    like $plain, qr/This is some update text with <strong>HTML<\/strong> and \*italics\*\./, 'plain text part contains exactly what was entered';
+    like $plain, qr/Public users <i>cannot<\/i> use HTML\./, 'plain text part contains exactly what was entered';
+
+    my $html = $mech->get_html_body_from_email($email);
+    like $html, qr{This is some update text with <strong>HTML</strong> and <i>italics</i>\.}, 'HTML part contains HTML tags';
+    unlike $html, qr/<script>/, 'HTML part contains no script tags';
+
+    $mech->delete_user( $user1 );
+    $mech->delete_user( $user2 );
+    $mech->delete_user( $user3 );
+};
+
+
 done_testing();

--- a/t/app/controller/questionnaire.t
+++ b/t/app/controller/questionnaire.t
@@ -351,7 +351,7 @@ my $comment = FixMyStreet::DB->resultset('Comment')->find_or_create(
         user_id    => $user->id,
         name       => 'A User',
         mark_fixed => 'false',
-        text       => 'This is some update text',
+        text       => 'This is some <strong>update</strong> text',
         state      => 'confirmed',
         confirmed  => $sent_time,
         anonymous  => 'f',
@@ -360,7 +360,12 @@ my $comment = FixMyStreet::DB->resultset('Comment')->find_or_create(
 subtest 'Check updates are shown correctly on questionnaire page' => sub {
     $mech->get_ok("/Q/" . $token->token);
     $mech->content_contains( 'Show all updates' );
-    $mech->content_contains( 'This is some update text' );
+    $mech->content_contains( 'This is some &lt;strong&gt;update&lt;/strong&gt; text' );
+};
+subtest 'Check staff update is shown correctly on questionnaire page' => sub {
+    $comment->update({ extra => { is_superuser => 1 } });
+    $mech->get_ok("/Q/" . $token->token);
+    $mech->content_contains( 'This is some <strong>update</strong> text' );
 };
 
 for my $test (

--- a/templates/email/default/_email_comment_list.html
+++ b/templates/email/default/_email_comment_list.html
@@ -5,7 +5,7 @@
         <img style="[% list_item_photo_style %]" src="[% inline_image(update.get_first_image_fp) %]" alt="">
       </a>
     [%~ END %]
-      [% update.item_text | html_para | replace('<p>', '<p style="' _ list_item_p_style _ '">') %]
+      [% email_sanitize_html(update) | html_para | replace('<p>', '<p style="' _ list_item_p_style _ '">') %]
       <p style="[% list_item_date_style %]">
         [%~ update.item_name | html IF update.item_name AND NOT update.item_anonymous -%]
         [% '(' _ cobrand.prettify_dt(update.confirmed) _ ') ' IF cobrand.include_time_in_update_alerts -%]

--- a/templates/email/default/_email_comment_list.txt
+++ b/templates/email/default/_email_comment_list.txt
@@ -1,7 +1,7 @@
 [% FOR row IN data -%]
 [% row.item_name _ ' : ' IF row.item_name AND NOT row.item_anonymous -%]
 [% '(' _ cobrand.prettify_dt(row.confirmed) _ ') ' IF cobrand.include_time_in_update_alerts -%]
-[% row.item_text %]
+[% email_sanitize_text(row) %]
 
 ------
 

--- a/templates/email/fixamingata/_email_comment_list.html
+++ b/templates/email/fixamingata/_email_comment_list.html
@@ -5,7 +5,7 @@
         <img style="[% list_item_photo_style %]" src="[% inline_image(update.get_first_image_fp) %]" alt="">
       </a>
     [%~ END %]
-      [% update.item_text | html_para | replace('<p>', '<p style="' _ list_item_p_style _ '">') %]
+      [% email_sanitize_html(update) | html_para | replace('<p>', '<p style="' _ list_item_p_style _ '">') %]
       <p style="[% list_item_date_style %]">
         [%~ update.item_name | html IF update.item_name AND NOT update.item_anonymous -%]
         [% '(' _ cobrand.prettify_dt(update.confirmed) _ ') ' IF cobrand.include_time_in_update_alerts -%]

--- a/templates/web/base/admin/users/log.html
+++ b/templates/web/base/admin/users/log.html
@@ -49,7 +49,7 @@ action_map = {
                 [%- tprintf(loc('Problem %s created on behalf of %s'), mark_safe(report_link), item.obj.name) %], ‘[% item.obj.title | html %]’
             [%~ CASE 'update' %]
                 [% tprintf(loc("Update %s created for problem %d"), mark_safe(report_link), item.obj.problem_id) %]
-                [% item.obj.text | add_links | markup(item.obj.user) | html_para %]
+                [% item.obj.text | staff_html_markup(item.obj.extra) %]
             [%~ CASE 'shortlistAdded' %]
                 [%- tprintf(loc('Problem %s added to shortlist'), mark_safe(report_link)) %]
             [%~ CASE 'shortlistRemoved' %]

--- a/templates/web/base/my/my.html
+++ b/templates/web/base/my/my.html
@@ -113,7 +113,7 @@ li .my-account-buttons a {
         <div class="item-list__update-wrap">
             [% INCLUDE 'report/photo.html' object=u %]
             <div class="item-list__update-text">
-                [% u.text | add_links | html_para %]
+                [% u.text | staff_html_markup(u.extra) %]
 
                 <p class="meta-2">
                     [% tprintf( loc("Added %s"), prettify_dt( u.confirmed, 'date' ) ) %]

--- a/templates/web/base/questionnaire/index.html
+++ b/templates/web/base/questionnaire/index.html
@@ -55,7 +55,7 @@
         <strong>[% loc('Last update') %]</strong>
         <a href="/report/[% problem.id %]">[% loc('Show all updates') %]</a>
     </p>
-    <p class="questionnaire-report-reminder__last-update">&ldquo;[% updates.last.text | add_links %]&rdquo;</p>
+    <p class="questionnaire-report-reminder__last-update">&ldquo;[% updates.last.text | staff_html_markup(updates.last.extra) %]&rdquo;</p>
   [% END %]
 </div>
 

--- a/templates/web/base/report/update.html
+++ b/templates/web/base/report/update.html
@@ -35,7 +35,7 @@
                 [% INCLUDE 'report/photo.html' object=update %]
                 <div class="item-list__update-text">
                     <div class="moderate-display">
-                        [% update.text | add_links | markup(update.user) | html_para %]
+                        [% update.text | staff_html_markup(update.extra) %]
                     </div>
                     [% IF can_moderate %]
                     <div class="moderate-edit">
@@ -43,7 +43,7 @@
                         <label><input type="checkbox" name="update_revert_text" class="revert-textarea">
                         [% loc('Revert to original') %]</label>
                         [% END %]
-                        <textarea class="form-control" name="update_text">[% update.text | add_links %]</textarea>
+                        <textarea class="form-control" name="update_text">[% update.text %]</textarea>
                     </div>
                     [% END %]
 


### PR DESCRIPTION
Response templates can now include HTML which is sanitized and rendered when shown on the front end and in update emails. This also extends to updates left by staff/superusers.

Not 100% happy with the approach but at this point would be good to have a second pair of eyes before I dig any further into the rabbit hole.


For https://github.com/mysociety/fixmystreet-commercial/issues/1928