### PR TITLE
[Docs] Remove mySociety header from FMS Pro manual

### DIFF
--- a/docs/_layouts/pro.html
+++ b/docs/_layouts/pro.html
@@ -21,20 +21,6 @@
   </head>
   <body{% if page.bodyclass %} class="{{ page.bodyclass }}"{% endif %}>
 
-  
-    <div class="ms-header">
-        <div class="container">
-            <div class="row">
-              <div class="col-sm-3 col-sm-push-9 ms-header__logo">
-                <a href="https://www.mysociety.org/">mySociety</a>
-              </div>
-              <a class="col-sm-9 col-sm-pull-3 ms-header__back-to-fms" href="https://www.fixmystreet.com">
-                <p><i class="glyphicon glyphicon-chevron-left"></i> <strong>Return to FixMyStreet.com</strong> to report a street issue in the UK</p>
-              </a>
-            </div>
-        </div>
-    </div>
-
     <header class="site-header">
       <div class="container">
         <a href="https://www.societyworks.org/" class="site-logo" aria-label="SocietyWorks home">SocietyWorks</a>

--- a/docs/_sass/fixmystreet-pro.scss
+++ b/docs/_sass/fixmystreet-pro.scss
@@ -5,29 +5,7 @@
  * the mySociety standard header - the following resets a lot of this
  */
 
- $pro-yellow: #FED876;
-
- .ms-header {
-     border: 0;
- }
-
-.ms-header__logo {
-    
-    border-radius: 0;
-    background-position: 0 0;
-    background-size: 0 0 ;
-    background-repeat: no-repeat;
-    background-image: none;
-    width: auto;
-    height: auto;
-    display: block;
-    position: static;
-    right: auto;
-    top: auto;
-    background-color:  transparent;
-    background-repeat: no-repeat;
-    margin: 10px 0;
-}
+$pro-yellow: #FED876;
 
 .site-header {
     background-color: white;
@@ -81,14 +59,12 @@ h4 {
 // user guide view, for printing (but these styles will be visible on screen too
 
 .user-guide-print {
-    .ms-header,
     .mysoc-footer,
     .site-nav,
     .secondary-content-column,
     a[href="#main-nav"] {
         display: none !important;
         visibility: hidden;
-        
     }
 
     .main-content-column {


### PR DESCRIPTION
Matches the corresponding change on the societyworks.org site:
https://github.com/mysociety/orgsites/issues/1156

![Screenshot_2020-08-11 What is FixMyStreet Pro – SocietyWorks](https://user-images.githubusercontent.com/739624/89881935-0907d980-dbbe-11ea-975f-7908de3ec68d.png)

[skip changelog]