### PR TITLE
Zoom in to asset if selected when changing asset.

### DIFF
--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -107,7 +107,13 @@ OpenLayers.Layer.VectorAsset = OpenLayers.Class(OpenLayers.Layer.Vector, {
         if (!this.inRange && this.resolutions) {
             var firstVisibleResolution = this.resolutions[0];
             var zoomLevel = fixmystreet.map.getZoomForResolution(firstVisibleResolution);
-            fixmystreet.map.zoomTo(zoomLevel);
+            if (window.selected_problem_id) {
+                var feature = fixmystreet.maps.get_marker_by_id(window.selected_problem_id);
+                var center = feature.geometry.getBounds().getCenterLonLat();
+                fixmystreet.map.setCenter(center, zoomLevel);
+            } else {
+                fixmystreet.map.zoomTo(zoomLevel);
+            }
         }
     },
 


### PR DESCRIPTION
Of course, only noticed this immediately after merge/deploy.  [skip changelog]

If you click the change asset button on a report page that was loaded inline from a map list page, you want to see assets around the report and not the centre of the map.