### PR TITLE
Fix number of asset changing confusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
         - Improve moderation diff display in a few small ways. #3105
         - Do not have bootstrap run sudo commands. #2930
         - Fix lookups in templates of categories with &s.
+        - Fix a few obscure asset layer changing issues.
     - Admin improvements:
         - Display user name/email for contributed as reports. #2990
         - Interface for enabling anonymous reports for certain categories. #2989

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -883,7 +883,7 @@ fixmystreet.assets = {
         if (!message) {
             message = get_asset_pick_message.call(this);
         }
-        $('.category_meta_message').html(message);
+        update_message_display.call(this, message);
     },
     named_select_action_not_found: function() {
         var message = get_asset_pick_message.call(this);

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -503,7 +503,7 @@ function layer_visibilitychanged() {
         }
         return;
     } else if (!this.getVisibility()) {
-        asset_unselected.call(this);
+        this.get_select_control().unselectAll();
         this.asset_not_found(); // as trigger won't call on non-visible layers
     }
 

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -399,6 +399,7 @@ function asset_selected(e) {
 
     // Keep track of selection in case layer is reloaded or hidden etc.
     selected_feature = feature.clone();
+    selected_feature.layer = feature.layer;
 
     // Hide the normal markers layer to keep things simple, but
     // move the green marker to the point of the click to stop
@@ -419,6 +420,11 @@ function asset_selected(e) {
 }
 
 function asset_unselected(e) {
+    if (selected_feature.layer !== this) {
+        // The selected feature has already changed to something in a different
+        // layer, so we don't want to mess that up by clearing it
+        return;
+    }
     fixmystreet.markers.setVisibility(true);
     selected_feature = null;
     this.clearAttributeFields();

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -493,6 +493,8 @@ function _update_message(message, c) {
     }
 }
 
+var lastVisible = 0;
+
 function layer_visibilitychanged() {
     if (this.fixmystreet.road) {
         if (!this.getVisibility()) {
@@ -527,12 +529,13 @@ function layer_visibilitychanged() {
             visible++;
         }
     }
-    if (visible === 2 || visible === 0) {
-        // We're either switching WFS layers (so going 1->2->1 or 1->0->1)
-        // or switching off WFS layer (so going 1->0). Either way, we want
-        // to show the marker again.
+    if (visible === 0 || visible > lastVisible) {
+        // We're either switching WFS layers (so going 1->2->1 or 1->0->1 or
+        // even 1->2->3->2) or switching off WFS layer (so going 1->0).
+        // Whichever way, we want to show the marker again.
         fixmystreet.markers.setVisibility(true);
     }
+    lastVisible = visible;
     if (!this.fixmystreet.non_interactive) {
         this.select_nearest_asset();
     }


### PR DESCRIPTION
To see these issues on live, go to https://report.peterborough.gov.uk/report/new?longitude=-0.247059&latitude=52.556479 - click middle of St Margarets Road then select Street Lighting, then Trees, then Street Lighting, then Trees. You'll see there are now two green pins (fixed by 80d47db and 919cb2b) and it says "You can pick a light from the map" (fixed by 4b659c6).

Then click a different tree asset (up to the left there are plenty) and change category to Street lighting, you'll see there are now two selected assets (fixed by 2f7ce01).

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1888 
