### PR TITLE
[Highways England] Work across whole network.

### DIFF
--- a/perllib/FixMyStreet/SendReport/Email/Highways.pm
+++ b/perllib/FixMyStreet/SendReport/Email/Highways.pm
@@ -12,11 +12,9 @@ sub build_recipient_list {
     my $contact = $self->fetch_category($body, $row) or return;
     my $email = $contact->email;
     my $area_name = $row->get_extra_field_value('area_name') || '';
-    if ($area_name eq 'Area 7') {
-        my $a7email = FixMyStreet->config('COBRAND_FEATURES') || {};
-        $a7email = $a7email->{open311_email}->{highwaysengland}->{area_seven};
-        $email = $a7email if $a7email;
-    }
+    my $area_email = FixMyStreet->config('COBRAND_FEATURES') || {};
+    $area_email = $area_email->{open311_email}->{highwaysengland}->{$area_name};
+    $email = $area_email if $area_email;
 
     @{$self->to} = map { [ $_, $body->name ] } split /,/, $email;
     return 1;

--- a/t/app/sendreport/email/highways.t
+++ b/t/app/sendreport/email/highways.t
@@ -34,7 +34,7 @@ is $e->build_recipient_list($row), 1, 'correct recipient list count';
 is_deeply $e->to, [ [ 'highways@example.com', 'Highways England' ] ], 'correct To line';
 
 FixMyStreet::override_config {
-    COBRAND_FEATURES => { open311_email => { highwaysengland => { area_seven => 'a7@example.com' } } }
+    COBRAND_FEATURES => { open311_email => { highwaysengland => { 'Area 7' => 'a7@example.com' } } }
 }, sub {
     $row->set_extra_fields( { name => 'area_name', value => 'Area 7' } );
     is $e->build_recipient_list($row), 1, 'correct recipient list count';

--- a/templates/web/highwaysengland/report/new/roads_message.html
+++ b/templates/web/highwaysengland/report/new/roads_message.html
@@ -6,12 +6,4 @@
         <a class="js-update-coordinates" href="https://www.fixmystreet.com/report/new?latitude=[% latitude %]&amp;longitude=[% longitude %]">FixMyStreet</a> to continue reporting your issue.
         </p>
     </div>
-
-    <div id="js-not-area7-road" class="hidden js-responsibility-message">
-        <strong>This site is currently only for reports in the East Midlands</strong>
-        <p>
-        Please follow this link to
-        <a class="js-update-coordinates" href="https://www.fixmystreet.com/report/new?latitude=[% latitude %]&amp;longitude=[% longitude %]">FixMyStreet</a> to continue reporting your issue.
-        </p>
-    </div>
 </div>

--- a/web/cobrands/highwaysengland/assets.js
+++ b/web/cobrands/highwaysengland/assets.js
@@ -61,18 +61,9 @@ fixmystreet.assets.add(defaults, {
     no_asset_msg_id: '#js-not-he-road',
     actions: {
         found: function(layer, feature) {
-            // If the road isn't in area 7 then we want to show the not found message.
-            fixmystreet.message_controller.road_found(layer, feature, function(feature) {
-                if (feature.attributes.area_name === 'Area 7') {
-                    $('#js-top-message').show();
-                    $('#form_category_row').show();
-                    return true;
-                } else {
-                    $('#js-top-message').hide();
-                    $('#form_category_row').hide();
-                    return false;
-                }
-            }, '#js-not-area7-road');
+            $('#js-top-message').show();
+            $('#form_category_row').show();
+            fixmystreet.message_controller.road_found(layer, feature);
         },
         not_found: function(layer) {
           fixmystreet.message_controller.road_not_found(layer);


### PR DESCRIPTION
This adjusts the cobrand so it allows reporting on any HE road, and adjusts the sending so it can utilise configured per-area emails for any area, not just 7, or just fall back as now to the  if none is present. [skip changelog]