### PR TITLE
[UK] hide change asset button if category drop downs hidden

### DIFF
--- a/t/app/controller/report_inspect.t
+++ b/t/app/controller/report_inspect.t
@@ -56,12 +56,14 @@ FixMyStreet::override_config {
         $mech->content_lacks('Private');
         $mech->content_lacks('Priority');
         $mech->content_lacks('Traffic management');
+        $mech->content_lacks('Change asset');
         $mech->content_lacks('/admin/report_edit/'.$report_id.'">admin</a>)');
 
         $user->user_body_permissions->create({ body => $oxon, permission_type => 'report_mark_private' });
         $mech->get_ok("/report/$report_id");
         $mech->content_contains('Private');
         $mech->content_contains('Save changes');
+        $mech->content_lacks('Change asset');
         $mech->content_lacks('Priority');
         $mech->content_lacks('Traffic management');
         $mech->content_lacks('/admin/report_edit/'.$report_id.'">admin</a>)');
@@ -71,6 +73,7 @@ FixMyStreet::override_config {
         $mech->content_contains('Private');
         $mech->content_contains('Save changes');
         $mech->content_contains('Priority');
+        $mech->content_lacks('Change asset');
         $mech->content_lacks('Traffic management');
         $mech->content_lacks('/admin/report_edit/'.$report_id.'">admin</a>)');
 
@@ -80,6 +83,7 @@ FixMyStreet::override_config {
         $mech->content_contains('Private');
         $mech->content_contains('Priority');
         $mech->content_contains('Traffic management');
+        $mech->content_contains('Change asset');
         $mech->content_lacks('/admin/report_edit/'.$report_id.'">admin</a>)');
     };
 

--- a/templates/web/base/report/inspect/information.html
+++ b/templates/web/base/report/inspect/information.html
@@ -54,10 +54,12 @@
           [% END %]
         [% END %]
 
+        [% IF permissions.report_edit_category OR permissions.report_inspect %]
         <!-- These fields are for the asset display code to use -->
         <input type="hidden" name="inspect_category_group" id="inspect_category_group" value="">
         <input type="hidden" name="inspect_form_category" id="inspect_form_category" value="">
         <p>
           <a href="#" class="btn btn--block btn--change-asset">[% loc('Change asset') %]</a>
         </p>
+        [% END %]
       </div>

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -277,7 +277,9 @@ fixmystreet.staff_set_up = {
             $('.btn--change-asset').hide();
         }
     }
-    update_change_asset_button();
+    if ( $('.btn--change-asset').length ) {
+        update_change_asset_button();
+    }
 
     $('.btn--change-asset').on('click', function(e) {
         e.preventDefault();


### PR DESCRIPTION
The change asset button code relies on the category drop downs being visible
which requires either the change report category or inspect report
permissions. Hide the button if these are not present and only fire the
update button code if it's present.

Fixes mysociety/fixmystreet-commercial#1961

[skip changelog]