### PR TITLE
extra states cobrand feature

### DIFF
--- a/perllib/FixMyStreet.pm
+++ b/perllib/FixMyStreet.pm
@@ -97,6 +97,9 @@ sub override_config($&) {
 
     mySociety::MaPit::configure($config->{MAPIT_URL}) if $config->{MAPIT_URL};
 
+    use Readonly;
+    Readonly my %ro_config => %$config;
+
     # NB: though we have this, templates tend to use [% c.config %].
     # This overriding happens after $c->config is set, so note that
     # FixMyStreet::App->setup_request rewrites $c->config if we are in
@@ -106,8 +109,8 @@ sub override_config($&) {
         "FixMyStreet::config",
         sub {
             my ($class, $key) = @_;
-            return { %CONFIG, %$config } unless $key;
-            return $config->{$key} if exists $config->{$key};
+            return { %CONFIG, %ro_config } unless $key;
+            return $ro_config{$key} if exists $ro_config{$key};
             return $CONFIG{$key} if exists $CONFIG{$key};
         }
     );

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -310,6 +310,19 @@ sub updates_disallowed {
     return $self->next::method(@_);
 }
 
+sub problem_state_processed {
+    my ($self, $comment) = @_;
+
+    my $state = $comment->problem_state || '';
+    my $code = $comment->get_extra_metadata('external_status_code') || '';
+
+    my ($cfg) = $self->per_body_config('extra_state_mapping', $comment->problem);
+
+    $state = ( $cfg->{$state}->{$code} || $state ) if $cfg->{$state};
+
+    return $state;
+}
+
 sub suppress_reporter_alerts {
     my $self = shift;
     my $c = $self->{c};

--- a/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
@@ -75,19 +75,6 @@ sub problems_on_map_restriction {
     return $self->problems_restriction($rs);
 }
 
-sub problem_state_processed {
-    my ($self, $comment) = @_;
-
-    my $state = $comment->problem_state || '';
-    my $code = $comment->get_extra_metadata('external_status_code') || '';
-
-    if ( $state eq 'investigating' and $code eq 'further' ) {
-        $state = 'Under further investigation';
-    }
-
-    return $state;
-}
-
 sub privacy_policy_url {
     'https://www3.northamptonshire.gov.uk/councilservices/council-and-democracy/transparency/information-policies/privacy-notice/place/Pages/street-doctor.aspx'
 }

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -270,6 +270,19 @@ sub relative_url_for_report {
     return FixMyStreet->config('BASE_URL');
 }
 
+sub problem_state_processed {
+    my ($self, $comment) = @_;
+
+    my $state = $comment->problem_state || '';
+    my $code = $comment->get_extra_metadata('external_status_code') || '';
+
+    my $cfg = $self->feature('extra_state_mapping');
+
+    $state = ( $cfg->{$state}->{$code} || $state ) if $cfg->{$state};
+
+    return $state;
+}
+
 sub admin_allow_user {
     my ( $self, $user ) = @_;
     return 1 if $user->is_superuser;

--- a/t/cobrand/northamptonshire.t
+++ b/t/cobrand/northamptonshire.t
@@ -114,6 +114,15 @@ subtest 'check further investigation state' => sub {
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => [ { northamptonshire => '.' } ],
         MAPIT_URL => 'http://mapit.uk/',
+        COBRAND_FEATURES => {
+            extra_state_mapping => {
+                northamptonshire => {
+                    investigating => {
+                        further => 'Under further investigation'
+                    }
+                }
+            }
+        }
     }, sub {
         $mech->get_ok('/report/' . $comment->problem_id);
     };
@@ -126,6 +135,76 @@ subtest 'check further investigation state' => sub {
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => [ { northamptonshire => '.' } ],
         MAPIT_URL => 'http://mapit.uk/',
+        COBRAND_FEATURES => {
+            extra_state_mapping => {
+                northamptonshire => {
+                    investigating => {
+                        further => 'Under further investigation'
+                    }
+                }
+            }
+        }
+    }, sub {
+        $mech->get_ok('/report/' . $comment->problem_id);
+    };
+
+    $mech->content_contains('Under further investigation');
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ { northamptonshire => '.' } ],
+        MAPIT_URL => 'http://mapit.uk/',
+        COBRAND_FEATURES => {
+            extra_state_mapping => {
+                northamptonshire => {
+                    fixed => {
+                        further => 'Under further investigation'
+                    }
+                },
+                fixmystreet => {
+                    'Northamptonshire County Council' => {
+                        fixed => {
+                            further => 'Under further investigation'
+                        }
+                    }
+                }
+            }
+        }
+    }, sub {
+        $mech->get_ok('/report/' . $comment->problem_id);
+    };
+
+    $mech->content_contains('Investigating');
+    $mech->content_lacks('Under further investigation');
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ { northamptonshire => '.' } ],
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $mech->get_ok('/report/' . $comment->problem_id);
+    };
+
+    $mech->content_contains('Investigating');
+    $mech->content_lacks('Under further investigation');
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ { fixmystreet => '.' } ],
+        MAPIT_URL => 'http://mapit.uk/',
+        COBRAND_FEATURES => {
+            extra_state_mapping => {
+                northamptonshire => {
+                    investigating => {
+                        further => 'Under further investigation'
+                    }
+                },
+                fixmystreet => {
+                    'Northamptonshire County Council' => {
+                        investigating => {
+                            further => 'Under further investigation'
+                        }
+                    }
+                }
+            }
+        }
     }, sub {
         $mech->get_ok('/report/' . $comment->problem_id);
     };

--- a/t/cobrand/northamptonshire.t
+++ b/t/cobrand/northamptonshire.t
@@ -210,6 +210,42 @@ subtest 'check further investigation state' => sub {
     };
 
     $mech->content_contains('Under further investigation');
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ { fixmystreet => '.' } ],
+        MAPIT_URL => 'http://mapit.uk/',
+        COBRAND_FEATURES => {
+            extra_state_mapping => {
+                northamptonshire => {
+                    fixed => {
+                        further => 'Under further investigation'
+                    }
+                },
+                fixmystreet => {
+                    'Northamptonshire County Council' => {
+                        fixed => {
+                            further => 'Under further investigation'
+                        }
+                    }
+                }
+            }
+        }
+    }, sub {
+        $mech->get_ok('/report/' . $comment->problem_id);
+    };
+
+    $mech->content_contains('Investigating');
+    $mech->content_lacks('Under further investigation');
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ { fixmystreet => '.' } ],
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $mech->get_ok('/report/' . $comment->problem_id);
+    };
+
+    $mech->content_contains('Investigating');
+    $mech->content_lacks('Under further investigation');
 };
 
 subtest 'check pin colour / reference shown' => sub {


### PR DESCRIPTION
This allows display strings for a state/external status combination to be configured as a cobrand feature.

For mysociety/fixmystreet-commercial#1952

[skip changelog]