### PR TITLE
[Hackney] Allow editing & addition of contacts with special destination addresses

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
@@ -255,7 +255,9 @@ sub update_contact : Private {
     $email =~ s/\s+//g;
     my $send_method = $c->get_param('send_method') || $contact->body->send_method || "";
     my $email_unchanged = $contact->email && $email && $contact->email eq $email;
-    unless ( $send_method eq 'Open311' || $email_unchanged ) {
+    my $cobrand = $contact->body->get_cobrand_handler;
+    my $cobrand_valid = $cobrand && $cobrand->call_hook(validate_contact_email => $email);
+    unless ( $send_method eq 'Open311' || $email_unchanged || $cobrand_valid ) {
         $errors{email} = _('Please enter a valid email') unless is_valid_email_list($email) || $email eq 'REFUSED';
     }
 

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -122,6 +122,8 @@ sub dispatch_request {
             $self->output({2326 => {parent_area => undef, id => 2326, name => "Cheltenham Borough Council", type => "DIS"}});
         } elsif ($areas eq 'UTA') {
             $self->output({2650 => {parent_area => undef, id => 2650, name => "Aberdeen Council", type => "UTA"}});
+        } elsif ($areas eq 'DIS,LBO,MTD,UTA,CTY,COI,LGD') {
+            $self->output({2508 => {parent_area => undef, id => 2508, name => "Hackney Council", type => "LBO"}});
         } elsif ($areas eq 'GRE') {
             $self->output({2493 => {parent_area => undef, id => 2493, name => "Greenwich Borough Council", type => "LBO"}});
         } elsif ($areas eq 'LBO') {


### PR DESCRIPTION
This adds a cobrand hook to validate the email address provided when editing a contact
in the admin.

[skip changelog]
