### PR TITLE
[Oxfordshire] Hide duplicate ‘Other’ category from map filters

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -254,6 +254,9 @@ sub check_and_stash_category : Private {
             distinct => 1
         }
     )->all_sorted;
+    # Ensure only uniquely named categories are shown
+    my %seen;
+    @categories = grep { !$seen{$_->category_display}++ } @categories;
     $c->stash->{filter_categories} = \@categories;
     my %categories_mapped = map { $_->category => 1 } @categories;
     $c->forward('/report/stash_category_groups', [ \@categories ]) if $c->cobrand->enable_category_groups;

--- a/perllib/FixMyStreet/App/Controller/My.pm
+++ b/perllib/FixMyStreet/App/Controller/My.pm
@@ -197,6 +197,9 @@ sub setup_page_data : Private {
         distinct => 1,
         order_by => [ "$table.category" ],
     } )->all;
+    # Ensure only uniquely named categories are shown
+    my %seen;
+    @categories = grep { !$seen{$_->category_display}++ } @categories;
     $c->stash->{filter_categories} = \@categories;
 
     if ($c->cobrand->enable_category_groups) {


### PR DESCRIPTION
Two rows would be returned because the district and county `Other` contacts have different `extra` fields, so this adds a `WHERE` for the Oxfordshire cobrand to only fetch the county contact.

This probably isn't the best way to fix the problem.

[skip changelog]

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1964