### PR TITLE
[Oxfordshire] Update SRS for new trees layer

### DIFF
--- a/web/cobrands/oxfordshire/assets.js
+++ b/web/cobrands/oxfordshire/assets.js
@@ -88,6 +88,7 @@ var owned_stylemap = new OpenLayers.StyleMap({
 fixmystreet.assets.add(defaults, {
     stylemap: occ_stylemap,
     wfs_feature: "Trees",
+    srsName: "EPSG:27700",
     asset_id_field: 'Ref',
     attributes: {
         feature_id: 'Ref'


### PR DESCRIPTION
The new highways-only trees layer needs the SRS set to 27700.

See https://github.com/mysociety/fixmystreet.com/commit/0ee41f218d1cc3c780256e741f1fbb67fd753982 for the parallel change for tilma.

Part of https://github.com/mysociety/fixmystreet-commercial/issues/1962

[skip changelog]
