### PR TITLE
[Central Beds] Add highways layer and prevent reports made off CBC roads

### DIFF
--- a/templates/web/centralbedfordshire/footer_extra_js.html
+++ b/templates/web/centralbedfordshire/footer_extra_js.html
@@ -1,0 +1,1 @@
+[% PROCESS 'footer_extra_js_base.html' highways=1 cobrand_js=1 roadworks=1 %]

--- a/templates/web/centralbedfordshire/report/new/roads_message.html
+++ b/templates/web/centralbedfordshire/report/new/roads_message.html
@@ -1,0 +1,13 @@
+<div id="js-roads-responsibility" class="box-warning hidden">
+    <strong>Not maintained by Central Bedfordshire Council</strong>
+    <div id="js-not-council-road" class="hidden js-responsibility-message">
+        <p>The selected road is not maintained by Central Bedfordshire Council;
+        to find out who owns this land/road please contact the Land Registry at
+        <a href="https://www.gov.uk/search-property-information-land-registry">https://www.gov.uk/search-property-information-land-registry</a>.
+        </p>
+    </div>
+    <div id="js-not-a-road" class="hidden js-responsibility-message">
+        <p>The location you have selected doesn't appear to be on a road.</p>
+        <p>Please select a road on which to make a report.</p>
+    </div>
+</div>

--- a/templates/web/fixmystreet.com/footer_extra_js.html
+++ b/templates/web/fixmystreet.com/footer_extra_js.html
@@ -10,6 +10,7 @@ IF bodyclass.match('mappage');
     scripts.push( version('/cobrands/bristol/assets.js') );
     scripts.push( version('/cobrands/bromley/assets.js') );
     scripts.push( version('/cobrands/buckinghamshire/assets.js') );
+    scripts.push( version('/cobrands/centralbedfordshire/assets.js') );
     scripts.push( version('/cobrands/cheshireeast/assets.js') );
     scripts.push( version('/cobrands/eastsussex/assets.js') );
     scripts.push( version('/cobrands/isleofwight/assets.js') );

--- a/web/cobrands/centralbedfordshire/assets.js
+++ b/web/cobrands/centralbedfordshire/assets.js
@@ -1,0 +1,62 @@
+(function(){
+
+if (!fixmystreet.maps) {
+    return;
+}
+
+
+var defaults = {
+    http_options: {
+        url: fixmystreet.staging ? "https://tilma.staging.mysociety.org/mapserver/centralbeds" : "https://tilma.mysociety.org/mapserver/centralbeds",
+        params: {
+            SERVICE: "WFS",
+            VERSION: "1.1.0",
+            REQUEST: "GetFeature",
+            SRSNAME: "urn:ogc:def:crs:EPSG::3857"
+        }
+    },
+    max_resolution: 9.554628534317017,
+    geometryName: 'msGeometry',
+    srsName: "EPSG:3857",
+    body: "Central Bedfordshire Council",
+    strategy_class: OpenLayers.Strategy.FixMyStreet
+};
+
+var centralbeds_types = [
+    "CBC",
+    "Fw",
+];
+
+fixmystreet.assets.add(defaults, {
+    http_options: {
+        params: {
+            TYPENAME: "Highways"
+        }
+    },
+    stylemap: fixmystreet.assets.stylemap_invisible,
+    non_interactive: true,
+    always_visible: true,
+    road: true,
+    all_categories: true,
+    usrn: {
+        attribute: 'streetref1',
+        field: 'NSGRef'
+    },
+    actions: {
+        found: function(layer, feature) {
+            fixmystreet.message_controller.road_found(layer, feature, function(feature) {
+                if (OpenLayers.Util.indexOf(centralbeds_types, feature.attributes.adoption) != -1) {
+                    return true;
+                }
+                return false;
+            }, "#js-not-council-road");
+        },
+        not_found: fixmystreet.message_controller.road_not_found,
+    },
+    asset_item: "road",
+    asset_type: 'road',
+    no_asset_msg_id: '#js-not-a-road',
+    name: "Highways"
+});
+
+})();


### PR DESCRIPTION
Adds an invisible highways layer which is used to check ownership of roads and prevents reports that aren't on CBC-responsible roads.

[skip changelog]