### PR TITLE
do not trigger duplicate check with stopper check

### DIFF
--- a/.cypress/cypress/integration/duplicates.js
+++ b/.cypress/cypress/integration/duplicates.js
@@ -77,4 +77,23 @@ describe('Duplicate tests', function() {
       cy.get('#js-duplicate-reports li h3 a').should('have.attr', 'href', '/report/1');
     });
 
+    it('does not redisplay duplicates when stopper questions are changed', function() {
+      cy.server();
+      cy.route('/report/new/ajax*').as('report-ajax');
+      cy.visit('http://borsetshire.localhost:3001/_test/setup/regression-duplicate-stopper'); // Server-side setup
+      cy.visit('http://borsetshire.localhost:3001/report/1');
+      cy.contains('Report another problem here').click();
+      cy.wait('@report-ajax');
+      cy.get('[id=category_group]').select('Flytipping');
+      cy.get('.extra-category-questions').should('not.be.visible');
+      cy.get('.js-hide-duplicate-suggestions:first').click();
+      cy.get('.js-hide-duplicate-suggestions:first').should('not.be.visible');
+      cy.get('.extra-category-questions').should('be.visible');
+      cy.get('[id=form_hazardous]').select('No');
+      cy.wait(500);
+      cy.get('.extra-category-questions').should('be.visible');
+      cy.get('.js-hide-duplicate-suggestions:first').should('not.be.visible');
+      cy.visit('http://borsetshire.localhost:3001/_test/teardown/regression-duplicate-stopper'); // Server-side setup
+    });
+
 });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
         - Fix lookups in templates of categories with &s.
         - Fix a few obscure asset layer changing issues.
         - Fix multiple disable messages for dropdown answers
+        - Do not trigger duplicate check when checking stoppers
     - Admin improvements:
         - Display user name/email for contributed as reports. #2990
         - Interface for enabling anonymous reports for certain categories. #2989

--- a/perllib/FixMyStreet/App/Controller/Test.pm
+++ b/perllib/FixMyStreet/App/Controller/Test.pm
@@ -42,6 +42,25 @@ sub setup : Path('/_test/setup') : Args(1) {
         my $problem = FixMyStreet::DB->resultset("Problem")->find(1);
         $problem->update({ category => 'Skips' });
         $c->response->body("OK");
+    } elsif ( $test eq 'regression-duplicate-stopper') {
+        my $problem = FixMyStreet::DB->resultset("Problem")->find(1);
+        $problem->update({ category => 'Flytipping' });
+        my $category = FixMyStreet::DB->resultset('Contact')->search({
+            category => 'Flytipping',
+        })->first;
+        $category->push_extra_fields({
+            code => 'hazardous',
+            datatype => 'singlevaluelist',
+            description => 'Hazardous material',
+            order => 0,
+            variable => 'true',
+            values => [
+                { key => 'yes', name => 'Yes', disable => 1, disable_message => 'Please phone' },
+                { key => 'no', name => 'No' },
+            ],
+        });
+        $category->update;
+        $c->response->body("OK");
     }
 }
 
@@ -50,6 +69,15 @@ sub teardown : Path('/_test/teardown') : Args(1) {
     if ($test eq 'regression-duplicate-hide') {
         my $problem = FixMyStreet::DB->resultset("Problem")->find(1);
         $problem->update({ category => 'Potholes' });
+        $c->response->body("OK");
+    } elsif ( $test eq 'regression-duplicate-stopper') {
+        my $problem = FixMyStreet::DB->resultset("Problem")->find(1);
+        $problem->update({ category => 'Potholes' });
+        my $category = FixMyStreet::DB->resultset('Contact')->search({
+            category => 'Flytipping',
+        })->first;
+        $category->remove_extra_field('hazardous');
+        $category->update;
         $c->response->body("OK");
     }
 }

--- a/templates/web/borsetshire/footer_extra_js.html
+++ b/templates/web/borsetshire/footer_extra_js.html
@@ -2,4 +2,8 @@
     version('/cobrands/fixmystreet-uk-councils/js.js'),
     version('/cobrands/borsetshire/google_maps_style.js'),
     version('/cobrands/borsetshire/js.js'),
-) %]
+);
+IF bodyclass.match('mappage');
+   scripts.push( version('/cobrands/fixmystreet/assets.js') );
+END;
+%]

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -470,7 +470,7 @@ $.extend(fixmystreet.set_up, {
             $.each(data.disable_form.questions, function(_, question) {
                 if (question.message && question.code) {
                     $('#form_' + question.code).on('change.category', function() {
-                        $(fixmystreet).trigger('report_new:category_change');
+                        $(fixmystreet).trigger('report_new:category_change', { skip_duplicates: true } );
                     });
                 }
             });


### PR DESCRIPTION
The stopper checking code is triggered using the category_change event
which, by default also calls the duplicate check code. This meant that
when an extra question dropdown with an associated stopper was updated
the duplicate check re-ran and the duplicate reports panel was re-shown.

The invocation of category_change on the extra questions now includes
the skip_duplicates parameter to avoid this.

Fixes mysociety/fixmystreet-commercial#2007