### PR TITLE
Record whether report made on desktop or mobile.

### DIFF
--- a/.cypress/cypress/integration/simple_spec.js
+++ b/.cypress/cypress/integration/simple_spec.js
@@ -20,6 +20,9 @@ describe('Clicking the map', function() {
         cy.get('#map_sidebar').should('contain', 'check and confirm your details');
         cy.get('#map_sidebar').parents('form').submit();
         cy.get('body').should('contain', 'Thank you for reporting this issue');
+        cy.visit('http://fixmystreet.localhost:3001/_test/setup/simple-service-check').then(function(w) {
+            expect(w.document.documentElement.innerText).to.equal('desktop');
+        });
     });
 });
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ install:
   - 'if [ "$CYPRESS" = "1" ]; then npm install cypress@3.8.3; fi'
 before_script:
   - commonlib/bin/gettext-makemo FixMyStreet
-  - 'if [ "$COVERAGE_PART" != "0" ]; then export HARNESS_PERL_SWITCHES="-MDevel::Cover=+ignore,local/lib/perl5,commonlib,perllib/Catalyst/[^A],perllib/Email,^t"; fi'
+  - 'if [ "$COVERAGE_PART" != "0" ]; then export HARNESS_PERL_SWITCHES="-MDevel::Cover=+ignore,local/lib/perl5,commonlib,perllib/Catalyst/[^A],perllib/Email,Test.pm,^t"; fi'
 script:
   - 'if [ "$CYPRESS" = "0" ] && [ "$COVERAGE_PART" = "0" ]; then script/test --jobs 3 t; fi'
   - 'if [ "$COVERAGE_PART" = "1" ]; then script/test --jobs 3 `find t/app/controller -name "*.t"`; fi'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
         - Allow inspectors to change report asset.
         - Staff users can use HTML tags in updates. #3143
         - Response templates can include HTML tags. #3143
+        - Record whether report made on desktop or mobile.
     - Development improvements:
         - `#geolocate_link` is now easier to re-style. #3006
         - Links inside `#front-main` can be customised using `$primary_link_*` Sass variables. #3007

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -29,8 +29,8 @@ Create a new report, or complete a partial one.
 
 submit_problem: true if a problem has been submitted, at all.
 submit_sign_in: true if the sign in button has been clicked by logged out user.
-submit_register: true if the register/confirm by email button has been clicked
-by logged out user.
+submit_register(_mobile): true if the register/confirm by email button has been clicked
+by logged out user, or submit button clicked by logged in user.
 
 =head2 location (required)
 
@@ -1046,7 +1046,13 @@ sub process_report : Private {
     $report->detail( $detail );
 
     # mobile device type
-    $report->service( $params{service} ) if $params{service};
+    if ($params{service}) {
+        $report->service($params{service});
+    } elsif ($c->get_param('submit_register_mobile')) {
+        $report->service('mobile');
+    } elsif ($c->get_param('submit_register')) {
+        $report->service('desktop');
+    }
 
     # set these straight from the params
     $report->category( _ $params{category} ) if $params{category};

--- a/perllib/FixMyStreet/App/Controller/Test.pm
+++ b/perllib/FixMyStreet/App/Controller/Test.pm
@@ -61,6 +61,9 @@ sub setup : Path('/_test/setup') : Args(1) {
         });
         $category->update;
         $c->response->body("OK");
+    } elsif ($test eq 'simple-service-check') {
+        my $problem = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+        $c->response->body($problem->service);
     }
 }
 

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -149,7 +149,7 @@ foreach my $test (
 
         $mech->submit_form_ok(
             {
-                button      => 'submit_register',
+                button      => 'submit_register_mobile',
                 with_fields => {
                     title         => 'Test Report',
                     detail        => 'Test report details.',

--- a/templates/web/base/report/form/submit.html
+++ b/templates/web/base/report/form/submit.html
@@ -1,0 +1,2 @@
+<input class="desk-only btn btn--primary btn--block btn--final js-submit_register" type="submit" name="submit_register" value="[% loc('Submit') %]">
+<input class="mob-only btn btn--primary btn--block btn--final js-submit_register" type="submit" name="submit_register_mobile" value="[% loc('Submit') %]">

--- a/templates/web/base/report/form/user_loggedout_by_email.html
+++ b/templates/web/base/report/form/user_loggedout_by_email.html
@@ -87,7 +87,7 @@
 
     [% PROCESS 'auth/form_extra.html' %]
 
-    <input class="btn btn--primary btn--block btn--final js-submit_register" type="submit" name="submit_register" value="[% loc('Submit') %]">
+    [% PROCESS 'report/form/submit.html' %]
 
 </div>
 <!-- /user_loggedout_by_email.html -->

--- a/templates/web/base/report/new/form_report.html
+++ b/templates/web/base/report/new/form_report.html
@@ -89,5 +89,6 @@
     <input type="hidden" id="single_body_only" name="single_body_only" value="">
     <input type="hidden" id="do_not_send" name="do_not_send" value="">
     <input type="hidden" name="submit_problem" value="1">
+    <input type="hidden" id="form_service" name="service" value="">
 </div>
 <!-- /report/new/form_report.html -->

--- a/templates/web/base/report/new/form_user_loggedin.html
+++ b/templates/web/base/report/new/form_user_loggedin.html
@@ -74,5 +74,5 @@
     </div>
 [% END %]
 
-<input class="btn btn--primary btn--block btn--final js-submit_register" type="submit" name="submit_register" value="[% loc('Submit') %]">
+[% PROCESS 'report/form/submit.html' %]
 <!-- /report/new/form_user_loggedin.html -->

--- a/templates/web/base/report/new/login_success_form.html
+++ b/templates/web/base/report/new/login_success_form.html
@@ -14,6 +14,6 @@
         [% PROCESS "report/form/user_loggedout.html" type='report' object=report %]
       [% END %]
       [% PROCESS 'report/new/form_report.html' %]
-      <input class="btn btn--primary btn--block btn--final js-submit_register" type="submit" name="submit_register" value="[% loc('Submit') %]">
+      [% PROCESS 'report/form/submit.html' %]
     </div>
 </fieldset>

--- a/templates/web/base/report/new/oauth_email_form.html
+++ b/templates/web/base/report/new/oauth_email_form.html
@@ -17,6 +17,6 @@
 
         <input type="hidden" name="oauth_need_email" value="1">
         [% PROCESS 'report/new/form_report.html' %]
-        <input class="btn btn--primary btn--block btn--final js-submit_register" type="submit" name="submit_register" value="[% loc('Submit') %]">
+        [% PROCESS 'report/form/submit.html' %]
     </div>
 </fieldset>

--- a/templates/web/base/report/update/form_user_loggedin.html
+++ b/templates/web/base/report/update/form_user_loggedin.html
@@ -38,5 +38,7 @@
     <label class="inline" for="form_add_alert">[% loc( 'Alert me to future updates' ) %]</label>
 </div>
 
-<div class="clearfix"><input class="btn btn--primary btn--block btn--final js-submit_register" type="submit" name="submit_register" value="[% loc('Post') %]"></div>
+<div class="clearfix">
+    [% PROCESS 'report/form/submit.html' %]
+</div>
 <!-- /report/update/form_user_loggedin.html -->

--- a/templates/web/zurich/report/new/fill_in_details_form.html
+++ b/templates/web/zurich/report/new/fill_in_details_form.html
@@ -70,7 +70,10 @@
 
                 <div class="form-txt-submit-box">
                     [%# class of submit_sign_in so name can be optional, name of submit_register so it doesn't try and sign us in %]
-                    <p><input class="green-btn js-submit_sign_in" type="submit" name="submit_register" value="[% loc('Submit') %]">
+                    <p>
+                    <input class="desk-only green-btn js-submit_sign_in" type="submit" name="submit_register" value="[% loc('Submit') %]">
+                    <input class="mob-only green-btn js-submit_sign_in" type="submit" name="submit_register_mobile" value="[% loc('Submit') %]">
+                    </p>
                 </div>
 
         </div>

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -659,6 +659,7 @@ $.extend(fixmystreet.set_up, {
         } else {
             fixmystreet.resize_to.desktop_page();
         }
+        $('#form_service').val(type);
         last_type = type;
     }).resize();
   },


### PR DESCRIPTION
Have two submit buttons, one of which displays at <48em, one of which displays at >=48em. Record desktop/mobile with report depending on which button is clicked.
If neither button is clicked, e.g. if they submit the form by hitting return (although spec says button should be clicked then? whatever), have a bit of fallback JS that sets the form field in the browser resize function.
If no-JS and no form button clicked, carry on storing nothing as now.