### PR TITLE
Don’t strip all spaces from Open311 categories.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
         - Fix a few obscure asset layer changing issues.
         - Fix multiple disable messages for dropdown answers
         - Do not trigger duplicate check when checking stoppers
+        - Do not strip spaces from middle of Open311 category codes. #3167
     - Admin improvements:
         - Display user name/email for contributed as reports. #2990
         - Interface for enabling anonymous reports for certain categories. #2989

--- a/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
@@ -252,8 +252,12 @@ sub update_contact : Private {
     }
 
     my $email = $c->get_param('email');
-    $email =~ s/\s+//g;
     my $send_method = $c->get_param('send_method') || $contact->body->send_method || "";
+    if ($send_method eq 'Open311') {
+        $email =~ s/^\s+|\s+$//g;
+    } else {
+        $email =~ s/\s+//g;
+    }
     my $email_unchanged = $contact->email && $email && $contact->email eq $email;
     my $cobrand = $contact->body->get_cobrand_handler;
     my $cobrand_valid = $cobrand && $cobrand->call_hook(validate_contact_email => $email);

--- a/t/app/controller/admin/bodies.t
+++ b/t/app/controller/admin/bodies.t
@@ -231,9 +231,10 @@ subtest 'check open311 devolved editing' => sub {
     $mech->content_contains("name=\"category\"\n    size=\"30\" value=\"test category\"\n    required>", 'Can edit as now devolved');
     $mech->submit_form_ok( { with_fields => {
         send_method => '',
-        email => 'open311-code',
+        email => 'open311 code',
         note => 'Removing email send method',
     } } );
+    $mech->content_contains('open311 code');
     $mech->content_contains('Values updated');
 };
 


### PR DESCRIPTION
If a category’s send method is Open311, only strip spaces from the
ends of the code. We are aware of active Open311 servers that have
codes with spaces in the middle.

Fixes #3167.