### PR TITLE
avoid caching the service worker for logged in users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
         - Do not strip spaces from middle of Open311 category codes. #3167
         - Show all category history even if category renamed.
         - Fix email alert on initial update template.
+        - Do not cache the service worker
     - Admin improvements:
         - Display user name/email for contributed as reports. #2990
         - Interface for enabling anonymous reports for certain categories. #2989

--- a/perllib/FixMyStreet/App/Controller/Offline.pm
+++ b/perllib/FixMyStreet/App/Controller/Offline.pm
@@ -22,6 +22,7 @@ Offline pages Catalyst Controller - service worker handling
 
 sub service_worker : Path("/service-worker.js") {
     my ($self, $c) = @_;
+    $c->res->headers->header('Cache-Control' => 'max-age=0');
     $c->res->content_type('application/javascript');
 }
 

--- a/t/app/controller/offline.t
+++ b/t/app/controller/offline.t
@@ -54,6 +54,7 @@ FixMyStreet::override_config {
 
 subtest 'service worker' => sub {
     $mech->get_ok('/service-worker.js');
+    is $mech->res->header('Cache-Control'), 'max-age=0', 'service worker is not cached';
     $mech->content_contains('translation_strings');
     $mech->content_contains('offline/fallback');
 };


### PR DESCRIPTION
As the contents vary if the user is logged in and depending on their
permissions we should not be caching the service worker. This sets the
Vary header to 'Cookie' to avoid this.