### PR TITLE
[Bromley] Nuanced template resolution codes.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Templates.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Templates.pm
@@ -100,7 +100,10 @@ sub edit : Path : Args(2) {
 
             $template->text( $c->get_param('text') );
             $template->state( $c->get_param('state') );
-            $template->external_status_code( $c->get_param('external_status_code') );
+
+            my $ext_code = $c->cobrand->call_hook('admin_templates_external_status_code_hook');
+            $ext_code ||= $c->get_param('external_status_code');
+            $template->external_status_code($ext_code);
 
             if ( $template->state && $template->external_status_code ) {
                 $c->stash->{errors} ||= {};

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -572,13 +572,20 @@ sub bin_services_for_address {
             my $ref = join(',', @{$_->{Ref}{Value}{anyType}});
             my $completed = construct_bin_date($_->{CompletedDate});
             my $state = $_->{State}{Name} || '';
+            my $task_type_id = $_->{TaskTypeId} || '';
 
             my $resolution = $_->{Resolution}{Name} || '';
             my $resolution_id = $_->{Resolution}{Ref}{Value}{anyType};
             if ($resolution_id) {
                 my $template = FixMyStreet::DB->resultset('ResponseTemplate')->search({
                     'me.body_id' => $self->body->id,
-                    'me.external_status_code' => $resolution_id,
+                    'me.external_status_code' => [
+                        "$resolution_id,$task_type_id,$state",
+                        "$resolution_id,$task_type_id,",
+                        "$resolution_id,,$state",
+                        "$resolution_id,,",
+                        $resolution_id,
+                    ],
                 })->first;
                 $resolution = $template->text if $template;
             }
@@ -867,6 +874,17 @@ sub waste_check_last_update {
         }
     }
     return 1;
+}
+
+sub admin_templates_external_status_code_hook {
+    my ($self) = @_;
+    my $c = $self->{c};
+
+    my $res_code = $c->get_param('resolution_code') || '';
+    my $task_type = $c->get_param('task_type') || '';
+    my $task_state = $c->get_param('task_state') || '';
+
+    return "$res_code,$task_type,$task_state";
 }
 
 1;

--- a/perllib/Integrations/Echo.pm
+++ b/perllib/Integrations/Echo.pm
@@ -94,6 +94,7 @@ sub GetTasks {
             Ref => { Value => { anyType => [ 123, 456 ] } },
             State => { Name => 'Completed' },
             Resolution => { Ref => { Value => { anyType => 187 } }, Name => 'Wrong Bin Out' },
+            TaskTypeId => 3216,
             CompletedDate => { DateTime => '2020-05-27T10:00:00Z' }
         },
         {

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -289,12 +289,22 @@ FixMyStreet::override_config {
         $mech->get_ok('/waste/uprn/12345');
         $mech->content_contains('(completed at 10:00am)');
         $mech->content_contains('Wrong Bin Out');
-        FixMyStreet::DB->resultset('ResponseTemplate')->create({
-            body_id => $body->id,
+    };
+
+    subtest 'test template creation' => sub {
+        $mech->log_in_ok('superuser@example.com');
+        $mech->get_ok('/admin/templates/' . $body->id . '/new');
+        $mech->submit_form_ok({ with_fields => {
             title => 'Wrong bin',
             text => 'We could not collect your waste as it was not correctly presented.',
-            external_status_code => 187,
-        });
+            resolution_code => 187,
+            task_type => 3216,
+            task_state => 'Completed',
+        } });
+        $mech->log_out_ok;
+    };
+
+    subtest 'test reporting before/after completion' => sub {
         $mech->get_ok('/waste/uprn/12345');
         $mech->content_contains('(completed at 10:00am)');
         $mech->content_contains('We could not collect your waste as it was not correctly presented.');

--- a/templates/web/base/admin/templates/_external.html
+++ b/templates/web/base/admin/templates/_external.html
@@ -1,0 +1,12 @@
+[% IF errors.external_status_code %]
+    <div class="form-error">[% errors.external_status_code %]</div>
+[% END %]
+<div class="admin-hint">
+  <p>
+    [% loc('If you want to use this template to prefill the update field when a report&rsquo;s <strong>external</strong> (e.g. Confirm) status code changes, enter the status code here.') %]
+  </p>
+</div>
+<p>
+  <label for="external_status_code">[% loc('External status code') %]</label>
+  <input type="text" id="external_status_code" name="external_status_code" class="form-control" size="30" value="[% rt.external_status_code | html %]">
+</p>

--- a/templates/web/base/admin/templates/edit.html
+++ b/templates/web/base/admin/templates/edit.html
@@ -51,18 +51,7 @@
       [% INCLUDE 'report/inspect/state_groups_select.html' current_state=rt.state include_empty=1 %]
     </p>
 
-    [% IF errors.external_status_code %]
-        <div class="form-error">[% errors.external_status_code %]</div>
-    [% END %]
-    <div class="admin-hint">
-      <p>
-        [% loc('If you want to use this template to prefill the update field when a report&rsquo;s <strong>external</strong> (e.g. Confirm) status code changes, enter the status code here.') %]
-      </p>
-    </div>
-    <p>
-      <label for="external_status_code">[% loc('External status code') %]</label>
-      <input type="text" name="external_status_code" class="form-control" size="30" value="[% rt.external_status_code | html %]">
-    </p>
+    [% PROCESS 'admin/templates/_external.html' %]
 
     [% IF errors.auto_response %]
         <div class="form-error">[% errors.auto_response %]</div>

--- a/templates/web/bromley/admin/templates/_external.html
+++ b/templates/web/bromley/admin/templates/_external.html
@@ -1,0 +1,24 @@
+[% parts = rt.external_status_code.split(',') ~%]
+
+[% IF errors.external_status_code %]
+    <div class="form-error">[% errors.external_status_code %]</div>
+[% END %]
+<p>
+  <label for="resolution_code">External status code / Resolution Code ID</label>
+  <input type="text" id="resolution_code" name="resolution_code" class="form-control" size="30" value="[% parts.0 %]">
+</p>
+
+<p>
+  <label for="task_type">Task type ID</label>
+  <input type="text" id="task_type" name="task_type" class="form-control" size="30" value="[% parts.1 %]">
+</p>
+
+<p>
+  <label for="task_state">Task state</label>
+  <select class="form-control" name="task_state" id="task_state">
+      <option value="">---</option>
+    [% FOR opt IN ['Completed', 'Not Completed'] %]
+      <option value="[% opt %]"[% ' selected' IF parts.2 == opt %]>[% opt %]</option>
+    [% END %]
+  </select>
+</p>


### PR DESCRIPTION
Have the response template external status code be a combination
of resolution code, task type ID, and task state. [skip changelog]