### PR TITLE
[Noise] check if the noise follows a pattern

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Noise.pm
+++ b/perllib/FixMyStreet/App/Controller/Noise.pm
@@ -127,6 +127,15 @@ sub process_noise_report : Private {
     my $now = $data->{happening_now} ? 'Yes' : 'No';
     my $days = join(', ', @{$data->{happening_days}||[]});
     my $times = join(', ', @{$data->{happening_time}||[]});
+    my $time_detail;
+    if ($data->{happening_pattern}) {
+        $time_detail = "Does the time of the noise follow a pattern? Yes
+What days does the noise happen? $days
+What time does the noise happen? $times";
+    } else {
+        $time_detail = "Does the time of the noise follow a pattern? No
+When has the noise occurred? $data->{happening_description}";
+    }
     if ($data->{report}) {
         # Update on existing report. Will be logged in.
         my $report = FixMyStreet::DB->resultset('Problem')->find($data->{report});
@@ -137,8 +146,7 @@ Kind of noise: $data->{kind}
 Noise details: $data->{more_details}
 
 Is the noise happening now? $now
-What days does the noise happen? $days
-What time does the noise happen? $times
+$time_detail
 EOF
         $object = $c->model('DB::Comment')->new({
             problem => $report,
@@ -159,8 +167,7 @@ Where is the noise coming from? $data->{where}
 Noise source: $addr
 
 Is the noise happening now? $now
-What days does the noise happen? $days
-What time does the noise happen? $times
+$time_detail
 EOF
         $object = $c->model('DB::Problem')->new({
             non_public => 1,

--- a/perllib/FixMyStreet/App/Form/Noise.pm
+++ b/perllib/FixMyStreet/App/Form/Noise.pm
@@ -414,9 +414,19 @@ has_field radius => (
 );
 
 has_page when => (
-    fields => ['happening_now', 'happening_days', 'happening_time', 'continue'],
+    fields => ['happening_now', 'happening_pattern', 'continue'],
     title => 'When does the noise happen?',
-    next => 'more_details',
+    next => sub { $_[0]->{happening_pattern} ? 'happening_time' : 'happening_description' },
+    post_process => sub {
+        my $form = shift;
+        my $saved_data = $form->saved_data;
+        if ($saved_data->{happening_pattern}) {
+            delete $saved_data->{happening_description};
+        } else {
+            delete $saved_data->{happening_days};
+            delete $saved_data->{happening_time};
+        }
+    },
 );
 
 has_field happening_now => (
@@ -426,6 +436,21 @@ has_field happening_now => (
         { label => 'Yes', value => 1 },
         { label => 'No', value => 0 },
     ],
+);
+
+has_field happening_pattern => (
+    type => 'Select', widget => 'RadioGroup',
+    label => 'Does the time of the noise follow a pattern?',
+    options => [
+        { label => 'Yes', value => 1 },
+        { label => 'No', value => 0 },
+    ],
+);
+
+has_page happening_time => (
+    fields => ['happening_days', 'happening_time', 'continue'],
+    title => 'When does the noise happen?',
+    next => 'more_details',
 );
 
 has_field happening_days => (
@@ -457,6 +482,18 @@ has_field happening_time => (
         { value => 'evening', label => 'Evening (6pm – 11pm)' },
         { value => 'night', label => 'Night time (11pm – 6am)' },
     ],
+);
+
+has_page happening_description => (
+    fields => ['happening_description', 'continue'],
+    title => 'When does the noise happen?',
+    next => 'more_details',
+);
+
+has_field happening_description => (
+    label => 'When has the noise occurred?',
+    type => 'Text',
+    widget => 'Textarea',
 );
 
 has_page more_details => (

--- a/templates/web/base/noise/summary.html
+++ b/templates/web/base/noise/summary.html
@@ -135,6 +135,11 @@
         <dd class="govuk-summary-list__value">[% data.happening_now ? 'Yes' : 'No' %]</dd>
     </div>
     <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key govuk-summary-list__key--sub">Does the time of the noise follow a pattern?</dt>
+        <dd class="govuk-summary-list__value">[% data.happening_pattern ? 'Yes' : 'No' %]</dd>
+    </div>
+    [% IF data.happening_pattern %]
+    <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key govuk-summary-list__key--sub">What days does the noise happen?</dt>
         <dd class="govuk-summary-list__value">[% data.happening_days.join(', ') %]</dd>
     </div>
@@ -142,6 +147,12 @@
         <dt class="govuk-summary-list__key govuk-summary-list__key--sub">What time does the noise happen?</dt>
         <dd class="govuk-summary-list__value">[% data.happening_time.join(', ') %]</dd>
     </div>
+    [% ELSE %]
+    <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key govuk-summary-list__key--sub">When has the noise occurred</dt>
+        <dd class="govuk-summary-list__value">[% data.happening_description %]</dd>
+    </div>
+    [% END %]
 
 </dl>
 


### PR DESCRIPTION
Add an extra question to the when screen to check if there's a pattern
to when the noise occurs, and only then ask about when, otherwise ask
for more information about when. To avoid people filling in all the day
and time boxes if there's no pattern.

For mysociety/fixmystreet-commercial#2015

[skip changelog]