### PR TITLE
Fix email alert on initial update template.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
         - Do not trigger duplicate check when checking stoppers
         - Do not strip spaces from middle of Open311 category codes. #3167
         - Show all category history even if category renamed.
+        - Fix email alert on initial update template.
     - Admin improvements:
         - Display user name/email for contributed as reports. #2990
         - Interface for enabling anonymous reports for certain categories. #2989

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1736,7 +1736,10 @@ sub create_related_things : Private {
         my $request = {
             service_request_id => $problem->id,
             update_id => 'auto-internal',
-            comment_time => DateTime->now,
+            # Add a second so it is definitely later than problem confirmed timestamp,
+            # which uses current_timestamp (and thus microseconds) whilst this update
+            # is rounded down to the nearest second
+            comment_time => DateTime->now->add( seconds => 1 ),
             status => 'open',
             description => $description,
         };

--- a/t/app/controller/report_new_update.t
+++ b/t/app/controller/report_new_update.t
@@ -1,4 +1,5 @@
 use FixMyStreet::TestMech;
+use FixMyStreet::Script::Alerts;
 
 # disable info logs for this test run
 FixMyStreet::App->log->disable('info');
@@ -43,6 +44,9 @@ subtest "test report creation with initial auto-update" => sub {
     is $comment->user->id, $comment_user->id;
     is $comment->external_id, 'auto-internal';
     is $comment->name, 'Glos Council';
+
+    FixMyStreet::Script::Alerts::send();
+    my $email = $mech->get_email;
 };
 
 done_testing;


### PR DESCRIPTION
A report's confirmation timestamp uses current_timestamp, and so
includes microseconds. An initial update text, to fit in with the
Open311 handling of updates, uses a DateTime object, which does not.
This means if a report is created when logged in, the initial update
can have a timestamp earlier than the report, and so is not alerted on.