### PR TITLE
Changes to updates left by staff

### DIFF
--- a/docs/_includes/admin-tasks-content.md
+++ b/docs/_includes/admin-tasks-content.md
@@ -147,26 +147,34 @@ recognition of your staff role.
 
 <div class="admin-task" markdown="1" id="create-reports-behalf-user">
 
-### Creating reports on behalf of another user/ the council
+### Creating reports/ updates on behalf of another user/ the council
 
 <span class="admin-task__permissions">Permissions required: User must be marked
-as staff; one or more of ‘Create reports/updates on a user's behalf’, ‘Create
-reports/updates as anonymous user’ and ‘Create reports/updates as the council’
-must be ticked.</span>
+as staff; optionally, one or more of ‘Create reports/updates on a user's
+behalf’, ‘Create reports/updates as anonymous user’ and ‘Create reports/updates
+as the council’ can be ticked.</span>
 
-If a resident makes a report by phone or in person, staff members with the appropriate
-permissions can add it to FixMyStreet on their behalf. The report may bear the resident’s name; or
-it may be anonymous (i.e. the report-maker’s name is not published on the site, but will still be
-available in the admin interface). Alternatively, reports can be made as if from the council itself.
-In such cases, staff should make a new report just as a member of the public would — see ‘[The
+If a resident makes a report or update by phone or in person, staff members
+with the appropriate permissions can add it to FixMyStreet on their behalf. The
+report will be anonymous on the site, but the resident’s name will still be
+available in the admin interface. Reports can also be made as if from the
+council.
+
+Staff should make a new report just as a member of the public would — see ‘[The
 citizen’s experience](/pro-manual/citizens-experience/)'. Those with the appropriate permissions will see a dropdown box in
-the report-making interface, labeled ‘Report As’. Select ‘the council’, ‘yourself’, ‘anonymous’ or
+the report-making interface, labeled ‘Report As’. Select either the council, ‘yourself’, ‘anonymous’ or
 ‘another user’.
 
 If a user has the ‘Default to creating reports/update as the council’
 permission then the dropdown will default to reporting as the council.
 Staff with the ’Markup problem details’ permission will also default to
 reporting as the council.
+
+When a staff member makes an update on the site, it will not be publicly
+displayed with the staff member’s name, but the name of the body to which the
+user is attached. Staff members with the ‘See user detail for reports created
+as the council’ permission will be able to see the staff user’s name on the
+report or update, but other staff and the public will not.
 
 </div>
 

--- a/perllib/FixMyStreet/Cobrand/Bexley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley.pm
@@ -221,4 +221,12 @@ sub _is_out_of_hours {
     return 0;
 }
 
+sub update_anonymous_message {
+    my ($self, $update) = @_;
+    my $t = Utils::prettify_dt( $update->confirmed );
+
+    my $staff = $update->user->from_body || $update->get_extra_metadata('is_body_user') || $update->get_extra_metadata('is_superuser');
+    return sprintf('Posted anonymously by a non-staff user at %s', $t) if !$staff;
+}
+
 1;

--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -267,9 +267,13 @@ sub meta_line {
 
     my $meta = '';
 
-    if ($self->anonymous or !$self->name) {
+    my $contributed_as = $self->get_extra_metadata('contributed_as') || '';
+    my $staff = $self->user->from_body || $self->get_extra_metadata('is_body_user') || $self->get_extra_metadata('is_superuser');
+    my $anon = $self->anonymous || !$self->name;
+
+    if ($anon && (!$staff || $contributed_as eq 'anonymous_user' || $contributed_as eq 'another_user')) {
         $meta = sprintf( _( 'Posted anonymously at %s' ), Utils::prettify_dt( $self->confirmed ) )
-    } elsif ($self->user->from_body || $self->get_extra_metadata('is_body_user') || $self->get_extra_metadata('is_superuser') ) {
+    } elsif ($staff) {
         my $user_name = FixMyStreet::Template::html_filter($self->user->name);
         my $body;
         if ($self->get_extra_metadata('is_superuser')) {

--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -272,7 +272,8 @@ sub meta_line {
     my $anon = $self->anonymous || !$self->name;
 
     if ($anon && (!$staff || $contributed_as eq 'anonymous_user' || $contributed_as eq 'another_user')) {
-        $meta = sprintf( _( 'Posted anonymously at %s' ), Utils::prettify_dt( $self->confirmed ) )
+        $meta = $cobrand->call_hook(update_anonymous_message => $self);
+        $meta ||= sprintf( _( 'Posted anonymously at %s' ), Utils::prettify_dt( $self->confirmed ) )
     } elsif ($staff) {
         my $user_name = FixMyStreet::Template::html_filter($self->user->name);
         my $body;

--- a/templates/web/base/report/_update_state.html
+++ b/templates/web/base/report/_update_state.html
@@ -12,7 +12,7 @@
 
 <p class="meta-2">
     [% INCLUDE meta_line %]
-  [% IF c.user_exists AND c.user.id == update.user_id AND !update.anonymous %]
+  [% IF c.user_exists AND c.user.id == update.user_id AND !update.anonymous AND NOT (c.user.from_body OR c.user.is_superuser) %]
     <small>(<a href="/my/anonymize?update=[% update.id | uri %]" class="js-hide-name">[% loc('Hide your name?') %]</a>)</small>
   [% END %]
   [% mlog = update.latest_moderation_log_entry(); IF mlog %]


### PR DESCRIPTION
Always show body name on normal staff updates even if marked anonymous, give Bexley a different message, and tidy up the docs related to this area.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/2002
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/2003

~~Improvements to staff leaving report/updates, and display of body name. A staff user's update is always displayed as posted by the body user, but when making the update, the staff user is shown their own user's name and given the option of showing/not showing, which does not correspond with what then happens. So show the body name as the name that will be displayed so that's clear, always show a body name on a staff update (that isn't contribute as another user/anonymous user), and related change for Bexley.~~ Leaving this for now, because more complex and reports/updates don't behave the same, but I think ideally the update form for staff users should not show them their name/show name tickbox because what they select there does not matter. But with this PR it doesn't matter if they tick anon, and they can just leave the boxes alone, so this will probably do.