### PR TITLE
Increase affordance on map buttons on mobile when making a new report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
         - Improve `#geolocate_link` display, especially for smaller screens. #2048
         - Allow email alert radius to be specified. #68
         - Update URL on /my when map moves. #3358
+        – Improve affordability of map buttons on mobile
     - Bugfixes:
         - Fix non-JS form when all extra questions answered. #3248
         - Improve display of disabled fields in iOS.

--- a/web/cobrands/fixmystreet.com/base.scss
+++ b/web/cobrands/fixmystreet.com/base.scss
@@ -163,11 +163,11 @@ svg|g.site-logo__svg {
         mix($primary, #fff, 50%),
         $primary,
         mix($primary, #ccc, 30%),
-        inherit,
+        #000,
         darken($primary, 3%),
         darken(mix($primary, #fff, 50%), 3%),
         mix($primary, #ccc, 30%),
-        inherit
+        #000
     );
 }
 

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2010,6 +2010,29 @@ html.js #map .noscript {
   background: #000;
 }
 
+// Make mobile buttons look better
+#problems_nearby {
+  @extend .btn;
+  border-left: 0;
+}
+
+#mob_ok {
+  @extend .btn-primary;
+}
+
+#problems_nearby,
+#mob_ok {
+  letter-spacing: 0.5px;
+  color: #000 !important;
+  border-radius: 0;
+  border-right: 0;
+  &:hover,
+  &:active,
+  &:focus {
+    color: #000 !important;
+  }
+}
+
 .big-green-banner {
   position: relative;
   top: -1.75em;


### PR DESCRIPTION
This pull request makes a visual change to the buttons to chose the location on the map on mobile (see screenshots)
- Increase affordance (they look like buttons now)
- Increase visibility (the yellow presents the next action as more visible)

Before
![image](https://user-images.githubusercontent.com/2292925/95731153-0fc2d380-0c77-11eb-8e93-0d9d8adf8a34.png)


After
![image](https://user-images.githubusercontent.com/2292925/95731187-16e9e180-0c77-11eb-8132-aec244661a2d.png)


Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Are the changes tested for accessibility?
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
