### PR TITLE
[Bexley] Add private comments field to report form

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley.pm
@@ -139,6 +139,11 @@ sub open311_extra_data_include {
         }
     }
 
+    # Add private comments field
+    push @$open311_only,
+        { name => 'private_comments', description => 'Private comments',
+          value => $row->get_extra_metadata('private_comments') || '' };
+
     return $open311_only;
 }
 
@@ -245,6 +250,10 @@ sub update_anonymous_message {
 
     my $staff = $update->user->from_body || $update->get_extra_metadata('is_body_user') || $update->get_extra_metadata('is_superuser');
     return sprintf('Posted anonymously by a non-staff user at %s', $t) if !$staff;
+}
+
+sub report_form_extras {
+    ( { name => 'private_comments' } )
 }
 
 1;

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -42,6 +42,7 @@ my @PLACES = (
     [ 'BR1 3UH', 51.402096, 0.015784, 2482, 'Bromley Council', 'LBO' ],
     [ 'BR1 3EF', 51.4039, 0.018697, 2482, 'Bromley Council', 'LBO' ],
     [ '?', 51.466707, 0.181108, 2494, 'London Borough of Bexley', 'LBO' ],
+    [ 'DA6 7AT', 51.45556, 0.15356, 2494, 'London Borough of Bexley', 'LBO' ],
     [ 'NN1 1NS', 52.236251, -0.892052, 2234, 'Northamptonshire County Council', 'CTY', 2397, 'Northampton Borough Council', 'DIS' ],
     [ 'NN1 2NS', 52.238301, -0.889992, 2234, 'Northamptonshire County Council', 'CTY', 2397, 'Northampton Borough Council', 'DIS' ],
     [ '?', 52.238827, -0.894970, 2234, 'Northamptonshire County Council', 'CTY', 2397, 'Northampton Borough Council', 'DIS' ],

--- a/t/cobrand/bexley.t
+++ b/t/cobrand/bexley.t
@@ -234,6 +234,16 @@ FixMyStreet::override_config {
         $mech->content_contains('http://public.example.org/dead_animals');
         $mech->content_lacks('http://staff.example.org/dead_animals');
     };
+
+    subtest 'private comments field' => sub {
+        my $user = $mech->log_in_ok('cs@example.org');
+        $user->update({ from_body => $body, is_superuser => 1, name => 'Staff User' });
+        for my $permission ( 'contribute_as_another_user', 'contribute_as_anonymous_user', 'contribute_as_body' ) {
+            $user->user_body_permissions->create({ body => $body, permission_type => $permission });
+        }
+        $mech->get_ok('/report/new?longitude=0.15356&latitude=51.45556');
+        $mech->content_contains('name="private_comments"');
+    };
 };
 
 subtest 'nearest road returns correct road' => sub {

--- a/templates/web/base/report/new/form_user_loggedin.html
+++ b/templates/web/base/report/new/form_user_loggedin.html
@@ -1,6 +1,8 @@
 <!-- report/new/form_user_loggedin.html -->
 [% PROCESS 'report/form/private_details.html' %]
 
+[% can_contribute_as_body = c.user.from_body AND c.user.has_permission_to("contribute_as_body", bodies_ids) %]
+
 [% IF js %]
   <div style="display:none" id="js-contribute-as-wrapper">
     [% INCLUDE form_as %]
@@ -8,7 +10,6 @@
 [% ELSE %]
   [% can_contribute_as_another_user = c.user.has_permission_to("contribute_as_another_user", bodies_ids) %]
   [% can_contribute_as_anonymous_user = c.user.has_permission_to("contribute_as_anonymous_user", bodies_ids) %]
-  [% can_contribute_as_body = c.user.from_body AND c.user.has_permission_to("contribute_as_body", bodies_ids) %]
   [% IF can_contribute_as_another_user OR can_contribute_as_anonymous_user OR can_contribute_as_body %]
     [% INCLUDE form_as %]
   [% END %]
@@ -73,6 +74,8 @@
         <label class="inline" for="form_non_public">[% loc('Private') %] </label>
     </div>
 [% END %]
-
+[% IF can_contribute_as_body %]
+[% TRY %][% INCLUDE 'report/form/private_comments.html' %][% CATCH file %][% END %]
+[% END %]
 [% PROCESS 'report/form/submit.html' %]
 <!-- /report/new/form_user_loggedin.html -->

--- a/templates/web/bexley/report/form/private_comments.html
+++ b/templates/web/bexley/report/form/private_comments.html
@@ -1,0 +1,6 @@
+<!-- private_comments.html -->
+<p>
+  <label for="form_private_comments">Private comments</label>
+  <textarea class="form-control" id="form_private_comments" name="private_comments"></textarea>
+</p>
+<!-- /private_comments.html -->


### PR DESCRIPTION
This allows staff to add private comments to a report when creating it.

Your user will need to have the `contribute_as_body` permission in order to see this box.

open311-adapter changes are in https://github.com/mysociety/open311-adapter/pull/156

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/1850

---

![image](https://user-images.githubusercontent.com/22996/96452444-effc5400-1210-11eb-9b8b-7c7137d38c88.png)

<!-- [skip changelog] -->
