### PR TITLE
[Cheshire East] Don’t show description of fetched reports

### DIFF
--- a/perllib/FixMyStreet/Cobrand/CheshireEast.pm
+++ b/perllib/FixMyStreet/Cobrand/CheshireEast.pm
@@ -110,4 +110,7 @@ sub council_rss_alert_options {
     return ( \@options, undef );
 }
 
+# Make sure fetched report description isn't shown.
+sub filter_report_description { "" }
+
 1;


### PR DESCRIPTION
For https://github.com/mysociety/fixmystreet-commercial/issues/2028

[skip changelog]