### PR TITLE
Some hopeful Cypress Travis fixes

### DIFF
--- a/.cypress/cypress.json
+++ b/.cypress/cypress.json
@@ -1,7 +1,7 @@
 {
   "baseUrl": "http://fixmystreet.localhost:3001",
   "projectId": "y8vvs1",
-  "blacklistHosts": ["gaze.mysociety.org", "*.openstreetmap.org", "portal.roadworks.org", "tilma.mysociety.org", "tilma.staging.mysociety.org"],
+  "blacklistHosts": ["gaze.mysociety.org", "*.openstreetmap.org", "portal.roadworks.org", "tilma.mysociety.org", "tilma.staging.mysociety.org", "isharemaps.bathnes.gov.uk"],
   "env": {
      "postcode": "BS10 5EE"
   },

--- a/.cypress/cypress/integration/borsetshire.js
+++ b/.cypress/cypress/integration/borsetshire.js
@@ -8,7 +8,9 @@ it('logs in without fuss', function() {
     cy.contains('Customer service').click();
     cy.url().should('include', '/reports');
 
-    cy.visit('http://borsetshire.localhost:3001/auth');
+    cy.contains('Your account').click();
+    cy.contains('Sign out').click();
+    cy.contains('Sign in').click();
     cy.contains('Inspector').click();
     cy.url().should('include', '/my/planned');
 

--- a/.cypress/cypress/integration/duplicates.js
+++ b/.cypress/cypress/integration/duplicates.js
@@ -51,12 +51,12 @@ describe('Duplicate tests', function() {
     });
 
     it('lets an inspector see duplicate reports coming from /reports', function() {
-      cy.request({
-        method: 'POST',
-        url: 'http://borsetshire.localhost:3001/auth?r=/my',
-        form: true,
-        body: { username: 'admin@example.org', password_sign_in: 'password' }
-      });
+      cy.visit('http://borsetshire.localhost:3001/auth');
+      cy.get('[name=username]').type('admin@example.org');
+      cy.contains('Sign in with a password').click();
+      cy.get('[name=password_sign_in]').type('password');
+      cy.get('[name=sign_in_by_password]').last().click();
+      cy.url().should('include', '/my');
       cy.visit('http://borsetshire.localhost:3001/reports');
       cy.get('[href$="/report/1"]:last').click();
       cy.get('#report_inspect_form #state').select('Duplicate');

--- a/templates/web/borsetshire/auth/_general_top.html
+++ b/templates/web/borsetshire/auth/_general_top.html
@@ -1,3 +1,5 @@
+<div class="hidden-nojs">
+
 <p>
 Click on one of the buttons below to log in as one of the four
 different types of user we’ve set up on this demo site:
@@ -21,3 +23,35 @@ different types of user we’ve set up on this demo site:
 <p>
 Or sign in as normal, with an email address and password:
 </p>
+
+</div>
+
+<script nonce="[% csp_nonce %]">
+(function(){
+
+    fixmystreet.borsetshire = fixmystreet.borsetshire || {};
+    fixmystreet.borsetshire.set_redirect = function(form) {
+        var e = form.username.value;
+        if (e == 'inspector@example.org') {
+            form.r.value = 'my/planned';
+        } else if (e == 'cs@example.org') {
+            form.r.value = 'reports';
+        } else if (e == 'super@example.org') {
+            form.r.value = 'admin';
+        }
+    };
+
+    function set_up_button() {
+        var form = document.forms.general_auth;
+        form.username.value = this.getAttribute('data-email');
+        form.password_sign_in.value = 'password';
+        fixmystreet.borsetshire.set_redirect(form);
+        form.submit();
+    }
+
+    [].forEach.call(document.querySelectorAll('#demo-user-list button'), function(b) {
+        b.addEventListener('click', set_up_button);
+    });
+
+})();
+</script>

--- a/web/cobrands/borsetshire/js.js
+++ b/web/cobrands/borsetshire/js.js
@@ -4,27 +4,8 @@
         return;
     }
 
-    function set_redirect(form) {
-        var e = form.username.value;
-        if (e == 'inspector@example.org') {
-            form.r.value = 'my/planned';
-        } else if (e == 'cs@example.org') {
-            form.r.value = 'reports';
-        } else if (e == 'super@example.org') {
-            form.r.value = 'admin';
-        }
-    }
-
-    $('#demo-user-list button').click(function(){
-        var form = document.forms.general_auth;
-        form.username.value = $(this).data('email');
-        form.password_sign_in.value = 'password';
-        set_redirect(form);
-        form.submit();
-    });
-
     $('form[name=general_auth]').on('submit', function() {
-        set_redirect(this);
+        fixmystreet.borsetshire.set_redirect(this);
     });
 
 })();


### PR DESCRIPTION
Three hopeful fixes, for three different things that sometimes but not always fail on Travis. [skip changelog]

The first fix, while a nice thing to do anyway, did not help, for some reason, looking at the video, on Travis the Inspector part of the test is submitting the form ok, must be logging in okay, redirecting to /my/planned, but that then thinks not logged in and redirects back to /auth?r=my/planned (can't see how else you end up at that URL instead anyway). Some cookie issue with the hostnames, or something? I dunno. I've added another commit to use links to log out and back in instead of using cy.visit(), shouldn't make any difference but will see. As intermittent, it passing first time doesn't mean it is fixed :-/ Cypress has many open cookie issues, e.g. https://github.com/cypress-io/cypress/issues/7133 

I have now rerun the tests on push and PR 4 or 5 times and it has passed every time. Still can't be sure, but I think this certainly helps, so feel free to merge and rebase things on top if that would be useful.