### PR TITLE
[Central Beds] Add asset layers & fix mobile header

### DIFF
--- a/web/cobrands/centralbedfordshire/assets.js
+++ b/web/cobrands/centralbedfordshire/assets.js
@@ -91,5 +91,16 @@ fixmystreet.assets.add(labeled_defaults, {
     asset_item: 'street light'
 });
 
+fixmystreet.assets.add(defaults, {
+    http_options: {
+        params: {
+            TYPENAME: "Gullies"
+        }
+    },
+    max_resolution: 1.194328566789627,
+    asset_category: ["Surface cover", "Drains/Ditches Blocked"],
+    asset_item: 'drain or manhole'
+});
+
 
 })();

--- a/web/cobrands/centralbedfordshire/assets.js
+++ b/web/cobrands/centralbedfordshire/assets.js
@@ -59,4 +59,37 @@ fixmystreet.assets.add(defaults, {
     name: "Highways"
 });
 
+var streetlight_stylemap = new OpenLayers.StyleMap({
+    'default': fixmystreet.assets.style_default,
+    'hover': fixmystreet.assets.style_default_hover,
+    'select': fixmystreet.assets.construct_named_select_style("${lighting_c}")
+  });
+
+  var labeled_defaults = $.extend(true, {}, defaults, {
+      select_action: true,
+      stylemap: streetlight_stylemap,
+      feature_code: 'lighting_c',
+      asset_type: 'spot',
+      asset_id_field: 'asset',
+      attributes: {
+          asset: 'asset'
+      },
+      actions: {
+          asset_found: fixmystreet.assets.named_select_action_found,
+          asset_not_found: fixmystreet.assets.named_select_action_not_found
+      }
+  });
+
+fixmystreet.assets.add(labeled_defaults, {
+    http_options: {
+        params: {
+            TYPENAME: "StreetLighting"
+        }
+    },
+    max_resolution: 2.388657133579254,
+    asset_category: ["Street Lights"],
+    asset_item: 'street light'
+});
+
+
 })();

--- a/web/cobrands/centralbedfordshire/base.scss
+++ b/web/cobrands/centralbedfordshire/base.scss
@@ -10,6 +10,10 @@
     padding-bottom: 0.75em;
 }
 
+.map-fullscreen .central-beds-header {
+    display: none;
+}
+
 .central-beds-header__logo,
 .central-beds-footer__logo {
     box-sizing: border-box;


### PR DESCRIPTION
Adds street lighting and gullies asset layers. Also fixes an issue where the header prevented the "continue" button being shown on mobile when making a report.

[skip changelog]