### PR TITLE
[Bromley] Cope if last instance has been rescheduled to the future

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -690,10 +690,19 @@ sub _parse_schedules {
 
         my $last = $schedule->{LastInstance};
         $d = construct_bin_date($last->{CurrentScheduledDate});
-        if ($d && (!$max_last || $d > $max_last->{date})) {
+        if ($d && $d->strftime("%F") gt $today && (!$min_next || $d < $min_next->{date})) {
+            my $last_changed = $last->{CurrentScheduledDate}{DateTime} ne $last->{OriginalScheduledDate}{DateTime};
+            $min_next = {
+                date => $d,
+                ordinal => ordinal($d->day),
+                changed => $last_changed,
+            };
+        } elsif ($d && (!$max_last || $d > $max_last->{date})) {
+            my $last_changed = $last->{CurrentScheduledDate}{DateTime} ne $last->{OriginalScheduledDate}{DateTime};
             $max_last = {
                 date => $d,
                 ordinal => ordinal($d->day),
+                changed => $last_changed,
                 ref => $last->{Ref}{Value}{anyType},
             };
         }

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -452,7 +452,7 @@ sub look_up_property {
     return {
         id => $result->{Id},
         uprn => $uprn,
-        address => $result->{Description},
+        address => FixMyStreet::Template::title($result->{Description}),
         latitude => $result->{Coordinates}{GeoPoint}{Latitude},
         longitude => $result->{Coordinates}{GeoPoint}{Longitude},
     };

--- a/perllib/Integrations/Echo.pm
+++ b/perllib/Integrations/Echo.pm
@@ -89,24 +89,30 @@ sub GetTasks {
         push @refs, \%a;
     }
 
-    return [
-        {
+    if ($self->sample_data) {
+        my %lookup = map { $_->[0] . ',' . $_->[1] => 1 } @_;
+        my $data = [];
+        push @$data, {
             Ref => { Value => { anyType => [ 123, 456 ] } },
             State => { Name => 'Completed' },
             Resolution => { Ref => { Value => { anyType => 187 } }, Name => 'Wrong Bin Out' },
             TaskTypeId => 3216,
             CompletedDate => { DateTime => '2020-05-27T10:00:00Z' }
-        },
-        {
+        } if $lookup{"123,456"};
+        push @$data, {
             Ref => { Value => { anyType => [ 234, 567 ] } },
             CompletedDate => undef
-        },
-        {
+        } if $lookup{"234,567"};
+        push @$data, {
             Ref => { Value => { anyType => [ 345, 678 ] } },
             State => { Name => 'Not Completed' }
-        },
-        { Ref => { Value => { anyType => [ 456, 789 ] } }, CompletedDate => undef },
-    ] if $self->sample_data;
+        } if $lookup{"345,678"};
+        push @$data, {
+            Ref => { Value => { anyType => [ 456, 789 ] } },
+            CompletedDate => undef
+        } if $lookup{"456,789"};
+        return $data;
+    }
 
     # This creates XML of the form <taskRefs><ObjectRef>...</ObjectRef><ObjectRef>...</ObjectRef>...</taskRefs>
     # uncoverable statement
@@ -186,6 +192,7 @@ sub GetServiceUnitsForObject {
                     OriginalScheduledDate => { DateTime => '2020-06-03T00:00:00Z' },
                 },
                 LastInstance => {
+                    OriginalScheduledDate => { DateTime => '2020-05-27T00:00:00Z' },
                     CurrentScheduledDate => { DateTime => '2020-05-27T00:00:00Z' },
                     Ref => { Value => { anyType => [ 123, 456 ] } },
                 },
@@ -205,6 +212,7 @@ sub GetServiceUnitsForObject {
                     OriginalScheduledDate => { DateTime => '2020-06-10T00:00:00Z' },
                 },
                 LastInstance => {
+                    OriginalScheduledDate => { DateTime => '2020-05-27T00:00:00Z' },
                     CurrentScheduledDate => { DateTime => '2020-05-27T00:00:00Z' },
                     Ref => { Value => { anyType => [ 234, 567 ] } },
                 },
@@ -224,6 +232,7 @@ sub GetServiceUnitsForObject {
                     OriginalScheduledDate => { DateTime => '2020-06-03T00:00:00Z' },
                 },
                 LastInstance => {
+                    OriginalScheduledDate => { DateTime => '2020-05-18T00:00:00Z' },
                     CurrentScheduledDate => { DateTime => '2020-05-20T00:00:00Z' },
                     Ref => { Value => { anyType => [ 345, 678 ] } },
                 },
@@ -239,6 +248,7 @@ sub GetServiceUnitsForObject {
             ServiceTaskSchedules => { ServiceTaskSchedule => [ {
                 EndDate => { DateTime => '2020-01-01T00:00:00Z' },
                 LastInstance => {
+                    OriginalScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
                     CurrentScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
                 },
             }, {
@@ -248,6 +258,7 @@ sub GetServiceUnitsForObject {
                     OriginalScheduledDate => { DateTime => '2020-06-01T00:00:00Z' },
                 },
                 LastInstance => {
+                    OriginalScheduledDate => { DateTime => '2020-05-18T00:00:00Z' },
                     CurrentScheduledDate => { DateTime => '2020-05-18T00:00:00Z' },
                     Ref => { Value => { anyType => [ 456, 789 ] } },
                 },

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -271,6 +271,7 @@ FixMyStreet::override_config {
     subtest 'test open enquiries' => sub {
         set_fixed_time('2020-05-19T12:00:00Z'); # After sample food waste collection
         $mech->get_ok('/waste/uprn/12345');
+        $mech->content_like(qr/Mixed Recycling.*?Next collection<\/dt>\s*<dd[^>]*>\s*Wednesday, 20th May\s+\(adjusted\)/s);
         $mech->follow_link_ok({ text => 'Report a problem with a food waste collection' });
         $mech->content_contains('Waste spillage');
         $mech->content_lacks('Gate not closed');
@@ -280,6 +281,7 @@ FixMyStreet::override_config {
     subtest 'test crew reported issue' => sub {
         set_fixed_time('2020-05-21T12:00:00Z'); # After sample container mix
         $mech->get_ok('/waste/uprn/12345');
+        $mech->content_like(qr/Mixed Recycling.*?Last collection<\/dt>\s*<dd[^>]*>\s*Wednesday, 20th May\s+\(adjusted\)/s);
         $mech->content_contains('A missed collection cannot be reported, please see the last collection status above.');
         $mech->content_lacks('Report a mixed recycling ');
         restore_time();

--- a/templates/web/base/waste/bin_days.html
+++ b/templates/web/base/waste/bin_days.html
@@ -46,19 +46,18 @@
           [% END %]
         </dd>
       </div>
+     [% IF unit.last %]
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Last collection</dt>
         <dd class="govuk-summary-list__value">
-          [% IF unit.last %]
             [% date.format(unit.last.date) | replace('~~~', unit.last.ordinal) %]
+            [% IF unit.last.changed %](adjusted)[% END %]
             [% IF unit.last.state == 'In progress' %](in progress)[% END %]
             [% IF unit.last.completed %](completed at [% date.format(unit.last.completed, '%l:%M%p') | lower ~%])[% END ~%]
             [% IF unit.last.resolution %][% unit.last.resolution | staff_html_markup({ is_body_user => 1 }) %][% END ~%]
-          [% ELSE %]
-            <i>None</i>
-          [% END %]
         </dd>
       </div>
+     [% END %]
     </dl>
 
     <p class="waste-panel-toggle hidden-nojs"><a data-toggle-visibility="#panel-[% unit.service_id %]" class="waste-service-name-link govuk-button govuk-button--secondary">[% unit.service_name %] services</a></p>

--- a/templates/web/base/waste/bin_days.html
+++ b/templates/web/base/waste/bin_days.html
@@ -7,7 +7,7 @@
 
 <dl class="waste__address">
   <dt class="waste__address__title">Address</dt>
-  <dd class="waste__address__property">[% property.address | title %]</dd>
+  <dd class="waste__address__property">[% property.address %]</dd>
 </dl>
 <div class="waste__collections">
   <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Your collections</h2>

--- a/templates/web/base/waste/enquiry.html
+++ b/templates/web/base/waste/enquiry.html
@@ -7,7 +7,7 @@
 
 <dl class="waste__address">
     <dt class="waste__address__title">Address</dt>
-    <dd class="waste__address__property">[% property.address | title %]</dd>
+    <dd class="waste__address__property">[% property.address %]</dd>
 </dl>
 
 <dl class="waste__address">

--- a/templates/web/base/waste/index.html
+++ b/templates/web/base/waste/index.html
@@ -9,7 +9,7 @@
   [% IF property %]
   <dl class="waste__address">
     <dt class="waste__address__title">Address</dt>
-    <dd class="waste__address__property">[% property.address | title %]</dd>
+    <dd class="waste__address__property">[% property.address %]</dd>
   </dl>
   [% END %]
 <form method="post">

--- a/templates/web/base/waste/summary.html
+++ b/templates/web/base/waste/summary.html
@@ -28,7 +28,7 @@
   </div>
     <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key govuk-summary-list__key--sub">Address</dt>
-        <dd class="govuk-summary-list__value">[% property.address | title %]</dd>
+        <dd class="govuk-summary-list__value">[% property.address %]</dd>
     </div>
     [% INCLUDE answers %]
   


### PR DESCRIPTION
The last instance is set by its original scheduled time, so if it is rescheduled to be in the future, it can still appear as the last instance. If this happens, treat it as a next instance instead (so then there will probably not be a last instance).