### PR TITLE
Allow setting a custom emergency message on homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
         - Select matches for both filter category and group. #3110
         - Add an extra zoom level to most map types. #3130
         - Improve new report form when using phone verification. #3191
+        - Add option to set an emergency message on the homepage.
     - Changes:
         - Mark user as active when sent an email alert. #3045
     - Bugfixes:

--- a/docs/running/admin_manual.md
+++ b/docs/running/admin_manual.md
@@ -229,7 +229,13 @@ them by clicking on the link at the top of any admin page:
 
 * **Configuration** <br/> This page shows you a summary of the live
   configuration information for your site.
- 
+
+* **Emergency message** <br/> This page allows you to set an emergency
+  message which will be displayed on the homepage.
+
+  <p>
+    To clear the message simply delete any contents in the box.
+  </p>
 <a name="report-states"></a>
 
 ## Report states

--- a/perllib/FixMyStreet/App/Controller/Admin/EmergencyMessage.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/EmergencyMessage.pm
@@ -1,0 +1,54 @@
+package FixMyStreet::App::Controller::Admin::EmergencyMessage;
+use Moose;
+use namespace::autoclean;
+
+BEGIN { extends 'Catalyst::Controller'; }
+
+sub index :Path :Args(0) {
+    my ( $self, $c ) = @_;
+
+    # Normal users can only edit message for the current body.
+    $c->detach('edit_emergency_message', [$c->user->from_body]) unless $c->user->is_superuser;
+
+    # Superusers can see a list of all bodies with emergency messages.
+    my @bodies = $c->model('DB::Body')->search(undef, { order_by => [ 'name', 'id' ] });
+    $c->stash->{bodies} = \@bodies;
+}
+
+sub edit :Local :Args(1) {
+    my ( $self, $c, $body_id ) = @_;
+
+    # Only superusers can edit arbitrary bodies
+    $c->detach('/page_error_403_access_denied', []) unless $c->user->is_superuser;
+
+    my $body = $c->model('DB::Body')->find($body_id)
+        || $c->detach( '/page_error_404_not_found', [] );
+
+    $c->detach('edit_emergency_message', [$body]);
+}
+
+sub edit_emergency_message :Private {
+    my ( $self, $c, $body ) = @_;
+
+    if ( $c->req->method eq 'POST' ) {
+        $c->forward('/auth/check_csrf_token');
+
+        my $emergency_message = FixMyStreet::Template::sanitize($c->get_param('emergency_message'));
+        $emergency_message =~ s/^\s+|\s+$//g;
+
+        if ( $emergency_message ) {
+            $body->set_extra_metadata(emergency_message => $emergency_message);
+        } else {
+            $body->unset_extra_metadata('emergency_message');
+        }
+
+        $body->update;
+    }
+
+    $c->forward('/auth/get_csrf_token');
+    $c->stash->{emergency_message} = $body->get_extra_metadata('emergency_message');
+
+    $c->stash->{template} = 'admin/emergencymessage/edit.html';
+}
+
+1;

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -734,6 +734,9 @@ sub admin_pages {
         $pages->{reportextrafields} = [ _('Extra Fields'), 10 ];
         $pages->{reportextrafields_edit} = [ undef, undef ];
     }
+    if ( $user->has_body_permission_to('emergency_message_edit') ) {
+        $pages->{emergencymessage} = [ _('Emergency message'), 12 ];
+    }
 
     return $pages;
 }
@@ -793,6 +796,7 @@ sub available_permissions {
             category_edit => _("Add/edit problem categories"),
             template_edit => _("Add/edit response templates"),
             responsepriority_edit => _("Add/edit response priorities"),
+            emergency_message_edit => _("Add/edit emergency message"),
         },
     };
 }
@@ -1335,5 +1339,19 @@ The URL of the privacy policy to use on the report and update submissions forms.
 =cut
 
 sub privacy_policy_url { '/privacy' }
+
+=item emergency_message
+
+Emergency message, if one has been set in the admin.
+
+=cut
+
+sub emergency_message {
+    my $self = shift;
+    return unless $self->can('body');
+    my $body = $self->body;
+    return unless $body;
+    FixMyStreet::Template::SafeString->new($body->get_extra_metadata('emergency_message'));
+}
 
 1;

--- a/t/app/controller/admin/emergencymessage.t
+++ b/t/app/controller/admin/emergencymessage.t
@@ -1,0 +1,47 @@
+use FixMyStreet::TestMech;
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $body = $mech->create_body_ok(2237, 'Oxfordshire County Council');
+my $user = $mech->create_user_ok('user@example.com', name => 'Test User', from_body => $body);
+
+$mech->log_in_ok( $user->email );
+ok $mech->host('oxfordshire.fixmystreet.com');
+
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => [ 'oxfordshire' ],
+}, sub {
+    subtest 'setting emergency message' => sub {
+        $user->user_body_permissions->create({
+            body => $body,
+            permission_type => 'emergency_message_edit',
+        });
+
+        $mech->get_ok('/admin/emergencymessage');
+        $mech->submit_form_ok({ with_fields => { emergency_message => 'Testing emergency message' } });
+        $mech->content_contains('Testing emergency message');
+        $mech->get_ok('/');
+        $mech->content_contains('Testing emergency message');
+
+        # Check removing message
+        $mech->get_ok('/admin/emergencymessage');
+        $mech->submit_form_ok({ with_fields => { emergency_message => '' } });
+        $mech->content_lacks('Testing emergency message');
+        $mech->get_ok('/');
+        $mech->content_lacks('Testing emergency message');
+    };
+
+    subtest "user without permissions can't set emergency message" => sub {
+        $user->user_body_permissions->delete;
+        $user->user_body_permissions->create({
+            body => $body,
+            permission_type => 'report_edit',
+        });
+
+        $mech->get('/admin/emergencymessage');
+        ok !$mech->res->is_success, "want a bad response";
+        is $mech->res->code, 404, "got 404";
+    };
+};
+
+done_testing;

--- a/t/app/controller/admin/users.t
+++ b/t/app/controller/admin/users.t
@@ -324,6 +324,7 @@ my %default_perms = (
     "permissions[template_edit]" => undef,
     "permissions[responsepriority_edit]" => undef,
     "permissions[category_edit]" => undef,
+    "permissions[emergency_message_edit]" => undef,
 );
 
 # Start this section with user having no name

--- a/templates/web/base/admin/emergencymessage/edit.html
+++ b/templates/web/base/admin/emergencymessage/edit.html
@@ -1,0 +1,22 @@
+[% INCLUDE 'admin/header.html' title=loc('Emergency message') %]
+
+<p>[% loc('This emergency message will be shown on the homepage.') %]</p>
+
+<form method="post"
+    accept-charset="utf-8"
+    class="validate">
+
+    [% IF errors.emergency_message %]
+        <div class="form-error">[% errors.emergency_message %]</div>
+    [% END %]
+    <p>
+        <strong>[% loc('Emergency message:') %] </strong>
+        <textarea name="emergency_message" class="form-control" rows="20">[% emergency_message %]</textarea>
+    </p>
+    <p>
+    <input type="hidden" name="token" value="[% csrf_token %]" >
+    <input type="submit" class="btn" value="[% emergency_message ? loc('Update message') : loc('Create message') %]" >
+    </p>
+</form>
+
+[% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/admin/emergencymessage/index.html
+++ b/templates/web/base/admin/emergencymessage/index.html
@@ -1,0 +1,31 @@
+[% INCLUDE 'admin/header.html' title=loc('Emergency message') %]
+
+<table>
+    <thead>
+        <tr>
+            <th>[% loc('Body') %]</th>
+            <th>[% loc('Emergency message') %]</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        [% FOR body IN bodies %]
+        [% emergency_message = body.get_extra_metadata('emergency_message') %]
+        <tr>
+            <td>[% body.name %]</td>
+            <td>[% IF emergency_message %][% emergency_message.substr(0, 60) %]&hellip;[% END %]</td>
+            <td>
+                <a href="[% c.uri_for('edit', body.id) %]">
+                    [% IF emergency_message %]
+                        [% loc('Edit') %]
+                    [% ELSE %]
+                        [% loc('Create') %]
+                    [% END %]
+                </a>
+            </td>
+        </tr>
+        [% END %]
+    </tbody>
+</table>
+
+[% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/front/emergency-message.html
+++ b/templates/web/base/front/emergency-message.html
@@ -1,0 +1,6 @@
+[% emergency_message = c.cobrand.emergency_message %]
+[% IF emergency_message %]
+<div class="emergency-message">
+  [% emergency_message | html_para %]
+</div>
+[% END %]

--- a/templates/web/base/front/pre-steps.html
+++ b/templates/web/base/front/pre-steps.html
@@ -1,0 +1,1 @@
+[% TRY %][% PROCESS 'front/emergency-message.html' %][% CATCH file %][% END %]

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2823,6 +2823,19 @@ $nicetable-hover-background: rgba($primary, 0.15) !default;
     }
 }
 
+$emergency-message-border: 1px solid #525252 !default;
+
+.emergency-message {
+  border: $emergency-message-border;
+  padding: 1em;
+  font-size: 1em;
+  margin: 0 0 2em;
+
+  & > :last-child {
+    margin-bottom: 0;
+  }
+}
+
 @import "_admin";
 @import "_dropzone";
 @import "_multiselect";

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -919,3 +919,8 @@ textarea.form-error {
     float: $right;
     width: 25%;
 }
+
+.emergency-message {
+  padding: 2em;
+  font-size: 1.2em;
+}


### PR DESCRIPTION
Add an `emergency_message` field to the Body's extra metadata which when set will display an emergency banner on the homepage.

Part of https://github.com/mysociety/fixmystreet-commercial/issues/2023

This is just a first pass at this as I'm not sure if this is the best approach. Feedback very welcome!

Some thoughts:

- Is extra metadata on the Body the best place to store this?
- Does having a whole page in the admin for this seem excessive? I guess at least it's clear?
- I've added a separate permission for this as it seemed like something that not everyone should be able to do. Not sure if that's excessively cautious?
- Design could probably do with some work, I just copied the styles we're using on the [Bexley homepage](https://fix.bexley.gov.uk/) for their emergency banner.

## Admin screenshot

![Admin screenshot](https://user-images.githubusercontent.com/22996/98833964-91547f80-2436-11eb-89da-2862391db003.png)

## Frontend screenshot

![Frontend screenshot](https://user-images.githubusercontent.com/22996/98834008-9ca7ab00-2436-11eb-9f52-5472f706c580.png)
