### PR TITLE
[Bexley] replace notice urls with staff specific ones

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley.pm
@@ -43,6 +43,23 @@ sub category_change_force_resend {
     return ($old =~ /^StreetLighting/ xor $new =~ /^StreetLighting/);
 }
 
+sub munge_report_new_category_list {
+    my ($self, $options, $contacts, $extras) = @_;
+
+    my $c = $self->{c};
+
+    if ( $c->user && $c->user->from_body && $c->user->from_body->id == $self->body->id && $self->feature('staff_url') ) {
+        for my $category ( keys %{ $self->feature('staff_url') } ) {
+            my $urls = $self->feature('staff_url')->{$category};
+            for my $extra ( @{ $extras->{$category} } ) {
+                if ($extra->{code} eq $urls->[0]) {
+                    $extra->{description} =~ s#$urls->[1]#$urls->[2]#s;
+                }
+            }
+        }
+    }
+}
+
 sub on_map_default_status { 'open' }
 
 sub open311_munge_update_params {

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -40,6 +40,7 @@ my @PLACES = (
     [ 'BR1 3UH', 51.4021, 0.01578, 2482, 'Bromley Council', 'LBO' ],
     [ 'BR1 3UH', 51.402096, 0.015784, 2482, 'Bromley Council', 'LBO' ],
     [ 'BR1 3EF', 51.4039, 0.018697, 2482, 'Bromley Council', 'LBO' ],
+    [ '?', 51.466707, 0.181108, 2494, 'London Borough of Bexley', 'LBO' ],
     [ 'NN1 1NS', 52.236251, -0.892052, 2234, 'Northamptonshire County Council', 'CTY', 2397, 'Northampton Borough Council', 'DIS' ],
     [ 'NN1 2NS', 52.238301, -0.889992, 2234, 'Northamptonshire County Council', 'CTY', 2397, 'Northampton Borough Council', 'DIS' ],
     [ '?', 52.238827, -0.894970, 2234, 'Northamptonshire County Council', 'CTY', 2397, 'Northampton Borough Council', 'DIS' ],


### PR DESCRIPTION
For some categories Bexley staff use a different URL from the public in
the notices. This allows the public URL in the notice to be replaced.

[skip changelog]