### PR TITLE
Cypress coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: Run coverage tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: Run Cypress tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -29,18 +29,27 @@ jobs:
         path: |
           ~/.npm
           node_modules
-        key: ${{ runner.os }}-node-8-cypress-3.8.3
+        key: ${{ runner.os }}-node-8-cypress-3.8.3-coverage
 
     - name: Install packages
       run: |
         sudo apt install -y gettext
-        npm install cypress@3.8.3
+        npm install cypress@3.8.3 @cypress/code-coverage codecov
         vendor/bin/carton install --deployment
         commonlib/bin/gettext-makemo FixMyStreet
         echo "$(npm bin)" >> $GITHUB_PATH
 
     - name: Run Cypress tests
       run: |
-        bin/browser-tests run ${CYPRESS_RECORD_KEY:+--record}
+        bin/browser-tests --coverage run ${CYPRESS_RECORD_KEY:+--record}
       env:
         CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+
+    - name: Upload code coverage results
+      run: codecov
+
+#    - name: Archive code coverage results
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: code-coverage-report
+#        path: coverage/lcov-report

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -5,13 +5,13 @@ on: [push, pull_request]
 jobs:
   test:
     name: Test on perl ${{ matrix.perl_version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false
       matrix:
         # stretch, buster, focal/bullseye, xenial, trusty
-        # bionic 5.26 is ubuntu-latest, in coverage run
+        # bionic 5.26 is ubuntu-18.04, in coverage run
         perl_version: [ 5.24.4, 5.28.3, 5.30.3, 5.22.4, 5.18.4 ]
 
     steps:


### PR DESCRIPTION
This pins the Ubuntu version on GitHub Actions, and adds coverage to the Cypress tests, posting to codecov same as the Perl tests, which is nice (even though it drops overall coverage to begin with!). [skip changelog]