### PR TITLE
Use div for inspector form wrapped extra questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     - Bugfixes:
         - Fix non-JS form when all extra questions answered. #3248
         - Improve display of disabled fields in iOS.
+        - Use div for inspector form wrapped extra questions. #3250
     - Admin improvements:
         - Enable per-category hint customisation.
 

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -21,12 +21,12 @@
              cat_safe = mark_safe(cat_name);
              cat_prefix = cat_name | lower | replace('[^a-z]', '');
              cat_prefix = "category_" _ cat_prefix _ "_" %]
-            <p data-category="[% cat_name | html %]"
+            <div data-category="[% cat_name | html %]"
                [%~ IF cat_name != problem.category %] class="hidden"[% END %]
                data-priorities='[% priorities_by_category.$cat_safe | html %]'
                data-templates='[% templates_by_category.$cat_safe | html %]'>
                 [% INCLUDE 'report/new/category_extras_fields.html' metas=category_extras.$cat_safe hide_notices=1 show_hidden=1 %]
-            </p>
+            </div>
         [% END %]
 
         [% IF permissions.report_inspect %]


### PR DESCRIPTION
As extra questions can include limited HTML now, including `<p>`,
wrapping them in a `<p>` can lead to display issues.