### PR TITLE
Multi page reporting

### DIFF
--- a/.cypress/cypress/fixtures/westminster-nameplates.json
+++ b/.cypress/cypress/fixtures/westminster-nameplates.json
@@ -1,2 +1,22 @@
 {
+    "type": "FeatureCollection", "crs": { "type": "name", "properties": { "name": "EPSG: 4326" } },
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [-0.141588, 51.501009]
+            }, "properties": {
+                "central_asset_id": "ABC1"
+            }
+        }, {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [-0.141598, 51.501019]
+            }, "properties": {
+                "central_asset_id": "ABC2"
+            }
+        }
+    ]
 }

--- a/.cypress/cypress/integration/bromley.js
+++ b/.cypress/cypress/integration/bromley.js
@@ -10,6 +10,7 @@ describe('Bromley cobrand', function() {
     cy.contains('Bromley');
     cy.wait('@prow');
     cy.wait('@report-ajax');
+    cy.get('#mob_ok').click();
   });
 
   it('fills the right of way field', function() {
@@ -19,6 +20,7 @@ describe('Bromley cobrand', function() {
 
   it('does not display asset based upon extra question', function() {
     cy.get('select').eq(1).select('Street Lighting and Road Signs');
+    cy.get('.js-reporting-page--next:visible').click();
     cy.get('select').eq(2).select('Non-asset');
     // https://stackoverflow.com/questions/47295287/cypress-io-assert-no-xhr-requests-to-url
     cy.on('fail', function(err) {
@@ -30,8 +32,11 @@ describe('Bromley cobrand', function() {
 
   it('displays assets based upon extra question', function() {
     cy.get('select').eq(1).select('Street Lighting and Road Signs');
+    cy.get('.js-reporting-page--next:visible').click();
     cy.get('select').eq(2).select('On in day');
     cy.wait('@lights');
+    cy.get('.js-reporting-page--next:visible').click();
+    cy.get('.mobile-map-banner').should('be.visible');
   });
 
 });

--- a/.cypress/cypress/integration/buckinghamshire.js
+++ b/.cypress/cypress/integration/buckinghamshire.js
@@ -21,6 +21,8 @@ describe('buckinghamshire cobrand', function() {
     cy.wait('@report-ajax');
     cy.get('select:eq(4)').select('Parks');
     cy.get('[name=site_code]').should('have.value', '7300268');
+    cy.get('.js-reporting-page--next:visible').click();
+    cy.contains('Photo').should('be.visible');
   });
 
   it('uses the label "Full name" for the name field', function() {
@@ -29,9 +31,11 @@ describe('buckinghamshire cobrand', function() {
     cy.get('select:eq(4)').select('Flytipping');
     cy.wait('@around-ajax');
 
+    cy.get('.js-reporting-page--next:visible').click();
+    cy.get('.js-reporting-page--next:visible').click(); // No photo
     cy.get('[name=title]').type('Title');
     cy.get('[name=detail]').type('Detail');
-    cy.get('.js-new-report-user-show').click();
+    cy.get('.js-reporting-page--next:visible').click();
     cy.get('label[for=form_name]').should('contain', 'Full name');
   });
 
@@ -41,7 +45,30 @@ describe('buckinghamshire cobrand', function() {
     cy.get('#map_box').click(290, 307);
     cy.wait('@report-ajax');
     cy.get('select').eq(4).select('Snow and ice problem/winter salting');
+    cy.wait('@winter-routes');
+    cy.get('.js-reporting-page--next:visible').click();
     cy.contains('The road you have selected is on a regular gritting route').should('be.visible');
   });
 
+});
+
+describe('buckinghamshire roads handling', function() {
+  it('makes you move the pin if not on a road', function() {
+    cy.server();
+    cy.route('**mapserver/bucks*Whole_Street*', 'fixture:roads.xml').as('roads-layer');
+    cy.route('/report/new/ajax*').as('report-ajax');
+    cy.viewport(480, 800);
+    cy.visit('http://buckinghamshire.localhost:3001/');
+    cy.get('[name=pc]').type('SL9 0NX');
+    cy.get('[name=pc]').parents('form').submit();
+
+    cy.get('.olMapViewport #fms_pan_zoom_zoomin').click({ force: true }); // Sometimes zoom appearing too high under, but not if I try manually
+    cy.wait('@roads-layer');
+    cy.get('#map_box').click(290, 307);
+    cy.wait('@report-ajax');
+    cy.get('#mob_ok').click();
+    cy.get('select:eq(4)').select('Parks');
+    cy.get('.js-reporting-page--next:visible').click();
+    cy.contains('Please select a road on which to make a report.').should('be.visible');
+  });
 });

--- a/.cypress/cypress/integration/category_tests.js
+++ b/.cypress/cypress/integration/category_tests.js
@@ -44,8 +44,11 @@ describe('Basic categories', function() {
         });
         cy.get('#subcategory_Bins').should('not.be.visible');
         cy.get('select:eq(3)').select('Bins');
+        cy.get('.js-reporting-page--next:visible').click();
         cy.get('#subcategory_Bins').should('be.visible');
+        cy.go('back');
         cy.get('select:eq(3)').select('Graffiti');
+        cy.get('.js-reporting-page--next:visible').click();
         cy.get('#subcategory_Bins').should('not.be.visible');
     });
 
@@ -60,6 +63,7 @@ describe('Basic categories', function() {
         cy.get('#subcategory_Bins').should('not.be.visible');
         cy.wait('@report-ajax');
         cy.get('select:eq(1)').select('Bins');
+        cy.get('.js-reporting-page--next:visible').click();
         cy.get('#subcategory_Bins').should('be.visible');
     });
 });

--- a/.cypress/cypress/integration/duplicates.js
+++ b/.cypress/cypress/integration/duplicates.js
@@ -12,24 +12,29 @@ describe('Duplicate tests', function() {
       cy.contains('Report another problem here').click();
       cy.wait('@report-ajax');
       cy.get('[id=category_group]').select('Potholes');
-      cy.wait(500);
-      cy.get('[name=title').should('be.visible');
+      cy.get('.js-reporting-page--next:visible').click();
+      cy.get('div.dropzone').should('be.visible');
     });
 
-    it('hides everything when duplicate suggestions are shown', function() {
+    it('has a separate duplicate suggestions step when needed', function() {
       cy.server();
       cy.route('/report/new/ajax*').as('report-ajax');
+      cy.route('/around/nearby*').as('nearby-ajax');
       cy.visit('http://borsetshire.localhost:3001/_test/setup/regression-duplicate-hide'); // Server-side setup
       cy.visit('http://borsetshire.localhost:3001/report/1');
       cy.contains('Report another problem here').click();
       cy.wait('@report-ajax');
       cy.get('[id=category_group]').select('Licensing');
+      cy.get('.js-reporting-page--next:visible').click();
       cy.get('[id=subcategory_Licensing]').select('Skips');
+      cy.wait('@nearby-ajax');
+      cy.get('.js-reporting-page--next:visible').click();
+      cy.contains('Already been reported?');
       cy.get('.extra-category-questions').should('not.be.visible');
       cy.visit('http://borsetshire.localhost:3001/_test/teardown/regression-duplicate-hide');
     });
 
-    it('does not show duplicate suggestions when signing in during reporting', function() {
+    it.only('does not show duplicate suggestions when signing in during reporting', function() {
       cy.server();
       cy.route('/report/new/ajax*').as('report-ajax');
       cy.route('/around/nearby*').as('nearby-ajax');
@@ -38,10 +43,13 @@ describe('Duplicate tests', function() {
       cy.wait('@report-ajax');
       cy.get('[id=category_group]').select('Potholes');
       cy.wait('@nearby-ajax');
-      cy.get('.js-hide-duplicate-suggestions:first').should('be.visible').click();
+      cy.get('.js-reporting-page--next:visible').click();
+      cy.contains('Already been reported?');
+      cy.get('.js-reporting-page--next:visible').click(); // Go past duplicates
+      cy.get('.js-reporting-page--next:visible').click(); // No photo
       cy.get('[name=title]').type('Title');
       cy.get('[name=detail]').type('Detail');
-      cy.get('.js-new-report-user-show').click();
+      cy.get('.js-reporting-page--next:visible').click();
       cy.get('.js-new-report-show-sign-in').should('be.visible').click();
       cy.get('#form_username_sign_in').type('user@example.org');
       cy.get('[name=password_sign_in]').type('password');
@@ -80,19 +88,20 @@ describe('Duplicate tests', function() {
     it('does not redisplay duplicates when stopper questions are changed', function() {
       cy.server();
       cy.route('/report/new/ajax*').as('report-ajax');
+      cy.route('/around/nearby*').as('nearby-ajax');
       cy.visit('http://borsetshire.localhost:3001/_test/setup/regression-duplicate-stopper'); // Server-side setup
       cy.visit('http://borsetshire.localhost:3001/report/1');
       cy.contains('Report another problem here').click();
       cy.wait('@report-ajax');
       cy.get('[id=category_group]').select('Flytipping');
+      cy.wait('@nearby-ajax');
+      cy.get('.js-reporting-page--next:visible').click();
       cy.get('.extra-category-questions').should('not.be.visible');
-      cy.get('.js-hide-duplicate-suggestions:first').click();
-      cy.get('.js-hide-duplicate-suggestions:first').should('not.be.visible');
+      cy.get('.js-reporting-page--next:visible').click(); // Go past duplicates
       cy.get('.extra-category-questions').should('be.visible');
       cy.get('[id=form_hazardous]').select('No');
-      cy.wait(500);
       cy.get('.extra-category-questions').should('be.visible');
-      cy.get('.js-hide-duplicate-suggestions:first').should('not.be.visible');
+      cy.get('.js-reporting-page--next:visible').click();
       cy.visit('http://borsetshire.localhost:3001/_test/teardown/regression-duplicate-stopper'); // Server-side setup
     });
 

--- a/.cypress/cypress/integration/highways.js
+++ b/.cypress/cypress/integration/highways.js
@@ -23,6 +23,7 @@ describe('Highways England tests', function() {
         cy.get('#js-councils_text').should('contain', 'Highways England');
         cy.get('#single_body_only').should('have.value', 'Highways England');
         cy.get('#form_category').should('contain', 'Sign issue');
+        cy.get('.js-reporting-page--next:visible').click();
         cy.get('#category_group').select('Sign issue');
         cy.get('#form_category').should('have.value', 'Sign issue');
     });

--- a/.cypress/cypress/integration/isleofwight.js
+++ b/.cypress/cypress/integration/isleofwight.js
@@ -13,21 +13,31 @@ describe('When you look at the Island Roads site', function() {
     cy.get('#map_box').click();
     cy.wait('@report-ajax');
     cy.get('select:eq(4)').select('Potholes');
+    cy.get('.js-reporting-page--next:visible').click();
+    cy.get('.js-reporting-page--next:visible').click(); // Photos
     cy.contains('sent to Island Roads').should('be.visible');
+    cy.go('back');
+    cy.go('back');
     cy.get('select:eq(4)').select('Private');
+    cy.get('.js-reporting-page--next:visible').click();
+    cy.get('.js-reporting-page--next:visible').click(); // Photos
     cy.contains('sent to Island Roads').should('be.visible');
+    cy.go('back');
+    cy.go('back');
     cy.get('select:eq(4)').select('Extra');
+    cy.get('.js-reporting-page--next:visible').click();
     cy.contains('Help Island Roads').should('be.visible');
   });
 
   it('displays nearby roadworks', function() {
-    cy.fixture('iow_roadworks.json');
     cy.route('/streetmanager.php**', 'fixture:iow_roadworks.json').as('roadworks');
     cy.visit('http://isleofwight.localhost:3001/');
     cy.get('[name=pc]').type('PO30 5XJ');
     cy.get('[name=pc]').parents('form').submit();
     cy.get('#map_box').click();
     cy.wait('@report-ajax');
+    cy.get('select').eq(4).select('Potholes');
+    cy.get('.js-reporting-page--next:visible').click();
     cy.wait('@roadworks');
     cy.contains('Roadworks are scheduled near this location').should('be.visible');
     cy.contains('Parapet improvement').should('be.visible');

--- a/.cypress/cypress/integration/northamptonshire.js
+++ b/.cypress/cypress/integration/northamptonshire.js
@@ -3,7 +3,7 @@ it('loads the right front page', function() {
     cy.contains('Northamptonshire');
 });
 
-it('prevents clicking unless asset selected', function() {
+it('prevents clicking unless asset selected, desktop flow', function() {
   cy.server();
   cy.route('**/northants.staging/**', 'fixture:bus_stops_none.json').as('empty-bus_stops-layer');
   cy.route('**/32602/21575/**', 'fixture:bus_stops.json').as('bus_stops-layer');
@@ -20,10 +20,61 @@ it('prevents clicking unless asset selected', function() {
   cy.wait('@bus_stops-layer');
   cy.wait('@empty-bus_stops-layer');
   cy.contains(/Please select a.*bus stop.*from the map/).should('be.visible');
-  cy.get('#js-councils_text').should('be.hidden');
+  cy.get('.js-reporting-page--next:visible').should('be.disabled');
 });
 
-it('selecting an asset allows a report', function() {
+it('prevents clicking unless asset selected, mobile flow', function() {
+  cy.server();
+  cy.route('**/northants.staging/**', 'fixture:bus_stops_none.json').as('empty-bus_stops-layer');
+  cy.route('**/32602/21575/**', 'fixture:bus_stops.json').as('bus_stops-layer');
+  cy.route('/report/new/ajax*').as('report-ajax');
+  cy.viewport(480, 800);
+  cy.visit('http://northamptonshire.localhost:3001/');
+  cy.get('[name=pc]').type('NN1 1NS');
+  cy.get('[name=pc]').parents('form').submit();
+
+  cy.get('#map_box').click();
+  cy.wait('@report-ajax');
+  cy.get('#mob_ok').click();
+
+  cy.get('[id=category_group]').select('Shelter Damaged');
+
+  cy.wait('@bus_stops-layer');
+  cy.wait('@empty-bus_stops-layer');
+  cy.contains(/Please select a.*bus stop.*from the map/).should('not.be.visible');
+  cy.get('.js-reporting-page--next:visible').click();
+  cy.get('.mobile-map-banner').should('be.visible');
+  cy.contains(/Please select a.*bus stop.*from the map/).should('be.visible');
+  cy.get('#mob_ok').should('not.be.visible');
+});
+
+it('selecting an asset allows a report, mobile flow', function() {
+  cy.server();
+  cy.route('**/northants.staging/**', 'fixture:bus_stops_none.json').as('empty-bus_stops-layer');
+  cy.route('**/32603/21575/**', 'fixture:bus_stops.json').as('bus_stops-layer');
+  cy.route('/report/new/ajax*').as('report-ajax');
+  cy.viewport(480, 800);
+  cy.visit('http://northamptonshire.localhost:3001/');
+  cy.get('[name=pc]').type('NN1 2NS');
+  cy.get('[name=pc]').parents('form').submit();
+
+  cy.get('#map_box').click();
+  cy.wait('@report-ajax');
+  cy.get('#mob_ok').click();
+
+  cy.get('[id=category_group]').select('Shelter Damaged');
+
+  cy.wait('@bus_stops-layer');
+  cy.wait('@empty-bus_stops-layer');
+  cy.contains(/Please select a.*bus stop.*from the map/).should('not.be.visible');
+  cy.get('.js-reporting-page--next:visible').click();
+  cy.get('.mobile-map-banner').should('be.visible');
+  cy.get('#mob_ok').click();
+  cy.get('.js-reporting-page--next:visible').click(); // No photo
+  cy.get('#js-councils_text').should('be.visible');
+});
+
+it('selecting an asset allows a report, desktop flow', function() {
   cy.server();
   cy.route('**/northants.staging/**', 'fixture:bus_stops_none.json').as('empty-bus_stops-layer');
   cy.route('**/32602/21575/**', 'fixture:bus_stops.json').as('bus_stops-layer');
@@ -40,6 +91,8 @@ it('selecting an asset allows a report', function() {
   cy.wait('@bus_stops-layer');
   cy.wait('@empty-bus_stops-layer');
 
+  cy.get('.js-reporting-page--next:visible').click();
+  cy.get('.js-reporting-page--next:visible').click(); // No photo
   cy.get('#js-councils_text').should('be.visible');
 });
 
@@ -61,6 +114,7 @@ it('detects multiple assets at same location', function() {
   cy.wait('@bus_stops-layer');
   cy.wait('@bus_stops-layer2');
   cy.wait('@empty-bus_stops-layer');
+  cy.get('.js-reporting-page--next:visible').click();
 
   cy.contains('more than one bus stop at this location').should('be.visible');
 });

--- a/.cypress/cypress/integration/peterborough.js
+++ b/.cypress/cypress/integration/peterborough.js
@@ -13,22 +13,24 @@ describe('new report form', function() {
 
   it('is hidden when emergency option is yes', function() {
     cy.get('select:eq(4)').select('Fallen branch');
+    cy.get('.js-reporting-page--next:visible').click();
     cy.get('#form_emergency').select('yes');
-    cy.get('#js-category-stopper').should('contain', 'Please phone customer services to report this problem.');
-    cy.get('.js-hide-if-invalid-category').should('be.hidden');
+    cy.get('.js-post-category-messages:visible').should('contain', 'Please phone customer services to report this problem.');
+    cy.get('.js-reporting-page--next:visible').should('be.disabled');
     cy.get('#form_emergency').select('no');
-    cy.get('#js-category-stopper').should('not.contain', 'Please phone customer services to report this problem.');
-    cy.get('.js-hide-if-invalid-category').should('be.visible');
+    cy.get('.js-post-category-messages:visible').should('not.contain', 'Please phone customer services to report this problem.');
+    cy.get('.js-reporting-page--next:visible').should('not.be.disabled');
   });
 
   it('is hidden when private land option is yes', function() {
     cy.get('select:eq(4)').select('Fallen branch');
+    cy.get('.js-reporting-page--next:visible').click();
     cy.get('#form_private_land').select('yes');
-    cy.get('#js-category-stopper').should('contain', 'The council do not have powers to address issues on private land.');
-    cy.get('.js-hide-if-invalid-category').should('be.hidden');
+    cy.get('.js-post-category-messages:visible').should('contain', 'The council do not have powers to address issues on private land.');
+    cy.get('.js-reporting-page--next:visible').should('be.disabled');
     cy.get('#form_private_land').select('no');
-    cy.get('#js-category-stopper').should('not.contain', 'The council do not have powers to address issues on private land.');
-    cy.get('.js-hide-if-invalid-category').should('be.visible');
+    cy.get('.js-post-category-messages:visible').should('not.contain', 'The council do not have powers to address issues on private land.');
+    cy.get('.js-reporting-page--next:visible').should('not.be.disabled');
   });
 
   it('correctly changes the asset select message', function() {
@@ -43,9 +45,12 @@ describe('new report form', function() {
     cy.route('/streetmanager.php**', 'fixture:peterborough_roadworks.json').as('roadworks');
     cy.wait('@roadworks');
     cy.get('select:eq(4)').select('Pothole');
+    cy.get('.js-reporting-page--next:visible').click();
     cy.contains('Roadworks are scheduled near this location').should('be.visible');
     cy.contains('Parapet improvement').should('be.visible');
+    cy.go('back');
     cy.get('select:eq(4)').select('Fallen branch');
+    cy.get('.js-reporting-page--next:visible').click();
     cy.should('not.contain', 'Roadworks are scheduled near this location');
   });
 

--- a/.cypress/cypress/integration/regressions.js
+++ b/.cypress/cypress/integration/regressions.js
@@ -50,7 +50,9 @@ describe('Regression tests', function() {
         // force to hopefully work around apparent Cypress SVG issue
         cy.get('image[title="Lights out in tunnel"]:last').click({force: true});
         cy.wait('@show-report');
-        cy.get('.report-a-problem-btn').eq(0).should('contain', 'Report another problem here').click();
+        // TODO as report-a-problem-btn not printed on around at the mo
+        cy.get('.big-green-banner').click({ force: true });
+        //cy.get('.report-a-problem-btn').eq(0).should('contain', 'Report another problem here').click();
         cy.get('.content').should('not.contain', 'toddler');
     });
 
@@ -78,11 +80,15 @@ describe('Regression tests', function() {
       cy.get('#map_box').click();
       cy.wait('@report-ajax');
       cy.get('[id=category_group]').select('Licensing');
+      cy.get('.js-reporting-page--next:visible').click();
       cy.get('[id=subcategory_Licensing]').select('Skips');
+      cy.get('.js-reporting-page--next:visible').click();
+      cy.get('[name=start_date').type('2019-01-01');
+      cy.get('.js-reporting-page--next:visible').click();
+      cy.get('.js-reporting-page--next:visible').click(); // No photo
       cy.get('[name=title]').type('Title');
       cy.get('[name=detail]').type('Detail');
-      cy.get('[name=start_date').type('2019-01-01');
-      cy.get('.js-new-report-user-show').click();
+      cy.get('.js-reporting-page--next:visible').click();
       cy.get('.js-new-report-show-sign-in').should('be.visible').click();
       cy.get('#form_username_sign_in').type('user@example.org');
       cy.get('[name=password_sign_in]').type('password');

--- a/.cypress/cypress/integration/simple_spec.js
+++ b/.cypress/cypress/integration/simple_spec.js
@@ -10,9 +10,11 @@ describe('Clicking the map', function() {
         cy.url().should('include', '/around');
         cy.get('#map_box').click(200, 200);
         cy.get('#category_group').select('Flyposting');
+        cy.get('.js-reporting-page--next:visible').click();
+        cy.get('.js-reporting-page--next:visible').click(); // No photo
         cy.get('[name=title]').type('Title');
         cy.get('[name=detail]').type('Detail');
-        cy.get('.js-new-report-user-show').click();
+        cy.get('.js-reporting-page--next:visible').click();
         cy.get('.js-new-report-show-sign-in').should('be.visible').click();
         cy.get('#form_username_sign_in').type('user@example.org');
         cy.get('[name=password_sign_in]').type('password');
@@ -84,6 +86,8 @@ describe('Clicking the "big green banner" on a map page', function() {
 
     it('begins a new report', function() {
         cy.url().should('include', '/report/new');
-        cy.get('#form_title').should('be.visible');
+        // Clicked randomly in middle of map, so no body, so top message shown
+        cy.get('#js-top-message').should('be.visible');
+        cy.get('.js-reporting-page--next').should('be.visible');
     });
 });

--- a/.cypress/cypress/integration/tfl.js
+++ b/.cypress/cypress/integration/tfl.js
@@ -1,7 +1,6 @@
 it('allows bus stop clicking outside London', function() {
     cy.server();
     cy.route('/report/new/ajax*').as('report-ajax');
-    cy.fixture('tfl-bus-stops.xml');
     cy.route('**/mapserver/tfl*busstops*', 'fixture:tfl-bus-stops.xml').as('tfl-bus-stops');
     cy.route('**/mapserver/tfl*RedRoutes*', 'fixture:tfl-tlrn.xml').as('tfl-tlrn');
 
@@ -11,9 +10,11 @@ it('allows bus stop clicking outside London', function() {
     cy.contains('Transport for London');
     cy.get('[id=category_group]').select('Bus Stops and Shelters');
     cy.wait('@tfl-bus-stops');
+    cy.get('.js-reporting-page--active .js-reporting-page--next').click();
     cy.get('.js-subcategory').select('Incorrect timetable');
 
     // Also check a category not on a red route
+    cy.go('back');
     cy.get('[id=category_group]').select('Mobile Crane Operation');
     cy.contains('does not maintain this road').should('be.visible');
 });
@@ -23,12 +24,17 @@ it('shows TfL roadworks', function() {
     cy.route('/report/new/ajax*').as('report-ajax');
     cy.route('**/mapserver/tfl*roadworks*', 'fixture:tfl-roadworks.xml').as('roadworks');
     cy.route('**/mapserver/tfl*RedRoutes*', 'fixture:tfl-tlrn.xml').as('tfl-tlrn');
+    cy.viewport(480, 800);
 
     cy.visit('http://tfl.localhost:3001/report/new?latitude=51.482286&longitude=-0.328163');
     cy.wait('@report-ajax');
+    cy.get('#mob_ok').click();
     cy.get('[id=category_group]').select('Roadworks');
-    cy.contains('You can pick a roadworks from the map').should('be.visible');
     cy.wait('@roadworks');
+    cy.get('.js-reporting-page--active .js-reporting-page--next').click();
+    cy.contains('You can pick a roadworks from the map').should('be.visible');
+    cy.get('.mobile-map-banner').should('be.visible');
+    cy.get('#mob_ok').click();
     cy.contains('At the junction').should('be.visible');
 });
 

--- a/.cypress/cypress/integration/westminster.js
+++ b/.cypress/cypress/integration/westminster.js
@@ -3,7 +3,7 @@ describe('Westminster cobrand', function() {
   beforeEach(function() {
     cy.server();
     cy.route('**/westminster.assets/40/*', 'fixture:westminster-usrn.json');
-    cy.route("**/westminster.assets/25/*PARENTUPRN='XXXX'*", 'fixture:westminster-uprn.json');
+    cy.route("**/westminster.assets/25/*PARENTUPRN='XXXX'*", 'fixture:westminster-uprn.json').as('uprn');
     cy.route("**/westminster.assets/25/*PARENTUPRN='1000123'*PARENTUPRN='1000234'", 'fixture:westminster-uprn-0123.json');
     cy.route('**/westminster.assets/46/*', 'fixture:westminster-nameplates.json').as('nameplates');
     cy.route('/report/new/ajax*').as('report-ajax');
@@ -11,18 +11,27 @@ describe('Westminster cobrand', function() {
     cy.visit('http://westminster.localhost:3001/report/new?latitude=51.501009&longitude=-0.141588');
     cy.contains('Westminster');
     cy.wait('@report-ajax');
+    cy.get('#mob_ok').click();
   });
 
   it('checks asset fetching when extra question answered', function() {
     cy.get('select').eq(1).select('Signs and bollards');
     cy.get('#form_USRN').should('have.value', 'USRN123');
+    cy.get('.js-reporting-page--next:visible').click();
     cy.get('select').eq(2).select('Nameplates');
     cy.wait('@nameplates');
+    cy.get('.js-reporting-page--next:visible').click();
+    cy.get('.mobile-map-banner').should('be.visible');
   });
 
   it('checks UPRN fetching', function() {
     cy.get('select').eq(1).select('Damaged, dirty, or missing bin');
+    cy.get('.js-reporting-page--next:visible').click();
     cy.get('select').eq(2).select('Request new bin');
+    cy.wait('@uprn');
+    cy.get('.js-reporting-page--next:visible').click();
+    cy.get('.mobile-map-banner').should('be.visible');
+    cy.get('#mob_ok').click();
     cy.get('#uprn').should('be.visible');
     cy.get('#uprn').contains('7 Address');
     cy.get('#uprn').contains('11-12 Address');

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Unreleased
     - Front end improvements:
+        - Multi-page form reporting.
         - New aerial map toggle.
         - Send text alerts for report updates to only-phone-verified users.
         - Add options for user to set global notification preferences.

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -328,6 +328,9 @@ if ($opt->test_fixtures) {
     $child_cat = FixMyStreet::DB->resultset("Contact")->find({ body => $bodies->{2498}, category => 'Glass broken' });
     $child_cat->set_extra_metadata(group => ['Bus Stops and Shelters']);
     $child_cat->update;
+    $child_cat = FixMyStreet::DB->resultset("Contact")->find({ body => $bodies->{2498}, category => 'Roadworks' });
+    $child_cat->set_extra_fields({ code => 'extra', datatype => 'string', order => 1, variable => 'true' });
+    $child_cat->update;
 }
 
 FixMyStreet::DB::Factory::ResponseTemplate->create({

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -294,6 +294,7 @@ sub by_category_ajax_data : Private {
             $c->stash->{unresponsive}->{$category} or $c->stash->{report_extra_fields}) {
         $body->{category_extra} = $c->render_fragment('report/new/category_extras.html', $vars);
         $body->{category_extra_json} = $c->forward('generate_category_extra_json');
+        $body->{extra_hidden} = 1 if $c->stash->{category_extras_hidden}->{$category};
     }
 
     my $unresponsive = $c->stash->{unresponsive}->{$category};

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -29,6 +29,7 @@ my @PLACES = (
     [ 'BS20 5EE', 51.496194, -2.603439, 2608, 'Borsetshire County Council', 'CTY', 148646, 'Bedminster', 'UTW' ],
     [ 'SL9 0NX', 51.615559, -0.556903, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS' ],
     [ '?', 51.615499, -0.556667, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS' ],
+    [ '?', 51.615965, -0.556367, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS' ],
     [ '?', 51.615439, -0.558362, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS' ],
     [ 'SW1A 1AA', 51.501009, -0.141588, 2504, 'Westminster City Council', 'LBO' ],
     [ 'GL50 2PR', 51.896268, -2.093063, 2226, 'Gloucestershire County Council', 'CTY', 2326, 'Cheltenham Borough Council', 'DIS', 4544, 'Lansdown', 'DIW', 143641, 'Lansdown and Park', 'CED' ],

--- a/templates/web/base/around/display_location.html
+++ b/templates/web/base/around/display_location.html
@@ -62,7 +62,6 @@
         [% map_html | safe %]
 
         <div class="mobile-map-banner">
-            <a href="/">[% loc('Home') %]</a>
             <span>[% loc('Place pin on map') %]</span>
         </div>
     </div>
@@ -84,6 +83,7 @@
 
       [% IF allow_creation %]
         <div style="display:none" id="side-form">
+            <a href="#" class="js-back problem-back problem-back--top">[% loc('Back') %]</a>
         [% INCLUDE "report/new/fill_in_details_form.html"
             js = 1,
             report.used_map = 1

--- a/templates/web/base/common_header_tags.html
+++ b/templates/web/base/common_header_tags.html
@@ -21,7 +21,7 @@
 h.style.overflow="hidden";h.appendChild(c)}b=n(f,b);c.fake?(c.parentNode.removeChild(c),h.style.overflow=g,h.offsetHeight):f.parentNode.removeChild(f);return!!b}k={_version:"3.11.4"};var g=function(){};g.prototype=k;g=new g;var h=e.documentElement,p=function(){var b=d.matchMedia||d.msMatchMedia;return b?function(d){return(d=b(d))&&d.matches||!1}:function(b){var a=!1;m("@media "+b+" { #modernizr { position: absolute; } }",function(b){a="absolute"===("getComputedStyle"in d?getComputedStyle(b):b.currentStyle).position});
 return a}}();k.mq=p;d.Modernizr=g})(window,document);
     var fixmystreet=fixmystreet||{};fixmystreet.page="[% page %]";fixmystreet.cobrand="[% c.cobrand.moniker %]";
-    (function(a){a=a.documentElement;a.className=a.className.replace(/\bno-js\b/,"js");var b=Modernizr.mq("(min-width: 48em)")?"desktop":"mobile";"IntersectionObserver"in window&&(a.className+=" lazyload");"mobile"==b&&(a.className+=' mobile[% " map-fullscreen only-map map-reporting" IF page == "around" %]')})(document);
+    (function(a){a=a.documentElement;a.className=a.className.replace(/\bno-js\b/,"js");var b=Modernizr.mq("(min-width: 48em)")?"desktop":"mobile";"IntersectionObserver"in window&&(a.className+=" lazyload");"mobile"==b&&(a.className+=' mobile[% " map-fullscreen only-map map-reporting" IF page == "around" || page == "new" %]')})(document);
 </script>
 
 <script nonce="[% csp_nonce %]">

--- a/templates/web/base/js/translation_strings.html
+++ b/templates/web/base/js/translation_strings.html
@@ -40,7 +40,6 @@ fixmystreet.password_minimum_length = [% c.cobrand.password_minimum_length %];
         first_name: '[% loc('Please enter your first name', "JS") %]',
         last_name: '[% loc('Please enter your second name', "JS") %]',
         right_place: '[% loc('Reposition if needed, then hit Continue', "JS") %]',
-        try_again: '[% loc('Try again', "JS") %]',
         place_pin_on_map: '[% loc('Place pin on map', "JS") %]',
         back: '[% loc('Back', "JS") %]',
         how_to_send: '[% loc('How to send successful reports', "JS") %]',
@@ -60,7 +59,6 @@ fixmystreet.password_minimum_length = [% c.cobrand.password_minimum_length %];
 
         reporting_a_problem: '[% loc('Reporting a problem', "JS") %]',
         ok: '[% loc('Continue', "JS") %]',
-        map: '[% loc('MAP', "JS") %]',
 
         map_aerial: '[% loc('Aerial map', "JS") %]',
         map_roads: '[% loc('Road map', "JS") %]',

--- a/templates/web/base/report/form/photo_upload.html
+++ b/templates/web/base/report/form/photo_upload.html
@@ -3,6 +3,7 @@
     <label for="form_photo">
         <span data-singular="[% loc('Photo') %]" data-plural="[% loc('Photos') %]">[% loc('Photo') %]</span>
         [% IF c.cobrand.moniker == 'zurich' %][% loc('(Defect &amp; location of defect)') %][% END %]
+        [% loc('(optional)') %]
     </label>
 
       [% IF field_errors.photo %]

--- a/templates/web/base/report/form/user.html
+++ b/templates/web/base/report/form/user.html
@@ -1,11 +1,13 @@
 <!-- report/form/user.html -->
-<div class="js-new-report-user-hidden form-section-preview form-section-preview--next
+<div class="[% IF type != 'report' %]js-new-report-user-hidden[% END %]
+    form-section-preview form-section-preview--next
     [%~ ' hidden-nojs' IF c.user_exists OR NOT c.cobrand.social_auth_enabled %]">
     <h2 class="form-section-heading form-section-heading--private hidden-nojs">
         [% loc('Next:') %] [% loc('Tell us about you') %]
     </h2>
+
 [% IF c.user_exists OR NOT c.cobrand.social_auth_enabled %]
-    <button type="button" class="btn btn--block hidden-nojs js-new-report-user-show">[% loc('Continue') %]</button>
+    <button type="button" class="btn btn--block hidden-nojs js-reporting-page--next[% IF type != 'report' %] js-new-report-user-show[% END %]">[% loc('Continue') %]</button>
 [% ELSE %]
   [% IF c.config.FACEBOOK_APP_ID %]
     <button name="social_sign_in" id="facebook_sign_in" value="facebook" class="btn btn--block btn--social btn--facebook">
@@ -24,7 +26,7 @@
         [% loc('Log in with Twitter') %]
     </button>
   [% END %]
-    <button type="button" class="btn btn--block hidden-nojs js-new-report-user-show">[% loc('Log in with email') %]</button>
+    <button type="button" class="btn btn--block hidden-nojs js-reporting-page--next[% IF type != 'report' %] js-new-report-user-show[% END %]">[% loc('Log in with email') %]</button>
 [% END %]
   <div class="js-show-if-anonymous
     [%~ ' hidden-js' UNLESS type == 'report' AND c.cobrand.allow_anonymous_reports == 'button' %]">
@@ -32,6 +34,7 @@
     <button name="report_anonymously" value="yes" class="btn btn--block js-new-report-submit">[% loc('Report anonymously') %]</button>
     <small>[% loc('No personal details will be stored, and you will not receive updates about this report.') %]</small>
   </div>
+
 </div>
 
 [% IF (c.user_exists OR NOT c.cobrand.social_auth_enabled) AND type == 'report' AND c.cobrand.allow_anonymous_reports == 'button' %]

--- a/templates/web/base/report/new/after_photo.html
+++ b/templates/web/base/report/new/after_photo.html
@@ -1,4 +1,3 @@
-[% IF c.cobrand.allow_photo_upload %]
 <div class="description_tips" aria-label="[% loc('Tips for perfect photos') %]">
     <ul class="do">
         <li>[% loc('For best results include a close-up and a wide shot') %]</li>
@@ -7,4 +6,3 @@
         <li>[% loc('Avoid personal information and vehicle number plates') %]</li>
     </ul>
 </div>
-[% END %]

--- a/templates/web/base/report/new/category.html
+++ b/templates/web/base/report/new/category.html
@@ -30,9 +30,4 @@ END
     >
         [%~ INCLUDE 'report/new/_category_select.html' ~%]
     </select>
-    [%~ IF category_groups.size ~%]
-          <label id="form_subcategory_label" class="hidden">
-            [%~ loc('Subcategory') ~%]
-        </label>
-    [%~ END ~%]
 [%~ END ~%]

--- a/templates/web/base/report/new/category_wrapper.html
+++ b/templates/web/base/report/new/category_wrapper.html
@@ -17,18 +17,10 @@
 [% END %]
 </div>
 
-[% PROCESS "report/new/duplicate_suggestions.html" %]
-
-[% IF disable_form_message %]
-<div id="js-category-stopper" class="box-warning" role="alert" aria-live="assertive">
-    [% disable_form_message | safe %]
+<div class="js-post-category-messages">
+  [% IF disable_form_message %]
+    <div id="js-category-stopper" class="box-warning" role="alert" aria-live="assertive">
+        [% disable_form_message | safe %]
+    </div>
+  [% END %]
 </div>
-[% ELSE %]
-<div id="js-post-category-messages" class="js-hide-if-invalid-category_extras">
-    [%# This section includes 'Pick an asset' text, roadworks info, extra category questions %]
-
-  [%- IF category_extras OR report_extra_fields %]
-    [% PROCESS "report/new/category_extras.html" %]
-  [%- END %]
-</div>
-[% END %]

--- a/templates/web/base/report/new/duplicate_suggestions.html
+++ b/templates/web/base/report/new/duplicate_suggestions.html
@@ -2,8 +2,7 @@
 [% extra_js.push(
     version('/js/duplicates.js'),
 ) -%]
-<div id="js-duplicate-reports" class="duplicate-report-suggestions hidden">
-    <button type="button" class="duplicate-report-suggestions__close js-hide-duplicate-suggestions">[% loc('Close') %]</button>
+<div data-page-name="duplicates" id="js-duplicate-reports" class="js-reporting-page js-reporting-page--duplicates js-reporting-page--skip duplicate-report-suggestions hidden">
     <h2 class="form-section-heading">[% loc('Already been reported?') %]</h2>
     <div class="form-section-description">
       [% IF c.cobrand.is_council %]
@@ -14,7 +13,7 @@
     </div>
 
     <ul class="item-list"></ul>
-    <button type="button" class="btn btn--block js-hide-duplicate-suggestions">[% loc('Continue – report a new problem') %]</button>
+    <button type="button" class="btn btn--block js-reporting-page--next">[% loc('Continue – report a new problem') %]</button>
 </div>
 <div class="js-template-get-updates hidden">
     <div id="alerts" class="get-updates js-alert-list">

--- a/templates/web/base/report/new/fill_in_details.html
+++ b/templates/web/base/report/new/fill_in_details.html
@@ -32,6 +32,10 @@
 
   [% IF report.used_map %]
     [% map_html | safe %]
+
+        <div class="mobile-map-banner">
+            <span>[% loc('Reposition if needed, then hit Continue') %]</span>
+        </div>
     </div>
     <div id="map_sidebar">
         <div id="side-form">
@@ -41,6 +45,7 @@
   [% END %]
 
             <div id="report-a-problem-main">
+                <a href="#" class="js-back problem-back problem-back--top">[% loc('Back') %]</a>
               [% IF login_success %]
                 [% PROCESS 'report/new/login_success_form.html' %]
               [% ELSIF oauth_need_email %]

--- a/templates/web/base/report/new/fill_in_details_form.html
+++ b/templates/web/base/report/new/fill_in_details_form.html
@@ -1,6 +1,9 @@
 [% PROCESS 'report/new/form_heading.html' %]
 
-<div class="js-new-report-user-hidden">
+[% TRY %][% INCLUDE 'report/new/roads_message.html' %][% CATCH file %][% END %]
+
+<fieldset>
+    <div id="problem_form">
 
 [% IF report.used_map %]
     <ul class="change_location">
@@ -8,12 +11,6 @@
         <li class="change_location__search">[% loc('Or <a href="/">search for a different location</a>') %]</li>
     </ul>
 [% END %]
-
-</div>
-
-[% TRY %][% INCLUDE 'report/new/roads_message.html' %][% CATCH file %][% END %]
-
-<div class="js-new-report-user-hidden">
 
 <div id="js-top-message">
     [% PROCESS 'report/new/top_message.html' %]
@@ -30,13 +27,8 @@
 
 [% INCLUDE 'errors.html' %]
 
-</div>
-
-<fieldset>
-    <div id="problem_form">
-        <div class="js-new-report-user-hidden">
-            [% PROCESS 'report/new/form_report.html' %]
-        </div>
+        [% PROCESS 'report/new/form_report.html' %]
         [% PROCESS 'report/new/form_user.html' %]
+
     </div>
 </fieldset>

--- a/templates/web/base/report/new/form_report.html
+++ b/templates/web/base/report/new/form_report.html
@@ -1,5 +1,6 @@
 [% SET form_show_category_only = NOT category || field_errors.category || disable_form_message || have_disable_qn_to_answer %]
 [% TRY %][% PROCESS 'report/new/_form_labels.html' %][% CATCH file %][% END %]
+[% PROCESS 'report/new/form_public_councils_text.html' ~%]
 
 <!-- report/new/form_report.html -->
 [% INCLUDE 'report/new/form_after_heading.html' %]
@@ -8,13 +9,34 @@
     <p class='form-error'>[% field_errors.bodies %]</p>
 [% END %]
 
-[% PROCESS 'report/new/form_public_councils_text.html' %]
-[% IF public_councils_text_at_top %]
+<div data-page-name="category" class="js-reporting-page js-reporting-page--category js-reporting-page--active">
+  [% IF public_councils_text_at_top %]
     [% INCLUDE public_councils_text %]
-[% END %]
+  [% END %]
 
-[% PROCESS "report/new/category_wrapper.html" %]
-[% TRY %][% PROCESS 'report/new/after_category.html' %][% CATCH file %][% END %]
+    [% PROCESS "report/new/category_wrapper.html" %]
+    [% TRY %][% PROCESS 'report/new/after_category.html' %][% CATCH file %][% END %]
+
+    <button class="btn btn--block btn--final hidden-nojs js-reporting-page--next"
+        [% ' disabled' IF disable_form_message %]>[% loc('Continue') %]</button>
+</div>
+
+<div data-page-name="subcategory" class="js-reporting-page js-reporting-page--subcategory js-reporting-page--skip hidden-nojs">
+    <label id="form_subcategory_label">[% loc('Subcategory') %]</label>
+    <div class="js-post-category-messages"></div>
+    <button class="btn btn--block btn--final hidden-nojs js-reporting-page--next">[% loc('Continue') %]</button>
+</div>
+
+[% PROCESS "report/new/duplicate_suggestions.html" %]
+
+<div data-page-name="extra" id="js-post-category-messages" class="js-reporting-page js-reporting-page--skip">
+    [%# This section includes 'Pick an asset' text, roadworks info, extra category questions %]
+  [% IF NOT disable_form_message %]
+    [% PROCESS "report/new/category_extras.html" %]
+  [% END %]
+    <div class="js-post-category-messages"></div>
+    <button class="btn btn--block btn--final hidden-nojs js-reporting-page--next">[% loc('Continue') %]</button>
+</div>
 
 [% IF form_show_category_only %]
     <div class="hidden-js">
@@ -25,49 +47,58 @@
     [% SET field_required = ' required' %]
 [% END %]
 
-<div class="js-hide-if-invalid-category[% ' hidden-nojs' IF form_show_category_only %]">
+[% IF c.cobrand.allow_photo_upload %]
+    <div data-page-name="photo" class="js-reporting-page[% ' hidden-nojs' IF form_show_category_only %]">
 
+        [% PROCESS 'report/form/photo_upload.html' type='report' %]
+        [% PROCESS 'report/new/after_photo.html' %]
+
+        <button class="btn btn--block btn--final hidden-nojs js-reporting-page--next">[% loc('Continue') %]</button>
+    </div>
+[% END %]
+
+<div data-page-name="details" class="js-reporting-page[% ' hidden-nojs' IF form_show_category_only %]">
   [% UNLESS public_councils_text_at_top %]
     [% INCLUDE public_councils_text %]
   [% END %]
 
     [% INCLUDE 'report/new/form_title.html' %]
 
-[% TRY %][% PROCESS 'report/new/after_title.html' %][% CATCH file %][% END %]
-
-[% PROCESS report/form/photo_upload.html type='report' %]
-
-[% TRY %][% PROCESS 'report/new/after_photo.html' %][% CATCH file %][% END %]
+    [% TRY %][% PROCESS 'report/new/after_title.html' %][% CATCH file %][% END %]
 
     [% DEFAULT form_detail_label = loc('Explain what’s wrong') %]
     <label for="form_detail">[% form_detail_label %]</label>
 
-[%# You can prevent a hint being printed by setting form_detail_placeholder to a Falsey value %]
-[% IF NOT form_detail_placeholder.defined %]
+    [%# You can prevent a hint being printed by setting form_detail_placeholder to a Falsey value %]
+  [% IF NOT form_detail_placeholder.defined %]
     [% SET form_detail_placeholder = loc('e.g. ‘This pothole has been here for two months and…’') %]
-[% END %]
+  [% END %]
 
-[% IF contact_detail_hint %]
+  [% IF contact_detail_hint %]
     <p class="form-hint" id="detail-hint">[% contact_detail_hint %]</p>
-[% ELSIF form_detail_placeholder %]
+  [% ELSIF form_detail_placeholder %]
     <p class="form-hint" id="detail-hint">[% form_detail_placeholder %]</p>
-[% END %]
+  [% END %]
 
-[% IF field_errors.detail %]
+  [% IF field_errors.detail %]
     <p class='form-error'>[% field_errors.detail %]</p>
-[% END %]
+  [% END %]
 
     <textarea class="form-control" rows="7" cols="26" name="detail" id="form_detail" [% IF form_detail_placeholder %]aria-describedby="detail-hint"[% END %][% field_required %]>[% report.detail | html %]</textarea>
 
-[% TRY %][% PROCESS 'report/new/inline-tips.html' %][% CATCH file %][% END %]
+    [% TRY %][% PROCESS 'report/new/inline-tips.html' %][% CATCH file %][% END %]
+
+    <div class="js-reporting-page--single-hidden">
+        [% PROCESS report/form/user.html type='report' %]
+    </div>
+</div>
 
 [% IF partial_token %]
     <input type="hidden" name="partial" value="[% partial_token.token %]">
 [% END %]
 
-    <input type="hidden" id="single_body_only" name="single_body_only" value="">
-    <input type="hidden" id="do_not_send" name="do_not_send" value="">
-    <input type="hidden" name="submit_problem" value="1">
-    <input type="hidden" id="form_service" name="service" value="">
-</div>
+<input type="hidden" id="single_body_only" name="single_body_only" value="">
+<input type="hidden" id="do_not_send" name="do_not_send" value="">
+<input type="hidden" name="submit_problem" value="1">
+<input type="hidden" id="form_service" name="service" value="">
 <!-- /report/new/form_report.html -->

--- a/templates/web/base/report/new/form_user.html
+++ b/templates/web/base/report/new/form_user.html
@@ -1,17 +1,5 @@
 <!-- report/new/form_user.html -->
-<div class="js-hide-if-invalid-category[% ' hidden-nojs' IF form_show_category_only %]">
-
-    [% PROCESS 'report/form/user.html' type='report' %]
-
-    <div class="hidden-js js-new-report-user-shown">
-        <div class="hidden-nojs form-section-preview">
-            <h2 class="form-section-heading">[% loc('About the problem') %]</h2>
-            <p>
-                <strong class="js-form-section-preview" data-source="#form_title"></strong>
-                <span class="js-form-section-preview" data-source="#form_detail"></span>
-            </p>
-            <button type="button" class="btn btn--block js-new-report-user-hide">[% loc('Edit report details') %]</button>
-        </div>
+<div data-page-name="user" class="js-reporting-page[% ' hidden-nojs' IF form_show_category_only %]">
 
 [% IF c.user_exists %]
   [% PROCESS "report/new/form_user_loggedin.html" type='report' %]
@@ -19,6 +7,5 @@
   [% PROCESS "report/form/user_loggedout.html" type='report' object=report %]
 [% END %]
 
-    </div>
 </div>
 <!-- /report/new/form_user.html -->

--- a/templates/web/base/report/new/login_success_form.html
+++ b/templates/web/base/report/new/login_success_form.html
@@ -7,7 +7,7 @@
 [% INCLUDE 'errors.html' %]
 
 <fieldset>
-    <div id="problem_form">
+    <div id="problem_form" class="js-reporting-page--single">
       [% IF c.user_exists %]
         [% PROCESS "report/new/form_user_loggedin.html" type='report' %]
       [% ELSE %]

--- a/templates/web/base/report/new/oauth_email_form.html
+++ b/templates/web/base/report/new/oauth_email_form.html
@@ -10,7 +10,7 @@
 [% INCLUDE 'errors.html' %]
 
 <fieldset>
-    <div id="problem_form">
+    <div id="problem_form" class="js-reporting-page--single">
         <div id="form_sign_in">
             [% PROCESS 'report/form/user_loggedout_by_email.html' object=report type='report' email_required=1 %]
         </div>

--- a/templates/web/hackney/report/form/user.html
+++ b/templates/web/hackney/report/form/user.html
@@ -1,10 +1,11 @@
 <!-- report/form/user.html -->
-<div class="js-new-report-user-hidden form-section-preview form-section-preview--next
+<div class="[% IF type != 'report' %]js-new-report-user-hidden[% END %]
+    form-section-preview form-section-preview--next
     [%~ ' hidden-nojs' IF c.user_exists OR NOT c.cobrand.social_auth_enabled %]">
     <h2 class="form-section-heading form-section-heading--private hidden-nojs">
         [% loc('Next:') %] [% loc('Tell us about you') %]
     </h2>
-  <button type="button" class="btn btn--block hidden-nojs js-new-report-user-show">[% loc('Continue') %]</button>
+  <button type="button" class="btn btn--block hidden-nojs js-reporting-page--next[% IF type != 'report' %] js-new-report-user-show[% END %]">[% loc('Continue') %]</button>
 [% IF NOT c.user_exists AND c.cobrand.feature('oidc_login') %]
   <button name="social_sign_in" id="oidc_sign_in" value="oidc" class="fake-link sso-staff-sign-in">
       Hackney Staff Sign-in

--- a/templates/web/tfl/report/new/after_photo.html
+++ b/templates/web/tfl/report/new/after_photo.html
@@ -1,4 +1,3 @@
-[% IF c.cobrand.allow_photo_upload %]
 <div class="description_tips" aria-label="[% loc('Tips for perfect photos') %]">
     <ul class="do">
         <li>[% loc('Use close-ups and wide shots to show the issue to us') %]</li>
@@ -7,4 +6,3 @@
         <li>[% loc('Avoid personal information and vehicle number plates') %]</li>
     </ul>
 </div>
-[% END %]

--- a/templates/web/tfl/report/new/roads_message.html
+++ b/templates/web/tfl/report/new/roads_message.html
@@ -5,7 +5,7 @@
         to the appropriate borough.</p>
     </div>
     <div id="js-not-an-asset" class="hidden js-responsibility-message">
-        <p><strong>Select a marker</strong></p>
-        <p>Please select <span class="js-roads-asset" data-original="an item">an item</span> from the map on which to make a report.</p>
+        <p><strong>Select a marker</strong>
+        <br>Please select <span class="js-roads-asset" data-original="an item">an item</span> from the map on which to make a report.</p>
     </div>
 </div>

--- a/templates/web/westminster/report/form/user.html
+++ b/templates/web/westminster/report/form/user.html
@@ -1,11 +1,12 @@
 <!-- report/form/user.html -->
-<div class="js-new-report-user-hidden form-section-preview form-section-preview--next
+<div class="[% IF type != 'report' %]js-new-report-user-hidden[% END %]
+    form-section-preview form-section-preview--next
     [%~ ' hidden-nojs' IF c.user_exists OR NOT c.cobrand.social_auth_enabled %]">
     <h2 class="form-section-heading form-section-heading--private hidden-nojs">
         [% loc('Next:') %] [% loc('Tell us about you') %]
     </h2>
 [% IF c.user_exists OR NOT c.cobrand.social_auth_enabled %]
-    <button type="button" class="btn btn--block hidden-nojs js-new-report-user-show">[% loc('Continue') %]</button>
+    <button type="button" class="btn btn--block hidden-nojs js-reporting-page--next[% IF type != 'report' %] js-new-report-user-show[% END %]">[% loc('Continue') %]</button>
 [% ELSE %]
   [% IF c.config.FACEBOOK_APP_ID %]
     <button name="social_sign_in" id="facebook_sign_in" value="facebook" class="btn btn--block btn--social btn--facebook">

--- a/templates/web/zurich/report/new/fill_in_details_form.html
+++ b/templates/web/zurich/report/new/fill_in_details_form.html
@@ -15,7 +15,7 @@
             [% END %]
 
             [% PROCESS 'report/form/photo_upload.html' %]
-            [% TRY %][% PROCESS 'report/new/after_photo.html' %][% CATCH file %][% END %]
+            [% PROCESS 'report/new/after_photo.html' %]
 
             <label for="form_detail">[% loc('Details') %]</label>
             [% IF field_errors.detail %]

--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -343,9 +343,9 @@ fixmystreet.assets.add(defaults, {
     road: true,
     actions: {
         found: function() {
-            var $div = $("#category_meta .js-gritting-notice");
+            var $div = $(".js-reporting-page.js-gritting-notice");
             if ($div.length) {
-                $div.show();
+                $div.removeClass('js-reporting-page--skip');
             } else {
                 var msg = "<div class='box-warning js-gritting-notice'>" +
                             "<h1>Winter Gritting</h1>" +
@@ -356,11 +356,11 @@ fixmystreet.assets.add(defaults, {
                             "policy</a>.</p>" +
                             "</div>";
                 $div = $(msg);
-                $div.prependTo("#category_meta");
+                fixmystreet.pageController.addNextPage('gritting', $div);
             }
         },
         not_found: function() {
-            $("#category_meta .js-gritting-notice").hide();
+            $('.js-reporting-page.js-gritting-notice').addClass('js-reporting-page--skip');
         }
     }
 });

--- a/web/cobrands/fixmystreet-uk-councils/roadworks.js
+++ b/web/cobrands/fixmystreet-uk-councils/roadworks.js
@@ -21,14 +21,13 @@ var roadworks_defaults = {
     all_categories: true,
     actions: {
         found: function(layer, feature) {
-            $(".js-roadworks-message-" + layer.id).remove();
             if (!fixmystreet.roadworks.filter || fixmystreet.roadworks.filter(feature)) {
                 fixmystreet.roadworks.display_message(feature);
                 return true;
             }
         },
         not_found: function(layer) {
-            $(".js-roadworks-message-" + layer.id).remove();
+            $(".js-roadworks-page").remove();
         }
     }
 };
@@ -51,7 +50,7 @@ fixmystreet.roadworks.display_message = function(feature) {
         tag_top = config.tag_top || 'p',
         colon = config.colon ? ':' : '';
 
-    var $msg = $('<div class="js-roadworks-message js-roadworks-message-' + feature.layer.id + ' box-warning"><' + tag_top + '>Roadworks are scheduled near this location, so you may not need to report your issue.</' + tag_top + '></div>');
+    var $msg = $('<div class="js-roadworks-message box-warning"><' + tag_top + '>Roadworks are scheduled near this location, so you may not need to report your issue.</' + tag_top + '></div>');
     var $dl = $("<dl></dl>").appendTo($msg);
     $dl.append("<dt>Dates" + colon + "</dt>");
     var $dates = $("<dd></dd>").appendTo($dl);
@@ -74,7 +73,15 @@ fixmystreet.roadworks.display_message = function(feature) {
         $dl.append(config.text_after);
     }
 
-    $msg.prependTo('#js-post-category-messages');
+    var $div = $(".js-reporting-page.js-roadworks-page");
+    if (!$div.length || $div.data('workRef') !== attr.work_ref) {
+        if (!$div.length) {
+            $div = $("<div class='js-roadworks-page'></div>");
+        }
+        $div.data('workRef', attr.work_ref);
+        $div.html($msg);
+        fixmystreet.pageController.addNextPage('roadworks', $div);
+    }
 };
 
 fixmystreet.assets.add(roadworks_defaults);

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -455,13 +455,16 @@ function check_zoom_message_visibility() {
         if ($p.length === 0) {
             $p = $("<p>").prop('class', 'category_meta_message');
             if ($('html').hasClass('mobile')) {
-                $p.click(function() {
-                    $("#mob_ok").trigger('click');
-                }).addClass("btn");
+                $p.appendTo('#map_box');
+            } else {
+                $p.appendTo('.js-reporting-page--active .js-post-category-messages');
             }
-            $p.prependTo('#js-post-category-messages');
         }
         $p.prop('id', id);
+
+        if (this.getVisibility() && $('html').hasClass('mobile')) {
+            fixmystreet.pageController.addMapPage(this);
+        }
 
         if (this.getVisibility() && this.inRange) {
             message = get_asset_pick_message.call(this);
@@ -471,6 +474,7 @@ function check_zoom_message_visibility() {
         $p.html(message);
     } else {
         update_message_display.call(this, null);
+        $('#' + this.id + '_map').remove();
     }
 }
 
@@ -535,6 +539,8 @@ function layer_visibilitychanged() {
         for (j = 0; j < controls.length; j++) {
             controls[j].deactivate();
         }
+        // Deactivating 2 controls means the pin layer z-index ends up being 1 too high...?
+        fixmystreet.map.resetLayersZIndex();
     }
 
     check_zoom_message_visibility.call(this);
@@ -1165,11 +1171,9 @@ fixmystreet.message_controller = (function() {
     var stopperId = 'js-category-stopper',
         stoppers = [],
         ignored_bodies = [];
-        msg_after_bodies = [];
 
     // This shows an error message because e.g. an asset isn't selected or a road hasn't been clicked
     function show_responsibility_error(id, asset_item, asset_type) {
-        $("#js-roads-responsibility").removeClass("hidden");
         $("#js-roads-responsibility .js-responsibility-message").addClass("hidden");
         var asset_strings = $(id).find('.js-roads-asset');
         if (asset_item) {
@@ -1187,6 +1191,13 @@ fixmystreet.message_controller = (function() {
             });
             return href;
         });
+        if ($('html').hasClass('mobile')) {
+            var msg = $(id).html();
+            $div = $('<div class="js-mobile-not-an-asset"></div>').html(msg);
+            $div.appendTo('#map_box');
+        } else {
+            $("#js-roads-responsibility").removeClass("hidden");
+        }
         $(id).removeClass("hidden");
     }
 
@@ -1198,6 +1209,7 @@ fixmystreet.message_controller = (function() {
         } else {
             $(id).addClass("hidden");
         }
+        $('.js-mobile-not-an-asset').remove();
         if (!$("#js-roads-responsibility .js-responsibility-message:not(.hidden)").length) {
             $("#js-roads-responsibility").addClass("hidden");
         }
@@ -1205,36 +1217,45 @@ fixmystreet.message_controller = (function() {
 
     // This shows the reporting form
     function enable_report_form() {
-        $(".js-hide-if-invalid-category").show();
-        $(".js-hide-if-invalid-category_extras").show();
+        $('.js-reporting-page--next').prop('disabled', false);
+        $("#mob_ok, #toggle-fullscreen").removeClass('hidden-js');
     }
 
     // This hides the reporting form, apart from the category selection
     // And perhaps the category_extras unless asked not to
-    function disable_report_form(keep_category_extras) {
-        $(".js-hide-if-invalid-category").hide();
-        if (!keep_category_extras) {
-            $(".js-hide-if-invalid-category_extras").hide();
+    function disable_report_form(type) {
+        if ($('html').hasClass('mobile') && type !== 'stopper') {
+            $("#mob_ok, #toggle-fullscreen").addClass('hidden-js');
+        } else {
+            $('.js-reporting-page--next').prop('disabled', true);
         }
     }
 
     // This hides the responsibility message, and (unless a
     // stopper message or dupes are shown) reenables the report form
-    function responsibility_off(layer_data) {
+    function responsibility_off(layer, type) {
+        var layer_data = layer.fixmystreet;
         var id = layer_data.no_asset_msg_id || '#js-not-an-asset';
         hide_responsibility_errors(id, layer_data);
         if (!document.getElementById(stopperId)) {
             enable_report_form();
+            if (type === 'road') {
+                $('#' + layer.id + '_map').remove();
+            }
         }
     }
 
     // This disables the report form and (unless a stopper
     // message is shown) shows a responsibility message
-    function responsibility_on(layer_data, override_id) {
+    function responsibility_on(layer, type, override_id) {
+        var layer_data = layer.fixmystreet;
         var id = override_id || layer_data.no_asset_msg_id || '#js-not-an-asset';
-        disable_report_form();
+        disable_report_form(type);
+        if (type === 'road') {
+            fixmystreet.pageController.addMapPage(layer);
+        }
         hide_responsibility_errors(id, layer_data);
-        if (!document.getElementById(stopperId) && !$('#js-duplicate-reports').is(':visible')) {
+        if (!document.getElementById(stopperId)) {
             show_responsibility_error(id, layer_data.asset_item, layer_data.asset_type);
         }
     }
@@ -1269,14 +1290,6 @@ fixmystreet.message_controller = (function() {
         }
     }
 
-    function stopper_after(stopper) {
-        var body =  fixmystreet.bodies[0];
-        if (OpenLayers.Util.indexOf( msg_after_bodies, body) > -1 ) {
-            return true;
-        }
-        return false;
-    }
-
     function check_for_stopper() {
         var only_send = fixmystreet.body_overrides.get_only_send();
         if (only_send == 'Highways England') {
@@ -1288,7 +1301,7 @@ fixmystreet.message_controller = (function() {
         var matching = $.grep(stoppers, is_matching_stopper);
         if (!matching.length) {
             $id.remove();
-            if ( !$('#js-roads-responsibility').is(':visible') && !$('#js-duplicate-reports').is(':visible') ) {
+            if ( !$('#js-roads-responsibility').is(':visible') ) {
                 enable_report_form();
             }
             return;
@@ -1305,32 +1318,28 @@ fixmystreet.message_controller = (function() {
         $msg.attr('role', 'alert');
         $msg.attr('aria-live', 'assertive');
 
+        // XXX Will this need to move the message from one 'page' to another ever?
         if ($id.length) {
             $id.replaceWith($msg);
         } else {
-            if (stopper_after(stopper)) {
-                $msg.insertAfter('#js-post-category-messages');
-            } else {
-                $msg.insertBefore('#js-post-category-messages');
-            }
-            $msg[0].scrollIntoView();
+            $msg.appendTo('.js-reporting-page--active .js-post-category-messages');
         }
-        disable_report_form(stopper.keep_category_extras);
+        disable_report_form('stopper');
     }
 
     $(fixmystreet).on('report_new:category_change', check_for_stopper);
 
     return {
         asset_found: function() {
-            responsibility_off(this.fixmystreet);
+            responsibility_off(this, 'asset');
             return ($('#' + stopperId).length);
         },
 
         asset_not_found: function() {
             if (!this.visibility) {
-                responsibility_off(this.fixmystreet);
+                responsibility_off(this, 'asset');
             } else {
-                responsibility_on(this.fixmystreet);
+                responsibility_on(this, 'asset');
             }
         },
 
@@ -1339,13 +1348,13 @@ fixmystreet.message_controller = (function() {
         // plus an ID of the message to be shown
         road_found: function(layer, feature, criterion, msg_id) {
             if (fixmystreet.assets.selectedFeature()) {
-                responsibility_off(layer.fixmystreet);
+                responsibility_off(layer, 'road');
             } else if (!criterion || criterion(feature)) {
-                responsibility_off(layer.fixmystreet);
+                responsibility_off(layer, 'road');
             } else {
                 fixmystreet.body_overrides.do_not_send(layer.fixmystreet.body);
                 if (is_only_body(layer.fixmystreet.body)) {
-                    responsibility_on(layer.fixmystreet, msg_id);
+                    responsibility_on(layer, 'road', msg_id);
                 }
             }
         },
@@ -1356,12 +1365,12 @@ fixmystreet.message_controller = (function() {
         road_not_found: function(layer) {
             // don't show the message if clicking on a highways england road
             if (fixmystreet.body_overrides.get_only_send() == 'Highways England' || !layer.visibility) {
-                responsibility_off(layer.fixmystreet);
+                responsibility_off(layer, 'road');
             } else if (fixmystreet.assets.selectedFeature()) {
                 fixmystreet.body_overrides.allow_send(layer.fixmystreet.body);
-                responsibility_off(layer.fixmystreet);
+                responsibility_off(layer, 'road');
             } else if (is_only_body(layer.fixmystreet.body)) {
-                responsibility_on(layer.fixmystreet);
+                responsibility_on(layer, 'road');
             }
         },
 
@@ -1377,10 +1386,6 @@ fixmystreet.message_controller = (function() {
 
         add_ignored_body: function(body) {
             ignored_bodies.push(body);
-        },
-
-        add_msg_after_bodies: function(body) {
-            msg_after_bodies.push(body);
         }
     };
 

--- a/web/cobrands/fixmystreet/header.js
+++ b/web/cobrands/fixmystreet/header.js
@@ -12,6 +12,6 @@ fixmystreet.cobrand = '[% c.cobrand.moniker %]';
         E.className += ' lazyload';
     }
     if (type == 'mobile') {
-        E.className += ' mobile[% " map-fullscreen only-map map-reporting" IF page == "around" %]';
+        E.className += ' mobile[% " map-fullscreen only-map map-reporting" IF page == "around" || page == "new" %]';
     }
 })(document);

--- a/web/cobrands/highways/assets.js
+++ b/web/cobrands/highways/assets.js
@@ -55,7 +55,7 @@ fixmystreet.assets.add(defaults, {
     actions: {
         found: function(layer, feature) {
             if (fixmystreet.assets.selectedFeature()) {
-                $('#highways').remove();
+                $('.js-reporting-page--highways').remove();
                 return;
             }
             var current_road_name = $('#highways strong').first().text();
@@ -70,7 +70,7 @@ fixmystreet.assets.add(defaults, {
                     non_he_selected();
                 }
             } else {
-                $('#highways').remove();
+                $('.js-reporting-page--highways').remove();
                 add_highways_warning(new_road_name);
             }
         },
@@ -79,7 +79,7 @@ fixmystreet.assets.add(defaults, {
                 fixmystreet.body_overrides.remove_only_send();
                 fixmystreet.body_overrides.do_not_send('Highways England');
             }
-            $('#highways').remove();
+            $('.js-reporting-page--highways').remove();
         }
     }
 });
@@ -128,6 +128,7 @@ function non_he_selected() {
 function add_highways_warning(road_name) {
   var $warning = $('<div class="box-warning" id="highways"><p>It looks like you clicked on the <strong>' + road_name + '</strong> which is managed by <strong>Highways England</strong>. ' +
                    'Does your report concern something on this road, or somewhere else (e.g a road crossing it)?<p></div>');
+  var $page = $('<div data-page-name="highwaysengland" class="js-reporting-page js-reporting-page--active js-reporting-page--highways"></div>');
   var $radios = $('<p class="segmented-control segmented-control--radio"></p>');
 
     $('<input>')
@@ -154,7 +155,12 @@ function add_highways_warning(road_name) {
         .addClass('btn')
         .appendTo($radios);
     $radios.appendTo($warning);
-    $('.change_location').after($warning);
+    $warning.wrap($page);
+    $page = $warning.parent();
+    $page.append('<button type="button" class="btn btn--block js-reporting-page--next">Continue</button>');
+
+    $('.js-reporting-page').first().before($page);
+    $page.nextAll('.js-reporting-page').removeClass('js-reporting-page--active');
     he_selected();
 }
 

--- a/web/cobrands/highwaysengland/assets.js
+++ b/web/cobrands/highwaysengland/assets.js
@@ -66,11 +66,11 @@ fixmystreet.assets.add(defaults, {
             fixmystreet.message_controller.road_found(layer, feature, function(feature) {
                 if (feature.attributes.area_name.indexOf('DBFO') === -1) {
                     $('#js-top-message').show();
-                    $('#form_category_row').show();
+                    $('.js-reporting-page--category').removeClass('hidden-js');
                     return true;
                 } else {
                     $('#js-top-message').hide();
-                    $('#form_category_row').hide();
+                    $('.js-reporting-page--category').addClass('hidden-js');
                     return false;
                 }
             }, '#js-dbfo-road');
@@ -78,7 +78,7 @@ fixmystreet.assets.add(defaults, {
         not_found: function(layer) {
           fixmystreet.message_controller.road_not_found(layer);
           $('#js-top-message').hide();
-          $('#form_category_row').hide();
+          $('.js-reporting-page--category').addClass('hidden-js');
         }
     }
 });

--- a/web/cobrands/isleofwight/assets.js
+++ b/web/cobrands/isleofwight/assets.js
@@ -272,7 +272,5 @@ fixmystreet.assets.add($.extend(true, {}, point_asset_defaults, {
     }
 }));
 
-fixmystreet.message_controller.add_msg_after_bodies(defaults.body);
-
 
 })();

--- a/web/cobrands/northamptonshire/assets.js
+++ b/web/cobrands/northamptonshire/assets.js
@@ -172,14 +172,13 @@ var northants_defaults = $.extend(true, {}, fixmystreet.alloyv2_defaults, {
               $p = $("<p id='overlapping_features_msg' class='hidden box-warning'>" +
               "There is more than one <span class='overlapping_item_name'></span> at this location. " +
               "Please describe which <span class='overlapping_item_name'></span> has the problem clearly.</p>");
-              $p.prependTo('#js-post-category-messages');
+              $('#category_meta').before($p).closest('.js-reporting-page').removeClass('js-reporting-page--skip');
           }
           $p.find(".overlapping_item_name").text(this.fixmystreet.asset_item);
           $p.removeClass('hidden');
       } else {
           $("#overlapping_features_msg").addClass('hidden');
       }
-
     },
     asset_not_found: function() {
       $("#overlapping_features_msg").addClass('hidden');

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -629,39 +629,28 @@ ul.error {
     }
 }
 
-.duplicate-report-suggestions__close {
-    position: absolute;
-    right: 0;
-    top: 0;
-    display: block;
-    width: 32px;
-    height: 0;
-    padding-top: 32px;
-    overflow: hidden;
-    border: none;
-    background: transparent;
-    opacity: 0.5;
-    line-height: 2em; // Make sure line box is taller than text, so text is pushed below hidden overflow.
+.js .js-reporting-page {
+  display: none;
+  visibility: hidden;
+}
 
-    &:hover,
-    &:focus {
-        opacity: 0.7;
-    }
+.js .js-reporting-page--single .js-reporting-page {
+  display: block;
+  visibility: visible;
+}
+.js .js-reporting-page--single .js-reporting-page button {
+  display: none;
+}
+.js .js-reporting-page--single .js-reporting-page--single-hidden {
+  display: none;
+}
+.js .js-reporting-page--active {
+  display: block;
+  visibility: visible;
+}
 
-    // Doing some gymnastics so we can reuse the existing .btn--close icon.
-    &:before {
-      content: "";
-      display: block;
-      width: 16px;
-      height: 16px;
-      position: absolute;
-      top: 8px;
-      left: 8px;
-      background-repeat: no-repeat;
-      background-size: 112px 16px;
-      @include svg-background-image('/cobrands/fixmystreet/images/button-icons');
-      background-position: -32px 0;
-    }
+.no-js .js-back {
+  display: none;
 }
 
 /*** LAYOUT ***/
@@ -1628,6 +1617,9 @@ input.final-submit {
     background-position: flip(0 0, -16px 0);
   }
 }
+.problem-back--top {
+    margin-top: 0;
+}
 
 // Banner showing report status, above report title on individual report page.
 .banner {
@@ -1941,13 +1933,8 @@ html.js #map .noscript {
     }
 
     #problems_nearby,
-    #try_again,
     #mob_ok {
         width: 50%;
-    }
-
-    #try_again {
-        display: none;
     }
 
     .feed:after {
@@ -1987,57 +1974,6 @@ html.js #map .noscript {
 // "Selected" styling for the report-list-filter toggle when selected.
 .mobile-filters-active #map_filter {
     background: #000;
-}
-
-// On mobile, once #mob_ok has been pressed, the new report form is shown,
-// and .sub-map-links transforms into a completely different-looking set
-// of buttons for return back to the map.
-.sub-map-links.map_complete {
-    // Undo flex.
-    display: block;
-
-    // "Fade out" the map.
-    top: 30px;
-    background-color: rgba(#000, 0.3);
-
-    #problems_nearby {
-        display: none;
-    }
-
-    #try_again,
-    #mob_ok {
-        position: absolute;
-        display: block;
-        bottom: 0;
-    }
-
-    // Turn #try_again into a black button, centred above the viewport.
-    #try_again {
-        #{$left}: 25%; // along with width of 50%, centres it
-        margin-bottom: 6em;
-        background: rgba(0, 0, 0, 0.8);
-        @include border-radius(0.5em);
-    }
-
-    // Turn #mob_ok into a white "tab" overlapping the map.
-    #mob_ok {
-        #{$right}: 1em;
-        width: 4em;
-        background: #fff;
-        color: #000;
-
-        // "Down" arrow.
-        &:before {
-            content: "";
-            display: block;
-            width: 16px;
-            height: 16px;
-            margin: 2px auto;
-            background-size: 112px 16px;
-            @include svg-background-image('/cobrands/fixmystreet/images/report-tools');
-            background-position: -32px 0;
-        }
-    }
 }
 
 .big-green-banner {
@@ -2081,10 +2017,13 @@ html.js #map .noscript {
   }
 }
 
-#change_asset_mobile {
+#change_asset_mobile,
+.map-page .js-mobile-not-an-asset,
+.only-map .category_meta_message {
     position: absolute;
     bottom: 3em;
     #{$left}: 0.25em;
+    #{$right}: 0.25em;
     padding: 0.25em;
     color: #fff;
     background-color: black;
@@ -2164,29 +2103,19 @@ img.pin {
   }
 }
 
-// When you're in the reporting flow on mobile, we hide the site-header
-// and make the map full screen to reduce distractions. JavaScript also
-// tweaks the text content of some of the map-related elements, to make
-// it more "app-like".
+// When you're in the reporting flow on mobile, we make the map full screen to
+// reduce distractions. JavaScript also tweaks the text content of some of the
+// map-related elements, to make it more "app-like".
 .map-fullscreen {
-  #site-header {
-    display: none;
-  }
-
   #map_box {
     position: absolute;
-    top: 0;
+    top: calc(60px + 0.25em);
     #{$left}: 0;
     #{$right}: 0;
     bottom: 0;
     height: auto; // override `.mobile #map_box` height:10em
     margin: 0;
     z-index: 1; // stack above positioned elements later on the page (eg: .report-list-filters)
-
-    &.above-form {
-      position: relative;
-      margin: 0 -1em;
-    }
   }
 }
 
@@ -2267,10 +2196,6 @@ label .muted {
 }
 .description_tips__heading--inline {
   display: inline-block;
-}
-
-#form_category_row > label:first-child {
-    margin-top: 0;
 }
 
 .box-warning,

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -31,6 +31,8 @@ $primary_link_hover_color: null !default;
     display: none !important ;
 }
 
+.js-back { display: none; }
+
 body {
     color: $base_fg;
     background: $base_bg;

--- a/web/cobrands/westminster/assets.js
+++ b/web/cobrands/westminster/assets.js
@@ -119,10 +119,15 @@ function add_to_uprn_select($select, assets) {
 
 function construct_uprn_select(assets, has_children) {
     old_uprn = $('#uprn').val();
-    $("#uprn_select").remove();
     $('.category_meta_message').html('');
-    var $div = $('<div class="extra-category-questions" id="uprn_select">');
+    var $div = $("#uprn_select");
+    if (!$div.length) {
+        $div = $('<div data-page-name="uprn" class="js-reporting-page extra-category-questions" id="uprn_select"></div>');
+        $div.insertBefore('.js-reporting-page[data-page-name="photo"]');
+    }
+    $div.removeClass('js-reporting-page--skip');
     if (assets.length > 1 || has_children) {
+        $div.empty();
         $div.append('<label for="uprn">Please choose a property:</label>');
         var $select = $('<select id="uprn" class="form-control" name="UPRN" required>');
         $select.append('<option value="">---</option>');
@@ -131,7 +136,7 @@ function construct_uprn_select(assets, has_children) {
     } else {
         $div.html('You have selected <b>' + assets[0].attributes.ADDRESS + '</b>');
     }
-    $div.appendTo('#js-post-category-messages');
+    $div.append("<button class='btn btn--block btn--final js-reporting-page--next'>Continue</button>");
 }
 
 $.each(layer_data, function(i, o) {
@@ -190,7 +195,7 @@ $.each(layer_data, function(i, o) {
             },
             asset_not_found: function() {
                 $('.category_meta_message').html('You can pick a <b class="asset-spot">' + this.fixmystreet.asset_item + '</b> from the map &raquo;');
-                $("#uprn_select").remove();
+                $("#uprn_select").addClass('js-reporting-page--skip');
                 fixmystreet.message_controller.asset_not_found.call(this);
             }
         }


### PR DESCRIPTION
This PR changes the new reporting flow to be, with JavaScript, more multi-page.

It should handle, any bugs notwithstanding:
* Separate pages for category and subcategory
* Extra questions on separate page
* roadworks message on its own page
* Highways England question shown immediately before anything else on its own page (it changes categories)
* stopper message shown on its own page
* assets get their own page on mobile, reshowing the map. Help text appears on top of map, and any selected asset. If the category demands an asset, on desktop form immediately prevents you continuing until asset picked, on mobile it lets you continue to this page and then no further until asset picked. If pin moved at this point and blanks out category, will take you back to category on continuation
* duplicates get their own page
* Then photo upload on own page, text on own page, user as now on its own page
* Back button (so adding more "Back to" help things as another ticket should hopefully be straightforward)

New tests have been added for a variety of things, including Bromley extra questions, Bucks gritting, HE DBFO roads, TfL roadworks, Westminster UPRN handling.

Remaining todos:
- [x] The footer commit needs more work, perhaps with Design. At present it removes the footer nav entirely on around/new (including desktop, whoops), on .com removes the extra mySoc footer on any map page (already hidden on desktop), and Peterborough footer on any map page (already hidden on desktop). The footer nav should not be removed, but hidden on mobile and the 'nav' top link should make it appear somewhere. Many other cobrands will need footers removing too I assume.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/2030