### PR TITLE
[Central Beds] Post go-live tweaks

### DIFF
--- a/perllib/FixMyStreet/Cobrand/CentralBedfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/CentralBedfordshire.pm
@@ -49,4 +49,7 @@ sub open311_extra_data_include {
 
 sub report_sent_confirmation_email { 'external_id' }
 
+# Don't show any reports made before the go-live date at all.
+sub cut_off_date { '2020-12-02' }
+
 1;

--- a/perllib/FixMyStreet/Cobrand/CentralBedfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/CentralBedfordshire.pm
@@ -47,4 +47,6 @@ sub open311_extra_data_include {
     }
 }
 
+sub report_sent_confirmation_email { 'external_id' }
+
 1;

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -807,7 +807,7 @@ sub defect_types {
 #     Note:   this only makes sense when called on a problem that has been sent!
 sub can_display_external_id {
     my $self = shift;
-    if ($self->external_id && $self->to_body_named('Oxfordshire|Lincolnshire|Isle of Wight|East Sussex')) {
+    if ($self->external_id && $self->to_body_named('Oxfordshire|Lincolnshire|Isle of Wight|East Sussex|Central Bedfordshire')) {
         return 1;
     }
     return 0;

--- a/t/cobrand/centralbedfordshire.t
+++ b/t/cobrand/centralbedfordshire.t
@@ -51,6 +51,11 @@ FixMyStreet::override_config {
 
         $mech->email_count_is(0);
     };
+
+    subtest 'External ID is shown on report page' => sub {
+        $mech->get_ok('/report/' . $report->id);
+        $mech->content_contains("Council ref:&nbsp;" . $report->external_id);
+    };
 };
 
 for my $cobrand ( "centralbedfordshire", "fixmystreet") {

--- a/t/cobrand/centralbedfordshire.t
+++ b/t/cobrand/centralbedfordshire.t
@@ -49,7 +49,9 @@ FixMyStreet::override_config {
         is $c->param('service_code'), 'BRIDGES';
         is $c->param('attribute[area_code]'), 'Area1';
 
-        $mech->email_count_is(0);
+        $mech->email_count_is(1);
+        $report->discard_changes;
+        like $mech->get_text_body_from_email, qr/reference number is @{[$report->external_id]}/;
     };
 
     subtest 'External ID is shown on report page' => sub {

--- a/t/cobrand/centralbedfordshire.t
+++ b/t/cobrand/centralbedfordshire.t
@@ -58,6 +58,28 @@ FixMyStreet::override_config {
         $mech->get_ok('/report/' . $report->id);
         $mech->content_contains("Council ref:&nbsp;" . $report->external_id);
     };
+
+    subtest "it doesn't show old reports on the cobrand" => sub {
+        $mech->create_problems_for_body(1, $body->id, 'An old problem made before Central Beds FMS launched', {
+            confirmed => '2018-12-25 09:00',
+            lastupdate => '2018-12-25 09:00',
+            latitude => 52.030692,
+            longitude => -0.357032
+        });
+
+        $mech->get_ok('/reports/Central+Bedfordshire');
+        $mech->content_lacks('An old problem made before Central Beds FMS launched');
+    };
+};
+
+subtest "it still shows old reports on fixmystreet.com" => sub {
+    FixMyStreet::override_config {
+        MAPIT_URL => 'http://mapit.uk/',
+        ALLOWED_COBRANDS => 'fixmystreet',
+    }, sub {
+        $mech->get_ok('/reports/Central+Bedfordshire');
+        $mech->content_contains('An old problem made before Central Beds FMS launched');
+    };
 };
 
 for my $cobrand ( "centralbedfordshire", "fixmystreet") {

--- a/templates/email/centralbedfordshire/_council_reference.html
+++ b/templates/email/centralbedfordshire/_council_reference.html
@@ -1,0 +1,4 @@
+[% IF problem.external_id ~%]
+<p style="[% p_style %]">The report's reference number is <strong>[% problem.external_id %]</strong>.
+  Please quote this if you need to contact the council about this report.</p>
+[%~ END %]

--- a/templates/email/centralbedfordshire/_council_reference.txt
+++ b/templates/email/centralbedfordshire/_council_reference.txt
@@ -1,0 +1,2 @@
+[% IF problem.external_id %]The report's reference number is [% problem.external_id %]. Please quote this if
+you need to contact the council about this report.[% END %]

--- a/templates/email/centralbedfordshire/confirm_report_sent.html
+++ b/templates/email/centralbedfordshire/confirm_report_sent.html
@@ -1,0 +1,1 @@
+[% INCLUDE 'other-reported.html' %]

--- a/templates/email/centralbedfordshire/confirm_report_sent.txt
+++ b/templates/email/centralbedfordshire/confirm_report_sent.txt
@@ -1,0 +1,1 @@
+[% INCLUDE 'other-reported.txt' %]


### PR DESCRIPTION
A few things not picked up in testing:

 - Show external Symology ID on report page
 - Send email to user with Symology ID after report is sent
 - Hide reports made before the cobrand launched.

[skip changelog]