### PR TITLE
User edit admin link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
         - Use div for inspector form wrapped extra questions. #3250
     - Admin improvements:
         - Enable per-category hint customisation.
+        - Move ban/unban buttons to user edit admin page.
     - Security:
         - Increase minimum password length to eight.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
     - Admin improvements:
         - Enable per-category hint customisation.
         - Move ban/unban buttons to user edit admin page.
+        - Add link to user edit admin from report/update edit admin.
+        - Improve layout of some admin pages.
     - Security:
         - Increase minimum password length to eight.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
         - Use div for inspector form wrapped extra questions. #3250
     - Admin improvements:
         - Enable per-category hint customisation.
+    - Security:
+        - Increase minimum password length to eight.
 
 * v3.1 (16th November 2020)
     - Security:

--- a/docs/_includes/admin-tasks-content.md
+++ b/docs/_includes/admin-tasks-content.md
@@ -244,20 +244,18 @@ user: see ‘[moderating reports](#deal-undesirable-content)’.
 
 #### Adding a user to the abuse list
 
-<span class="admin-task__permissions">Permissions required: User must be marked as staff, ‘Edit reports’ must be ticked.</span>
+<span class="admin-task__permissions">Permissions required: User must be marked as staff, ‘Edit users’ must be ticked.</span>
 
 You can add an abusive user's email to the abuse list, which automatically hides any reports they
 create, and means that their reports are not sent. Instead, the user sees a message that there was
 an error in confirming their report.
 
-Staff with the required permissions can ban a user directly from a report page, using the ‘Ban user’
+Staff with the required permissions can ban a user directly from their user admin page, using the ‘Ban user’
 button.
-
-<img alt="Ban a user directly from a report page" src="/assets/img/pro-user-guide/ban-user-report-page.png" class="admin-screenshot" />
 
 #### Removing users from the banned list
 
-When a user has been banned, an ‘unban’ button will be visible on their records and reports. This
+When a user has been banned, an ‘unban’ button will be visible on their user admin page. This
 restores them to the status of a standard user, but it does not have any effect on reports which
 were made during the period when the user was banned — these remain unsent.
 

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -206,18 +206,7 @@ sub update_edit : Path('update_edit') : Args(1) {
 
     $c->forward('check_username_for_abuse', [ $update->user ] );
 
-    if ( $c->get_param('banuser') ) {
-        $c->forward('users/ban');
-    }
-    elsif ( $c->get_param('flaguser') ) {
-        $c->forward('users/flag');
-        $c->stash->{update}->discard_changes;
-    }
-    elsif ( $c->get_param('removeuserflag') ) {
-        $c->forward('users/flag_remove');
-        $c->stash->{update}->discard_changes;
-    }
-    elsif ( $c->get_param('submit') ) {
+    if ( $c->get_param('submit') ) {
         $c->forward('/auth/check_csrf_token');
 
         my $old_state = $update->state;

--- a/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
@@ -289,17 +289,6 @@ sub edit : Path('/admin/report_edit') : Args(1) {
         $c->stash->{status_message} = _('That problem has been marked as sent.');
         $c->forward( '/admin/log_edit', [ $id, 'problem', 'marked sent' ] );
     }
-    elsif ( $c->get_param('flaguser') ) {
-        $c->forward('/admin/users/flag');
-        $c->stash->{problem}->discard_changes;
-    }
-    elsif ( $c->get_param('removeuserflag') ) {
-        $c->forward('/admin/users/flag_remove');
-        $c->stash->{problem}->discard_changes;
-    }
-    elsif ( $c->get_param('banuser') ) {
-        $c->forward('/admin/users/ban');
-    }
     elsif ( $c->get_param('submit') ) {
         $c->forward('/auth/check_csrf_token');
 

--- a/perllib/FixMyStreet/App/Controller/Admin/Users.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Users.pm
@@ -219,24 +219,27 @@ sub edit : Chained('user') : PathPart('') : Args(0) {
 
     $c->forward('/auth/check_csrf_token') if $c->get_param('submit');
 
-    if ( $c->get_param('submit') and $c->get_param('unban') ) {
+    my $submit = $c->get_param('submit');
+    if ( $submit and $c->get_param('unban') ) {
         $c->forward('unban', [ $user ]);
-    } elsif ( $c->get_param('submit') and $c->get_param('logout_everywhere') ) {
+    } elsif ( $submit and $c->get_param('banuser') ) {
+        $c->forward('ban');
+    } elsif ( $submit and $c->get_param('logout_everywhere') ) {
         $c->forward('user_logout_everywhere', [ $user ]);
-    } elsif ( $c->get_param('submit') and $c->get_param('anon_everywhere') ) {
+    } elsif ( $submit and $c->get_param('anon_everywhere') ) {
         $c->forward('user_anon_everywhere', [ $user ]);
-    } elsif ( $c->get_param('submit') and $c->get_param('hide_everywhere') ) {
+    } elsif ( $submit and $c->get_param('hide_everywhere') ) {
         $c->forward('user_hide_everywhere', [ $user ]);
-    } elsif ( $c->get_param('submit') and $c->get_param('remove_account') ) {
+    } elsif ( $submit and $c->get_param('remove_account') ) {
         $c->forward('user_remove_account', [ $user ]);
-    } elsif ( $c->get_param('submit') and $c->get_param('send_login_email') ) {
+    } elsif ( $submit and $c->get_param('send_login_email') ) {
         my $email = lc $c->get_param('email');
         my %args = ( email => $email );
         $args{user_id} = $user->id if $user->email ne $email || !$user->email_verified;
         $c->forward('send_login_email', [ \%args ]);
     } elsif ( $c->get_param('update_alerts') ) {
         $c->forward('update_alerts');
-    } elsif ( $c->get_param('submit') ) {
+    } elsif ( $submit ) {
 
         my $name = $c->get_param('name');
         my $email = lc $c->get_param('email');
@@ -647,7 +650,7 @@ already in there and sets status_message accordingly.
 sub ban : Private {
     my ( $self, $c ) = @_;
 
-    my $user;
+    my $user = $c->stash->{user};
     if ($c->stash->{problem}) {
         $user = $c->stash->{problem}->user;
     } elsif ($c->stash->{update}) {
@@ -701,64 +704,6 @@ sub unban : Private {
         }
         $c->stash->{username_in_abuse} = 0;
     }
-}
-
-=head2 flag
-
-Sets the flag on a user
-
-=cut
-
-sub flag : Private {
-    my ( $self, $c ) = @_;
-
-    my $user;
-    if ($c->stash->{problem}) {
-        $user = $c->stash->{problem}->user;
-    } elsif ($c->stash->{update}) {
-        $user = $c->stash->{update}->user;
-    }
-
-    if ( !$user ) {
-        $c->stash->{status_message} = _('Could not find user');
-    } else {
-        $user->flagged(1);
-        $user->update;
-        $c->forward( '/admin/log_edit', [ $user->id, 'user', 'edit' ] );
-        $c->stash->{status_message} = _('User flagged');
-    }
-
-    $c->stash->{user_flagged} = 1;
-
-    return 1;
-}
-
-=head2 flag_remove
-
-Remove the flag on a user
-
-=cut
-
-sub flag_remove : Private {
-    my ( $self, $c ) = @_;
-
-    my $user;
-    if ($c->stash->{problem}) {
-        $user = $c->stash->{problem}->user;
-    } elsif ($c->stash->{update}) {
-        $user = $c->stash->{update}->user;
-    }
-
-    if ( !$user ) {
-        $c->stash->{status_message} = _('Could not find user');
-    } else {
-        $user->flagged(0);
-        $user->update;
-        $c->forward( '/admin/log_edit', [ $user->id, 'user', 'edit' ] );
-        $c->stash->{status_message} = _('User flag removed');
-    }
-
-    return 1;
 }
 
 

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -97,7 +97,7 @@ Returns the minimum length a password can be set to.
 
 =cut
 
-sub password_minimum_length { 6 }
+sub password_minimum_length { 8 }
 
 =item country
 

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -714,7 +714,6 @@ sub admin_pages {
         $pages->{reports} = [ _('Reports'), 2 ];
         $pages->{report_edit} = [ undef, undef ];
         $pages->{update_edit} = [ undef, undef ];
-        $pages->{abuse_edit} = [ undef, undef ];
     }
     if ( $user->has_body_permission_to('template_edit') ) {
         $pages->{templates} = [ _('Templates'), 3 ];

--- a/t/app/controller/admin/report_edit.t
+++ b/t/app/controller/admin/report_edit.t
@@ -523,65 +523,6 @@ subtest 'change email to new user' => sub {
     is $report->user_id, $user3->id, 'user changed to new user';
 };
 
-subtest 'adding email to abuse list from report page' => sub {
-    my $email = $report->user->email;
-
-    my $abuse = FixMyStreet::DB->resultset('Abuse')->find( { email => $email } );
-    $abuse->delete if $abuse;
-
-    $mech->get_ok( '/admin/report_edit/' . $report->id );
-    $mech->content_contains('Ban user');
-
-    $mech->click_ok('banuser');
-
-    $mech->content_contains('User added to abuse list');
-    $mech->content_contains('<small>User in abuse table</small>');
-
-    $abuse = FixMyStreet::DB->resultset('Abuse')->find( { email => $email } );
-    ok $abuse, 'entry created in abuse table';
-
-    $mech->get_ok( '/admin/report_edit/' . $report->id );
-    $mech->content_contains('<small>User in abuse table</small>');
-};
-
-subtest 'flagging user from report page' => sub {
-    $report->user->flagged(0);
-    $report->user->update;
-
-    $mech->get_ok( '/admin/report_edit/' . $report->id );
-    $mech->content_contains('Flag user');
-
-    $mech->click_ok('flaguser');
-
-    $mech->content_contains('User flagged');
-    $mech->content_contains('Remove flag');
-
-    $report->discard_changes;
-    ok $report->user->flagged, 'user flagged';
-
-    $mech->get_ok( '/admin/report_edit/' . $report->id );
-    $mech->content_contains('Remove flag');
-};
-
-subtest 'unflagging user from report page' => sub {
-    $report->user->flagged(1);
-    $report->user->update;
-
-    $mech->get_ok( '/admin/report_edit/' . $report->id );
-    $mech->content_contains('Remove flag');
-
-    $mech->click_ok('removeuserflag');
-
-    $mech->content_contains('User flag removed');
-    $mech->content_contains('Flag user');
-
-    $report->discard_changes;
-    ok !$report->user->flagged, 'user not flagged';
-
-    $mech->get_ok( '/admin/report_edit/' . $report->id );
-    $mech->content_contains('Flag user');
-};
-
 subtest "Test setting a report from unconfirmed to something else doesn't cause a front end error" => sub {
     $report->update( { confirmed => undef, state => 'unconfirmed', non_public => 0 } );
     $mech->get_ok("/admin/report_edit/$report_id");

--- a/t/app/controller/admin/update_edit.t
+++ b/t/app/controller/admin/update_edit.t
@@ -299,65 +299,6 @@ subtest 'editing update email creates new user if required' => sub {
     is $update->user->id, $user->id, 'update set to new user';
 };
 
-subtest 'adding email to abuse list from update page' => sub {
-    my $email = $update->user->email;
-
-    my $abuse = FixMyStreet::DB->resultset('Abuse')->find( { email => $email } );
-    $abuse->delete if $abuse;
-
-    $mech->get_ok( '/admin/update_edit/' . $update->id );
-    $mech->content_contains('Ban user');
-
-    $mech->click_ok('banuser');
-
-    $mech->content_contains('User added to abuse list');
-    $mech->content_contains('<small>User in abuse table</small>');
-
-    $abuse = FixMyStreet::DB->resultset('Abuse')->find( { email => $email } );
-    ok $abuse, 'entry created in abuse table';
-
-    $mech->get_ok( '/admin/update_edit/' . $update->id );
-    $mech->content_contains('<small>User in abuse table</small>');
-};
-
-subtest 'flagging user from update page' => sub {
-    $update->user->flagged(0);
-    $update->user->update;
-
-    $mech->get_ok( '/admin/update_edit/' . $update->id );
-    $mech->content_contains('Flag user');
-
-    $mech->click_ok('flaguser');
-
-    $mech->content_contains('User flagged');
-    $mech->content_contains('Remove flag');
-
-    $update->discard_changes;
-    ok $update->user->flagged, 'user flagged';
-
-    $mech->get_ok( '/admin/update_edit/' . $update->id );
-    $mech->content_contains('Remove flag');
-};
-
-subtest 'unflagging user from update page' => sub {
-    $update->user->flagged(1);
-    $update->user->update;
-
-    $mech->get_ok( '/admin/update_edit/' . $update->id );
-    $mech->content_contains('Remove flag');
-
-    $mech->click_ok('removeuserflag');
-
-    $mech->content_contains('User flag removed');
-    $mech->content_contains('Flag user');
-
-    $update->discard_changes;
-    ok !$update->user->flagged, 'user not flagged';
-
-    $mech->get_ok( '/admin/update_edit/' . $update->id );
-    $mech->content_contains('Flag user');
-};
-
 subtest 'hiding comment marked as fixed reopens report' => sub {
     $update->mark_fixed( 1 );
     $update->update;

--- a/t/app/controller/admin/users.t
+++ b/t/app/controller/admin/users.t
@@ -32,8 +32,16 @@ $user5->add_to_roles($occ_role);
 
 $mech->log_in_ok( $superuser->email );
 
+subtest 'add user to abuse list from edit user page' => sub {
+    $mech->get_ok( '/admin/users/' . $user->id );
+    $mech->content_lacks('User in abuse table');
+    $mech->click_ok('banuser');
+    my $abuse = FixMyStreet::DB->resultset('Abuse')->find( { email => $user->email } );
+    ok $abuse, 'record added to abuse table';
+};
+
+
 subtest 'search abuse' => sub {
-    my $abuse = FixMyStreet::DB->resultset('Abuse')->find_or_create( { email => $user->email } );
     $mech->get_ok( '/admin/users?search=example' );
     $mech->content_like(qr{test\@example.com.*</td>\s*<td>.*?</td>\s*<td>User in abuse table}s);
 };

--- a/t/app/controller/auth.t
+++ b/t/app/controller/auth.t
@@ -275,7 +275,7 @@ subtest 'check password length/common' => sub {
     $mech->content_contains("Please make sure your password is at least");
     $mech->submit_form_ok({
         form_name => 'general_auth',
-        fields => { username => $test_email, password_register => 'common' },
+        fields => { username => $test_email, password_register => 'secret123' },
         button => 'sign_in_by_code',
     });
     $mech->content_contains("Please choose a less commonly-used password");

--- a/t/app/controller/auth_phone.t
+++ b/t/app/controller/auth_phone.t
@@ -46,7 +46,7 @@ FixMyStreet::override_config {
     subtest 'Log in using mobile, by text' => sub {
         $mech->submit_form_ok({
             form_name => 'general_auth',
-            fields => { username => '+18165550100', password_register => 'secret' },
+            fields => { username => '+18165550100', password_register => 'secretsecret' },
             button => 'sign_in_by_code',
         }, "sign in using mobile");
 
@@ -77,7 +77,7 @@ FixMyStreet::override_config {
         $mech->content_contains('There was a problem');
         $mech->submit_form_ok({
             form_name => 'general_auth',
-            fields => { username => '+18165550100', password_sign_in => 'secret' },
+            fields => { username => '+18165550100', password_sign_in => 'secretsecret' },
             button => 'sign_in_by_password',
         }, "sign in using password");
 

--- a/t/app/controller/auth_profile.t
+++ b/t/app/controller/auth_profile.t
@@ -163,7 +163,7 @@ subtest 'check password length/common' => sub {
     $mech->content_contains("Please make sure your password is at least");
     $mech->submit_form_ok({
         form_name => 'change_password',
-        fields => { current_password => $test_password, new_password => 'common', confirm => 'common' },
+        fields => { current_password => $test_password, new_password => 'secret123', confirm => 'secret123' },
     });
     $mech->content_contains("Please choose a less commonly-used password");
 };

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -159,7 +159,7 @@ foreach my $test (
                     username_register => 'test-1@example.com',
                     phone         => '07903 123 456',
                     category      => 'Street lighting',
-                    password_register => $test->{password} ? 'secret' : '',
+                    password_register => $test->{password} ? 'secretsecret' : '',
                 }
             },
             "submit good details"
@@ -208,7 +208,7 @@ foreach my $test (
 
     is $report->name, 'Joe Bloggs', 'name updated correctly';
     if ($test->{password}) {
-        ok $report->user->check_password('secret'), 'password updated correctly';
+        ok $report->user->check_password('secretsecret'), 'password updated correctly';
     } elsif ($test->{user}) {
         ok $report->user->check_password('old_password'), 'password unchanged, as no new one given';
     } else {

--- a/t/app/controller/report_new_text.t
+++ b/t/app/controller/report_new_text.t
@@ -181,7 +181,7 @@ foreach my $test (
                     update_method => 'phone',
                     phone => $test_phone,
                     category => 'Street lighting',
-                    password_register => $test->{password} ? 'secret' : '',
+                    password_register => $test->{password} ? 'secretsecret' : '',
                 }
             },
             "submit good details"
@@ -218,7 +218,7 @@ foreach my $test (
 
     is $report->name, 'Joe Bloggs', 'name updated correctly';
     if ($test->{password}) {
-        ok $report->user->check_password('secret'), 'password updated correctly';
+        ok $report->user->check_password('secretsecret'), 'password updated correctly';
     } elsif ($test->{user}) {
         ok $report->user->check_password('old_password'), 'password unchanged, as no new one given';
     } else {

--- a/templates/web/base/admin/flagged.html
+++ b/templates/web/base/admin/flagged.html
@@ -48,7 +48,7 @@
         </td>
         <td>
           <a href="[% c.uri_for( 'reports', search => user.email ) %]">list content</a>
-          [% IF user.id %] | <a href="[% c.uri_for( 'user_edit', user.id ) %]">[% loc('edit user') %]</a>[% END %]
+          [% IF user.id %] | <a href="[% c.uri_for_action( '/admin/users/edit', [ user.id ] ) %]">[% loc('Edit user') %]</a>[% END %]
         </td>
     </tr>
     [%- END %]

--- a/templates/web/base/admin/header.html
+++ b/templates/web/base/admin/header.html
@@ -8,7 +8,7 @@ dt { clear: left; float: left; font-weight: bold; }
 dd { margin-left: 8em !important; }
 .adminhidden { color: #666666; }
 .error { color: red; }
-select { width: auto; }
+select { width: auto; max-width: 100%; }
 .sm { font-size: smaller; }
 </style>
 

--- a/templates/web/base/admin/report_blocks.html
+++ b/templates/web/base/admin/report_blocks.html
@@ -13,16 +13,6 @@ SET state_groups = c.cobrand.state_groups_admin;
     [%- IF time %][% time.ymd %]&nbsp;[% time.hms %][% ELSE %][% no_time || '&nbsp;' %][% END %][% no_time = '' %]
 [%- END %]
 
-[% BLOCK abuse_button -%]
-[% IF allowed_pages.abuse_edit -%]
-[% IF username_in_abuse %]<small>[% loc('User in abuse table') %]</small>[% ELSE %]<input type="submit" class="btn" name="banuser" value="[% loc('Ban user') %]" />[% END %]
-[%- END %]
-[%- END %]
-
-[% BLOCK flag_button -%]
-[% IF user.flagged || user_flagged %]<input type="submit" class="btn" name="removeuserflag" value="[% loc('Remove flag') %]">[% ELSE %]<input type="submit" class="btn" name="flaguser" value="[% loc('Flag user') %]" />[% END %]
-[%- END %]
-
 [%# note: date format here (i.e., dd.mm.YYYY) currently used by Zurich %]
 [% BLOCK format_date -%]
     [%- IF this_date %]

--- a/templates/web/base/admin/reports/edit.html
+++ b/templates/web/base/admin/reports/edit.html
@@ -131,6 +131,7 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
 <li><label class="inline-text" for="category">[% loc('Category:') %]</label>
     [% INCLUDE 'admin/report-category.html' %]
 </li>
+
 <li>[% loc('Extra data:') ~%]
     [%~ IF extra_fields.size ~%]
         <ul>
@@ -154,8 +155,6 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
     <input type='text' class="form-control" name='name' id='name' value='[% problem.name | html %]'></li>
 <li><label for="username">[% loc('User:') %]</label>
     <input type='text' class="form-control" id='username' name='username' value='[% problem.user.username | html %]'>
-    [% PROCESS abuse_button %]
-    [% PROCESS flag_button user=problem.user %]
 </li>
 [% IF problem.user.phone_display != problem.user.username %]
 <li>[% loc('Phone:') %] [% problem.user.phone_display | html %]</li>
@@ -167,6 +166,7 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
 [% END %]
 <li><label class="inline-text" for="flagged">[% loc('Flagged:') %]</label>
     <input type="checkbox" id="flagged" name="flagged"[% ' checked' IF problem.flagged %]></li>
+
 <li><label class="inline-text" for="non_public">[% loc('Private') %]:</label>
     <input type="checkbox" id="non_public" name="non_public"[% ' checked' IF problem.non_public %]></li>
 

--- a/templates/web/base/admin/reports/edit.html
+++ b/templates/web/base/admin/reports/edit.html
@@ -146,29 +146,15 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
         </ul>
     [%~ ELSE %] No[% END ~%]
 </li>
-<li><label class="inline-text" for="anonymous">[% loc('Anonymous:') %]</label>
-<select class="form-control" name="anonymous"  id="anonymous">
-<option [% 'selected ' IF problem.anonymous %]value="1">[% loc('Yes') %]</option>
-<option [% 'selected ' IF !problem.anonymous %]value="0">[% loc('No') %]</option>
-</select></li>
-<li><label for="name">[% loc('Name:') %]</label>
-    <input type='text' class="form-control" name='name' id='name' value='[% problem.name | html %]'></li>
-<li><label for="username">[% loc('User:') %]</label>
-    <input type='text' class="form-control" id='username' name='username' value='[% problem.user.username | html %]'>
-</li>
-[% IF problem.user.phone_display != problem.user.username %]
-<li>[% loc('Phone:') %] [% problem.user.phone_display | html %]</li>
-[% END %]
-[% IF problem.user.email != problem.user.username %]
-<li>[% loc('Email:') %]
-<a href="mailto:[% problem.user.email | html %]">[% problem.user.email | html %]</a>
-</li>
-[% END %]
-<li><label class="inline-text" for="flagged">[% loc('Flagged:') %]</label>
-    <input type="checkbox" id="flagged" name="flagged"[% ' checked' IF problem.flagged %]></li>
 
 <li><label class="inline-text" for="non_public">[% loc('Private') %]:</label>
     <input type="checkbox" id="non_public" name="non_public"[% ' checked' IF problem.non_public %]></li>
+
+<li><label class="inline-text" for="closed_updates">[% loc('Closed to updates') %]:</label>
+    <input type="checkbox" id="closed_updates" name="closed_updates"[% ' checked' IF problem.extra.closed_updates %]></li>
+
+<li><label class="inline-text" for="flagged">[% loc('Flagged:') %]</label>
+    <input type="checkbox" id="flagged" name="flagged"[% ' checked' IF problem.flagged %]></li>
 
 [% IF problem.photo %]
 <li>
@@ -181,8 +167,8 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
                 <span>zoom</span>
             </a>
         </div>
-        <input type="submit" name="rotate_photo_[% loop.index %]" value="[% loc('Rotate Left') %]">
-        <input type="submit" name="rotate_photo_[% loop.index %]" value="[% loc('Rotate Right') %]">
+        <input class="btn" type="submit" name="rotate_photo_[% loop.index %]" value="[% loc('Rotate Left') %]">
+        <input class="btn" type="submit" name="rotate_photo_[% loop.index %]" value="[% loc('Rotate Right') %]">
         <br><input type="checkbox" id="remove_photo_[% loop.index %]" name="remove_photo_[% loop.index %]" value="1">
         <label class="inline" for="remove_photo_[% loop.index %]">[% loc("Remove photo (can't be undone!)") %]</label></li>
     </li>
@@ -190,12 +176,40 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
 </ul>
 </li>
 [% END %]
-
-<li><label class="inline-text" for="closed_updates">[% loc('Closed to updates') %]:</label>
-    <input type="checkbox" id="closed_updates" name="closed_updates"[% ' checked' IF problem.extra.closed_updates %]></li>
-
 </ul>
-<input type="submit" class="btn" name="Submit changes" value="[% loc('Submit changes') %]">
+
+<div class="clearfix full-width" style="background-color: #eee; padding: 1em 1em 0;">
+  [% IF allowed_pages.user_edit %]
+    <p style="float:right"><a href="[% c.uri_for_action('/admin/users/edit', [ problem.user.id ]) %]">[% loc('Edit user') %]</a>
+  [% END %]
+
+<ul class="plain-list">
+<li><label class="inline-text" for="anonymous">[% loc('Anonymous:') %]</label>
+<select class="form-control" name="anonymous"  id="anonymous">
+<option [% 'selected ' IF problem.anonymous %]value="1">[% loc('Yes') %]</option>
+<option [% 'selected ' IF !problem.anonymous %]value="0">[% loc('No') %]</option>
+</select></li>
+<li><label class="inline-text" for="name">[% loc('Name:') %]</label>
+    [% loc('(for this report)') %]
+    <input type='text' class="form-control" name='name' id='name' value='[% problem.name | html %]'></li>
+
+<li><label class="inline-text" for="username">[% loc('User:') %]</label>
+    [% loc('(for this report)') %]
+    <input type='text' class="form-control" id='username' name='username' value='[% problem.user.username | html %]'>
+</li>
+
+[% IF problem.user.phone_display != problem.user.username %]
+<li>[% loc('Phone:') %] [% problem.user.phone_display OR loc('None') %]</li>
+[% END %]
+[% IF problem.user.email != problem.user.username %]
+<li>[% loc('Email:') %]
+[% IF problem.user.email %]<a href="mailto:[% problem.user.email | html %]">[% problem.user.email %]</a>[% ELSE %][% loc('None') %][% END %]
+</li>
+[% END %]
+</ul>
+</div>
+
+<p><input type="submit" class="btn btn--block btn--final" name="Submit changes" value="[% loc('Submit changes') %]">
 </form>
 
 </div>

--- a/templates/web/base/admin/update_edit.html
+++ b/templates/web/base/admin/update_edit.html
@@ -49,7 +49,7 @@
 [% ELSIF update.user.id == update.problem.user.id && update.mark_open %]
 <li>[% loc('Update reopened problem') %]</li>
 [% END %]
-[% PROCESS abuse_button %] [% PROCESS flag_button user=update.user %]</li>
+</li>
 <li>[% loc('Cobrand:') %] [% update.cobrand %]</li>
 <li>[% loc('Cobrand data:') %] [% update.cobrand_data %]</li>
 <li>[% loc('Created:') %] [% PROCESS format_time time=update.created %]</li>

--- a/templates/web/base/admin/update_edit.html
+++ b/templates/web/base/admin/update_edit.html
@@ -31,9 +31,14 @@
         <option [% 'selected ' IF state.0 == update.state %] value="[% state.0 %]">[% state.1 %]</option>
     [% END %]
 </select></li>
-<li><label for="name">[% loc('Name:') %]</label>
+<li><label class="inline-text" for="name">[% loc('Name:') %]</label>
+    [% loc('(for this update)') %]
     <input type='text' class="form-control" name='name' id='name' value='[% update.name | html %]'></li>
-<li><label for="username">[% loc('User:') %]</label>
+<li><label class="inline-text" for="username">[% loc('User:') %]</label>
+    [% loc('(for this update)') %]
+  [% IF allowed_pages.user_edit %]
+    &ndash; <a href="[% c.uri_for_action('admin/users/edit', [ update.user.id ]) %]">[% loc('Edit user') %]</a>
+  [% END %]
     <input type='text' class="form-control" id='username' name='username' value='[% update.user.username | html %]'>
 [%- IF update.user.from_body && update.user.from_body.id == update.problem.bodies_str %]
 [% ' (' _ tprintf(loc('user is from same council as problem - %d'), update.user.from_body.id ) _')' %]
@@ -51,7 +56,7 @@
 [% END %]
 </li>
 <li>[% loc('Cobrand:') %] [% update.cobrand %]</li>
-<li>[% loc('Cobrand data:') %] [% update.cobrand_data %]</li>
+<li>[% loc('Cobrand data:') %] [% update.cobrand_data OR loc('None') %]</li>
 <li>[% loc('Created:') %] [% PROCESS format_time time=update.created %]</li>
 [% IF update.get_extra_metadata('external_status_code') %]
 <li>[% loc('External status code:') %] [% update.get_extra_metadata('external_status_code') | html %]</li>

--- a/templates/web/base/admin/users/_form_details.html
+++ b/templates/web/base/admin/users/_form_details.html
@@ -25,9 +25,3 @@
 <input type='text' class="form-control" id='phone' name='phone' value='[% user.phone | html %]'></li>
 <li><label class="inline-text" for="phone_verified">[% loc('Phone verified:') %]</label>
 <input type="checkbox" id="phone_verified" name="phone_verified" value="1" [% user.phone_verified ? ' checked' : '' %]>
-
-[% IF username_in_abuse %]
-<li>
-    <p class="error">[% loc('User in abuse table') %] <input name="unban" type="submit" value="[% loc('Unban') %]"></p>
-</li>
-[% END %]

--- a/templates/web/base/admin/users/form.html
+++ b/templates/web/base/admin/users/form.html
@@ -9,6 +9,29 @@
     <ul class="no-bullets">
         [% PROCESS 'admin/users/_form_details.html' %]
 
+        <li>
+          <div class="admin-hint">
+            <p>
+              [% loc("Mark users whose behaviour you want to keep a check on as <strong>flagged</strong>.") %]
+              <br>
+              [% tprintf(loc("Flagged users are listed on the <a href='%s'>flagged</a> page."), c.uri_for_action( 'admin/flagged' )) %]
+              <br>
+              [% loc("You can add an abusive user's email to the abuse list, which automatically hides (and never sends) reports they create.") %]
+            </p>
+          </div>
+
+          <label>
+            [% loc('Flagged:') %]
+            <input type="checkbox" id="flagged" name="flagged"[% user.flagged ? ' checked' : '' %]>
+          </label>
+          [% IF username_in_abuse %]
+           <small>[% loc('User in abuse table') %]</small>
+           <input class="btn" name="unban" type="submit" value="[% loc('Unban') %]">
+          [% ELSE %]
+           <input type="submit" class="btn" name="banuser" value="[% loc('Ban user') %]">
+          [% END %]
+        </li>
+
       [% IF c.user.is_superuser %]
         <li>
           <div class="admin-hint">
@@ -86,23 +109,6 @@
           </label>
         </li>
       [% END %]
-
-        <li>
-          <div class="admin-hint">
-            <p>
-              [% loc("Mark users whose behaviour you want to keep a check on as <strong>flagged</strong>.") %]
-              <br>
-              [% tprintf(loc("Flagged users are listed on the <a href='%s'>flagged</a> page."), c.uri_for_action( 'admin/flagged' )) %]
-              <br>
-              [% loc("You can add an abusive user's email to the abuse list, which automatically hides (and never sends) reports they create.") %]
-            </p>
-          </div>
-
-          <label>
-            [% loc('Flagged:') %]
-            <input type="checkbox" id="flagged" name="flagged"[% user.flagged ? ' checked' : '' %]>
-          </label>
-        </li>
 
         [% IF c.user.is_superuser %]
           <li>

--- a/templates/web/zurich/admin/header.html
+++ b/templates/web/zurich/admin/header.html
@@ -7,6 +7,6 @@
     .active { background-color: #ffffee; cursor: pointer; }
     .error { color: red; }
     .overdue { background-color: #ffcccc; }
-    select { width: auto; }
+    select { width: auto; max-width: 100%; }
     .admin-report-edit select { max-width: 100%; }
 </style>


### PR DESCRIPTION
This moves the ban/flag buttons to the user edit admin, which seems a better place for them; and adds a link to the user admin from a report/update admin page. And tries to clarify that changing the name/user on a report/update changes it for that report/update, it isn't changing the user. And a fix to overflowing category dropdown when there are very long categories on report admin page.

Some of this has been done with inline styling that should be done properly, however that may be, help appreciated there :)