### PR TITLE
Banes housing layer restriction

### DIFF
--- a/.cypress/cypress/fixtures/banes-caro-group-housing-layer.json
+++ b/.cypress/cypress/fixtures/banes-caro-group-housing-layer.json
@@ -1,0 +1,56 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "ogc_fid": "24",
+        "lr_title": "AV10813",
+        "tenure": "Absolute Freehold",
+        "proprietor": "Somer Community Housing Trust",
+        "globalid": "{417311a0-e5c8-453c-96e0-e59500c3e0f7}",
+        "shape__are": "117.55656051600",
+        "shape__len": "51.68386469410",
+        "h_link": "\\\\somernt\\curo\\shared\\Curo Maps Docs\\Land Registry\\Documents\\AV10813.pdf",
+        "shape__a_1": "117.55656051600",
+        "shape__l_1": "51.68386469410",
+        "creationda": "2018-06-25",
+        "editdate": "2018-06-25",
+        "mi_style": "",
+        "mi_prinx": "4"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              375054.04,
+              164465.97,
+              0.0
+            ],
+            [
+              375128.71,
+              164465.61,
+              0.0
+            ],
+            [
+              375129.05,
+              164536.36,
+              0.0
+            ],
+            [
+              375054.38,
+              164536.72,
+              0.0
+            ],
+            [
+              375054.04,
+              164465.97,
+              0.0
+            ]
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/.cypress/cypress/integration/bathnes.js
+++ b/.cypress/cypress/integration/bathnes.js
@@ -27,3 +27,14 @@ it('loads the staff layer correctly', function() {
         expect(llpg).to.equal(1);
     });
 });
+
+it('uses the Curo Group housing layer correctly', function() {
+    cy.server();
+    cy.route(/.*?isharemaps.*?Curo_Land_Registry.*/, 'fixture:banes-caro-group-housing-layer.json').as('banes-caro-group-housing-layer-tilma');
+    cy.route('/report/new/ajax*').as('report-ajax');
+    cy.visit('http://bathnes.localhost:3001/report/new?longitude=-2.359276&latitude=51.379009');
+    cy.contains('Bath & North East Somerset Council');
+    cy.wait('@banes-caro-group-housing-layer-tilma');
+    cy.pickCategory('Dog fouling');
+    cy.contains('Maintained by Curo Group').should('be.visible');
+});

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -116,6 +116,7 @@ if ($opt->test_fixtures) {
         { area_id => 2566, categories => [ 'Fallen branch', 'Light Out', 'Light Dim', 'Fallen Tree', 'Damaged Tree', 'Pothole' ], name => 'Peterborough City Council' },
         { area_id => 2498, categories => [ 'Incorrect timetable', 'Glass broken', 'Mobile Crane Operation', 'Roadworks' ], name => 'TfL' },
         { area_id => 2237, categories => [ 'Flytipping', 'Roads', 'Parks' ], name => 'Oxfordshire County Council' },
+        { area_id => 2551, categories => [ 'Dog fouling' ], name => 'Bath and North East Somerset Council' }
     ) {
         $bodies->{$_->{area_id}} = FixMyStreet::DB::Factory::Body->find_or_create($_);
         my $cats = join(', ', @{$_->{categories}});

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -61,6 +61,7 @@ my @PLACES = (
     [ 'OX28 4DS', 51.784721, -1.494453 ],
     [ 'E14 2DN', 51.508536, '0.000001' ],
     [ '?', 52.51093, -1.86514, 11809, 'West Midlands', 'EUR' ],
+    [ '?', 51.379009, -2.359276, 2551, 'Bath and North East Somerset Council', 'UTA' ],
     # Norway
     [ '3290', 59, 10, 709, 'Larvik', 'NKO', 7, 'Vestfold', 'NFY' ],
     [ '0045', "59.9", "10.9", 301, 'Oslo', 'NKO', 3, 'Oslo', 'NFY' ],

--- a/templates/web/bathnes/report/new/roads_message.html
+++ b/templates/web/bathnes/report/new/roads_message.html
@@ -4,4 +4,11 @@
         <p>The location you have selected doesn't appear to be on <span class="js-roads-asset" data-original="a road">a road</span> that Bath &amp; North East Somerset Council maintain.</p>
         <p>Please select <span class="js-roads-asset" data-original="a road">a road</span> on which to make a report.</p>
     </div>
+
+    <div id="js-curo-group-restriction" class="js-responsibility-message hidden">
+        <strong>Maintained by Curo Group</strong>
+        <p>The location you have selected is maintained by Curo Group.</p>
+        <p>You can report this issue to Curo Group directly by emailing <span class="js-roads-asset"></span>.</p>
+    </div>
+
 </div>

--- a/templates/web/fixmystreet.com/report/new/roads_message.html
+++ b/templates/web/fixmystreet.com/report/new/roads_message.html
@@ -19,4 +19,9 @@
     <div id="js-not-an-asset" class="hidden js-responsibility-message">
         <p>Please select <span class="js-roads-asset" data-original="an item">an item</span> from the map on which to make a report.</p>
     </div>
+    <div id="js-curo-group-restriction" class="js-responsibility-message hidden">
+        <strong>Maintained by Curo Group</strong>
+        <p>The location you have selected is maintained by Curo Group.</p>
+        <p>You can report this issue to Curo Group directly by emailing <span class="js-roads-asset"></span>.</p>
+    </div>
 </div>

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -1215,8 +1215,11 @@ fixmystreet.message_controller = (function() {
         }
     }
 
-    // This shows the reporting form
+    // Show the reporting form, unless the road responsibility message is visible.
     function enable_report_form() {
+        if ( $('#js-roads-responsibility').is(':visible') ) {
+            return;
+        }
         $('.js-reporting-page--next').prop('disabled', false);
         $("#mob_ok, #toggle-fullscreen").removeClass('hidden-js');
     }
@@ -1301,9 +1304,7 @@ fixmystreet.message_controller = (function() {
         var matching = $.grep(stoppers, is_matching_stopper);
         if (!matching.length) {
             $id.remove();
-            if ( !$('#js-roads-responsibility').is(':visible') ) {
-                enable_report_form();
-            }
+            enable_report_form();
             return;
         }
 


### PR DESCRIPTION
Adds a new asset layer containing housing association information. When a pin is dropped onto one of these housing association areas and it's in the category whitelist a warning message will be shown telling the user to email the housing association instead.

Part of https://github.com/mysociety/fixmystreet-commercial/issues/2051

<!-- [skip changelog] -->