### PR TITLE
Move emergency-banner.html include out of pre-steps.html

### DIFF
--- a/templates/web/base/front/pre-steps.html
+++ b/templates/web/base/front/pre-steps.html
@@ -1,1 +1,0 @@
-[% TRY %][% PROCESS 'front/emergency-message.html' %][% CATCH file %][% END %]

--- a/templates/web/base/index.html
+++ b/templates/web/base/index.html
@@ -6,6 +6,8 @@
     <p class="form-error">[% error %]</p>
 [% END %]
 
+[% TRY %][% PROCESS 'front/emergency-message.html' %][% CATCH file %][% END %]
+
 [% TRY %][% PROCESS 'front/pre-steps.html' %][% CATCH file %][% END %]
 
 <div class="tablewrapper">


### PR DESCRIPTION
I originally put it in pre-steps.html so that cobrands that already had
a banner wouldn't also show the emergency message. The idea being that
we'd migrate the existing emergency banners over.

However we've had a support ticket from Bucks saying that they've tried
to set an emergency message but of course it isn't showing because
they've already got a custom pre-steps.html with a banner in.

I think it's going to be easier to show both the existing banners and
the new emergency message banner. Then if it seems necessary we can
migrate the custom banners into the new emergency banner system
gradually over time, rather than having to do it all at once.

Related to https://github.com/mysociety/fixmystreet-commercial/issues/2071

<!-- [skip changelog] -->