### PR TITLE
[Buckinghamshire] Migrate emergency banner to new system

### DIFF
--- a/templates/web/buckinghamshire/front/pre-steps.html
+++ b/templates/web/buckinghamshire/front/pre-steps.html
@@ -1,7 +1,0 @@
-<p style="margin: 1em -20px; padding: 20px; background-color: #f79f73; color: #000;">
-In light of the ongoing COVID 19 crisis an element of TfB workforce has reduced
-by the need for self-isolation. This regrettably means that for the immediate
-future some work will have to be delayed. We apologise for any possible delay
-in addressing your report and hope that you will understand in the
-circumstances.
-</p>

--- a/web/cobrands/buckinghamshire/base.scss
+++ b/web/cobrands/buckinghamshire/base.scss
@@ -153,3 +153,10 @@ label {
     color: $bucks_warning;
   }
 }
+
+.emergency-message {
+  margin: 1em -20px;
+  background-color: #f79f73;
+  color: #000;
+  border: none;
+}

--- a/web/cobrands/buckinghamshire/layout.scss
+++ b/web/cobrands/buckinghamshire/layout.scss
@@ -163,3 +163,8 @@ body.mappage {
 body, .content {
   color: $g1;
 }
+
+.emergency-message {
+  font-size: 1em;
+  padding: 20px;
+}


### PR DESCRIPTION
This migrates the Buckinghamshire emergency banner over to the new system that allows them to update the content of the banner.

I've already added the text from the banner in the admin, so this should work when it's put live.

Should fix https://github.com/mysociety/fixmystreet-commercial/issues/2071

<!-- [skip changelog] -->