### PR TITLE
[Highways England] Disable contact form & point links to HE site

### DIFF
--- a/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
+++ b/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
@@ -4,6 +4,8 @@ use parent 'FixMyStreet::Cobrand::UK';
 use strict;
 use warnings;
 
+sub council_name { 'Highways England' }
+
 sub council_url { 'highwaysengland' }
 
 sub site_key { 'highwaysengland' }
@@ -28,6 +30,8 @@ sub problems_sql_restriction { FixMyStreet::Cobrand::UKCouncils::problems_sql_re
 sub users_restriction { FixMyStreet::Cobrand::UKCouncils::users_restriction($_[0], $_[1]) }
 sub updates_restriction { FixMyStreet::Cobrand::UKCouncils::updates_restriction($_[0], $_[1]) }
 sub base_url { FixMyStreet::Cobrand::UKCouncils::base_url($_[0]) }
+sub contact_name { FixMyStreet::Cobrand::UKCouncils::contact_name($_[0]) }
+sub contact_email { FixMyStreet::Cobrand::UKCouncils::contact_email($_[0]) }
 
 sub munge_problem_list {
     my ($self, $problem) = @_;
@@ -87,6 +91,8 @@ sub allow_photo_upload { 0 }
 sub allow_anonymous_reports { 'button' }
 
 sub admin_user_domain { 'highwaysengland.co.uk' }
+
+sub abuse_reports_only { 1 }
 
 sub anonymous_account {
     my $self = shift;

--- a/templates/web/highwaysengland/about/_sidebar.html
+++ b/templates/web/highwaysengland/about/_sidebar.html
@@ -1,0 +1,15 @@
+<div class="sticky-sidebar">
+    <aside>
+        <ul class="plain-list">
+            <li>[% INCLUDE link h='/faq' t=loc('Frequently Asked Questions') %]</li>
+            <li>[% INCLUDE link h=c.cobrand.privacy_policy_url t=loc('Privacy and cookies') %]</li>
+            <li>[% INCLUDE link h='https://highwaysengland.co.uk/about-us/contact-us/' t="Contact us" %]</li>
+        </ul>
+    </aside>
+</div>
+
+[% BLOCK link -%]
+<[% IF c.req.uri.path == h %]strong[% ELSE %]a href="[% h %]"[% END %]>
+[%- t -%]
+</[% IF c.req.uri.path == h %]strong[% ELSE %]a[% END %]>
+[%- END %]

--- a/templates/web/highwaysengland/about/faq-en-gb.html
+++ b/templates/web/highwaysengland/about/faq-en-gb.html
@@ -21,7 +21,6 @@ cleaning</strong> or <strong>clearing</strong>.
 <ul>
     <li>Urgent and emergency problems</li>
     <li>Complaints about people, including anti-social behaviour</li>
-    <li>Issues with council services, such as bins and recycling</li>
     <li>Proposals for change, eg to road layouts</li>
     <li>Complaints about [% c.cobrand.council_name %]</li>
 </ul>
@@ -71,7 +70,7 @@ cleaning</strong> or <strong>clearing</strong>.
 <dd>
 <p>
     Begin by entering the location of your issue <a href="/">on the front
-    page</a>. You can use the name of a street, area, a place or a postcode —
+    page</a>. You can use the name of a motorway, area, a place or a postcode —
     or you can click “use my location” which will automatically detect where
     you are.
 </p>
@@ -87,29 +86,6 @@ cleaning</strong> or <strong>clearing</strong>.
 </p>
 <p>
     You’ll then be asked to fill in a few details.
-</p>
-</dd>
-
-<dt>Do I have to be a [% c.cobrand.council_name %] resident to use this site?</dt>
-
-<dd>
-<p>
-    No — anyone can use this site.
-</p>
-</dd>
-
-<dt>Do I need to make an account to use this site?</dt>
-
-<dd>
-<p>
-    No; if you wish to see previous reports you have made, you can sign in by
-    clicking ‘Sign in’ and then either have a link sent to your email, sign in
-    with a previously set password, or set a password using the ‘create an
-    account’ link.
-</p>
-<p>
-    If you already have an account on fixmystreet.com, you can use the same
-    details on this site.
 </p>
 </dd>
 
@@ -135,9 +111,8 @@ cleaning</strong> or <strong>clearing</strong>.
 
 <dd>
 <p>
-    When there’s a change in your report’s status, and where you have provided
-    your email address, you’ll receive an update. This might tell you, for
-    example, that:
+    When there’s a change in your report’s status, an update will be left on
+    the report on the site. This might tell you, for example, that:
 </p>
 
 <ul>
@@ -147,10 +122,6 @@ cleaning</strong> or <strong>clearing</strong>.
     <li>The issue has been deemed unsuitable for fixing (as happens in some cases)</li>
 </ul>
 
-<p>
-    These updates are also published on the site so that everyone can see what
-    progress has been made.
-</p>
 </dd>
 
 <dt>Can I use this site on my smartphone or tablet?</dt>
@@ -176,60 +147,11 @@ cleaning</strong> or <strong>clearing</strong>.
 </p>
 </dd>
 
-<dt>What else can I do on this site?</dt>
-
-<dd>
+<dt>Can I make updates to my report?</dt>
 <p>
-    You can subscribe to a specific area, so you’ll get an email whenever
-    someone makes a report in your chosen neighbourhood.
+    Yes, you can leave updates on open reports, by visiting a report page and
+    filling in the update form.
 </p>
-<p>
-    Search for a location, and then click ‘get updates’ at the bottom of the
-    list of reports.
-</p>
-<p>
-    If you run a website and you’d like to publish reports automatically from a
-    specific area, you can also access an RSS feed from the ‘get updates’
-    interface.
-</p>
-</dd>
-
-<dt>Can I edit or delete a report?</dt>
-
-<dd>
-<p>
-    You can remove your name from a report if you have included it by accident,
-    or changed your mind about it being published. Visit the report page when
-    signed in and click on the link marked ‘hide your name?’.
-</p>
-<p>
-    You’ll then have the option to remove your name from one report or every
-    report you’ve made.
-</p>
-<p>
-    If you’d like to edit some other part of your report, please get in touch.
-</p>
-</dd>
-
-[% IF c.cobrand.feature('updates_allowed') == 'open' %]
-    <dt>Can I make updates to my report?</dt>
-    <p>
-        Yes, you can leave updates on open reports, by visiting a report page and
-        filling in the update form.
-    </p>
-[% ELSIF c.cobrand.feature('updates_allowed') == 'reporter-open' %]
-    <dt>Can I make updates to my report?</dt>
-    <p>
-        Yes, you can leave updates on open reports you have made, by visiting a
-        report page and filling in the update form.
-    </p>
-[% ELSIF c.cobrand.feature('updates_allowed') == 'reporter' %]
-    <dt>Can I make updates to my report?</dt>
-    <p>
-        Yes, you can leave updates on reports you have made, by visiting a report
-        page and filling in the update form.
-    </p>
-[% END %]
 
 <dt>Do you remove content from this site?</dt>
 

--- a/templates/web/highwaysengland/about/privacy.html
+++ b/templates/web/highwaysengland/about/privacy.html
@@ -1,0 +1,229 @@
+[% INCLUDE 'header.html',
+    title = 'Privacy policy',
+    bodyclass = 'twothirdswidthpage' %]
+
+[% INCLUDE 'about/_sidebar.html' %]
+
+<h1>Privacy policy</h1>
+
+<h2>Who runs this service?</h2>
+
+<p>
+    This site is a service provided to [% c.cobrand.council_name %] by
+    <a href="https://www.societyworks.org/">SocietyWorks Ltd</a>, a limited
+    company (05798215). SocietyWorks is a trading subsidiary of mySociety, a
+    registered charity in England and Wales (1076346), who also run the
+    national <a href="https://www.fixmystreet.com/">fixmystreet.com</a> website
+    with which this site is linked. Henceforth this privacy policy will refer
+    to mySociety.
+</p>
+
+<p>
+    Reports made on this site also appear on fixmystreet.com, and vice versa.
+    These reports and the associated user data are stored in a single database
+    which is hosted by mySociety. They are accessible to mySociety and
+    [% c.cobrand.council_name %] administrators.
+</p>
+
+<h2>What information we collect and how we use it</h2>
+
+<h3>
+When you make a report or update
+</h3>
+
+<p>
+    Details of the issue are routed directly to the contact or contacts
+    responsible for fixing it, based on its location. Your report or update
+    appears publicly on both this site and on fixmystreet.com.
+</p>
+
+<p>
+    FixMyStreet provides RSS/JSON feeds, accessible from both fixmystreet.com
+    and this site, which allow anyone to publish reports on their own website
+    or page. Typically these feeds consist of reports made within a specific
+    local area, and are published on community or local interest sites.
+</p>
+
+<p>
+    <strong>Note that</strong> anything you include in the body of your report
+    will be published in one or all of the places listed above, so
+    <strong>please take care to keep personal information such as your contact
+        details to the correct fields</strong>.
+</p>
+
+<p>
+    Data are accessible only to mySociety’s administrators, who adhere to
+    strict data-handling policies, and to [% c.cobrand.council_name %] staff,
+    who abide by their own data-handling and security policies.
+</p>
+
+<h3>
+    When you contact the support team
+</h3>
+
+<p>
+    Your message will be accessible to [% c.cobrand.council_name %]’s support
+    staff, who adhere to our data-handling and security policies. If your issue
+    is about the use or functions of FixMyStreet, it may be passed to
+    mySociety’s support staff (including personal details, such as name and
+    email address, in order to help troubleshoot issues), whose privacy policy
+    <a href="https://www.fixmystreet.com/about/privacy">can be seen here</a>.
+</p>
+
+<p>
+    <b>Your personal information is never shared, or used for purposes other than those
+    listed above, unless we are obliged to by law.</b>
+</p>
+
+<h2>
+    Research
+</h2>
+
+<p>
+    mySociety sometimes use report data, or share it with trusted third
+    parties, for research. This data is completely anonymised and contains
+    <strong>no identifying details</strong> such as names, email addresses or
+    the content of reports. mySociety’s Research Data Release policy may be
+    seen <a href="mailto:research@mysociety.org">on request to them</a>.
+</p>
+
+<h2>
+    Legal basis for processing
+</h2>
+
+<p>
+    In using FixMyStreet for any of the functions listed above (sending a
+    report, leaving an update, email alerts or site registration), your data is
+    processed by both [% c.cobrand.council_name %] and mySociety.
+</p>
+<p>
+    [% c.cobrand.council_name %] is the data controller and mySociety is a data
+    processor.
+</p>
+<p>
+    Your data is processed by [% c.cobrand.council_name %] under the legal
+    basis 6(1)(e) – <strong>public task</strong>. [% c.cobrand.council_name %]
+    asserts that the processing of users’ personal information is necessary for
+    us to perform a task in the public interest or for our official functions,
+    and the task or function has a clear basis in law. Our obligation to keep
+    highways in good order and to keep public areas safe and functional are set
+    in law.
+</p>
+
+<p>
+    mySociety also runs a service called FixMyStreet. If you report a problem
+    that [% c.cobrand.council_name %] is responsible for directly on
+    FixMyStreet, rather than this site, mySociety will share your report (and
+    personal details if provided) with us.
+</p>
+
+<p>
+    This sharing is in accordance with the FixMyStreet
+    <a href="https://www.fixmystreet.com/faq">terms of service</a> and their
+    <a href="https://www.fixmystreet.com/about/privacy">privacy statement</a>.
+    When [% c.cobrand.council_name %] receives this information we will hold it
+    as explained on this page.
+</p>
+
+<h2>
+    Retention periods and your right to removal
+</h2>
+
+<h3>
+    Reports and updates
+</h3>
+
+<p>
+    Except in exceptional circumstances, reports or updates made through this site
+    or FixMyStreet are not deleted. Historic reports provide an invaluable resource for
+    researchers into the quantity and type of street problems made across the UK during
+    the years the site has been running. This research can help inform civic planners,
+    developers, coders, historians and social scientists, among others.
+</p>
+
+<p>
+    Therefore, <b>if you ask for a report to be removed, in most cases you will instead be
+    invited to anonymise it</b>, so that there is no public connection between the content and
+    your name. You can anonymise reports singly, or in bulk, by logging in to your account
+    on either this site or on fixmystreet.com and clicking on the ‘“Hide your
+    name” link beside the time and date of your report. From here you may
+    anonymise this report or all reports you have made.
+</p>
+
+<p>
+    If you do not already have an account, it is simple to register, and once
+    you have done so you will have access to all the reports you have made
+    under that email address.
+</p>
+
+<p>
+    Changes you make to your reports will apply immediately on this site, on
+    fixmystreet.com and will also be reflected, sometimes with a delay,
+    anywhere else they appear (see “What information we collect and how we use
+    it”, above, for more details about where reports are published). If you do
+    not see the changes, please ‘hard refresh’ your browser by eg pressing the
+    Ctrl and F5 keys simultaneously.
+</p>
+
+<p>
+    Search engines such as Google often take a little time to reflect changes
+    to content, but anonymising your report should also remove your name from
+    their search results once the pages have been recrawled by their robots.
+</p>
+
+<h2>
+    Your right to object
+</h2>
+<p>
+    The General Data Protection Regulation gives you the right to object to our
+    processing of your personal information and to ask us to stop processing it.
+    However, it also gives us the right to continue to process it if we can demonstrate
+    compelling legitimate grounds for the processing that override your interests, rights
+    and freedoms. To exercise your right to object, you can <a href="/contact">
+    contact us</a>, giving specific reasons why you are objecting to the processing of
+    your personal data. These reasons should be based upon your particular situation.
+</p>
+
+<h2>
+    Your right to access
+</h2>
+
+<p>
+    You may <a href="/contact">contact us</a> at any time to ask to see what
+    personal data we hold about you.
+</p>
+
+<h2>
+    Your right to complain
+</h2>
+
+<p>
+    If you believe that we have mishandled your data, you have the right to
+    lodge a complaint with the Information Commissioner’s Office.
+    <a href="https://ico.org.uk/concerns/handling/">You can report a concern here</a>
+    (but do contact us first, so that we can try and help).
+</p>
+
+<h2 id="cookies">Cookies</h2>
+
+<p>To make our service easier or more useful, we sometimes place small data
+files on your computer or mobile phone, known as cookies; many websites do
+this. We use this information to, for example, remember you have logged in so
+you don’t need to do that on every page, or to measure how people use the
+website so we can improve it and make sure it works properly. Below, we list
+the cookies and services that this site can use.
+
+<table class="nicetable">
+    <tr>
+        <th scope="col">Name</th>
+        <th scope="col">Typical Content</th>
+        <th scope="col">Expires</th>
+    </tr>
+    <tr>
+        <td>fixmystreet_app_session</td>
+        <td nowrap>A random unique identifier</td>
+        <td>When browser is closed</td>
+    </tr>
+</table>
+
+[% INCLUDE 'footer.html' pagefooter = 'yes' %]


### PR DESCRIPTION
 - Remove links from help pages to /contact
 - Switch on abuse_reports_only
 - Respect contact_email cobrand feature instead of global CONTACT_EMAIL

[skip changelog]