### PR TITLE
Open311 JSON fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
         - Fix non-JS form when all extra questions answered. #3248
         - Improve display of disabled fields in iOS.
         - Use div for inspector form wrapped extra questions. #3250
+        - Fix Open311 JSON services output. #3279
     - Admin improvements:
         - Enable per-category hint customisation.
         - Move ban/unban buttons to user edit admin page.

--- a/perllib/FixMyStreet/App/Controller/Open311.pm
+++ b/perllib/FixMyStreet/App/Controller/Open311.pm
@@ -109,40 +109,25 @@ sub get_discovery : Private {
     my $spec_url = 'http://wiki.open311.org/GeoReport_v2';
     my $info =
     {
-        'contact' => ["Send email to $contact_email."],
-        'changeset' => [$prod_changeset],
-        'max_requests' => [ $c->config->{OPEN311_LIMIT} || 1000 ],
+        'contact' => "Send email to $contact_email.",
+        'changeset' => $prod_changeset,
+        'max_requests' => $c->config->{OPEN311_LIMIT} || 1000,
         'endpoints' => [
             {
-                'endpoint' => [
-                    {
-                        'formats' => [
-                            {'format' => [ 'text/xml',
-                                           'application/json',
-                                           'text/html' ]
-                            }
-                            ],
-                        'specification' => [ $spec_url ],
-                        'changeset' => [ $prod_changeset ],
-                        'url' => [ $prod_url ],
-                        'type' => [ 'production' ]
-                    },
-                    {
-                        'formats' => [
-                            {
-                                'format' => [ 'text/xml',
-                                              'application/json',
-                                              'text/html' ]
-                            }
-                            ],
-                        'specification' => [ $spec_url ],
-                        'changeset' => [ $test_changeset ],
-                        'url' => [ $test_url ],
-                        'type' => [ 'test' ]
-                    }
-                    ]
+                'formats' => [ 'text/xml', 'application/json', 'text/html' ],
+                'specification' => $spec_url,
+                'changeset' => $prod_changeset,
+                'url' => $prod_url,
+                'type' => 'production'
+            },
+            {
+                'formats' => [ 'text/xml', 'application/json', 'text/html' ],
+                'specification' => $spec_url,
+                'changeset' => $test_changeset,
+                'url' => $test_url,
+                'type' => 'test'
             }
-            ]
+        ]
     };
     $c->forward( 'format_output', [ {
         'discovery' => $info
@@ -182,13 +167,13 @@ sub get_services : Private {
              {
                  # FIXME Open311 v2 seem to require all three, and we
                  # only have one value.
-                 'service_name' => [ $categoryname ],
-                 'description' =>  [ $categoryname ],
-                 'service_code' => [ $categoryname ],
-                 'metadata' => [ 'false' ],
-                 'type' => [ 'realtime' ],
-#                 'group' => [ '' ],
-#                 'keywords' => [ '' ],
+                 'service_name' => $categoryname,
+                 'description' => $categoryname,
+                 'service_code' => $categoryname,
+                 'metadata' => 'false',
+                 'type' => 'realtime',
+#                 'group' => '',
+#                 'keywords' => '',
              }
             );
     }
@@ -422,6 +407,8 @@ sub format_output : Private {
             service_requests => 'request',
             errors => 'error',
             service_request_updates => 'request_update',
+            endpoints => 'endpoint',
+            formats => 'format',
         };
         $c->res->body( XMLout($hashref,
             KeyAttr => {},

--- a/t/app/controller/open311.t
+++ b/t/app/controller/open311.t
@@ -2,18 +2,25 @@ use JSON::MaybeXS;
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;
 
-# Check old .cgi links redirect correctly
-$mech->get_ok('/open311.cgi/v2/requests.rss?jurisdiction_id=fiksgatami.no&status=open&agency_responsible=1854');
-like $mech->uri, qr[/open311/v2/requests\.rss\?.{65}]; # Don't know order parameters will be in now
+my $body = $mech->create_body_ok(2237 => 'Oxfordshire');
+my $body_id = $body->id;
+$mech->create_contact_ok(body_id => $body_id, category => 'Open doors', email => 'OD');
 
-my ($problem1, $problem2) = $mech->create_problems_for_body(2, 2237, 'Around page');
-$mech->get_ok('/open311/v2/requests.xml?jurisdiction_id=foo&status=open&agency_responsible=2237');
-$mech->content_contains('<description>Around page Test 2 for 2237: Around page Test 2 for 2237 Detail</description>');
+my ($problem1, $problem2) = $mech->create_problems_for_body(2, $body_id, 'Around page');
+$mech->get_ok('/open311/v2/requests.xml?jurisdiction_id=foo&status=open&agency_responsible=' . $body_id);
+$mech->content_contains("<description>Around page Test 2 for $body_id: Around page Test 2 for $body_id Detail</description>");
 $mech->content_contains('<interface_used>Web interface</interface_used>');
 $mech->content_contains('<status>open</status>');
 
-$mech->get_ok('/open311/v2/requests.json?jurisdiction_id=foo&status=open&agency_responsible=2237');
-my $json = decode_json($mech->content);
+$mech->get_ok('/open311/v2/discovery.xml');
+
+$mech->get_ok('/open311/v2/services.xml?jurisdiction_id=foo');
+$mech->content_contains('<service_name>Open doors</service_name>');
+
+my $json = $mech->get_ok_json('/open311/v2/services.json?jurisdiction_id=foo');
+is $json->{services}[0]{service_name}, 'Open doors';
+
+$json = $mech->get_ok_json('/open311/v2/requests.json?jurisdiction_id=foo&status=open&agency_responsible=' . $body_id);
 my $problems = $json->{service_requests};
 is @$problems, 2;
 like $problems->[0]{description}, qr/Around page Test/;
@@ -23,16 +30,14 @@ subtest "non_public reports aren't available" => sub {
         non_public => 1,
         detail => 'This report is now private',
     });
-    $mech->get_ok('/open311/v2/requests.json?jurisdiction_id=foo');
-    $json = decode_json($mech->content);
+    $json = $mech->get_ok_json('/open311/v2/requests.json?jurisdiction_id=foo');
     $problems = $json->{service_requests};
     is @$problems, 1;
     like $problems->[0]{description}, qr/Around page Test/;
     $mech->content_lacks('This report is now private');
 
     my $problem_id = $problem1->id;
-    $mech->get_ok("/open311/v2/requests/$problem_id.json?jurisdiction_id=foo");
-    $json = decode_json($mech->content);
+    $json = $mech->get_ok_json("/open311/v2/requests/$problem_id.json?jurisdiction_id=foo");
     $problems = $json->{service_requests};
     is @$problems, 0;
 };
@@ -43,16 +48,14 @@ subtest "hidden reports aren't available" => sub {
         detail => 'This report is now hidden',
         state => "hidden",
     });
-    $mech->get_ok('/open311/v2/requests.json?jurisdiction_id=foo');
-    $json = decode_json($mech->content);
+    $json = $mech->get_ok_json('/open311/v2/requests.json?jurisdiction_id=foo');
     $problems = $json->{service_requests};
     is @$problems, 1;
     like $problems->[0]{description}, qr/Around page Test/;
     $mech->content_lacks('This report is now hidden');
 
     my $problem_id = $problem1->id;
-    $mech->get_ok("/open311/v2/requests/$problem_id.json?jurisdiction_id=foo");
-    $json = decode_json($mech->content);
+    $json = $mech->get_ok_json("/open311/v2/requests/$problem_id.json?jurisdiction_id=foo");
     $problems = $json->{service_requests};
     is @$problems, 0;
 };

--- a/templates/web/base/open311/index.html
+++ b/templates/web/base/open311/index.html
@@ -71,6 +71,7 @@ for council problem-reporting systems.</p>
 <ul>
 <li><a rel="nofollow" href="http://www.open311.org/">[% loc('Open311 initiative web page') %]</a></li>
 <li><a rel="nofollow" href="http://wiki.open311.org/GeoReport_v2">[% loc('Open311 specification') %]</a></li>
+<li><a href="https://github.com/mysociety/fixmystreet/wiki/Open311-FMS---Complete-Spec">Open311 specification, with mySociety additions</a></li>
 </ul>
 
 <p>[% tprintf( loc('At most %d requests are returned in each query.  The returned requests are ordered by requested_datetime, so to get all requests, do several searches with rolling start_date and end_date.'), c.config.OPEN311_LIMIT ) %]</p>
@@ -90,41 +91,41 @@ for council problem-reporting systems.</p>
 [% jurisdiction_id = c.cobrand.jurisdiction_id_example %]
 [% examples = [
     {
-        url = c.cobrand.base_url _ "/open311/v2/discovery.xml?jurisdiction_id=$jurisdiction_id",
+        url = "/open311/v2/discovery.xml?jurisdiction_id=$jurisdiction_id",
         info = 'discovery information',
     },
     {
-        url = c.cobrand.base_url _ "/open311/v2/services.xml?jurisdiction_id=$jurisdiction_id",
+        url = "/open311/v2/services.xml?jurisdiction_id=$jurisdiction_id",
         info = 'list of services provided',
     },
     {
-        url = c.cobrand.base_url _ "/open311/v2/services.xml?jurisdiction_id=$jurisdiction_id&lat=60&long=11",
+        url = "/open311/v2/services.xml?jurisdiction_id=$jurisdiction_id&lat=60&long=11",
         info = 'list of services provided for WGS84 coordinate latitude 60 longitude 11',
     },
     {
-        url = c.cobrand.base_url _ "/open311/v2/requests/1.xml?jurisdiction_id=$jurisdiction_id",
+        url = "/open311/v2/requests/1.xml?jurisdiction_id=$jurisdiction_id",
         info = 'Request number 1',
     },
     {
-        url = c.cobrand.base_url _ "/open311/v2/requests.xml?jurisdiction_id=$jurisdiction_id&status=open&agency_responsible=1601&end_date=2011-03-10",
+        url = "/open311/v2/requests.xml?jurisdiction_id=$jurisdiction_id&status=open&agency_responsible=1601&end_date=2011-03-10",
         info = 'All open requests reported before 2011-03-10 to Trondheim (id 1601)',
     },
     {
-        url = c.cobrand.base_url _ "/open311/v2/requests.xml?jurisdiction_id=$jurisdiction_id&status=open&agency_responsible=219|220",
+        url = "/open311/v2/requests.xml?jurisdiction_id=$jurisdiction_id&status=open&agency_responsible=219|220",
         info = 'All open requests in Asker (id 220) and Bærum (id 219)',
     },
     {
-        url = c.cobrand.base_url _ "/open311/v2/requests.xml?jurisdiction_id=$jurisdiction_id&service_code=Vannforsyning",
+        url = "/open311/v2/requests.xml?jurisdiction_id=$jurisdiction_id&service_code=Vannforsyning",
         info = "All requests with the category 'Vannforsyning'",
     },
     {
-        url = c.cobrand.base_url _ "/open311/v2/requests.xml?jurisdiction_id=$jurisdiction_id&status=closed",
+        url = "/open311/v2/requests.xml?jurisdiction_id=$jurisdiction_id&status=closed",
         info = 'All closed requests',
     },
 ] %]
 [% FOREACH examples %]
-    <li><a href="[% url %]">[% info %]</a>
-    <br>[% url | html %]</li>
+    <li>[% info %]: <a href="[% url %]">XML</a> or <a href="[% url.replace('xml', 'json') %]">JSON</a>
+    <br>[% url.replace('xml', '<i>format</i>') | safe %]</li>
 [% END %]
 
 </ul>


### PR DESCRIPTION
Stop the JSON output using arrays where not needed (was fixed for requests back in 2017, looks like, but this was missed), and also include JSON links on the index page.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/2106
