### PR TITLE
[Hackney] Send email on noise update

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Noise.pm
+++ b/perllib/FixMyStreet/App/Controller/Noise.pm
@@ -203,6 +203,21 @@ EOF
 
     if ($c->stash->{report}) {
         $c->forward('/report/new/create_related_things');
+    } else {
+        # Send alert email, like would be sent for report
+        my $recipient = $c->cobrand->noise_destination_email($object->problem, $c->cobrand->council_name);
+        $c->send_email('alert-update.txt', {
+            to => $recipient,
+            report => $object->problem,
+            cobrand => $c->cobrand,
+            problem_url => $c->cobrand->base_url . $object->problem->url,
+            data => [ {
+                item_photo => $object->photo,
+                item_text => $object->text,
+                item_name => $object->name,
+                item_anonymous => $object->anonymous,
+            } ],
+        });
     }
 
     return 1;

--- a/perllib/FixMyStreet/Template.pm
+++ b/perllib/FixMyStreet/Template.pm
@@ -39,6 +39,10 @@ sub Filter : ATTR(CODE,BEGIN) {
     add_attr(\%FILTERS, $_[1], $_[2], $_[4]);
 }
 
+sub FilterFactory : ATTR(CODE,BEGIN) {
+    add_attr(\%FILTERS, $_[1], [ $_[2], 1 ], $_[4]);
+}
+
 sub Fn : ATTR(CODE,BEGIN) {
     add_attr(\%SUBS, $_[1], $_[2], $_[4]);
 }
@@ -140,6 +144,16 @@ sub html_paragraph : Filter('html_para') {
     s/\r?\n/<br>\n/g for @paras;
     $text = "<p>\n" . join("\n</p>\n\n<p>\n", @paras) . "</p>\n";
     return FixMyStreet::Template::SafeString->new($text);
+}
+
+sub html_paragraph_email_factory : FilterFactory('html_para_email') {
+    my ($c, $style) = @_;
+    return sub {
+        my $text = shift;
+        $text = html_paragraph($text);
+        $text =~ s/<p>/<p style="$style">/g;
+        return FixMyStreet::Template::SafeString->new($text);
+    }
 }
 
 sub sanitize {

--- a/t/app/controller/noise.t
+++ b/t/app/controller/noise.t
@@ -85,9 +85,9 @@ FixMyStreet::override_config {
         is $report->title, "Noise report";
         is $report->detail, "Kind of noise: music\nNoise details: Details\n\nWhere is the noise coming from? residence\nNoise source: 100000333\n\nIs the noise happening now? Yes\nDoes the time of the noise follow a pattern? Yes\nWhat days does the noise happen? monday, thursday\nWhat time does the noise happen? morning, evening\n";
         is $report->latitude, 53;
+        $mech->clear_emails_ok;
     };
     subtest 'Report new noise, no pattern to times' => sub {
-        $mech->clear_emails_ok;
         $mech->get_ok('/noise');
         $mech->submit_form_ok({ button => 'start' });
         $mech->submit_form_ok({ with_fields => { existing => 0 } });
@@ -126,6 +126,7 @@ FixMyStreet::override_config {
         is $report->title, "Noise report";
         is $report->detail, "Kind of noise: road\nNoise details: Details\n\nWhere is the noise coming from? residence\nNoise source: 100000333\n\nIs the noise happening now? No\nDoes the time of the noise follow a pattern? No\nWhen has the noise occurred? late at night\n";
         is $report->latitude, 53;
+        $mech->clear_emails_ok;
     };
     subtest 'Report new noise, your address missing, source address not a postcode' => sub {
         $mech->get_ok('/noise');
@@ -231,6 +232,7 @@ FixMyStreet::override_config {
         $mech->content_contains('Your additional report has been submitted');
         my $update = $user->comments->first;
         is $update->text, "Kind of noise: music\nNoise details: Details\n\nIs the noise happening now? Yes\nDoes the time of the noise follow a pattern? Yes\nWhat days does the noise happen? friday, saturday\nWhat time does the noise happen? night\n";
+        like $mech->get_text_body_from_email, qr/Kind of noise: music/;
     };
 };
 

--- a/templates/email/buckinghamshire/other-reported.html
+++ b/templates/email/buckinghamshire/other-reported.html
@@ -36,7 +36,7 @@ there may be a delay in fixing the defect.
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
 [% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/_email_comment_list.html
+++ b/templates/email/default/_email_comment_list.html
@@ -5,7 +5,7 @@
         <img style="[% list_item_photo_style %]" src="[% inline_image(update.get_first_image_fp) %]" alt="">
       </a>
     [%~ END %]
-      [% email_sanitize_html(update) | html_para | replace('<p>', '<p style="' _ list_item_p_style _ '">') %]
+      [% email_sanitize_html(update) | replace('<p>', '<p style="' _ list_item_p_style _ '">') %]
       <p style="[% list_item_date_style %]">
         [%~ update.item_name | html IF update.item_name AND NOT update.item_anonymous -%]
         [% '(' _ cobrand.prettify_dt(update.confirmed) _ ') ' IF cobrand.include_time_in_update_alerts -%]

--- a/templates/email/default/_email_report_list.html
+++ b/templates/email/default/_email_report_list.html
@@ -10,7 +10,7 @@
       [%~ report.title | html ~%]
     </a>
   </h2>
-  [% report.detail | html_para | replace('<p>', '<p style="' _ list_item_p_style _ '">') %]
+  [% report.detail | html_para_email(list_item_p_style) %]
   <p style="[% list_item_date_style %]">
     [% cobrand.prettify_dt( report.confirmed ) %].
     [% report.nearest %]

--- a/templates/email/default/contact.html
+++ b/templates/email/default/contact.html
@@ -36,7 +36,7 @@ INCLUDE '_email_top.html';
 <tr>
 <th style="[% td_style %][% only_column_style %]">
   <h1 style="[% h1_style %]">[% subject | html %]</h1>
-  [% message | html | html_para | replace('<p>', '<p style="' _ p_style _ '">') %]
+  [% message | html_para_email(p_style) %]
   [%~ IF complaint %]
   <p style="[% secondary_p_style %]">
     [% complaint | html %]

--- a/templates/email/default/other-reported.html
+++ b/templates/email/default/other-reported.html
@@ -33,7 +33,7 @@ of report, so it will instead be sent to [% report.body %].</p>
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
 [% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/problem-confirm-not-sending.html
+++ b/templates/email/default/problem-confirm-not-sending.html
@@ -24,7 +24,7 @@ council.</p>
 </th>
 [% WRAPPER '_email_sidebar.html' object = report, url = token_url %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
 [% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/problem-confirm.html
+++ b/templates/email/default/problem-confirm.html
@@ -30,7 +30,7 @@ of problem, so it will instead be sent to [% report.body %].
 </th>
 [% WRAPPER '_email_sidebar.html' object = report, url = token_url %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
 [% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/questionnaire.html
+++ b/templates/email/default/questionnaire.html
@@ -27,7 +27,7 @@ INCLUDE '_email_top.html';
 </th>
 [% WRAPPER '_email_sidebar.html' object = report, url = url %]
     <h2 style="[% h2_style %]">[% title %]</h2>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
 [% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/submit.html
+++ b/templates/email/default/submit.html
@@ -48,7 +48,7 @@ of a local problem that they believe might require your attention.</p>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
     <p style="[% secondary_p_style %]">[% report.category | html %]</p>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
   [% IF report.get_extra_fields %]
     <p style="[% secondary_p_style %]">
       [%~ FOR field IN report.get_extra_fields %][% IF field.value %]

--- a/templates/email/fixamingata/_email_comment_list.html
+++ b/templates/email/fixamingata/_email_comment_list.html
@@ -5,7 +5,7 @@
         <img style="[% list_item_photo_style %]" src="[% inline_image(update.get_first_image_fp) %]" alt="">
       </a>
     [%~ END %]
-      [% email_sanitize_html(update) | html_para | replace('<p>', '<p style="' _ list_item_p_style _ '">') %]
+      [% email_sanitize_html(update) | replace('<p>', '<p style="' _ list_item_p_style _ '">') %]
       <p style="[% list_item_date_style %]">
         [%~ update.item_name | html IF update.item_name AND NOT update.item_anonymous -%]
         [% '(' _ cobrand.prettify_dt(update.confirmed) _ ') ' IF cobrand.include_time_in_update_alerts -%]

--- a/templates/email/fixamingata/_email_report_list.html
+++ b/templates/email/fixamingata/_email_report_list.html
@@ -10,7 +10,7 @@
       [%~ report.title | html ~%]
     </a>
   </h2>
-  [% report.detail | html_para | replace('<p>', '<p style="' _ list_item_p_style _ '">') %]
+  [% report.detail | html_para_email(list_item_p_style) %]
   <p style="[% list_item_date_style %]">
     [% cobrand.prettify_dt( report.confirmed ) %].
     [% report.nearest %]

--- a/templates/email/fixamingata/other-reported.html
+++ b/templates/email/fixamingata/other-reported.html
@@ -31,7 +31,7 @@ rapporter, så kommer rapporten istället att skickas till [% report.body %].
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
 [% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/fixamingata/problem-confirm-not-sending.html
+++ b/templates/email/fixamingata/problem-confirm-not-sending.html
@@ -24,7 +24,7 @@ skickas till kommunen.</p>
 </th>
 [% WRAPPER '_email_sidebar.html' object = report, url = token_url %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
 [% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/fixamingata/problem-confirm.html
+++ b/templates/email/fixamingata/problem-confirm.html
@@ -23,7 +23,7 @@ måste du klicka på nedanstående knapp.</p>
 </th>
 [% WRAPPER '_email_sidebar.html' object = report, url = token_url %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
 [% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/fixamingata/questionnaire.html
+++ b/templates/email/fixamingata/questionnaire.html
@@ -27,7 +27,7 @@ INCLUDE '_email_top.html';
 </th>
 [% WRAPPER '_email_sidebar.html' object = report, url = url %]
     <h2 style="[% h2_style %]">[% title %]</h2>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
 [% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/fixamingata/submit.html
+++ b/templates/email/fixamingata/submit.html
@@ -47,7 +47,7 @@ tror medborgaren behöver er uppmärksamhet.</p>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
     <p style="[% secondary_p_style %]">[% report.category | html %]</p>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
     <p style="[% secondary_p_style %]">
       <strong>Plats:</strong>
       <a href="[% osm_url %]" title="Se den här platsen på OpenStreetMap">

--- a/templates/email/fixmystreet.com/submit.html
+++ b/templates/email/fixmystreet.com/submit.html
@@ -48,7 +48,7 @@ of a local problem that they believe might require your attention.</p>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
     <p style="[% secondary_p_style %]"><strong>Category:</strong> [% report.category | html %]</p>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
   [% IF report.get_extra_fields %]
     <p style="[% secondary_p_style %]">
       [%~ FOR field IN report.get_extra_fields %][% IF field.value %]

--- a/templates/email/highwaysengland/submit.html
+++ b/templates/email/highwaysengland/submit.html
@@ -24,7 +24,7 @@ of a local problem that they believe might require your attention.</p>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
     <p style="[% secondary_p_style %]">[% report.category | html %]</p>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
     <p style="[% secondary_p_style %]">
       <strong>Location:</strong>
       <a href="[% osm_url %]" title="View OpenStreetMap of this location">

--- a/templates/email/hounslow/other-reported.html
+++ b/templates/email/hounslow/other-reported.html
@@ -32,7 +32,7 @@ of report, so it will instead be sent to [% report.body %].</p>
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
 [% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/hounslow/problem-confirm.html
+++ b/templates/email/hounslow/problem-confirm.html
@@ -25,7 +25,7 @@ INCLUDE '_email_top.html';
 </th>
 [% WRAPPER '_email_sidebar.html' object = report, url = token_url %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
 [% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/hounslow/submit.html
+++ b/templates/email/hounslow/submit.html
@@ -51,7 +51,7 @@ of a local problem that they believe might require your attention.</p>
       <p style="[% secondary_p_style %]"><strong>Enquiry ref:</strong> [% report.external_id | html %]</p>
     [% END %]
     <p style="[% secondary_p_style %]"><strong>Category:</strong> [% report.category | html %]</p>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
     <p style="[% secondary_p_style %]">
       <strong>Location:</strong>
       <br>Easting/Northing

--- a/templates/email/isleofwight/confirm_report_sent.html
+++ b/templates/email/isleofwight/confirm_report_sent.html
@@ -36,7 +36,7 @@ of report, so it will instead be sent to [% report.body %].</p>
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
 [% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/isleofwight/problem-confirm.html
+++ b/templates/email/isleofwight/problem-confirm.html
@@ -25,7 +25,7 @@ INCLUDE '_email_top.html';
 </th>
 [% WRAPPER '_email_sidebar.html' object = report, url = token_url %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
 [% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/lincolnshire/contact.html
+++ b/templates/email/lincolnshire/contact.html
@@ -25,7 +25,7 @@ INCLUDE '_email_top.html';
 <tr>
 <th style="[% td_style %][% only_column_style %]">
   <h1 style="[% h1_style %]">[% subject | html %]</h1>
-  [% message | html | html_para | replace('<p>', '<p style="' _ p_style _ '">') %]
+  [% message | html_para_email(p_style) %]
   [%~ IF complaint %]
   <p style="[% secondary_p_style %]">
     [% complaint | html %]

--- a/templates/email/oxfordshire/submit.html
+++ b/templates/email/oxfordshire/submit.html
@@ -48,7 +48,7 @@ of a local problem that they believe might require your attention.</p>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
     <p style="[% secondary_p_style %]"><strong>Category:</strong> [% report.category | html %]</p>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
     <p style="[% secondary_p_style %]">
       <strong>Location:</strong>
       <br>Easting/Northing

--- a/templates/email/tfl/other-reported.html
+++ b/templates/email/tfl/other-reported.html
@@ -27,7 +27,7 @@ using the email address associated with the report.</p>
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
 [% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/tfl/problem-confirm.html
+++ b/templates/email/tfl/problem-confirm.html
@@ -22,7 +22,7 @@ INCLUDE '_email_top.html';
 </th>
 [% WRAPPER '_email_sidebar.html' object = report, url = token_url %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
 [% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/tfl/submit.html
+++ b/templates/email/tfl/submit.html
@@ -57,7 +57,7 @@ of a local problem that they believe might require your attention.</p>
     [% IF report.get_extra_field_value('site') %]
       <p style="[% secondary_p_style %]"><strong>Signal site number:</strong> [% report.get_extra_field_value('site') | html %]</p>
     [% END %]
-    <p style="[% secondary_p_style %]">[% report.detail | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
     <p style="[% secondary_p_style %]">
       <strong>Location:</strong>
       <br>Easting/Northing


### PR DESCRIPTION
Also improve display of report detail/update text in emails (former, use html_para so it gets spacing okay, latter, fix issue where it was double calling html_para on update email lists). I imagine not all integrations might want to send an email but at this stage didn't seem worth cobranding it. [skip changelog]