### PR TITLE
Fix clicking of /about sidebar on desktop

### DIFF
--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -440,7 +440,6 @@ body.twothirdswidthpage {
       position:absolute;
       #{$left}: 42em;
       top:0;
-      z-index: -1;
       width:13em;
       padding:1em;
       h2 {
@@ -453,7 +452,6 @@ body.twothirdswidthpage {
     .sticky-sidebar {
       position: absolute;
       #{$left}: 42em;
-      z-index: -1;
       aside {
         position: fixed;
         top:7em;


### PR DESCRIPTION
Removes the z-index values from the sticky-sidebar and aside.
This doesn’t appear to affect anything else...

For #3287

[skip changelog]