### PR TITLE
[Hackney] Hide noise category from normal flow.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -136,6 +136,9 @@ sub munge_report_new_contacts {
     if ( $bodies{'Bromley Council'} ) {
         @$contacts = grep { grep { $_ ne 'Waste' } @{$_->groups} } @$contacts;
     }
+    if ( $bodies{'Hackney Council'} ) {
+        @$contacts = grep { $_->category ne 'Noise report' } @$contacts;
+    }
     if ( $bodies{'TfL'} ) {
         # Presented categories vary if we're on/off a red route
         my $tfl = FixMyStreet::Cobrand->get_class_for_moniker( 'tfl' )->new({ c => $self->{c} });

--- a/perllib/FixMyStreet/Cobrand/Hackney.pm
+++ b/perllib/FixMyStreet/Cobrand/Hackney.pm
@@ -238,6 +238,12 @@ sub get_body_sender {
     return $self->SUPER::get_body_sender($body, $problem);
 }
 
+sub munge_report_new_contacts {
+    my ($self, $contacts) = @_;
+    @$contacts = grep { $_->category ne 'Noise report' } @$contacts;
+    $self->SUPER::munge_report_new_contacts($contacts);
+}
+
 # Translate email address to actual delivery address
 sub noise_destination_email {
     my ($self, $row, $name) = @_;

--- a/t/app/controller/noise.t
+++ b/t/app/controller/noise.t
@@ -30,6 +30,19 @@ $geo->mock('string', sub {
     return $ret;
 });
 
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => ['fixmystreet', 'hackney'],
+    MAPIT_URL => 'http://mapit.uk/',
+}, sub {
+    subtest 'Check category not displayed in normal flow' => sub {
+        $mech->host('www.fixmystreet.com');
+        $mech->get_ok('/report/new?latitude=51.552267&longitude=-0.063316');
+        $mech->content_lacks('Noise report');
+        $mech->host('hackney.gov.uk');
+        $mech->get_ok('/report/new?latitude=51.552267&longitude=-0.063316');
+        $mech->content_lacks('Noise report');
+    };
+};
 
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => 'hackney',


### PR DESCRIPTION
[skip changelog]
I guess we should add a new state or flag for contacts that hides them from normal flow which could then work for waste etc as well, but just for now to stop any more staff-made reports.