### PR TITLE
[Open311] Add support for waste_only service keyword

### DIFF
--- a/perllib/Open311/PopulateServiceList.pm
+++ b/perllib/Open311/PopulateServiceList.pm
@@ -183,6 +183,7 @@ sub _handle_existing_contact {
 
     $self->_set_contact_group($contact) unless $protected;
     $self->_set_contact_non_public($contact);
+    $self->_set_contact_as_waste_only($contact);
 
     push @{ $self->found_contacts }, $self->_current_service->{service_code};
 }
@@ -218,6 +219,7 @@ sub _create_contact {
 
     $self->_set_contact_group($contact);
     $self->_set_contact_non_public($contact);
+    $self->_set_contact_as_waste_only($contact);
 
     if ( $contact ) {
         push @{ $self->found_contacts }, $self->_current_service->{service_code};
@@ -321,6 +323,21 @@ sub _set_contact_non_public {
         non_public => 1,
         %{ $self->_action_params("marked private") },
     }) if $keywords{private};
+}
+
+sub _set_contact_as_waste_only {
+    my ($self, $contact) = @_;
+
+    my %keywords = map { $_ => 1 } split /,/, ( $self->_current_service->{keywords} || '' );
+    my $waste_only = $keywords{waste_only} ? 1 : 0;
+    my $old_waste_only = $contact->get_extra_metadata("waste_only") || 0;
+
+    if ($waste_only != $old_waste_only) {
+        $contact->set_extra_metadata(waste_only => $waste_only);
+        $contact->update({
+            %{ $self->_action_params("set waste_only to $waste_only") },
+        });
+    }
 }
 
 sub _get_new_groups {

--- a/t/open311/populate-service-list.t
+++ b/t/open311/populate-service-list.t
@@ -484,6 +484,103 @@ subtest 'check existing non_public category does not get marked public' => sub {
     is $contact->non_public, 1, 'contact remains non_public';
 };
 
+subtest 'check new category marked waste_only' => sub {
+    FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->delete();
+
+    my $services_xml = '<?xml version="1.0" encoding="utf-8"?>
+    <services>
+      <service>
+        <service_code>404</service_code>
+        <service_name>Food bin missing</service_name>
+        <description></description>
+        <metadata>false</metadata>
+        <type>realtime</type>
+        <keywords>waste_only</keywords>
+        <group>Missing bin</group>
+      </service>
+    </services>
+        ';
+
+    my $service_list = get_xml_simple_object( $services_xml );
+
+    my $processor = Open311::PopulateServiceList->new();
+    $processor->_current_body( $body );
+    $processor->process_services( $service_list );
+
+    my $contact_count = FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->count();
+    is $contact_count, 1, 'correct number of contacts';
+
+    my $contact = FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->first;
+    is $contact->email, '404', 'email correct';
+    is $contact->category, 'Food bin missing', 'category correct';
+    is $contact->get_extra_metadata('waste_only'), 1, 'contact marked as waste_only in extra';
+};
+
+subtest 'check new category not marked waste_only' => sub {
+    FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->delete();
+
+    my $services_xml = '<?xml version="1.0" encoding="utf-8"?>
+    <services>
+      <service>
+        <service_code>404</service_code>
+        <service_name>Food bin missing</service_name>
+        <description></description>
+        <metadata>false</metadata>
+        <type>realtime</type>
+        <keywords></keywords>
+        <group>Missing bin</group>
+      </service>
+    </services>
+        ';
+
+    my $service_list = get_xml_simple_object( $services_xml );
+
+    my $processor = Open311::PopulateServiceList->new();
+    $processor->_current_body( $body );
+    $processor->process_services( $service_list );
+
+    my $contact_count = FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->count();
+    is $contact_count, 1, 'correct number of contacts';
+
+    my $contact = FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->first;
+    is $contact->email, '404', 'email correct';
+    is $contact->category, 'Food bin missing', 'category correct';
+    is $contact->get_extra_metadata('waste_only'), undef, 'contact not marked as waste_only in extra';
+};
+
+subtest 'check existing category marked waste_only' => sub {
+    my $contact = FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->first;
+    is $contact->get_extra_metadata('waste_only'), undef, 'contact not marked as waste_only in extra';
+
+    my $services_xml = '<?xml version="1.0" encoding="utf-8"?>
+    <services>
+      <service>
+        <service_code>404</service_code>
+        <service_name>Food bin missing</service_name>
+        <description></description>
+        <metadata>false</metadata>
+        <type>realtime</type>
+        <keywords>waste_only</keywords>
+        <group>Missing bin</group>
+      </service>
+    </services>
+        ';
+
+    my $service_list = get_xml_simple_object( $services_xml );
+
+    my $processor = Open311::PopulateServiceList->new();
+    $processor->_current_body( $body );
+    $processor->process_services( $service_list );
+
+    my $contact_count = FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->count();
+    is $contact_count, 1, 'correct number of contacts';
+
+    $contact = FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->first;
+    is $contact->email, '404', 'email correct';
+    is $contact->category, 'Food bin missing', 'category correct';
+    is $contact->get_extra_metadata('waste_only'), 1, 'contact marked as waste_only in extra';
+};
+
 for my $test (
     {
         desc => 'check meta data added to existing contact',


### PR DESCRIPTION
Stores a flag in the contact’s extra indicating whether it should only appear on the waste workflow, and not the main report flow.

This will be used by the Peterborough cobrand as part of the waste product.

[skip changelog]