### PR TITLE
[fixmystreet.com] Respect cobrand’s cut_off_date on responsiveness stats

### DIFF
--- a/perllib/FixMyStreet/DB/Result/Body.pm
+++ b/perllib/FixMyStreet/DB/Result/Body.pm
@@ -242,6 +242,13 @@ sub calculate_average {
     my ($self, $threshold) = @_;
     $threshold ||= 0;
 
+    # respect the cobrand's cut-off date for displaying problems, if it exists
+    my %cutoff;
+    my $handler = $self->get_cobrand_handler;
+    if ($handler && $handler->can('cut_off_date')) {
+      $cutoff{'problem.confirmed'} = { '>=', $handler->cut_off_date };
+    }
+
     my $substmt = "select min(id) from comment where me.problem_id=comment.problem_id and (problem_state in ('fixed', 'fixed - council', 'fixed - user') or mark_fixed)";
     my $subquery = FixMyStreet::DB->resultset('Comment')->to_body($self)->search({
         -or => [
@@ -251,6 +258,7 @@ sub calculate_average {
         'me.id' => \"= ($substmt)",
         'me.state' => 'confirmed',
         'problem.state' => [ FixMyStreet::DB::Result::Problem->visible_states() ],
+        %cutoff,
     }, {
         select   => [
             { extract => \"epoch from me.confirmed-problem.confirmed", -as => 'time' },


### PR DESCRIPTION
Recently launched cobrands for councils who previously refused FMS reports
would see a misleadingly high figure in the ‘how responsive is ...’ section
on the councillor dashboard.
This commit respects the cobrand’s cut_off_date figure when calculating
these stats, meaning reports made before the cobrand launched are ignored.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/2151

[skip changelog]