### PR TITLE
[Open311] Trim leading/trailing whitespace from service groups

### DIFF
--- a/perllib/Open311/PopulateServiceList.pm
+++ b/perllib/Open311/PopulateServiceList.pm
@@ -328,11 +328,13 @@ sub _get_new_groups {
     return [] unless $self->_current_body_cobrand && $self->_current_body_cobrand->enable_category_groups;
 
     my $groups = $self->_current_service->{groups} || [];
-    return $groups if @$groups;
+    my @groups = map { Utils::trim_text($_) } @$groups;
+    return \@groups if @groups;
 
     my $group = $self->_current_service->{group} || [];
     $group = [] if @$group == 1 && !$group->[0]; # <group></group> becomes [undef]...
-    return $group;
+    @groups = map { Utils::trim_text($_) } @$group;
+    return \@groups;
 }
 
 sub _groups_different {

--- a/t/open311/populate-service-list.t
+++ b/t/open311/populate-service-list.t
@@ -101,7 +101,8 @@ for my $test (
             <metadata>false</metadata>
             <type>realtime</type>
             <keywords>lorem, ipsum, dolor</keywords>
-            <group>street</group>
+            <group>street
+</group>
             <service_name>Construction plate shifted</service_name>
             <description>Metal construction plate covering the street or sidewalk has been moved.</description>
           </service>


### PR DESCRIPTION
Fixes an issue preventing reports being made in categories whose group had trailing whitespace.

[skip changelog]