### PR TITLE
Send email when staff member subscribes user to alerts

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Develop.pm
+++ b/perllib/FixMyStreet/App/Controller/Develop.pm
@@ -61,7 +61,8 @@ sub email_list : Path('/_dev/email') : Args(0) {
     my %with_problem = ('alert-update' => 1, 'other-reported' => 1,
         'problem-confirm' => 1, 'problem-confirm-not-sending' => 1,
         'confirm_report_sent' => 1,
-        'problem-moderated' => 1, 'questionnaire' => 1, 'submit' => 1);
+        'problem-moderated' => 1, 'questionnaire' => 1, 'submit' => 1,
+        'alert-subscribed' => 1);
 
     my $update = $c->model('DB::Comment')->search(undef, { rows => 1 } )->first;
     my $problem = $c->model('DB::Problem')->search(undef, { rows => 1 } )->first;

--- a/t/app/controller/alert_new.t
+++ b/t/app/controller/alert_new.t
@@ -337,6 +337,16 @@ subtest 'Test body user signing someone else up for alerts' => sub {
         confirmed  => 1,
     });
     is $alert, undef, 'No alert created for staff user';
+
+    # Check that email is sent to newly subscribed user.
+    my $email = $mech->get_email;
+    my $title = $report->title;
+    like $mech->get_text_body_from_email($email), qr/You have been subscribed to FixMyStreet alerts for $title/i, "Correct email text";
+    my @urls = $mech->get_link_from_email($email, 1);
+    ok $urls[0] =~ m{/report/\S+}, "report URL '$urls[0]'";
+    ok $urls[-1] =~ m{/A/\S+}, "unsubscribe URL '$urls[-1]'";
+
+    $mech->clear_emails_ok;
 };
 
 $report->delete; # Emails sent otherwise below

--- a/templates/email/default/alert-subscribed.html
+++ b/templates/email/default/alert-subscribed.html
@@ -1,0 +1,19 @@
+[%
+
+email_summary = "Subscribed to " _ site_name _ " alerts";
+email_columns = 1;
+
+PROCESS '_email_settings.html';
+
+INCLUDE '_email_top.html';
+
+%]
+
+<th style="[% td_style %][% only_column_style %]">
+  <h1 style="[% h1_style %]">Subscribed to [% site_name %] alerts</h1>
+  <p style="[% p_style %]">You have been subscribed to [% site_name %] alerts for <a href="[% problem_url %]">[% problem.title %]</a>.</p>
+
+  <p style="[% p_style %]"><a href="[% unsubscribe_url %]">Unsubscribe from alerts about [% problem.title %].</a></p>
+</th>
+
+[% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/alert-subscribed.txt
+++ b/templates/email/default/alert-subscribed.txt
@@ -1,0 +1,17 @@
+Subject: Subscribed to [% site_name %] alerts
+
+You have been subscribed to [% site_name %] alerts for [% problem.title %].
+
+[% problem_url %]
+
+Email alerts are a free service from [% site_name %].
+
+This email was sent automatically, from an unmonitored email account - so
+please do not reply to it.
+
+[% signature %]
+
+Unsubscribe?
+
+If you no longer wish to receive an email whenever this report is updated,
+please follow this link: [% unsubscribe_url %]


### PR DESCRIPTION
This adds a new email that is sent when someone is subscribed to email alerts by a member of staff. Councils sometimes use this when someone phones to report a problem and they enter it into the system.

The email that is sent contains an unsubscribe link so that users can stop receiving updates if they wish.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/2049

<!-- [skip changelog] -->
