### PR TITLE
add reports failed count to sendreports output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
         - Move ban/unban buttons to user edit admin page.
         - Add link to user edit admin from report/update edit admin.
         - Improve layout of some admin pages.
+    - Development improvements:
+        - Include failure count in send report error output, #3316
     - Security:
         - Increase minimum password length to eight.
 

--- a/perllib/FixMyStreet/Script/Reports.pm
+++ b/perllib/FixMyStreet/Script/Reports.pm
@@ -122,15 +122,25 @@ sub end_summary_failures {
         whensent => undef,
         bodies_str => { '!=', undef },
         send_fail_count => { '>', 0 }
-    } );
+    },
+    {
+        order_by => { -desc => 'confirmed' }
+    });
+    my %bodies;
     while (my $row = $unsent->next) {
         my $base_url = FixMyStreet->config('BASE_URL');
+        my $key =  join ', ', @{ $row->body_names };
+        $bodies{$key} ||= [];
+        push @{ $bodies{$key} }, $row->id;
         $sending_errors .= "\n" . '=' x 80 . "\n\n" . "* " . $base_url . "/report/" . $row->id . ", failed "
             . $row->send_fail_count . " times, last at " . $row->send_fail_timestamp
             . ", reason " . $row->send_fail_reason . "\n";
     }
     if ($sending_errors) {
-        print "The following reports had problems sending:\n$sending_errors";
+        my $count = $unsent->count;
+        my $bodies = join '\n', map { "$_ (" . scalar @{ $bodies{$_} } . "): " . join ', ', @{ $bodies{$_} } } keys %bodies;
+
+        print "The following $count reports had problems sending:\n$bodies\n$sending_errors";
     }
 }
 

--- a/t/sendreport/failures.t
+++ b/t/sendreport/failures.t
@@ -1,0 +1,47 @@
+use FixMyStreet;
+use FixMyStreet::DB;
+use FixMyStreet::Script::Reports;
+use FixMyStreet::TestMech;
+
+use Test::Output;
+use DateTime;
+
+ok( my $mech = FixMyStreet::TestMech->new, 'Created mech object' );
+
+# area id 1000
+my $params = { id => 1000, name => 'Council of the Thousand' };
+my $body = FixMyStreet::DB->resultset('Body')->find_or_create($params);
+ok $body, "found/created body";
+
+my $contact = $mech->create_contact_ok(
+    email => 'council@example.com',
+    body_id => 1000,
+    category => 'category',
+    note => '',
+);
+
+my $user = $mech->create_user_ok( 'test@example.com' );
+
+my $dt = DateTime->now->add( minutes => -5 );
+
+my ($p1, $p2) = $mech->create_problems_for_body(2, $body->id, 'Test', {
+    user => $user,
+    bodies_str => '1000',
+    category => 'category',
+    send_fail_timestamp => \'current_timestamp',
+    send_fail_reason => 'this is a test failure',
+    send_fail_count => 1
+} );
+
+$p1->update({
+    confirmed => $dt,
+});
+
+subtest "check sendreport failure messages" => sub {
+    my $e = FixMyStreet::Script::Reports->new;
+    my ($id1, $id2) = ( $p1->id, $p2->id );
+    stdout_like { $e->end_summary_failures } qr%The following 2 reports had problems sending:\nCouncil of the Thousand \(2\): $id2, $id1.*report/$id2.*report/$id1%s, "includes count of reports and reports in fixed order"
+
+};
+
+done_testing();


### PR DESCRIPTION
Also have a list of ids and order output so it's consistent to make
it a bit easier to scan.