### PR TITLE
Let the cobrand function always_view_body_contribute_details take contributed_as into account

### DIFF
--- a/perllib/FixMyStreet/Cobrand/FixaMinGata.pm
+++ b/perllib/FixMyStreet/Cobrand/FixaMinGata.pm
@@ -182,7 +182,8 @@ sub state_groups_inspect {
 }
 
 sub always_view_body_contribute_details {
-    return 1;
+    my ( $self, $contributed_as ) = @_;
+    return $contributed_as eq '';
 }
 
 # Average responsiveness will only be calculated if a body

--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -298,7 +298,7 @@ sub meta_line {
                 $body = 'Island Roads';
             }
         }
-        my $cobrand_always_view_body_user = $cobrand->call_hook("always_view_body_contribute_details");
+        my $cobrand_always_view_body_user = $cobrand->call_hook(always_view_body_contribute_details => $contributed_as);
         my $can_view_contribute = $cobrand_always_view_body_user ||
             ($user && $user->has_permission_to('view_body_contribute_details', $self->problem->bodies_str_ids));
         if ($self->text) {

--- a/t/cobrand/fixamingata.t
+++ b/t/cobrand/fixamingata.t
@@ -107,7 +107,7 @@ subtest "Test ajax decimal points" => sub {
     };
 };
 
-subtest "check user details always shown" => sub {
+subtest "check user details shown when staff user comments as themselves" => sub {
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => [ 'fixamingata' ],
     }, sub {
@@ -116,6 +116,22 @@ subtest "check user details always shown" => sub {
         my $update_meta = $mech->extract_update_metas;
         like $update_meta->[0], qr/Body \(Commenter\) /;
         $user2->update({ from_body => undef });
+    };
+};
+
+subtest "check user details aren't shown when staff user comments as body" => sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'fixamingata' ],
+    }, sub {
+        $user2->update({ from_body => $body });
+        $comment->set_extra_metadata( contributed_as => 'body' );
+        $comment->update;
+        $mech->get_ok('/report/' . $report->id);
+        my $update_meta = $mech->extract_update_metas;
+        unlike $update_meta->[0], qr/Commenter/;
+        $user2->update({ from_body => undef });
+        $comment->unset_extra_metadata('contributed_as');
+        $comment->update;
     };
 };
 


### PR DESCRIPTION
Some background:

For FixaMinGata we've shown the names of staff users in their updates. This has been a wish from some of our municipalities, although some have disagreed (leading some staff users to change their names to just first name or something anonymous).

We've started using the functionality now where a staff user can create update "as body" rather than "as myself", I was hoping this would solve the problem by giving the user the choice of who's shown as the source of the comment.

I had assumed when creating an update "as body", only the body name was shown, but because of our override in our cobrand's `always_view_body_contribute_details` , both body name and staff user name was shown regardless of how the update was made.

However removing our override instead leads to only the body name showing (even when creating an update "as myself").

Now I'm starting to feel like I don't really understand the purpose of creating updates "as body" versus "as myself", so perhaps my proposed solution is a bad idea.

Anyway, by sending in contributed_as to the cobrand function, we can get the behaviour I expected; when creating an update as "myself" both body name and staff user name is shown, and when creating an update "as body" only the body name is shown.

I'm just a bit concerned that I'm misunderstanding mySociety's intention with this feature...what's the intended difference between "as body" and "as myself" if it doesn't show up in the comment's meta line? Perhaps I'm setting myself up for trouble down the line if I'm working against the intended way of using FixMyStreet :-)

Sorry for the long PR description, the changes are at least quite small :-)