### PR TITLE
Add support for OS Maps API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
         - Send text alerts for report updates to only-phone-verified users.
         - Add options for user to set global notification preferences.
         - Pop over mobile navigation menu. #3270
+        - Add support for the OS Maps API. #3328
     - Bugfixes:
         - Fix non-JS form when all extra questions answered. #3248
         - Improve display of disabled fields in iOS.

--- a/perllib/FixMyStreet/App.pm
+++ b/perllib/FixMyStreet/App.pm
@@ -230,7 +230,7 @@ sub setup_request {
 
     $c->model('DB::Problem')->set_restriction( $cobrand->site_key() );
 
-    FixMyStreet::Map::set_map_class( $cobrand->map_type || $c->get_param('map_override') );
+    FixMyStreet::Map::set_map_class($cobrand);
     # All pages need this, either loading it or prefetching it
     $c->stash->{map_js} = FixMyStreet::Map::map_javascript();
 

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -39,6 +39,11 @@ sub disambiguate_location {
     };
 }
 
+sub map_type {
+    my $self = shift;
+    return 'OS::FMS' if $self->feature('os_maps_url') || $self->feature('os_maps_api_key');
+}
+
 sub process_open311_extras {
     my $self    = shift;
     my $ctx     = shift;

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -1006,12 +1006,12 @@ sub static_map {
     my $orig_map_class = FixMyStreet::Map::set_map_class('OSM')
         unless $FixMyStreet::Map::map_class->isa("FixMyStreet::Map::OSM");
 
-    my $map_data = $FixMyStreet::Map::map_class->generate_map_data(
-        {
-            cobrand => $self->get_cobrand_logged,
-            distance => 1, # prevents the call to Gaze which isn't necessary
-            $params{zoom} ? ( zoom => $params{zoom} ) : (),
-        },
+    my $map = $FixMyStreet::Map::map_class->new({
+        cobrand => $self->get_cobrand_logged,
+        distance => 1, # prevents the call to Gaze which isn't necessary
+        $params{zoom} ? ( zoom => $params{zoom} ) : (),
+    });
+    my $map_data = $map->generate_map_data(
         latitude  => $self->latitude,
         longitude => $self->longitude,
         pins      => $self->used_map

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -1006,8 +1006,9 @@ sub static_map {
     my $orig_map_class = FixMyStreet::Map::set_map_class('OSM')
         unless $FixMyStreet::Map::map_class->isa("FixMyStreet::Map::OSM");
 
+    my $cobrand = $FixMyStreet::Map::map_cobrand || $self->get_cobrand_logged;
     my $map = $FixMyStreet::Map::map_class->new({
-        cobrand => $self->get_cobrand_logged,
+        cobrand => $cobrand,
         distance => 1, # prevents the call to Gaze which isn't necessary
         $params{zoom} ? ( zoom => $params{zoom} ) : (),
     });
@@ -1018,7 +1019,7 @@ sub static_map {
         ? [ {
             latitude  => $self->latitude,
             longitude => $self->longitude,
-            colour    => $self->get_cobrand_logged->pin_colour($self, 'report'),
+            colour    => $cobrand->pin_colour($self, 'report'),
             type      => 'big',
           } ]
         : [],

--- a/perllib/FixMyStreet/Map.pm
+++ b/perllib/FixMyStreet/Map.pm
@@ -53,8 +53,18 @@ Returns the old map class, if any.
 =cut
 
 our $map_class;
+our $map_cobrand;
 sub set_map_class {
-    my $str = shift;
+    my $arg = shift;
+    my $str;
+    if (ref $arg) {
+        # A cobrand object
+        $map_cobrand = $arg;
+        $str = $arg->map_type;
+    } else {
+        $map_cobrand = undef;
+        $str = $arg;
+    }
     $str = __PACKAGE__.'::'.$str if $str;
     my %avail = map { $_ => 1 } @ALL_MAP_CLASSES;
     $str = $ALL_MAP_CLASSES[0] unless $str && $avail{$str};

--- a/perllib/FixMyStreet/Map/Base.pm
+++ b/perllib/FixMyStreet/Map/Base.pm
@@ -1,0 +1,80 @@
+# FixMyStreet:Map::Base
+# Base map class
+
+package FixMyStreet::Map::Base;
+
+use Moo;
+use FixMyStreet::Gaze;
+use Utils;
+
+has zoom_levels => ( is => 'ro', default => 7 );
+has min_zoom_level => ( is => 'ro', default => 13 );
+has min_zoom_level_any => ( is => 'ro', default => 0 );
+has default_zoom => ( is => 'ro', default => 3 );
+
+has cobrand => ( is => 'ro' );
+has distance => ( is => 'ro' );
+has zoom => (is => 'ro' );
+
+# display_map C PARAMS
+# PARAMS include:
+# latitude, longitude for the centre point of the map
+# CLICKABLE is set if the map is clickable
+# PINS is array of pins to show, location and colour
+sub display_map {
+    my ($cls, $c, %params) = @_;
+
+    # Map centre may be overridden in the query string
+    $params{latitude} = Utils::truncate_coordinate($c->get_param('lat') + 0)
+        if defined $c->get_param('lat');
+    $params{longitude} = Utils::truncate_coordinate($c->get_param('lon') + 0)
+        if defined $c->get_param('lon');
+    $params{zoomToBounds} = $params{any_zoom} && !defined $c->get_param('zoom');
+
+    $params{aerial} = $c->get_param("aerial") && FixMyStreet->config('BING_MAPS_API_KEY') ? 1 : 0;
+
+    my $map = $cls->new({
+        cobrand => $c->cobrand,
+        distance => $c->stash->{distance},
+        defined $c->get_param('zoom') ? (zoom => $c->get_param('zoom') + 0) : (),
+    });
+    $c->stash->{map} = $map->generate_map_data(%params);
+}
+
+sub calculate_zoom {
+    my ($self, %params) = @_;
+
+    my $numZoomLevels = $self->zoom_levels;
+    my $zoomOffset = $self->min_zoom_level;
+    my $anyZoomOffset = $self->min_zoom_level_any;
+
+    # Adjust zoom level dependent upon population density if cobrand hasn't
+    # specified a default zoom.
+    my $default_zoom;
+    if (my $cobrand_default_zoom = $self->cobrand->default_map_zoom) {
+        $default_zoom = $cobrand_default_zoom;
+    } else {
+        my $dist = $self->distance
+            || FixMyStreet::Gaze::get_radius_containing_population( $params{latitude}, $params{longitude} );
+        $default_zoom = $dist < 10 ? $self->default_zoom : $self->default_zoom - 1;
+    }
+
+    if ($params{any_zoom}) {
+        $numZoomLevels += $zoomOffset - $anyZoomOffset;
+        $default_zoom += $zoomOffset - $anyZoomOffset;
+        $zoomOffset = $anyZoomOffset;
+    }
+
+    my $zoom = $self->zoom || $default_zoom;
+    $zoom = $numZoomLevels - 1 if $zoom >= $numZoomLevels;
+    $zoom = 0 if $zoom < 0;
+
+    return {
+        zoom => $zoom,
+        zoom_act => $zoomOffset + $zoom,
+        numZoomLevels => $numZoomLevels,
+        zoomOffset => $zoomOffset,
+    };
+}
+
+1;

--- a/perllib/FixMyStreet/Map/Bing.pm
+++ b/perllib/FixMyStreet/Map/Bing.pm
@@ -2,19 +2,19 @@
 # Bing maps on FixMyStreet, using OpenLayers.
 
 package FixMyStreet::Map::Bing;
-use base 'FixMyStreet::Map::OSM';
 
-use strict;
+use Moo;
+extends 'FixMyStreet::Map::OSM';
 
-sub map_type { '' }
+has '+map_type' => ( default => '' );
+
+has '+copyright' => ( default => '' );
 
 sub map_javascript { [
     '/vendor/OpenLayers/OpenLayers.fixmystreet.js',
     '/js/map-OpenLayers.js',
     '/js/map-bing-ol.js',
 ] }
-
-sub copyright { '' }
 
 sub get_quadkey {
     my ($self, $x, $y, $z) = @_;

--- a/perllib/FixMyStreet/Map/Bromley.pm
+++ b/perllib/FixMyStreet/Map/Bromley.pm
@@ -5,10 +5,9 @@
 # Email: matthew@mysociety.org; WWW: http://www.mysociety.org/
 
 package FixMyStreet::Map::Bromley;
-use base 'FixMyStreet::Map::FMS';
+use Moo;
+extends 'FixMyStreet::Map::FMS';
 
-use strict;
-
-sub map_tile_base { "bromley" }
+has '+base_tile_url' => ( default => '//%stilma.mysociety.org/bromley' );
 
 1;

--- a/perllib/FixMyStreet/Map/CheshireEast.pm
+++ b/perllib/FixMyStreet/Map/CheshireEast.pm
@@ -1,10 +1,10 @@
 package FixMyStreet::Map::CheshireEast;
-use base 'FixMyStreet::Map::OSM';
 
-use strict;
+use Moo;
 use Utils;
+extends 'FixMyStreet::Map::OSM';
 
-use constant MIN_ZOOM_LEVEL => 7;
+has '+min_zoom_level' => ( default => 7 );
 
 sub map_javascript { [
     '/vendor/OpenLayers/OpenLayers.wfs.js',

--- a/perllib/FixMyStreet/Map/FMS.pm
+++ b/perllib/FixMyStreet/Map/FMS.pm
@@ -22,6 +22,8 @@ sub map_javascript { [
 
 has '+base_tile_url' => ( default => '//%stilma.mysociety.org/oml' );
 
+has map_tile_prefix  => ( is => 'ro', default => sub { [ 'a-', 'b-', 'c-', '' ] } );
+
 sub map_tiles {
     my ( $self, %params ) = @_;
     my ( $x, $y, $z ) = ( $params{x_tile}, $params{y_tile}, $params{zoom_act} );
@@ -30,12 +32,14 @@ sub map_tiles {
         return $self->SUPER::map_tiles(%params);
     } elsif ($z >= 16) {
         my $tile_base = $self->base_tile_url . '/%d/%d/%d.png';
-        return [
-            sprintf($tile_base, 'a-', $z, $x-1, $y-1),
-            sprintf($tile_base, 'b-', $z, $x, $y-1),
-            sprintf($tile_base, 'c-', $z, $x-1, $y),
-            sprintf($tile_base, '', $z, $x, $y),
-        ];
+        my $prefixes = $self->map_tile_prefix;
+        my @urls;
+        for (my $i=0; $i<4; $i++) {
+            my @args = ($z, $x-1+($i%2), $y-1+int($i/2));
+            unshift @args, $prefixes->[$i] if defined $prefixes->[$i];
+            push @urls, sprintf($tile_base, @args);
+        }
+        return \@urls;
     } elsif ($z > 11) {
         my $key = FixMyStreet->config('BING_MAPS_API_KEY');
         my $base = "//ecn.%s.tiles.virtualearth.net/tiles/r%s?g=8702&lbl=l1&productSet=mmOS&key=$key";

--- a/perllib/FixMyStreet/Map/FMS.pm
+++ b/perllib/FixMyStreet/Map/FMS.pm
@@ -5,13 +5,13 @@
 # Email: matthew@mysociety.org; WWW: http://www.mysociety.org/
 
 package FixMyStreet::Map::FMS;
-use base 'FixMyStreet::Map::Bing';
 
-use strict;
+use Moo;
+extends 'FixMyStreet::Map::Bing';
 
-use constant ZOOM_LEVELS => 6;
+has '+zoom_levels' => ( default => 6 );
 
-sub map_template { 'fms' }
+has '+map_template' => ( default => 'fms' );
 
 sub map_javascript { [
     '/vendor/OpenLayers/OpenLayers.wfs.js',
@@ -20,7 +20,7 @@ sub map_javascript { [
     '/js/map-fms.js',
 ] }
 
-sub map_tile_base { "oml" }
+has '+base_tile_url' => ( default => '//%stilma.mysociety.org/oml' );
 
 sub map_tiles {
     my ( $self, %params ) = @_;
@@ -29,7 +29,7 @@ sub map_tiles {
     if ($params{aerial} || $ni || $z <= 11) {
         return $self->SUPER::map_tiles(%params);
     } elsif ($z >= 16) {
-        my $tile_base = '//%stilma.mysociety.org/' . $self->map_tile_base . '/%d/%d/%d.png';
+        my $tile_base = $self->base_tile_url . '/%d/%d/%d.png';
         return [
             sprintf($tile_base, 'a-', $z, $x-1, $y-1),
             sprintf($tile_base, 'b-', $z, $x, $y-1),
@@ -50,7 +50,7 @@ sub map_tiles {
 
 sub in_northern_ireland_box {
     my ($lat, $lon) = @_;
-    return 1 if $lat >= 54.015 && $lat <= 55.315 && $lon >= -8.18 && $lon <= -5.415;
+    return 1 if $lat && $lon && $lat >= 54.015 && $lat <= 55.315 && $lon >= -8.18 && $lon <= -5.415;
     return 0;
 }
 

--- a/perllib/FixMyStreet/Map/Google.pm
+++ b/perllib/FixMyStreet/Map/Google.pm
@@ -6,64 +6,23 @@
 
 package FixMyStreet::Map::Google;
 
-use strict;
-use FixMyStreet::Gaze;
-use Utils;
-
-use constant ZOOM_LEVELS    => 7;
-use constant MIN_ZOOM_LEVEL => 13;
-use constant DEFAULT_ZOOM   => 3;
+use Moo;
+extends 'FixMyStreet::Map::Base';
 
 sub map_javascript { [
     "http://maps.googleapis.com/maps/api/js?sensor=false",
     '/js/map-google.js',
 ] }
 
-# display_map C PARAMS
-# PARAMS include:
-# latitude, longitude for the centre point of the map
-# CLICKABLE is set if the map is clickable
-# PINS is array of pins to show, location and colour
-sub display_map {
-    my ($self, $c, %params) = @_;
+sub generate_map_data {
+    my ($self, %params) = @_;
 
-    my $numZoomLevels = ZOOM_LEVELS;
-    my $zoomOffset = MIN_ZOOM_LEVEL;
+    my $zoom_params = $self->calculate_zoom(%params);
 
-    # Adjust zoom level dependent upon population density
-    my $default_zoom;
-    if (my $cobrand_default_zoom = $c->cobrand->default_map_zoom) {
-        $default_zoom = $cobrand_default_zoom;
-    } else {
-        my $dist = $c->stash->{distance}
-            || FixMyStreet::Gaze::get_radius_containing_population( $params{latitude}, $params{longitude} );
-        $default_zoom = $dist < 10 ? $self->DEFAULT_ZOOM : $self->DEFAULT_ZOOM - 1;
-    }
-
-    # Map centre may be overridden in the query string
-    $params{latitude} = Utils::truncate_coordinate($c->get_param('lat') + 0)
-        if defined $c->get_param('lat');
-    $params{longitude} = Utils::truncate_coordinate($c->get_param('lon') + 0)
-        if defined $c->get_param('lon');
-    $params{zoomToBounds} = $params{any_zoom} && !defined $c->get_param('zoom');
-
-    if ($params{any_zoom}) {
-        $numZoomLevels += $zoomOffset;
-        $default_zoom += $zoomOffset;
-        $zoomOffset = 0;
-    }
-
-    my $zoom = defined $c->get_param('zoom') ? $c->get_param('zoom') + 0 : $default_zoom;
-    $zoom = $numZoomLevels - 1 if $zoom >= $numZoomLevels;
-    $zoom = 0 if $zoom < 0;
-    $params{zoom_act} = $zoomOffset + $zoom;
-
-    $c->stash->{map} = {
+    return {
         %params,
+        %$zoom_params,
         type => 'google',
-        zoom => $zoom,
-        zoomOffset => $zoomOffset,
-        numZoomLevels => $numZoomLevels,
     };
 }
 

--- a/perllib/FixMyStreet/Map/GoogleOL.pm
+++ b/perllib/FixMyStreet/Map/GoogleOL.pm
@@ -5,13 +5,11 @@
 # Email: matthew@mysociety.org; WWW: http://www.mysociety.org/
 
 package FixMyStreet::Map::GoogleOL;
-use parent 'FixMyStreet::Map::OSM';
+use Moo;
+extends 'FixMyStreet::Map::OSM';
 
-use strict;
-
-sub map_type { '' }
-
-sub map_template { 'google-ol' }
+has '+map_type' => ( default => '' );
+has '+map_template' => ( default => 'google-ol' );
 
 sub map_javascript {
     my $google_maps_url = "https://maps.googleapis.com/maps/api/js?v=3";

--- a/perllib/FixMyStreet/Map/HighwaysEngland.pm
+++ b/perllib/FixMyStreet/Map/HighwaysEngland.pm
@@ -1,8 +1,8 @@
 package FixMyStreet::Map::HighwaysEngland;
-use base 'FixMyStreet::Map::FMS';
 
-use strict;
+use Moo;
+extends 'FixMyStreet::Map::FMS';
 
-use constant MIN_ZOOM_LEVEL => 12;
+has '+min_zoom_level' => ( default => 12 );
 
 1;

--- a/perllib/FixMyStreet/Map/MasterMap.pm
+++ b/perllib/FixMyStreet/Map/MasterMap.pm
@@ -3,14 +3,12 @@
 # A combination of FMS OS maps and our own tiles
 
 package FixMyStreet::Map::MasterMap;
-use base 'FixMyStreet::Map::FMS';
 
-use strict;
+use Moo;
+extends 'FixMyStreet::Map::FMS';
 
-use constant ZOOM_LEVELS => 7;
-use constant DEFAULT_ZOOM => 4;
-
-sub map_template { 'fms' }
+has '+zoom_levels' => ( default => 7 );
+has '+default_zoom' => ( default => 4 );
 
 sub map_javascript { [
     '/vendor/OpenLayers/OpenLayers.wfs.js',

--- a/perllib/FixMyStreet/Map/OS/API.pm
+++ b/perllib/FixMyStreet/Map/OS/API.pm
@@ -1,0 +1,41 @@
+# FixMyStreet:Map::OS::API
+# Display OS Maps API tiles (zoom levels 7-16, 17-20 if premium)
+
+package FixMyStreet::Map::OS::API;
+
+use Moo;
+extends 'FixMyStreet::Map::OSM';
+with 'FixMyStreet::Map::OS::Base';
+
+has '+map_type' => ( default => 'OpenLayers.Layer.OSMaps' );
+
+sub map_javascript { [
+    '/vendor/OpenLayers/OpenLayers.wfs.js',
+    '/js/map-OpenLayers.js',
+    FixMyStreet->config('BING_MAPS_API_KEY') ? ('/js/map-bing-ol.js') : (),
+    '/js/map-os.js',
+] }
+
+has '+copyright' => ( default => sub {
+    my $year = 1900 + (localtime)[5];
+    "Contains Highways England and OS data &copy; Crown copyright and database rights $year";
+});
+
+sub map_tiles {
+    my ( $self, %params ) = @_;
+    my ( $x, $y, $z ) = ( $params{x_tile}, $params{y_tile}, $params{zoom_act} );
+    if ($params{aerial}) {
+        return $self->SUPER::map_tiles(%params);
+    } else {
+        my $tile_url = sprintf($self->base_tile_url, $self->layer);
+        my $key = $self->key;
+        return [
+            "$tile_url/$z/" . ($x-1) . "/" . ($y-1) . ".png?key=$key",
+            "$tile_url/$z/$x/" . ($y-1) . ".png?key=$key",
+            "$tile_url/$z/" . ($x-1) . "/$y.png?key=$key",
+            "$tile_url/$z/$x/$y.png?key=$key",
+        ];
+    }
+}
+
+1;

--- a/perllib/FixMyStreet/Map/OS/Base.pm
+++ b/perllib/FixMyStreet/Map/OS/Base.pm
@@ -1,0 +1,43 @@
+# FixMyStreet::Map::OS::Base
+#
+# Provides configuration for using the OS Maps API classes.
+# In your COBRAND_FEATURES configuration, you can supply:
+# * os_maps_url: Optional proxy URL, defaults to direct access
+# * os_maps_api_key: Your API key
+# * os_maps_layer: Which layer to use (Road_3857, Outdoor_3857, Light_3857)
+# * os_maps_premium: Boolean for if you have a Premium account and can access more zoom levels
+
+package FixMyStreet::Map::OS::Base;
+
+use Moo::Role;
+
+has '+min_zoom_level_any' => ( is => 'ro', default => 7 );
+
+has '+zoom_levels' => ( is => 'lazy', default => sub {
+    $_[0]->cobrand->feature('os_maps_premium') ? 8 : 4
+} );
+
+has '+base_tile_url' => ( is => 'lazy', default => sub {
+    $_[0]->cobrand->feature('os_maps_url') || 'https://api.os.uk/maps/raster/v1/zxy/%s'
+} );
+
+has key => ( is => 'lazy', default => sub {
+    $_[0]->cobrand->feature('os_maps_api_key') || ''
+} );
+
+has layer => ( is => 'lazy', default => sub {
+    $_[0]->cobrand->feature('os_maps_layer') || 'Road_3857'
+} );
+
+around generate_map_data => sub {
+    my ($orig, $self) = (shift, shift);
+    my $data = $self->$orig(@_);
+    $data->{os_maps} = {
+        key => $self->key,
+        layer => $self->layer,
+        url => $self->base_tile_url,
+    };
+    return $data;
+};
+
+1;

--- a/perllib/FixMyStreet/Map/OS/FMS.pm
+++ b/perllib/FixMyStreet/Map/OS/FMS.pm
@@ -1,0 +1,35 @@
+# FixMyStreet:Map::OS::FMS
+# Bing Maps zoomed out, OS Maps zoomed in
+
+package FixMyStreet::Map::OS::FMS;
+
+use Moo;
+extends 'FixMyStreet::Map::FMS';
+with 'FixMyStreet::Map::OS::Base';
+
+# As OS Maps API only has one host, we can (ab)use the
+# prefix to insert our chosen layer
+has '+map_tile_prefix' => ( is => 'lazy', default => sub {
+    my $layer = $_[0]->layer;
+    [$layer, $layer, $layer, $layer]
+} );
+
+sub map_javascript {
+    my $self = shift;
+    my $js = $self->SUPER::map_javascript;
+    push @$js, '/js/map-fms-os.js';
+    return $js;
+}
+
+sub map_tiles {
+    my ( $self, %params ) = @_;
+    my $urls = $self->SUPER::map_tiles(%params);
+    if ($urls->[0] =~ /api\.os\.uk/) {
+        my $key = $self->key;
+        $urls = [ map { $_ .= "?key=$key" } @$urls ];
+    }
+    return $urls;
+}
+
+1;
+

--- a/perllib/FixMyStreet/Map/OSM.pm
+++ b/perllib/FixMyStreet/Map/OSM.pm
@@ -13,6 +13,7 @@ use Utils;
 
 use constant ZOOM_LEVELS    => 7;
 use constant MIN_ZOOM_LEVEL => 13;
+use constant MIN_ZOOM_LEVEL_ANY => 0;
 use constant DEFAULT_ZOOM   => 3;
 
 sub map_type { 'OpenLayers.Layer.OSM.Mapnik' }
@@ -77,6 +78,7 @@ sub generate_map_data {
 
     my $numZoomLevels = $self->ZOOM_LEVELS;
     my $zoomOffset = $self->MIN_ZOOM_LEVEL;
+    my $anyZoomOffset = $self->MIN_ZOOM_LEVEL_ANY;
 
     # Adjust zoom level dependent upon population density if cobrand hasn't
     # specified a default zoom.
@@ -90,9 +92,9 @@ sub generate_map_data {
     }
 
     if ($params{any_zoom}) {
-        $numZoomLevels += $zoomOffset;
-        $default_zoom += $zoomOffset;
-        $zoomOffset = 0;
+        $numZoomLevels += $zoomOffset - $anyZoomOffset;
+        $default_zoom += $zoomOffset - $anyZoomOffset;
+        $zoomOffset = $anyZoomOffset;
     }
 
     my $zoom = $data->{zoom} || $default_zoom;

--- a/perllib/FixMyStreet/Map/OSM/CycleMap.pm
+++ b/perllib/FixMyStreet/Map/OSM/CycleMap.pm
@@ -5,14 +5,12 @@
 # Email: matthew@mysociety.org; WWW: http://www.mysociety.org/
 
 package FixMyStreet::Map::OSM::CycleMap;
-use base 'FixMyStreet::Map::OSM';
 
-use strict;
+use Moo;
+extends 'FixMyStreet::Map::OSM';
 
-sub map_type { 'OpenLayers.Layer.OSM.CycleMap' }
+has '+map_type' => ( default => 'OpenLayers.Layer.OSM.CycleMap' );
 
-sub base_tile_url {
-    return 'tile.opencyclemap.org/cycle';
-}
+has '+base_tile_url' => ( default => 'tile.opencyclemap.org/cycle' );
 
 1;

--- a/perllib/FixMyStreet/Map/OSM/StreetView.pm
+++ b/perllib/FixMyStreet/Map/OSM/StreetView.pm
@@ -5,13 +5,13 @@
 # Email: matthew@mysociety.org; WWW: http://www.mysociety.org/
 
 package FixMyStreet::Map::OSM::StreetView;
-use base 'FixMyStreet::Map::OSM';
 
-use strict;
+use Moo;
+extends 'FixMyStreet::Map::OSM';
 
-use constant ZOOM_LEVELS => 6;
+has '+zoom_levels' => ( default => 6 );
 
-sub map_type { '' }
+has '+map_type' => ( default => '' );
 
 sub map_javascript { [
     '/vendor/OpenLayers/OpenLayers.fixmystreet.js',
@@ -19,12 +19,8 @@ sub map_javascript { [
     '/js/map-streetview.js',
 ] }
 
-sub base_tile_url {
-    return 'os.openstreetmap.org/sv';
-}
+has '+base_tile_url' => ( default => 'os.openstreetmap.org/sv' );
 
-sub copyright {
-    'Contains OS data &copy; Crown copyright and database right 2016';
-}
+has '+copyright' => ( default => 'Contains OS data &copy; Crown copyright and database right 2016' );
 
 1;

--- a/perllib/FixMyStreet/Map/OSM/TonerLite.pm
+++ b/perllib/FixMyStreet/Map/OSM/TonerLite.pm
@@ -10,11 +10,10 @@
 # Email: hakim@mysociety.org; WWW: http://www.mysociety.org/
 
 package FixMyStreet::Map::OSM::TonerLite;
-use base 'FixMyStreet::Map::OSM';
+use Moo;
+extends 'FixMyStreet::Map::OSM';
 
-use strict;
-
-sub map_type { 'OpenLayers.Layer.Stamen' }
+has '+map_type' => ( default => 'OpenLayers.Layer.Stamen' );
 
 sub map_javascript { [
     '/vendor/OpenLayers/OpenLayers.fixmystreet.js',
@@ -23,9 +22,9 @@ sub map_javascript { [
     '/js/map-toner-lite.js',
 ] }
 
-sub copyright {
+has '+copyright' => ( default => 
     'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
-}
+);
 
 sub map_tiles {
     my ( $self, %params ) = @_;

--- a/perllib/FixMyStreet/Queue/Item/Report.pm
+++ b/perllib/FixMyStreet/Queue/Item/Report.pm
@@ -64,7 +64,7 @@ sub process {
     }
 
     $self->cobrand->set_lang_and_domain($self->report->lang, 1);
-    FixMyStreet::Map::set_map_class($self->cobrand_handler->map_type);
+    FixMyStreet::Map::set_map_class($self->cobrand_handler);
 
     return unless $self->_check_abuse;
     $self->_create_vars;

--- a/perllib/FixMyStreet/Script/Alerts.pm
+++ b/perllib/FixMyStreet/Script/Alerts.pm
@@ -352,7 +352,7 @@ sub _send_aggregated_alert_email {
 
     my $cobrand = $data{cobrand};
 
-    FixMyStreet::Map::set_map_class($cobrand->map_type);
+    FixMyStreet::Map::set_map_class($cobrand);
 
     my $sender = FixMyStreet::Email::unique_verp_id([ 'alert', $data{alert_id} ], $cobrand->call_hook('verp_email_domain'));
     my $result = FixMyStreet::Email::send_cron(

--- a/perllib/FixMyStreet/Script/ArchiveOldEnquiries.pm
+++ b/perllib/FixMyStreet/Script/ArchiveOldEnquiries.pm
@@ -165,7 +165,7 @@ sub send_email_and_close {
 
     my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker($opts->{cobrand})->new();
     $cobrand->set_lang_and_domain($problems[0]->lang, 1);
-    FixMyStreet::Map::set_map_class($cobrand->map_type);
+    FixMyStreet::Map::set_map_class($cobrand);
 
     my %h = (
       reports => [@problems],

--- a/perllib/FixMyStreet/Script/Questionnaires.pm
+++ b/perllib/FixMyStreet/Script/Questionnaires.pm
@@ -45,7 +45,7 @@ sub send_questionnaires_period {
 
         my $cobrand = $row->get_cobrand_logged;
         $cobrand->set_lang_and_domain($row->lang, 1);
-        FixMyStreet::Map::set_map_class($cobrand->map_type);
+        FixMyStreet::Map::set_map_class($cobrand);
 
         # Not all cobrands send questionnaires
         next unless $cobrand->send_questionnaires;

--- a/t/Mock/Nominatim.pm
+++ b/t/Mock/Nominatim.pm
@@ -3,6 +3,7 @@ package t::Mock::Nominatim;
 use JSON::MaybeXS;
 use LWP::Protocol::PSGI;
 use Web::Simple;
+use mySociety::Locale;
 
 has json => (
     is => 'lazy',

--- a/t/app/controller/around.t
+++ b/t/app/controller/around.t
@@ -1,8 +1,9 @@
 package FixMyStreet::Map::Tester;
-use base 'FixMyStreet::Map::FMS';
 
-use constant ZOOM_LEVELS    => 99;
-use constant MIN_ZOOM_LEVEL => 88;
+use Moo;
+extends 'FixMyStreet::Map::FMS';
+has '+zoom_levels' => ( default => 99 );
+has '+min_zoom_level' => ( default => 88 );
 
 1;
 

--- a/t/map/bing.t
+++ b/t/map/bing.t
@@ -1,11 +1,13 @@
 use Test::More;
 use FixMyStreet::Map::Bing;
 
-my $tiles = FixMyStreet::Map::Bing->map_tiles(x_tile => 8105, y_tile => 5375, zoom_act => 14);
+my $map = FixMyStreet::Map::Bing->new;
+
+my $tiles = $map->map_tiles(x_tile => 8105, y_tile => 5375, zoom_act => 14);
 $tiles = [ map { m{ch/([^?]*)}; $1; } @$tiles ];
 is_deeply $tiles, [ '03131132323220', '03131132323221', '03131132323222', '03131132323223' ];
 
-$tiles = FixMyStreet::Map::Bing->map_tiles(x_tile => 8105, y_tile => 5375, zoom_act => 14, aerial => 1);
+$tiles = $map->map_tiles(x_tile => 8105, y_tile => 5375, zoom_act => 14, aerial => 1);
 $tiles = [ map { m{ch/([^?]*)\?.*A,G,L}; $1; } @$tiles ];
 is_deeply $tiles, [ '03131132323220', '03131132323221', '03131132323222', '03131132323223' ];
 

--- a/t/map/cheshireeast.t
+++ b/t/map/cheshireeast.t
@@ -2,16 +2,16 @@ use Test::More;
 use FixMyStreet::Map::CheshireEast;
 
 # https://maps-cache.cheshiresharedservices.gov.uk/maps/?wmts/CE_OS_AllBasemaps_COLOUR/oscce_grid/10/10187/8134.jpeg&KEY=3a3f5c60eca1404ea114e6941c9d3895
-my $tiles = FixMyStreet::Map::CheshireEast->map_tiles(x_tile => 10187, y_tile => 8134, zoom_act => 10);
+my $map = FixMyStreet::Map::CheshireEast->new;
+my $tiles = $map->map_tiles(x_tile => 10187, y_tile => 8134, zoom_act => 10);
 $tiles = [ map { m{(\d+/\d+/\d+)}; $1; } @$tiles ];
 is_deeply $tiles, [ '10/10186/8133', '10/10187/8133', '10/10186/8134', '10/10187/8134' ];
 
-use Data::Dumper;
-my ($x, $y) = FixMyStreet::Map::CheshireEast->latlon_to_tile_with_adjust(53.150624, -2.386809, 10);
+my ($x, $y) = $map->latlon_to_tile_with_adjust(53.150624, -2.386809, 10);
 is $x, 10187;
 is $y, 8134;
 
-my ($lat, $lon) = FixMyStreet::Map::CheshireEast->tile_to_latlon(10187, 8134, 10);
+my ($lat, $lon) = $map->tile_to_latlon(10187, 8134, 10);
 is sprintf("%.6f", $lat), 53.150624;
 is sprintf("%.6f", $lon), -2.386809;
 

--- a/t/map/fms.t
+++ b/t/map/fms.t
@@ -36,10 +36,11 @@ my $expected = {
 };
 
 subtest "Correct tiles with various parameters" => sub {
+    my $map = FixMyStreet::Map::FMS->new;
     for my $aerial (0, 1) {
         for my $ni (0, 1) {
             for my $zoom (qw(10 13 16)) {
-                my $tiles = FixMyStreet::Map::FMS->map_tiles(
+                my $tiles = $map->map_tiles(
                     x_tile => 32421, y_tile => 21505, zoom_act => $zoom,
                     aerial => $aerial,
                     latitude => $ni ? 55 : 51,

--- a/t/map/google.t
+++ b/t/map/google.t
@@ -15,6 +15,7 @@ is_deeply $c->stash->{map}, {
     zoomOffset => 0,
     numZoomLevels => 20,
     zoom_act => 15,
+    aerial => 0,
 };
 
 done_testing();

--- a/t/map/mastermap.t
+++ b/t/map/mastermap.t
@@ -3,12 +3,13 @@ use FixMyStreet::TestMech;
 use FixMyStreet::Map::MasterMap;
 
 subtest 'correct map tiles used' => sub {
+    my $map = FixMyStreet::Map::MasterMap->new;
     my %test = (
         16 => [ '-', 'oml' ],
         20 => [ '.', 'mastermap-staging' ]
     );
     foreach my $zoom (qw(16 20)) {
-        my $tiles = FixMyStreet::Map::MasterMap->map_tiles(x_tile => 123, y_tile => 456, zoom_act => $zoom);
+        my $tiles = $map->map_tiles(x_tile => 123, y_tile => 456, zoom_act => $zoom);
         my ($sep, $lyr) = @{$test{$zoom}};
         is_deeply $tiles, [
             "//a${sep}tilma.mysociety.org/$lyr/$zoom/122/455.png",

--- a/t/map/os.t
+++ b/t/map/os.t
@@ -1,0 +1,56 @@
+use Test::More;
+use FixMyStreet::Cobrand;
+use FixMyStreet::Map::OS::FMS;
+use FixMyStreet::Map::OS::API;
+
+my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker('fixmystreet');
+
+subtest 'correct map tiles used' => sub {
+    foreach (
+        { zoom => 10, layer => 'Road_3857' },
+        { zoom => 13, layer => 'Outdoor_3857' },
+        { zoom => 16, layer => 'Light_3857' },
+    ) {
+        my $layer = $_->{layer};
+        my $zoom = $_->{zoom};
+        FixMyStreet::override_config {
+            COBRAND_FEATURES => {
+                os_maps_api_key => { default => "123" },
+                os_maps_layer => { default => $layer },
+            }
+        }, sub {
+            my $map = FixMyStreet::Map::OS::API->new({ cobrand => $cobrand });
+            my $tiles = $map->map_tiles(x_tile => 123, y_tile => 456, zoom_act => $zoom);
+            is_deeply $tiles, [
+                "https://api.os.uk/maps/raster/v1/zxy/$layer/$zoom/122/455.png?key=123",
+                "https://api.os.uk/maps/raster/v1/zxy/$layer/$zoom/123/455.png?key=123",
+                "https://api.os.uk/maps/raster/v1/zxy/$layer/$zoom/122/456.png?key=123",
+                "https://api.os.uk/maps/raster/v1/zxy/$layer/$zoom/123/456.png?key=123",
+            ], "with $layer and $zoom";
+        };
+    }
+};
+
+subtest "Correct OS::FMS tiles" => sub {
+    foreach (
+        { zoom => 10, expected => 'ch/1010100100.*?=G,L' },
+        { zoom => 13, expected => 'r3131010100100.*?mmOS' },
+        { zoom => 16, layer => 'Light_3857', expected => 'zxy/Light_3857/16/32420/21504.png\?key=456' },
+        { zoom => 18, layer => 'Road_3857', expected => 'zxy/Road_3857/18/32420/21504.png\?key=456' },
+    ) {
+        my $layer = $_->{layer};
+        my $zoom = $_->{zoom};
+        FixMyStreet::override_config {
+            COBRAND_FEATURES => {
+                os_maps_api_key => { default => "456" },
+                os_maps_layer => { default => $layer },
+            }
+        }, sub {
+            my $map = FixMyStreet::Map::OS::FMS->new({ cobrand => $cobrand });
+            my $tiles = $map->map_tiles(x_tile => 32421, y_tile => 21505, zoom_act => $zoom);
+            like $tiles->[0], qr/$_->{expected}/, "with zoom $zoom";
+        };
+    }
+};
+
+done_testing();

--- a/t/map/tests.t
+++ b/t/map/tests.t
@@ -24,7 +24,7 @@ my $requires = {
 };
 
 foreach (FixMyStreet::Map->maps) {
-    next if /WMTSBase|UKCouncilWMTS|WMSBase|WMXBase/; # Only its subclasses have JS
+    next if /Base|UKCouncilWMTS/; # Only its subclasses have JS
     my $js = $_->map_javascript;
     my $test_file = $js->[-1];
     s/.*:://;

--- a/t/map/tests.t
+++ b/t/map/tests.t
@@ -6,7 +6,6 @@ my $requires = {
     'Bristol' => 'map-wmts-bristol.js',
     'Bromley' => 'map-fms.js',
     'Buckinghamshire' => 'map-wmts-buckinghamshire.js',
-    'Lincolnshire' => 'lincolnshire/assets.js',
     'CheshireEast' => 'map-cheshireeast.js',
     'FMS' => 'map-fms.js',
     'Google' => 'map-google.js',
@@ -14,12 +13,16 @@ my $requires = {
     'HighwaysEngland' => 'map-fms.js',
     'Hounslow' => 'map-wmts-hounslow.js',
     'IsleOfWight' => 'map-wmts-isleofwight.js',
-    'OSM' => 'OpenStreetMap.js',
+    'Lincolnshire' => 'lincolnshire/assets.js',
     'MasterMap' => 'map-mastermap.js',
     'Northamptonshire' => 'map-wms-northamptonshire.js',
-    'CycleMap' => 'OpenStreetMap.js',
-    'StreetView' => 'map-streetview.js',
-    'TonerLite' => 'map-toner-lite.js',
+    'OS::FMS' => 'map-fms-os.js',
+    'OS::API' => 'map-os.js',
+    'OS::Premium' => 'map-os.js',
+    'OSM' => 'OpenStreetMap.js',
+    'OSM::CycleMap' => 'OpenStreetMap.js',
+    'OSM::StreetView' => 'map-streetview.js',
+    'OSM::TonerLite' => 'map-toner-lite.js',
     'Zurich' => 'map-wmts-zurich.js',
 };
 
@@ -27,7 +30,7 @@ foreach (FixMyStreet::Map->maps) {
     next if /Base|UKCouncilWMTS/; # Only its subclasses have JS
     my $js = $_->map_javascript;
     my $test_file = $js->[-1];
-    s/.*:://;
+    s/^FixMyStreet::Map:://;
     isnt $requires->{$_}, undef, "$_ requires present";
     like $test_file, qr/$requires->{$_}/, "$_ JS okay";
 }

--- a/templates/web/base/around/display_location.html
+++ b/templates/web/base/around/display_location.html
@@ -46,9 +46,6 @@
 [% IF allow_creation %]
 <form action="[% c.uri_for('/report/new') %]" method="post" name="mapForm" id="mapForm" enctype="multipart/form-data" class="validate" novalidate>
     <input type="hidden" name="token" value="[% csrf_token %]">
-    [% IF c.req.params.map_override %]
-        <input type="hidden" name="map_override" value="[% c.req.params.map_override | html %]">
-    [% END %]
     <input type="hidden" name="pc" value="[% pc | html %]">
 
     <input type="hidden" name="latitude" id="fixmystreet.latitude" value="[% latitude | html %]">

--- a/templates/web/base/maps/openlayers.html
+++ b/templates/web/base/maps/openlayers.html
@@ -27,7 +27,12 @@
     data-map_type="[% map.map_type %]"
 [% IF include_key -%]
     data-bing_key='[% c.config.BING_MAPS_API_KEY %]'
-[%- END -%]
+[% END -%]
+[% IF map.os_maps -%]
+    data-os_key='[% map.os_maps.key %]'
+    data-os_layer='[% map.os_maps.layer %]'
+    data-os_url='[% map.os_maps.url %]'
+[% END -%]
 [% IF list_of_names_as_string -%]
     data-bodies='[% list_of_names_as_string | html %]'
 [%- END -%]

--- a/templates/web/base/maps/openlayers.html
+++ b/templates/web/base/maps/openlayers.html
@@ -26,7 +26,7 @@
     data-zoomOffset=[% map.zoomOffset %]
     data-map_type="[% map.map_type %]"
 [% IF include_key -%]
-    data-key='[% c.config.BING_MAPS_API_KEY %]'
+    data-bing_key='[% c.config.BING_MAPS_API_KEY %]'
 [%- END -%]
 [% IF list_of_names_as_string -%]
     data-bodies='[% list_of_names_as_string | html %]'

--- a/templates/web/base/report/new/fill_in_details.html
+++ b/templates/web/base/report/new/fill_in_details.html
@@ -14,9 +14,6 @@
 [% IF report.used_map %]
 
 <form action="[% c.uri_for('/report/new') %]" method="post" name="mapForm" id="mapForm"[% IF c.cobrand.allow_photo_upload %] enctype="multipart/form-data"[% END %] class="validate">
-    [% IF c.req.params.map_override %]
-        <input type="hidden" name="map_override" value="[% c.req.params.map_override | html %]">
-    [% END %]
 
 [% ELSE %]
 

--- a/web/cobrands/fixmystreet/map.js
+++ b/web/cobrands/fixmystreet/map.js
@@ -3,7 +3,7 @@ var fixmystreet = fixmystreet || {};
 (function(){
 
     var map_data = document.getElementById('js-map-data'),
-        map_keys = [ 'area', 'latitude', 'longitude', 'zoomToBounds', 'zoom', 'pin_prefix', 'pin_new_report_colour', 'numZoomLevels', 'zoomOffset', 'map_type', 'bing_key', 'bodies', 'staging' ],
+        map_keys = [ 'area', 'latitude', 'longitude', 'zoomToBounds', 'zoom', 'pin_prefix', 'pin_new_report_colour', 'numZoomLevels', 'zoomOffset', 'map_type', 'bing_key', 'bodies', 'staging', 'os_key', 'os_layer', 'os_url' ],
         numeric = { zoom: 1, numZoomLevels: 1, zoomOffset: 1, id: 1 },
         bool = { draggable: 1 },
         pin_keys = [ 'lat', 'lon', 'colour', 'id', 'title', 'type', 'draggable' ];

--- a/web/cobrands/fixmystreet/map.js
+++ b/web/cobrands/fixmystreet/map.js
@@ -3,7 +3,7 @@ var fixmystreet = fixmystreet || {};
 (function(){
 
     var map_data = document.getElementById('js-map-data'),
-        map_keys = [ 'area', 'latitude', 'longitude', 'zoomToBounds', 'zoom', 'pin_prefix', 'pin_new_report_colour', 'numZoomLevels', 'zoomOffset', 'map_type', 'key', 'bodies', 'staging' ],
+        map_keys = [ 'area', 'latitude', 'longitude', 'zoomToBounds', 'zoom', 'pin_prefix', 'pin_new_report_colour', 'numZoomLevels', 'zoomOffset', 'map_type', 'bing_key', 'bodies', 'staging' ],
         numeric = { zoom: 1, numZoomLevels: 1, zoomOffset: 1, id: 1 },
         bool = { draggable: 1 },
         pin_keys = [ 'lat', 'lon', 'colour', 'id', 'title', 'type', 'draggable' ];

--- a/web/js/map-fms-os.js
+++ b/web/js/map-fms-os.js
@@ -1,0 +1,20 @@
+OpenLayers.Layer.OSFMS = OpenLayers.Class(OpenLayers.Layer.BingUK, {
+    get_urls: function(bounds, z) {
+        var in_gb = this.in_gb(bounds.getCenterLonLat());
+        if (z >= 16 && in_gb) {
+            var url = fixmystreet.os_url.replace('%s', fixmystreet.os_layer) + "/${z}/${x}/${y}.png";
+            if (fixmystreet.os_key) {
+                url += "?key=" + fixmystreet.os_key;
+            }
+            return [url];
+        }
+        return OpenLayers.Layer.BingUK.prototype.get_urls.apply(this, arguments);
+    },
+
+    CLASS_NAME: "OpenLayers.Layer.OSFMS"
+});
+
+fixmystreet.layer_options = [
+  { map_type: OpenLayers.Layer.OSFMS },
+  { map_type: OpenLayers.Layer.BingAerial }
+];

--- a/web/js/map-fms.js
+++ b/web/js/map-fms.js
@@ -56,7 +56,7 @@ OpenLayers.Layer.BingUK = OpenLayers.Class(OpenLayers.Layer.Bing, {
                 urls.push( fixmystreet.maps.tile_base.replace('{S}', this.tile_prefix[i]) + "/${z}/${x}/${y}.png" );
             }
         } else if (z > 11 && in_uk) {
-            var type = 'g=8702&lbl=l1&productSet=mmOS&key=' + fixmystreet.key;
+            var type = 'g=8702&lbl=l1&productSet=mmOS&key=' + fixmystreet.bing_key;
             var tile_base = "//ecn.t{S}.tiles.virtualearth.net/tiles/r${id}?" + type;
             for (i=0; i<4; i++) {
                 urls.push(tile_base.replace('{S}', i));

--- a/web/js/map-fms.js
+++ b/web/js/map-fms.js
@@ -1,20 +1,20 @@
 fixmystreet.maps.tile_base = '//{S}tilma.mysociety.org/oml';
 
 OpenLayers.Layer.BingUK = OpenLayers.Class(OpenLayers.Layer.Bing, {
-    uk_bounds: [
+    gb_bounds: [
         new OpenLayers.Bounds(-6.6, 49.8, 1.102680, 51),
         new OpenLayers.Bounds(-5.4, 51, 2.28, 54.94),
         new OpenLayers.Bounds(-5.85, 54.94, -1.15, 55.33),
         new OpenLayers.Bounds(-9.35, 55.33, -0.7, 60.98)
     ],
 
-    in_uk: function(c) {
+    in_gb: function(c) {
         c = c.clone();
         c.transform(
             fixmystreet.map.getProjectionObject(),
             new OpenLayers.Projection("EPSG:4326")
         );
-        if ( this.uk_bounds[0].contains(c.lon, c.lat) || this.uk_bounds[1].contains(c.lon, c.lat) || this.uk_bounds[2].contains(c.lon, c.lat) || this.uk_bounds[3].contains(c.lon, c.lat) ) {
+        if ( this.gb_bounds[0].contains(c.lon, c.lat) || this.gb_bounds[1].contains(c.lon, c.lat) || this.gb_bounds[2].contains(c.lon, c.lat) || this.gb_bounds[3].contains(c.lon, c.lat) ) {
             return true;
         }
         return false;
@@ -30,13 +30,13 @@ OpenLayers.Layer.BingUK = OpenLayers.Class(OpenLayers.Layer.Bing, {
         var copyrights;
         var logo = '';
         var c = this.map.getCenter();
-        var in_uk = c ? this.in_uk(c) : true;
+        var in_gb = c ? this.in_gb(c) : true;
         var year = (new Date()).getFullYear();
-        if (z >= 16 && in_uk) {
+        if (z >= 16 && in_gb) {
             copyrights = 'Contains Highways England and Ordnance Survey data &copy; Crown copyright and database right ' + year;
         } else {
             logo = '<a href="https://www.bing.com/maps/"><img border=0 src="//dev.virtualearth.net/Branding/logo_powered_by.png"></a>';
-            if (in_uk) {
+            if (in_gb) {
                 copyrights = '&copy; ' + year + ' <a href="https://www.bing.com/maps/">Microsoft</a>, HERE, Highways England, Ordnance Survey';
             } else {
                 copyrights = '&copy; ' + year + ' <a href="https://www.bing.com/maps/">Microsoft</a>, HERE, Ordnance Survey';
@@ -49,13 +49,13 @@ OpenLayers.Layer.BingUK = OpenLayers.Class(OpenLayers.Layer.Bing, {
 
     get_urls: function(bounds, z) {
         var urls = [], i;
-        var in_uk = this.in_uk(bounds.getCenterLonLat());
-        if (z >= 16 && in_uk) {
+        var in_gb = this.in_gb(bounds.getCenterLonLat());
+        if (z >= 16 && in_gb) {
             urls = [];
             for (i=0; i< this.tile_prefix.length; i++) {
                 urls.push( fixmystreet.maps.tile_base.replace('{S}', this.tile_prefix[i]) + "/${z}/${x}/${y}.png" );
             }
-        } else if (z > 11 && in_uk) {
+        } else if (z > 11 && in_gb) {
             var type = 'g=8702&lbl=l1&productSet=mmOS&key=' + fixmystreet.bing_key;
             var tile_base = "//ecn.t{S}.tiles.virtualearth.net/tiles/r${id}?" + type;
             for (i=0; i<4; i++) {

--- a/web/js/map-os.js
+++ b/web/js/map-os.js
@@ -1,0 +1,34 @@
+fixmystreet.maps.config = function() {
+    fixmystreet.controls = [
+        new OpenLayers.Control.ArgParserFMS(),
+        new OpenLayers.Control.Navigation(),
+        new OpenLayers.Control.PermalinkFMS('map'),
+        new OpenLayers.Control.PanZoomFMS({id: 'fms_pan_zoom' })
+    ];
+
+    if (OpenLayers.Layer.BingAerial) {
+        fixmystreet.layer_options = [
+          { map_type: OpenLayers.Layer.OSMaps },
+          { map_type: OpenLayers.Layer.BingAerial }
+        ];
+    }
+};
+
+OpenLayers.Layer.OSMaps = OpenLayers.Class(OpenLayers.Layer.OSM, {
+    initialize: function(name, options) {
+        var url = fixmystreet.os_url.replace('%s', fixmystreet.os_layer) + "/${z}/${x}/${y}.png";
+        if (fixmystreet.os_key) {
+            url += "?key=" + fixmystreet.os_key;
+        }
+        options = OpenLayers.Util.extend({
+            /* Below line added to OSM's file in order to allow minimum zoom level */
+            maxResolution: 156543.03390625/Math.pow(2, options.zoomOffset || 0),
+            numZoomLevels: 20,
+            buffer: 0
+        }, options);
+        var newArguments = [name, url, options];
+        OpenLayers.Layer.OSM.prototype.initialize.apply(this, newArguments);
+    },
+
+    CLASS_NAME: "OpenLayers.Layer.OSMaps"
+});


### PR DESCRIPTION
OS Maps key, layer, URL, and whether it's premium or not can be provided on a per-cobrand basis. In order to do that I had to switch the OSM map classes to use Moo (so e.g. number of zoom levels could look at configuration to work itself out), which hopefully tidies it up a bit at the same time.

The other base change was to store the cobrand being used to set a map class, not just the map class. This is so that, if you are in the scenario where someone is generating a map on a OS-Maps-API-using cobrand, for a report that was generated on a non-OS-Maps-API-using cobrand, it would still be able to access the right information for the API key etc.