### PR TITLE
[Zurich] Open311 docs changes

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Open311.pm
+++ b/perllib/FixMyStreet/App/Controller/Open311.pm
@@ -235,7 +235,7 @@ sub output_requests : Private {
         unless $limit && $limit <= $default_limit;
 
     my $attr = {
-        order_by => { -desc => 'confirmed' },
+        order_by => { -desc => $c->cobrand->moniker == 'zurich' ? 'created' : 'confirmed' },
         rows => $limit
     };
 
@@ -401,7 +401,7 @@ sub rss_query : Private {
 
     my $attr = {
         result_class => 'DBIx::Class::ResultClass::HashRefInflator',
-        order_by => { -desc => 'confirmed' },
+        order_by => { -desc => $c->cobrand->moniker == 'zurich' ? 'created' : 'confirmed' },
         rows => $limit
     };
 

--- a/perllib/FixMyStreet/App/Controller/Open311.pm
+++ b/perllib/FixMyStreet/App/Controller/Open311.pm
@@ -102,31 +102,23 @@ sub get_discovery : Private {
     my ( $self, $c ) = @_;
 
     my $contact_email = $c->cobrand->contact_email;
-    my $prod_url = 'http://www.fiksgatami.no/open311';
-    my $test_url = 'http://fiksgatami-dev.nuug.no/open311';
-    my $prod_changeset = '2011-04-08T00:00:00Z';
-    my $test_changeset = $prod_changeset;
+    my $endpoint_url = $c->request->uri;
+    $endpoint_url->path_query('/open311');
+    my $changeset = '2021-03-01T00:00:00Z';
     my $spec_url = 'http://wiki.open311.org/GeoReport_v2';
     my $info =
     {
         'contact' => "Send email to $contact_email.",
-        'changeset' => $prod_changeset,
+        'changeset' => $changeset,
         'max_requests' => $c->config->{OPEN311_LIMIT} || 1000,
         'endpoints' => [
             {
                 'formats' => [ 'text/xml', 'application/json', 'text/html' ],
                 'specification' => $spec_url,
-                'changeset' => $prod_changeset,
-                'url' => $prod_url,
-                'type' => 'production'
+                'changeset' => $changeset,
+                'url' => $endpoint_url->as_string,
+                'type' => $c->config->{STAGING_SITE} ? 'test' : 'production'
             },
-            {
-                'formats' => [ 'text/xml', 'application/json', 'text/html' ],
-                'specification' => $spec_url,
-                'changeset' => $test_changeset,
-                'url' => $test_url,
-                'type' => 'test'
-            }
         ]
     };
     $c->forward( 'format_output', [ {

--- a/t/app/controller/open311.t
+++ b/t/app/controller/open311.t
@@ -60,4 +60,21 @@ subtest "hidden reports aren't available" => sub {
     is @$problems, 0;
 };
 
+subtest "Zurich open311 docs differ from main docs" => sub {
+    $mech->get_ok('/open311');
+    $mech->content_contains('agency_responsible');
+    $mech->content_contains('list of services provided for WGS84 coordinate latitude 60 longitude 11');
+    $mech->content_contains('&lt;description&gt;Mangler brustein');
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'zurich',
+    }, sub {
+        ok $mech->host("www.zueriwieneu.ch"), 'host to zueriwieneu';
+        $mech->get_ok('/open311');
+        $mech->content_lacks('agency_responsible');
+        $mech->content_contains('list of services provided for WGS84 coordinate latitude 47.3 longitude 8.5');
+        $mech->content_contains('&lt;description&gt;Unebener');
+    };
+};
+
 done_testing();

--- a/templates/web/base/open311/index.html
+++ b/templates/web/base/open311/index.html
@@ -80,49 +80,16 @@ for council problem-reporting systems.</p>
 
 <p>[% loc('In addition, the following attributes that are not part of the Open311 v2 specification are returned: agency_sent_datetime, title (also returned as part of description), interface_used, comment_count, requestor_name (only present if requestor allowed the name to be shown on this site).') %]</p>
 
+[% IF show_agency_responsible %]
 <p>[% loc('The Open311 v2 attribute agency_responsible is used to list the administrations that received the problem report, which is not quite the way the attribute is defined in the Open311 v2 specification.') %]</p>
 
 <p>[% tprintf( loc('With request searches, it is also possible to search for agency_responsible to limit the requests to those sent to a single administration.  The search term is the administration ID provided by <a href="%s">MaPit</a>.'), c.config.MAPIT_URL ) %]</p>
+[% END %]
 
 <p>[% loc('Examples:') %]</p>
 
 <ul>
 
-[% jurisdiction_id = c.cobrand.jurisdiction_id_example %]
-[% examples = [
-    {
-        url = "/open311/v2/discovery.xml?jurisdiction_id=$jurisdiction_id",
-        info = 'discovery information',
-    },
-    {
-        url = "/open311/v2/services.xml?jurisdiction_id=$jurisdiction_id",
-        info = 'list of services provided',
-    },
-    {
-        url = "/open311/v2/services.xml?jurisdiction_id=$jurisdiction_id&lat=60&long=11",
-        info = 'list of services provided for WGS84 coordinate latitude 60 longitude 11',
-    },
-    {
-        url = "/open311/v2/requests/1.xml?jurisdiction_id=$jurisdiction_id",
-        info = 'Request number 1',
-    },
-    {
-        url = "/open311/v2/requests.xml?jurisdiction_id=$jurisdiction_id&status=open&agency_responsible=1601&end_date=2011-03-10",
-        info = 'All open requests reported before 2011-03-10 to Trondheim (id 1601)',
-    },
-    {
-        url = "/open311/v2/requests.xml?jurisdiction_id=$jurisdiction_id&status=open&agency_responsible=219|220",
-        info = 'All open requests in Asker (id 220) and Bærum (id 219)',
-    },
-    {
-        url = "/open311/v2/requests.xml?jurisdiction_id=$jurisdiction_id&service_code=Vannforsyning",
-        info = "All requests with the category 'Vannforsyning'",
-    },
-    {
-        url = "/open311/v2/requests.xml?jurisdiction_id=$jurisdiction_id&status=closed",
-        info = 'All closed requests',
-    },
-] %]
 [% FOREACH examples %]
     <li>[% info %]: <a href="[% url %]">XML</a> or <a href="[% url.replace('xml', 'json') %]">JSON</a>
     <br>[% url.replace('xml', '<i>format</i>') | safe %]</li>
@@ -154,9 +121,11 @@ for council problem-reporting systems.</p>
 <dd>Only return requests with requested_datetime set before the date
   and time specified.  Same format as start_date.</dd>
 
+[% IF show_agency_responsible %]
 <dt>agency_responsible</dt>
 <dd>ID of government body receiving the request.  Several IDs can be
   specified with | as a separator.</dd>
+[% END %]
 
 <dt>interface_used<dt>
 <dd>Name / identifier of interface used.</dd>
@@ -175,6 +144,28 @@ call, the value provided is ignored.</dd>
 
 <p>The search result might look like this:</p>
 
+[% IF c.cobrand.moniker == 'zurich' %]
+<pre>[% "
+  <service_requests>
+    <request>
+      <agency_sent_datetime>2013-04-04T07:25:05+02:00</agency_sent_datetime>
+      <description>Unebener Bürgersteig: Auf dem Asphalt des Bürgersteigs hat es eine Erhebung, die man wirklich nicht sieht und immer wieder drüber stolpert.</description>
+      <detail>Auf dem Asphalt des Bürgersteigs hat es eine Erhebung, die man wirklich nicht sieht und immer wieder drüber stolpert.</detail>
+      <interface_used>Web interface</interface_used>
+      <lat>47.374042</lat>
+      <long>8.484223</long>
+      <requested_datetime>2013-03-17T00:38:14+01:00</requested_datetime>
+      <service_code>Strasse/Trottoir/Platz</service_code>
+      <service_name>Strasse/Trottoir/Platz</service_name>
+      <service_notice>Diese Reparatur wird von uns in den kommenden Wochen / Monaten ausgeführt.</service_notice>
+      <service_request_id>1</service_request_id>
+      <status>closed</status>
+      <title>Unebener Bürgersteig</title>
+      <updated_datetime>2013-04-12T07:59:30+02:00</updated_datetime>
+    </request>
+  </service_requests>
+" | html %]</pre>
+[% ELSE %]
 <pre>[% "
   <requests>
     <request>
@@ -199,6 +190,7 @@ call, the value provided is ignored.</dd>
     </request>
   </requests>
 " | html %]</pre>
+[% END %]
 
 [% INCLUDE 'footer.html' %]
 


### PR DESCRIPTION
Makes the open311 documentation at https://www.zueriwieneu.ch/open311 more Zurich-specific.

Fixes https://github.com/mysociety/fixmystreet/issues/3288
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/2150

<!-- [skip changelog] -->
