### PR TITLE
Ignore deleted bodies when generating responsiveness stats for /reports

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -68,7 +68,7 @@ sub index : Path : Args(0) {
     } else {
         my @bodies = $c->model('DB::Body')->search(undef, {
             columns => [ "id", "name" ],
-        })->active->translated->with_area_count->all_sorted;
+        })->translated->with_area_count->all_sorted;
         @bodies = @{$c->cobrand->call_hook('reports_hook_restrict_bodies_list', \@bodies) || \@bodies };
         $c->stash->{bodies} = \@bodies;
     }

--- a/perllib/FixMyStreet/Script/UpdateAllReports.pm
+++ b/perllib/FixMyStreet/Script/UpdateAllReports.pm
@@ -267,7 +267,7 @@ sub calculate_top_five_bodies {
 
     my(@top_five_bodies);
 
-    my $bodies = FixMyStreet::DB->resultset('Body')->search;
+    my $bodies = FixMyStreet::DB->resultset('Body')->active;
     while (my $body = $bodies->next) {
         my $avg = $body->calculate_average($cobrand_cls->call_hook("body_responsiveness_threshold"));
         push @top_five_bodies, { name => $body->name, days => int($avg / 60 / 60 / 24 + 0.5) }


### PR DESCRIPTION
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/2185

[skip changelog]