### PR TITLE
Make GitHub detect the Perl correctly.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,7 @@
 # breaks if they e.g. run vagrant up.
 
 * -text
+
+# Fix language detection on GitHub:
+*.pm linguist-language=Perl
+*.t linguist-language=Perl


### PR DESCRIPTION
Minor commit that makes GitHub's linguist language detection correctly identify all the .pm and .t files as Perl rather than Raku.

Added as a nicety, mainly as trying to identify why ./script/test has failing tests in my vagrant vm, but this commit when tested via CI on github actions all tests pass. 
 