### PR TITLE
[TfL] Ensure all relevant ‘action scheduled’ reports are auto-closed

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -501,8 +501,6 @@ sub inspect : Private {
 
                 $update_params{problem_state} = $problem->state;
 
-                my $state = $problem->state;
-
                 # If an inspector has changed the state, subscribe them to
                 # updates
                 my $options = {
@@ -590,6 +588,7 @@ sub inspect : Private {
                     confirmed => $timestamp,
                     user => $c->user->obj,
                     photo => $c->stash->{upload_fileid} || undef,
+                    problem_state => $problem->state,
                     %update_params,
                 } );
             }

--- a/perllib/FixMyStreet/Script/TfL/AutoClose.pm
+++ b/perllib/FixMyStreet/Script/TfL/AutoClose.pm
@@ -92,15 +92,16 @@ sub close_reports {
             { problem_id => $r->id },
             { order_by => 'confirmed' }
         );
-        my $earliest;
+        my $old_state = '';
+        my $last_change;
         while ( my $c = $comments->next ) {
-            if ( ($c->problem_state || '') ne 'action scheduled' ) {
-                $earliest = undef;
-                next;
+            my $new_state = $c->problem_state || '';
+            if ( $new_state eq 'action scheduled' && $new_state ne $old_state) {
+                $last_change = $c->confirmed;
             }
-            $earliest = $c->confirmed unless defined $earliest;
+            $old_state = $new_state if $new_state;
         }
-        next unless defined $earliest && $earliest < $self->newest;
+        next unless defined $last_change && $last_change < $self->newest;
         if ($self->commit) {
             $r->update({
                 state => 'fixed - council',

--- a/t/app/controller/report_inspect.t
+++ b/t/app/controller/report_inspect.t
@@ -387,6 +387,13 @@ FixMyStreet::override_config {
       is $alert_count, 1 , 'User has only one alert';
     };
 
+    subtest "adding update without changing state sets problem_state" =>sub {
+      is $report->comments->search({ problem_state => 'investigating' })->count, 1;
+      $mech->get_ok("/report/$report_id");
+      $mech->submit_form_ok({ button => 'save', with_fields => { state => 'Investigating', public_update => "We're still investigating.", include_update => "1" } });
+      is $report->comments->search({ problem_state => 'investigating' })->count, 2;
+    };
+
     subtest "marking a report as a duplicate doesn't clobber user-provided update" => sub {
         my $old_state = $report->state;
         $report->comments->delete_all;

--- a/t/script/tfl/autoclose.t
+++ b/t/script/tfl/autoclose.t
@@ -187,7 +187,25 @@ subtest 'check that changing state accounted for' => sub {
         state => 'confirmed',
         problem_state => 'action scheduled',
         user => $body_user,
-        confirmed => $now
+        confirmed => $now->clone->add( hours => -2 ),
+    });
+
+    # regression test for problem_state not always being set
+    FixMyStreet::DB->resultset('Comment')->create({
+        problem => $p,
+        text => 'comment',
+        state => 'confirmed',
+        problem_state => undef,
+        user => $body_user,
+        confirmed => $now->clone->add( hours => -1 ),
+    });
+    FixMyStreet::DB->resultset('Comment')->create({
+        problem => $p,
+        text => 'comment',
+        state => 'confirmed',
+        problem_state => 'action scheduled',
+        user => $body_user,
+        confirmed => $now,
     });
 
     ok $close->close_reports({ 'Grafitti' => $t2 }), "close reports ran";


### PR DESCRIPTION
 - Don't skip reports that have comments with empty `problem_state` value
 - Ensure `problem_state` is always set when leaving comments via the inspector form


Fixes https://github.com/mysociety/fixmystreet-commercial/issues/2208
[skip changelog]
