### PR TITLE
Skip UK specific tests, if modules not present.

### DIFF
--- a/t/app/controller/admin/templates.t
+++ b/t/app/controller/admin/templates.t
@@ -326,6 +326,9 @@ subtest "category groups are shown" => sub {
 };
 
 subtest "TfL cobrand only shows TfL templates" => sub {
+    eval "use Net::Subnet";
+    plan skip_all => 'Net::Subnet required' if $@;
+
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => [ 'tfl' ],
         COBRAND_FEATURES => { internal_ips => { tfl => [ '127.0.0.1' ] } },

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -7,6 +7,9 @@ use FixMyStreet::Script::Reports;
 FixMyStreet::App->log->disable('info');
 END { FixMyStreet::App->log->enable('info'); }
 
+eval "use SOAP::Lite";
+plan skip_all => 'SOAP::Lite required' if $@;
+
 # Mock fetching bank holidays
 my $uk = Test::MockModule->new('FixMyStreet::Cobrand::UK');
 $uk->mock('_fetch_url', sub { '{}' });

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -482,6 +482,10 @@ FixMyStreet::override_config {
         waste => { bromley => 1 }
     },
 }, sub {
+  subtest 'test special cases on waste pages' => sub {
+    eval "use SOAP::Lite";
+    plan skip_all => 'SOAP::Lite required' if $@;
+
     subtest 'test open enquiries' => sub {
         set_fixed_time('2020-05-19T12:00:00Z'); # After sample food waste collection
         $mech->get_ok('/waste/12345');
@@ -604,6 +608,7 @@ FixMyStreet::override_config {
         $mech->content_lacks('Subscribe to Green Garden Waste');
     };
 
+  };
 };
 
 subtest 'test waste max-per-day' => sub {
@@ -646,6 +651,9 @@ sub new { my $c = shift; bless { @_ }, $c; }
 package main;
 
 subtest 'updating of waste reports' => sub {
+    eval "use SOAP::Lite";
+    plan skip_all => 'SOAP::Lite required' if $@;
+
     my $integ = Test::MockModule->new('SOAP::Lite');
     $integ->mock(call => sub {
         my ($cls, @args) = @_;
@@ -1026,6 +1034,9 @@ subtest 'check pro-rata calculation' => sub {
 };
 
 subtest 'check direct debit reconcilliation' => sub {
+    eval "use SOAP::Lite";
+    plan skip_all => 'SOAP::Lite required' if $@;
+
     set_fixed_time('2021-03-19T12:00:00Z'); # After sample food waste collection
     my $echo = Test::MockModule->new('Integrations::Echo');
     $echo->mock('GetServiceUnitsForObject' => sub {

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -3,6 +3,9 @@ use FixMyStreet::App;
 use FixMyStreet::Script::Reports;
 use FixMyStreet::Script::Questionnaires;
 
+eval "use Net::Subnet";
+plan skip_all => 'Net::Subnet required' if $@;
+
 # disable info logs for this test run
 FixMyStreet::App->log->disable('info');
 END { FixMyStreet::App->log->enable('info'); }

--- a/t/integrations/pay360.t
+++ b/t/integrations/pay360.t
@@ -6,8 +6,10 @@ use Test::MockTime ':all';
 use Path::Tiny;
 use DateTime;
 use XML::Simple;
-use SOAP::Lite;
-use SOAP::Transport::HTTP;
+
+eval "use SOAP::Lite";
+plan skip_all => 'SOAP::Lite required' if $@;
+eval "use SOAP::Transport::HTTP";
 use HTTP::Request::Common;
 
 use Integrations::Pay360;

--- a/t/integrations/scp.t
+++ b/t/integrations/scp.t
@@ -4,8 +4,10 @@ use Test::More;
 use Test::MockModule;
 use Test::MockTime ':all';
 use Path::Tiny;
-use SOAP::Lite;
-use SOAP::Transport::HTTP;
+
+eval "use SOAP::Lite";
+plan skip_all => 'SOAP::Lite required' if $@;
+eval "use SOAP::Transport::HTTP";
 use HTTP::Request::Common;
 
 use Integrations::SCP;


### PR DESCRIPTION
These 4 test files rely on modules only included in the UK build,
which is not done by default by script/update.

* t/app/controller/admin/templates.t
* t/app/controller/waste.t
* t/cobrand/bromley.t
* t/cobrand/tfl.t

This prevents the need to run the following, which installs missing modules
to make a fresh VM pass all tests:

 vendor/bin/carton install --deployment --without zurich --without kiitc

This commit addresses: https://github.com/mysociety/fixmystreet/issues/3340
