### PR TITLE
[Central Beds] Ignore invalid features when doing server-side NSGRef lookup

### DIFF
--- a/perllib/FixMyStreet/Cobrand/CentralBedfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/CentralBedfordshire.pm
@@ -49,7 +49,15 @@ sub lookup_site_code_config {
         srsname => "urn:ogc:def:crs:EPSG::27700",
         typename => "Highways",
         property => $property,
-        accept_feature => sub { 1 }
+        accept_feature => sub {
+            # Sometimes the nearest feature has a NULL streetref1 property
+            # but there is an overlapping feature that correctly has a streetref1
+            # value a very small distance away. To avoid choosing the feature
+            # with an empty streetref1 we reject those features, forcing selection
+            # of the nearest feature that has a valid value.
+            my $f = shift;
+            return $f->{properties} && $f->{properties}->{$property};
+        }
     }
 }
 

--- a/t/cobrand/centralbedfordshire.t
+++ b/t/cobrand/centralbedfordshire.t
@@ -11,13 +11,24 @@ my $ukc = Test::MockModule->new('FixMyStreet::Cobrand::UKCouncils');
 $ukc->mock('_fetch_features', sub {
     my ($self, $cfg, $x, $y) = @_;
     is $y, 238194, 'Correct latitude';
-    return [{
-        properties => { streetref1 => 'Road ID' },
-        geometry => {
-            type => 'LineString',
-            coordinates => [ [ $x-1, $y-1 ], [ $x+1, $y+1 ] ],
-        }
-    }];
+    return [
+        {
+            properties => { streetref1 => 'Road ID' },
+            geometry => {
+                type => 'LineString',
+                coordinates => [ [ $x-2, $y+2 ], [ $x+2, $y+2 ] ],
+            }
+        },
+        # regression test to ensure that a closer feature with no streetref1
+        # isn't picked for NSGRef.
+        {
+            properties => { streetref1 => '' },
+            geometry => {
+                type => 'LineString',
+                coordinates => [ [ $x-1, $y-1 ], [ $x+1, $y-1 ] ],
+            }
+        },
+    ];
 });
 
 my $mech = FixMyStreet::TestMech->new;


### PR DESCRIPTION
Sometimes the nearest feature has a NULL `streetref1` property but there is an overlapping feature that correctly has a `streetref1` value a very small distance away. To avoid choosing the feature with an empty `streetref1` we reject those features, forcing selection of the nearest feature that has a valid value.

[skip changelog]

For https://github.com/mysociety/fixmystreet-commercial/issues/2231