### PR TITLE
Update URL on /my when map moves.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
         - Speed up /report/new/ajax call. #3335
         - Improve `#geolocate_link` display, especially for smaller screens. #2048
         - Allow email alert radius to be specified. #68
+        - Update URL on /my when map moves. #3358
     - Bugfixes:
         - Fix non-JS form when all extra questions answered. #3248
         - Improve display of disabled fields in iOS.

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -1135,7 +1135,7 @@ OpenLayers.Control.PermalinkFMS = OpenLayers.Class(OpenLayers.Control, {
         this.element.href = href;
 
         if ('replaceState' in history) {
-            if (fixmystreet.page.match(/around|reports/)) {
+            if (fixmystreet.page.match(/around|reports|my/)) {
                 history.replaceState(
                     history.state,
                     null,


### PR DESCRIPTION
Wasn't sure if there was a reason we didn't do this when we did around/reports back in https://github.com/mysociety/fixmystreet/pull/2301 but a user has asked if they can have a "home location" when viewing their previous reports and this would be the easiest way of doing so, I think.