### PR TITLE
[Westminster] Street Entertainment custom text

### DIFF
--- a/.cypress/cypress/fixtures/westminster-street-entertainment.json
+++ b/.cypress/cypress/fixtures/westminster-street-entertainment.json
@@ -1,0 +1,26 @@
+{
+  "type": "FeatureCollection",
+  "crs": {
+    "type": "name",
+    "properties": {
+      "name": "EPSG:4326"
+    }
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.12690110595622592,
+          51.507530517722408
+        ]
+      },
+      "properties": {
+        "Site": "Northumberland Avenue",
+        "Category": "Non-Amplified",
+        "Terms_Conditions": "•   Pitch 24 is 1.5 metres.\u003cbr\u003e•   All the busking and street entertainments, the performance itself and anything used in connection with the performance must be contained within the designated and marked pitch.\u003cbr\u003e•   This pitch is suitable to attract audiences providing they do not cause an obstruction\u003cbr\u003e•   Amplification, brass, wind percussion and percussive instruments are not permitted here."
+      }
+    }
+  ]
+}

--- a/.cypress/cypress/integration/westminster.js
+++ b/.cypress/cypress/integration/westminster.js
@@ -2,10 +2,11 @@ describe('Westminster cobrand', function() {
 
   beforeEach(function() {
     cy.server();
-    cy.route('**/westminster.assets/40/*', 'fixture:westminster-usrn.json');
-    cy.route("**/westminster.assets/25/*PARENTUPRN='XXXX'*", 'fixture:westminster-uprn.json').as('uprn');
-    cy.route("**/westminster.assets/25/*PARENTUPRN='1000123'*PARENTUPRN='1000234'", 'fixture:westminster-uprn-0123.json');
-    cy.route('**/westminster.assets/46/*', 'fixture:westminster-nameplates.json').as('nameplates');
+    cy.route('**/westminster.staging/40/*', 'fixture:westminster-usrn.json');
+    cy.route("**/westminster.staging/25/*PARENTUPRN='XXXX'*", 'fixture:westminster-uprn.json').as('uprn');
+    cy.route("**/westminster.staging/25/*PARENTUPRN='1000123'*PARENTUPRN='1000234'", 'fixture:westminster-uprn-0123.json');
+    cy.route('**/westminster.staging/46/*', 'fixture:westminster-nameplates.json').as('nameplates');
+    cy.route('**/westminster.staging/66/*', 'fixture:westminster-street-entertainment.json').as('street-entertainment');
     cy.route('/report/new/ajax*').as('report-ajax');
     cy.viewport(480, 800);
     cy.visit('http://westminster.localhost:3001/report/new?latitude=51.501009&longitude=-0.141588');
@@ -37,6 +38,20 @@ describe('Westminster cobrand', function() {
     cy.get('#uprn').contains('11-12 Address');
     cy.get('#uprn').contains('7b Address');
     cy.get('#uprn').should('not.contain', '4 Address');
+  });
+
+  it('shows extra info for street entertainment pitches', function() {
+    cy.visit('http://westminster.localhost:3001/report/new?longitude=-0.126890&latitude=51.507461');
+    cy.wait('@report-ajax');
+    cy.get('#mob_ok').click();
+    cy.pickCategory('Street Entertainment');
+    cy.wait('@street-entertainment');
+    cy.nextPageReporting();
+    cy.get('#mob_ok').click();
+    cy.get('.js-street-entertainment-message').should('be.visible');
+    cy.get('.js-street-entertainment-message').contains('Northumberland Avenue');
+    cy.get('.js-street-entertainment-message').contains('Non-Amplified');
+    cy.get('.js-street-entertainment-message').contains('Pitch 24 is 1.5 metres.');
   });
 
 });

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -104,7 +104,7 @@ if ($opt->test_fixtures) {
     say "Created body $params->{name} for MapIt area ID $params->{area_id}, categories $cats";
 
     foreach (
-        { area_id => 2504, categories => ['Damaged, dirty, or missing bin', 'Signs and bollards'], name => 'Westminster City Council' },
+        { area_id => 2504, categories => ['Damaged, dirty, or missing bin', 'Signs and bollards', 'Street Entertainment'], name => 'Westminster City Council' },
         { area_id => 2482, categories => ['Street Lighting and Road Signs'], name => 'Bromley Council' },
         { area_id => 2234, categories => ['Shelter Damaged', 'Very Urgent'], name => 'Northamptonshire Highways' },
         { area_id => 2217, categories => ['Flytipping', 'Roads', 'Parks', 'Snow and ice problem/winter salting'], name => 'Buckinghamshire Council' },
@@ -318,6 +318,24 @@ if ($opt->test_fixtures) {
     }, {
         code => 'USRN',
         automated => 'hidden_field',
+    });
+    $child_cat->update;
+
+    $child_cat = FixMyStreet::DB->resultset("Contact")->find({
+        body => $bodies->{2504},
+        category => 'Street Entertainment',
+    });
+    $child_cat->set_extra_fields({
+        code => 'type',
+        datatype => 'singlevaluelist',
+        order => 1,
+        variable => 'true',
+        required => 'true',
+        values => [
+            { key => '1', name => 'Obstruction' },
+            { key => '2', name => 'Indecent or offensive behaviour' },
+            { key => '3', name => 'Animal safety concerns' },
+        ],
     });
     $child_cat->update;
 

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -32,6 +32,7 @@ my @PLACES = (
     [ '?', 51.615965, -0.556367, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS' ],
     [ '?', 51.615439, -0.558362, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS' ],
     [ 'SW1A 1AA', 51.501009, -0.141588, 2504, 'Westminster City Council', 'LBO' ],
+    [ '?', 51.507461, -0.126890, 2504, 'Westminster City Council', 'LBO' ],
     [ 'GL50 2PR', 51.896268, -2.093063, 2226, 'Gloucestershire County Council', 'CTY', 2326, 'Cheltenham Borough Council', 'DIS', 4544, 'Lansdown', 'DIW', 143641, 'Lansdown and Park', 'CED' ],
     [ 'OX20 1SZ', 51.754926, -1.256179, 2237, 'Oxfordshire County Council', 'CTY', 2421, 'Oxford City Council', 'DIS' ],
     [ 'OX16 9UP', 52.038712, -1.346397, 2237, 'Oxfordshire County Council', 'CTY', 2419, 'Cherwell District Council', 'DIS', 151767, "Banbury, Calthorpe & Easington", "DIW" ],

--- a/templates/web/westminster/footer_extra_js.html
+++ b/templates/web/westminster/footer_extra_js.html
@@ -1,1 +1,8 @@
 [% PROCESS 'footer_extra_js_base.html' cobrand_js=1 tfl=1 roadworks=1 %]
+[%
+IF bodyclass.match('mappage');
+    scripts.push(
+        version('/cobrands/westminster/js.js')
+    );
+END
+%]

--- a/web/cobrands/westminster/js.js
+++ b/web/cobrands/westminster/js.js
@@ -1,0 +1,11 @@
+// Disable roadworks for certain groups
+fixmystreet.roadworks.filter = function(_feature) {
+  var group = fixmystreet.reporting.selectedCategory().group;
+  if (group === '') {
+    return false;
+  }
+  var disabledGroups = [
+      'Street Entertainment'
+  ];
+  return OpenLayers.Util.indexOf(disabledGroups, group) === -1;
+};


### PR DESCRIPTION
Adds an asset layer for street entertainment pitches. When a pitch is selected the name and terms and conditions are displayed.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/2222

## Todo

- [x]  Fix bug with mobile version going in a loop
- [x] Bug when you don't quite manage to click the asset the whole layer and the extra question disappears from view and there's just a continue button?!
- [x] Tests are written but not passing because of the mobile bug

## Demo


https://user-images.githubusercontent.com/22996/113185311-363cf100-924e-11eb-99b3-263fa246ca89.mov



<!-- [skip changelog] -->