### PR TITLE
Map control updates

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -353,6 +353,7 @@ sub generate_map_tags : Private {
         $c,
         latitude  => $problem->latitude,
         longitude => $problem->longitude,
+        no_compass => 1,
         pins      => $problem->used_map
             ? [ $problem->pin_data('report', type => 'big', draggable => 1) ]
             : [],

--- a/templates/web/base/maps/_compass.html
+++ b/templates/web/base/maps/_compass.html
@@ -1,3 +1,4 @@
+[% RETURN IF map.no_compass %]
 [%
     north    = c.uri_with( { lat = map.compass.north.0, lon = map.compass.north.1, zoom = map.zoom } )
     south    = c.uri_with( { lat = map.compass.south.0, lon = map.compass.south.1, zoom = map.zoom } )

--- a/templates/web/base/maps/openlayers.html
+++ b/templates/web/base/maps/openlayers.html
@@ -56,7 +56,7 @@
   [% IF map_type_toggle %]
     [% IF c.config.BING_MAPS_API_KEY OR c.cobrand.moniker == 'zurich' %]
       [% aerial = c.req.params.aerial %]
-      [% aerial = 1 IF c.cobrand.moniker == 'zurich' AND NOT c.req.params.aerial.defined %]
+      [% SET aerial = 1 IF c.cobrand.moniker == 'zurich' AND NOT c.req.params.aerial.defined %]
       [% IF aerial %]
         <a class="map-layer-toggle roads" rel="nofollow" href="[% c.uri_with( { aerial => 0 } ) %]">[% loc('Road map') %]</a>
       [% ELSE %]


### PR DESCRIPTION
Removes the HTML compass from report pages because there isn't really any point in panning the map (I guess you might want to zoom in/out, which could maintain if wanted, but easier to drop both), and fixes the road map toggle button if at an aerial=1 URL.