### PR TITLE
Email alert text updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
         - Fix Open311 JSON services output. #3279
         - Send email reports in staff-only categories.
         - Fix Gaze sometimes being called twice on /around. #3324
+        - Improved alert signup for phone-only user. #3367
     - Admin improvements:
         - Enable per-category hint customisation.
         - Move ban/unban buttons to user edit admin page.

--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -213,6 +213,38 @@ sub phone_display {
     return $parsed->{phone} ? $parsed->{phone}->format_for_country($country) : $self->phone;
 }
 
+sub alert_by {
+    my ($self, $is_update, $cobrand) = @_;
+    return $is_update
+        ? $self->alert_updates_by($cobrand)
+        : $self->alert_local_by;
+}
+
+# How does this user want to receive local alerts?
+# email or none, so will be none for a phone-only user
+sub alert_local_by {
+    my $self = shift;
+    my $pref = $self->get_extra_metadata('alert_notify') || '';
+    return 'none' if $pref eq 'none';
+    return 'none' unless $self->email_verified;
+    return 'email';
+}
+
+# How does this user want to receive update alerts?
+# If the cobrand allows text, this could include phone
+sub alert_updates_by {
+    my ($self, $cobrand) = @_;
+    my $pref = $self->get_extra_metadata('update_notify') || '';
+    return 'none' if $pref eq 'none';
+
+    # Only send text alerts for new report updates at present
+    my $allow_phone_update = ($self->phone_verified && $cobrand->sms_authentication);
+
+    return 'none' unless $self->email_verified || $allow_phone_update;
+    return 'phone' if $allow_phone_update && (!$self->email_verified || $pref eq 'phone');
+    return 'email';
+}
+
 sub latest_anonymity {
     my $self = shift;
     my $p = $self->problems->search(undef, { rows => 1, order_by => { -desc => 'id' } } )->first;

--- a/templates/web/base/alert/_list.html
+++ b/templates/web/base/alert/_list.html
@@ -66,10 +66,10 @@
 
   <div class="alerts__cta-box">
     <h3>[% loc('Subscribe by email') %]</h3>
-    [% UNLESS c.user_exists %]
+    [% UNLESS c.user_exists AND c.user.email_verified %]
       <label for="rznvy">[% loc('Email address') %]</label>
       <div class="form-txt-submit-box">
-        <input class="form-control" type="text" id="rznvy" name="rznvy" value="[% rznvy | html %]">
+        <input class="form-control" type="text" id="rznvy" name="rznvy" value="[% rznvy %]">
         <input id="alert_email_button" class="btn-primary" type="submit" name="alert" value="[% loc('Subscribe') %]">
       </div>
     [% ELSE %]

--- a/templates/web/base/alert/_updates.html
+++ b/templates/web/base/alert/_updates.html
@@ -1,0 +1,37 @@
+<form action="[% c.uri_for( '/alert/subscribe' ) %]" method="post">
+
+    <p><a href="[% c.uri_for( '/rss', problem.id ) %]">
+        <img src="/i/feed.png" width="16" height="16" title="[% loc('RSS feed') %]" alt="[% loc('RSS feed of updates to this problem' ) %]" border="0" style="float:right">
+    </a>
+    [% loc('Receive email when updates are left on this problem.') %]
+    </p>
+
+    [% PROCESS 'auth/form_extra.html' %]
+
+    <fieldset>
+      [% IF c.user_exists %]
+        [% IF permissions.contribute_as_another_user %]
+          <label for="alert_rznvy">[% loc('Email') %]</label>
+          <div class="form-txt-submit-box">
+              <input type="email" class="form-control" name="rznvy" id="alert_rznvy" value="[% email %]" size="30">
+              <input class="green-btn" type="submit" name="alert" value="[% loc('Subscribe') %]">
+          </div>
+        [% ELSE %]
+          <input class="green-btn" type="submit" name="alert" value="[% loc('Subscribe') %]">
+        [% END %]
+      [% ELSE %]
+        <label for="alert_rznvy">[% loc('Your email') %]</label>
+
+        <div class="form-txt-submit-box">
+            <input type="email" class="form-control" name="rznvy" id="alert_rznvy" value="[% email %]" size="30">
+            <input class="green-btn" type="submit" name="alert" value="[% loc('Subscribe') %]">
+        </div>
+      [% END %]
+
+        <input type="hidden" name="token" value="[% csrf_token %]">
+        <input type="hidden" name="id" value="[% problem.id %]">
+        <input type="hidden" name="type" value="updates">
+    </fieldset>
+</form>
+
+

--- a/templates/web/base/alert/_updates.html
+++ b/templates/web/base/alert/_updates.html
@@ -3,7 +3,12 @@
     <p><a href="[% c.uri_for( '/rss', problem.id ) %]">
         <img src="/i/feed.png" width="16" height="16" title="[% loc('RSS feed') %]" alt="[% loc('RSS feed of updates to this problem' ) %]" border="0" style="float:right">
     </a>
-    [% loc('Receive email when updates are left on this problem.') %]
+
+    [% IF NOT c.user_exists OR c.user.alert_updates_by(c.cobrand) != 'phone' %]
+        [% loc('Receive email when updates are left on this problem.') %]
+    [% ELSE %]
+        [% loc('Receive a text when updates are left on this problem.') %]
+    [% END %]
     </p>
 
     [% PROCESS 'auth/form_extra.html' %]

--- a/templates/web/base/alert/updates.html
+++ b/templates/web/base/alert/updates.html
@@ -1,47 +1,8 @@
 [% title = loc('Local RSS feeds and email alerts') %]
-
-[% INCLUDE 'header.html', title => title %]
-
-
+[% INCLUDE 'header.html' %]
 [% INCLUDE 'errors.html' %]
-
-<p><a href="[% c.uri_for( '/rss', problem.id ) %]">
-        <img src="/i/feed.png" width="16" height="16" title="[% loc('RSS feed') %]" alt="[% loc('RSS feed of updates to this problem' ) %]" border="0" style="float:right">
-    </a>
-</p>
-
-<p>
-[% loc('Receive email when updates are left on this problem.') %]
-</p>
-
-<form action="/alert/subscribe" method="post">
-    [% PROCESS 'auth/form_extra.html' %]
-
-    <fieldset>
-      [% IF c.user_exists %]
-        [% IF c.user.has_permission_to("contribute_as_another_user", problem.bodies_str_ids) %]
-          <label class="hidden n" for="alert_rznvy">[% loc('Email') %]</label>
-          <div class="form-txt-submit-box">
-              <input class="form-control" type="email" name="rznvy" id="alert_rznvy" value="[% email | html %]">
-              <input class="green-btn" type="submit" value="[% loc('Subscribe') %]">
-          </div>
-        [% ELSE %]
-          <input class="green-btn" type="submit" name="alert" value="[% loc('Subscribe') %]">
-        [% END %]
-      [% ELSE %]
-        <label class="hidden n" for="alert_rznvy">[% loc('Your email') %]</label>
-
-        <div class="form-txt-submit-box">
-            <input class="form-control" type="email" name="rznvy" id="alert_rznvy" value="[% email | html %]">
-            <input class="green-btn" type="submit" value="[% loc('Subscribe') %]">
-        </div>
-      [% END %]
-
-        <input type="hidden" name="token" value="[% csrf_token %]">
-        <input type="hidden" name="id" value="[% problem.id | html %]">
-        <input type="hidden" name="type" value="updates">
-    </fieldset>
-</form>
-
-
+[% permissions = {
+    contribute_as_another_user = c.user.has_permission_to("contribute_as_another_user", problem.bodies_str_ids)
+} %]
+[% INCLUDE 'alert/_updates.html' %]
 [% INCLUDE 'footer.html' %]

--- a/templates/web/base/report/display_tools.html
+++ b/templates/web/base/report/display_tools.html
@@ -39,35 +39,7 @@
 [% END %]
 
 <div id="report-updates-data" class="hidden-js">
-    <form action="[% c.uri_for( '/alert/subscribe' ) %]" method="post">
-        <p><a href="[% c.uri_for( '/rss', problem.id ) %]">
-            <img src="/i/feed.png" width="16" height="16" title="[% loc('RSS feed') %]" alt="[% loc('RSS feed of updates to this problem' ) %]" border="0">
-        </a>
-        [% loc('Receive email when updates are left on this problem.' ) %]</p>
-        [% PROCESS 'auth/form_extra.html' %]
-        <fieldset>
-      [% IF c.user_exists %]
-          [% IF permissions.contribute_as_another_user %]
-            <label for="alert_rznvy">[% loc('Email') %]</label>
-            <div class="form-txt-submit-box">
-                <input type="email" class="form-control" name="rznvy" id="alert_rznvy" value="[% email | html %]" size="30">
-                <input class="green-btn" type="submit" name="alert" value="[% loc('Subscribe') %]">
-            </div>
-          [% ELSE %]
-            <input class="green-btn" type="submit" name="alert" value="[% loc('Subscribe') %]">
-          [% END %]
-      [% ELSE %]
-        <label for="alert_rznvy">[% loc('Your email') %]</label>
-        <div class="form-txt-submit-box">
-            <input type="email" class="form-control" name="rznvy" id="alert_rznvy" value="[% email | html %]" size="30">
-            <input class="green-btn" type="submit" name="alert" value="[% loc('Subscribe') %]">
-        </div>
-      [% END %]
-        <input type="hidden" name="token" value="[% csrf_token %]">
-        <input type="hidden" name="id" value="[% problem.id %]">
-        <input type="hidden" name="type" value="updates">
-        </fieldset>
-    </form>
+    [% INCLUDE 'alert/_updates.html' %]
 </div>
 
 </div>

--- a/templates/web/base/tokens/confirm_alert.html
+++ b/templates/web/base/tokens/confirm_alert.html
@@ -2,12 +2,21 @@
 
 <div class="confirmation-header">
 
+[% SET alert_by = alert.user.alert_by(alert.alert_type.ref == 'new_updates', c.cobrand) %]
   [% IF confirm_type == 'subscribe' || confirm_type == 'created' %]
-    <h1>[% loc('Email alert created') %]</h1>
-    <p>[% loc('Why stop there? <a href="/alert">Set up more alerts</a> for free.') %]</p>
+    [% IF alert_by != 'phone' %]
+        <h1>[% loc('Email alert created') %]</h1>
+        <p>[% loc('Why stop there? <a href="/alert">Set up more alerts</a> for free.') %]</p>
+    [% ELSE %]
+        <h1>[% loc('Text alert created') %]</h1>
+    [% END %]
 
   [% ELSIF confirm_type == 'unsubscribe' %]
-    <h1>[% loc('Email alert deleted') %]</h1>
+    [% IF alert_by != 'phone' %]
+        <h1>[% loc('Email alert deleted') %]</h1>
+    [% ELSE %]
+        <h1>[% loc('Text alert deleted') %]</h1>
+    [% END %]
     <p>[% loc('Inbox zero, here we come!') %]</p>
 
   [% END %]


### PR DESCRIPTION
Improves the text on update alert signup for phone-only users (stops referring to email alerts), and fixes an issue whereby a phone-only user could sign up for a local alert but wouldn't ever get anything, so instead ask for email and do a merge, like the verify email step would do, if that makes sense. [skip changelog]
