### PR TITLE
[Bromley] use a single category for subscriptions

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -115,9 +115,9 @@ sub pay : Path('pay') : Args(0) {
 
     my $p = $c->stash->{report};
 
-    my $amount = $p->get_extra_field( name => 'pro_rata' );
+    my $amount = $p->get_extra_field_value( 'pro_rata' );
     unless ($amount) {
-        $amount = $p->get_extra_field( name => 'payment' );
+        $amount = $p->get_extra_field_value( 'payment' );
     }
 
     my $redirect_id = mySociety::AuthToken::random_token();
@@ -130,7 +130,7 @@ sub pay : Path('pay') : Args(0) {
         ref => $p->id,
         request_id => $p->id,
         description => $p->title,
-        amount => $amount->{value},
+        amount => $amount,
     });
 
     if ( $result ) {
@@ -724,6 +724,7 @@ sub process_garden_cancellation : Private {
     $data->{email} = $c->user->email;
     $data->{phone} = $c->user->phone;
     $data->{category} = 'Cancel Garden Subscription';
+    $data->{title} = 'Garden Subscription - Cancel';
 
     my $bin_count = $c->cobrand->get_current_garden_bins;
 
@@ -772,7 +773,8 @@ sub get_original_sub : Private {
 
     my $p = $c->model('DB::Problem')->search({
         user_id => $c->user->id,
-        category => 'New Garden Subscription',
+        category => 'Garden Subscription',
+        title => 'Garden Subscription - New',
         extra => { like => '%property_id,T5:value,I_:'. $c->stash->{property}{id} . '%' }
     },
     {
@@ -795,7 +797,6 @@ sub setup_garden_sub_params : Private {
 
     my %container_types = map { $c->{stash}->{containers}->{$_} => $_ } keys %{ $c->stash->{containers} };
 
-    $data->{title} = $data->{category};
     $data->{detail} = "$data->{category}\n\n$address";
 
     $c->set_param('service_id', $c->cobrand->garden_waste_service_id);
@@ -819,7 +820,8 @@ sub process_garden_modification : Private {
     my ($self, $c, $form) = @_;
     my $data = $form->saved_data;
 
-    $data->{category} = 'Amend Garden Subscription'; # XXX
+    $data->{category} = 'Garden Subscription';
+    $data->{title} = 'Garden Subscription - Amend';
     $c->set_param('Subscription_Type', $c->stash->{garden_subs}->{Amend});
 
     my $new_bins = $data->{bin_number} - $c->stash->{garden_form_data}->{bins};
@@ -869,10 +871,12 @@ sub process_garden_renew : Private {
 
 
     if ( !$service || $c->cobrand->waste_sub_overdue( $service->{end_date} ) ) {
-        $data->{category} = 'New Garden Subscription';
+        $data->{category} = 'Garden Subscription';
+        $data->{title} = 'Garden Subscription - New';
         $c->set_param('Subscription_Type', $c->stash->{garden_subs}->{New});
     } else {
-        $data->{category} = 'Renew Garden Subscription';
+        $data->{category} = 'Garden Subscription';
+        $data->{title} = 'Garden Subscription - Renew';
         $c->set_param('Subscription_Type', $c->stash->{garden_subs}->{Renew});
 
         # only override the new bin count if we know the current bin number
@@ -910,6 +914,8 @@ sub process_garden_data : Private {
     my ($self, $c, $form) = @_;
     my $data = $form->saved_data;
 
+    $data->{category} = 'Garden Subscription';
+    $data->{title} = 'Garden Subscription - New';
     $c->set_param('Subscription_Type', $c->stash->{garden_subs}->{New});
 
     my $bin_count = $data->{new_bins} + $data->{current_bins};

--- a/perllib/FixMyStreet/App/Form/Waste/Garden.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Garden.pm
@@ -4,7 +4,6 @@ use utf8;
 use HTML::FormHandler::Moose;
 extends 'FixMyStreet::App::Form::Waste';
 
-has_field category => ( type => 'Hidden', default => 'New Garden Subscription' );
 has_field service_id => ( type => 'Hidden' );
 
 has_page intro => (

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -38,7 +38,7 @@ create_contact({ category => 'Request new container', email => 'request@example.
 );
 create_contact({ category => 'General enquiry', email => 'general@example.org' },
     { code => 'Notes', description => 'Notes', required => 1, datatype => 'text' });
-create_contact({ category => 'New Garden Subscription', email => 'garden@example.com'},
+create_contact({ category => 'Garden Subscription', email => 'garden@example.com'},
         { code => 'Subscription_Type', required => 1, automated => 'hidden_field' },
         { code => 'Subscription_Details_Quantity', required => 1, automated => 'hidden_field' },
         { code => 'Subscription_Details_Container_Type', required => 1, automated => 'hidden_field' },
@@ -48,31 +48,7 @@ create_contact({ category => 'New Garden Subscription', email => 'garden@example
         { code => 'current_containers', required => 1, automated => 'hidden_field' },
         { code => 'new_containers', required => 1, automated => 'hidden_field' },
         { code => 'payment_method', required => 1, automated => 'hidden_field' },
-        { code => 'payment', required => 1, automated => 'hidden_field' },
-);
-create_contact({ category => 'Amend Garden Subscription', email => 'garden_amend@example.com'},
-        { code => 'Subscription_Type', required => 1, automated => 'hidden_field' },
-        { code => 'Subscription_Details_Quantity', required => 1, automated => 'hidden_field' },
-        { code => 'Subscription_Details_Container_Type', required => 1, automated => 'hidden_field' },
-        { code => 'Container_Request_Details_Quantity', required => 1, automated => 'hidden_field' },
-        { code => 'Container_Request_Details_Action', required => 1, automated => 'hidden_field' },
-        { code => 'Container_Request_Details_Container_Type', required => 1, automated => 'hidden_field' },
-        { code => 'current_containers', required => 1, automated => 'hidden_field' },
-        { code => 'new_containers', required => 1, automated => 'hidden_field' },
-        { code => 'payment_method', required => 1, automated => 'hidden_field' },
-        { code => 'payment', required => 1, automated => 'hidden_field' },
-        { code => 'pro_rata', required => 1, automated => 'hidden_field' },
-);
-create_contact({ category => 'Renew Garden Subscription', email => 'garden_renew@example.com'},
-        { code => 'Subscription_Type', required => 1, automated => 'hidden_field' },
-        { code => 'Subscription_Details_Quantity', required => 1, automated => 'hidden_field' },
-        { code => 'Subscription_Details_Container_Type', required => 1, automated => 'hidden_field' },
-        { code => 'Container_Request_Details_Quantity', required => 1, automated => 'hidden_field' },
-        { code => 'Container_Request_Details_Action', required => 1, automated => 'hidden_field' },
-        { code => 'Container_Request_Details_Container_Type', required => 1, automated => 'hidden_field' },
-        { code => 'current_containers', required => 1, automated => 'hidden_field' },
-        { code => 'new_containers', required => 1, automated => 'hidden_field' },
-        { code => 'payment_method', required => 1, automated => 'hidden_field' },
+        { code => 'pro_rata', required => 0, automated => 'hidden_field' },
         { code => 'payment', required => 1, automated => 'hidden_field' },
 );
 create_contact({ category => 'Cancel Garden Subscription', email => 'garden_renew@example.com'},
@@ -262,10 +238,11 @@ FixMyStreet::override_config {
         } },
     },
 }, sub {
-    my ($p) = $mech->create_problems_for_body(1, $body->id, 'New Garden Subscription', {
+    my ($p) = $mech->create_problems_for_body(1, $body->id, 'Garden Subscription - New', {
         user_id => $user->id,
-        category => 'Request new container',
+        category => 'Garden Subscription',
     });
+    $p->title('Garden Subscription - New');
     $p->update_extra_field({ name => 'property_id', value => 12345});
     $p->update;
 
@@ -394,7 +371,8 @@ FixMyStreet::override_config {
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
-        is $new_report->category, 'New Garden Subscription', 'correct category on report';
+        is $new_report->category, 'Garden Subscription', 'correct category on report';
+        is $new_report->title, 'Garden Subscription - New', 'correct title on report';
         is $new_report->get_extra_field_value('payment_method'), 'credit_card', 'correct payment method on report';
         is $new_report->get_extra_field_value('Subscription_Details_Quantity'), 1, 'correct bin count';
         is $new_report->get_extra_field_value('Container_Request_Details_Action'), 1, 'correct container request action';
@@ -444,7 +422,8 @@ FixMyStreet::override_config {
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
-        is $new_report->category, 'New Garden Subscription', 'correct category on report';
+        is $new_report->category, 'Garden Subscription', 'correct category on report';
+        is $new_report->title, 'Garden Subscription - New', 'correct title on report';
         is $new_report->get_extra_field_value('payment_method'), 'credit_card', 'correct payment method on report';
         is $new_report->get_extra_field_value('Subscription_Details_Quantity'), 1, 'correct bin count';
         is $new_report->get_extra_field_value('Container_Request_Details_Action'), '', 'no container request action';
@@ -486,7 +465,8 @@ FixMyStreet::override_config {
                 extra => { like => '%redirect_id,T18:'. $token . '%' }
         } )->first;
 
-        is $new_report->category, 'New Garden Subscription', 'correct category on report';
+        is $new_report->category, 'Garden Subscription', 'correct category on report';
+        is $new_report->title, 'Garden Subscription - New', 'correct title on report';
         is $new_report->get_extra_field_value('payment_method'), 'direct_debit', 'correct payment method on report';
         is $new_report->state, 'unconfirmed', 'report not confirmed';
 
@@ -519,7 +499,8 @@ FixMyStreet::override_config {
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
-        is $new_report->category, 'Amend Garden Subscription', 'correct category on report';
+        is $new_report->category, 'Garden Subscription', 'correct category on report';
+        is $new_report->title, 'Garden Subscription - Amend', 'correct title on report';
         is $new_report->get_extra_field_value('payment_method'), 'credit_card', 'correct payment method on report';
         is $new_report->state, 'unconfirmed', 'report not confirmed';
 
@@ -590,7 +571,8 @@ FixMyStreet::override_config {
             { order_by => { -desc => 'id' } },
         )->first;
 
-        is $new_report->category, 'Amend Garden Subscription', 'correct category on report';
+        is $new_report->category, 'Garden Subscription', 'correct category on report';
+        is $new_report->title, 'Garden Subscription - Amend', 'correct title on report';
         is $new_report->get_extra_field_value('payment_method'), 'credit_card', 'correct payment method on report';
         is $new_report->state, 'confirmed', 'report confirmed';
         is $new_report->get_extra_field_value('Subscription_Details_Quantity'), 1, 'correct bin count';
@@ -600,7 +582,8 @@ FixMyStreet::override_config {
         is $sent_params, undef, "no one off payment if reducing bin count";
     };
 
-    $p->category('New Garden Subscription');
+    $p->category('Garden Subscription');
+    $p->title('Garden Subscription - New');
     $p->update_extra_field({ name => 'payment_method', value => 'direct_debit' });
     $p->update;
 
@@ -621,7 +604,8 @@ FixMyStreet::override_config {
             { order_by => { -desc => 'id' } },
         )->first;
 
-        is $new_report->category, 'Amend Garden Subscription', 'correct category on report';
+        is $new_report->category, 'Garden Subscription', 'correct category on report';
+        is $new_report->title, 'Garden Subscription - Amend', 'correct title on report';
         is $new_report->get_extra_field_value('payment_method'), 'direct_debit', 'correct payment method on report';
         is $new_report->state, 'unconfirmed', 'report not confirmed';
 
@@ -690,7 +674,8 @@ FixMyStreet::override_config {
             { order_by => { -desc => 'id' } },
         )->first;
 
-        is $new_report->category, 'Amend Garden Subscription', 'correct category on report';
+        is $new_report->category, 'Garden Subscription', 'correct category on report';
+        is $new_report->title, 'Garden Subscription - Amend', 'correct title on report';
         is $new_report->get_extra_field_value('payment_method'), 'direct_debit', 'correct payment method on report';
         is $new_report->state, 'unconfirmed', 'report not confirmed';
 
@@ -758,7 +743,8 @@ FixMyStreet::override_config {
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
-        is $new_report->category, 'Renew Garden Subscription', 'correct category on report';
+        is $new_report->category, 'Garden Subscription', 'correct category on report';
+        is $new_report->title, 'Garden Subscription - Renew', 'correct title on report';
         is $new_report->get_extra_field_value('payment_method'), 'credit_card', 'correct payment method on report';
         is $new_report->get_extra_field_value('Subscription_Details_Quantity'), 1, 'correct bin count';
         is $new_report->get_extra_field_value('Container_Request_Details_Action'), '', 'no container request action';
@@ -797,7 +783,8 @@ FixMyStreet::override_config {
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
-        is $new_report->category, 'Renew Garden Subscription', 'correct category on report';
+        is $new_report->category, 'Garden Subscription', 'correct category on report';
+        is $new_report->title, 'Garden Subscription - Renew', 'correct title on report';
         is $new_report->get_extra_field_value('payment_method'), 'credit_card', 'correct payment method on report';
         is $new_report->get_extra_field_value('Subscription_Details_Quantity'), 2, 'correct bin count';
         is $new_report->get_extra_field_value('Container_Request_Details_Action'), 1, 'correct container request action';
@@ -870,7 +857,8 @@ FixMyStreet::override_config {
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
-        is $new_report->category, 'Renew Garden Subscription', 'correct category on report';
+        is $new_report->category, 'Garden Subscription', 'correct category on report';
+        is $new_report->title, 'Garden Subscription - Renew', 'correct title on report';
         is $new_report->get_extra_field_value('payment_method'), 'credit_card', 'correct payment method on report';
         is $new_report->get_extra_field_value('Subscription_Details_Quantity'), 1, 'correct bin count';
         is $new_report->get_extra_field_value('Container_Request_Details_Action'), 2, 'correct container request action';
@@ -907,7 +895,8 @@ FixMyStreet::override_config {
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
-        is $new_report->category, 'New Garden Subscription', 'correct category on report';
+        is $new_report->category, 'Garden Subscription', 'correct category on report';
+        is $new_report->title, 'Garden Subscription - New', 'correct title on report';
         is $new_report->get_extra_field_value('payment_method'), 'credit_card', 'correct payment method on report';
         is $new_report->get_extra_field_value('Subscription_Details_Quantity'), 1, 'correct bin count';
         is $new_report->get_extra_field_value('Container_Request_Details_Action'), '', 'no container request action';
@@ -991,7 +980,8 @@ FixMyStreet::override_config {
 
             my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
-            is $new_report->category, 'New Garden Subscription', 'correct category on report';
+            is $new_report->category, 'Garden Subscription', 'correct category on report';
+            is $new_report->title, 'Garden Subscription - New', 'correct title on report';
             is $new_report->get_extra_field_value('payment_method'), 'credit_card', 'correct payment method on report';
             is $new_report->get_extra_field_value('Subscription_Details_Quantity'), 1, 'correct bin count';
             is $new_report->get_extra_field_value('Container_Request_Details_Action'), 1, 'correct container request action';


### PR DESCRIPTION
Apart from cancellation all subscription actions use the same event code
in Echo so don't have different categories for each one

[skip changelog]