### PR TITLE
[Bromley] handle service tasks with multiple schedules

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -627,7 +627,7 @@ sub bin_services_for_address {
     foreach (@$result) {
         next unless $_->{ServiceTasks};
 
-        my $servicetask = $_->{ServiceTasks}{ServiceTask};
+        my $servicetask = _get_current_service_task($_);
         my $schedules = _parse_schedules($servicetask);
 
         next unless $schedules->{next} or $schedules->{last};
@@ -650,7 +650,7 @@ sub bin_services_for_address {
     foreach (@$result) {
         next unless $schedules{$_->{Id}};
         my $schedules = $schedules{$_->{Id}};
-        my $servicetask = $_->{ServiceTasks}{ServiceTask};
+        my $servicetask = _get_current_service_task($_);
 
         my $events = $calls->{"GetEventsForObject ServiceUnit $_->{Id}"};
         my $open_unit = $self->_parse_open_events($events);
@@ -766,6 +766,28 @@ sub bin_services_for_address {
     }
 
     return \@out;
+}
+
+sub _get_current_service_task {
+    my $service = shift;
+
+    my $task = $service->{ServiceTasks}{ServiceTask};
+    my $type = ref $task;
+    return $task if $type eq 'HASH';
+
+    my ($current, $last_date);
+    if ( $type eq 'ARRAY' ) {
+        foreach ( @$task ) {
+            my $end = construct_bin_date($_->{EndDate});
+
+            next if $last_date && $end && $end < $last_date;
+            $last_date = $end;
+            $current = $_;
+        }
+        return $current;
+    }
+
+    return {};
 }
 
 sub _parse_open_events {

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -295,6 +295,80 @@ FixMyStreet::override_config {
         $dd_sent_params->{'cancel_plan'} = shift;
     });
 
+    subtest 'check bin calendar with multiple service tasks' => sub {
+        set_fixed_time('2021-03-09T17:00:00Z'); # After sample data collection
+        $sent_params = undef;
+        my $echo = Test::MockModule->new('Integrations::Echo');
+        $echo->mock('GetServiceUnitsForObject', sub {
+            return [ {
+                Id => 1005,
+                ServiceId => 545,
+                ServiceName => 'Garden waste collection',
+                ServiceTasks => { ServiceTask => [ {
+                    Id => 405,
+                    ScheduleDescription => 'every other Monday',
+                    Data => { ExtensibleDatum => [ {
+                        DatatypeName => 'LBB - GW Container',
+                        ChildData => { ExtensibleDatum => {
+                            DatatypeName => 'Quantity',
+                            Value => 2,
+                        } },
+                    } ] },
+                    ServiceTaskSchedules => { ServiceTaskSchedule => [ {
+                        EndDate => { DateTime => '2020-01-01T00:00:00Z' },
+                        LastInstance => {
+                            OriginalScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
+                            CurrentScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
+                        },
+                    }, {
+                        EndDate => { DateTime => '2020-03-30T00:00:00Z' },
+                        NextInstance => {
+                            CurrentScheduledDate => { DateTime => '2020-06-01T00:00:00Z' },
+                            OriginalScheduledDate => { DateTime => '2020-06-01T00:00:00Z' },
+                        },
+                        LastInstance => {
+                            OriginalScheduledDate => { DateTime => '2020-05-18T00:00:00Z' },
+                            CurrentScheduledDate => { DateTime => '2020-05-18T00:00:00Z' },
+                            Ref => { Value => { anyType => [ 567, 890 ] } },
+                        },
+                    } ] },
+                },
+                {
+                    Id => 405,
+                    ScheduleDescription => 'every other Monday',
+                    Data => { ExtensibleDatum => [ {
+                        DatatypeName => 'LBB - GW Container',
+                        ChildData => { ExtensibleDatum => {
+                            DatatypeName => 'Quantity',
+                            Value => 2,
+                        } },
+                    } ] },
+                    ServiceTaskSchedules => { ServiceTaskSchedule => [ {
+                        EndDate => { DateTime => '2020-01-01T00:00:00Z' },
+                        LastInstance => {
+                            OriginalScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
+                            CurrentScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
+                        },
+                    }, {
+                        EndDate => { DateTime => '2021-03-30T00:00:00Z' },
+                        NextInstance => {
+                            CurrentScheduledDate => { DateTime => '2020-06-01T00:00:00Z' },
+                            OriginalScheduledDate => { DateTime => '2020-06-01T00:00:00Z' },
+                        },
+                        LastInstance => {
+                            OriginalScheduledDate => { DateTime => '2020-05-18T00:00:00Z' },
+                            CurrentScheduledDate => { DateTime => '2020-05-18T00:00:00Z' },
+                            Ref => { Value => { anyType => [ 567, 890 ] } },
+                        },
+                    } ] },
+                } ] },
+            } ];
+        });
+
+        $mech->get_ok('/waste/12345');
+        $mech->content_like(qr#Renewal</dt>\s*<dd[^>]*>2021-03-30#m);
+    };
+
     subtest 'check new sub bin limits' => sub {
         $mech->get_ok('/waste/12345/garden');
         $mech->submit_form_ok({ form_number => 2 });


### PR DESCRIPTION
When a service task is cancelled and then later renewed you end up with
multiple service task schedules which we need to handle by using the one
with the latest end date for the current schedule

[skip changelog]