### PR TITLE
[Bromley] Some waste fixes 

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -950,7 +950,9 @@ sub admin_templates_external_status_code_hook {
     my $task_type = $c->get_param('task_type') || '';
     my $task_state = $c->get_param('task_state') || '';
 
-    return "$res_code,$task_type,$task_state";
+    my $code = "$res_code,$task_type,$task_state";
+    $code = '' if $code eq ',,';
+    return $code;
 }
 
 sub call_api {

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -879,6 +879,7 @@ sub construct_waste_open311_update {
         status => $status,
         update_id => 'waste',
         external_status_code => "$resolution_id,,",
+        prefer_template => 1,
     };
 }
 

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -711,7 +711,8 @@ sub _parse_schedules {
         my $next = $schedule->{NextInstance};
         my $d = construct_bin_date($next->{CurrentScheduledDate});
         if ($d && (!$min_next || $d < $min_next->{date})) {
-            $next_changed = $next->{CurrentScheduledDate}{DateTime} ne $next->{OriginalScheduledDate}{DateTime};
+            my $next_original = construct_bin_date($next->{OriginalScheduledDate});
+            $next_changed = $d->strftime("%F") ne $next_original->strftime("%F");
             $min_next = {
                 date => $d,
                 ordinal => ordinal($d->day),
@@ -724,14 +725,16 @@ sub _parse_schedules {
         # It is possible the last instance for this schedule has been rescheduled to
         # be in the future. If so, we should treat it like it is a next instance.
         if ($d && $d->strftime("%F") gt $today && (!$min_next || $d < $min_next->{date})) {
-            my $last_changed = $last->{CurrentScheduledDate}{DateTime} ne $last->{OriginalScheduledDate}{DateTime};
+            my $last_original = construct_bin_date($last->{OriginalScheduledDate});
+            my $last_changed = $d->strftime("%F") ne $last_original->strftime("%F");
             $min_next = {
                 date => $d,
                 ordinal => ordinal($d->day),
                 changed => $last_changed,
             };
         } elsif ($d && (!$max_last || $d > $max_last->{date})) {
-            my $last_changed = $last->{CurrentScheduledDate}{DateTime} ne $last->{OriginalScheduledDate}{DateTime};
+            my $last_original = construct_bin_date($last->{OriginalScheduledDate});
+            my $last_changed = $d->strftime("%F") ne $last_original->strftime("%F");
             $max_last = {
                 date => $d,
                 ordinal => ordinal($d->day),

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -631,7 +631,7 @@ sub bin_services_for_address {
             }
 
             my $row = $task_ref_to_row{$ref};
-            $row->{last}{state} = $state;
+            $row->{last}{state} = $state unless $state eq 'Completed' || $state eq 'Not Completed' || $state eq 'Outstanding' || $state eq 'Allocated';
             $row->{last}{completed} = $completed;
             $row->{last}{resolution} = $resolution;
             $row->{report_allowed} = within_working_days($row->{last}{date}, 2);

--- a/perllib/Open311/UpdatesBase.pm
+++ b/perllib/Open311/UpdatesBase.pm
@@ -265,7 +265,7 @@ sub comment_text_for_request {
     }
 
     my $desc = $request->{description} || '';
-    if ($desc && (!$template || $template !~ /\{\{description}}/)) {
+    if ($desc && (!$template || ($template !~ /\{\{description}}/ && !$request->{prefer_template}))) {
         return $desc;
     }
 

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -300,7 +300,7 @@ FixMyStreet::override_config {
         set_fixed_time('2020-05-27T11:00:00Z');
         $mech->get_ok('/waste/12345');
         $mech->content_like(qr/Refuse collection.*?Last collection<\/dt>\s*<dd[^>]*>\s*Wednesday, 27th May\s+\(completed at 10:00am\)\s*<p>\s*Wrong Bin Out/s);
-        $mech->content_like(qr/Paper &amp; Cardboard.*?Next collection<\/dt>\s*<dd[^>]*>\s*Wednesday, 27th May\s+\(in progress\)/s);
+        $mech->content_like(qr/Paper &amp; Cardboard.*?Next collection<\/dt>\s*<dd[^>]*>\s*Wednesday, 27th May\s+\(In progress\)/s);
         $mech->follow_link_ok({ text => 'Report a problem with a paper & cardboard collection' });
         $mech->content_lacks('Waste spillage');
 

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -422,6 +422,11 @@ subtest 'updating of waste reports' => sub {
             waste => { bromley => 1 }
         },
     }, sub {
+        $body->response_templates->create({
+            title => 'Allocated title', text => 'This has been allocated',
+            'auto_response' => 1, state => 'action scheduled',
+        });
+
         @reports = $mech->create_problems_for_body(2, $body->id, 'Report missed collection', {
             category => 'Report missed collection',
             cobrand_data => 'waste',
@@ -444,6 +449,8 @@ subtest 'updating of waste reports' => sub {
         } qr/Updating report to state action scheduled, Allocated to Crew/;
         $report->discard_changes;
         is $report->comments->count, 1, 'A new update';
+        my $update = $report->comments->first;
+        is $update->text, 'This has been allocated';
         is $report->state, 'action scheduled', 'A state change';
 
         $report->update({ external_id => 'waste-15003-' });

--- a/templates/web/base/waste/bin_days.html
+++ b/templates/web/base/waste/bin_days.html
@@ -38,7 +38,7 @@
           [% IF unit.next %]
             [% date.format(unit.next.date) | replace('~~~', unit.next.ordinal) %]
             [% IF unit.next.changed %](this collection has been adjusted from its usual time)[% END %]
-            [% IF unit.next.state == 'In progress' %](in progress)[% END %]
+            [% IF unit.next.state %]([% unit.next.state %])[% END %]
           [% ELSE %]
             <i>None</i>
           [% END %]
@@ -50,7 +50,7 @@
         <dd class="govuk-summary-list__value">
             [% date.format(unit.last.date) | replace('~~~', unit.last.ordinal) %]
             [% IF unit.last.changed %](this collection has been adjusted from its usual time)[% END %]
-            [% IF unit.last.state == 'In progress' %](in progress)[% END %]
+            [% IF unit.last.state %]([% unit.last.state %])[% END %]
             [% IF unit.last.completed %](completed at [% date.format(unit.last.completed, '%l:%M%p') | lower ~%])[% END ~%]
             [% IF unit.last.resolution %][% unit.last.resolution | staff_html_markup({ is_body_user => 1 }) %][% END ~%]
         </dd>


### PR DESCRIPTION
Fix admin template setting by making sure blank external status is actually blank; show more task states than just in progress (e.g. delayed should be shown), and prefer templates over description (don't want to just blank out description as don't know if templates will be created for all states, though I guess they probably will be). [skip changelog]