### PR TITLE
CSV export, improve Site Used and add Device Type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
         - Include email in inspector form information.
         - Improve wording of new report Private checkbox.
         - No questionnaires on reports as body/anonymous.
+        - CSV export, improve Site Used and add Device Type.
     - Development improvements:
         - Include failure count in send report error output, #3316
         - Sort output in export script. #3323

--- a/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
+++ b/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
@@ -181,12 +181,9 @@ sub report_new_is_on_he_road {
 sub dashboard_export_problems_add_columns {
     my ($self, $csv) = @_;
 
-    $csv->modify_csv_header( "Site Used" => 'Device Type' );
-
     $csv->add_csv_columns(
         area_name => 'Area name',
         where_hear => 'How you found us',
-        cobrand => 'Site Used',
     );
 
     $csv->csv_extra_data(sub {
@@ -195,7 +192,6 @@ sub dashboard_export_problems_add_columns {
         return {
             area_name => $report->get_extra_field_value('area_name'),
             where_hear => $report->get_extra_metadata('where_hear'),
-            cobrand => $report->cobrand,
         };
     });
 }

--- a/perllib/FixMyStreet/Reporting.pm
+++ b/perllib/FixMyStreet/Reporting.pm
@@ -208,6 +208,7 @@ sub _csv_parameters_problems {
         'Easting',
         'Northing',
         'Report URL',
+        'Device Type',
         'Site Used',
         'Reported As',
     ]);
@@ -230,6 +231,7 @@ sub _csv_parameters_problems {
         'local_coords_x',
         'local_coords_y',
         'url',
+        'device_type',
         'site_used',
         'reported_as',
     ]);
@@ -302,7 +304,10 @@ sub generate_csv {
         my $base = $self->cobrand->base_url_for_report($obj->can('problem') ? $obj->problem : $obj);
         $hashref->{url} = join '', $base, $obj->url;
 
-        $hashref->{site_used} = $obj->can('service') ? ($obj->service || $obj->cobrand) : $obj->cobrand;
+        if ($asked_for{device_type}) {
+            $hashref->{device_type} = $obj->service || 'website';
+        }
+        $hashref->{site_used} = $obj->cobrand;
 
         $hashref->{reported_as} = $obj->get_extra_metadata('contributed_as') || '';
 

--- a/t/app/controller/dashboard.t
+++ b/t/app/controller/dashboard.t
@@ -189,7 +189,7 @@ FixMyStreet::override_config {
         my @rows = $mech->content_as_csv;
         is scalar @rows, 19, '1 (header) + 18 (reports) = 19 lines';
 
-        is scalar @{$rows[0]}, 21, '21 columns present';
+        is scalar @{$rows[0]}, 22, '22 columns present';
 
         is_deeply $rows[0],
             [
@@ -212,6 +212,7 @@ FixMyStreet::override_config {
                 'Easting',
                 'Northing',
                 'Report URL',
+                'Device Type',
                 'Site Used',
                 'Reported As',
             ],

--- a/t/cobrand/bathnes.t
+++ b/t/cobrand/bathnes.t
@@ -84,7 +84,7 @@ subtest 'extra CSV columns are absent if permission not granted' => sub {
     my @rows = $mech->content_as_csv;
     is scalar @rows, 5, '1 (header) + 4 (reports) = 5 lines';
 
-    is scalar @{$rows[0]}, 20, '20 columns present';
+    is scalar @{$rows[0]}, 21, '21 columns present';
 
     is_deeply $rows[0],
         [
@@ -106,6 +106,7 @@ subtest 'extra CSV columns are absent if permission not granted' => sub {
             'Easting',
             'Northing',
             'Report URL',
+            'Device Type',
             'Site Used',
             'Reported As',
         ],
@@ -140,7 +141,7 @@ subtest 'extra CSV columns are present if permission granted' => sub {
     my @rows = $mech->content_as_csv;
     is scalar @rows, 5, '1 (header) + 4 (reports) = 5 lines';
 
-    is scalar @{$rows[0]}, 24, '24 columns present';
+    is scalar @{$rows[0]}, 25, '25 columns present';
 
     is_deeply $rows[0],
         [
@@ -162,6 +163,7 @@ subtest 'extra CSV columns are present if permission granted' => sub {
             'Easting',
             'Northing',
             'Report URL',
+            'Device Type',
             'Site Used',
             'Reported As',
             'User Email',
@@ -171,33 +173,37 @@ subtest 'extra CSV columns are present if permission granted' => sub {
         ],
         'Column headers look correct';
 
-    is $rows[1]->[18], 'iOS', 'Site Used shows whether report made via app';
-    is $rows[1]->[19], '', 'Reported As is empty if not made on behalf of another user/body';
-    is $rows[1]->[20], $normaluser->email, 'User email is correct';
-    is $rows[1]->[21], '+447123456789', 'User phone number is correct';
-    is $rows[1]->[22], '', 'Staff User is empty if not made on behalf of another user';
-    is $rows[1]->[23], 'width = 10cm; depth = 25cm', 'Attribute Data is correct';
+    is $rows[1]->[18], 'iOS', 'Device Type shows whether report made via app';
+    is $rows[1]->[19], 'fixmystreet', 'Site Used shows cobrand';
+    is $rows[1]->[20], '', 'Reported As is empty if not made on behalf of another user/body';
+    is $rows[1]->[21], $normaluser->email, 'User email is correct';
+    is $rows[1]->[22], '+447123456789', 'User phone number is correct';
+    is $rows[1]->[23], '', 'Staff User is empty if not made on behalf of another user';
+    is $rows[1]->[24], 'width = 10cm; depth = 25cm', 'Attribute Data is correct';
 
-    is $rows[2]->[18], 'bathnes', 'Site Used shows correct cobrand';
-    is $rows[2]->[19], 'body', 'Reported As is correct if made on behalf of body';
-    is $rows[2]->[20], $counciluser->email, 'User email is correct';
-    is $rows[2]->[21], '', 'User phone number is correct';
-    is $rows[2]->[22], '', 'Staff User is empty if not made on behalf of another user';
-    is $rows[2]->[23], '', 'Attribute Data is correct';
+    is $rows[2]->[18], 'website', 'No device type';
+    is $rows[2]->[19], 'bathnes', 'Site Used shows correct cobrand';
+    is $rows[2]->[20], 'body', 'Reported As is correct if made on behalf of body';
+    is $rows[2]->[21], $counciluser->email, 'User email is correct';
+    is $rows[2]->[22], '', 'User phone number is correct';
+    is $rows[2]->[23], '', 'Staff User is empty if not made on behalf of another user';
+    is $rows[2]->[24], '', 'Attribute Data is correct';
 
-    is $rows[3]->[18], 'bathnes', 'Site Used shows correct cobrand';
-    is $rows[3]->[19], 'another_user', 'Reported As is set if reported on behalf of another user';
-    is $rows[3]->[20], $normaluser->email, 'User email is correct';
-    is $rows[3]->[21], '+447123456789', 'User phone number is correct';
-    is $rows[3]->[22], $counciluser->email, 'Staff User is correct if made on behalf of another user';
-    is $rows[3]->[23], '', 'Attribute Data is correct';
+    is $rows[3]->[18], 'website', 'No device type';
+    is $rows[3]->[19], 'bathnes', 'Site Used shows correct cobrand';
+    is $rows[3]->[20], 'another_user', 'Reported As is set if reported on behalf of another user';
+    is $rows[3]->[21], $normaluser->email, 'User email is correct';
+    is $rows[3]->[22], '+447123456789', 'User phone number is correct';
+    is $rows[3]->[23], $counciluser->email, 'Staff User is correct if made on behalf of another user';
+    is $rows[3]->[24], '', 'Attribute Data is correct';
 
-    is $rows[4]->[18], 'bathnes', 'Site Used shows correct cobrand';
-    is $rows[4]->[19], 'anonymous_user', 'Reported As is set if reported on behalf of another user';
-    is $rows[4]->[20], $counciluser->email, 'User email is correct';
-    is $rows[4]->[21], '', 'User phone number is correct';
-    is $rows[4]->[22], '', 'Staff User is empty if not made on behalf of another user';
-    is $rows[4]->[23], '', 'Attribute Data is correct';
+    is $rows[4]->[18], 'website', 'No device type';
+    is $rows[4]->[19], 'bathnes', 'Site Used shows correct cobrand';
+    is $rows[4]->[20], 'anonymous_user', 'Reported As is set if reported on behalf of another user';
+    is $rows[4]->[21], $counciluser->email, 'User email is correct';
+    is $rows[4]->[22], '', 'User phone number is correct';
+    is $rows[4]->[23], '', 'Staff User is empty if not made on behalf of another user';
+    is $rows[4]->[24], '', 'Attribute Data is correct';
 
     $mech->get_ok('/dashboard?export=1&updates=1');
 

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -264,21 +264,21 @@ subtest 'extra CSV columns are present' => sub {
 
     my @rows = $mech->content_as_csv;
     is scalar @rows, 6, '1 (header) + 4 (reports) = 6 lines';
-    is scalar @{$rows[0]}, 21, '21 columns present';
+    is scalar @{$rows[0]}, 22, '22 columns present';
 
     is_deeply $rows[0],
         [
             'Report ID', 'Title', 'Detail', 'User Name', 'Category',
             'Created', 'Confirmed', 'Acknowledged', 'Fixed', 'Closed',
             'Status', 'Latitude', 'Longitude', 'Query', 'Ward',
-            'Easting', 'Northing', 'Report URL', 'Site Used',
+            'Easting', 'Northing', 'Report URL', 'Device Type', 'Site Used',
             'Reported As', 'Staff User',
         ],
         'Column headers look correct';
 
-    is $rows[1]->[20], '', 'Staff User is empty if not made on behalf of another user';
-    is $rows[2]->[20], $counciluser->email, 'Staff User is correct if made on behalf of another user';
-    is $rows[3]->[20], '', 'Staff User is empty if not made on behalf of another user';
+    is $rows[1]->[21], '', 'Staff User is empty if not made on behalf of another user';
+    is $rows[2]->[21], $counciluser->email, 'Staff User is correct if made on behalf of another user';
+    is $rows[3]->[21], '', 'Staff User is empty if not made on behalf of another user';
 
     $mech->create_comment_for_problem($report, $counciluser, 'Staff User', 'Some update text', 'f', 'confirmed', undef, {
         extra => { contributed_as => 'body' }});

--- a/t/cobrand/highwaysengland.t
+++ b/t/cobrand/highwaysengland.t
@@ -132,9 +132,9 @@ subtest 'Dashboard CSV extra columns' => sub {
     }, sub {
         $mech->get_ok('/dashboard?export=1');
     };
-    $mech->content_contains('URL","Device Type","Reported As","Area name","How you found us","Site Used"');
-    $mech->content_contains('http://highwaysengland.example.org/report/' . $problem1->id .',desktop,,"South West","Social media",highwaysengland');
-    $mech->content_contains('http://highwaysengland.example.org/report/' . $problem2->id .',mobile,,"Area 7","Search engine",fixmystreet');
+    $mech->content_contains('URL","Device Type","Site Used","Reported As","Area name","How you found us"');
+    $mech->content_contains('http://highwaysengland.example.org/report/' . $problem1->id .',desktop,highwaysengland,,"South West","Social media"');
+    $mech->content_contains('http://highwaysengland.example.org/report/' . $problem2->id .',mobile,fixmystreet,,"Area 7","Search engine"');
 };
 
 done_testing();

--- a/t/cobrand/oxfordshire.t
+++ b/t/cobrand/oxfordshire.t
@@ -185,21 +185,21 @@ FixMyStreet::override_config {
 
         my @rows = $mech->content_as_csv;
         is scalar @rows, 7, '1 (header) + 6 (reports) = 7 lines';
-        is scalar @{$rows[0]}, 21, '21 columns present';
+        is scalar @{$rows[0]}, 22, '22 columns present';
 
         is_deeply $rows[0],
             [
                 'Report ID', 'Title', 'Detail', 'User Name', 'Category',
                 'Created', 'Confirmed', 'Acknowledged', 'Fixed', 'Closed',
                 'Status', 'Latitude', 'Longitude', 'Query', 'Ward',
-                'Easting', 'Northing', 'Report URL', 'Site Used',
+                'Easting', 'Northing', 'Report URL', 'Device Type', 'Site Used',
                 'Reported As', 'HIAMS/Exor Ref',
             ],
             'Column headers look correct';
 
-        is $rows[1]->[20], 'ENQ12456', 'HIAMS reference included in row';
-        is $rows[2]->[20], '', 'Report without HIAMS ref has empty ref field';
-        is $rows[3]->[20], '123098123', 'Older Exor report has correct ref';
+        is $rows[1]->[21], 'ENQ12456', 'HIAMS reference included in row';
+        is $rows[2]->[21], '', 'Report without HIAMS ref has empty ref field';
+        is $rows[3]->[21], '123098123', 'Older Exor report has correct ref';
     };
 
     $oxon->update({


### PR DESCRIPTION
Since we started recording mobile/desktop website use in service, Site Used now contains that, rather than the cobrand used. Rename Site Used to Device Type (and only show service column), and add a new Site Used column that always contains the cobrand used. (This was already done for the Highways England cobrand.)