### PR TITLE
No questionnaires if reported as other, no details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
         - Improve layout of some admin pages.
         - Include email in inspector form information.
         - Improve wording of new report Private checkbox.
+        - No questionnaires on reports as body/anonymous.
     - Development improvements:
         - Include failure count in send report error output, #3316
         - Sort output in export script. #3323

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -941,7 +941,9 @@ sub process_user : Private {
             $user->name($name) unless $user->name;
             $c->stash->{no_reporter_alert} = 1;
         } elsif ($c->stash->{contributing_as_another_user}) {
+            # If we are here, the user picked report as another user but gave neither email or phone
             $c->stash->{no_reporter_alert} = 1;
+            $report->send_questionnaire(0);
         }
 
         return 1;

--- a/t/app/controller/report_as_other.t
+++ b/t/app/controller/report_as_other.t
@@ -54,6 +54,7 @@ subtest "Body user, has permission to add report as another user with email" => 
     is $report->name, 'Another User', 'report name is given name';
     is $report->user->name, 'Another User', 'user name matches';
     is $report->user->email, 'another@example.net', 'user email correct';
+    is $report->send_questionnaire, 1, 'questionnaire';
     isnt $report->user->id, $user->id, 'user does not match';
     like $mech->get_text_body_from_email, qr/Your report to Oxfordshire County Council has been logged/;
     is $report->send_questionnaire, 1, 'send questionnaire';
@@ -114,6 +115,7 @@ subtest "Body user, has permission to add report as another user with only name"
     is $report->user->name, 'Body User', 'user name unchanged';
     is $report->user->id, $user->id, 'user matches';
     is $report->anonymous, 1, 'report anonymous';
+    is $report->send_questionnaire, 0, 'no questionnaire';
 };
 
 subtest "Body user, has permission to add report as another (existing) user with email" => sub {
@@ -133,6 +135,7 @@ subtest "Body user, has permission to add report as another (existing) user with
     is $report->name, 'Existing Yooser', 'report name is given name';
     is $report->user->name, 'Existing User', 'user name remains same';
     is $report->user->email, $existing->email, 'user email correct';
+    is $report->send_questionnaire, 1, 'questionnaire';
     isnt $report->user->id, $user->id, 'user does not match';
     like $mech->get_text_body_from_email, qr/Your report to Oxfordshire County Council has been logged/;
 


### PR DESCRIPTION
This is similar to reporting as anonymous, in that it uses the staff user account, except you could have provided a different name. (Also see previous commit de8084885daffd3f4203cc46cfa3edf4d0a1dc0d)
