### PR TITLE
configure FLOC disabling header on a per cobrand basis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
     - Development improvements:
         - Include failure count in send report error output, #3316
         - Sort output in export script. #3323
+        - Add config option for disabling FLOC
     - Security:
         - Increase minimum password length to eight.
 

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -89,6 +89,10 @@ sub add_response_headers {
         my $csp_nonce = $self->{c}->stash->{csp_nonce} = unpack('h*', mySociety::Random::random_bytes(16, 1));
         $self->{c}->res->header('Content-Security-Policy', "script-src 'self' 'unsafe-inline' 'nonce-$csp_nonce' $csp_domains; object-src 'none'; base-uri 'none'")
     }
+
+    if ($self->feature('disable_floc')) {
+        $self->{c}->res->header('Permissions-Policy', 'interest-cohort=()');
+    }
 }
 
 =item password_minimum_length

--- a/t/cobrand/councils.t
+++ b/t/cobrand/councils.t
@@ -115,4 +115,22 @@ subtest "CSP header from feature" => sub {
     }
 };
 
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => [ 'oxfordshire', 'fixmystreet' ],
+    COBRAND_FEATURES => {
+        disable_floc => {
+            fixmystreet => 1
+        }
+    }
+}, sub {
+    subtest 'check floc tracking turned off' => sub {
+        ok $mech->host("www.fixmystreet.com"), "set host to fixmystreet";
+        $mech->get_ok('/');
+        is $mech->res->header('Permissions-Policy'), 'interest-cohort=()', 'FLOC header present for fixmystreet';
+        ok $mech->host("oxfordshire.fixmystreet.com"), "set host to oxfordshire";
+        $mech->get_ok('/');
+        is $mech->res->header('Permissions-Policy'), undef, 'FLOC header missing for oxfordshire';
+    };
+};
+
 done_testing();


### PR DESCRIPTION
Add a cobrand feature to send a header to remove the site from being
used as part of FLOC tracking.