### PR TITLE
[Waste] Verify email address

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Noise.pm
+++ b/perllib/FixMyStreet/App/Controller/Noise.pm
@@ -240,7 +240,7 @@ EOF
     $object->insert;
 
     if ($c->stash->{report}) {
-        $c->forward('/report/new/create_related_things');
+        $c->forward('/report/new/create_related_things', [ $c->stash->{report} ]);
     } else {
         # Send alert email, like would be sent for report
         my $recipient = $c->cobrand->noise_destination_email($object->problem, $c->cobrand->council_name);

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1363,6 +1363,9 @@ sub tokenize_user : Private {
         password => $report->user->password,
         title => $report->user->title,
     };
+    if (my $template = $c->stash->{override_confirmation_template}) {
+        $c->stash->{token_data}->{template} = $template;
+    }
     $c->forward('/auth/set_oauth_token_data', [ $c->stash->{token_data} ])
         if $c->get_param('oauth_need_email');
 }
@@ -1415,8 +1418,8 @@ sub confirm_by_text : Path('text') {
 sub process_confirmation : Private {
     my ( $self, $c ) = @_;
 
-    $c->stash->{template} = 'tokens/confirm_problem.html';
     my $data = $c->stash->{token_data};
+    $c->stash->{template} = $data->{template} || 'tokens/confirm_problem.html';
 
     unless ($c->stash->{report}) {
         # Look at all problems, not just cobrand, in case am approving something we don't actually show

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -159,7 +159,7 @@ sub report_new_ajax : Path('mobile') : Args(0) {
 
     my $report = $c->stash->{report};
     if ( $report->confirmed ) {
-        $c->forward( 'create_related_things' );
+        $c->forward( 'create_related_things', [ $report ] );
         $c->stash->{ json_response } = { success => 1, report => $report->id };
     } else {
         $c->forward( 'send_problem_confirm_email' );
@@ -1472,7 +1472,7 @@ sub process_confirmation : Private {
     );
 
     # Subscribe problem reporter to email updates
-    $c->forward( '/report/new/create_related_things' );
+    $c->forward( '/report/new/create_related_things', [ $problem ] );
 
     # log the problem creation user in to the site
     if ( $data->{name} || $data->{password} ) {
@@ -1751,7 +1751,7 @@ sub redirect_or_confirm_creation : Private {
     # If confirmed send the user straight there.
     if ( $report->confirmed ) {
         # Subscribe problem reporter to email updates
-        $c->forward( 'create_related_things' );
+        $c->forward( 'create_related_things', [ $report ] );
         if ($c->stash->{contributing_as_another_user} && $report->user->email
             && $report->user->id != $c->user->id
             && !$c->cobrand->report_sent_confirmation_email($report)) {
@@ -1794,9 +1794,7 @@ sub redirect_or_confirm_creation : Private {
 }
 
 sub create_related_things : Private {
-    my ( $self, $c ) = @_;
-
-    my $problem = $c->stash->{report};
+    my ( $self, $c, $problem ) = @_;
 
     # If there is a special template, create a comment using that
     foreach my $body (values %{$problem->bodies}) {

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -197,7 +197,8 @@ sub process_request_data : Private {
     my ($self, $c, $form) = @_;
     my $data = $form->saved_data;
     my $address = $c->stash->{property}->{address};
-    my @services = grep { /^container-/ && $data->{$_} } keys %$data;
+    my @services = grep { /^container-/ && $data->{$_} } sort keys %$data;
+    my @reports;
     foreach (@services) {
         my ($id) = /container-(.*)/;
         my $container = $c->stash->{containers}{$id};
@@ -207,9 +208,20 @@ sub process_request_data : Private {
         $c->set_param('Container_Type', $id);
         $c->set_param('Quantity', $quantity);
         $c->forward('add_report', [ $data ]) or return;
-        push @{$c->stash->{report_ids}}, $c->stash->{report}->id;
+        push @reports, $c->stash->{report};
     }
+    group_reports($c, @reports);
     return 1;
+}
+
+sub group_reports {
+    my ($c, @reports) = @_;
+    my $report = shift @reports;
+    if (@reports) {
+        $report->set_extra_metadata(grouped_ids => [ map { $_->id } @reports ]);
+        $report->update;
+    }
+    $c->stash->{report} = $report;
 }
 
 sub construct_bin_report_form {
@@ -253,7 +265,8 @@ sub process_report_data : Private {
     my ($self, $c, $form) = @_;
     my $data = $form->saved_data;
     my $address = $c->stash->{property}->{address};
-    my @services = grep { /^service-/ && $data->{$_} } keys %$data;
+    my @services = grep { /^service-/ && $data->{$_} } sort keys %$data;
+    my @reports;
     foreach (@services) {
         my ($id) = /service-(.*)/;
         my $service = $c->stash->{services}{$id}{service_name};
@@ -261,8 +274,9 @@ sub process_report_data : Private {
         $data->{detail} = "$data->{title}\n\n$address";
         $c->set_param('service_id', $id);
         $c->forward('add_report', [ $data ]) or return;
-        push @{$c->stash->{report_ids}}, $c->stash->{report}->id;
+        push @reports, $c->stash->{report};
     }
+    group_reports($c, @reports);
     return 1;
 }
 
@@ -333,7 +347,6 @@ sub process_enquiry_data : Private {
     }
     $c->set_param('service_id', $data->{service_id});
     $c->forward('add_report', [ $data ]) or return;
-    push @{$c->stash->{report_ids}}, $c->stash->{report}->id;
     return 1;
 }
 
@@ -379,7 +392,10 @@ sub form : Private {
 
     $form->process unless $form->processed;
 
-    $c->stash->{template} = $form->template || 'waste/index.html';
+    # If we have sent a confirmation email, that function will have
+    # set a template that we need to show
+    $c->stash->{template} = $form->template || 'waste/index.html'
+        unless $c->stash->{sent_confirmation_message};
     $c->stash->{form} = $form;
 }
 
@@ -400,6 +416,7 @@ sub add_report : Private {
     my ( $self, $c, $data ) = @_;
 
     $c->stash->{cobrand_data} = 'waste';
+    $c->stash->{override_confirmation_template} = 'waste/confirmation.html';
 
     # XXX Is this best way to do this?
     if ($c->user_exists && $c->user->from_body && $c->user->email ne $data->{email}) {
@@ -426,17 +443,7 @@ sub add_report : Private {
 
     $c->forward('setup_categories_and_bodies') unless $c->stash->{contacts};
     $c->forward('/report/new/non_map_creation', [['/waste/remove_name_errors']]) or return;
-    my $report = $c->stash->{report};
-    $report->confirm;
-    $report->update;
-
-    $c->model('DB::Alert')->find_or_create({
-        user => $report->user,
-        alert_type => 'new_updates',
-        parameter => $report->id,
-        cobrand => $report->cobrand,
-        lang => $report->lang,
-    })->confirm;
+    $c->forward('/report/new/redirect_or_confirm_creation');
 
     return 1;
 }

--- a/perllib/FixMyStreet/App/Form/Waste.pm
+++ b/perllib/FixMyStreet/App/Form/Waste.pm
@@ -49,4 +49,16 @@ before after_build => sub {
     map { $saved_data->{$_} = 1 } grep { /^(service|container)-/ && $c->req->params->{$_} } keys %{$c->req->params};
 };
 
+sub validate {
+    my $self = shift;
+
+    my $c = $self->c;
+    my $is_staff_user = ($c->user_exists && ($c->user->from_body || $c->user->is_superuser));
+    $self->add_form_error('Please specify an email address')
+        unless $self->field('email')->is_inactive || $self->field('email')->value || $is_staff_user;
+
+    $self->add_form_error('Please specify at least one of phone or email')
+        unless $self->field('phone')->is_inactive || $self->field('phone')->value || $self->field('email')->value;
+}
+
 1;

--- a/perllib/FixMyStreet/App/Form/Waste/AboutYou.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/AboutYou.pm
@@ -31,7 +31,7 @@ has_field phone => (
 has_field email => (
     type => 'Email',
     tags => {
-        hint => 'If you provide an email address, we can send you order status updates'
+        hint => 'Provide an email address so we can send you order status updates'
     },
 );
 

--- a/perllib/FixMyStreet/App/Form/Waste/Report.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Report.pm
@@ -57,8 +57,7 @@ sub validate {
     $self->add_form_error('Please specify what was missed')
         unless $any;
 
-    $self->add_form_error('Please specify at least one of phone or email')
-        unless $self->field('phone')->is_inactive || $self->field('phone')->value || $self->field('email')->value;
+    $self->next::method();
 }
 
 1;

--- a/perllib/FixMyStreet/App/Form/Waste/Request.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Request.pm
@@ -57,8 +57,7 @@ sub validate {
     $self->add_form_error('Please specify what you need')
         unless $any;
 
-    $self->add_form_error('Please specify at least one of phone or email')
-        unless $self->field('phone')->is_inactive || $self->field('phone')->value || $self->field('email')->value;
+    $self->next::method();
 }
 
 1;

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -94,6 +94,8 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { name => "Test" } });
         $mech->content_contains('Please enter your full name');
         $mech->content_contains('Please specify at least one of phone or email');
+        $mech->submit_form_ok({ with_fields => { name => "Test McTest", phone => '+441234567890' } });
+        $mech->content_contains('Please specify an email address');
         $mech->submit_form_ok({ with_fields => { name => "Test McTest", email => 'test@example.org' } });
         $mech->content_contains('Refuse collection');
         $mech->content_contains('Test McTest');

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -104,7 +104,10 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { name => "Test McTest", email => $user->email } });
         $mech->content_contains($user->email);
         $mech->submit_form_ok({ with_fields => { process => 'summary' } });
-        $mech->content_contains('Your report has been sent');
+        $mech->content_contains('Now check your email');
+        my $link = $mech->get_link_from_email;
+        $mech->get_ok($link);
+        $mech->content_contains('Your missed collection has been reported');
         FixMyStreet::Script::Reports::send();
         my @emails = $mech->get_email;
         is $emails[0]->header('To'), '"Bromley Council" <missed@example.org>';
@@ -113,6 +116,7 @@ FixMyStreet::override_config {
         like $body, qr/Your report to Bromley Council has been logged/;
 
         is $user->alerts->count, 1;
+        $mech->clear_emails_ok;
     };
     subtest 'Check report visibility' => sub {
         my $report = FixMyStreet::DB->resultset("Problem")->first;
@@ -150,11 +154,39 @@ FixMyStreet::override_config {
         $mech->content_contains('Test McTest');
         $mech->content_contains($user->email);
         $mech->submit_form_ok({ with_fields => { process => 'summary' } });
-        $mech->content_contains('Your request has been sent');
+        $mech->content_contains('Your container request has been sent');
         my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
         is $report->get_extra_field_value('uprn'), 1000000002;
         is $report->get_extra_field_value('Quantity'), 2;
         is $report->get_extra_field_value('Container_Type'), 1;
+    };
+    subtest 'Request multiple bins' => sub {
+        $mech->log_out_ok;
+        $mech->get_ok('/waste/12345/request');
+        $mech->submit_form_ok({ with_fields => { 'container-9' => 1, 'quantity-9' => 2, 'container-10' => 1, 'quantity-10' => 1 } });
+        $mech->submit_form_ok({ with_fields => { name => "Test McTest", email => $user->email } });
+        $mech->content_like(qr{Outside Food Waste Container</dt>\s*<dd[^>]*>1</dd>});
+        $mech->content_like(qr{Kitchen Caddy</dt>\s*<dd[^>]*>2</dd>});
+        $mech->submit_form_ok({ with_fields => { process => 'summary' } });
+        $mech->content_contains('Now check your email');
+        my $link = $mech->get_link_from_email; # Only one email sent, this also checks
+        $mech->get_ok($link);
+        $mech->content_contains('Your container request has been sent');
+        FixMyStreet::Script::Reports::send();
+        my @emails = $mech->get_email;
+        is $emails[0]->header('To'), '"Bromley Council" <request@example.org>';
+        is $emails[1]->header('To'), $user->email;
+        my $body = $mech->get_text_body_from_email($emails[1]);
+        like $body, qr/Your report to Bromley Council has been logged/;
+        my @reports = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' }, rows => 2 });
+        is $reports[0]->state, 'confirmed';
+        is $reports[0]->get_extra_field_value('uprn'), 1000000002;
+        is $reports[0]->get_extra_field_value('Quantity'), 2;
+        is $reports[0]->get_extra_field_value('Container_Type'), 9;
+        is $reports[1]->state, 'confirmed';
+        is $reports[1]->get_extra_field_value('uprn'), 1000000002;
+        is $reports[1]->get_extra_field_value('Quantity'), 1;
+        is $reports[1]->get_extra_field_value('Container_Type'), 10;
     };
     subtest 'Thing already requested' => sub {
         $mech->get_ok('/waste/12345');
@@ -189,7 +221,7 @@ FixMyStreet::override_config {
         $mech->content_contains('Test McTest');
         $mech->content_contains($user->email);
         $mech->submit_form_ok({ with_fields => { process => 'summary' } });
-        $mech->content_contains('Your enquiry has been sent');
+        $mech->content_contains('Your enquiry has been submitted');
         my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
         is $report->get_extra_field_value('Notes'), 'Some notes';
         is $report->user->email, $user->email;

--- a/templates/web/base/waste/confirmation.html
+++ b/templates/web/base/waste/confirmation.html
@@ -1,10 +1,10 @@
 [%
-IF first_page == 'request';
-    title = 'Container request sent';
-ELSIF first_page == 'report';
-    title = 'Missed collection reported';
+IF report.category == 'Request new container';
+    title = 'Container request has been sent';
+ELSIF report.category == 'Report missed collection';
+    title = 'Missed collection has been reported';
 ELSE;
-    title = 'Enquiry submitted';
+    title = 'Enquiry has been submitted';
 END ~%]
 [% PROCESS 'waste/header.html' %]
 
@@ -13,19 +13,19 @@ END ~%]
         [% title %]
     </h1>
     <div class="govuk-panel__body">
-        <p>Your [% first_page %] has been sent;
-          [% IF data.email %]
-            a copy has been sent to your email address, [% data.email %].
+        <p>Your [% title | lower %];
+          [% IF report.user.email %]
+            a copy has been sent to your email address, [% report.user.email %].
           [% END %]
         </p>
         <p>
-          [% IF first_page == 'request' %]
+          [% IF report.category == 'Request new container' %]
             Containers arrive typically within two weeks, but this may vary due to demand.
           [% END %]
-          [% IF report_ids.size > 1 %]
-            Your reference numbers are: <strong>[% report_ids.join(', ') %]</strong>.
+          [% IF report.get_extra_metadata('grouped_ids') %]
+            Your reference numbers are: <strong>[% report.id %], [% report.get_extra_metadata('grouped_ids').join(', ') %]</strong>.
           [% ELSE %]
-            Your reference number is <strong>[% report_ids.join(', ') %]</strong>.
+            Your reference number is <strong>[% report.id %]</strong>.
           [% END %]
         </p>
     </div>


### PR DESCRIPTION
Fixes https://github.com/mysociety/fixmystreet-commercial/issues/2272 [skip changelog]
The first four commits set things up for multiple reports being created/confirmed in one go and having a different confirmation template, then we make sure email given, and the final commit switches to using the normal confirmation flow.

The way it works is the first report (which is the 'key' one with the confirmation token associated with it etc) also stores the subsequent report IDs in its metadata, then when it's confirmed it looks up and confirms its grouped reports.