### PR TITLE
[Buckinghamshire] make it clear only bucks streelights are displayed

### DIFF
--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -83,7 +83,18 @@ fixmystreet.assets.add(labeled_defaults, {
         'Street light dim',
         'Street light intermittent',
         'Street light not working' ],
-    asset_item: 'street light'
+    asset_item: 'street light',
+    asset_item_message: 'You can pick a <b class="asset-ITEM">ITEM</b> from the map &raquo;<br>If there is no yellow dot showing then this ITEM is not maintained by Transport for Buckinghamshire',
+    construct_selected_asset_message: function(asset) {
+        var id = asset.attributes[this.fixmystreet.feature_code] || '';
+        if (id === '') {
+            return;
+        }
+        var data = this.fixmystreet.construct_asset_name(id);
+        var extra = '. Only ITEMs maintained by Transport for Buckinghamshire are displayed.';
+        extra = extra.replace(/ITEM/g, data.name);
+        return 'You have selected ' + data.name + ' <b>' + data.id + '</b>' + extra;
+    }
 });
 
 fixmystreet.assets.add(labeled_defaults, {

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -485,7 +485,7 @@ function get_asset_pick_message() {
     var message;
     if (typeof this.fixmystreet.asset_item_message !== 'undefined') {
         message = this.fixmystreet.asset_item_message;
-        message = message.replace('ITEM', this.fixmystreet.asset_item);
+        message = message.replace(/ITEM/g, this.fixmystreet.asset_item);
     } else {
         message = 'You can pick a <b class="asset-' + this.fixmystreet.asset_type + '">' + this.fixmystreet.asset_item + '</b> from the map &raquo;';
     }


### PR DESCRIPTION
plus a small tweak to enable multiple asset item placeholders in message string.

[skip changlog]
