### PR TITLE
do not allow blank category on triage

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Triage.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Triage.pm
@@ -111,6 +111,14 @@ sub update : Private {
     my $current_category = $problem->category;
     my $new_category = $c->get_param('category');
 
+    if (!$new_category) {
+        my $errors = $c->stash->{errors} || [];
+        push @$errors, _"Please choose a category";
+        $c->stash->{errors} = $errors;
+
+        $c->detach;
+    }
+
     my $changed = $c->forward('/admin/reports/edit_category', [ $problem, 1 ] );
 
     if ( $changed ) {

--- a/t/app/controller/admin/triage.t
+++ b/t/app/controller/admin/triage.t
@@ -71,6 +71,28 @@ FixMyStreet::override_config {
         $mech->content_contains('CONFIRM Subject');
     };
 
+    subtest "user has to select a category" => sub {
+        my $report_url = '/report/' . $report->id;
+        $mech->get_ok($report_url);
+        $mech->content_contains('Traffic lights');
+
+        $mech->submit_form_ok( {
+                with_fields => {
+                    category => '',
+                    include_update => 0,
+                }
+            },
+            'triage form submitted'
+        );
+
+        $mech->content_contains('Please choose a category', "displays error message if no category selected");
+
+        $report->discard_changes;
+        is $report->category, 'Potholes', 'category still unchanged';
+        is $report->state, 'for triage', 'report still in triage state';
+        ok $report->whensent, 'report not marked to resend';
+    };
+
     subtest "changing report category marks report as confirmed" => sub {
         my $report_url = '/report/' . $report->id;
         $mech->get_ok($report_url);


### PR DESCRIPTION
Prevent the user from unsetting the category when triaging a report.

[skip changelog]