### PR TITLE
[CheshireEast] Use new selectedCategory method in JS

### DIFF
--- a/web/cobrands/cheshireeast/assets.js
+++ b/web/cobrands/cheshireeast/assets.js
@@ -56,8 +56,7 @@ var cleaning_cats = [
   'Needles, Syringes or Glass',
   'Play Area Safety Issue',
   'Street Sweeping',
-  'Abandoned Vehicles - Not Taxed',
-  'Abandoned Vehicles - Taxed'
+  'Abandoned Vehicle',
 ];
 
 fixmystreet.assets.add(defaults, {

--- a/web/cobrands/cheshireeast/assets.js
+++ b/web/cobrands/cheshireeast/assets.js
@@ -77,7 +77,8 @@ fixmystreet.assets.add(defaults, {
     actions: {
         found: fixmystreet.message_controller.road_found,
         not_found: function(layer) {
-            var cat = $('select#form_category').val();
+            var selected = fixmystreet.reporting.selectedCategory();
+            var cat = selected.category !== '' ? selected.category : selected.group;
             if (OpenLayers.Util.indexOf(cleaning_cats, cat) != -1) {
               fixmystreet.message_controller.road_found(layer);
             } else {


### PR DESCRIPTION
Cheshire East have been in touch to say that the change in https://github.com/mysociety/fixmystreet/pull/3232 to allow reports in cleaning categories to be made anywhere isn't working.

After a bit of investigation it turns out that the original code was written and reviewed before the change that introduced the `selectedCategory` helper function, but was merged into master without being re-reviewed (my bad).

So this changes the code to use the new helper function so it works as expected.

Follows on from the original PR that introduced this change: https://github.com/mysociety/fixmystreet/pull/3232

Related to https://github.com/mysociety/fixmystreet-commercial/issues/2239

<!-- [skip changelog] -->
