### PR TITLE
Make anonymous comments clearer in alert emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
         - Improve `#geolocate_link` display, especially for smaller screens. #2048
         - Allow email alert radius to be specified. #68
         - Update URL on /my when map moves. #3358
+        - Make anonymous updates clearer in email alerts. #3417
     - Bugfixes:
         - Fix non-JS form when all extra questions answered. #3248
         - Improve display of disabled fields in iOS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
     - Development improvements:
         - Include failure count in send report error output, #3316
         - Sort output in export script. #3323
+        - Show relevant updates in alert-update email preview. #3417
     - Open311 improvements:
         - Consistent protected field ordering.
     - Security:

--- a/perllib/FixMyStreet/App/Controller/Develop.pm
+++ b/perllib/FixMyStreet/App/Controller/Develop.pm
@@ -103,7 +103,12 @@ sub email_previewer : Path('/_dev/email') : Args(1) {
         $vars->{data} = [ $c->model('DB::Problem')->search({}, { rows => 5 })->all ];
     } elsif ($template eq 'alert-update') {
         $vars->{data} = [];
-        my $q = $c->model('DB::Comment')->search({}, { rows => 5 });
+        my $q;
+        if ($vars->{problem}->comment_count > 0) {
+            $q = $vars->{problem}->comments;
+        } else {
+            $q = $c->model('DB::Comment')->search({}, { rows => 5 });
+        }
         while (my $u = $q->next) {
             my $fn = sub {
                 return FixMyStreet::App::Model::PhotoSet->new({

--- a/t/app/controller/alert_new.t
+++ b/t/app/controller/alert_new.t
@@ -497,7 +497,8 @@ subtest "Test normal alert signups and that alerts are sent" => sub {
 
     my $email = $emails[0];
     is +(my $c = () = $email->as_string =~ /Other User/g), 2, 'Update name given, twice';
-    unlike $email->as_string, qr/Anonymous User/, 'Update name not given';
+    unlike $email->as_string, qr/Anonymous User/, 'Update name not given for anonymous update';
+    like $email->as_string, qr/Posted anonymously/, '"Posted anonymously" text shown for anonymous update';
 
     $report->discard_changes;
     ok $report->get_extra_metadata('closure_alert_sent_at'), 'Closure time set';

--- a/templates/email/default/_email_comment_list.html
+++ b/templates/email/default/_email_comment_list.html
@@ -7,7 +7,11 @@
     [%~ END %]
       [% email_sanitize_html(update) | replace('<p>', '<p style="' _ list_item_p_style _ '">') %]
       <p style="[% list_item_date_style %]">
-        [%~ update.item_name | html IF update.item_name AND NOT update.item_anonymous -%]
+        [%~ IF update.item_anonymous %]
+          [%~ loc('Posted anonymously') -%]
+        [%~ ELSE %]
+          [%~ update.item_name | html IF update.item_name -%]
+        [%~ END %]
         [% '(' _ cobrand.prettify_dt(update.confirmed) _ ') ' IF cobrand.include_time_in_update_alerts -%]
       </p>
     </div>


### PR DESCRIPTION
When showing a list of comments in HTML emails we previously didn't show anything for updates that were left anonymously. This led to some confusion about which text related to which update.

This change means that anonymous comments will show the text "Posted anonymously" next to them, which should make things a bit clearer.

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/2236