### PR TITLE
Handle first map page asset not found better.

### DIFF
--- a/.cypress/cypress/integration/highwaysengland.js
+++ b/.cypress/cypress/integration/highwaysengland.js
@@ -27,3 +27,22 @@ describe('Highways England cobrand tests', function() {
         cy.nextPageReporting();
     });
 });
+
+describe('Highways England cobrand mobile tests', function() {
+    it('does not allow reporting on DBFO roads on mobile either', function() {
+        cy.server();
+        cy.route('POST', '**/mapserver/highways', 'fixture:highways.xml').as('highways-tilma');
+        cy.route('**/report/new/ajax*').as('report-ajax');
+
+        cy.viewport(320, 568);
+        cy.visit('http://highwaysengland.localhost:3001/');
+        cy.contains('Go');
+        cy.get('[name=pc]').type(Cypress.env('postcode'));
+        cy.get('[name=pc]').parents('form').submit();
+        cy.url().should('include', '/around');
+        cy.wait('@highways-tilma');
+        cy.get('#map_box').click(80, 249);
+        cy.wait('@report-ajax');
+        cy.contains('report on roads directly maintained').should('be.visible');
+    });
+});

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -195,7 +195,7 @@ fixmystreet.mobile_reporting = {
   remove_ui: function() {
     // Removes the "app-like" mobile reporting UI, reverting all the
     // changes made by fixmystreet.mobile_reporting.apply_ui().
-    $('html').removeClass('map-fullscreen only-map map-reporting');
+    $('html').removeClass('map-fullscreen only-map map-reporting map-page');
     $('#mob_sub_map_links').remove();
 
     // Turn off the mobile map filters.
@@ -301,6 +301,9 @@ fixmystreet.pageController = {
         $(fixmystreet).trigger('report_new:page_change', [ $curr, $page ]);
     },
     mapStepButtons: function() {
+        // We are now in the reporting flow, so set the page flag used for error display
+        $('html').addClass('map-page');
+
         var $map_box = $('#map_box');
         var links = '<a href="#ok" id="mob_ok">' + translation_strings.ok + '</a>';
         if (fixmystreet.page !== 'new') {
@@ -1777,6 +1780,7 @@ fixmystreet.display = {
         fixmystreet.page = fixmystreet.original.page;
         if ($('html').hasClass('mobile') && fixmystreet.page == 'around') {
             $('#mob_sub_map_links').remove();
+            $('html').removeClass('map-page');
             fixmystreet.mobile_reporting.apply_ui();
         }
 


### PR DESCRIPTION
On mobile, the message controller code moves an asset not found message to within the map box (given that takes up the whole page) and displays it based upon a map-page class. This class was added to subsequent map pages (e.g. asset selection), but not the first map page, which meant if the asset selection failure happened then (e.g. you have to click on a road to continue), the Continue button was hidden but no message was shown, which was confusing.

[skip changelog]

Fixes https://github.com/mysociety/fixmystreet-commercial/issues/2325