### PR TITLE
[Bromley] waste direct debit payment processing

### DIFF
--- a/bin/fixmystreet.com/bromley-reconcile-dd
+++ b/bin/fixmystreet.com/bromley-reconcile-dd
@@ -1,0 +1,15 @@
+#!/usr/bin/env perl
+
+use v5.14;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../setenv.pl";
+}
+
+use FixMyStreet::Cobrand::Bromley;
+
+my $cb = FixMyStreet::Cobrand::Bromley->new;
+$cb->waste_reconcile_direct_debits;

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -329,7 +329,8 @@ sub direct_debit_modify : Path('dd_amend') : Args(0) {
         my $dt = $c->cobrand->waste_get_next_dd_day;
 
         my $one_off_ref = $i->one_off_payment( {
-                payer_reference => 1, # XXX
+                # this will be set when the initial payment is confirmed
+                payer_reference => $c->stash->{orig_sub}->get_extra_metadata('payerReference'),
                 amount => sprintf('%.2f', $ad_hoc / 100),
                 reference => $p->id,
                 comments => '',
@@ -337,7 +338,7 @@ sub direct_debit_modify : Path('dd_amend') : Args(0) {
     }
 
     my $update_ref = $i->amend_plan( {
-        payer_reference => 1, # XXX
+        payer_reference => $c->stash->{orig_sub}->get_extra_metadata('payerReference'),
         amount => sprintf('%.2f', $total / 100),
     } );
 }
@@ -350,7 +351,7 @@ sub direct_debit_cancel_sub : Path('dd_cancel_sub') : Args(0) {
     my $i = Integrations::Pay360->new( { config => $c->cobrand->feature('payment_gateway') } );
 
     my $update_ref = $i->cancel_plan( {
-        payer_reference => 1, # XXX
+        payer_reference => $c->stash->{orig_sub}->get_extra_metadata('payerReference'),
     } );
 }
 

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -574,6 +574,20 @@ sub bin_payment_types {
     };
 }
 
+sub waste_subscription_types {
+    return {
+        New => 1,
+        Renew => 2,
+        Amend => 3,
+    };
+}
+
+sub waste_container_actions {
+    return {
+        deliver => 1,
+        remove => 2
+    };
+}
 
 sub bin_services_for_address {
     my $self = shift;
@@ -590,10 +604,7 @@ sub bin_services_for_address {
         45 => 'Wheeled Bin (Food)',
     };
 
-    $self->{c}->stash->{container_actions} = {
-        deliver => 1,
-        remove => 2
-    };
+    $self->{c}->stash->{container_actions} = $self->waste_container_actions;
 
     my %service_to_containers = (
         535 => [ 1 ],
@@ -617,11 +628,7 @@ sub bin_services_for_address {
 
     $self->{c}->stash->{quantity_max} = \%quantity_max;
 
-    $self->{c}->stash->{garden_subs} = {
-        New => 1,
-        Renew => 2,
-        Amend => 3,
-    };
+    $self->{c}->stash->{garden_subs} = $self->waste_subscription_types;
 
     my $result = $self->{api_serviceunits};
     return [] unless @$result;
@@ -1152,6 +1159,274 @@ sub garden_waste_cost {
     $bin_count ||= 1;
 
     return $self->feature('payment_gateway')->{ggw_cost} * $bin_count;
+}
+
+sub waste_payment_type {
+    my ($self, $type, $ref) = @_;
+
+    my ($sub_type, $category);
+    if ( $type eq 'Payment: 01' ) {
+        $category = 'Garden Subscription';
+        $sub_type = $self->waste_subscription_types->{New};
+    } elsif ( $type eq 'Payment: 17' ) {
+        $category = 'Garden Subscription';
+        if ( $ref ) {
+            $sub_type = $self->waste_subscription_types->{Amend};
+        } else {
+            $sub_type = $self->waste_subscription_types->{Renew};
+        }
+    } elsif ( $type eq 'AUDDIS: 0C' ) {
+        $sub_type = 0;
+        $category = 'Cancel';
+    }
+
+    return ($category, $sub_type);
+}
+
+sub waste_reconcile_direct_debits {
+    my $self = shift;
+
+    my $today = DateTime->now;
+    my $start = $today->clone->add( days => -4 );
+
+    my $config = $self->feature('payment_gateway');
+    my $i = Integrations::Pay360->new({
+        config => $config
+    });
+
+    my $recent = $i->get_recent_payments(
+        start => $start,
+        end => $today
+    );
+
+
+    RECORD: for my $payment ( @$recent ) {
+
+        my $date = $payment->{CollectionDate};
+        my ($category, $type) = $self->waste_payment_type ( $payment->{Type}, $payment->{YourRef} );
+
+        next unless $category && $date;
+
+        my $payer = $payment->{PayerReference};
+
+        (my $uprn = $payer) =~ s/^GGW//;
+
+        my $len = length($uprn);
+        my $rs = FixMyStreet::DB->resultset('Problem')->search({
+            extra => { like => '%uprn,T5:value,I' . $len . ':'. $uprn . '%' },
+        },
+        {
+                order_by => { -desc => 'created' }
+        })->to_body( $self->body );
+
+        my $handled;
+
+        # Work out what to do with the payment.
+        # Processed payments are indicated by a matching record with a dd_date the
+        # same as the CollectionDate of the payment
+        #
+        # Renewal is an automatic event so there is never a record in the database
+        # and we have to generate one.
+        #
+        # Cancellations may have an event in the database if the user has cancelled
+        # through the front end but they can also cancel the Direct Debit itself in
+        # which case we need to create a report.
+        #
+        #
+        # If we're a renew payment then find the initial subscription payment, also
+        # checking if we've already processed this payment. If we've not processed it
+        # create a renewal record using the original subscription as a basis.
+        if ( $type && $type eq $self->waste_subscription_types->{Renew} ) {
+            next unless $payment->{Status} eq 'Paid';
+            $rs = $rs->search({ category => 'Garden Subscription' });
+            my $p;
+            while ( my $cur = $rs->next ) {
+                my $sub_type = $cur->get_extra_field_value('Subscription_Type');
+                if ( $sub_type eq $self->waste_subscription_types->{New} ) {
+                    $p = $cur;
+                } elsif ( $sub_type eq $self->waste_subscription_types->{Renew} ) {
+                    # already processed
+                    next RECORD if $cur->get_extra_metadata('dd_date') && $cur->get_extra_metadata('dd_date') eq $date;
+                }
+            }
+            if ( $p ) {
+                my $service = $self->waste_get_current_garden_sub( $p->get_extra_field_value('property_id') );
+                unless ($service) {
+                    warn "no matching service to renew for $payer\n";
+                    next;
+                }
+                my $renew = _duplicate_waste_report($p, 'Garden Subscription', {
+                    Subscription_Type => $self->waste_subscription_types->{Renew},
+                    service_id => 545,
+                    uprn => $uprn,
+                    Subscription_Details_Container_Type => 44,
+                    Subscription_Details_Quantity => $self->waste_get_sub_quantity($service),
+                } );
+                $renew->set_extra_metadata('dd_date', $date);
+                $renew->insert;
+                $handled = 1;
+            }
+        # There's two options with a cancel payment. If the user has cancelled it outside of
+        # WasteWorks then we need to find the original sub and generate a new cancel subscription
+        # report.
+        #
+        # If it's been cancelled inside WasteWorks then we'll have an unconfirmed cancel report
+        # which we need to confirm.
+        } elsif ( $category eq 'Cancel' ) {
+            next unless $payment->{Status} eq 'Processed';
+            $rs = $rs->search({ category => { -in => ['Garden Subscription', 'Cancel Garden Subscription'] } });
+            my ($p, $r);
+            while ( my $cur = $rs->next ) {
+                my $sub_type = $cur->get_extra_field_value('Subscription_Type') || '';
+                if ( $sub_type eq $self->waste_subscription_types->{New} ) {
+                    $p = $cur;
+                } elsif ( $cur->category eq 'Cancel Garden Subscription' ) {
+                    if ( $cur->state eq 'unconfirmed' ) {
+                        $r = $cur;
+                    # already processed
+                    } elsif ( $cur->get_extra_metadata('dd_date') && $cur->get_extra_metadata('dd_date') eq $date) {
+                        next RECORD;
+                    }
+                }
+            }
+            if ( $r ) {
+                my $service = $self->waste_get_current_garden_sub( $r->get_extra_field_value('property_id') );
+                # if there's not a service then it's fine as it's already been cancelled
+                if ( $service ) {
+                    $r->set_extra_metadata('dd_date', $date);
+                    $r->state('confirmed');
+                    $r->update;
+                # there's no service but we don't want to be processing the report all the time.
+                } else {
+                    $r->state('hidden');
+                    $r->update;
+                }
+                # regardless this has been handled so no need to alert on it.
+                $handled = 1;
+            } elsif ( $p ) {
+                my $service = $self->waste_get_current_garden_sub( $p->get_extra_field_value('property_id') );
+                unless ($service) {
+                    warn "no matching service to cancel for $payer\n";
+                    next;
+                }
+                my $cancel = _duplicate_waste_report($p, 'Cancel Garden Subscription', {
+                    service_id => 545,
+                    uprn => $uprn,
+                    Container_Instruction_Action => $self->waste_container_actions->{remove},
+                    Container_Instruction_Container_Type => 44,
+                    Container_Instruction_Quantity => $self->waste_get_sub_quantity($service),
+                } );
+                $cancel->set_extra_metadata('dd_date', $date);
+                $cancel->insert;
+                $handled = 1;
+            }
+        # this covers new subscriptions and ad-hoc payments, both of which already have
+        # a record in the database as they are the result of user action
+        } else {
+            next unless $payment->{Status} eq 'Paid';
+            # we fetch the confirmed ones as well as we explicitly want to check for
+            # processed reports so we can warn on those we are missing.
+            $rs = $rs->search({ category => 'Garden Subscription' });
+            while ( my $cur = $rs->next ) {
+
+                if ( my $type = $self->_report_matches_payment( $cur, $payment ) ) {
+                    if ( $cur->state eq 'unconfirmed' ) {
+                        if ( $type eq 'New' ) {
+                            if ( !$cur->get_extra_metadata('payerReference') ) {
+                                $cur->set_extra_metadata('payerReference', $payer);
+                            }
+                        }
+                        $cur->set_extra_metadata('dd_date', $date);
+                        $cur->confirm;
+                        $cur->update;
+                        $handled = 1;
+                    } elsif ( $cur->get_extra_metadata('dd_date') eq $date)  {
+                        next RECORD;
+                    }
+                }
+            }
+        }
+
+        unless ( $handled ) {
+            warn "no matching record found for $category payment with id $payer\n";
+        }
+    }
+}
+
+sub _report_matches_payment {
+    my ($self, $r, $p) = @_;
+
+    my $match = 0;
+    if ( $p->{YourRef} && $r->id eq $p->{YourRef} ) {
+        $match = 'Ad-Hoc';
+    } elsif ( !$p->{YourRef}
+            && $r->get_extra_field_value('Subscription_Type') eq $self->waste_subscription_types->{New}
+    ) {
+        $match = 'New';
+    }
+
+    return $match;
+}
+
+sub _duplicate_waste_report {
+    my ( $report, $category, $extra ) = @_;
+    my $new = FixMyStreet::DB->resultset('Problem')->new({
+        category => $category,
+        user => $report->user,
+        latitude => $report->latitude,
+        longitude => $report->longitude,
+        cobrand => $report->cobrand,
+        bodies_str => $report->bodies_str,
+        title => $report->title,
+        detail => $report->detail,
+        postcode => $report->postcode,
+        used_map => $report->used_map,
+        name => $report->user->name,
+        areas => $report->areas,
+        anonymous => $report->anonymous,
+        state => 'confirmed',
+    });
+
+    my @extra = map { { name => $_, value => $extra->{$_} } } keys %$extra;
+    $new->set_extra_fields(@extra);
+
+    return $new;
+}
+
+sub waste_get_current_garden_sub {
+    my ( $self, $id ) = @_;
+
+    my $echo = $self->feature('echo');
+    $echo = Integrations::Echo->new(%$echo);
+    my $services = $echo->GetServiceUnitsForObject( $id );
+    return undef unless $services;
+
+    my $garden;
+    for my $service ( @$services ) {
+        if ( $service->{ServiceId} == $self->garden_waste_service_id ) {
+            $garden = _get_current_service_task($service);
+            last;
+        }
+    }
+
+    return $garden;
+}
+
+sub waste_get_sub_quantity {
+    my ($self, $service) = @_;
+
+    my $quantity;
+    for my $data ( @{ $service->{Data}->{ExtensibleDatum} } ) {
+        next unless $data->{DatatypeName} eq 'LBB - GW Container';
+        my $kids = $data->{ChildData}->{ExtensibleDatum};
+        $kids = [ $kids ] if ref $kids eq 'HASH';
+        for my $child ( @$kids ) {
+            next unless $child->{DatatypeName} eq 'Quantity';
+            $quantity = $child->{Value}
+        }
+    }
+
+    return $quantity;
 }
 
 sub admin_templates_external_status_code_hook {

--- a/perllib/Integrations/Pay360.pm
+++ b/perllib/Integrations/Pay360.pm
@@ -112,6 +112,65 @@ sub amend_plan {
     }
 }
 
+sub get_payers {
+    my ($self, $args) = @_;
+
+    my $obj = [
+        clientSUN => $self->config->{dd_sun},
+        clientID => $self->config->{dd_client_id},
+    ];
+
+    my $res = $self->call('GetPayers', @$obj);
+
+    if ( $res ) {
+        $res = $res->{GetPayersResponse}->{GetPayersResult};
+
+        if ($res->{StatusCode} eq 'SA') {
+            if ($res->{Payers}) {
+                return force_arrayref( $res, 'Payers' );
+            } else {
+                return [];
+            }
+        } else {
+            return {
+                error => $res->{StatusMessage}
+            }
+        }
+    }
+
+    return { error => "unknown error" };
+}
+
+sub get_all_history {
+    my ($self, $args) = @_;
+
+    my $obj = [
+        clientSUN => $self->config->{dd_sun},
+        clientID => $self->config->{dd_client_id},
+    ];
+
+    my $res = $self->call('GetPaymentHistoryAllPayers', @$obj);
+
+    if ( $res ) {
+        return $res;
+        $res = $res->{GetPaymentHistoryAllPayersResponse}->{GetPaymentHistoryAllPayersResult};
+
+        if ($res->{StatusCode} eq 'SA') {
+            if ($res->{Payments}) {
+                return force_arrayref( $res, 'Payments' );
+            } else {
+                return [];
+            }
+        } else {
+            return {
+                error => $res->{StatusMessage}
+            }
+        }
+    }
+
+    return { error => "unknown error" };
+}
+
 sub get_recent_payments {
     my ($self, $args) = @_;
 
@@ -129,7 +188,7 @@ sub get_recent_payments {
 
         if ($res->{StatusCode} eq 'SA') {
             if ($res->{Payments}) {
-                return force_arrayref( $res, 'Payements' );
+                return force_arrayref( $res, 'Payments' );
             } else {
                 return [];
             }

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -694,6 +694,7 @@ FixMyStreet::override_config {
     $p->category('Garden Subscription');
     $p->title('Garden Subscription - New');
     $p->update_extra_field({ name => 'payment_method', value => 'direct_debit' });
+    $p->set_extra_metadata('payerReference', 'GGW1000000002');
     $p->update;
 
     subtest 'check modify sub direct debit payment' => sub {
@@ -722,13 +723,13 @@ FixMyStreet::override_config {
         is $new_report->state, 'unconfirmed', 'report not confirmed';
 
         is_deeply $dd_sent_params->{one_off_payment}, {
-            payer_reference => 1,
+            payer_reference => 'GGW1000000002',
             amount => '5.50',
             reference => $new_report->id,
             comments => '',
         }, "correct direct debit ad hoc payment params sent";
         is_deeply $dd_sent_params->{amend_plan}, {
-            payer_reference => 1,
+            payer_reference => 'GGW1000000002',
             amount => '40.00',
         }, "correct direct debit amendment params sent";
     };
@@ -756,7 +757,7 @@ FixMyStreet::override_config {
 
         is $dd_sent_params->{one_off_payment}, undef, "no one off payment if reducing bin count";
         is_deeply $dd_sent_params->{amend_plan}, {
-            payer_reference => 1,
+            payer_reference => 'GGW1000000002',
             amount => '20.00',
         }, "correct direct debit amendment params sent";
     };
@@ -787,7 +788,7 @@ FixMyStreet::override_config {
         is $new_report->state, 'unconfirmed', 'report confirmed';
 
         is_deeply $dd_sent_params->{cancel_plan}, {
-            payer_reference => 1,
+            payer_reference => 'GGW1000000002',
         }, "correct direct debit cancellation params sent";
     };
 

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -1,6 +1,7 @@
 use CGI::Simple;
 use Test::MockModule;
 use Test::MockTime qw(:all);
+use Test::Warn;
 use DateTime;
 use Test::Output;
 use FixMyStreet::TestMech;
@@ -635,5 +636,533 @@ subtest 'check pro-rata calculation' => sub {
         }
     };
 };
+
+subtest 'check direct debit reconcilliation' => sub {
+    set_fixed_time('2021-03-19T12:00:00Z'); # After sample food waste collection
+    my $echo = Test::MockModule->new('Integrations::Echo');
+    $echo->mock('GetServiceUnitsForObject' => sub {
+        my ($self, $id) = @_;
+
+        if ( $id == 54321 ) {
+            return [ {
+                Id => 1005,
+                ServiceId => 545,
+                ServiceName => 'Garden waste collection',
+                ServiceTasks => { ServiceTask => {
+                    Id => 405,
+                    ScheduleDescription => 'every other Monday',
+                    Data => { ExtensibleDatum => [ {
+                        DatatypeName => 'LBB - GW Container',
+                        ChildData => { ExtensibleDatum => {
+                            DatatypeName => 'Quantity',
+                            Value => 2,
+                        } },
+                    } ] },
+                    ServiceTaskSchedules => { ServiceTaskSchedule => [ {
+                        EndDate => { DateTime => '2020-01-01T00:00:00Z' },
+                        LastInstance => {
+                            OriginalScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
+                            CurrentScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
+                        },
+                    }, {
+                        EndDate => { DateTime => '2021-03-30T00:00:00Z' },
+                        NextInstance => {
+                            CurrentScheduledDate => { DateTime => '2020-06-01T00:00:00Z' },
+                            OriginalScheduledDate => { DateTime => '2020-06-01T00:00:00Z' },
+                        },
+                        LastInstance => {
+                            OriginalScheduledDate => { DateTime => '2020-05-18T00:00:00Z' },
+                            CurrentScheduledDate => { DateTime => '2020-05-18T00:00:00Z' },
+                            Ref => { Value => { anyType => [ 567, 890 ] } },
+                        },
+                    }
+                ] }
+            } } } ];
+        }
+        if ( $id == 54322 || $id == 54324 || $id == 84324 ) {
+            return [ {
+                Id => 1005,
+                ServiceId => 545,
+                ServiceName => 'Garden waste collection',
+                ServiceTasks => { ServiceTask => {
+                    Id => 405,
+                    ScheduleDescription => 'every other Monday',
+                    Data => { ExtensibleDatum => [ {
+                        DatatypeName => 'LBB - GW Container',
+                        ChildData => { ExtensibleDatum => {
+                            DatatypeName => 'Quantity',
+                            Value => 1,
+                        } },
+                    } ] },
+                    ServiceTaskSchedules => { ServiceTaskSchedule => [ {
+                        EndDate => { DateTime => '2020-01-01T00:00:00Z' },
+                        LastInstance => {
+                            OriginalScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
+                            CurrentScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
+                        },
+                    }, {
+                        EndDate => { DateTime => '2021-03-30T00:00:00Z' },
+                        NextInstance => {
+                            CurrentScheduledDate => { DateTime => '2020-06-01T00:00:00Z' },
+                            OriginalScheduledDate => { DateTime => '2020-06-01T00:00:00Z' },
+                        },
+                        LastInstance => {
+                            OriginalScheduledDate => { DateTime => '2020-05-18T00:00:00Z' },
+                            CurrentScheduledDate => { DateTime => '2020-05-18T00:00:00Z' },
+                            Ref => { Value => { anyType => [ 567, 890 ] } },
+                        },
+                    }
+                ] }
+            } } } ];
+        }
+    });
+
+    my $ad_hoc_orig = setup_dd_test_report({
+        'Subscription_Type' => 1,
+        'Subscription_Details_Quantity' => 1,
+        'payment_method' => 'direct_debit',
+        'property_id' => '54325',
+        'uprn' => '654325',
+    });
+    $ad_hoc_orig->set_extra_metadata('dd_date', '01/01/2021');
+    $ad_hoc_orig->update;
+
+    my $ad_hoc = setup_dd_test_report({
+        'Subscription_Type' => 3,
+        'Subscription_Details_Quantity' => 1,
+        'payment_method' => 'direct_debit',
+        'property_id' => '54325',
+        'uprn' => '654325',
+    });
+    $ad_hoc->state('unconfirmed');
+    $ad_hoc->update;
+
+    my $ad_hoc_processed = setup_dd_test_report({
+        'Subscription_Type' => 3,
+        'Subscription_Details_Quantity' => 1,
+        'payment_method' => 'direct_debit',
+        'property_id' => '54426',
+        'uprn' => '654326',
+    });
+    $ad_hoc_processed->set_extra_metadata('dd_date' => '26/02/2021');
+    $ad_hoc_processed->update;
+
+    my $ad_hoc_skipped = setup_dd_test_report({
+        'Subscription_Type' => 3,
+        'Subscription_Details_Quantity' => 1,
+        'payment_method' => 'direct_debit',
+        'property_id' => '94325',
+        'uprn' => '954325',
+    });
+    $ad_hoc_skipped->state('unconfirmed');
+    $ad_hoc_skipped->update;
+
+    my $integ = Test::MockModule->new('Integrations::Pay360');
+    $integ->mock('get_recent_payments', sub {
+        return [
+            {   # new sub
+                AlternateKey => "",
+                Amount => 10.00,
+                ClientName => "London Borough of Bromley",
+                CollectionDate => "26/02/2021",
+                DueDate => "26/02/2021",
+                PayerAccountHoldersName => "A Payer",
+                PayerAccountNumber => 123,
+                PayerName => "A Payer",
+                PayerReference => "GGW654321",
+                PayerSortCode => "12345",
+                ProductName => "Garden Waste",
+                Status => "Paid",
+                Type => "Payment: 01",
+            },
+            {   # unhandled new sub
+                AlternateKey => "",
+                Amount => 10.00,
+                ClientName => "London Borough of Bromley",
+                CollectionDate => "26/02/2021",
+                DueDate => "26/02/2021",
+                PayerAccountHoldersName => "A Payer",
+                PayerAccountNumber => 123,
+                PayerName => "A Payer",
+                PayerReference => "GGW554321",
+                PayerSortCode => "12345",
+                ProductName => "Garden Waste",
+                Status => "Paid",
+                Type => "Payment: 01",
+            },
+            {   # cancel
+                AlternateKey => "",
+                Amount => 10.00,
+                ClientName => "London Borough of Bromley",
+                CollectionDate => "26/02/2021",
+                DueDate => "26/02/2021",
+                PayerAccountHoldersName => "A Payer",
+                PayerAccountNumber => 123,
+                PayerName => "A Payer",
+                PayerReference => "GGW654323",
+                PayerSortCode => "12345",
+                ProductName => "Garden Waste",
+                Status => "Processed",
+                Type => "AUDDIS: 0C",
+            },
+            {   # ad hoc already processed
+                AlternateKey => "",
+                YourRef => $ad_hoc_processed->id,
+                Amount => 10.00,
+                ClientName => "London Borough of Bromley",
+                CollectionDate => "26/02/2021",
+                DueDate => "26/02/2021",
+                PayerAccountHoldersName => "A Payer",
+                PayerAccountNumber => 123,
+                PayerName => "A Payer",
+                PayerReference => "GGW654326",
+                PayerSortCode => "12345",
+                ProductName => "Garden Waste",
+                Status => "Paid",
+                Type => "Payment: 17",
+            },
+            {   # renewal
+                AlternateKey => "",
+                Amount => 10.00,
+                ClientName => "London Borough of Bromley",
+                CollectionDate => "26/02/2021",
+                DueDate => "26/02/2021",
+                PayerAccountHoldersName => "A Payer",
+                PayerAccountNumber => 123,
+                PayerName => "A Payer",
+                PayerReference => "GGW654322",
+                PayerSortCode => "12345",
+                ProductName => "Garden Waste",
+                Status => "Paid",
+                Type => "Payment: 17",
+            },
+            {   # renewal already handled
+                AlternateKey => "",
+                Amount => 10.00,
+                ClientName => "London Borough of Bromley",
+                CollectionDate => "26/02/2021",
+                DueDate => "26/02/2021",
+                PayerAccountHoldersName => "A Payer",
+                PayerAccountNumber => 123,
+                PayerName => "A Payer",
+                PayerReference => "GGW654324",
+                PayerSortCode => "12345",
+                ProductName => "Garden Waste",
+                Status => "Paid",
+                Type => "Payment: 17",
+            },
+            {   # renewal but nothing in echo
+                AlternateKey => "",
+                Amount => 10.00,
+                ClientName => "London Borough of Bromley",
+                CollectionDate => "26/02/2021",
+                DueDate => "26/02/2021",
+                PayerAccountHoldersName => "A Payer",
+                PayerAccountNumber => 123,
+                PayerName => "A Payer",
+                PayerReference => "GGW754322",
+                PayerSortCode => "12345",
+                ProductName => "Garden Waste",
+                Status => "Paid",
+                Type => "Payment: 17",
+            },
+            {   # renewal but nothing in fms
+                AlternateKey => "",
+                Amount => 10.00,
+                ClientName => "London Borough of Bromley",
+                CollectionDate => "26/02/2021",
+                DueDate => "26/02/2021",
+                PayerAccountHoldersName => "A Payer",
+                PayerAccountNumber => 123,
+                PayerName => "A Payer",
+                PayerReference => "GGW854324",
+                PayerSortCode => "12345",
+                ProductName => "Garden Waste",
+                Status => "Paid",
+                Type => "Payment: 17",
+            },
+            {   # ad hoc
+                AlternateKey => "",
+                YourRef => $ad_hoc->id,
+                Amount => 10.00,
+                ClientName => "London Borough of Bromley",
+                CollectionDate => "26/03/2021",
+                DueDate => "26/02/2021",
+                PayerAccountHoldersName => "A Payer",
+                PayerAccountNumber => 123,
+                PayerName => "A Payer",
+                PayerReference => "GGW654325",
+                PayerSortCode => "12345",
+                ProductName => "Garden Waste",
+                Status => "Paid",
+                Type => "Payment: 17",
+            },
+            {   # unhandled new sub, ad hoc with same uprn
+                AlternateKey => "",
+                Amount => 10.00,
+                ClientName => "London Borough of Bromley",
+                CollectionDate => "26/02/2021",
+                DueDate => "26/02/2021",
+                PayerAccountHoldersName => "A Payer",
+                PayerAccountNumber => 123,
+                PayerName => "A Payer",
+                PayerReference => "GGW954325",
+                PayerSortCode => "12345",
+                ProductName => "Garden Waste",
+                Status => "Paid",
+                Type => "Payment: 01",
+            },
+            {   # unhandled cancel
+                AlternateKey => "",
+                Amount => 10.00,
+                ClientName => "London Borough of Bromley",
+                CollectionDate => "21/02/2021",
+                DueDate => "26/02/2021",
+                PayerAccountHoldersName => "A Payer",
+                PayerAccountNumber => 123,
+                PayerName => "A Payer",
+                PayerReference => "GGW954326",
+                PayerSortCode => "12345",
+                ProductName => "Garden Waste",
+                Status => "Processed",
+                Type => "AUDDIS: 0C",
+            },
+            {   # unprocessed cancel
+                AlternateKey => "",
+                Amount => 10.00,
+                ClientName => "London Borough of Bromley",
+                CollectionDate => "21/02/2021",
+                DueDate => "26/02/2021",
+                PayerAccountHoldersName => "A Payer",
+                PayerAccountNumber => 123,
+                PayerName => "A Payer",
+                PayerReference => "GGW854325",
+                PayerSortCode => "12345",
+                ProductName => "Garden Waste",
+                Status => "Processed",
+                Type => "AUDDIS: 0C",
+            },
+            {   # cancel nothing in echo
+                AlternateKey => "",
+                Amount => 10.00,
+                ClientName => "London Borough of Bromley",
+                CollectionDate => "21/02/2021",
+                DueDate => "26/02/2021",
+                PayerAccountHoldersName => "A Payer",
+                PayerAccountNumber => 123,
+                PayerName => "A Payer",
+                PayerReference => "GGW954324",
+                PayerSortCode => "12345",
+                ProductName => "Garden Waste",
+                Status => "Processed",
+                Type => "AUDDIS: 0C",
+            },
+        ];
+    });
+
+    my $contact = $mech->create_contact_ok(body => $body, category => 'Garden Subscription', email => 'garden@example.com');
+    $contact->set_extra_fields(
+            { name => 'uprn', required => 1, automated => 'hidden_field' },
+            { name => 'property_id', required => 1, automated => 'hidden_field' },
+            { name => 'service_id', required => 0, automated => 'hidden_field' },
+            { name => 'Subscription_Type', required => 1, automated => 'hidden_field' },
+            { name => 'Subscription_Details_Quantity', required => 1, automated => 'hidden_field' },
+            { name => 'Subscription_Details_Container_Type', required => 1, automated => 'hidden_field' },
+            { name => 'Container_Instruction_Quantity', required => 1, automated => 'hidden_field' },
+            { name => 'Container_Instruction_Action', required => 1, automated => 'hidden_field' },
+            { name => 'Container_Instruction_Container_Type', required => 1, automated => 'hidden_field' },
+            { name => 'current_containers', required => 1, automated => 'hidden_field' },
+            { name => 'new_containers', required => 1, automated => 'hidden_field' },
+            { name => 'payment_method', required => 1, automated => 'hidden_field' },
+            { name => 'pro_rata', required => 0, automated => 'hidden_field' },
+            { name => 'payment', required => 1, automated => 'hidden_field' },
+            { name => 'client_reference', required => 1, automated => 'hidden_field' },
+    );
+    $contact->update;
+
+    my $sub_for_renewal = setup_dd_test_report({
+        'Subscription_Type' => 1,
+        'Subscription_Details_Quantity' => 1,
+        'payment_method' => 'direct_debit',
+        'property_id' => '54321',
+        'uprn' => '654322',
+    });
+
+    my $sub_for_cancel = setup_dd_test_report({
+        'Subscription_Type' => 1,
+        'Subscription_Details_Quantity' => 1,
+        'payment_method' => 'direct_debit',
+        'property_id' => '54322',
+        'uprn' => '654323',
+    });
+
+    my $new_sub = setup_dd_test_report({
+        'Subscription_Type' => 1,
+        'Subscription_Details_Quantity' => 1,
+        'payment_method' => 'direct_debit',
+        'property_id' => '54323',
+        'uprn' => '654321',
+    });
+    $new_sub->state('unconfirmed');
+    $new_sub->update;
+
+    my $sub_for_unprocessed_cancel = setup_dd_test_report({
+        'Subscription_Type' => 1,
+        'Subscription_Details_Quantity' => 1,
+        'payment_method' => 'direct_debit',
+        'property_id' => '84324',
+        'uprn' => '854325',
+    });
+    my $unprocessed_cancel = setup_dd_test_report({
+        'payment_method' => 'direct_debit',
+        'property_id' => '84324',
+        'uprn' => '854325',
+    });
+    $unprocessed_cancel->state('unconfirmed');
+    $unprocessed_cancel->category('Cancel Garden Subscription');
+    $unprocessed_cancel->update;
+
+    my $sub_for_processed_cancel = setup_dd_test_report({
+        'Subscription_Type' => 1,
+        'Subscription_Details_Quantity' => 1,
+        'payment_method' => 'direct_debit',
+        'property_id' => '54324',
+        'uprn' => '654324',
+    });
+    my $processed_renewal = setup_dd_test_report({
+        'Subscription_Type' => 2,
+        'Subscription_Details_Quantity' => 1,
+        'payment_method' => 'direct_debit',
+        'property_id' => '54324',
+        'uprn' => '654324',
+    });
+    $processed_renewal->set_extra_metadata('dd_date' => '26/02/2021');
+    $processed_renewal->update;
+
+    my $renewal_nothing_in_echo = setup_dd_test_report({
+        'Subscription_Type' => 1,
+        'Subscription_Details_Quantity' => 1,
+        'payment_method' => 'direct_debit',
+        'property_id' => '74321',
+        'uprn' => '754322',
+    });
+
+    my $sub_for_cancel_nothing_in_echo = setup_dd_test_report({
+        'Subscription_Type' => 1,
+        'Subscription_Details_Quantity' => 1,
+        'payment_method' => 'direct_debit',
+        'property_id' => '94324',
+        'uprn' => '954324',
+    });
+
+    my $cancel_nothing_in_echo = setup_dd_test_report({
+        'payment_method' => 'direct_debit',
+        'property_id' => '94324',
+        'uprn' => '954324',
+    });
+    $cancel_nothing_in_echo->state('unconfirmed');
+    $cancel_nothing_in_echo->category('Cancel Garden Subscription');
+    $cancel_nothing_in_echo->update;
+
+    my $c = FixMyStreet::Cobrand::Bromley->new;
+    warnings_are {
+        $c->waste_reconcile_direct_debits;
+    } [
+        "no matching record found for Garden Subscription payment with id GGW554321\n",
+        "no matching service to renew for GGW754322\n",
+        "no matching record found for Garden Subscription payment with id GGW854324\n",
+        "no matching record found for Garden Subscription payment with id GGW954325\n",
+        "no matching record found for Cancel payment with id GGW954326\n",
+    ], "warns if no matching record";
+
+    $new_sub->discard_changes;
+    is $new_sub->state, 'confirmed', "New report confirmed";
+    is $new_sub->get_extra_metadata('payerReference'), "GGW654321", "payer reference set";
+
+    $ad_hoc_orig->discard_changes;
+    is $ad_hoc_orig->get_extra_metadata('dd_date'), "01/01/2021", "dd date unchanged ad hoc orig";
+
+    $ad_hoc->discard_changes;
+    is $ad_hoc->state, 'confirmed', "ad hoc report confirmed";
+    is $ad_hoc->get_extra_metadata('dd_date'), "26/03/2021", "dd date set for ad hoc";
+
+    $ad_hoc_skipped->discard_changes;
+    is $ad_hoc_skipped->state, 'unconfirmed', "ad hoc report not confirmed";
+
+    $cancel_nothing_in_echo->discard_changes;
+    is $cancel_nothing_in_echo->state, 'hidden', 'hide already cancelled report';
+
+    my $renewal = FixMyStreet::DB->resultset('Problem')->search({
+            extra => { like => '%uprn,T5:value,I6:654322%' }
+        },
+        {
+            order_by => { -desc => 'id' }
+        }
+    );
+
+    is $renewal->count, 2, "two records for renewal property";
+    my $p = $renewal->first;
+    ok $p->id != $sub_for_renewal->id, "not the original record";
+    is $p->get_extra_field_value('Subscription_Type'), 2, "renewal has correct type";
+    is $p->get_extra_field_value('Subscription_Details_Quantity'), 2, "renewal has correct number of bins";
+    is $p->get_extra_field_value('Subscription_Type'), 2, "renewal has correct type";
+    is $p->state, 'confirmed';
+
+    my $cancel = FixMyStreet::DB->resultset('Problem')->search({
+            extra => { like => '%uprn,T5:value,I6:654323%' }
+        },
+        {
+            order_by => { -desc => 'id' }
+        }
+    );
+
+    is $cancel->count, 2, "two records for cancel property";
+    $p = $cancel->first;
+    ok $p->id != $sub_for_cancel->id, "not the original record";
+    is $p->get_extra_field_value('Container_Instruction_Action'), 2, "correct containter instruction";
+    is $p->get_extra_field_value('Container_Instruction_Quantity'), 1, "cancel has correct number of bins";
+    is $p->category, 'Cancel Garden Subscription', 'cancel has correct category';
+    is $p->get_extra_metadata('dd_date'), "26/02/2021", "dd date set for cancelled";
+    is $p->state, 'confirmed';
+
+    my $processed = FixMyStreet::DB->resultset('Problem')->search({
+            extra => { like => '%uprn,T5:value,I6:654324%' }
+        },
+        {
+            order_by => { -desc => 'id' }
+        }
+    );
+    is $processed->count, 2, "two records for processed renewal property";
+
+    my $ad_hoc_processed_rs = FixMyStreet::DB->resultset('Problem')->search({
+            extra => { like => '%uprn,T5:value,I6:654326%' }
+        },
+        {
+            order_by => { -desc => 'id' }
+        }
+    );
+    is $ad_hoc_processed_rs->count, 1, "one records for processed ad hoc property";
+
+    $unprocessed_cancel->discard_changes;
+    is $unprocessed_cancel->state, 'confirmed', 'Unprocessed cancel is confirmed';
+    is $unprocessed_cancel->get_extra_metadata('dd_date'), "21/02/2021", "dd date set for unprocessed cancelled";
+};
+
+sub setup_dd_test_report {
+    my $extras = shift;
+    my ($report) = $mech->create_problems_for_body( 1, $body->id, 'Test', {
+        category => 'Garden Subscription',
+        latitude => 51.402096,
+        longitude => 0.015784,
+        cobrand => 'bromley',
+        areas => '2482,8141',
+        user => $user,
+    });
+    my @extras = map { { name => $_, value => $extras->{$_} } } keys %$extras;
+    $report->set_extra_fields( @extras );
+    $report->update;
+
+    return $report;
+}
 
 done_testing();

--- a/t/integrations/pay360.t
+++ b/t/integrations/pay360.t
@@ -246,9 +246,25 @@ subtest "check get payment list" => sub {
         'get payments sent xml correct'
     );
 
-    is_deeply $res, [
-
-    ],
+    is_deeply $res, [ {
+        PaymentAPI => {
+            AlternateKey => "",
+            Amount => '10.00',
+            ClientName => "London Borough of Bromley",
+            CollectionDate => "26/02/2021",
+            Comments => "Test payment",
+            DueDate => "26/02/2021",
+            PayerAccountHoldersName => "Anthony Other",
+            PayerAccountNumber => 11111111,
+            PayerName => "Anthony Other",
+            PayerReference => "REF123456",
+            PayerSortCode => "010101",
+            ProductName => "Non Frequency",
+            Status => "Paid",
+            Type => "First Time",
+            YourRef => 65432
+        }
+    } ],
     "correct return from get payment list";
 };
 


### PR DESCRIPTION
Fetch a list of recent Direct Debit payments and match them to up to the
relevant report in FixMyStreet and then process accordingly.

For new and ad-hoc payments (the latter is for adding a bin half way
through) find the matching report and confirm it.

For renewals and cancellations we need to find the original subscription
report and then use that to create a new report that then cancels or
renews the subscription.

Issues warnings for reports not handled.

[skip changelog]