### PR TITLE
[Hackney] Noise research banner on final noise reporting screen

### DIFF
--- a/templates/web/base/noise/confirmation.html
+++ b/templates/web/base/noise/confirmation.html
@@ -1,4 +1,14 @@
 [% title = 'Report sent' %]
+[% pre_container_extra = BLOCK %]
+[% IF c.cobrand.moniker == 'hackney' %]
+<div class="hackney-announcement">
+    <div class="container">
+        <h2>Help us improve this form</h2>
+        <p><a href="https://docs.google.com/forms/d/e/1FAIpQLSchpHxLhr3g-dgVL2sw-mbNX6KlO4Z6q9umvBzxsKTEpbvfIw/viewform" target="_blank">Let us know your email address</a> and we’ll contact you in June to show you our work in progress and get your feedback, so we can make the noise reporting process better for everyone.</p>
+    </div>
+</div>
+[% END %]
+[% END %]
 [% INCLUDE header.html %]
 
 <div>

--- a/web/cobrands/hackney/base.scss
+++ b/web/cobrands/hackney/base.scss
@@ -205,4 +205,22 @@ select.form-error {
   margin: 1em 0;
 }
 
+.hackney-announcement {
+  padding: 24px 0;
+  margin: 20px 0 36px 0;
+  color: #0b0c0c;
+  background-color: rgba(164,214,94,.5);
+  border-top: 1px solid #84bd00;
+  border-bottom: 1px solid #84bd00;
+
+  h2 {
+    margin-top: 0;
+    font-weight: 600;
+  }
+
+  p:last-child {
+    margin-bottom: 0;
+  }
+}
+
 @import "../sass/noise";

--- a/web/cobrands/hackney/layout.scss
+++ b/web/cobrands/hackney/layout.scss
@@ -141,3 +141,7 @@ a.platform-logo {
   text-align: left;
   
 }
+
+.hackney-announcement {
+  margin: -12px 0 48px 0;
+}

--- a/web/cobrands/sass/_noise.scss
+++ b/web/cobrands/sass/_noise.scss
@@ -1,4 +1,8 @@
 body.noise {
+    .content {
+      padding: 1em 0;
+    }
+
     label, legend {
       margin-top: 0; font-weight: normal !important;
     } /* from base/h5bp */


### PR DESCRIPTION
Adds a banner to the top of the Hackney noise reporting form’s final page, prompting people to sign up to help us with our noise case management research in June:

![Screenshot_2021-05-11 Report unwelcome noise](https://user-images.githubusercontent.com/739624/117815284-383a9c80-b25d-11eb-9bc3-ffffecf6e61c.png)

@dracos could you test this out, and check it appears on the right page and looks like this? ⬆️ I had to hack around a bit to test this out (submitting a noise report in my setup fails) so designed this on a different page and then moved it into the `confirmation.html` template after the fact. Should all work, but just need someone to check 🙂 

[skip changelog]