### PR TITLE
[Rutland] Show group and category hint text from Salesforce

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Rutland.pm
+++ b/perllib/FixMyStreet/Cobrand/Rutland.pm
@@ -40,6 +40,20 @@ sub open311_extra_data_include {
     ];
 }
 
+sub open311_contact_meta_override {
+    my ($self, $service, $contact, $meta) = @_;
+
+    my ($hint) = grep { $_->{code} eq 'hint' } @$meta;
+    my ($group_hint) = grep { $_->{code} eq 'group_hint' } @$meta;
+    @$meta = grep { $_->{code} ne 'hint' && $_->{code} ne 'group_hint' } @$meta;
+
+    # Rutland provide HTML that we want to store for display on the frontend.
+    $contact->set_extra_metadata(
+        category_hint => $hint->{description},
+        group_hint => $group_hint->{description},
+    );
+}
+
 sub disambiguate_location {
     my $self    = shift;
     my $string  = shift;

--- a/t/cobrand/rutland.t
+++ b/t/cobrand/rutland.t
@@ -3,15 +3,34 @@ use FixMyStreet::TestMech;
 use FixMyStreet::Script::Reports;
 my $mech = FixMyStreet::TestMech->new;
 
+use Open311::PopulateServiceList;
+
 # Create test data
 my $user = $mech->create_user_ok( 'rutland@example.com' );
-my $body = $mech->create_body_ok( 2482, 'Rutland County Council');
+my $body = $mech->create_body_ok( 2600, 'Rutland County Council');
 my $contact = $mech->create_contact_ok(
     body_id => $body->id,
     category => 'Other',
     email => 'LIGHT',
 );
+$contact->set_extra_metadata(
+    group => 'Street Furniture',
+    group_hint => '<span>This is for things like lights and bins</span>',
+    category_hint => '<span>For problems with street lighting</span>',
+);
 $contact->update;
+
+my $contact2 = $mech->create_contact_ok(
+    body_id => $body->id,
+    category => 'Bins',
+    email => 'BINS',
+);
+$contact2->set_extra_metadata(
+    group => 'Street Furniture',
+    group_hint => '<span>This is for things like lights and bins</span>',
+    category_hint => '<span>For problems with overflowing bins etc</span>',
+);
+$contact2->update;
 
 my @reports = $mech->create_problems_for_body( 1, $body->id, 'Test', {
     cobrand => 'rutland',
@@ -56,6 +75,90 @@ subtest 'testing special Open311 behaviour', sub {
     is $c->param('attribute[description]'), $report->detail, 'Request had description';
     is $c->param('attribute[external_id]'), $report->id, 'Request had correct ID';
     is $c->param('jurisdiction_id'), 'FMS', 'Request had correct jurisdiction';
+};
+
+subtest "shows category and group hints when creating a new report", sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'rutland' ],
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $mech->get_ok('/around');
+        $mech->submit_form_ok( { with_fields => { pc => 'LE15 0GJ', } },
+            "submit location" );
+        # click through to the report page
+        $mech->follow_link_ok( { text_regex => qr/skip this step/i, },
+            "follow 'skip this step' link" );
+        $mech->content_contains('This is for things like lights and bins') or diag $mech->content;
+        $mech->content_contains('For problems with overflowing bins etc') or diag $mech->content;
+        $mech->content_contains('For problems with street lighting') or diag $mech->content;
+    };
+};
+
+subtest 'check open311_contact_meta_override' => sub {
+    my $processor = Open311::PopulateServiceList->new();
+
+    my $meta_xml = '<?xml version="1.0" encoding="utf-8"?>
+<service_definition>
+    <service_code>100</service_code>
+    <attributes>
+        <attribute>
+            <automated>server_set</automated>
+            <code>hint</code>
+            <datatype>string</datatype>
+            <datatype_description></datatype_description>
+            <description>&lt;span&gt;Text for Traffic Lights will go here&lt;/span&gt;</description>
+            <order>1</order>
+            <required>false</required>
+            <variable>false</variable>
+        </attribute>
+        <attribute>
+            <automated>server_set</automated>
+            <code>group_hint</code>
+            <datatype>string</datatype>
+            <datatype_description></datatype_description>
+            <description>&lt;span&gt;Text for Lights, Signals and Sign will go here&lt;/span&gt;</description>
+            <order>2</order>
+            <required>false</required>
+            <variable>false</variable>
+        </attribute>
+    </attributes>
+</service_definition>
+    ';
+
+    my $contact = FixMyStreet::DB->resultset('Contact')->create({
+        body_id => $body->id,
+        email => '100',
+        category => 'Traffic Lights',
+        state => 'confirmed',
+        editor => $0,
+        whenedited => \'current_timestamp',
+        note => 'test contact',
+    });
+
+    my $o = Open311->new(
+        jurisdiction => 'mysociety',
+        endpoint => 'http://example.com',
+        test_mode => 1,
+        test_get_returns => { 'services/100.xml' => $meta_xml }
+    );
+
+    $processor->_current_open311( $o );
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'rutland' ],
+    }, sub {
+        $processor->_current_body( $body );
+    };
+    $processor->_current_service( { service_code => 100, service_name => 'Traffic Lights' } );
+    $processor->_add_meta_to_contact( $contact );
+
+    $contact->discard_changes;
+
+    my $expected_hint = '<span>Text for Traffic Lights will go here</span>';
+    my $expected_group_hint = '<span>Text for Lights, Signals and Sign will go here</span>';
+
+    is scalar(@{ $contact->get_extra_fields }), 0, "hints aren't included in extra fields";
+    is $contact->get_extra_metadata('category_hint'), $expected_hint, 'hint set correctly on contact';
+    is $contact->get_extra_metadata('group_hint'), $expected_group_hint, 'group_hint set correctly on contact';
 };
 
 done_testing();

--- a/templates/web/base/report/new/category.html
+++ b/templates/web/base/report/new/category.html
@@ -26,6 +26,12 @@ END
           [% IF group_or_cat.name %]
                 <input class="govuk-radios__input" required id="category_[% group_or_cat.id %]" type="radio" name="category" value="[% group_or_cat.name %]" data-subcategory="[% group_or_cat.id %]"[% ' checked' IF filter_group == group_or_cat.name %]>
             <label class="govuk-label govuk-radios__label" for="category_[% group_or_cat.id %]">[% group_or_cat.name %]</label>
+            [% group_hint = group_or_cat.categories.first.get_extra_metadata('group_hint') %]
+            [%~ IF group_hint %]
+            <div class="govuk-hint govuk-radios__hint">
+              [% group_hint | safe %]
+            </div>
+            [% END ~%]
           [% ELSE # A category not in a group %]
             [% cat_lc = group_or_cat.category | lower =%]
             <input class="govuk-radios__input" required id="category_[% group_or_cat.id %]" type="radio" name="category" value='[% group_or_cat.category %]'[% ' checked' IF ( report.category == group_or_cat.category || category_lc == cat_lc ) AND NOT filter_group ~%]>
@@ -34,6 +40,11 @@ END
                 ([% group_or_cat.get_extra_metadata('help_text') %])
             [% END ~%]
             </label>
+            [%~ IF group_or_cat.get_extra_metadata('category_hint') %]
+            <div class="govuk-hint govuk-radios__hint">
+              [% group_or_cat.get_extra_metadata('category_hint') | safe %]
+            </div>
+            [% END ~%]
           [%~ END =%]
             </div>
         [%~ END =%]

--- a/templates/web/base/report/new/subcategories.html
+++ b/templates/web/base/report/new/subcategories.html
@@ -10,6 +10,11 @@
         <label class="govuk-label govuk-radios__label" for="subcategory_[% cat.id %]">[% cat.category_display %]
             [%~ IF cat.get_extra_metadata('help_text') %] ([% cat.get_extra_metadata('help_text') %])[% END ~%]
         </label>
+        [%~ IF cat.get_extra_metadata('category_hint') %]
+        <div class="govuk-hint govuk-radios__hint">
+          [% cat.get_extra_metadata('category_hint') | safe %]
+        </div>
+        [% END ~%]
         </div>
       [%~ END ~%]
     </fieldset>


### PR DESCRIPTION
Rutland have started including some HTML hint text in their Salesforce instance that they want to display on FixMyStreet.

I've added the Salesforce bits to open311-adapter in https://github.com/mysociety/open311-adapter/pull/188, so this pull request follows on/is linked to that pull request.

Part of https://github.com/mysociety/societyworks/issues/2206

<!-- [skip changelog] -->