### PR TITLE
[Noise] Prevent duplicate form submission.

### DIFF
--- a/perllib/FixMyStreet/App/Form/Noise.pm
+++ b/perllib/FixMyStreet/App/Form/Noise.pm
@@ -4,7 +4,6 @@ extends 'FixMyStreet::App::Form::Wizard';
 
 use utf8;
 
-has c => ( is => 'ro' );
 has addresses => ( is => 'rw');
 
 has default_page_type => ( is => 'ro', isa => 'Str', default => 'Noise' );

--- a/perllib/FixMyStreet/App/Form/Waste.pm
+++ b/perllib/FixMyStreet/App/Form/Waste.pm
@@ -3,8 +3,6 @@ package FixMyStreet::App::Form::Waste;
 use HTML::FormHandler::Moose;
 extends 'FixMyStreet::App::Form::Wizard';
 
-has c => ( is => 'ro' );
-
 has default_page_type => ( is => 'ro', isa => 'Str', default => 'Waste' );
 
 has finished_action => ( is => 'ro' );

--- a/t/app/controller/noise.t
+++ b/t/app/controller/noise.t
@@ -56,6 +56,7 @@ FixMyStreet::override_config {
     MAPIT_URL => 'http://mapit.uk/',
 }, sub {
     subtest 'Report new noise, source address known' => sub {
+        $mech->host('localhost');
         $mech->get_ok('/noise');
         $mech->submit_form_ok({ button => 'start' });
         $mech->submit_form_ok({ with_fields => { existing => 0 } });
@@ -101,6 +102,9 @@ FixMyStreet::override_config {
         is $report->latitude, 51.524448;
         is $report->areas, ',144379,2508,';
         $mech->clear_emails_ok;
+        $mech->back;
+        $mech->submit_form_ok({ with_fields => { process => 'summary' } });
+        $mech->content_contains('You have already submitted this form.');
     };
     subtest 'Report new noise, no pattern to times' => sub {
         $mech->get_ok('/noise');

--- a/templates/web/base/noise/existing.html
+++ b/templates/web/base/noise/existing.html
@@ -61,6 +61,7 @@
 
   <input type="hidden" name="token" value="[% form.fif.token %]">
   <input type="hidden" name="process" value="[% form.fif.process %]">
+  <input type="hidden" name="unique_id" value="[% form.fif.unique_id %]">
   <input type="hidden" name="saved_data" value="[% form.fif.saved_data %]">
 </form>
 


### PR DESCRIPTION
Store a random value in both session and form, and mandate that they
always match; on successful submission, delete the value from the
session so that any resubmission of the same form will error.
[skip changelog]
