### PR TITLE
[Oxfordshire] Archive script marks comments sent for Open311 reports

### DIFF
--- a/perllib/FixMyStreet/Script/ArchiveOldEnquiries.pm
+++ b/perllib/FixMyStreet/Script/ArchiveOldEnquiries.pm
@@ -215,11 +215,14 @@ sub close_problems {
             $cobrand->set_lang_and_domain($problem->lang, 1);
         }
 
+        my $whensent = \'current_timestamp' if $problem->send_method_used && $problem->send_method_used eq 'Open311';
+
         my $comment = $problem->add_to_comments( {
             text => get_closure_message() || '',
             user => FixMyStreet::DB->resultset("User")->find($opts->{user}),
             problem_state => $opts->{closed_state},
             extra => $extra,
+            $whensent ? ( whensent => $whensent ) : (),
         } );
         $problem->update({ state => $opts->{closed_state}, send_questionnaire => 0 });
 

--- a/t/app/script/archive_old_enquiries.t
+++ b/t/app/script/archive_old_enquiries.t
@@ -210,6 +210,20 @@ subtest 'can configure comment message' => sub {
   is $p->comments->first->text, "This report is now closed", "closure text set";
 };
 
+subtest 'comments for Open311 reports marked as sent' => sub {
+  my ($p) = $mech->create_problems_for_body(4, $oxfordshire->id, 'Report sent via Open311', {
+      areas            => ',2237,',
+      lastupdate       => '2014-12-01 07:00:00',
+      user             => $user,
+      send_method_used => 'Open311',
+  });
+
+  $opts->{closure_text} = "This report is now closed";
+  FixMyStreet::Script::ArchiveOldEnquiries::archive($opts);
+
+  is $p->comments->first->whensent, $p->comments->first->confirmed, "comment marked as sent";
+};
+
 
 subtest 'can provide close message as file' => sub {
     $opts->{closure_text} = '';


### PR DESCRIPTION
This prevents a huge backlog of unsent updates building up that don’t actually need to be sent anywhere.

[skip changelog]