### PR TITLE
[Peterborough] Don’t delete inactive Open311 categories

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -148,4 +148,11 @@ sub dashboard_export_problems_add_columns {
     });
 }
 
+sub open311_filter_contacts_for_deletion {
+    my ($self, $contacts) = @_;
+
+    # Don't delete inactive contacts
+    return $contacts->search({ state => { '!=' => 'inactive' } });
+}
+
 1;


### PR DESCRIPTION
Peterborough have a number of Open311 categories marked as ‘inactive’ on the site
pending the launch of a new integration. For some reason these categories were
omitted from the service list from Open311 adapter for a short period, which
resulted in the inactive categories being deleted. When they subsequently
reappeared in the service list, they were reinstated as ‘confirmed’ categories
instead of going back into the ‘inactive’ state. This meant users could unexpectedly
raise reports in these new categories.

For https://github.com/mysociety/societyworks/issues/2391

[skip changelog]
