### PR TITLE
[Bromley] handle waste events with no data

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -730,7 +730,7 @@ sub _parse_open_events {
         my $event_type = $_->{EventTypeId};
         my $service_id = $_->{ServiceId};
         if ($event_type == 2104) { # Request
-            my $data = $_->{Data}{ExtensibleDatum};
+            my $data = $_->{Data} ? $_->{Data}{ExtensibleDatum} : [];
             my $container;
             DATA: foreach (@$data) {
                 if ($_->{ChildData}) {


### PR DESCRIPTION
Default to an empty array if the event has no data to avoid errors.

[skip changelog]