### PR TITLE
[Bromley] Park name lookup

### DIFF
--- a/bin/bromley/make-parks-database
+++ b/bin/bromley/make-parks-database
@@ -1,0 +1,67 @@
+#!/usr/bin/env perl
+
+=head1 NAME
+
+make-parks-database
+
+=head1 USAGE
+
+make-parks-database
+
+=head1 DESCRIPTION
+
+Creates a SQLite database for park name lookups in Bromley.
+
+=cut
+
+use strict;
+use warnings;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use DBI;
+use Text::CSV;
+use FixMyStreet;
+use BromleyParks;
+use Cwd qw(abs_path);
+use feature qw(say);
+
+my $parks_csv = FixMyStreet->path_to('../fixmystreet.com/data/bromley_parks.csv');
+my $db = DBI->connect('dbi:SQLite:dbname='. BromleyParks::database_file);
+
+say "Creating parks database...";
+
+$db->do(<<EOF) or die;
+CREATE VIRTUAL TABLE parks USING fts4 (
+    name TEXT NOT NULL,
+    easting INTEGER NOT NULL,
+    northing INTEGER NOT NULL,
+    tokenize=porter
+);
+EOF
+
+my $q_parks = $db->prepare(
+    'INSERT OR IGNORE INTO parks (name, easting, northing) ' .
+    'VALUES (?, ?, ?)'
+);
+
+my $csv = Text::CSV->new ({ binary => 1, auto_diag => 1 });
+open my $fh, "<:encoding(utf8)", $parks_csv;
+$csv->header($fh);
+
+while (my $row = $csv->getline_hr($fh)) {
+    my $name = $row->{"name"};
+    $name =~ s/^\s+|\s+$//g;
+
+    my $e = int $row->{"easting"};
+    my $n = int $row->{"northing"};
+
+    $q_parks->execute($name, $e, $n);
+}
+
+say "Done. Parks database created: " . abs_path(BromleyParks::database_file);

--- a/perllib/BromleyParks.pm
+++ b/perllib/BromleyParks.pm
@@ -1,0 +1,37 @@
+package BromleyParks;
+
+use strict;
+use warnings;
+
+use FixMyStreet;
+use DBI;
+use Utils;
+
+sub database_file { FixMyStreet->path_to('../data/bromley_parks.sqlite') }
+
+sub lookup {
+    my $search = shift;
+
+    my $results = _db_results($search);
+    return unless $results;
+
+    if (@$results) {
+        my ($lat, $lon) = Utils::convert_en_to_latlon($results->[0]{easting}, $results->[0]{northing});
+        return { latitude => $lat, longitude => $lon };
+    }
+}
+
+sub _db_results {
+    my $search = shift;
+
+    return unless -e database_file();
+    my $db = DBI->connect("dbi:SQLite:dbname=".database_file(), undef, undef) or return;
+
+    return $db->selectall_arrayref(
+        "SELECT * FROM parks where name match ?",
+        { Slice => {} },
+        $search
+    );
+}
+
+1;

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -18,6 +18,7 @@ use FixMyStreet::DateRange;
 use FixMyStreet::WorkingDays;
 use Open311::GetServiceRequestUpdates;
 use Memcached;
+use BromleyParks;
 
 sub council_area_id { return 2482; }
 sub council_area { return 'Bromley'; }
@@ -92,6 +93,16 @@ sub disambiguate_location {
 
 sub get_geocoder {
     return 'OSM'; # default of Bing gives poor results, let's try overriding.
+}
+
+sub geocode_postcode {
+    my ( $self, $s ) = @_;
+
+    if (my $parks_lookup = BromleyParks::lookup($s)) {
+        return $parks_lookup;
+    }
+
+    return $self->next::method($s);
 }
 
 # Bromley pins always yellow


### PR DESCRIPTION
Bromley have provided us with a spreadsheet of park names/aliases and the corresponding easting and northing. This change integrates that dataset into the location search on the homepage.

The code for this is largely inspired by/based on the Highways England junction lookup code that was added in #2918.

Fixes https://github.com/mysociety/societyworks/issues/2280

## Notes to deployer

- [ ] Run `bin/bromley/make-parks-database` after deploying this code to create the parks database

<!-- [skip changelog] -->
