### PR TITLE
Send contact form email from fixmystreet.com email if dmarc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
         - Consistent protected field ordering.
     - Security:
         - Increase minimum password length to eight.
+    - Changes
+        - Send contact form emails from do-not-reply address if sender's domain uses DMARC.
 
 * v3.1 (16th November 2020)
     - Security:

--- a/perllib/FixMyStreet/App/Controller/Contact.pm
+++ b/perllib/FixMyStreet/App/Controller/Contact.pm
@@ -302,7 +302,7 @@ sub send_email : Private {
     };
     if (FixMyStreet::Email::test_dmarc($c->stash->{em})) {
         $params->{'Reply-To'} = [ $from ];
-        $params->{from} = [ $recipient, $c->stash->{form_name} ];
+        $params->{from} = [ FixMyStreet->config('DO_NOT_REPLY_EMAIL'), $c->stash->{form_name} ];
     } else {
         $params->{from} = $from;
     }


### PR DESCRIPTION
Previously we were sending emails from the recipient's address if we detected dmarc on the email entered into the contact form. This caused issues if the other end also had dmarc, since it would detect the incoming emails as spoofing attempts and reject them.

To avoid these issues change the contact form to send from the do-not-reply email address if the sending email address domain uses dmarc.

Fixes https://github.com/mysociety/societyworks/issues/2344