### PR TITLE
[Highways England] Move fallback lookup to sender.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
+++ b/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
@@ -158,32 +158,6 @@ sub munge_report_new_contacts {
     }
 }
 
-sub munge_sendreport_params {
-    my ($self, $row, $h, $params) = @_;
-
-    if (!$row->get_extra_field_value('area_name')) {
-        my $cfg = $self->lookup_site_code_config;
-        my ($x, $y) = $row->local_coords;
-        my $ukc = FixMyStreet::Cobrand::UKCouncils->new;
-        my $features = $ukc->_fetch_features($cfg, $x, $y);
-        my $nearest = $ukc->_nearest_feature($cfg, $x, $y, $features);
-        if ($nearest) {
-            my $attr = $nearest->{properties};
-            $row->update_extra_field({ name => 'road_name', value => $attr->{ROA_NUMBER}, description => 'Road name' });
-            $row->update_extra_field({ name => 'area_name', value => $attr->{area_name}, description => 'Area name' });
-            $row->update_extra_field({ name => 'sect_label', value => $attr->{sect_label}, description => 'Road sector' });
-        }
-    }
-}
-
-sub lookup_site_code_config { {
-    buffer => 15, # metres
-    url => "https://tilma.mysociety.org/mapserver/highways",
-    srsname => "urn:ogc:def:crs:EPSG::27700",
-    typename => "Highways",
-    accept_feature => sub { 1 }
-} }
-
 sub report_new_is_on_he_road {
     my ( $self ) = @_;
 

--- a/t/cobrand/highwaysengland.t
+++ b/t/cobrand/highwaysengland.t
@@ -40,7 +40,7 @@ $r = $he->geocode_postcode('m1');
 ok $r->{error}, "searching for lowecase road only generates error";
 
 my $mech = FixMyStreet::TestMech->new;
-my $highways = $mech->create_body_ok(2234, 'Highways England');
+my $highways = $mech->create_body_ok(2234, 'Highways England', { send_method => 'Email::Highways' });
 
 $mech->create_contact_ok(email => 'highways@example.com', body_id => $highways->id, category => 'Pothole', group => 'Highways England');
 

--- a/t/sendreport/email/highways.t
+++ b/t/sendreport/email/highways.t
@@ -15,6 +15,7 @@ my $row = FixMyStreet::DB->resultset('Problem')->new( {
     bodies_str => '1000',
     category => 'Pothole',
     cobrand => '',
+    extra => { _fields => [ { name => 'area_name', value => 'Area 8' } ] },
 } );
 
 my $e = FixMyStreet::SendReport::Email::Highways->new;


### PR DESCRIPTION
Turns out #3474 worked for HE cobrand but not .com (see comment at https://github.com/mysociety/fixmystreet/blob/0f4f1b48e471f6827be1e1928c5c9f6f60c4054a/perllib/FixMyStreet/Cobrand/UK.pm#L377 ). So here's a new way of doing the same thing.

Due to not setting cobrand handler for HE (for correct email templates) the munge function was not being called if the report was made on .com. As HE has its own SendReport handler, we can put the same code in there instead for both sites.

[skip changelog]