### PR TITLE
[Hackney] Update URL for citizen beta testing signup form

### DIFF
--- a/templates/web/base/noise/confirmation.html
+++ b/templates/web/base/noise/confirmation.html
@@ -4,7 +4,7 @@
 <div class="hackney-announcement">
     <div class="container">
         <h2>Help us improve this form</h2>
-        <p><a href="https://docs.google.com/forms/d/e/1FAIpQLSchpHxLhr3g-dgVL2sw-mbNX6KlO4Z6q9umvBzxsKTEpbvfIw/viewform" target="_blank">Let us know your email address</a> and we’ll contact you in June to show you our work in progress and get your feedback, so we can make the noise reporting process better for everyone.</p>
+        <p><a href="https://forms.gle/Kt8FLzCMXEi1V2pb6" target="_blank">Let us know your email address</a> and we’ll contact you this summer to show you our work in progress and get your feedback, so we can make the noise reporting process better for everyone.</p>
     </div>
 </div>
 [% END %]


### PR DESCRIPTION
We’ve closed the old (alpha testing) signup form, and now want to redirect people to a new (beta testing) form that’ll stay up throughout the Summer.