### PR TITLE
Remove webinar link from council report emails

### DIFF
--- a/templates/email/fixmystreet.com/_submit_footer.html
+++ b/templates/email/fixmystreet.com/_submit_footer.html
@@ -6,9 +6,7 @@
         FixMyStreet Pro is making savings for authorities across the UK
       </h2>
       <p style="margin: 0;">
-        <a href="https://www.fixmystreet.com/pro/take-a-tour/webinar-schedule/?utm_source=council_submit_email&amp;utm_content=[% "Join one of our regular informal webinars" | uri %]&amp;utm_medium=email&amp;utm_campaign=fms_webinars_promo">
-          Join one of our regular informal webinars
-        </a> to discover how FixMyStreet Pro
+        <a href="https://www.societyworks.org/services/highways/?utm_source=fms&utm_medium=council_submit_email">Request a free, informal demo</a> to discover how FixMyStreet Pro
         integrates with your existing systems,
         drives channel shift,
         and saves you money from day one.

--- a/templates/web/fixmystreet.com/reports/summary.html
+++ b/templates/web/fixmystreet.com/reports/summary.html
@@ -40,20 +40,20 @@
             </p>
             <div class="healthcheck-cta-trio">
                 <div class="dashboard-item dashboard-item--4">
-                    <h3 style="margin-top: 0;">Join one of our regular&nbsp;webinars</h3>
-                    <a href="https://www.fixmystreet.com/pro/webinar-schedule/" class="btn">
-                        Show webinar schedule
+                    <h3 style="margin-top: 0;">Ask questions</h3>
+                    <a href="https://www.societyworks.org/contact/" class="btn">
+                        Contact us
                     </a>
                 </div>
                 <div class="dashboard-item dashboard-item--4">
                     <h3 style="margin-top: 0;">Schedule a<br>one-to-one demo</h3>
-                    <a href="https://www.fixmystreet.com/pro/contact/" class="btn">
-                        Request a callback
+                    <a href="https://www.societyworks.org/demo-request/" class="btn">
+                        Request a demo
                     </a>
                 </div>
                 <div class="dashboard-item dashboard-item--4">
                     <h3 style="margin-top: 0;">See FixMyStreet Pro for&nbsp;yourself</h3>
-                    <a href="https://demo.fixmystreet.com/" class="btn">
+                    <a href="https://showcase.societyworks.org/" class="btn">
                         Try our live demo
                     </a>
                 </div>
@@ -242,15 +242,15 @@
 
 <div class="dashboard-row dashboard-row--yellow" style="text-align: center; margin-bottom: -1em;">
     <div class="dashboard-item dashboard-item--4">
-        <h3 style="margin-top: 0;">Join one of our regular&nbsp;webinars</h3>
-        <a href="https://www.fixmystreet.com/pro/webinar-schedule/" class="btn">
-            Show webinar schedule
+        <h3 style="margin-top: 0;">Ask questions</h3>
+        <a href="https://www.societyworks.org/contact/" class="btn">
+            Contact us
         </a>
     </div>
     <div class="dashboard-item dashboard-item--4">
         <h3 style="margin-top: 0;">Schedule a one-to-one demo</h3>
-        <a href="https://www.fixmystreet.com/pro/contact/" class="btn">
-            Request a callback
+        <a href="https://www.societyworks.org/demo-request/" class="btn">
+            Request a demo
         </a>
     </div>
     <div class="dashboard-item dashboard-item--4">


### PR DESCRIPTION
I've updated the copy to remove the webinar link and changed it to a request a demo link. 
[skip changelog]