### PR TITLE
Add category restrictions to roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,8 @@
         - Allow throttling by user login attempts
     - Changes
         - Send contact form emails from do-not-reply address if sender's domain uses DMARC.
+    - New features:
+        - Roles can now have category restrictions like users.
 
 * v3.1 (16th November 2020)
     - Security:

--- a/bin/update-schema
+++ b/bin/update-schema
@@ -215,6 +215,7 @@ else {
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
     return 'EMPTY' if ! table_exists('problem');
+    return '0080' if column_exists('roles', 'extra');
     return '0079' if column_exists('response_templates', 'email_text');
     return '0078' if column_exists('problem','send_fail_body_ids');
     return '0077' if column_exists('comment', 'send_state');

--- a/db/downgrade_0080---0079.sql
+++ b/db/downgrade_0080---0079.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE roles
+    DROP COLUMN extra;
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -86,6 +86,7 @@ create table roles (
     body_id         integer not null references body(id) ON DELETE CASCADE,
     name            text,
     permissions     text ARRAY,
+    extra           text,
     unique(body_id, name)
 );
 

--- a/db/schema_0080-roles-add-extra.sql
+++ b/db/schema_0080-roles-add-extra.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE roles
+    ADD COLUMN extra TEXT;
+
+COMMIT;

--- a/docs/_includes/admin-tasks-content.md
+++ b/docs/_includes/admin-tasks-content.md
@@ -557,6 +557,10 @@ maintenance) to a staff user by editing the user and checking the relevant categ
 staff user, when logged in, will then only see reports within those categories. This is useful where a
 staff user only deals with reports of a specific type.
 
+Roles can also have categories associated with them. This works in the same way as assigning categories
+to a user. You can assign categories to a role by editing the role and checking the relevant category
+boxes. Users will then only be able to see categories relevant to their role.
+
 #### Removing staff status from accounts
 
 To remove the staff status from an account visit the user page and

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -163,6 +163,21 @@ sub fetch_contacts : Private {
     return 1;
 }
 
+sub stash_contacts_for_template : Private {
+    my ( $self, $c, $contacts ) = @_;
+
+    my %active_contacts = map { $_ => 1 } @$contacts;
+    my @live_contacts = $c->stash->{live_contacts}->all;
+    my @all_contacts = map { {
+        id => $_->id,
+        category => $_->category,
+        active => $active_contacts{$_->id},
+        group => $_->groups,
+    } } @live_contacts;
+
+    $c->stash->{contacts} = \@all_contacts;
+}
+
 sub fetch_languages : Private {
     my ( $self, $c ) = @_;
 

--- a/perllib/FixMyStreet/App/Controller/Admin/Users.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Users.pm
@@ -417,17 +417,10 @@ sub edit : Chained('user') : PathPart('') : Args(0) {
             $c->stash->{body} = $user->from_body;
             $c->forward('/admin/fetch_contacts');
         }
-        my @contacts = @{$user->get_extra_metadata('categories') || []};
-        my %active_contacts = map { $_ => 1 } @contacts;
-        my @live_contacts = $c->stash->{live_contacts}->all;
-        my @all_contacts = map { {
-            id => $_->id,
-            category => $_->category,
-            active => $active_contacts{$_->id},
-            group => $_->groups,
-        } } @live_contacts;
-        $c->stash->{contacts} = \@all_contacts;
-        $c->forward('/report/stash_category_groups', [ \@all_contacts, { combine_multiple => 1 } ]);
+        $c->forward('/admin/stash_contacts_for_template', [
+            \@{$user->get_extra_metadata('categories') || []}
+        ]);
+        $c->forward('/report/stash_category_groups', [ $c->stash->{contacts}, { combine_multiple => 1 } ]);
     }
 
     # this goes after in case we've delete any alerts

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -95,8 +95,8 @@ sub display :PathPart('') :Chained('id') :Args(0) {
         my $okay = 1;
         my $contact = $c->stash->{problem}->contact;
         if ($contact && ($c->user->get_extra_metadata('assigned_categories_only') || $contact->get_extra_metadata('assigned_users_only'))) {
-            my $user_cats = $c->user->get_extra_metadata('categories') || [];
-            $okay = any { $contact->id eq $_ } @$user_cats;
+            my $user_cats = $c->user->categories || [];
+            $okay = any { $contact->category eq $_ } @$user_cats;
         }
         if ($okay) {
             $c->stash->{relevant_staff_user} = 1;

--- a/perllib/FixMyStreet/App/Form/Role.pm
+++ b/perllib/FixMyStreet/App/Form/Role.pm
@@ -6,6 +6,7 @@ extends 'HTML::FormHandler::Model::DBIC';
 use namespace::autoclean;
 
 has 'body_id' => ( isa => 'Int', is => 'ro' );
+has 'categories' => ( isa => 'Maybe[ArrayRef[Int]]', is => 'rw' );
 
 has '+widget_name_space' => ( default => sub { ['FixMyStreet::App::Form::Widget'] } );
 has '+widget_tags' => ( default => sub { { wrapper_tag => 'p' } } );
@@ -22,6 +23,7 @@ has_field 'permissions' => (
 before 'update_model' => sub {
     my $self = shift;
     $self->item->body_id($self->body_id) if $self->body_id;
+    $self->item->set_extra_metadata('categories', $self->categories);
 };
 
 sub _build_language_handle { FixMyStreet::App::Form::I18N->new }

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -360,6 +360,21 @@ sub should_skip_sending_update {
     return $update->user->from_body && !$update->text && !$private_comments;
 }
 
+sub munge_report_new_category_list {
+    my ($self, $category_options, $contacts) = @_;
+
+    my $user = $self->{c}->user;
+    if ($user && $user->belongs_to_body($self->body->id) && $user->get_extra_metadata('assigned_categories_only')) {
+        my %user_categories = map { $_ => 1} @{$user->categories};
+        my $non_bromley_or_assigned_category = sub {
+            $_->body_id != $self->body->id || $user_categories{$_->category}
+        };
+
+        @$category_options = grep &$non_bromley_or_assigned_category, @$category_options;
+        @$contacts = grep &$non_bromley_or_assigned_category, @$contacts;
+    }
+}
+
 sub updates_disallowed {
     my $self = shift;
     my ($problem) = @_;

--- a/perllib/FixMyStreet/DB/Result/Role.pm
+++ b/perllib/FixMyStreet/DB/Result/Role.pm
@@ -28,6 +28,8 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 1 },
   "permissions",
   { data_type => "text[]", is_nullable => 1 },
+  "extra",
+  { data_type => "text", is_nullable => 1 },
 );
 __PACKAGE__->set_primary_key("id");
 __PACKAGE__->add_unique_constraint("roles_body_id_name_key", ["body_id", "name"]);
@@ -45,9 +47,17 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2019-05-23 18:03:28
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:KkzVQZuzExH8PhZLJsnZgg
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2021-06-17 15:48:52
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:UJk6NBNCsHDY/te2F7tJWA
 
 __PACKAGE__->many_to_many( users => 'user_roles', 'user' );
+
+__PACKAGE__->load_components("+FixMyStreet::DB::RABXColumn");
+__PACKAGE__->rabx_column('extra');
+
+use Moo;
+use namespace::clean -except => [ 'meta' ];
+
+with 'FixMyStreet::Roles::Extra';
 
 1;

--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -673,9 +673,18 @@ has categories => (
     lazy => 1,
     default => sub {
         my $self = shift;
-        return [] unless $self->get_extra_metadata('categories');
+
+        my @category_ids;
+        my $user_categories = $self->get_extra_metadata('categories');
+        push @category_ids, @$user_categories if scalar $user_categories;
+        foreach my $role ($self->roles) {
+            my $role_categories = $role->get_extra_metadata('categories');
+            push @category_ids, @$role_categories if scalar $role_categories;
+        }
+        return [] unless @category_ids;
+
         my @categories = $self->result_source->schema->resultset("Contact")->search({
-            id => $self->get_extra_metadata('categories'),
+            id => \@category_ids,
         }, {
             order_by => 'category',
         })->get_column('category')->all;

--- a/t/app/controller/admin/roles.t
+++ b/t/app/controller/admin/roles.t
@@ -22,6 +22,12 @@ $user->user_body_permissions->create({
     permission_type => 'report_edit_priority',
 });
 
+my $contact = $mech->create_contact_ok(
+    body_id => $body->id,
+    category => 'Traffic lights',
+    email => 'lights@example.com'
+);
+
 my $role_a = FixMyStreet::DB->resultset("Role")->create({
     body => $body,
     name => 'Role A',
@@ -77,6 +83,17 @@ FixMyStreet::override_config {
     subtest 'delete a role' => sub {
         $mech->submit_form_ok({ button => 'delete_role' });
         $mech->content_lacks('Role A');
+    };
+
+    subtest 'adding category restrictions to a role' => sub {
+        $mech->get_ok("/admin/roles");
+        $mech->follow_link_ok({ text => 'Edit' });
+
+        my $contact_id = $contact->id;
+        $mech->content_contains("contacts[$contact_id]");
+        $mech->submit_form_ok({ with_fields => { "contacts[$contact_id]" =>  1 } });
+        $mech->follow_link_ok({ text => 'Edit' });
+        $mech->content_like(qr/name="contacts\[$contact_id\]"[^>]*checked/);
     };
 
     subtest 'assign a user to a role' => sub {

--- a/t/app/controller/report_inspect.t
+++ b/t/app/controller/report_inspect.t
@@ -999,6 +999,27 @@ FixMyStreet::override_config {
         $mech->content_lacks('shortlist');
         $contact2->unset_extra_metadata('assigned_users_only');
         $contact2->update;
+
+        # Now add user to a role with a category of "Sheep".
+        # User should then be able to see staff things on 2 and 3.
+        $user->set_extra_metadata(assigned_categories_only => 1);
+        $user->update;
+        my $role = $user->roles->create({
+            body => $oxon,
+            name => 'Role B',
+            permissions => ['moderate', 'planned_reports'],
+        });
+        $role->set_extra_metadata('categories', [$contact2->id]);
+        $role->update;
+        $user->add_to_roles($role);
+        $mech->get_ok("/report/$report2_id");
+        $mech->content_contains('<select class="form-control" name="state"  id="state">');
+        $mech->content_contains('<div class="inspect-section">');
+        $mech->get_ok("/report/$report3_id");
+        $mech->content_contains('<select class="form-control" name="state"  id="state">');
+        $mech->content_contains('<div class="inspect-section">');
+        $user->unset_extra_metadata('assigned_categories_only');
+        $user->update;
     };
 
     subtest 'instruct defect' => sub {

--- a/t/app/model/user.t
+++ b/t/app/model/user.t
@@ -100,6 +100,23 @@ subtest 'OIDC ids can be manipulated correctly' => sub {
 
 };
 
+subtest 'user categories includes role categories' => sub {
+    my $user = $problem->user;
+
+    my $body = $mech->create_body_ok(2237, 'Oxfordshire County Council');
+    my $contact = $mech->create_contact_ok( body_id => $body->id, category => 'Cows', email => 'cows@example.net' );
+    my $role = $user->roles->create({
+        body => $body,
+        name => 'Role A',
+        permissions => ['moderate', 'user_edit'],
+    });
+    $role->set_extra_metadata('categories', [$contact->id]);
+    $role->update;
+    $user->add_to_roles($role);
+
+    is $user->categories_string, 'Cows';
+};
+
 done_testing();
 
 sub create_update {

--- a/templates/web/base/admin/roles/form.html
+++ b/templates/web/base/admin/roles/form.html
@@ -15,6 +15,12 @@
     </div>
     [% form.field('permissions').render | safe %]
 
+    [% IF contacts %]
+    <div class="js-user-categories">
+      [% INCLUDE 'admin/category-checkboxes.html' hint=loc("Roles can be associated with the categories in which they operate.") %]
+    </div>
+    [% END %]
+
     [% form.field('submit').render | safe %]
 
     <p>


### PR DESCRIPTION
Adds category restrictions to roles, which should work in the same way as category restrictions for users.

This includes adding an admin interface for assigning categories to roles, as well as a couple of tweaks to the logic that checks user's categories to take a role's categories into account.

Fixes https://github.com/mysociety/societyworks/issues/2382

## Todo

- [x] Write documentation for this feature in the manual