### PR TITLE
[Bromley] fix available services call for waste

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -586,20 +586,20 @@ sub image_for_service {
 sub available_bin_services_for_address {
     my ($self, $property) = @_;
 
-    my $result = $self->{api_serviceunits};
-    return {} unless @$result;
+    my $services = $self->{c}->stash->{services};
+    return {} unless keys %$services;
 
-    my $services = {};
-    for my $service ( @$result ) {
-        my $name = service_name_override($service);
+    my $available_services = {};
+    for my $service ( values %$services ) {
+        my $name = $service->{service_name};
         $name =~ s/ /_/g;
-        $services->{$name} = {
-            service_id => $service->{ServiceId},
-            is_active => defined $service->{ServiceTasks} && $service->{ServiceTasks} ne '',
+        $available_services->{$name} = {
+            service_id => $service->{service_id},
+            is_active => 1,
         };
     }
 
-    return $services;
+    return $available_services;
 }
 
 sub garden_waste_service_id {

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -664,8 +664,17 @@ FixMyStreet::override_config {
     };
 
     subtest 'check subscription link present' => sub {
-        set_fixed_time('2021-03-09T17:00:00Z'); # After sample data collection
+        set_fixed_time('2021-03-09T17:00:00Z');
+        $mech->get_ok('/waste/12345');
+        $mech->content_lacks('Subscribe to Green Garden Waste', 'Subscribe link not present for active sub');
+        set_fixed_time('2021-04-05T17:00:00Z');
+        $mech->get_ok('/waste/12345');
+        $mech->content_lacks('Subscribe to Green Garden Waste', 'Subscribe link not present if in renew window');
+        set_fixed_time('2021-05-05T17:00:00Z');
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('Subscribe to Green Garden Waste', 'Subscribe link present if expired');
         my $echo = Test::MockModule->new('Integrations::Echo');
+        set_fixed_time('2021-03-09T17:00:00Z');
         $echo->mock('GetServiceUnitsForObject', sub {
             return [ {
                 Id => 1001,
@@ -691,7 +700,7 @@ FixMyStreet::override_config {
             } ];
         } );
         $mech->get_ok('/waste/12345');
-        $mech->content_contains('Subscribe to Green Garden Waste');
+        $mech->content_contains('Subscribe to Green Garden Waste', 'Subscribe link present if never had a sub');
     };
 
     my $echo = Test::MockModule->new('Integrations::Echo');


### PR DESCRIPTION
Because expired services can show up do this differently by checking for
services that show up on the bin list. If it's not there then it's not
active. Previously we were listing expired services that weren't on the
bin list as active which meant the garden waste subscribe link wasn't
displayed

[skip changelog]