### PR TITLE
[Bexley] override split postcode so it's inside Bexley

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley.pm
@@ -23,6 +23,20 @@ sub disambiguate_location {
     };
 }
 
+sub geocode_postcode {
+    my ( $self, $s ) = @_;
+
+    # split postcode with a centroid in neighbouring Dartford
+    if ($s =~ /^DA5\s*2BD$/i) {
+        return {
+            latitude => 51.431244,
+            longitude => 0.166464,
+        };
+    }
+
+    return $self->next::method($s);
+}
+
 sub disable_resend_button { 1 }
 
 # We can resend reports upon category change, unless it will be going to the

--- a/t/cobrand/bexley.t
+++ b/t/cobrand/bexley.t
@@ -282,6 +282,14 @@ $geo->mock('cache', sub {
     } if $typ eq 'bexley';
 });
 
+subtest 'split postcode overridden' => sub {
+    my $data = FixMyStreet::Cobrand::Bexley->geocode_postcode('DA5 2BD');
+    is_deeply $data, {
+            latitude => 51.431244,
+            longitude => 0.166464,
+        }, 'override postcode';
+};
+
 subtest 'geocoder' => sub {
     my $c = ctx_request('/');
     my $results = FixMyStreet::Geocode::Bexley->string("Brampton Road", $c);


### PR DESCRIPTION
DA5 2BD is split over Bexley and Dartford but the centroid is in
Dartford so using it results in a "not in bexley" error. So catch this
and return a hardcoded just inside Bexley result.

Fixes mysociety/fixmystreet-commercial#2418

[skip changelog]