### PR TITLE
Update Pro footer link on FixMyStreet homepage

### DIFF
--- a/templates/web/borsetshire/front/footer-marketing.html
+++ b/templates/web/borsetshire/front/footer-marketing.html
@@ -2,5 +2,5 @@
     <h2>FixMyStreet Pro</h2>
     <p class="lead">The one-stop street reporting service for councils.</p>
     <p>Integrate FixMyStreet with your council system for smooth, end-to-end report fulfilment.</p>
-    <p><a href="https://www.fixmystreet.com/pro/" class="btn">Learn more about Pro</a></p>
+    <p><a href="https://www.societyworks.org/services/fixmystreetpro/" class="btn">Learn more about Pro</a></p>
 </div>

--- a/templates/web/fixmystreet.com/front/footer-marketing.html
+++ b/templates/web/fixmystreet.com/front/footer-marketing.html
@@ -3,7 +3,7 @@
         <h2>Go Pro</h2>
         <p class="lead">Integrate FixMyStreet Pro with your council system for smooth, end-to-end report fulfilment.</p>
         <p>How much could <em>you</em> save?</p>
-        <p><a href="/pro/" class="btn">Learn more about Pro</a></p>
+        <p><a href="https://www.societyworks.org/services/fixmystreetpro/" class="btn">Learn more about Pro</a></p>
     </div>
     <div class="fms-pro-promo__stats">
         <h2>Free statistics for councils</h2>


### PR DESCRIPTION
Updated the link to go directly to the FixMyStreet Pro page instead of SocietyWorks homepage
