### PR TITLE
[Highways England] Show staff user name in CSV export.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
+++ b/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
@@ -184,7 +184,8 @@ sub dashboard_export_problems_add_columns {
     $csv->modify_csv_header( Ward => 'Council' );
 
     $csv->objects_attrs({
-        '+columns' => ['comments.text', 'comments.extra'],
+        '+columns' => ['comments.text', 'comments.extra', 'user.name'],
+        join => { comments => 'user' },
     });
 
     $csv->add_csv_columns(
@@ -214,7 +215,7 @@ sub dashboard_export_problems_add_columns {
             $fields->{"update_text_$i"} = $update->text;
             $fields->{"update_date_$i"} = $update->confirmed;
             my $staff = $update->get_extra_metadata('contributed_by') || $update->get_extra_metadata('is_body_user') || $update->get_extra_metadata('is_superuser');
-            $fields->{"update_name_$i"} = $staff ? $update->name : 'public';
+            $fields->{"update_name_$i"} = $staff ? $update->user->name : 'public';
             $i++;
         }
 

--- a/t/cobrand/highwaysengland.t
+++ b/t/cobrand/highwaysengland.t
@@ -161,7 +161,7 @@ subtest 'Dashboard CSV extra columns' => sub {
     my @row1 = (
         'http://highwaysengland.example.org/report/' . $problem1->id,
         'desktop', 'highwaysengland', '', '"South West"', '"Social media"',
-        '"This is an update"', $comment1->confirmed->datetime, '"Name Name"',
+        '"This is an update"', $comment1->confirmed->datetime, '"Council User"',
         '"Second update"', $comment2->confirmed->datetime, 'public',
     );
     $mech->content_contains(join ',', @row1);


### PR DESCRIPTION
The update name is generally always the body name for staff, they want to see the real user name. [skip changelog]
