### PR TITLE
[Greenwich] turn off questionnaires

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Greenwich.pm
+++ b/perllib/FixMyStreet/Cobrand/Greenwich.pm
@@ -44,6 +44,8 @@ sub reports_per_page { return 20; }
 
 sub admin_user_domain { 'royalgreenwich.gov.uk' }
 
+sub send_questionnaires { 0 }
+
 sub open311_extra_data_include {
     my ($self, $row, $h) = @_;
 


### PR DESCRIPTION
Re-opening reports is turned off so we should also turn off
questionnaires.

Fixes mysociety/societyworks#2425

[skip changelog]