### PR TITLE
add more options to process update file script

### DIFF
--- a/bin/fixmystreet.com/process_update_file
+++ b/bin/fixmystreet.com/process_update_file
@@ -22,6 +22,7 @@ my ($opts, $usage) = describe_options(
     ['file|f=s', 'file containing updates' , { required => 1 }],
     ['body|b=s', 'body name to add updates to', { required => 1 } ],
     ['commit|c', 'actually commit changes to the database'],
+    ['suppress_alerts|s', 'do not send alerts on any updates added'],
     ['verbose|v', 'more verbose output'],
     ['help|h', "print usage message and exit" ],
 );
@@ -29,6 +30,7 @@ $usage->die if $opts->help;
 
 my %params = (
     commit => $opts->commit,
+    suppress_alerts => $opts->suppress_alerts,
     verbose => $opts->verbose,
     body_name => $opts->body,
     file => $opts->file,

--- a/bin/fixmystreet.com/process_update_file
+++ b/bin/fixmystreet.com/process_update_file
@@ -21,12 +21,14 @@ my ($opts, $usage) = describe_options(
     '%c %o',
     ['file|f=s', 'file containing updates' , { required => 1 }],
     ['body|b=s', 'body name to add updates to', { required => 1 } ],
+    ['commit|c', 'actually commit changes to the database'],
     ['verbose|v', 'more verbose output'],
     ['help|h', "print usage message and exit" ],
 );
 $usage->die if $opts->help;
 
 my %params = (
+    commit => $opts->commit,
     verbose => $opts->verbose,
     body_name => $opts->body,
     file => $opts->file,

--- a/perllib/FixMyStreet/Script/ProcessUpdateFile.pm
+++ b/perllib/FixMyStreet/Script/ProcessUpdateFile.pm
@@ -15,6 +15,8 @@ use Open311::GetServiceRequestUpdates;
 
 has verbose => ( is => 'ro', default => 0 );
 
+has commit => ( is => 'ro', default => 0 );
+
 has body_name => ( is => 'ro' );
 
 has file => ( is => 'ro' );
@@ -61,6 +63,7 @@ sub process {
 
     my $updates = Open311::GetServiceRequestUpdates->new(
         verbose => $self->verbose,
+        commit => $self->commit,
     );
     $updates->initialise_body($self->body);
 

--- a/perllib/FixMyStreet/Script/ProcessUpdateFile.pm
+++ b/perllib/FixMyStreet/Script/ProcessUpdateFile.pm
@@ -61,13 +61,17 @@ sub process {
 
     die "Problem loading body\n" unless $self->body;
 
+    print "Dry run, not adding comments. Use --commit to add\n";
+
     my $updates = Open311::GetServiceRequestUpdates->new(
         verbose => $self->verbose,
         commit => $self->commit,
     );
     $updates->initialise_body($self->body);
 
-    $updates->process_requests( $self->data, [$self->start_date, $self->end_date] )
+    $updates->process_requests( $self->data, [$self->start_date, $self->end_date] );
+
+    printf("added %d comments\n", $updates->comments_created);
 }
 
 1;

--- a/perllib/FixMyStreet/Script/ProcessUpdateFile.pm
+++ b/perllib/FixMyStreet/Script/ProcessUpdateFile.pm
@@ -17,6 +17,8 @@ has verbose => ( is => 'ro', default => 0 );
 
 has commit => ( is => 'ro', default => 0 );
 
+has suppress_alerts => ( is => 'ro', default => 0 );
+
 has body_name => ( is => 'ro' );
 
 has file => ( is => 'ro' );
@@ -61,13 +63,14 @@ sub process {
 
     die "Problem loading body\n" unless $self->body;
 
-    print "Dry run, not adding comments. Use --commit to add\n";
+    print "Dry run, not adding comments. Use --commit to add\n" unless $self->commit;
 
     my $updates = Open311::GetServiceRequestUpdates->new(
         verbose => $self->verbose,
         commit => $self->commit,
     );
     $updates->initialise_body($self->body);
+    $updates->suppress_alerts(1) if $self->suppress_alerts;
 
     $updates->process_requests( $self->data, [$self->start_date, $self->end_date] );
 

--- a/perllib/Open311/GetServiceRequestUpdates.pm
+++ b/perllib/Open311/GetServiceRequestUpdates.pm
@@ -10,6 +10,8 @@ has '+send_comments_flag' => ( default => 1 );
 has start_date => ( is => 'ro', default => sub { undef } );
 has end_date => ( is => 'ro', default => sub { undef } );
 
+has comments_created => ( is => 'rw', default => 0 );
+
 Readonly::Scalar my $AREA_ID_BROMLEY     => 2482;
 Readonly::Scalar my $AREA_ID_OXFORDSHIRE => 2237;
 
@@ -62,6 +64,7 @@ sub process_body {
 sub process_requests {
     my ($self, $requests, $args) = @_;
 
+    my $created = 0;
     for my $request (@$requests) {
         next unless defined $request->{update_id};
 
@@ -69,8 +72,11 @@ sub process_requests {
         my $c = $p->comments->search( { external_id => $request->{update_id} } );
         next if $c->first;
 
+        $created++;
+
         $self->process_update($request, $p);
     }
+    $self->comments_created( $created );
 }
 
 sub _find_problem {

--- a/perllib/Open311/UpdatesBase.pm
+++ b/perllib/Open311/UpdatesBase.pm
@@ -7,6 +7,9 @@ use FixMyStreet::DB;
 
 has send_comments_flag => ( is => 'ro' );
 
+# Default is yes, as this has previously been assumed
+has commit => ( is => 'ro', default => 1 );
+
 has system_user => ( is => 'rw' );
 has body => ( is => 'ro', default => sub { undef } );
 has verbose => ( is => 'ro', default => 0 );
@@ -219,6 +222,9 @@ sub process_update {
     # will *also* reshift comment->created's time zone to TIME_ZONE.
     my $created = $comment->created->set_time_zone(FixMyStreet->local_time_zone);
     $p->lastupdate($created->clone);
+
+    return $comment unless $self->commit;
+
     $p->update;
     $comment->insert();
 

--- a/t/script/process_updates_file.t
+++ b/t/script/process_updates_file.t
@@ -61,6 +61,7 @@ my $data = [
 my $p = FixMyStreet::Script::ProcessUpdateFile->new(
     body_name => 'City of Edinburgh Council',
     data => $data,
+    commit => 1,
 );
 
 $p->process;


### PR DESCRIPTION
Adds the option to suppress alerts, dry run by default and also print out summary statistics

[skip changelog]