### PR TITLE
Handle spaces in code names of extra data.

### DIFF
--- a/.cypress/cypress/integration/bathnes.js
+++ b/.cypress/cypress/integration/bathnes.js
@@ -39,3 +39,12 @@ it('uses the Curo Group housing layer correctly', function() {
     cy.pickCategory('Dog fouling');
     cy.contains('Maintained by Curo Group').should('be.visible');
 });
+
+it('handles code names with spaces without error', function() {
+    cy.visit('http://bathnes.localhost:3001/report/new?longitude=-2.359276&latitude=51.379009');
+    cy.contains('Bath & North East Somerset Council');
+    cy.get('input[value="Abandoned vehicles"]').click();
+    cy.get('input[value="Blocked drain"]').click();
+    cy.get('input[value="Abandoned vehicles"]').click();
+    cy.contains('Not maintained by Bath & North East Somerset Council');
+});

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -116,7 +116,7 @@ if ($opt->test_fixtures) {
         { area_id => 2566, categories => [ 'General fly tipping', 'Fallen branch', 'Light Out', 'Light Dim', 'Fallen Tree', 'Damaged Tree', 'Pothole' ], name => 'Peterborough City Council' },
         { area_id => 2498, categories => [ 'Incorrect timetable', 'Glass broken', 'Mobile Crane Operation', 'Roadworks' ], name => 'TfL' },
         { area_id => 2237, categories => [ 'Flytipping', 'Roads', 'Parks' ], name => 'Oxfordshire County Council' },
-        { area_id => 2551, categories => [ 'Dog fouling' ], name => 'Bath and North East Somerset Council' }
+        { area_id => 2551, categories => [ 'Abandoned vehicles', 'Dog fouling', 'Blocked drain' ], name => 'Bath and North East Somerset Council' }
     ) {
         $bodies->{$_->{area_id}} = FixMyStreet::DB::Factory::Body->find_or_create($_);
         my $cats = join(', ', @{$_->{categories}});
@@ -140,6 +140,20 @@ if ($opt->test_fixtures) {
         $cat->set_extra_metadata( group => 'Street lighting' );
         $cat->update;
     }
+
+    my $drain = FixMyStreet::DB->resultset('Contact')->find({
+        body => $bodies->{2551},
+        category => 'Blocked drain',
+    });
+    $drain->set_extra_fields( { code => 'Extra Question' } );
+    $drain->update;
+
+    my $ab_vehicle = FixMyStreet::DB->resultset('Contact')->find({
+        body => $bodies->{2551},
+        category => 'Abandoned vehicles',
+    });
+    $ab_vehicle->set_extra_fields( { code => 'Extra Question' } );
+    $ab_vehicle->update;
 
     my $child_cat = FixMyStreet::DB->resultset("Contact")->find({
         body => $bodies->{2234},

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -564,7 +564,7 @@ $.extend(fixmystreet.set_up, {
             $new_category_meta.closest('.js-reporting-page').toggleClass('js-reporting-page--skip', !!data.extra_hidden);
             // Preserve any existing values
             $category_meta.find("[name]").each(function() {
-                $new_category_meta.find("[name="+this.name+"]").val(this.value);
+                $new_category_meta.find("[name='"+this.name+"']").val(this.value);
             });
         } else {
             $category_meta.closest('.js-reporting-page').addClass('js-reporting-page--skip');


### PR DESCRIPTION
An uncaught exception was being thrown by extra data which
included a space in the code (name), e.g. 'public safety',
when the user chose a report category.

+ **fixmystreet.js**: fix applied (single quotes around code name)
+ **fixture**: BathNES has new categories and extra data for testing
+ **bathnes.js**: additional Cypress test to trigger uncaught exception by clicking between road responsibility categories
+ **cypress.json**: fix to ensure Cypress tests run (is this appropriate?)

Fixes mysociety/fixmystreet#3308

Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Are the changes tested for accessibility?
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
