### PR TITLE
[TfL] [Hounslow] Stop default text in submit email

### DIFF
--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -416,6 +416,8 @@ subtest "extra information included in email" => sub {
     is $email[0]->header('To'), 'TfL <busstops@example.com>';
     like $mech->get_text_body_from_email($email[0]), qr/Report reference: FMS$id/, "FMS-prefixed ID in TfL email";
     like $mech->get_text_body_from_email($email[0]), qr/Stop number: 12345678/, "Bus stop code in TfL email";
+    my $body = $mech->get_html_body_from_email($email[0]);
+    unlike $body, qr/Please do not reply/;
     is $email[1]->header('To'), $report->user->email;
     is $email[1]->header('From'), '"TfL Street Care" <fms-tfl-DO-NOT-REPLY@example.com>';
     like $mech->get_text_body_from_email($email[1]), qr/report's reference number is FMS$id/, "FMS-prefixed ID in reporter email";

--- a/templates/email/default/_email_bottom.html
+++ b/templates/email/default/_email_bottom.html
@@ -8,7 +8,7 @@
     <tr>
       <th class="spacer-cell"></th>
       <th width="[% wrapper_max_width %]" style="[% td_style %][% hint_style %]" class="hint">
-        [%~ IF email_footer %]
+        [%~ IF email_footer.defined %]
           [% email_footer | safe %]
         [%~ ELSE %]
           This email was sent automatically, from an unmonitored email account. Please do not reply to it.

--- a/templates/email/hackney/_email_bottom.html
+++ b/templates/email/hackney/_email_bottom.html
@@ -8,7 +8,7 @@
     <tr>
       <th class="spacer-cell"></th>
       <th width="[% wrapper_max_width %]" style="[% td_style %][% hint_style %]" class="hint">
-        [%~ IF email_footer %]
+        [%~ IF email_footer.defined %]
           [% email_footer | safe %]
         [%~ ELSE %]
           This email was sent automatically, from an unmonitored email account. Please do not reply to it.


### PR DESCRIPTION
Check for defined-ness so empty footer can be used.
[skip changelog]