### PR TITLE
[Bromley] only process one row for a dd record

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -1607,6 +1607,14 @@ sub waste_reconcile_direct_debits {
         } elsif ( $p ) {
             my $service = $self->waste_get_current_garden_sub( $p->get_extra_field_value('property_id') );
             unless ($service) {
+                my $hidden = FixMyStreet::DB->resultset('Problem')->search({
+                    category => 'Cancel Garden Subscription',
+                    state => 'hidden',
+                    extra => { like => '%uprn,T5:value,I' . $len . ':'. $uprn . '%' },
+                    created => \" > now() - interval '7' day",
+                });
+                # no service and we're already seen it
+                next if $hidden->count;
                 warn "no matching service to cancel for $payer\n";
                 next;
             }

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -1506,7 +1506,7 @@ sub waste_reconcile_direct_debits {
             while ( my $cur = $rs->next ) {
 
                 if ( my $type = $self->_report_matches_payment( $cur, $payment ) ) {
-                    if ( $cur->state eq 'unconfirmed' ) {
+                    if ( $cur->state eq 'unconfirmed' && !$handled) {
                         if ( $type eq 'New' ) {
                             if ( !$cur->get_extra_metadata('payerReference') ) {
                                 $cur->set_extra_metadata('payerReference', $payer);
@@ -1526,6 +1526,11 @@ sub waste_reconcile_direct_debits {
                         $cur->confirm;
                         $cur->update;
                         $handled = 1;
+                    } elsif ( $cur->state eq 'unconfirmed' ) {
+                        # if we've pulled out more that one record, e.g. because they
+                        # failed to make a payment then skip remaining ones.
+                        $cur->state('hidden');
+                        $cur->update;
                     } elsif ( $cur->get_extra_metadata('dd_date') eq $date)  {
                         next RECORD;
                     }


### PR DESCRIPTION
Avoid problems if someone has tried to create a direct debit payment and
failed, and then succeeded by hiding any matching records that were not
confirmed and not matched.

[skip changelog]