### PR TITLE
[Bromley] hidden direct debit subs should not prevent renewal

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -989,7 +989,8 @@ sub get_original_sub : Private {
     my $p = $c->model('DB::Problem')->search({
         category => 'Garden Subscription',
         title => 'Garden Subscription - New',
-        extra => { like => '%property_id,T5:value,I_:'. $c->stash->{property}{id} . '%' }
+        extra => { like => '%property_id,T5:value,I_:'. $c->stash->{property}{id} . '%' },
+        state => { '!=' => 'hidden' },
     },
     {
         order_by => { -desc => 'id' }

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -1260,6 +1260,17 @@ FixMyStreet::override_config {
 
         $mech->content_contains('This property has a direct debit subscription which will renew automatically.',
             "error message displayed if try to renew by direct debit");
+
+        $p->state('hidden');
+        $p->update;
+
+        $mech->get_ok('/waste/12345/garden_renew');
+
+        $mech->content_lacks('This property has a direct debit subscription which will renew automatically.',
+            "error message displayed not displayed for hidden direct debit sub");
+
+        $p->state('confirmed');
+        $p->update;
     };
 
     subtest 'cancel direct debit sub' => sub {


### PR DESCRIPTION
This allows us to hide failed direct debit subs and not have them effect
renewal by other means, or by trying again.

Fixes mysociety/societyworks#2441

[skip changelog]