### PR TITLE
Remove revalidation of verified landline number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
         - Fix moderation of update text.
         - Only trigger one refresh going Back to list view. #3476
         - Fix checked order of updates in dashboard export.
+        - Fix unable to edit user with verified landline #3295
     - Admin improvements:
         - Enable per-category hint customisation.
         - Move ban/unban buttons to user edit admin page.

--- a/perllib/FixMyStreet/App/Controller/Admin/Users.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Users.pm
@@ -259,7 +259,7 @@ sub edit : Chained('user') : PathPart('') : Args(0) {
             $c->stash->{field_errors}->{email} = _('Please enter a valid email');
         }
 
-        if ($phone_v) {
+        if ($phone_v && ($phone ne $user->phone)) {
             my $parsed_phone = $c->forward('phone_check', [ $phone ]);
             $phone = $parsed_phone if $parsed_phone;
         }
@@ -276,6 +276,7 @@ sub edit : Chained('user') : PathPart('') : Args(0) {
         my $existing_email_cobrand = $email_v && $c->cobrand->users->search($email_params)->first;
         my $existing_phone_cobrand = $phone_v && $c->cobrand->users->search($phone_params)->first;
         my $existing_user_cobrand = $existing_email_cobrand || $existing_phone_cobrand;
+
         if ($existing_phone_cobrand && $existing_email_cobrand && $existing_email_cobrand->id != $existing_phone_cobrand->id) {
             $c->stash->{field_errors}->{username} = _('User already exists');
         }

--- a/t/app/controller/admin/users.t
+++ b/t/app/controller/admin/users.t
@@ -550,6 +550,27 @@ FixMyStreet::override_config {
         $mech->content_contains( 'Updated!' );
     };
 
+    subtest "Test edit user name with phone number unchanged who has verified landline" => sub {
+        my $existing_user = $mech->create_user_ok('existing@example.com', name => 'Existing User', phone => '01184960017', phone_verified => 1 );
+	$mech->get_ok( '/admin/users/' . $existing_user->id );
+	$mech->submit_form_ok( { with_fields => {
+            name => 'Existing E. User',
+        } } );
+	$mech->content_contains( 'Updated!' );
+    };
+
+    subtest "Test edit user change phone number who has verified landline" => sub {
+        my $existing_user = $mech->create_user_ok('existing@example.com', name => 'Existing User', phone => '01184960017', phone_verified => 1 );
+	$mech->get_ok( '/admin/users/' . $existing_user->id );
+	$mech->submit_form_ok( { with_fields => {
+            phone => '01184960018',
+	} } );
+	$mech->content_lacks( 'Updated!' );
+	$mech->content_contains( 'Please check your phone number is correct' );
+    };
+
+
+
     subtest "Test changing user to an existing one" => sub {
         my $existing_user = $mech->create_user_ok('existing@example.com', name => 'Existing User');
         $mech->create_problems_for_body(2, 2514, 'Title', { user => $existing_user });


### PR DESCRIPTION
Fixes #3295 

PROBLEM: Admin can create a user and put in a landline phone number and verify it if reporting on behalf of a user. But phone numbers are expected to be mobile numbers (for confirming number by SMS). Editing a user created by an admin in this way leads to the phone number being revalidated and the edit is rejected, whatever it is, if the number is a landline.

SOLUTION: When submitting an 'edit user' form, we will no longer revalidate the phone number if the phone number is the same as the original. If the phone number is changed, revalidation will take place.

TESTS: Test if changing the user name on a user with a verified landline succeeds. Test if changing the phone number from one landline to another fails.