### PR TITLE
[Highways England] Add cut off date for problems

### DIFF
--- a/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
+++ b/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
@@ -23,7 +23,7 @@ sub body {
 }
 
 # Copying of functions from UKCouncils that are needed here also - factor out to a role of some sort?
-sub cut_off_date { '' }
+sub cut_off_date { '2020-11-09' }
 sub problems_restriction { FixMyStreet::Cobrand::UKCouncils::problems_restriction($_[0], $_[1]) }
 sub problems_on_map_restriction { $_[0]->problems_restriction($_[1]) }
 sub problems_sql_restriction { FixMyStreet::Cobrand::UKCouncils::problems_sql_restriction($_[0], $_[1]) }


### PR DESCRIPTION
Highways England have requested that reports made before 9th November
aren't visible on their cobrand.

Fixes https://github.com/mysociety/societyworks/issues/2445

[skip changelog]
