### PR TITLE
[Bromley] prevent garden sub modification during renewal window

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -830,7 +830,7 @@ sub garden_modify : Chained('property') : Args(0) {
 
     my $max_bins = $c->stash->{quantity_max}->{$service};
     $service = $c->stash->{services}{$service};
-    if (!$service) {
+    if (!$service || $service->{garden_due}) {
         $c->res->redirect('/waste/' . $c->stash->{property}{id});
         $c->detach;
     }

--- a/templates/web/bromley/waste/services.html
+++ b/templates/web/bromley/waste/services.html
@@ -83,10 +83,12 @@
   </form>
   [% END %]
   [% IF NOT pending_cancellation && NOT unit.garden_overdue %]
+  [% IF NOT unit.garden_due %]
   <form method="post" action="[% c.uri_for_action('waste/garden_modify', [ property.id ]) %]">
     <input type="hidden" name="token" value="[% csrf_token %]">
     <input type="submit" value="Modify your [% unit.service_name FILTER lower %] subscription" class="waste-service-descriptor waste-service-link">
   </form>
+  [% END %]
   <form method="post" action="[% c.uri_for_action('waste/garden_cancel', [ property.id ]) %]">
     <input type="hidden" name="token" value="[% csrf_token %]">
     <input type="submit" value="Cancel your [% unit.service_name FILTER lower %] subscription" class="waste-service-descriptor waste-service-link">


### PR DESCRIPTION
At his point the user should renew and change the number of bins while
renewing. This avoids complications with modifications and then
renewals.

[skpi changelog]