### PR TITLE
Stop sending UK Council questionaires if users can't update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
         - Always record contributed_by for staff users.
         - Add per-photo moderation. #3055
         - Redaction support for photos.
+        - UK Councils no questionnaires for non-updating users
     - Development improvements:
         - Include failure count in send report error output, #3316
         - Sort output in export script. #3323

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -1378,4 +1378,10 @@ sub emergency_message {
     FixMyStreet::Template::SafeString->new($body->get_extra_metadata($field));
 }
 
+# Report if cobrand denies updates by user
+# Default 'allows'
+sub deny_updates_by_user {
+    return;
+}
+
 1;

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -501,6 +501,21 @@ sub updates_disallowed {
     return $self->next::method(@_);
 }
 
+# Report if cobrand denies updates by user
+sub deny_updates_by_user {
+    my ($self, $row) = @_;
+    my $cfg = $self->feature('updates_allowed') || '';
+    if ($cfg eq 'none' || $cfg eq 'staff') {
+        return 1;
+    } elsif ($cfg eq 'reporter-open' && !$row->is_open) {
+        return 1;
+    } elsif ($cfg eq 'open' && !$row->is_open) {
+        return 1;
+    } else {
+        return;
+    }
+};
+
 sub extra_contact_validation {
     my $self = shift;
     my $c = shift;

--- a/perllib/FixMyStreet/Script/Questionnaires.pm
+++ b/perllib/FixMyStreet/Script/Questionnaires.pm
@@ -50,6 +50,10 @@ sub send_questionnaires_period {
         # Not all cobrands send questionnaires
         next unless $cobrand->send_questionnaires;
 
+        # If cobrand doesn't allow users to
+        # update don't send questionnaires
+        next if $cobrand->deny_updates_by_user($row);
+
         # Cobrands can also override sending per row if they wish
         my $cobrand_send = $cobrand->call_hook('send_questionnaire', $row) // 1;
 


### PR DESCRIPTION
Don't send questionnaires for closed reports if cobrand prevents re-opening closed reports. [1d] https://github.com/mysociety/societyworks/issues/2427

* There is a setting to not send questionnaires but this can be forgotten.
* If UK Council doesn't allow updates by users, don't send questionnaires.
* Adds method to test if users allowed to edit.
* Skips sending questionnaire if method returns true
* Adds tests
* Updates changelog