### PR TITLE
Cheshire east inspector tool upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
         - Do not email inactive body comment users. #3587
         - Look up organizational domain in DMARC checking. #3603
     - Admin improvements:
+        - Assignees of reports are now visible in admin reports list and report edit pages.
         - Enable per-category hint customisation.
         - Move ban/unban buttons to user edit admin page.
         - Add link to user edit admin from report/update edit admin.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
         - Make anonymous updates clearer in email alerts. #3417
         - Add Maidenhead Locator support to search box.
         - Update RSS link when distance box changed. #3624
+        - Inspector-managers can assign reports to inspectors
+          in the inspector toolbar.
     - Bugfixes:
         - Fix non-JS form when all extra questions answered. #3248
         - Improve display of disabled fields in iOS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
         - Update RSS link when distance box changed. #3624
         - Inspector-managers can assign reports to inspectors
           in the inspector toolbar.
+        - Inspectors & inspector-managers can see who a report is assigned
+          to or 'unassigned' if a report is unassigned.
     - Bugfixes:
         - Fix non-JS form when all extra questions answered. #3248
         - Improve display of disabled fields in iOS.

--- a/docs/_includes/admin-tasks-content.md
+++ b/docs/_includes/admin-tasks-content.md
@@ -448,6 +448,8 @@ they are in a practical order for your route or priorities.
 
 Managers of teams of inspectors can assign reports to the shortlists of inspectors (i.e. staff with the 'Markup problem details' permission). The assignment dropdown appears when editing reports with the inspector tool.
 
+Reports can also be assigned in bulk from the 'All reports' page, where inspector managers can see at a glance which reports are assigned to which inspectors, as well as which are unassigned.
+
 Assigned users can also be viewed on the Reports list page in the Admin area, as well as when editing a report in that list by clicking its 'Edit' link.
 
 #### Seeing which reports are assigned and unassigned

--- a/docs/_includes/admin-tasks-content.md
+++ b/docs/_includes/admin-tasks-content.md
@@ -454,7 +454,7 @@ Assigned users can also be viewed on the Reports list page in the Admin area, as
 
 <span class="admin-task__permissions">Permissions required: User must be marked as staff and 'Markup problem details' must be ticked.</span>
 
-In addition to seeing their own shortlist, inspectors can, like inspector managers, see which reports are assigned to other inspectors and which are unassigned in the individual report webpage.
+In addition to seeing their own shortlist, inspectors can, like inspector managers, see which reports are assigned to other inspectors and which are unassigned both in the individual report webpage and in the 'All reports' list.
 
 #### Viewing navigation routes
 

--- a/docs/_includes/admin-tasks-content.md
+++ b/docs/_includes/admin-tasks-content.md
@@ -442,6 +442,20 @@ Shortlists can be ordered and filtered in the same way as the main list, by usin
 menus. You can also use the arrows beside each report title to move them up or down the list, until
 they are in a practical order for your route or priorities.
 
+#### Assigning reports to another user's shortlist
+
+<span class="admin-task__permissions">Permissions required: User must be marked as staff and 'Assign problem reports to users' must be ticked.</span>
+
+Managers of teams of inspectors can assign reports to the shortlists of inspectors (i.e. staff with the 'Markup problem details' permission). The assignment dropdown appears when editing reports with the inspector tool.
+
+Assigned users can also be viewed on the Reports list page in the Admin area, as well as when editing a report in that list by clicking its 'Edit' link.
+
+#### Seeing which reports are assigned and unassigned
+
+<span class="admin-task__permissions">Permissions required: User must be marked as staff and 'Markup problem details' must be ticked.</span>
+
+In addition to seeing their own shortlist, inspectors can, like inspector managers, see which reports are assigned to other inspectors and which are unassigned in the individual report webpage.
+
 #### Viewing navigation routes
 
 From any report, you can click the button marked ‘navigate to this problem’. This will open a

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -521,6 +521,15 @@ sub inspect : Private {
             }
         }
 
+        # set assignment
+        my $assigned = ($c->get_param('assignment'));
+        if ($assigned && $assigned eq 'unassigned') {
+            # take off shortlist
+            $problem->user->remove_from_planned_reports($problem);
+        } elsif ($assigned) {
+            my $assignee = $c->model('DB::User')->find({ id => $assigned });
+            $assignee->add_to_planned_reports($problem);
+        }
         $problem->non_public($c->get_param('non_public') ? 1 : 0);
         if ($problem->non_public) {
             $problem->get_photoset->delete_cached(plus_updates => 1);

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -793,6 +793,7 @@ sub available_permissions {
             contribute_as_body => _("Create reports/updates as the council"),
             default_to_body => _("Default to creating reports/updates as the council"),
             view_body_contribute_details => _("See user detail for reports created as the council"),
+            assign_report_to_user => _("Assign problem reports to users"),
         },
         _("Users") => {
             user_edit => _("Edit users' details/search for their reports"),

--- a/perllib/FixMyStreet/DB/Result/Body.pm
+++ b/perllib/FixMyStreet/DB/Result/Body.pm
@@ -280,4 +280,22 @@ sub calculate_average {
     return $count >= $threshold ? $avg : undef;
 }
 
+=head2 staff_with_permission
+
+Returns a resultset of all staff users for the body who have been
+granted a specific permission.
+
+=cut
+
+sub staff_with_permission {
+    my ( $self, $permission ) = @_;
+    return $self->users->search([
+        { 'user_body_permissions.permission_type' => $permission },
+        { permissions => \"@> ARRAY['$permission']" }
+    ], {
+        join => [ 'user_body_permissions', { "user_roles" => "role" } ],
+        order_by => { '-asc' => ['name'] },
+    });
+}
+
 1;

--- a/t/app/controller/admin/users.t
+++ b/t/app/controller/admin/users.t
@@ -319,6 +319,7 @@ my %default_perms = (
     "permissions[report_edit_priority]" => undef,
     "permissions[report_inspect]" => undef,
     "permissions[report_instruct]" => undef,
+    "permissions[assign_report_to_user]" => undef,
     "permissions[report_prefill]" => undef,
     "permissions[contribute_as_another_user]" => undef,
     "permissions[contribute_as_anonymous_user]" => undef,

--- a/t/app/controller/my_assigned.t
+++ b/t/app/controller/my_assigned.t
@@ -1,0 +1,116 @@
+use FixMyStreet::TestMech;
+use Test::MockModule;
+use Path::Class;
+
+use HTML::Selector::Element qw(find);
+use Test::WWW::Mechanize::Catalyst;
+my $mech = FixMyStreet::TestMech->new;
+my $oxon = $mech->create_body_ok(2237, 'Oxfordshire County Council', { can_be_devolved => 1 } );
+
+my $contact = $mech->create_contact_ok( body_id => $oxon->id, category => 'Cows', email => 'cows@example.net' );
+my $contact2 = $mech->create_contact_ok( body_id => $oxon->id, category => 'Sheep', email => 'SHEEP', send_method => 'Open311' );
+my $contact3 = $mech->create_contact_ok( body_id => $oxon->id, category => 'Badgers & Voles', email => 'badgers@example.net' );
+
+my ($report, $report2, $report3) = $mech->create_problems_for_body(3, $oxon->id, 'Test', {
+    category => 'Cows', cobrand => 'fixmystreet', areas => ',2237,2421,',
+    whensent => \'current_timestamp',
+    latitude => 51.754926, longitude => -1.256179,
+});
+my $report_id = $report->id;
+my $report2_id = $report2->id;
+my $report3_id = $report3->id;
+
+$mech->create_user_ok('inspector.manager@example.com', name => 'Inspector Manager');
+my $mgr = $mech->log_in_ok('inspector.manager@example.com');
+my $ian = $mech->create_user_ok('inspector.ian@example.com', name => 'Inspector Ian');
+$ian->from_body( $oxon->id );
+$ian->user_body_permissions->create({
+    body => $oxon,
+    permission_type => 'report_inspect',
+});
+$ian->update;
+$mgr->user_body_permissions->create({ body => $oxon, permission_type => 'assign_report_to_user' });
+$mgr->user_body_permissions->create({ body => $oxon, permission_type => 'report_inspect' });
+$mgr->set_extra_metadata('categories', [ $contact->id ]);
+$mgr->update({from_body => $oxon});
+
+
+FixMyStreet::override_config {
+    MAPIT_URL => 'http://mapit.uk/',
+    ALLOWED_COBRANDS => 'oxfordshire',
+}, sub {
+    subtest "test report assignment" => sub {
+        $mech->get_ok("/reports");
+        $mech->content_contains('Assign to');
+
+        my $root = HTML::TreeBuilder->new_from_content($mech->content());
+        ok ($root->find('select#inspector'), 'Inspector assignment dropdown exists');
+        ok ($root->find('input.bulk-assign'), 'Inspector assignment checkboxes exist');
+
+        # check report(s) are not assigned to Ian
+        my $get_assignees = sub {
+            my @span = $root->find('li div.assigned-to span.assignee');
+            return map {map { s/ ^ \s+ | \s+ $ //grx } $_->content_list} @span;
+        };
+        my @all_match_unassigned = qw((unassigned) (unassigned) (unassigned));
+        is_deeply([$get_assignees->()], \@all_match_unassigned, 'all reports correctly unassigned');
+
+        $mech->form_name('bulk-assign-form');
+        # HTML::Form does not seem to find external form inputs :(
+        # So, copy the checkboxes to inside the form, then tick them.
+        my $bulk_form = $mech->current_form;
+        my @tickboxes = $root->find('input.bulk-assign');
+        for my $box (@tickboxes) {
+            $bulk_form->push_input('checkbox', {
+                name  => $box->attr('name'),
+                id    => $box->id,
+                value => $box->attr('value'),
+            });
+        }
+
+        # check that unassigning unassigned problems
+        # isn't a problem
+        $mech->select('inspector', 'unassigned');
+        $mech->tick('bulk-assign-reports', $report_id);
+        $mech->tick('bulk-assign-reports', $report2_id);
+        $mech->tick('bulk-assign-reports', $report3_id);
+        $mech->click;
+
+        # check report(s) are still not assigned
+        $root = HTML::TreeBuilder->new_from_content($mech->content());
+        my @assigned_to = $get_assignees->();
+        for (0..2) {
+            like($assigned_to[$_], qr/unassigned/, 'Report ' . ($_ + 1) . ' still unassigned');
+        }
+
+        $mech->form_name('bulk-assign-form');
+        # HTML::Form does not seem to find external form inputs :(
+        # So, copy the checkboxes to inside the form, then tick them.
+        $bulk_form = $mech->current_form;
+        @tickboxes = $root->find('input.bulk-assign');
+        for my $box (@tickboxes) {
+            $bulk_form->push_input('checkbox', {
+                name  => $box->attr('name'),
+                id    => $box->id,
+                value => $box->attr('value'),
+            });
+        }
+
+        # now try assigning the reports to Ian
+        $mech->form_name('bulk-assign-form');
+        $mech->select('inspector', $ian->id);
+        $mech->tick('bulk-assign-reports', $report_id);
+        $mech->tick('bulk-assign-reports', $report2_id);
+        $mech->tick('bulk-assign-reports', $report3_id);
+        $mech->click;
+
+        # check appropriate report(s) are now assigned to Ian
+        $root = HTML::TreeBuilder->new_from_content($mech->content());
+        @assigned_to = $get_assignees->();
+        for (0..2) {
+            like($assigned_to[$_], qr/Inspector Ian/, 'Report ' . ($_ + 1) . ' assigned to Ian');
+        }
+    };
+};
+
+done_testing;

--- a/templates/web/base/admin/_report-assignment.html
+++ b/templates/web/base/admin/_report-assignment.html
@@ -1,0 +1,11 @@
+[%  IF c.user.has_permission_to('report_inspect', problem.bodies_str_ids ) OR c.user.has_permission_to('assign_report_to_user', problem.bodies_str_ids) %]
+    [%# see report's assigned user %]
+    <span>[% loc('Assigned to:') %]</span>
+    <span class="assignee">
+        [% IF problem.shortlisted_user %]
+            [% problem.shortlisted_user.name OR problem.shortlisted_user.username %]
+        [% ELSE %]
+            [% loc('(unassigned)') %]
+        [% END %]
+    </span>
+[% END %]

--- a/templates/web/base/admin/problem_row.html
+++ b/templates/web/base/admin/problem_row.html
@@ -12,8 +12,8 @@
         <a href="[% uri %]" class="admin-offsite-link">[% problem.id %]</a>
         [%- ELSE %]
         [%- problem.id %]
-        [%- END -%]</td> 
-        <td>[% PROCESS value_or_nbsp value=problem.title %]</td> 
+        [%- END -%]</td>
+        <td>[% PROCESS value_or_nbsp value=problem.title %]</td>
         <td>
             [% PROCESS value_or_nbsp value=problem.name %]
             <br>[% PROCESS value_or_nbsp value=problem.user.email %]
@@ -29,6 +29,13 @@
                 [%- PROCESS value_or_nbsp value=problem.bodies_str -%]
             [%- END -%]
             <br>[% problem.cobrand %]<br>[% problem.cobrand_data | html %]
+            <br>
+            [% IF c.user.has_body_permission_to('assign_report_to_user') %] [%# see report's assigned user %]
+                <span>[% loc('Assigned to') %]: </span>
+                <span>
+                    [%- problem.shortlisted_user.name OR problem.shortlisted_user.username OR loc('unassigned') -%]
+                </span>
+            [%- END -%]
         </td>
         <td>[% prettify_state(problem.state, 1) %]<br><small>
             [% loc('Created') %]:&nbsp;[% PROCESS format_time time=problem.created %]

--- a/templates/web/base/admin/reports/edit.html
+++ b/templates/web/base/admin/reports/edit.html
@@ -131,6 +131,9 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
 <li><label class="inline-text" for="category">[% loc('Category:') %]</label>
     [% INCLUDE 'admin/report-category.html' %]
 </li>
+<li>
+    [% INCLUDE 'admin/_report-assignment.html' %]
+</li>
 
 <li>[% loc('Extra data:') ~%]
     [%~ IF extra_fields.size ~%]

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -34,6 +34,7 @@
             <label for="state">[% loc('State') %]</label>
             [% INCLUDE 'report/inspect/state_groups_select.html' %]
           </p>
+          [% INCLUDE 'report/inspect/assignment.html'%]
           [% TRY %][% INCLUDE 'report/inspect/_raise_defect.html' %][% CATCH file %][% END %]
           <div id="js-duplicate-reports" class="[% "hidden" UNLESS problem.duplicate_of %]">
             <input type="hidden" name="duplicate_of" value="[% problem.duplicate_of.id %]">

--- a/templates/web/base/report/_item.html
+++ b/templates/web/base/report/_item.html
@@ -119,7 +119,7 @@ END;
     [%# The around page list is already contained within the new report form %]
     [% item_action.replace('("shortlist-[^"]*)', '$1-' _ problem.id) | safe %]
   [% ELSE ~%]
-    <form method="post" action="/my/planned/change">
+    <form method="post" id="add_remove_shortlist_[% problem.id %]" action="/my/planned/change">
         <input type="hidden" name="id" value="[% problem.id %]">
         <input type="hidden" name="token" value="[% csrf_token %]">
         [% item_action | safe %]

--- a/templates/web/base/report/_item.html
+++ b/templates/web/base/report/_item.html
@@ -43,9 +43,13 @@ END;
   [% PROCESS 'report/_item_extra_class.html' %]
 [%~ CATCH file ~%]
 [%~ END ~%]
-
 <li class="item-list__item item-list--reports__item [% item_extra_class %]"
     data-report-id="[% problem.id | html %]" data-lastupdate="[% problem.lastupdate %]" id="report-[% problem.id | html %]">
+[% IF relevant_staff AND (c.user.has_permission_to('assign_report_to_user', problem.bodies_str_ids)) %]
+    [% UNLESS page == 'my' OR page == 'around' OR page == '' %]
+        <input type='checkbox' class='bulk-assign' name='bulk-assign-reports' form='bulk-assign-form' value='[%- problem.id -%]'>
+    [% END %]
+[% END %]
 <a href="[% c.cobrand.relative_url_for_report( problem ) %][% problem.url %]">
   [% TRY ~%]
     [% PROCESS 'report/_item_photo_title.html' ~%]
@@ -126,4 +130,5 @@ END;
     </form>
   [% END ~%]
 [% END %]
+
 </li>

--- a/templates/web/base/report/_item_small.html
+++ b/templates/web/base/report/_item_small.html
@@ -30,3 +30,8 @@
     [% ELSIF problem.bodies_str_ids.size == 0 %] [% loc('(not sent to council)') %]
     [% END %]
 [% END %]
+[% IF page != '' %]
+    <div class='assigned-to'>
+    [% INCLUDE 'admin/_report-assignment.html' %]
+    </div>
+[% END %]

--- a/templates/web/base/report/inspect/_assignment-options.html
+++ b/templates/web/base/report/inspect/_assignment-options.html
@@ -1,0 +1,12 @@
+[% FOR user IN body.staff_with_permission('report_inspect')  %]
+    <option value='[% user.id %]'
+    [%- IF problem AND (user.id == problem.shortlisted_user.id) -%]
+        selected="selected"
+    [%- END -%]>
+    [% user.name OR user.username %]
+    </option>
+[% END %]
+<option value='unassigned'
+[%- UNLESS problem.shortlisted_user -%] selected="selected"[%- END -%]
+>[% loc('unassigned') %]</option>
+

--- a/templates/web/base/report/inspect/assignment.html
+++ b/templates/web/base/report/inspect/assignment.html
@@ -1,0 +1,8 @@
+[% IF c.user.has_permission_to('assign_report_to_user', problem.bodies_str_ids) %]
+    <p>
+    <label for="assignment">[% loc('Assign to:') %]</label>
+    <select class="form-control" name="assignment" id="assignment">
+        [% INCLUDE 'report/inspect/_assignment-options.html' body = c.user.from_body %]
+    </select>
+    </p>
+[% END %]

--- a/templates/web/base/reports/_bulk-assign.html
+++ b/templates/web/base/reports/_bulk-assign.html
@@ -1,0 +1,10 @@
+[%  IF c.user.has_body_permission_to('assign_report_to_user') %]
+<form id='bulk-assign-form' name='bulk-assign-form' method='post' action='/my/planned/bulk_assign'>
+    <label for='inspector'>[% loc('Assign to') %]</label>
+    <input type="hidden" name="token" value="[% csrf_token %]">
+    <select class="form-control report-list-filters multi-select-button" name="inspector" id="inspector">
+        [% INCLUDE 'report/inspect/_assignment-options.html' %]
+    </select>
+    <button id='bulk-assign-btn' class='multi-select-button' type='submit' name='bulk-assign-btn' value='bulk-assign'>[% loc('Assign') %]</button>
+</form>
+[% END %]

--- a/templates/web/base/reports/_problem-list.html
+++ b/templates/web/base/reports/_problem-list.html
@@ -3,7 +3,7 @@
 %]
 
 [% BLOCK column %]
-    <ul class="item-list item-list--reports">
+    <ul class="item-list item-list--reports" data-user-name="[% c.user.name %]" data-user-email="[% c.user.email %]">
         [% IF problems %]
             [% FOREACH problem IN problems %]
                 [% INCLUDE 'reports/_list-entry.html' include_sentinfo = 1 include_lastupdate = 1 %]

--- a/templates/web/base/reports/body.html
+++ b/templates/web/base/reports/body.html
@@ -71,6 +71,9 @@
 
 <section class="full-width">
 [% INCLUDE "reports/_list-filters.html", use_form_wrapper = 1 %]
+<div class="bulk-assignment-form">
+[% INCLUDE "reports/_bulk-assign.html" %]
+</div>
 <div class="js-pagination">
 [% INCLUDE 'pagination.html', param = 'p' %]
 </div>

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -53,8 +53,10 @@ fixmystreet.staff_set_up = {
         $item.insertBefore( $item.prev() );
       } else if ('shortlist-remove' === whatUserWants) {
           fixmystreet.utils.toggle_shortlist($submitButton, 'add', report_id);
+          fixmystreet.utils.update_unassigned($item, $list);
       } else if ('shortlist-add' === whatUserWants) {
           fixmystreet.utils.toggle_shortlist($submitButton, 'remove', report_id);
+          fixmystreet.utils.update_assignee($item, $list);
       }
 
       // Items have moved around. We need to make sure the "up" button on the
@@ -77,10 +79,14 @@ fixmystreet.staff_set_up = {
           fixmystreet.utils.toggle_shortlist($submitButton, 'add', report_id);
         }
         fixmystreet.update_list_item_buttons($list);
+        // undo assignee changes
+        $('.oldassign').removeClass('oldassign').show();
+        $('.newassign').remove();
       }).complete(function() {
         if ($hiddenInput) {
           $hiddenInput.remove();
         }
+        $('.oldassign').remove();
       });
     });
   },
@@ -562,6 +568,17 @@ $.extend(fixmystreet.utils, {
             sw += '-' + id;
         }
         btn.attr('name', 'shortlist-' + sw);
+    },
+    update_unassigned: function($li, $ul) {
+        $li.find('span.assignee').addClass('oldassign').hide();
+        $li.find('span.assignee').after('<span class="assignee newassign">(unassigned)</span>');
+    },
+    update_assignee: function($li, $ul) {
+        var user_name = $ul.data('userName');
+        var user_email = $ul.data('userEmail');
+        var user_handle = user_name ? user_name : user_email;
+        $li.find('span.assignee').addClass('oldassign').hide();
+        $li.find('span.assignee').after('<span class="assignee newassign">' + user_handle + '</span>');
     }
 });
 

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2144,6 +2144,19 @@ img.pin {
   }
 }
 
+#map_sidebar .assignee {
+  font-weight: bold;
+}
+
+.admin #map_sidebar .assignee {
+  font-style: italic;
+  font-weight: normal;
+}
+
+div.assigned-to {
+    margin-top: 0.25em;
+}
+
 // When you're in the reporting flow on mobile, we make the map full screen to
 // reduce distractions. JavaScript also tweaks the text content of some of the
 // map-related elements, to make it more "app-like".

--- a/web/cobrands/sass/_report_list.scss
+++ b/web/cobrands/sass/_report_list.scss
@@ -1,4 +1,4 @@
-.report-list-filters-wrapper {
+.report-list-filters-wrapper, #bulk-assign-form {
   color: #666;
 
   .mobile-filters-active & {
@@ -12,7 +12,7 @@
   }
 }
 
-.report-list-filters {
+.report-list-filters, #bulk-assign-form {
   padding: 1em;
   padding-bottom: 0.75em; // compensate for 0.25em border-top on .item-list__item
   margin-bottom: 0;
@@ -66,4 +66,32 @@
     line-height: 1.8em;
     vertical-align: top;
   }
+
+  .multi-select-button #bulk-assign-btn {
+    display: inline;
+  }
+
+  #bulk-assign-form {
+    padding-top: 0;
+  }
+
+  #inspector {
+    max-width: 40%;
+  }
+
+  #bulk-assign-btn {
+    width: 25%;
+    line-height: 1.7em;
+  }
+
+  #bulk-assign-btn::after {
+    content: none;
+  }
+
+}
+
+input.bulk-assign {
+    float: right;
+    margin: 2em;
+    transform: scale(2);
 }


### PR DESCRIPTION
- [x] 1.  New "assign reports" permission set up in admin. 
- [x] 2.  Update report screen to show who a report is assigned to.  
- [x] 3.  Update inspector sidebar with a dropdown to allow reports to be assigned to staff. 
- [x] 4.  Update report list to show who a report is assigned to. 
- [x] 5.  Update report list to allow bulk assignment of reports. 
- [x] 6.  (Tests.) 

Depends on https://github.com/mysociety/fixmystreet/pull/3562
Fixes https://github.com/mysociety/societyworks/issues/2455


_Please check the following:_
 
- [x] _Whether this PR should include changes to any documentation, or the FAQ;_
- [x] _Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;_
- [ ] _Are the changes tested for accessibility?_
- [x] _Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog_ 


