### PR TITLE
[Bromley] Add contributing user's role to open311 report_title

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -222,6 +222,17 @@ sub open311_extra_data_include {
         $title .= ' | PROW ID: ' . $_->{value} if $_->{name} eq 'prow_reference';
     }
 
+    # Add contributing user's roles to report title
+    my $contributed_by = $row->get_extra_metadata('contributed_by');
+    my $contributing_user = FixMyStreet::DB->resultset('User')->find({ id => $contributed_by });
+    my $roles;
+    if ($contributing_user) {
+        $roles = join(',', map { $_->name } $contributing_user->roles->all);
+    }
+    if ($roles) {
+        $title .= ' | ROLES: ' . $roles;
+    }
+
     my $open311_only = [
         { name => 'report_url',
           value => $h->{url} },

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -124,7 +124,7 @@ for my $test (
           'attribute[easting]' => 540315,
           'attribute[northing]' => 168935,
           'attribute[service_request_id_ext]' => $report->id,
-          'attribute[report_title]' => 'Test Test 1 for ' . $body->id,
+          'attribute[report_title]' => 'Test Test 1 for ' . $body->id . ' | ROLES: Role A',
           'jurisdiction_id' => 'FMS',
           address_id => undef,
         },
@@ -148,7 +148,7 @@ for my $test (
         feature_id => '1234',
         expected => {
           'attribute[service_request_id_ext]' => $report->id,
-          'attribute[report_title]' => 'Test Test 1 for ' . $body->id . ' | ID: 1234',
+          'attribute[report_title]' => 'Test Test 1 for ' . $body->id . ' | ID: 1234 | ROLES: Role A',
         },
     },
 ) {


### PR DESCRIPTION
Bromley have requested that we add the role into the open311 report_title field so that they can use it to update the point of contact field in their Confirm instance.

Fixes https://github.com/mysociety/societyworks/issues/2450

<!-- [skip changelog] -->