### PR TITLE
Script to insert odour category to fixmystreet.com

### DIFF
--- a/bin/fixmystreet.com/one-off-add-ics-body
+++ b/bin/fixmystreet.com/one-off-add-ics-body
@@ -1,0 +1,92 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use v5.14;
+use utf8;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use FixMyStreet::DB;
+use FixMyStreet::MapIt;
+use Term::ANSIColor;
+use Getopt::Long::Descriptive;
+
+my ($opt, $usage) = describe_options(
+    '%c %o',
+    [ 'commit', "Actually commit changes to the database" ],
+    [ 'help', "print usage message and exit", { shortcircuit => 1 } ],
+);
+print($usage->text), exit if $opt->help;
+
+my $db;
+END {
+    if ($db) {
+        $opt->commit ? $db->txn_commit : $db->txn_rollback;
+    }
+}
+
+$db = FixMyStreet::DB->schema->storage;
+$db->txn_begin;
+if (!$opt->commit) {
+    say colored("NOT COMMITTING TO DATABASE", 'cyan');
+}
+
+my $areas = mySociety::MaPit::call('areas', 'CTY,UTA,MTD,LBO');
+
+my $body_ics = FixMyStreet::DB->resultset("Body")->find_or_create({
+	name => 'Environment Agency',
+});
+
+my $new_category_name = 'Odour';
+
+my $cat = FixMyStreet::DB->resultset('Contact')->find_or_new({
+	body => $body_ics,
+	category => $new_category_name,
+	email => 'ics@environment-agency.gov.uk',
+	state =>    'confirmed',
+	editor => 'one-off-add-ics-body',
+	whenedited => \'current_timestamp',
+	note => 'Adding odour category automatically',
+});
+
+unless ($cat->in_storage) {
+	$cat->set_extra_fields({
+	code => 'odour-level',
+	datatype => 'singlevaluelist',
+	description => '
+		<div>How strong is the odour?</div>
+		<ul>
+			<li>Very faint odour (need to inhale into the wind to smell anything)</li>
+			<li>Faint odour (you can detect an odour when you inhale normally)</li>
+			<li>Distinct odour (there is clearly an odour in the air as you leave your car or enter the area)</li>
+			<li>Strong odour (a bearable odour but strong, you could stay in the area for some time)</li>
+			<li>Very strong odour (unpleasantly strong, you will want to leave the area quickly)</li>
+			<li>Extremely strong odour (likely to cause nausea and a strong need to remove yourself from the odour immediately)</li>
+		</ul>
+				', 
+	order => 100,
+	required => 'true',
+	variable => 'true',
+	values => [
+	{ key => '1', name => 'Very faint odour' },
+	{ key => '2', name => 'Faint odour' },
+	{ key => '3', name => 'Distinct odour' },
+	{ key => '4', name => 'Strong odour' },
+	{ key => '5', name => 'Very strong odour' },
+	{ key => '6', name => 'Extremely strong odour' },
+	],
+	},
+	);
+$cat->insert;
+}
+
+for my $area ( values %{ $areas } ) {
+    next unless $area->{country} eq 'E';
+    FixMyStreet::DB->resultset('BodyArea')->find_or_create( { body => $body_ics, area_id => $area->{id} } );
+}

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -417,6 +417,11 @@ sub munge_report_new_bodies {
     if (!$on_he_road) {
         %$bodies = map { $_->id => $_ } grep { $_->name ne 'Highways England' } values %$bodies;
     }
+    # Environment agency added with odour category for FixmyStreet
+    # in all England areas, but should not show for cobrands
+    if ( $bodies->{'Environment Agency'} ) {
+        %$bodies = map { $_->id => $_ } grep { $_->name ne 'Environment Agency' } values %$bodies;
+    }
 }
 
 sub munge_surrounding_london {

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -331,6 +331,12 @@ sub munge_report_new_bodies {
             %$bodies = map { $_->id => $_ } grep { $_->name ne 'Highways England' } values %$bodies;
         }
     }
+
+    # Environment agency added with odour category for FixmyStreet
+    # in all England areas, but should not show for cobrands
+    if ( $bodies{'Environment Agency'} ) {
+        %$bodies = map { $_->id => $_ } grep { $_->name ne 'Environment Agency' } values %$bodies;
+    }
 }
 
 sub munge_report_new_contacts {

--- a/t/cobrand/bexley.t
+++ b/t/cobrand/bexley.t
@@ -32,6 +32,7 @@ FixMyStreet::override_config {
 
 my $mech = FixMyStreet::TestMech->new;
 
+
 my $body = $mech->create_body_ok(2494, 'London Borough of Bexley', {
     send_method => 'Open311', api_key => 'key', 'endpoint' => 'e', 'jurisdiction' => 'j' });
 $mech->create_contact_ok(body_id => $body->id, category => 'Abandoned and untaxed vehicles', email => "ConfirmABAN");
@@ -84,6 +85,16 @@ FixMyStreet::override_config {
     subtest 'cobrand displays council name' => sub {
         $mech->get_ok('/reports/Bexley');
         $mech->content_contains('Bexley');
+    };
+
+    subtest 'cobrand does not show Environment Agency categories' => sub {
+        my $bexley = $mech->create_body_ok(2494, 'London Borough of Bexley');
+        my $environment_agency = $mech->create_body_ok(2494, 'Environment Agency');
+        my $odour_contact = $mech->create_contact_ok(body_id => $environment_agency->id, category => 'Odour', email => 'ics@example.com');
+        my $tree_contact = $mech->create_contact_ok(body_id => $bexley->id, category => 'Trees', email => 'foo@bexley');
+        $mech->get_ok("/report/new/ajax?latitude=51.466707&longitude=0.181108");
+        $mech->content_contains('Trees');
+        $mech->content_lacks('Odour');
     };
 
     my $report;
@@ -330,5 +341,7 @@ EOF
     set_fixed_time('2019-12-25T12:00:00Z');
     is $cobrand->_is_out_of_hours(), 1, 'out of hours on bank holiday';
 };
+
+
 
 done_testing();

--- a/t/cobrand/fixmystreet.t
+++ b/t/cobrand/fixmystreet.t
@@ -208,4 +208,19 @@ FixMyStreet::override_config {
     };
 };
 
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => 'fixmystreet',
+    MAPIT_URL => 'http://mapit.uk/',
+}, sub {
+    subtest 'fixmystreet shows Environment Agency categories' => sub {
+        my $bexley = $mech->create_body_ok(2494, 'London Borough of Bexley');
+        my $environment_agency = $mech->create_body_ok(2494, 'Environment Agency');
+        my $odour_contact = $mech->create_contact_ok(body_id => $environment_agency->id, category => 'Odour', email => 'ics@example.com');
+        my $tree_contact = $mech->create_contact_ok(body_id => $bexley->id, category => 'Trees', email => 'foo@bexley');
+        $mech->get_ok("/report/new/ajax?latitude=51.466707&longitude=0.181108");
+        $mech->content_contains('Trees');
+        $mech->content_contains('Odour');
+    };
+};
+
 done_testing();


### PR DESCRIPTION
Add Environment Agency Odor category to FixMyStreet.com #2110

* Environment Agency would like odour issues in England to be emailed to them
* Model script on update_areas_covered
* Create Environment Agency body
* Add Odour category with dropdown and notes
* Add areas this applies to, to the new body