### PR TITLE
[Bexley] Show FixMyStreet report ID as Council ref

### DIFF
--- a/t/cobrand/bexley.t
+++ b/t/cobrand/bexley.t
@@ -255,6 +255,11 @@ FixMyStreet::override_config {
         $mech->get_ok('/report/new?longitude=0.15356&latitude=51.45556');
         $mech->content_contains('name="private_comments"');
     };
+
+    subtest 'reference number is shown' => sub {
+        $mech->get_ok('/report/' . $report->id);
+        $mech->content_contains('Council ref:&nbsp;' . $report->id);
+    };
 };
 
 subtest 'nearest road returns correct road' => sub {

--- a/templates/web/bexley/report/_council_sent_info.html
+++ b/templates/web/bexley/report/_council_sent_info.html
@@ -1,0 +1,17 @@
+[% SET duration_clause = problem.duration_string %]
+[% IF duration_clause || problem.whensent %]
+    <p class="council_sent_info">
+    [%- IF problem.whensent %]
+        [%- IF duration_clause %]
+            [%- external_ref_clause = tprintf(loc('Report ref:&nbsp;%s'), problem.id) %]
+        [%- ELSE %]
+            [%- external_ref_clause = tprintf(loc('%s ref:&nbsp;%s'), problem.external_body, problem.id) %]
+        [%- END %]
+    [%- END -%]
+    [% duration_clause %]
+    [%- IF external_ref_clause %]
+        [%- IF duration_clause %]. [% END %]
+        <strong>[% external_ref_clause %].</strong>
+    [%- END %]
+    </p>
+[% END %]


### PR DESCRIPTION
Bexley have requested that the FixMyStreet ID be visible on report pages. This adds the **Council ref** text along with the FMS ID for the report.

Fixes https://github.com/mysociety/societyworks/issues/2464

<!-- [skip changelog] -->

![image](https://user-images.githubusercontent.com/22996/126199720-5afe2fd4-49b8-4eb7-9d8d-1023d379cc03.png)
