### PR TITLE
Adds language-pack-sv and language-pack-de to install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
         - Include failure count in send report error output, #3316
         - Sort output in export script. #3323
         - Show relevant updates in alert-update email preview. #3417
+        - Add German and Swiss language packs to default
+        linux install #3544
         - Upgrade jQuery. #3017
     - Open311 improvements:
         - Consistent protected field ordering.

--- a/conf/packages.docker
+++ b/conf/packages.docker
@@ -15,3 +15,6 @@ libexpat1-dev
 libssl-dev
 zlib1g-dev
 libxml2-dev
+language-pack-sv
+language-pack-de
+

--- a/conf/packages.generic
+++ b/conf/packages.generic
@@ -16,3 +16,5 @@ libexpat1-dev
 libssl-dev
 zlib1g-dev
 libxml2-dev
+language-pack-sv
+language-pack-de


### PR DESCRIPTION
Swedish and German language packs should be part of install for tests to pass on linux #3544

This makes Swedish and German language packs part of the manual install for debian/ubuntu linux instructions.
