### PR TITLE
[Bromley] make sure duplicated report has a name

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -1688,7 +1688,7 @@ sub _duplicate_waste_report {
         detail => $report->detail,
         postcode => $report->postcode,
         used_map => $report->used_map,
-        name => $report->user->name,
+        name => $report->user->name || $report->name,
         areas => $report->areas,
         anonymous => $report->anonymous,
         state => 'confirmed',


### PR DESCRIPTION
It's possible for the user for a subscription not to have a name so fall
pack to the one on the report to avoid DB errors.

[skip changelog]