### PR TITLE
[Buckinghamshire] Add help text to time field

### DIFF
--- a/perllib/FixMyStreet/App/Form/Claims.pm
+++ b/perllib/FixMyStreet/App/Form/Claims.pm
@@ -339,6 +339,7 @@ has_field incident_time => (
     required => 1,
     type => 'Text',
     html5_type_attr => 'time',
+    tags => { hint => 'For example 06:30 PM or 18:30 depending on your settings' },
     label => 'What time did the incident happen?',
 );
 

--- a/web/cobrands/sass/_claims.scss
+++ b/web/cobrands/sass/_claims.scss
@@ -12,7 +12,7 @@ body.formflow {
     }
 
     input[type="time"].govuk-input {
-      max-width: 12ex;
+      max-width: 20ex;
     }
 
     input[type="text"].govuk-input, input[type="time"].govuk-input {


### PR DESCRIPTION
Add tooltip / label on IE 11 Red Claims Time Picker [0.5d] 

https://github.com/mysociety/societyworks/issues/2471

Ticket created from https://mysocietysupport.freshdesk.com/a/tickets/1280

Client tester says confused by form in IE11 requiring date in AM/PM format rather than 24 hour clock.

Seems this is a feature of the base HTML 5 time element - it honours the computers locale settings for how to enter time.
I have observed the AM/PM input on all browsers through browswerstack, so think it's not a browser issue.

But adding hint text seems to be a good all round solution.
