### PR TITLE
Add HTML::Selector::Element to test modules

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -175,6 +175,7 @@ recommends 'Mac::FSEvents' if $^O eq 'darwin';
 # Modules used by the test suite
 requires 'Test::PostgreSQL', '1.27';
 requires 'CGI::Simple';
+requires 'HTML::Selector::Element';
 requires 'HTTP::Headers';
 requires 'HTTP::Response';
 requires 'LWP::Protocol::PSGI';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -3542,6 +3542,19 @@ DISTRIBUTIONS
       perl 5.008
       strict 0
       warnings 0
+  HTML-Selector-Element-0.95
+    pathname: B/BA/BARTL/HTML-Selector-Element-0.95.tar.gz
+    provides:
+      HTML::Element 0.95
+      HTML::Selector::Element 0.95
+      HTML::Selector::Element::Trait 0.95
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      HTML::TreeBuilder 0
+      perl 5.008001
+      strict 0
   HTML-Selector-XPath-0.15
     pathname: C/CO/CORION/HTML-Selector-XPath-0.15.tar.gz
     provides:


### PR DESCRIPTION
HTML::Selector::Element makes tests less
brittle, easier to write and more idiomatic
by allowing content and values to be searched
for and specified via the Selectors API.

This allows us to avoid having to use whole
strings of HTML for comparison, which could
break if minor changes are made.

It also makes it much easier to find and check
values in specific areas of the page e.g. to
verify that a particular problem in a list is
showing the right value, when the wrong value
could also be present in another problem listing
also showing which would be caught by
$mech->content_contains().

POD: https://metacpan.org/pod/HTML::Selector::Element

relates to mysociety/societyworks#2455

Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
