### PR TITLE
[TfL] Add drain cover missing category to tfl red route list

### DIFF
--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -494,6 +494,7 @@ sub _tlrn_categories { [
     "Damage - general (Trees)",
     "Dead animal in the carriageway or footway",
     "Debris in the carriageway",
+    "Drain Cover - Missing or Damaged",
     "Fallen Tree",
     "Flooding",
     "Graffiti / Flyposting (non-offensive)",

--- a/web/cobrands/tfl/assets.js
+++ b/web/cobrands/tfl/assets.js
@@ -233,6 +233,7 @@ var tlrn_categories = [
     "Damage - general (Trees)",
     "Dead animal in the carriageway or footway",
     "Debris in the carriageway",
+    "Drain Cover - Missing or Damaged",
     "Fallen Tree",
     "Flooding",
     "Graffiti / Flyposting (non-offensive)",


### PR DESCRIPTION
[TFL] Add an extra category of "Drain Cover - Missing or Damaged" to tfl red route only list.

https://github.com/mysociety/societyworks/issues/2503

[skip changelog]