### PR TITLE
Fixes issue with not being able to order dropdowns in extra questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
         - Fix checked order of updates in dashboard export.
         - Fix unable to edit user with verified landline #3295
         - Fix 'sites' page to reflect active fixmystreet sites #2481
+        - Fix ordering of dropdown lists in extra questions #3566
     - Admin improvements:
         - Enable per-category hint customisation.
         - Move ban/unban buttons to user edit admin page.

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -507,10 +507,8 @@ sub fetch_body_areas : Private {
 
 sub update_extra_fields : Private {
     my ($self, $c, $object) = @_;
-
     my @indices = grep { /^metadata\[\d+\]\.code/ } keys %{ $c->req->params };
     @indices = sort map { /(\d+)/ } @indices;
-
     my @extra_fields;
     foreach my $i (@indices) {
         my $meta = {};
@@ -532,7 +530,7 @@ sub update_extra_fields : Private {
                 $meta->{values} = [];
                 my $re = qr{^metadata\[$i\]\.values\[\d+\]\.key};
                 my @vindices = grep { /$re/ } keys %{ $c->req->params };
-                @vindices = sort map { /values\[(\d+)\]/ } @vindices;
+                @vindices = sort { $a <=> $b } map { /values\[(\d+)\]/ } @vindices;
                 foreach my $j (@vindices) {
                     my $name = $c->get_param("metadata[$i].values[$j].name");
                     my $key = $c->get_param("metadata[$i].values[$j].key");

--- a/t/app/controller/admin/reportextrafields.t
+++ b/t/app/controller/admin/reportextrafields.t
@@ -137,6 +137,42 @@ FixMyStreet::override_config {
         $contact->discard_changes;
         is_deeply $contact->get_extra_fields, $contact_extra_fields, 'new field was added';
 
+        $mech->get_ok("/admin/body/" . $body->id . "/" . $contact->category);
+        $mech->submit_form_ok( { with_fields => {
+            "metadata[9999].order" => "4",
+            "metadata[9999].code" => "list_test_order",
+            "metadata[9999].behaviour" => "question",
+            "metadata[9999].disable_form" => "1",
+            "metadata[9999].description" => "this field is a list with multiple options",
+            "metadata[9999].datatype" => "singlevaluelist",
+            "note" => "Added list field",
+        }});
+        $mech->content_contains('Values updated');
+
+        push @$contact_extra_fields, {
+            order => "4",
+            code => "list_test_order",
+            required => "false",
+            variable => "true",
+            protected => "false",
+            description => "this field is a list with multiple options",
+            datatype => "singlevaluelist",
+            values => [],
+        };
+
+        for my $num (1..11) {
+            $mech->get_ok("/admin/body/" . $body->id . "/" . $contact->category);
+            $mech->submit_form_ok( { with_fields => {
+                "metadata[3].values[8888].key" => "key" . $num,
+                "metadata[3].values[8888].name" => "name" . $num,
+            } } );
+            $mech->content_contains('Values updated');
+            push @{ $contact_extra_fields->[3]{values} }, { name => 'name' . $num, key => 'key' . $num };
+        };
+
+        $contact->discard_changes;
+        is_deeply $contact->get_extra_fields, $contact_extra_fields, 'multiple fields were added and retain order';
+
         $contact->set_extra_fields();
         $contact->update;
     };


### PR DESCRIPTION
Ordering of dropdown list options is now sorted numerically on the index position. This means the order will be that expected by the user when creating the options.

https://github.com/mysociety/societyworks/issues/2511


