### PR TITLE
[Bromley] Private comments for reports

### DIFF
--- a/templates/web/base/report/new/form_report.html
+++ b/templates/web/base/report/new/form_report.html
@@ -93,6 +93,8 @@
 
     [% TRY %][% PROCESS 'report/new/inline-tips.html' %][% CATCH file %][% END %]
 
+    [% TRY %][% PROCESS 'report/new/after_detail.html' %][% CATCH file %][% END %]
+
     <div class="js-reporting-page--single-hidden">
         [% PROCESS report/form/user.html type='report' %]
     </div>

--- a/templates/web/bromley/report/new/after_detail.html
+++ b/templates/web/bromley/report/new/after_detail.html
@@ -1,0 +1,12 @@
+<!-- after_detail.html -->
+
+[% can_contribute_as_body = c.user.from_body AND c.user.has_permission_to("contribute_as_body", bodies_ids) %]
+
+[% IF can_contribute_as_body %]
+<p>
+  <label for="form_private_comments">Private comments</label>
+  <textarea class="form-control" id="form_private_comments" name="private_comments"></textarea>
+</p>
+[% END %]
+
+<!-- /after_detail.html -->


### PR DESCRIPTION
Adds private comments field to the report form for people with the `can_contribute_as_body` permission. This is then sent over open311 in the description field.

Bromley also want this field adding to updates, but I'm going to do that as a separate change.

Part of https://github.com/mysociety/societyworks/issues/2293

<!-- [skip changelog] -->
