### PR TITLE
WIP on 2462-limit-bin-request

### DIFF
--- a/perllib/Integrations/Echo.pm
+++ b/perllib/Integrations/Echo.pm
@@ -6,6 +6,7 @@ with 'FixMyStreet::Roles::SOAPIntegration';
 use DateTime;
 use Tie::IxHash;
 use FixMyStreet;
+use Data::Dumper;
 
 has attr => ( is => 'ro', default => 'http://www.twistedfish.com/xmlns/echo/api/v1' );
 has action => ( is => 'lazy', default => sub { $_[0]->attr . "/Service/" } );
@@ -75,7 +76,6 @@ sub call {
 # corresponding tasks.
 sub GetTasks {
     my $self = shift;
-
     my @refs;
     foreach my $ref (@_) {
         my $a = ixhash(
@@ -88,7 +88,6 @@ sub GetTasks {
         );
         push @refs, $a;
     }
-
     if ($self->sample_data) {
         my %lookup = map { $_->[0] . ',' . $_->[1] => 1 } @_;
         my $data = [];
@@ -420,7 +419,7 @@ sub GetEventsForObject {
             ] },
             ServiceId => 535,
             ResolutionCodeId => 584,
-        } ] if $type eq 'PointAddress';
+        } ] if ($type eq 'PointAddress');
         return [ {
             # Missed collection for service 537 (paper)
             EventTypeId => 2099,

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -129,11 +129,17 @@ FixMyStreet::override_config {
         $mech->content_contains('A food waste collection has been reported as missed');
         $mech->content_contains('A paper &amp; cardboard collection has been reported as missed'); # as part of service unit, not property
     };
-    subtest 'Report a missed bin' => sub {
-        $mech->content_contains('service-531', 'Can report, last collection was 27th');
+    subtest 'Cannot report situations' => sub {
+        $mech->content_lacks('service-531', 'Cannot report, last collection was 27th but has a completed report since last collection');
         $mech->content_lacks('service-537', 'Cannot report, last collection was 27th but the service unit has a report');
         $mech->content_lacks('service-535', 'Cannot report, last collection was 20th');
         $mech->content_lacks('service-542', 'Cannot report, last collection was 18th');
+    };
+    subtest 'Report a missed bin' => sub {
+        my $echo = Test::MockModule->new('Integrations::Echo');
+        $echo->mock('GetEventsForObjects', sub { return []});
+        set_fixed_time('2020-05-28T17:00:00Z');
+        $mech->get_ok('/waste/15345');
         $mech->follow_link_ok({ text => 'Report a missed collection' });
         $mech->content_contains('service-531', 'Checkbox, last collection was 27th');
         $mech->content_lacks('service-537', 'No checkbox, last collection was 27th but the service unit has a report');


### PR DESCRIPTION
The idea is to limit users from repeating a report of a missed bin within a bin cycle - so if they've reported it missed, they have to wait until next cycle to report another missed bin.

When testing in `bromley.t` I've mocked out `getEventsForObjects` to return an empty array which allows me to test that the 'report within two days' feature is working despite the mock data coming from `Echo.pm` reporting as completed.

I'm trying to repeat this on `waste.t`, but finding that the report of completed still exists so I don't seem to be influencing it. I'm pretty sure I'm making a dumb error that I can't see or understand. Thought I had it after `bromley.t` but seems I'm not understanding after all.
