### PR TITLE
[Zurich] Fix bug with lastupdate not appearing in CSV

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -1295,7 +1295,7 @@ sub export_as_csv {
             'Interne meldung',
         ],
         csv_columns => [
-            'id', 'created', 'whensent',' lastupdate', 'local_coords_x',
+            'id', 'created', 'whensent', 'lastupdate', 'local_coords_x',
             'local_coords_y', 'category', 'state', 'closure_status',
             'user_id', 'user_email', 'user_phone', 'user_name',
             'body_name', 'sum_time_spent', 'title', 'detail',

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -1080,6 +1080,14 @@ subtest 'A visit to /reports is okay' => sub {
     $mech->content_contains('<option value="Cat1">');
 };
 
+subtest 'CSV export includes lastupdate for problem' => sub {
+    $mech->get_ok( '/admin/stats?export=1' );
+    is $mech->res->code, 200, 'csv retrieved ok';
+    my @rows = $mech->content_as_csv;
+    is $rows[0]->[3], 'Last Updated', "Last Updated field has correct column heading";
+    isnt $rows[1]->[3], '', "Last Updated field isn't blank";
+};
+
 };
 
 done_testing();


### PR DESCRIPTION
The lastupdate column wasn't being populated in the CSV. After some investigation Matthew noticed that there was an errant space in the field name, which meant that column wasn't being populated.

This change removes that space and adds a test to check that this column is correctly populated.

Fixes https://github.com/mysociety/societyworks/issues/2550

<!-- [skip changelog] -->
