### PR TITLE
[Bromley] Update DD lead time text after garden waste subscription

### DIFF
--- a/templates/email/default/waste/direct_debit_in_progress.html
+++ b/templates/email/default/waste/direct_debit_in_progress.html
@@ -13,8 +13,11 @@ INCLUDE '_email_top.html';
   <h1 style="[% h1_style %]">Your report has been&nbsp;logged</h1>
   <p style="[% p_style %]">Your application for a Direct Debit waste subscription for [% report.body %] has been logged on [% site_name %].</p>
 
+[% IF c.cobrand.moniker == 'bromley' %]
+  <p style="[% p_style %]">The Direct Debit will take up to 10 working days to process and the payment a further 5 working days to be receipted by the London Borough of Bromley.</p>
+[% ELSE %]
   <p style="[% p_style %]">It will take up to 10 working days to process this.</p>
-
+[% END %]
 
 [% TRY %][% INCLUDE '_council_reference.html' problem=report %][% CATCH file %][% END %]
 

--- a/templates/email/default/waste/direct_debit_in_progress.txt
+++ b/templates/email/default/waste/direct_debit_in_progress.txt
@@ -7,7 +7,13 @@ has been logged on [% site_name %].
 
 [% TRY %][% INCLUDE '_council_reference.txt' problem=report %][% CATCH file %][% END %]
 
+[% IF c.cobrand.moniker == 'bromley' %]
+The Direct Debit will take up to 10 working days to process
+and the payment a further 5 working days to be receipted by
+the London Borough of Bromley.
+[% ELSE %]
 It will take up to 10 working days to process this.
+[% END %]
 
 This email was sent automatically, from an unmonitored email account - so
 please do not reply to it.


### PR DESCRIPTION
Updated text in direct_debit_in_progress email templates to match true lead times. 

For https://mysocietysupport.freshdesk.com/a/tickets/1401

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
[skip changelog]
