### PR TITLE
[Bromley] email amendments

### DIFF
--- a/templates/email/bromley/_council_reference_alert_update.html
+++ b/templates/email/bromley/_council_reference_alert_update.html
@@ -1,0 +1,4 @@
+[% IF problem.cobrand_data == 'waste' %]
+    [% SET property_id = problem.get_extra_field_value('property_id') %]
+<a href="https://recyclingservices.bromley.gov.uk/waste[% IF property_id %]/[% property_id %][% END %]">Check your bin collections day</a>
+[% END %]

--- a/templates/email/bromley/_council_reference_alert_update.txt
+++ b/templates/email/bromley/_council_reference_alert_update.txt
@@ -1,0 +1,4 @@
+[% IF problem.cobrand_data == 'waste' %]
+    [% SET property_id = problem.get_extra_field_value('property_id') %]
+Check your bin collections day: https://recyclingservices.bromley.gov.uk/waste[% IF property_id %]/[% property_id %][% END %]
+[% END %]


### PR DESCRIPTION
Adds bin days link with optional personalisation to new garden waste subscription email
for https://mysocietysupport.freshdesk.com/a/tickets/1410

[skip changelog]
