### PR TITLE
[Bromley] Private comments for updates

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/Update.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/Update.pm
@@ -353,6 +353,11 @@ sub process_update : Private {
         $update->extra( $extra );
     }
 
+    my $private_comments = $c->get_param('private_comments');
+    if ( $private_comments ) {
+        $update->set_extra_metadata(private_comments => $private_comments);
+    }
+
     $c->stash->{add_alert} = $c->get_param('add_alert');
 
     return 1;

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -303,7 +303,22 @@ sub _include_user_title_in_extra {
 
 sub open311_pre_send_updates {
     my ($self, $row) = @_;
+
+    $self->{bromley_original_update_text} = $row->text;
+
+    my $private_comments = $row->get_extra_metadata('private_comments');
+    if ($private_comments) {
+        my $text = $row->text . "\n\nPrivate comments: $private_comments";
+        $row->text($text);
+    }
+
     return $self->_include_user_title_in_extra($row);
+}
+
+sub open311_post_send_updates {
+    my ($self, $row) = @_;
+
+    $row->text($self->{bromley_original_update_text});
 }
 
 sub open311_munge_update_params {
@@ -369,7 +384,10 @@ sub open311_contact_meta_override {
 
 sub should_skip_sending_update {
     my ($self, $update) = @_;
-    return $update->user->from_body && !$update->text;
+
+    my $private_comments = $update->get_extra_metadata('private_comments');
+
+    return $update->user->from_body && !$update->text && !$private_comments;
 }
 
 # If any subcategories ticked in user edit admin, make sure they're saved.

--- a/perllib/Open311/PostServiceRequestUpdates.pm
+++ b/perllib/Open311/PostServiceRequestUpdates.pm
@@ -130,6 +130,8 @@ sub process_update {
 
     my $id = $o->post_service_request_update( $comment );
 
+    $cobrand->call_hook(open311_post_send_updates => $comment);
+
     if ( $id ) {
         $comment->update( {
             external_id => $id,

--- a/templates/web/base/report/update/form_update.html
+++ b/templates/web/base/report/update/form_update.html
@@ -14,6 +14,8 @@
 [% END %]
 <textarea rows="7" cols="30" name="update" class="form-control" id="form_update" required>[% update.text | html %]</textarea>
 
+[% TRY %][% PROCESS 'report/update/after_update.html' %][% CATCH file %][% END %]
+
 [% IF relevant_staff_user %]
     <label for="state">[% loc( 'State' ) %]</label>
     [% INCLUDE 'report/inspect/state_groups_select.html' %]

--- a/templates/web/bromley/report/update/after_update.html
+++ b/templates/web/bromley/report/update/after_update.html
@@ -1,0 +1,12 @@
+<!-- after_update.html -->
+
+[% can_contribute_as_body = c.user.from_body AND permissions.contribute_as_body %]
+
+[% IF can_contribute_as_body %]
+<p>
+  <label for="form_private_comments">Private comments</label>
+  <textarea class="form-control" id="form_private_comments" name="private_comments"></textarea>
+</p>
+[% END %]
+
+<!-- /after_update.html -->


### PR DESCRIPTION
Adds a private comments box for updates and sends those comments over open311 to Bromley's backend.

Fixes https://github.com/mysociety/societyworks/issues/2293

![image](https://user-images.githubusercontent.com/22996/133054430-08f1083d-7117-45f1-b9f9-230e62a5b7d8.png)

<!-- [skip changelog] -->