### PR TITLE
[Open311] Move test handling out of core code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
         - Upgrade jQuery. #3017
     - Open311 improvements:
         - Consistent protected field ordering.
+        - Move test handling out of core code.
     - Security:
         - Increase minimum password length to eight.
     - Changes

--- a/perllib/FixMyStreet/Queue/Item/Report.pm
+++ b/perllib/FixMyStreet/Queue/Item/Report.pm
@@ -232,8 +232,6 @@ sub _send {
                     }
                 }
             }
-            $self->manager->test_data->{test_req_used} = $sender->open311_test_req_used
-                if FixMyStreet->test_mode && $sender->can('open311_test_req_used');
         }
     }
 

--- a/perllib/FixMyStreet/Script/Reports.pm
+++ b/perllib/FixMyStreet/Script/Reports.pm
@@ -9,7 +9,6 @@ use FixMyStreet::Queue::Item::Report;
 has verbose => ( is => 'ro' );
 
 has unconfirmed_data => ( is => 'ro', default => sub { {} } );
-has test_data => ( is => 'ro', default => sub { {} } );
 
 # Static method, used by send-reports cron script and tests.
 # Creates a manager object from provided data and processes it.
@@ -44,8 +43,6 @@ sub send {
         $manager->end_line($unsent_count);
         $manager->end_summary_unconfirmed;
     });
-
-    return $manager->test_data;
 }
 
 sub construct_query {

--- a/perllib/FixMyStreet/Test.pm
+++ b/perllib/FixMyStreet/Test.pm
@@ -30,4 +30,46 @@ END {
     $db->txn_rollback if $db;
 }
 
+BEGIN {
+    # The following block patches Open311, so that any sent requests store the
+    # request and return either an injected response or a default response (for
+    # a posted report). Injected responses are only used once, and the stored
+    # request is removed after being read.
+
+    use Open311;
+    my $test_req_used;
+    my %injected;
+
+    my $default_response = HTTP::Response->new();
+    $default_response->code(200);
+    $default_response->content('<?xml version="1.0" encoding="utf-8"?><service_requests><request><service_request_id>248</service_request_id></request></service_requests>');
+
+    package Open311;
+    use Class::Method::Modifiers;
+
+    around _make_request => sub {
+        my ($orig, $self) = (shift, shift);
+        my ($req) = @_;
+        $test_req_used = $req;
+        my $path = $req->uri->path;
+        my $ret = $injected{$path} || $default_response;
+        delete $injected{$path};
+        return $ret;
+    };
+
+    sub test_req_used {
+        my $ret = $test_req_used;
+        $test_req_used = undef;
+        return $ret;
+    }
+
+    sub _inject_response {
+        my ($self, $path, $content, $code) = @_;
+        my $test_res = HTTP::Response->new();
+        $test_res->code($code || 200);
+        $test_res->content($content);
+        $injected{$path} = $test_res;
+    }
+}
+
 1;

--- a/t/app/controller/claims.t
+++ b/t/app/controller/claims.t
@@ -158,13 +158,13 @@ Age and Mileage of the tyre(s) at the time of the incident: 20
 EOF
         is $report->detail, $expected_detail;
         is $report->latitude, 51.81386;
-        my $test_data = FixMyStreet::Script::Reports::send();
+        FixMyStreet::Script::Reports::send();
         my @email = $mech->get_email;
         is $email[0]->header('To'), 'TfB <claims@example.net>';
         is $email[0]->header('Subject'), "New claim - vehicle - Test McTest - $report_id - Rain Road, Aylesbury";
         like $email[1]->header('To'), qr/madeareport\@/;
         is $email[1]->header('Subject'), "Your claim has been submitted, ref $report_id";
-        my $req = $test_data->{test_req_used};
+        my $req = Open311->test_req_used;
         is $req, undef, 'Nothing sent by Open311';
         is $report->user->alerts->count, 1, 'User has an alert for this report';
         is $report->user->alerts->first->alerts_sent->count, 1, 'But has been sent in the logged email';
@@ -212,7 +212,7 @@ EOF
         $mech->content_contains('is a lengthy process');
         my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
         is $report->comments->count, 0, 'No updates added to report';
-        my $test_data = FixMyStreet::Script::Reports::send();
+        FixMyStreet::Script::Reports::send();
         $report->discard_changes;
         is $report->comments->count, 1, 'updates added to report post send';
         my @email = $mech->get_email;
@@ -223,7 +223,7 @@ EOF
         is $email[1]->header('Subject'), "Your claim has been submitted, ref 248";
         like $text, qr/reference number is 248/;
         like $text, qr/is a lengthy process/;
-        my $req = $test_data->{test_req_used};
+        my $req = Open311->test_req_used;
         my $c = CGI::Simple->new($req->content);
         is $c->param('service_code'), 'CLAIM';
         is $c->param('attribute[title]'), 'east';

--- a/t/app/controller/contact_enquiry.t
+++ b/t/app/controller/contact_enquiry.t
@@ -249,8 +249,8 @@ FixMyStreet::override_config {
     subtest 'Check Open311 sending of the above report' => sub {
         my $module = Test::MockModule->new('FixMyStreet::Cobrand::UKCouncils');
         $module->mock(get => sub ($) { '{}' });
-        my $test_data = FixMyStreet::Script::Reports::send();
-        my $req = $test_data->{test_req_used};
+        FixMyStreet::Script::Reports::send();
+        my $req = Open311->test_req_used;
         my $found = 0;
         foreach ($req->parts) {
             my $cd = $_->header('Content-Disposition');

--- a/t/app/model/problem.t
+++ b/t/app/model/problem.t
@@ -179,7 +179,7 @@ for my $test (
         $problem->update;
         my $w3c = DateTime::Format::W3CDTF->new();
 
-        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1 );
+        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
         my $updates = Open311::GetUpdates->new(
             current_open311 => $o,
             current_body => $body,

--- a/t/cobrand/bexley.t
+++ b/t/cobrand/bexley.t
@@ -137,8 +137,8 @@ FixMyStreet::override_config {
         }
 
         subtest 'NSGRef and correct email config' => sub {
-            my $test_data = FixMyStreet::Script::Reports::send();
-            my $req = $test_data->{test_req_used};
+            FixMyStreet::Script::Reports::send();
+            my $req = Open311->test_req_used;
             my $c = CGI::Simple->new($req->content);
             is $c->param('service_code'), $test->{code};
             if ($test->{code} =~ /Confirm/) {
@@ -180,18 +180,19 @@ FixMyStreet::override_config {
     subtest "resending of reports by changing category" => sub {
         $mech->get_ok('/admin/report_edit/' . $report->id);
         $mech->submit_form_ok({ with_fields => { category => 'Damaged road' } });
-        my $test_data = FixMyStreet::Script::Reports::send();
-        my $req = $test_data->{test_req_used};
+        FixMyStreet::Script::Reports::send();
+        my $req = Open311->test_req_used;
         my $c = CGI::Simple->new($req->content);
         is $c->param('service_code'), 'ROAD', 'Report resent in new category';
 
         $mech->submit_form_ok({ with_fields => { category => 'Gulley covers' } });
-        $test_data = FixMyStreet::Script::Reports::send();
-        is_deeply $test_data, {}, 'Report not resent';
+        FixMyStreet::Script::Reports::send();
+        $req = Open311->test_req_used;
+        is_deeply $req, undef, 'Report not resent';
 
         $mech->submit_form_ok({ with_fields => { category => 'Lamp post' } });
-        $test_data = FixMyStreet::Script::Reports::send();
-        $req = $test_data->{test_req_used};
+        FixMyStreet::Script::Reports::send();
+        $req = Open311->test_req_used;
         $c = CGI::Simple->new($req->content);
         is $c->param('service_code'), 'StreetLightingLAMP', 'Report resent';
     };
@@ -211,13 +212,13 @@ FixMyStreet::override_config {
         });
         my $report = $reports[0];
 
-        my $test_data = FixMyStreet::Script::Reports::send();
+        FixMyStreet::Script::Reports::send();
         $report->discard_changes;
         ok $report->whensent, 'Report marked as sent';
         is $report->send_method_used, 'Open311', 'Report sent via Open311';
         is $report->external_id, 248, 'Report has right external ID';
 
-        my $req = $test_data->{test_req_used};
+        my $req = Open311->test_req_used;
         my $c = CGI::Simple->new($req->content);
         is $c->param('attribute[title]'), 'Test Test 1 for ' . $body->id, 'Request had correct title';
         is_deeply [ $c->param('media_url') ], [

--- a/t/cobrand/bristol.t
+++ b/t/cobrand/bristol.t
@@ -91,9 +91,8 @@ subtest 'check services override' => sub {
     my $o = Open311->new(
         jurisdiction => 'mysociety',
         endpoint => 'http://example.com',
-        test_mode => 1,
-        test_get_returns => { 'services/LIGHT.xml' => $meta_xml }
     );
+    Open311->_inject_response('/services/LIGHT.xml', $meta_xml);
 
     $processor->_current_open311( $o );
     FixMyStreet::override_config {

--- a/t/cobrand/centralbedfordshire.t
+++ b/t/cobrand/centralbedfordshire.t
@@ -73,8 +73,8 @@ FixMyStreet::override_config {
     subtest 'Correct area_code and NSGRef parameters for Open311' => sub {
         $report->set_extra_fields({ name => 'UnitID', value => 'Asset 123' });
         $report->update;
-        my $test_data = FixMyStreet::Script::Reports::send();
-        my $req = $test_data->{test_req_used};
+        FixMyStreet::Script::Reports::send();
+        my $req = Open311->test_req_used;
         my $c = CGI::Simple->new($req->content);
         is $c->param('service_code'), 'BRIDGES';
         is $c->param('attribute[area_code]'), 'Area1';
@@ -116,8 +116,8 @@ FixMyStreet::override_config {
             latitude => 52.030695, longitude => -0.357033, areas => ',117960,11804,135257,148868,21070,37488,44682,59795,65718,83582,',
         });
 
-        my $test_data = FixMyStreet::Script::Reports::send();
-        my $req = $test_data->{test_req_used};
+        FixMyStreet::Script::Reports::send();
+        my $req = Open311->test_req_used;
         my $c = CGI::Simple->new($req->content);
         is $c->param('service_code'), 'POTHOLES';
 

--- a/t/cobrand/cheshireeast.t
+++ b/t/cobrand/cheshireeast.t
@@ -96,14 +96,14 @@ FixMyStreet::override_config {
         $report->geocode($data);
         $report->update;
 
-        my $test_data = FixMyStreet::Script::Reports::send();
+        FixMyStreet::Script::Reports::send();
         $report->discard_changes;
         ok $report->whensent, 'Report marked as sent';
         is $report->send_method_used, 'Open311', 'Report sent via Open311';
         is $report->external_id, 248, 'Report has right external ID';
         is $report->detail, 'Test Test 1 for ' . $body->id . ' Detail', 'Report detail is unchanged';
 
-        my $req = $test_data->{test_req_used};
+        my $req = Open311->test_req_used;
         my $c = CGI::Simple->new($req->content);
         is $c->param('attribute[title]'), 'Test Test 1 for ' . $body->id, 'Request had correct title';
         my $expected_desc = 'Test Test 1 for ' . $body->id . " Detail\n\n(this report was made by <" . $staff_user->email . "> (" . $staff_user->name .") on behalf of the user)";

--- a/t/cobrand/eastsussex.t
+++ b/t/cobrand/eastsussex.t
@@ -17,13 +17,12 @@ $p->update;
 
 subtest 'Check special Open311 request handling', sub {
     my $orig_detail = $p->detail;
-    my $test_data;
     FixMyStreet::override_config {
         STAGING_FLAGS => { send_reports => 1 },
         ALLOWED_COBRANDS => 'eastsussex',
         BASE_URL => 'https://www.fixmystreet.com',
     }, sub {
-        $test_data = FixMyStreet::Script::Reports::send();
+        FixMyStreet::Script::Reports::send();
     };
 
     $p->discard_changes;
@@ -32,7 +31,7 @@ subtest 'Check special Open311 request handling', sub {
     is $p->external_id, 248, 'Report has right external ID';
     is $p->detail, $orig_detail, 'Detail in database not changed';
 
-    my $req = $test_data->{test_req_used};
+    my $req = Open311->test_req_used;
     my $c = CGI::Simple->new($req->content);
     my $expected = join "\r\n", $p->title, '', $p->detail, '',
         'Is it urgent?', 'no', '', "https://www.fixmystreet.com" . $p->url, '';

--- a/t/cobrand/hackney.t
+++ b/t/cobrand/hackney.t
@@ -324,8 +324,8 @@ FixMyStreet::override_config {
                 my ($self, $cfg, $x, $y) = @_;
                 return []; # Not in park or estate
             });
-            my $test_data = FixMyStreet::Script::Reports::send();
-            my $req = $test_data->{test_req_used};
+            FixMyStreet::Script::Reports::send();
+            my $req = Open311->test_req_used;
             my $c = CGI::Simple->new($req->content);
             is $c->param('service_code'), 'OTHER';
         };

--- a/t/cobrand/loading.t
+++ b/t/cobrand/loading.t
@@ -95,14 +95,14 @@ FixMyStreet::override_config {
 };
 
 # check that the moniker works as expected both on class and object.
-is FixMyStreet::Cobrand::FiksGataMi->moniker, 'fiksgatami',
-  'class->moniker works';
-is FixMyStreet::Cobrand::FiksGataMi->new->moniker, 'fiksgatami',
-  'object->moniker works';
+is(FixMyStreet::Cobrand::FiksGataMi->moniker, 'fiksgatami',
+  'class->moniker works');
+is(FixMyStreet::Cobrand::FiksGataMi->new->moniker, 'fiksgatami',
+  'object->moniker works');
 
 # check is_default works
-ok FixMyStreet::Cobrand::Default->is_default,     '::Default is default';
-ok !FixMyStreet::Cobrand::FiksGataMi->is_default, '::FiksGataMi is not default';
+ok(FixMyStreet::Cobrand::Default->is_default,     '::Default is default');
+ok(!FixMyStreet::Cobrand::FiksGataMi->is_default, '::FiksGataMi is not default');
 
 # all done
 done_testing();

--- a/t/cobrand/oxfordshire.t
+++ b/t/cobrand/oxfordshire.t
@@ -270,7 +270,7 @@ FixMyStreet::override_config {
             $p->set_extra_fields({ name => $test->{field}, value => $test->{value}});
             $p->update;
 
-            my $test_data = FixMyStreet::Script::Reports::send();
+            FixMyStreet::Script::Reports::send();
 
             $p->discard_changes;
             ok $p->whensent, 'Report marked as sent';
@@ -278,7 +278,7 @@ FixMyStreet::override_config {
             is $p->external_id, 248, 'Report has right external ID';
             unlike $p->detail, qr/$test->{text}:/, $test->{text} . ' not saved to report detail';
 
-            my $req = $test_data->{test_req_used};
+            my $req = Open311->test_req_used;
             my $c = CGI::Simple->new($req->content);
             like $c->param('description'), qr/$test->{text}: $test->{value}/, $test->{text} . ' included in body';
         };
@@ -306,16 +306,12 @@ FixMyStreet::override_config {
                 properties => { TYPE1_2_USRN => 13579 },
             } ];
         });
-        my $test_res = HTTP::Response->new();
-        $test_res->code(200);
-        $test_res->message('OK');
-        $test_res->content('<?xml version="1.0" encoding="utf-8"?><service_request_updates><request_update><update_id>248</update_id></request_update></service_request_updates>');
+        my $test_res = '<?xml version="1.0" encoding="utf-8"?><service_request_updates><request_update><update_id>248</update_id></request_update></service_request_updates>';
 
         my $o = Open311->new(
             fixmystreet_body => $oxon,
-            test_mode => 1,
-            test_get_returns => { 'servicerequestupdates.xml' => $test_res },
         );
+        Open311->_inject_response('/servicerequestupdates.xml', $test_res);
 
         $o->post_service_request_update($comment);
         my $cgi = CGI::Simple->new($o->test_req_used->content);

--- a/t/cobrand/warwickshire.t
+++ b/t/cobrand/warwickshire.t
@@ -54,9 +54,8 @@ subtest 'check Warwickshire override' => sub {
     my $o = Open311->new(
         jurisdiction => 'mysociety',
         endpoint => 'http://example.com',
-        test_mode => 1,
-        test_get_returns => { 'services/100.xml' => $meta_xml }
     );
+    Open311->_inject_response('/services/100.xml', $meta_xml);
 
     $processor->_current_open311( $o );
     FixMyStreet::override_config {

--- a/t/cobrand/westminster.t
+++ b/t/cobrand/westminster.t
@@ -180,8 +180,8 @@ FixMyStreet::override_config {
     COBRAND_FEATURES => { anonymous_account => { westminster => 'anon' } },
 }, sub {
     subtest 'USRN set correctly' => sub {
-        my $test_data = FixMyStreet::Script::Reports::send();
-        my $req = $test_data->{test_req_used};
+        FixMyStreet::Script::Reports::send();
+        my $req = Open311->test_req_used;
         my $c = CGI::Simple->new($req->content);
         is $c->param('service_code'), 'BIKE';
         is $c->param('attribute[USRN]'), 'My USRN';

--- a/t/open311.t
+++ b/t/open311.t
@@ -42,6 +42,7 @@ for my $sfc (0..2) {
     } );
     my $expected_error = qr{Failed to submit problem 1 over Open311}ism;
 
+    Open311->_inject_response('/open311/requests.xml', 'Failure', 400);
     if ($sfc == 1) {
         warning_like {$o2->send_service_request( $p, { url => 'http://example.com/' }, 1 )} $expected_error, 'warning generated on failed call';
     } else {
@@ -921,18 +922,12 @@ sub _make_req {
     my %open311_conf = %{ $args->{open311_conf} || {} };
     my @args         = @{ $args->{method_args} || [] };
 
-    $open311_conf{'test_mode'} = 1;
     $open311_conf{'end_point'} = 'http://localhost/o311';
     $open311_conf{fixmystreet_body} = $bromley;
     my $o =
       Open311->new( %open311_conf );
 
-    my $test_res = HTTP::Response->new();
-    $test_res->code(200);
-    $test_res->message('OK');
-    $test_res->content($xml);
-
-    $o->test_get_returns( { $path => $test_res } );
+    Open311->_inject_response($path, $xml);
 
     my $res = $o->$method($object, @args);
 

--- a/t/open311/getservicerequests.t
+++ b/t/open311/getservicerequests.t
@@ -74,9 +74,8 @@ my $requests_xml = qq{<?xml version="1.0" encoding="utf-8"?>
 my $o = Open311->new(
     jurisdiction => 'mysociety',
     endpoint => 'http://example.com',
-    test_mode => 1,
-    test_get_returns => { 'requests.xml' => $requests_xml }
 );
+Open311->_inject_response('/requests.xml', $requests_xml);
 
 my $p1_date = $dtf->parse_datetime('2010-04-14T06:37:38-08:00')
                 ->set_time_zone(FixMyStreet->local_time_zone);
@@ -178,9 +177,8 @@ for my $test (
         my $o = Open311->new(
             jurisdiction => 'mysociety',
             endpoint => 'http://example.com',
-            test_mode => 1,
-            test_get_returns => { 'requests.xml' => $xml}
         );
+        Open311->_inject_response('/requests.xml', $xml);
 
         my $count = FixMyStreet::DB->resultset('Problem')->count;
         my $update = Open311::GetServiceRequests->new( system_user => $user );
@@ -234,9 +232,8 @@ for my $test (
         my $o = Open311->new(
             jurisdiction => 'mysociety',
             endpoint => 'http://example.com',
-            test_mode => 1,
-            test_get_returns => { 'requests.xml' => $xml}
         );
+        Open311->_inject_response('/requests.xml', $xml);
 
         my $update = Open311::GetServiceRequests->new(
             start_date => $test->{start_date},
@@ -276,11 +273,10 @@ subtest 'check fetch_all body setting ignores date errors' => sub {
     $update = Test::MockObject::Extends->new($update);
 
     $update->mock('create_open311_object', sub {
+        Open311->_inject_response('/requests.xml', $xml);
         return Open311->new(
             jurisdiction => 'mysociety',
             endpoint => 'http://example.com',
-            test_mode => 1,
-            test_get_returns => { 'requests.xml' => $xml}
         );
     } );
 
@@ -308,9 +304,8 @@ for my $test (
         my $o = Open311->new(
             jurisdiction => 'mysociety',
             endpoint => 'http://example.com',
-            test_mode => 1,
-            test_get_returns => { 'requests.xml' => $xml}
         );
+        Open311->_inject_response('/requests.xml', $xml);
 
         my $update = Open311::GetServiceRequests->new(
             system_user => $user,
@@ -403,9 +398,8 @@ for my $test (
         my $o = Open311->new(
             jurisdiction => 'mysociety',
             endpoint => 'http://example.com',
-            test_mode => 1,
-            test_get_returns => { 'requests.xml' => $xml}
         );
+        Open311->_inject_response('/requests.xml', $xml);
 
         my $update = Open311::GetServiceRequests->new(
             system_user => $user,
@@ -469,9 +463,8 @@ for my $test (
         my $o = Open311->new(
             jurisdiction => 'mysociety',
             endpoint => 'http://example.com',
-            test_mode => 1,
-            test_get_returns => { 'requests.xml' => $xml}
         );
+        Open311->_inject_response('/requests.xml', $xml);
 
         my $update = Open311::GetServiceRequests->new(
             system_user => $user,
@@ -504,9 +497,8 @@ subtest "non_public contacts result in non_public reports" => sub {
     my $o = Open311->new(
         jurisdiction => 'mysociety',
         endpoint => 'http://example.com',
-        test_mode => 1,
-        test_get_returns => { 'requests.xml' => prepare_xml( {} ) }
     );
+    Open311->_inject_response('/requests.xml', prepare_xml({}));
 
     my $update = Open311::GetServiceRequests->new(
         system_user => $user,
@@ -543,9 +535,8 @@ subtest "staff and non_public contacts result in non_public reports" => sub {
     my $o = Open311->new(
         jurisdiction => 'mysociety',
         endpoint => 'http://example.com',
-        test_mode => 1,
-        test_get_returns => { 'requests.xml' => prepare_xml( {} ) }
     );
+    Open311->_inject_response('/requests.xml', prepare_xml({}));
 
     my $update = Open311::GetServiceRequests->new(
         system_user => $user,
@@ -594,9 +585,8 @@ for my $test (
         my $o = Open311->new(
             jurisdiction => 'mysociety',
             endpoint => 'http://example.com',
-            test_mode => 1,
-            test_get_returns => { 'requests.xml' => $xml}
         );
+        Open311->_inject_response('/requests.xml', $xml);
 
         my $update = Open311::GetServiceRequests->new(
             system_user => $user,

--- a/t/open311/getservicerequestupdates.t
+++ b/t/open311/getservicerequestupdates.t
@@ -98,7 +98,8 @@ for my $test (
         my $local_requests_xml = $requests_xml;
         $local_requests_xml =~ s/UPDATED_DATETIME/$test->{updated_datetime}/;
 
-        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $local_requests_xml } );
+        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com');
+        Open311->_inject_response('/servicerequestupdates.xml', $local_requests_xml);
 
         my $res = $o->get_service_request_updates;
         is_deeply $res->[0], $test->{ res }, 'result looks correct';
@@ -126,7 +127,8 @@ subtest 'check extended request parsed correctly' => sub {
 
     $extended_requests_xml =~ s/UPDATED_DATETIME/$updated_datetime/;
 
-    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $extended_requests_xml } );
+    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com');
+    Open311->_inject_response('/servicerequestupdates.xml', $extended_requests_xml);
 
     my $res = $o->get_service_request_updates;
     is_deeply $res->[0], $expected_res, 'result looks correct';
@@ -431,7 +433,8 @@ for my $test (
 ) {
     subtest $test->{desc} => sub {
         my $local_requests_xml = setup_xml($problem->external_id, $problem->id, $test->{comment_status}, $test->{xml_description});
-        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', extended_statuses => $test->{extended_statuses}, test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $local_requests_xml } );
+        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', extended_statuses => $test->{extended_statuses} );
+        Open311->_inject_response('/servicerequestupdates.xml', $local_requests_xml);
 
         $problem->lastupdate( DateTime->now()->subtract( days => 1 ) );
         $problem->state( $test->{start_state} );
@@ -463,7 +466,8 @@ my $response_template_vars = $bodies{2482}->response_templates->create({
 });
 subtest 'Check template placeholders' => sub {
     my $local_requests_xml = setup_xml($problem->external_id, $problem->id, 'ACTION_SCHEDULED', 'We will do this in the morning.');
-    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', extended_statuses => undef, test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $local_requests_xml } );
+    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', extended_statuses => undef );
+    Open311->_inject_response('/servicerequestupdates.xml', $local_requests_xml);
 
     $problem->lastupdate( DateTime->now()->subtract( days => 1 ) );
     $problem->state( 'fixed - council' );
@@ -506,7 +510,8 @@ for my $test (
 ) {
     subtest $test->{desc} => sub {
         my $local_requests_xml = setup_xml($problemB->external_id, $problemB->id, $test->{comment_status});
-        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $local_requests_xml } );
+        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
+        Open311->_inject_response('/servicerequestupdates.xml', $local_requests_xml);
 
         $problemB->lastupdate( DateTime->now()->subtract( days => 1 ) );
         $problemB->state( $test->{start_state} );
@@ -537,7 +542,8 @@ for (
 ) {
     subtest "Marking report as fixed closes it for updates ($_->{cobrand})" => sub {
         my $local_requests_xml = setup_xml($problemB->external_id, $problemB->id, 'CLOSED');
-        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $local_requests_xml } );
+        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
+        Open311->_inject_response('/servicerequestupdates.xml', $local_requests_xml);
 
         $problemB->update( { bodies_str => $bodies{$_->{id}}->id } );
 
@@ -572,7 +578,8 @@ subtest 'Update with media_url includes image in update' => sub {
     my $local_requests_xml = setup_xml($problem->external_id, 1, "");
     $local_requests_xml =~ s#</service_request_id>#</service_request_id>
         <media_url>http://example.com/image.jpeg</media_url>#;
-    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $local_requests_xml } );
+    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
+    Open311->_inject_response('/servicerequestupdates.xml', $local_requests_xml);
 
     $problem->lastupdate( DateTime->now()->subtract( days => 1 ) );
     $problem->state('confirmed');
@@ -599,7 +606,8 @@ subtest 'Update with customer_reference adds reference to problem' => sub {
     my $local_requests_xml = setup_xml($problem->external_id, 1, "");
     $local_requests_xml =~ s#</service_request_id>#</service_request_id>
         <customer_reference>REFERENCE</customer_reference>#;
-    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $local_requests_xml } );
+    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
+    Open311->_inject_response('/servicerequestupdates.xml', $local_requests_xml);
 
     $problem->lastupdate( DateTime->now()->subtract( days => 1 ) );
     $problem->state('confirmed');
@@ -622,7 +630,8 @@ subtest 'Update with customer_reference adds reference to problem' => sub {
 
 subtest 'date for comment correct' => sub {
     my $local_requests_xml = setup_xml($problem->external_id, $problem->id, "");
-    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $local_requests_xml } );
+    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
+    Open311->_inject_response('/servicerequestupdates.xml', $local_requests_xml);
 
     my $update = Open311::GetServiceRequestUpdates->new(
         system_user => $user,
@@ -665,7 +674,8 @@ for my $test (
 ) {
     subtest $test->{desc} => sub {
         my $local_requests_xml = setup_xml($test->{request_id}, $test->{request_id_ext}, "");
-        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $local_requests_xml } );
+        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
+        Open311->_inject_response('/servicerequestupdates.xml', $local_requests_xml);
 
         my $update = Open311::GetServiceRequestUpdates->new(
             system_user => $user,
@@ -681,7 +691,8 @@ for my $test (
 
 subtest 'using start and end date' => sub {
     my $local_requests_xml = $requests_xml;
-    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $local_requests_xml } );
+    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
+    Open311->_inject_response('/servicerequestupdates.xml', $local_requests_xml);
 
     my $start_dt = DateTime->now(formatter => DateTime::Format::W3CDTF->new);
     my $end_dt = $start_dt->clone;
@@ -700,7 +711,7 @@ subtest 'using start and end date' => sub {
     my $start = $start_dt . '';
     my $end = $end_dt . '';
 
-    my $uri = URI->new( $o->test_uri_used );
+    my $uri = $o->test_req_used->uri;
     my $c = CGI::Simple->new( $uri->query );
 
     is $c->param('start_date'), $start, 'start date used';
@@ -749,7 +760,7 @@ subtest 'check that existing comments are not duplicated' => sub {
     my $confirmed = DateTime::Format::W3CDTF->format_datetime($comment->confirmed);
     $requests_xml =~ s/UPDATED_DATETIME/$confirmed/;
 
-    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $requests_xml } );
+    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
 
     my $update = Open311::GetServiceRequestUpdates->new(
         system_user => $user,
@@ -757,16 +768,19 @@ subtest 'check that existing comments are not duplicated' => sub {
         current_body => $bodies{2482},
     );
 
+    Open311->_inject_response('/servicerequestupdates.xml', $requests_xml);
     $update->process_body;
 
     $problem->discard_changes;
     is $problem->comments->count, 2, 'two comments after fetching updates';
 
+    Open311->_inject_response('/servicerequestupdates.xml', $requests_xml);
     $update->process_body;
     $problem->discard_changes;
     is $problem->comments->count, 2, 're-fetching updates does not add comments';
 
     $problem->comments->delete;
+    Open311->_inject_response('/servicerequestupdates.xml', $requests_xml);
     $update->process_body;
     $problem->discard_changes;
     is $problem->comments->count, 2, 'if comments are deleted then they are added';
@@ -791,7 +805,8 @@ subtest 'check that can limit fetching to a body' => sub {
 
     $requests_xml =~ s/UPDATED_DATETIME/$dt/;
 
-    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $requests_xml } );
+    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
+    Open311->_inject_response('/servicerequestupdates.xml', $requests_xml);
 
     my $update = Open311::GetServiceRequestUpdates->new(
         body => 'Oxfordshire',
@@ -842,7 +857,8 @@ subtest 'check that external_status_code is stored correctly' => sub {
     $requests_xml =~ s/UPDATED_DATETIME2/$dt/;
     $requests_xml =~ s/UPDATED_DATETIME/$dt2/;
 
-    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $requests_xml } );
+    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
+    Open311->_inject_response('/servicerequestupdates.xml', $requests_xml);
 
     my $update = Open311::GetServiceRequestUpdates->new(
         system_user => $user,
@@ -880,7 +896,8 @@ subtest 'check that external_status_code is stored correctly' => sub {
     my $dt3 = $dt->clone->add( minutes => 1 );
     $requests_xml =~ s/UPDATED_DATETIME/$dt3/;
 
-    $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $requests_xml } );
+    $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
+    Open311->_inject_response('/servicerequestupdates.xml', $requests_xml);
 
     $update = Open311::GetServiceRequestUpdates->new(
         system_user => $user,
@@ -919,7 +936,8 @@ subtest 'check that external_status_code triggers auto-responses' => sub {
 
     $requests_xml =~ s/UPDATED_DATETIME/$dt/;
 
-    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $requests_xml } );
+    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
+    Open311->_inject_response('/servicerequestupdates.xml', $requests_xml);
 
     my $update = Open311::GetServiceRequestUpdates->new(
         system_user => $user,
@@ -973,7 +991,8 @@ foreach my $test ( {
         $requests_xml =~ s/UPDATED_DATETIME/$test->{dt1}/;
         $requests_xml =~ s/UPDATED_DATETIME2/$test->{dt2}/;
 
-        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $requests_xml } );
+        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
+        Open311->_inject_response('/servicerequestupdates.xml', $requests_xml);
 
         my $update = Open311::GetServiceRequestUpdates->new(
             system_user => $user,
@@ -1044,7 +1063,8 @@ for my $test (
         $requests_xml =~ s/UPDATED_DATETIME/$dt/;
         $requests_xml =~ s/UPDATED_DATETIME2/$dt2/;
 
-        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $requests_xml } );
+        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
+        Open311->_inject_response('/servicerequestupdates.xml', $requests_xml);
 
         my $update = Open311::GetServiceRequestUpdates->new(
             system_user => $user,
@@ -1085,7 +1105,8 @@ subtest 'check that first comment always updates state'  => sub {
 
     $requests_xml =~ s/UPDATED_DATETIME/@{[$dt->clone->subtract( minutes => 62 )]}/;
 
-    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $requests_xml } );
+    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
+    Open311->_inject_response('/servicerequestupdates.xml', $requests_xml);
 
     my $update = Open311::GetServiceRequestUpdates->new(
         system_user => $user,
@@ -1150,7 +1171,8 @@ foreach my $test ( {
 
         $requests_xml =~ s/UPDATED_DATETIME/$dt/;
 
-        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $requests_xml } );
+        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
+        Open311->_inject_response('/servicerequestupdates.xml', $requests_xml);
 
         my $update = Open311::GetServiceRequestUpdates->new(
             system_user => $user,
@@ -1214,7 +1236,8 @@ foreach my $test ( {
 
         $requests_xml =~ s/UPDATED_DATETIME/$dt/;
 
-        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $requests_xml } );
+        my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
+        Open311->_inject_response('/servicerequestupdates.xml', $requests_xml);
 
         my $update = Open311::GetServiceRequestUpdates->new(
             system_user => $user,
@@ -1271,7 +1294,8 @@ subtest 'check matching on fixmystreet_id overrides service_request_id' => sub {
     $requests_xml =~ s/UPDATED_DATETIME2/$dt2/;
     $requests_xml =~ s/UPDATED_DATETIME/$dt3/;
 
-    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $requests_xml } );
+    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
+    Open311->_inject_response('/servicerequestupdates.xml', $requests_xml);
 
     my $update = Open311::GetServiceRequestUpdates->new(
         system_user => $user,
@@ -1308,7 +1332,8 @@ subtest 'check bad fixmystreet_id is handled' => sub {
 
     $requests_xml =~ s/UPDATED_DATETIME/$dt/;
 
-    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com', test_mode => 1, test_get_returns => { 'servicerequestupdates.xml' => $requests_xml } );
+    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com');
+    Open311->_inject_response('/servicerequestupdates.xml', $requests_xml);
 
     my $update = Open311::GetServiceRequestUpdates->new(
         system_user => $user,

--- a/t/open311/populate-service-list.t
+++ b/t/open311/populate-service-list.t
@@ -810,9 +810,9 @@ for my $test (
         my $o = Open311->new(
             jurisdiction => 'mysociety',
             endpoint => 'http://example.com',
-            test_mode => 1,
-            test_get_returns => { 'services.xml' => $services_xml, 'services/100.xml' => $test->{meta_xml} }
         );
+        Open311->_inject_response('/services.xml', $services_xml);
+        Open311->_inject_response('/services/100.xml', $test->{meta_xml});
 
         my $service_list = get_xml_simple_object( $services_xml );
 
@@ -890,9 +890,8 @@ subtest 'check attribute ordering' => sub {
     my $o = Open311->new(
         jurisdiction => 'mysociety',
         endpoint => 'http://example.com',
-        test_mode => 1,
-        test_get_returns => { 'services/100.xml' => $meta_xml }
     );
+    Open311->_inject_response('/services/100.xml', $meta_xml);
 
     $processor->_current_open311( $o );
     $processor->_current_body( $body );
@@ -1000,8 +999,6 @@ subtest 'check Bromley skip code' => sub {
     my $o = Open311->new(
         jurisdiction => 'mysociety',
         endpoint => 'http://example.com',
-        test_mode => 1,
-        test_get_returns => { 'services/100.xml' => $meta_xml }
     );
 
     $processor->_current_open311( $o );
@@ -1012,6 +1009,7 @@ subtest 'check Bromley skip code' => sub {
     };
     $processor->_current_service( { service_code => 100 } );
 
+    Open311->_inject_response('/services/100.xml', $meta_xml);
     $processor->_add_meta_to_contact( $contact );
 
     my $extra = [ {
@@ -1046,6 +1044,7 @@ subtest 'check Bromley skip code' => sub {
     is_deeply $contact->get_extra_fields, $extra, 'only non std bromley meta data saved';
 
     $processor->_current_body( $body );
+    Open311->_inject_response('/services/100.xml', $meta_xml);
     $processor->_add_meta_to_contact( $contact );
 
     $extra = [
@@ -1126,8 +1125,6 @@ subtest 'check Buckinghamshire extra code' => sub {
     my $o = Open311->new(
         jurisdiction => 'mysociety',
         endpoint => 'http://example.com',
-        test_mode => 1,
-        test_get_returns => { 'services/100.xml' => $meta_xml }
     );
 
     $processor->_current_open311( $o );
@@ -1137,6 +1134,7 @@ subtest 'check Buckinghamshire extra code' => sub {
         $processor->_current_body( $bucks );
     };
     $processor->_current_service( { service_code => 100, service_name => 'Flytipping' } );
+    Open311->_inject_response('/services/100.xml', $meta_xml);
     $processor->_add_meta_to_contact( $contact );
 
     my $extra = [ {
@@ -1164,6 +1162,7 @@ subtest 'check Buckinghamshire extra code' => sub {
     is_deeply $contact->get_extra_fields, $extra, 'extra Bucks field returned for flytipping';
 
     $processor->_current_service( { service_code => 100, service_name => 'Street lights' } );
+    Open311->_inject_response('/services/100.xml', $meta_xml);
     $processor->_add_meta_to_contact( $contact );
 
     $extra = [ {

--- a/t/open311/post-service-request-updates.t
+++ b/t/open311/post-service-request-updates.t
@@ -109,15 +109,11 @@ subtest 'Check Bexley munging' => sub {
     my $bexley = $mech->create_body_ok(2494, 'Bexley', $params);
     $mech->create_contact_ok(body_id => $bexley->id, category => 'Other', email => "OTHER");
 
-    my $test_res = HTTP::Response->new();
-    $test_res->code(200);
-    $test_res->message('OK');
-    $test_res->content('<?xml version="1.0" encoding="utf-8"?><service_request_updates><request_update><update_id>248</update_id></request_update></service_request_updates>');
+    my $test_res = '<?xml version="1.0" encoding="utf-8"?><service_request_updates><request_update><update_id>248</update_id></request_update></service_request_updates>';
     my $o = Open311->new(
         fixmystreet_body => $bexley,
-        test_mode => 1,
-        test_get_returns => { 'servicerequestupdates.xml' => $test_res },
     );
+    Open311->_inject_response('servicerequestupdates.xml', $test_res);
     my ($p5, $c5) = p_and_c($bexley);
     my $id = $o->post_service_request_update($c5);
     is $id, 248, 'correct update ID returned';
@@ -142,6 +138,7 @@ subtest 'Oxfordshire gets an ID' => sub {
 subtest 'Devolved contact' => sub {
     $mech->create_contact_ok(body_id => $bromley->id, category => 'Other', email => "OTHER", send_method => 'Open311', endpoint => '/devolved-endpoint/');
     $c1->update({ send_fail_count => 0 });
+    Open311->_inject_response('/devolved-endpoint/servicerequestupdates.xml', "", 500);
     $o->send;
     $c1->discard_changes;
     like $c1->send_fail_reason, qr/devolved-endpoint/, 'Failure message contains correct endpoint';

--- a/t/sendreport/open311_send.t
+++ b/t/sendreport/open311_send.t
@@ -34,20 +34,19 @@ my ($report) = $mech->create_problems_for_body( 1, $body->id, 'Test', {
 
 subtest 'testing Open311 behaviour', sub {
     $body->update( { send_method => 'Open311', endpoint => 'http://endpoint.example.com', jurisdiction => 'FMS', api_key => 'test' } );
-    my $test_data;
     FixMyStreet::override_config {
         STAGING_FLAGS => { send_reports => 1 },
         ALLOWED_COBRANDS => [ 'fixmystreet' ],
         MAPIT_URL => 'http://mapit.uk/',
     }, sub {
-        $test_data = FixMyStreet::Script::Reports::send();
+        FixMyStreet::Script::Reports::send();
     };
     $report->discard_changes;
     ok $report->whensent, 'Report marked as sent';
     is $report->send_method_used, 'Open311', 'Report sent via Open311';
     is $report->external_id, 248, 'Report has right external ID';
 
-    my $req = $test_data->{test_req_used};
+    my $req = Open311->test_req_used;
     my $c = CGI::Simple->new($req->content);
     is $c->param('attribute[easting]'), 529025, 'Request had easting';
     is $c->param('attribute[northing]'), 179716, 'Request had northing';
@@ -69,7 +68,6 @@ $photo_report->update;
 
 subtest 'test report with multiple photos only sends one', sub {
     $body->update( { send_method => 'Open311', endpoint => 'http://endpoint.example.com', jurisdiction => 'FMS', api_key => 'test' } );
-    my $test_data;
 
     FixMyStreet::override_config {
         STAGING_FLAGS => { send_reports => 1 },
@@ -80,14 +78,14 @@ subtest 'test report with multiple photos only sends one', sub {
             UPLOAD_DIR => $UPLOAD_DIR,
         },
     }, sub {
-        $test_data = FixMyStreet::Script::Reports::send();
+        FixMyStreet::Script::Reports::send();
     };
     $photo_report->discard_changes;
     ok $photo_report->whensent, 'Report marked as sent';
     is $photo_report->send_method_used, 'Open311', 'Report sent via Open311';
     is $photo_report->external_id, 248, 'Report has right external ID';
 
-    my $req = $test_data->{test_req_used};
+    my $req = Open311->test_req_used;
     my $c = CGI::Simple->new($req->content);
     is $c->param('attribute[easting]'), 529025, 'Request had easting';
     is $c->param('attribute[northing]'), 179716, 'Request had northing';
@@ -106,7 +104,6 @@ $photo_report->update();
 
 subtest 'test sending multiple photos', sub {
     $body->update( { send_method => 'Open311', endpoint => 'http://endpoint.example.com', jurisdiction => 'FMS', api_key => 'test' } );
-    my $test_data;
 
     FixMyStreet::override_config {
         STAGING_FLAGS => { send_reports => 1 },
@@ -117,14 +114,14 @@ subtest 'test sending multiple photos', sub {
             UPLOAD_DIR => $UPLOAD_DIR,
         },
     }, sub {
-        $test_data = FixMyStreet::Script::Reports::send();
+        FixMyStreet::Script::Reports::send();
     };
     $photo_report->discard_changes;
     ok $photo_report->whensent, 'Report marked as sent';
     is $photo_report->send_method_used, 'Open311', 'Report sent via Open311';
     is $photo_report->external_id, 248, 'Report has right external ID';
 
-    my $req = $test_data->{test_req_used};
+    my $req = Open311->test_req_used;
     my $c = CGI::Simple->new($req->content);
     my @media = $c->param('media_url');
     is_deeply \@media, [
@@ -142,13 +139,12 @@ my ($bad_category_report) = $mech->create_problems_for_body( 1, $body->id, 'Test
 
 subtest 'test handles bad category', sub {
     $body->update( { send_method => 'Open311', endpoint => 'http://endpoint.example.com', jurisdiction => 'FMS', api_key => 'test' } );
-    my $test_data;
     FixMyStreet::override_config {
         STAGING_FLAGS => { send_reports => 1 },
         ALLOWED_COBRANDS => [ 'fixmystreet' ],
         MAPIT_URL => 'http://mapit.uk/',
     }, sub {
-        $test_data = FixMyStreet::Script::Reports::send();
+        FixMyStreet::Script::Reports::send();
     };
     $bad_category_report->discard_changes;
     ok !$bad_category_report->whensent, 'Report not marked as sent';


### PR DESCRIPTION
Instead, patch Open311 in the test code to store requests and inject responses