### PR TITLE
Fix issue searching for numeric IDs.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
@@ -71,15 +71,7 @@ sub index : Path {
         my $valid_phone = $parsed->{phone};
         my $valid_email = $parsed->{email};
 
-        if ($valid_email) {
-            $query->{'-or'} = [
-                'user.email' => { ilike => $like_search },
-            ];
-        } elsif ($valid_phone) {
-            $query->{'-or'} = [
-                'user.phone' => { ilike => $like_search },
-            ];
-        } elsif ($search =~ /^id:(\d+)$/) {
+        if ($search =~ /^id:(\d+)$/) {
             $query->{'-or'} = [
                 'me.id' => int($1),
             ];
@@ -90,6 +82,14 @@ sub index : Path {
         } elsif ($search =~ /^ref:(\d+)$/) {
             $query->{'-or'} = [
                 'me.external_id' => { like => "%$1%" }
+            ];
+        } elsif ($valid_email) {
+            $query->{'-or'} = [
+                'user.email' => { ilike => $like_search },
+            ];
+        } elsif ($valid_phone) {
+            $query->{'-or'} = [
+                'user.phone' => { ilike => $like_search },
             ];
         } else {
             $problems = $problems->search_text($search);

--- a/t/app/controller/admin/search.t
+++ b/t/app/controller/admin/search.t
@@ -118,4 +118,15 @@ subtest 'report search' => sub {
     $mech->content_like( qr{href="http://[^/]*[^.]/report/$r_id"[^>]*>$r_id</a>} );
 };
 
+FixMyStreet::override_config {
+    PHONE_COUNTRY => 'GB',
+}, sub {
+    subtest 'numeric external ID search' => sub {
+        $report->external_id('402609');
+        $report->update;
+        $mech->get_ok('/admin/reports?search=ref:402609');
+        $mech->content_contains("/report/" . $report->id);
+    };
+};
+
 done_testing();


### PR DESCRIPTION
There is an issue with Number::Phone that means it is matching e.g. 402609 as a Jersey phone number. Reported and behaviour improved at https://github.com/DrHyde/perl-modules-Number-Phone/issues/101, but until a new release, move the searches around so a ref search takes precedence. [skip changelog] For FD#1398