### PR TITLE
Add feature for always using Reply-To in emails.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Contact.pm
+++ b/perllib/FixMyStreet/App/Controller/Contact.pm
@@ -283,6 +283,7 @@ sub send_email : Private {
 
     my $recipient      = $c->cobrand->contact_email;
     my $recipient_name = $c->cobrand->contact_name();
+    my $use_reply_to = $c->cobrand->feature('always_use_reply_to');
 
     if (my $localpart = $c->get_param('recipient')) {
         $recipient = join('@', $localpart, FixMyStreet->config('EMAIL_DOMAIN'));
@@ -300,7 +301,7 @@ sub send_email : Private {
         to => [ [ $recipient, _($recipient_name) ] ],
         user_agent => $c->req->user_agent,
     };
-    if (FixMyStreet::Email::test_dmarc($c->stash->{em})) {
+    if ($use_reply_to || FixMyStreet::Email::test_dmarc($c->stash->{em})) {
         $params->{'Reply-To'} = [ $from ];
         $params->{from} = [ FixMyStreet->config('DO_NOT_REPLY_EMAIL'), $c->stash->{form_name} ];
     } else {

--- a/perllib/FixMyStreet/SendReport/Email.pm
+++ b/perllib/FixMyStreet/SendReport/Email.pm
@@ -106,8 +106,11 @@ sub send {
         $params->{From} = [ $sender, $name ];
     }
 
-    if (FixMyStreet::Email::test_dmarc($params->{From}[0])
-      || $self->use_replyto
+    my $use_reply_to = $cobrand->feature('always_use_reply_to');
+
+    if ( $self->use_replyto
+      || $use_reply_to
+      || FixMyStreet::Email::test_dmarc($params->{From}[0])
       || Utils::Email::same_domain($params->{From}, $params->{To})) {
         $params->{'Reply-To'} = [ $params->{From} ];
         $params->{From} = [ $sender, $params->{From}[1] ];

--- a/t/app/controller/contact.t
+++ b/t/app/controller/contact.t
@@ -353,6 +353,24 @@ subtest 'use do-not-reply address when recepient uses DMARC' => sub {
     is $email->header('From'), "\"$common{name}\" <$from_email>", 'from name and email correct';
 };
 
+subtest 'use reply-to when cobrand asks to' => sub {
+    FixMyStreet::override_config {
+        COBRAND_FEATURES => {
+            always_use_reply_to => { default => 1 }
+        },
+    }, sub {
+        $mech->clear_emails_ok;
+        $mech->get_ok('/contact');
+        $mech->submit_form_ok( { with_fields => \%common } );
+        $mech->content_contains('Thank you for your enquiry');
+
+        my $email = $mech->get_email;
+        my $from_email = FixMyStreet->config('DO_NOT_REPLY_EMAIL');
+        is $email->header('From'), "\"$common{name}\" <$from_email>", 'from name and email correct';
+        is $email->header('Reply-To'), "\"$common{name}\" <$common{em}>", 'reply-to correct';
+    }
+};
+
 for my $test (
     { fields => \%common }
   )


### PR DESCRIPTION
This means we can choose in configuration to set a cobrand or cobrands to always use Reply-To for the user's details and our own email (matching the SMTP envelope) in the From, regardless of DMARC settings.

[skip changelog] For Freshdesk https://mysocietysupport.freshdesk.com/a/tickets/1472 (whereby a recipient is performing a DMARC check regardless of actual DMARC settings)