### PR TITLE
Look up organizational domain in DMARC checking.

### DIFF
--- a/t/utils/email.t
+++ b/t/utils/email.t
@@ -14,13 +14,15 @@ $resolver->mock('send', sub {
     is $type, 'TXT';
     if ($domain eq '_dmarc.yahoo.com') {
         @rrs = (
-            Net::DNS::RR->new(name => '_dmarc.yahoo.com', type => 'TXT', txtdata => 'p=reject'),
+            Net::DNS::RR->new(name => '_dmarc.yahoo.com', type => 'TXT', txtdata => 'v=DMARC1; p=reject'),
             Net::DNS::RR->new(name => '_dmarc.yahoo.com', type => 'A'),
         );
     } elsif ($domain eq 'cname.example.com') {
-        @rrs = Net::DNS::RR->new(name => 'cname.example.com', type => 'TXT', txtdata => 'p=none');
-    } else {
+        @rrs = Net::DNS::RR->new(name => 'cname.example.com', type => 'TXT', txtdata => 'v=DMARC1; p=none; sp=quarantine');
+    } elsif ($domain eq '_dmarc.example.net') {
         @rrs = Net::DNS::RR->new(name => '_dmarc.example.net', type => 'CNAME', cname => 'cname.example.com');
+    } elsif ($domain eq '_dmarc.example.com') {
+        @rrs = Net::DNS::RR->new(name => '_dmarc.example.com', type => 'TXT', txtdata => 'v=DMARC1; p=reject; sp=none');
     }
     my $pkt = Net::DNS::Packet->new;
     push @{$pkt->{answer}}, @rrs;
@@ -30,6 +32,10 @@ $resolver->mock('send', sub {
 is Utils::Email::test_dmarc('BAD'), undef;
 is Utils::Email::test_dmarc('test@yahoo.com'), 1;
 is Utils::Email::test_dmarc('test@example.net'), undef;
+is Utils::Email::test_dmarc('test@subdomain.yahoo.com'), 1, 'subdomain inherits parent';
+is Utils::Email::test_dmarc('test@subdomain.example.net'), 1, 'subdomain parent has sp set';
+is Utils::Email::test_dmarc('test@subdomain.example.com'), undef, 'subdomain parent has sp=none';
+is Utils::Email::test_dmarc('test@subdomain.fixmystreet.com'), undef, 'subdomain and parent not there';
 
 is Utils::Email::same_domain(['test@example.net', ''], [ ['to@example.net', ''], ['to@example.com', ''] ]), 1;
 is Utils::Email::same_domain(['test@example.org', ''], [ ['to@example.net', ''] ]), '';


### PR DESCRIPTION
To cope with the case where the subdomain does not have its own DMARC configuration. 
Fixes https://github.com/mysociety/societyworks/issues/2594