### PR TITLE
Staff access to filter non public places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
         - UK Councils no questionnaires for non-updating users
         - Script to export/import response templates, #3549
         - Include non-public report in front page search for staff. #3616
+        - Include staff categories in map filters for staff. #3616
     - Development improvements:
         - Include failure count in send report error output, #3316
         - Sort output in export script. #3323

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -186,7 +186,13 @@ sub ward : Path : Args(2) {
 sub setup_categories :Private {
     my ($self, $c) = @_;
 
-    my @categories = $c->stash->{body}->contacts->not_deleted->search( undef, {
+    my $rs = $c->stash->{body}->contacts;
+    if ($c->user_exists && ($c->user->is_superuser || $c->user->from_body == $c->stash->{body}->id)) {
+        $rs = $rs->not_deleted_admin;
+    } else {
+        $rs = $rs->not_deleted;
+    }
+    my @categories = $rs->search( undef, {
         columns => [ 'id', 'category', 'extra', 'body_id', 'send_method' ],
         distinct => 1,
     } )->all_sorted;

--- a/t/app/controller/report_new_staff.t
+++ b/t/app/controller/report_new_staff.t
@@ -248,6 +248,9 @@ subtest 'staff-only categories when reporting' => sub {
         $mech->get_ok('/admin/templates/' . $body_ids{2651} . '/new');
         $mech->content_contains('Trees');
 
+        $mech->get_ok('/reports/City+of+Edinburgh');
+        $mech->content_contains('<option value="Trees">');
+
         my $extra_details = $mech->get_ok_json( '/report/new/ajax?latitude=55.952055&longitude=-3.189579' );
         is_deeply [ sort keys %{$extra_details->{by_category}} ], [ 'Street lighting', 'Trees' ], 'Superuser can see staff-only category';
 


### PR DESCRIPTION
Two related changes - one to let staff search non-public reports in the front page external ID search, and another for staff to see staff categories in the map filters.