### PR TITLE
Update RSS link when distance box changed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
         - Update URL on /my when map moves. #3358
         - Make anonymous updates clearer in email alerts. #3417
         - Add Maidenhead Locator support to search box.
+        - Update RSS link when distance box changed. #3624
     - Bugfixes:
         - Fix non-JS form when all extra questions answered. #3248
         - Improve display of disabled fields in iOS.

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1234,16 +1234,21 @@ $.extend(fixmystreet.set_up, {
   alert_page_buttons: function() {
     // Go directly to RSS feed if RSS button clicked on alert page
     // (due to not wanting around form to submit, though good thing anyway)
+    $('#distance').on('change', function() {
+        var dist = this.value;
+        if (!parseInt(dist)) {
+            return;
+        }
+        var a = $('a.js-alert-local');
+        if (!a.data('originalHref')) {
+            a.data('originalHref', a.attr('href'));
+        }
+        a.attr('href', a.data('originalHref') + '/' + dist);
+    });
     $('body').on('click', '#alert_rss_button', function(e) {
         e.preventDefault();
         var a = $('input[name=feed][type=radio]:checked').parent().prevAll('a');
         var feed = a.attr('href');
-        if (a.hasClass('js-alert-local')) {
-            var dist = $('#distance').val();
-            if (parseInt(dist)) {
-                feed += '/' + dist;
-            }
-        }
         window.location.href = feed;
     });
     $('body').on('click', '#alert_email_button', function(e) {


### PR DESCRIPTION
The button at the bottom did the right thing, but if you clicked the RSS logo it did not.
[skip changelog]