### PR TITLE
Simplify robots.txt

### DIFF
--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,8 +1,3 @@
 User-agent: *
 Disallow: /photo/
-
-User-agent: msnbot
-Crawl-delay: 3
-
-User-agent: bingbot
 Crawl-delay: 3


### PR DESCRIPTION
As each robot may simply ignore anything not within its specific stanza
consolidate rules into a single section to match all user-agents that
observe this file.

Out ruleset is simple and this prevents duplication of rules that need
to apply to all user-agents as otherwise these will need to be set for
each individually.

Not all user-agents observe the Crawl-delay directive, so it shouldn't
hurt to just set that globally. Slowing the crawl rate shouldn't really
matter that much for FixMyStreet as it's not important for search to
drive traffic to specific report pages anyway.

[skip changelog]
