### PR TITLE
[National Highways] Add area_name to emails

### DIFF
--- a/t/cobrand/highwaysengland.t
+++ b/t/cobrand/highwaysengland.t
@@ -83,7 +83,7 @@ FixMyStreet::override_config {
         my $body = $mech->get_text_body_from_email($email);
         like $body, qr/Heard from: Facebook/, 'where hear included in email';
         like $body, qr/Road: M1/, 'road data included in email';
-
+        like $body, qr/Area: Area 1/, 'area data included in email';
     };
 
     my ($problem) = $mech->create_problems_for_body(1, $highways->id, 'Title');

--- a/templates/email/fixmystreet.com/submit.html
+++ b/templates/email/fixmystreet.com/submit.html
@@ -79,6 +79,12 @@ of a local problem that they believe might require your attention.</p>
         [% report.get_extra_field_value('sect_label') %]
     </p>
   [% END %]
+  [% IF report.get_extra_field_value('area_name') %]
+    <p style="[% secondary_p_style %]">
+      <strong>Area:</strong>
+        [% report.get_extra_field_value('area_name') %]
+    </p>
+  [% END %]
 [% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/fixmystreet.com/submit.txt
+++ b/templates/email/fixmystreet.com/submit.txt
@@ -44,6 +44,9 @@ Road: [% report.get_extra_field_value('road_name') %]
 [% IF report.get_extra_field_value('sect_label') ~%]
 Section: [% report.get_extra_field_value('sect_label') %]
 [% END %]
+[% IF report.get_extra_field_value('area_name') ~%]
+Area: [% report.get_extra_field_value('area_name') %]
+[% END %]
 
 View OpenStreetMap of this location: [% osm_url %]
 

--- a/templates/email/highwaysengland/submit.html
+++ b/templates/email/highwaysengland/submit.html
@@ -41,6 +41,10 @@ of a local problem that they believe might require your attention.</p>
         [% report.get_extra_field_value('sect_label') %]
     </p>
     <p style="[% secondary_p_style %]">
+      <strong>Area:</strong>
+        [% report.get_extra_field_value('area_name') %]
+    </p>
+    <p style="[% secondary_p_style %]">
       <strong>Heard from:</strong>
         [% report.get_extra_metadata('where_hear') %]
     </p>

--- a/templates/email/highwaysengland/submit.txt
+++ b/templates/email/highwaysengland/submit.txt
@@ -27,6 +27,8 @@ Road: [% report.get_extra_field_value('road_name') %]
 
 Section: [% report.get_extra_field_value('sect_label') %]
 
+Area: [% report.get_extra_field_value('area_name') %]
+
 Heard from: [% report.get_extra_metadata('where_hear') %]
 
 View OpenStreetMap of this location: [% osm_url %]


### PR DESCRIPTION
Adds area_name to emails for National Highways from fixmystreet and
National Highways site

Added for future reference: https://github.com/mysociety/societyworks/issues/2677

[skip changelog]