### PR TITLE
[Merton] Milestone 63: some configuration for Merton cobrand

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Merton.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton.pm
@@ -78,4 +78,6 @@ sub lookup_site_code_config { {
     accept_feature => sub { 1 },
 } }
 
+sub cut_off_date { '2020-12-06' } # 1 yr prior to FMS Pro go-live
+
 1;

--- a/templates/web/merton/before_wrapper.html
+++ b/templates/web/merton/before_wrapper.html
@@ -1,3 +1,10 @@
+[% IF c.config.BASE_URL == "https://www.fixmystreet.com" %]
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MTTLXZ4"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+[% END %]
+
 <div class="merton-header">
     <div class="container">
         <a href="https://www.merton.gov.uk" class="merton-header__logo">Merton Council</a>

--- a/templates/web/merton/header_extra.html
+++ b/templates/web/merton/header_extra.html
@@ -1,0 +1,1 @@
+[% INCLUDE 'tracking_code.html' %]

--- a/templates/web/merton/tracking_code.html
+++ b/templates/web/merton/tracking_code.html
@@ -1,0 +1,7 @@
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MTTLXZ4');</script>
+<!-- End Google Tag Manager -->


### PR DESCRIPTION
A group of key configurations and code updates towards ensuring the Merton cobrand fits the agreed technical specification. 

for mysociety/societyworks/issues/2629 
- [ ] (but take this out!)

for mysociety/societyworks/issues/2628

#### TO DO
- [ ] remove 535f2998f983525a1c4b11fe0f8672a401e9dfef (always allow reopening)
- [ ] remove 2d81a1dafb2614fb52121033e62ff463e6d95b49 (replace FMS ID with Dyn. ID)

#### To check:
- [x] ~Whether this PR should include changes to any documentation, or the FAQ;~
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [ ] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Are the changes tested for accessibility?
[skip changelog]

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

- [ ] add 'fixes...' links from commits to this PR description
