### PR TITLE
Add perlmagick tap to manual install instructions

### DIFF
--- a/docs/install/manual-install.md
+++ b/docs/install/manual-install.md
@@ -62,6 +62,7 @@ $ port install gettext p5-locale-gettext p5-perlmagick jhead postgresql91-server
 ##### ii. HomeBrew
 
 {% highlight bash %}
+$ brew tap davea/perlmagick
 $ brew install gettext perlmagick jhead postgresql
 $ brew link gettext --force
 {% endhighlight %}


### PR DESCRIPTION
When following https://fixmystreet.org/install/manual-install/ with @lucascumsille, we noticed that `brew install gettext perlmagick jhead postgresql` failed, because a `perlmagick` homebrew package could not be found. I guessed we were referencing https://github.com/davea/homebrew-perlmagick, so have added the required `brew tap` step to the instructions.