### PR TITLE
[National Highways] High priority text changes

### DIFF
--- a/templates/web/highwaysengland/around/_report_banner.html
+++ b/templates/web/highwaysengland/around/_report_banner.html
@@ -1,7 +1,9 @@
 <h1 class="big-green-banner">
     Click map to report a problem
 </h1>
-<a id="skip-this-step" href="[% url_skip %]" rel="nofollow">
-    Can’t see the map? Skip this step or, if you prefer, contact us on
+<span id="skip-this-step" tabindex="0">
+    Can’t see the map?
+    <a href="[% url_skip %]" rel="nofollow">Skip this step</a>
+    or, if you prefer, contact us on
     <a href="tel:03001235000">0300 123 5000</a>.
-</a>
+</span>

--- a/templates/web/highwaysengland/around/intro.html
+++ b/templates/web/highwaysengland/around/intro.html
@@ -1,5 +1,9 @@
-            <h1>Report a problem <span>on our network</span></h1>
+            <h1>Report a maintenance issue <span>on our network</span></h1>
             <div class="front-blurb">
                 <p>We work hard to make sure our network of motorways and major A-roads is in good condition, minimising disruption for our customers.</p>
                 <p>We carry out regular inspections and maintenance activities, but we also want to hear from you if you spot something wrong with our roads or any of the assets alongside them. This could be anything from a broken sign or barrier, to litter, overgrown vegetation or potholes.</p>
+            </div>
+            <div class="highwaysengland-warning">
+                <h2>Please do not report an incident here</h2>
+                <p>In an emergency, call <a href="tel:999"><strong>999</strong></a>. Other incidents should be reported via our Customer Contact Centre on <a href="tel:+443001235000"><strong>0300 123 5000</strong></a>.</p>
             </div>

--- a/templates/web/highwaysengland/report/new/councils_text_all.html
+++ b/templates/web/highwaysengland/report/new/councils_text_all.html
@@ -3,7 +3,7 @@
 [% UNLESS non_public_categories.$category;
 
     tprintf(
-        'These will be sent to us and also published online for others to see, in line with our <a href="%s">privacy policy</a>.',
+        'Anything you include in your report will be published online for others to see. Please take care not to include personal information, such as your contact details. Find out more in our <a href="%s">privacy policy</a>.',
         c.cobrand.privacy_policy_url
     );
 

--- a/templates/web/highwaysengland/report/new/form_heading.html
+++ b/templates/web/highwaysengland/report/new/form_heading.html
@@ -1,2 +1,2 @@
-<h1>Report a problem on our road network</h1>
+<h1>Report a maintenance issue on our road network</h1>
 

--- a/templates/web/highwaysengland/report/new/inline-tips.html
+++ b/templates/web/highwaysengland/report/new/inline-tips.html
@@ -1,10 +1,17 @@
-<div class="description_tips" >
-    <p>
-        Content of reports shall be monitored and any language that could be deemed to cause offense or be inappropriate shall be removed.
-    </p>
+<div class="description_tips" aria-label="Tips for successful reports">
+    <ul class="do">
+        <li>Be polite</li>
+        <li>Use exact locations</li>
+        <li>Say how long the issue’s been&nbsp;present</li>
+    </ul>
+    <ul class="dont">
+        <li>Don’t include contact details</li>
+        <li>Don’t identify or accuse other&nbsp;people</li>
+        <li>Don’t use language that could be deemed to cause offence or be inappropriate. This will be removed</li>
+    </ul>
 </div>
 
-<label for="where_hear">How did you hear about us?</label>
+<label for="where_hear">How did you hear about this reporting tool?</label>
 
 [%~ SET where_hear = report.get_extra_metadata('where_hear') %]
 <select class="form-control" name="where_hear" id="where_hear">

--- a/templates/web/highwaysengland/report/new/top_message.html
+++ b/templates/web/highwaysengland/report/new/top_message.html
@@ -1,5 +1,5 @@
 <div class="box-warning">
-    If the issue you’re reporting is safety critical (ie debris/spillage or not
+    If the maintenance issue you’re reporting is safety critical (ie debris/spillage or not
     working traffic light) then do not continue with this report. Please call
     us on <a href="tel:03001235000"><strong>0300 123 5000</strong></a> from a safe place.
 </div>

--- a/web/cobrands/highwaysengland/base.scss
+++ b/web/cobrands/highwaysengland/base.scss
@@ -130,6 +130,10 @@ p.form-error {
         }
     }
 
+    .form-hint {
+        max-width: 32em;
+    }
+
     a#geolocate_link {
         border-radius: 4em;
     }
@@ -145,9 +149,21 @@ p.form-error {
     }
 }
 
-.front-blurb {
+.front-blurb,
+.highwaysengland-warning {
     max-width: 32em;
     margin: 1em 0;
+}
+
+.highwaysengland-warning {
+    box-sizing: border-box;
+    padding: 1em 1.5em;
+    border-radius: 0.25em;
+    background: #f9e4ae;
+
+    h2 {
+        font-weight: bold;
+    }
 }
 
 .form-control,

--- a/web/cobrands/highwaysengland/layout.scss
+++ b/web/cobrands/highwaysengland/layout.scss
@@ -77,7 +77,8 @@ p.form-error {
     }
 }
 
-.front-blurb {
+.front-blurb,
+.highwaysengland-warning {
     margin: 2em 0;
 }
 

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -381,7 +381,8 @@ body.mappage.admin {
     position: absolute;
     top: -999px;
 
-    &:focus {
+    &:focus,
+    &:focus-within {
       // And show it again if it receives focus (eg: via tab key)
       position: static;
     }


### PR DESCRIPTION
Freshdesk ticket https://mysocietysupport.freshdesk.com/a/tickets/1534

- Homepage – replace "problem" with "maintenance issue" in main heading
- Homepage – add yellow warning box about emergencies and incidents
- New report page – replace "problem" with "maintenance issue" in main heading
- New report page – "maintenance issue" in blue box, not just "issue"
- Reporting form – new wording about public details
- Reporting form – new "do and don’t" tips below descripton
- Reporting form – "How did you hear about this reporting tool" not "about us"

I’m really not a fan of how messy this has made the homepage hero element, but it’ll do as a temporary fix, until we implement the rest of the requested changes.

![Screenshot 2021-10-29 at 14-53-50 National Highways Report a problem](https://user-images.githubusercontent.com/739624/139447543-94be08b9-7476-45c3-aef0-8f4d934cc5d4.png)