### PR TITLE
[Shropshire] Set blocked categories to be staff usable

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Shropshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Shropshire.pm
@@ -46,4 +46,12 @@ sub lookup_site_code_config { {
     accept_feature => sub { 1 }
 } }
 
+sub staff_ignore_form_disable_form {
+    my $self = shift;
+    my $c = $self->{c};
+
+    return $c->user_exists
+        && $c->user->belongs_to_body( $self->body->id );
+}
+
 1;


### PR DESCRIPTION
* Categories with disabled forms should be usable by staff

[skip changelog]
