### PR TITLE
Stop slashes breaking csv report downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
         - Fix removal of cached opengraph photos.
         - Do not email inactive body comment users. #3587
         - Look up organizational domain in DMARC checking. #3603
+        - Stop slash in category name breaking csv download #3642
     - Admin improvements:
         - Assignees of reports are now visible in admin reports list and report edit pages.
         - Enable per-category hint customisation.

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -336,7 +336,7 @@ sub open311_post_send {
     if ($error =~ /Cannot renew this property, a new request is required/ && $row->title eq "Garden Subscription - Renew") {
         # Was created as a renewal, but due to DD delay has now expired. Switch to new subscription
         $row->title("Garden Subscription - New");
-        $row->set_extra_metadata(Subscription_Type => $self->waste_subscription_types->{New});
+        $row->update_extra_field({ name => "Subscription_Type", value => $self->waste_subscription_types->{New} });
     }
     if ($error =~ /Missed Collection event already open for the property/) {
         $row->state('duplicate');

--- a/perllib/FixMyStreet/Reporting.pm
+++ b/perllib/FixMyStreet/Reporting.pm
@@ -101,7 +101,7 @@ has filename => ( is => 'rw', isa => Str, lazy => 1, default => sub {
         $self->on_updates ? ('updates') : (),
         map {
             my $value = $where{$_};
-            (my $nosp = $value || '') =~ s/ /-/g;
+            (my $nosp = $value || '') =~ s/[ \/\\]/-/g;
             (defined $value and length $value) ? ($_, $nosp) : ()
         } sort keys %where
 });

--- a/t/app/controller/dashboard.t
+++ b/t/app/controller/dashboard.t
@@ -271,6 +271,12 @@ FixMyStreet::override_config {
         $mech->content_contains('Report ID');
     };
 
+    subtest 'export CSV with slash in category name' => sub {
+        $mech->create_contact_ok(body_id => $body->id, category => "This/That", email => "this\@example.org");
+        my $token = 'access_token=' . $counciluser->id . '-1234567890abcdefgh';
+        $mech->get_ok("/dashboard?export=2&$token&category=This/That");
+    };
+
     subtest 'view status page' => sub {
         # Simulate a partly done file
         my $f = Path::Tiny->tempfile(SUFFIX => '.csv-part', DIR => path($UPLOAD_DIR, 'dashboard_csv', $counciluser->id));

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -266,7 +266,7 @@ subtest 'test DD taking so long it expires' => sub {
             url => 'http://example.org/',
         });
     };
-    is $report->get_extra_metadata("Subscription_Type"), 1, 'Type updated';
+    is $report->get_extra_field_value("Subscription_Type"), 1, 'Type updated';
     is $report->title, "Garden Subscription - New";
     $report->update({ title => $title });
 };


### PR DESCRIPTION
Removes slashes from category names used in file name for csv download.

Backward slash makes the file not retrievable.
Forward slash makes the file not saveable.

https://github.com/mysociety/societyworks/issues/2679
