### PR TITLE
[Merton] Additional CSS changes for accessibility

### DIFF
--- a/web/cobrands/merton/base.scss
+++ b/web/cobrands/merton/base.scss
@@ -25,6 +25,7 @@ a:focus,
 input:focus,
 button:focus,
 .green-btn:focus,
+.btn-primary:focus,
 select:focus,
 textarea:focus,
 .multi-select-button:focus,
@@ -38,6 +39,7 @@ textarea:focus,
 
 .button,
 .green-btn,
+.btn-primary,
 input[type=button],
 input[type=reset],
 input[type=submit] :not(.item-list__item__shortlist-add) :not(item-list__item__shortlist-remove),
@@ -59,6 +61,7 @@ a#geolocate_link,
 .button:hover,
 .btn:hover,
 .green-btn:hover,
+.btn-primary:hover,
 input[type=button]:hover,
 input[type=reset]:hover,
 input[type=submit]:hover :not(.item-list__item__shortlist-add) :not(item-list__item__shortlist-remove),
@@ -255,3 +258,22 @@ ol.big-numbers {
 }
 
 @import "../fixmystreet-uk-councils/societyworks-footer";
+
+/* fixes for around page */
+.big-green-banner {
+    font-weight: bold;
+}
+
+.item-list__item--empty p {
+    color: #666666;
+}
+
+.item-list__item__state {
+    background-color: #666666;
+}
+
+.item-list--reports__item a {
+    color: black;
+}
+/* end of fixes for around page */
+

--- a/web/cobrands/merton/layout.scss
+++ b/web/cobrands/merton/layout.scss
@@ -63,3 +63,8 @@ body.twothirdswidthpage .content {
         top: 0;
     }
 }
+
+#skip-this-step em {
+    color: black;
+}
+


### PR DESCRIPTION
Additional style changes for Merton for accessibility and branding compliance. 

- 'click map to report a problem' -> bold
- 'skip this step' -> black
- 'here are some other nearby reports' -> color: #666666
- 'Fixed/Closed' (problem state) labels -> bg : #666666
- report title text -> black
- another type of big green button (.btn-primary) added
  to Merton's preferred big jade green button styles

Please check the following:
- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Are the changes tested for accessibility?
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
