### PR TITLE
[Shropshire] External ID display

### DIFF
--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -807,7 +807,7 @@ sub defect_types {
 #     Note:   this only makes sense when called on a problem that has been sent!
 sub can_display_external_id {
     my $self = shift;
-    if ($self->external_id && $self->to_body_named('Oxfordshire|Lincolnshire|Isle of Wight|East Sussex|Central Bedfordshire')) {
+    if ($self->external_id && $self->to_body_named('Oxfordshire|Lincolnshire|Isle of Wight|East Sussex|Central Bedfordshire|Shropshire')) {
         return 1;
     }
     return 0;

--- a/t/cobrand/shropshire.t
+++ b/t/cobrand/shropshire.t
@@ -1,0 +1,44 @@
+use CGI::Simple;
+use Test::MockModule;
+use Test::MockTime qw(:all);
+use FixMyStreet::TestMech;
+use FixMyStreet::Script::Reports;
+use Catalyst::Test 'FixMyStreet::App';
+
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $body = $mech->create_body_ok(2238, 'Shropshire Council');
+$mech->create_contact_ok(body_id => $body->id, category => 'Bridges', email => 'bridges@example.org');
+
+my ($report) = $mech->create_problems_for_body(1, $body->id, 'Test Report', {
+    category => 'Bridges', cobrand => 'shropshire',
+    latitude => 52.859331, longitude => -3.054912, areas => ',11809,129425,144013,144260,148857,2238,39904,47098,66017,95047,',
+    external_id => '1309813', whensent => \'current_timestamp',
+});
+
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => [ 'shropshire' ],
+    MAPIT_URL => 'http://mapit.uk/',
+    STAGING_FLAGS => { send_reports => 1, skip_checks => 0 },
+}, sub {
+
+    subtest 'cobrand displays council name' => sub {
+        ok $mech->host("shropshire.fixmystreet.com"), "change host to shropshire";
+        $mech->get_ok('/');
+        $mech->content_contains('Shropshire Council');
+    };
+
+    subtest 'cobrand displays council name' => sub {
+        $mech->get_ok('/reports/Shropshire');
+        $mech->content_contains('Shropshire Council');
+    };
+
+    subtest 'External ID is shown on report page' => sub {
+        $mech->get_ok('/report/' . $report->id);
+        $mech->content_contains("Council ref:&nbsp;" . $report->external_id);
+    };
+
+};
+
+done_testing();

--- a/templates/web/shropshire/tokens/_confirm_problem_council_id.html
+++ b/templates/web/shropshire/tokens/_confirm_problem_council_id.html
@@ -1,0 +1,1 @@
+<h2>Your issue has been sent.</h2>


### PR DESCRIPTION
Shows the Confirm ID publicly on the report page:

<img width="457" alt="image" src="https://user-images.githubusercontent.com/4776/141212585-dfb49bf9-c7c0-4571-9840-6acb5f88ba5a.png">

(Also removes the FMS ID from the problem confirmation page where it's shown by default.)

For https://github.com/mysociety/societyworks/issues/2641

[skip changelog]