### PR TITLE
[Shropshire] Fix illegible grey text colour for pagination links

### DIFF
--- a/web/cobrands/shropshire/base.scss
+++ b/web/cobrands/shropshire/base.scss
@@ -19,6 +19,10 @@ a:focus,
     outline: solid 3px $shropshire-yellow;
 }
 
+.pagination a {
+    color: #fff;
+}
+
 .olButton:focus {
     z-index: 1; // pull forward, so entire outline is visible
 }


### PR DESCRIPTION
Looks like this now:

![Screenshot 2021-11-11 at 16 49 58](https://user-images.githubusercontent.com/739624/141337193-dfb3a3c1-28b9-4306-a5c0-5e06170c0702.png)

Makes me wonder whether this bug might also be present on other recent cobrands, where the primary button colour has been changed to somethign dark…