### PR TITLE
[Buckinghamshire] Fix illegible text colour for pagination links

### DIFF
--- a/web/cobrands/buckinghamshire/base.scss
+++ b/web/cobrands/buckinghamshire/base.scss
@@ -125,6 +125,10 @@ dl dt {
     }
 }
 
+.pagination a {
+  color: #fff;
+}
+
 label {
   @extend %bold-font;
 }


### PR DESCRIPTION
Oh look, here’s [another one](https://github.com/mysociety/fixmystreet/pull/3650)!

![Screenshot 2021-11-11 at 17 18 25](https://user-images.githubusercontent.com/739624/141340997-8149284c-c932-4670-8c01-6181049b0194.png)

Fixes mysociety/societyworks#2709

@lizettal / @ClareA it might be worth scheduling a ticket for the next design sprint, to check through these buttons on every cobrand. I bet there’ll be one or two more that exhibit the same issue.

<!-- [skip changelog] -->