### PR TITLE
[Shropshire] Remove text to pick salt bin for new salt bin

### DIFF
--- a/web/cobrands/shropshire/assets.js
+++ b/web/cobrands/shropshire/assets.js
@@ -120,7 +120,7 @@ fixmystreet.assets.add(defaults, {
             TYPENAME: "Grit_Bins"
         }
     },
-    asset_category: ["Salt bins new", "Salt bins replenish"],
+    asset_category: ["Salt bins replenish"],
     asset_item: 'grit bin',
     actions: {
         asset_found: fixmystreet.assets.named_select_action_found,


### PR DESCRIPTION
Stops user from being asked to pick a salt/grit bin when they are requesting a new salt/grit bin

[skip changelog]