### PR TITLE
Focus style for #key-tools links/buttons

### DIFF
--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -866,7 +866,8 @@ html.mobile.js-nav-open #js-menu-open-modal {
     border-radius: 0;
 
     &:hover,
-    &.hover {
+    &.hover,
+    &:focus {
       text-decoration: none;
       background-color: #333;
       color: #fff !important;


### PR DESCRIPTION
Super quick fix, in core, for everyone, but spotted by the team at Shropshire. More noticeable `:focus` style for the `#key-tools` links at the bottom of the map page and report page sidebars.