### PR TITLE
[Shropshire] Set 'Abandoned since field to mandatory

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Shropshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Shropshire.pm
@@ -57,6 +57,7 @@ sub open311_contact_meta_override {
     for my $meta_data (@$meta) {
         if ($meta_data->{'description'} && $meta_data->{'description'} =~ 'Abandoned since') {
             $meta_data->{'fieldtype'} = 'date';
+            $meta_data->{'required'} = 'true';
             last;
         }
     }

--- a/t/cobrand/shropshire.t
+++ b/t/cobrand/shropshire.t
@@ -65,7 +65,7 @@ subtest 'check open311_contact_meta_override' => sub {
             <code>group_hint</code>
             <datatype>string</datatype>
             <datatype_description></datatype_description>
-            <description>Model number</description>
+            <description>Registration Mark</description>
             <order>2</order>
             <required>false</required>
             <variable>false</variable>
@@ -102,7 +102,8 @@ subtest 'check open311_contact_meta_override' => sub {
     my @extra_fields = $contact->get_extra_fields;
 
     is $extra_fields[0][0]->{fieldtype}, 'date', "added fieldtype 'date' to 'Abandoned since'";
-    is $extra_fields[0][1]->{fieldtype}, undef, "not added fieldtype 'date' to 'Model number'";
+    is $extra_fields[0][0]->{required}, 'true', "set required to true";
+    is $extra_fields[0][1]->{fieldtype}, undef, "not added fieldtype 'date' to 'Registration Mark'";
 };
 
 done_testing();


### PR DESCRIPTION
The 'Abandoned since' field requires input or is rejected by confirm.

Request to make 'Registration Mark' mandatory too.