### PR TITLE
Add delay before FMS's Open311 `GET service_request_id for a token` call 

### DIFF
--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -284,3 +284,6 @@ FETCH_COMMENTS_PROCESS_TIMEOUT: 0
 # If you use the daemon for sending reports, rather than the cron script,
 # this is how many children it will have.
 QUEUE_DAEMON_PROCESSES: 4
+
+O311_POLLING_INTERVAL: 2
+O311_POLLING_MAX_TRIES: 5


### PR DESCRIPTION
fixes #3663

Please check the following:

- [ ] Whether this PR should include changes to any documentation, or the FAQ;
- [ ] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [ ] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [ ] Are the changes tested for accessibility?
- [ ] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
