### PR TITLE
[Hounslow] fix admin-panel-edited categories disappearing

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Hounslow.pm
+++ b/perllib/FixMyStreet/Cobrand/Hounslow.pm
@@ -68,6 +68,7 @@ sub categories_restriction {
         'body.name' => [ 'Hounslow Borough Council', 'National Highways' ],
         -or => [
             'me.send_method' => undef,
+            'me.send_method' => q[],
             'me.category' => { -in => [
                 'Pavement Overcrowding',
                 'Streetspace Suggestions and Feedback',


### PR DESCRIPTION
When a category with a send_method of undef is edited in the admin
panel, the send_method is updated to an empty string. Adding this
to the query in categories_restriction() prevents the categories
disappearing after any update.

Fixes https://mysocietysupport.freshdesk.com/a/tickets/1604

[skip changelog]

