### PR TITLE
[Shropshire] Make Oxfordhshire report archiving script generic to use for Shropshire integration report archiving

### DIFF
--- a/bin/archive-old-enquiries
+++ b/bin/archive-old-enquiries
@@ -22,7 +22,7 @@ BEGIN {
     use File::Basename qw(dirname);
     use File::Spec;
     my $d = dirname(File::Spec->rel2abs($0));
-    require "$d/../../setenv.pl";
+    require "$d/../setenv.pl";
 }
 
 use FixMyStreet::Script::ArchiveOldEnquiries;
@@ -38,6 +38,7 @@ my ($opts, $usage) = describe_options(
         ['email-cutoff=s',     "Anything before this will be closed with an email sent to the reporter" ],
         ['reports=s',          "csv file with a single column of report ids" ],
     ], required => 1 } ],
+    ['council_name=s', "Name of council for templates", { required => 1 }],
     ['closure-cutoff=s',  "Anything before this will be closed with no email/alert", { required => 1 } ],
     ['closure_file=s',    "path to text file with the message to add to reports" ],
     ['closure_text=s', "text of the message to add to reports" ],

--- a/perllib/FixMyStreet/Script/ArchiveOldEnquiries.pm
+++ b/perllib/FixMyStreet/Script/ArchiveOldEnquiries.pm
@@ -101,7 +101,9 @@ sub get_closure_message {
         my $file = path($opts->{closure_file});
         chomp(my $message = $file->slurp_utf8);
         return $message;
-
+    } else {
+        my $message = "FixMyStreet is being updated in " . $opts->{council_name} . " to improve how problems get reported.\n\nAs part of this process we are closing all reports made before the update.\n\nAll of your reports will have been received and reviewed by " . $opts->{council_name} . " but, if you believe that this issue has not been resolved, please open a new report on it.\n\nThank you.";
+        return $message;
     }
 }
 
@@ -171,6 +173,7 @@ sub send_email_and_close {
       reports => [@problems],
       report_count => scalar(@problems),
       site_name => $cobrand->moniker,
+      council_name => $opts->{council_name},
       user => $user,
       cobrand => $cobrand,
     );
@@ -179,7 +182,7 @@ sub send_email_and_close {
     printf("    Sending email about %d reports: ", scalar(@problems));
     my $email_error = FixMyStreet::Email::send_cron(
         $problems->result_source->schema,
-        'archive.txt',
+        'archive-old-enquiries.txt',
         \%h,
         {
             To => [ [ $user->email, $user->name ] ],

--- a/templates/email/default/archive-old-enquiries.html
+++ b/templates/email/default/archive-old-enquiries.html
@@ -1,0 +1,55 @@
+[%
+
+email_summary = "Your reports on " _ site_name;
+
+PROCESS '_email_settings.html';
+
+INCLUDE '_email_top.html';
+
+%]
+
+<th style="[% td_style %][% only_column_style %]">
+  <h1 style="[% h1_style %]">Your reports on [% site_name %]</h1>
+  <p style="[% p_style %]">
+    Hello [% user.name %],
+  </p>
+  <p style="[% p_style %]">
+    FixMyStreet is being updated in [% council_name %] to
+    improve how problems get reported.
+  </p>
+  <p style="[% p_style %]">
+    As part of this process we are closing all reports
+    made before the update.
+  </p>
+  <p style="[% p_style %]">
+    We noticed that you have [% report_count %] old [% nget('report', 'reports', report_count) %] on the system,
+    which we've listed below.
+  </p>
+  <p style="[% p_style %]">
+    All of your reports will have been received and reviewed by [% council_name %], so if
+    your report is no longer an issue, you don't need to do anything.
+  </p>
+  <p style="[% p_style %]">
+    If you believe that the issue has not been resolved you can <a href="[% cobrand.base_url %]">report it again here.</a>
+  </p>
+
+  [% FOR report IN reports %]
+  <div style="[% list_item_style %]">
+  [% IF report.photo %]
+    <a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
+      <img style="[% list_item_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="">
+    </a>
+  [% END %]
+    <h2 style="[% list_item_h2_style %]"><a href="[% cobrand.base_url_for_report( report ) %]report/[% report.id %]">
+      [%~ report.title | html ~%]
+    </a></h2>
+    <p style="[% list_item_p_style %]">[% report.detail | html %]</p>
+    <p style="[% list_item_date_style %]">
+      Reported [% report.time_ago %] ago.
+    </p>
+  </div>
+  [% END %]
+
+</th>
+
+[% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/archive-old-enquiries.txt
+++ b/templates/email/default/archive-old-enquiries.txt
@@ -1,0 +1,28 @@
+Subject: Your reports on [% site_name %]
+
+Hello [% user.name %],
+
+FixMyStreet is being updated in [% council_name %] to improve how problems get reported.
+
+As part of this process we are closing all reports made before the update.
+
+We noticed that you have [% report_count %] old [% nget('report', 'reports', report_count) %] on the system, which we've listed below.
+
+All of your reports will have been received and reviewed by [% council_name %], so if your report is no longer an issue, you don't need to do anything.
+
+If you believe that the issue has not been resolved you can report it again here: [% cobrand.base_url %]
+
+[% FOR report IN reports %]
+
+[% report.title %]
+
+Reported [% report.time_ago %] ago.
+
+View report: [% cobrand.base_url_for_report( report ) %]report/[% report.id %]
+
+----
+
+[% END %]
+
+The FixMyStreet team and [% council_name %] Council
+


### PR DESCRIPTION
This adds the necessary templates for Shropshire to have files closed using automated script

Moves script 'archive-old-enquiries' out of oxfordshire directory as it's a generic script that will run on all cobrands

[skip changelog]