### PR TITLE
[Open311] Improve template lookup behaviour.

### DIFF
--- a/perllib/Open311/UpdatesBase.pm
+++ b/perllib/Open311/UpdatesBase.pm
@@ -259,10 +259,11 @@ sub comment_text_for_request {
     my $template;
     if ($state_changed || $ext_code_changed) {
         my $order;
-        my $state_params = {
-            'me.state' => $state
-        };
-        if ($ext_code) {
+        my $state_params = {};
+        if ($state_changed) {
+            $state_params->{'me.state'} = $state;
+        }
+        if ($ext_code_changed && $ext_code) {
             $state_params->{'me.external_status_code'} = $ext_code;
             # make sure that empty string/nulls come last.
             $order = { order_by => \"me.external_status_code DESC NULLS LAST" };

--- a/t/open311/getservicerequestupdates.t
+++ b/t/open311/getservicerequestupdates.t
@@ -1057,6 +1057,7 @@ for my $test (
             external_status_code => $test->{external_code}
         });
 
+        $problem->update({ state => "confirmed" });
         $problem->comments->delete;
 
         my $dt2 = $dt->clone->add( minutes => 1 );


### PR DESCRIPTION
Do not look for state change templates if only the external status code has changed.
