### PR TITLE
[UK] Fix removal of roadworks message.

### DIFF
--- a/web/cobrands/fixmystreet-uk-councils/roadworks.js
+++ b/web/cobrands/fixmystreet-uk-councils/roadworks.js
@@ -24,6 +24,8 @@ var roadworks_defaults = {
             if (!fixmystreet.roadworks.filter || fixmystreet.roadworks.filter(feature)) {
                 fixmystreet.roadworks.display_message(feature);
                 return true;
+            } else {
+                $(".js-roadworks-page").remove();
             }
         },
         not_found: function(layer) {


### PR DESCRIPTION
If the roadworks message had already been shown, but you e.g. change category to something for which the filter returns false, the message would not be removed. Spotted in https://mysocietysupport.freshdesk.com/a/tickets/1558 but nothing to actually do for that ticket.