### PR TITLE
Replace FMS problem ID with Merton SRQ case reference 

### DIFF
--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -807,7 +807,7 @@ sub defect_types {
 #     Note:   this only makes sense when called on a problem that has been sent!
 sub can_display_external_id {
     my $self = shift;
-    if ($self->external_id && $self->to_body_named('Oxfordshire|Lincolnshire|Isle of Wight|East Sussex|Central Bedfordshire|Shropshire')) {
+    if ($self->external_id && $self->to_body_named('Oxfordshire|Lincolnshire|Isle of Wight|East Sussex|Central Bedfordshire|Shropshire|Merton')) {
         return 1;
     }
     return 0;

--- a/t/cobrand/merton.t
+++ b/t/cobrand/merton.t
@@ -35,6 +35,33 @@ my ($problem2) = $mech->create_problems_for_body(1, $hackney->id, 'Title', {
     cobrand => 'fixmystreet', user => $normaluser, state => 'fixed'
 });
 
+
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => [ 'merton' ],
+    MAPIT_URL => 'http://mapit.uk/',
+}, sub {
+
+    subtest 'cobrand homepage displays council name' => sub {
+        $mech->get_ok('/');
+        $mech->content_contains('Merton Council');
+    };
+
+    subtest 'reports page displays council name' => sub {
+        $mech->get_ok('/reports/Merton');
+        $mech->content_contains('Merton Council');
+    };
+
+    subtest 'External ID is shown on report page' => sub {
+        my ($report) = $mech->create_problems_for_body(1, $merton->id, 'Test Report', {
+            category => 'Litter', cobrand => 'merton',
+            external_id => 'merton-123', whensent => \'current_timestamp',
+        });
+        $mech->get_ok('/report/' . $report->id);
+        $mech->content_contains("Council ref:&nbsp;" . $report->external_id);
+    };
+
+};
+
 subtest 'only Merton staff can reopen closed reports on Merton cobrand' => sub {
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => [ 'merton' ],

--- a/templates/web/merton/tokens/_confirm_problem_council_id.html
+++ b/templates/web/merton/tokens/_confirm_problem_council_id.html
@@ -1,0 +1,1 @@
+<h2>Your issue has been sent.</h2>


### PR DESCRIPTION
Replaces mention of the numeric FMS problem ID with Merton's 'SRQ' code from their MS Dynamics CRM as the case reference number. 

to fix mysociety/societyworks/issues/2621

Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [ ] Are the changes tested for accessibility?
[skip changelog]
