### PR TITLE
[Shropshire] Privacy and accessibility links in footer

### DIFF
--- a/templates/web/shropshire/footer_extra.html
+++ b/templates/web/shropshire/footer_extra.html
@@ -1,3 +1,16 @@
+<div class="shropshire-footer">
+    <div class="container">
+        <ul>
+            <li>
+                <a href="https://shropshire.gov.uk/website-information/help-using-our-website/accessibility-statement-for-shropshire-council/">Accessibility statement</a>
+            </li>
+            <li>
+                <a href="https://shropshire.gov.uk/privacy/">Privacy</a>
+            </li>
+        </ul>
+    </div>
+</div>
+
 <div class="societyworks-footer">
     <div class="container">
         <p>

--- a/web/cobrands/shropshire/base.scss
+++ b/web/cobrands/shropshire/base.scss
@@ -46,6 +46,28 @@ a:focus,
     overflow: hidden;
 }
 
+.shropshire-footer {
+    background: $shropshire-dark-grey;
+    border-bottom: solid 1px $shropshire-mid-grey;
+    color: #fff;
+    padding: 1.5em 0;
+
+    ul {
+        margin: 0;
+        font-size: 12px;
+    }
+
+    li {
+        list-style: none;
+        margin: 0.66em 0;
+    }
+
+    a {
+        color: inherit;
+        text-decoration: underline;
+    }
+}
+
 #report-cta {
     border-color: #fff;
 }

--- a/web/cobrands/shropshire/layout.scss
+++ b/web/cobrands/shropshire/layout.scss
@@ -83,7 +83,7 @@ textarea.form-error {
     border-radius: 4px;
 }
 
-.societyworks-footer {
+.shropshire-footer {
     margin-top: 4em;
 }
 


### PR DESCRIPTION
Adds a new footer to the Shropshire cobrand, with the required links:

![Screenshot 2021-11-29 at 12-27-08 FixMyStreet](https://user-images.githubusercontent.com/739624/143868473-2caef3b0-0483-4f42-8f44-0521408605a7.png)

[skip changelog]