### PR TITLE
[Merton] Allow anonymous reports

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Merton.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton.pm
@@ -31,6 +31,16 @@ sub admin_user_domain { 'merton.gov.uk' }
 
 sub privacy_policy_url { "https://www.merton.gov.uk/legal/privacy-and-cookies" }
 
+sub allow_anonymous_reports { 'button' }
+
+sub anonymous_account {
+    my $self = shift;
+    return {
+        email => $self->feature('anonymous_account') . '@' . $self->admin_user_domain,
+        name => 'Anonymous user',
+    };
+}
+
 sub open311_config {
     my ($self, $row, $h, $params) = @_;
 


### PR DESCRIPTION
Enable anonymous reporting for the Merton cobrand and a test to ensure it's working as expected.

The test is copied from TfL's one, which seemed to be testing the right things.

Fixes https://github.com/mysociety/societyworks/issues/2615

<!-- [skip changelog] -->
