### PR TITLE
Explicit z-indexes to stack mobile menu above map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
         - Do not email inactive body comment users. #3587
         - Look up organizational domain in DMARC checking. #3603
         - Stop slash in category name breaking csv download #3642
+        - Fix CSS z-index bug that resulted in the main menu being hidden behind the map on small screens #3686
     - Admin improvements:
         - Assignees of reports are now visible in admin reports list and report edit pages.
         - Enable per-category hint customisation.

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -773,6 +773,7 @@ html.mobile.js-nav-open #js-menu-open-modal {
   left: 0;
   right: 0;
   background-color: rgba(0, 0, 0, 0.4);
+  z-index: 2; // So appears over map
 }
 
 #main-nav {
@@ -781,7 +782,7 @@ html.mobile.js-nav-open #js-menu-open-modal {
   overflow: auto;
   left: 0;
   right: 0;
-  z-index: 1; // So appears over map
+  z-index: 3; // So appears over map and #js-menu-open-modal
 }
 
 #main-nav-btn {


### PR DESCRIPTION
I am totally at a loss as to when this bug was introduced, or what caused it. The stacking clearly worked fine when the new JavaScript-powered pop-over menu was added 12 months ago (in a01e927), so something must have changed, in core, since then.

I think the absolute positions of everything on the map page have always been relative to the viewport (rather than there being any `position: relative` parents). If so, it can’t be that a positioned parent has been removed, causing the `z-indexes` to no longer be in the right stacking context.

The `z-index: 1` for `.map-fullscreen #map_box` was [set 5 years ago](https://github.com/mysociety/fixmystreet/blame/master/web/cobrands/sass/_base.scss#L2171) in a5ef113, with a comment: `// stack above positioned elements later on the page (eg: .report-list-filters)`.

The `z-index: 1` for `#main-nav` was [set 12 months ago](https://github.com/mysociety/fixmystreet/blame/master/web/cobrands/sass/_base.scss#L784) in 1784886 (part of the same pop-over menu pull request #3270) and it even has an inline comment saying `// So appears over map`!

Anyway, unless someone else can find what changed in the meantime, I’ve done the most obvious thing necessary, which is to define higher z-indexes for the `#js-menu-open-modal` and `#main-nav`.

Fixes #3617

