### PR TITLE
Fix permissions setting in admin.

### DIFF
--- a/web/cobrands/fixmystreet/admin.js
+++ b/web/cobrands/fixmystreet/admin.js
@@ -81,10 +81,12 @@ $(function(){
     });
 
     $('form#user_edit select#roles').on('change', function() {
-        var $perms = $('.permissions-checkboxes');
-        if ($(this).val()) {
+        var $perms = $('.permissions-checkboxes'),
+            $this = $(this),
+            value = $this.val() || [];
+        if (value.length) {
             var selected_perms = {};
-            $(this).find(':selected').each(function() {
+            $this.find(':selected').each(function() {
                 $.each($(this).data('permissions'), function(i, p) {
                     selected_perms['permissions[' + p + ']'] = 1;
                 });


### PR DESCRIPTION
The upgrade to jQuery 3 broke the fetching of val() on the roles
multiple select input, as the code assumed this returned null if
no role was selected, whereas now it returns an empty array.

I've checked all the other uses of val() and can't see any others on a select multiple.

Fixes https://mysocietysupport.freshdesk.com/a/tickets/1634
[skip changelog] (as upgrade was before last release)