### PR TITLE
[Shropshire] Footer link to FMS privacy page, not Shropshire one

### DIFF
--- a/templates/web/shropshire/footer_extra.html
+++ b/templates/web/shropshire/footer_extra.html
@@ -5,7 +5,7 @@
                 <a href="https://shropshire.gov.uk/website-information/help-using-our-website/accessibility-statement-for-shropshire-council/">Accessibility statement</a>
             </li>
             <li>
-                <a href="https://shropshire.gov.uk/privacy/">Privacy</a>
+                <a href="/about/privacy">Privacy</a>
             </li>
         </ul>
     </div>


### PR DESCRIPTION
Turns out #3683 linked to the wrong Privacy page.