### PR TITLE
[Buckinghamshire] Change default map filters

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -31,7 +31,7 @@ sub disambiguate_location {
     };
 }
 
-sub on_map_default_status { 'open' }
+sub on_map_default_status { ('open', 'fixed') }
 
 sub pin_colour {
     my ( $self, $p, $context ) = @_;


### PR DESCRIPTION
Client has requested that the default map filters are changed to "Open" and "Fixed".

Fixes https://github.com/mysociety/societyworks/issues/2766

<!-- [skip changelog] -->