### PR TITLE
[Oxfordshire] Send FMS ID to reporter in confirmation email.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -501,4 +501,6 @@ sub extra_reports_pins {
     return $self->pins_from_wfs(\@box);
 }
 
+sub report_sent_confirmation_email { 'id' }
+
 1;

--- a/t/cobrand/oxfordshire.t
+++ b/t/cobrand/oxfordshire.t
@@ -7,12 +7,17 @@ use FixMyStreet::Script::Reports;
 use Open311;
 my $mech = FixMyStreet::TestMech->new;
 
+# disable info logs for this test run
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
 my $oxon = $mech->create_body_ok(2237, 'Oxfordshire County Council');
 my $counciluser = $mech->create_user_ok('counciluser@example.com', name => 'Council User', from_body => $oxon);
 my $role = FixMyStreet::DB->resultset("Role")->create({ body => $oxon, name => 'Role', permissions => [] });
 $counciluser->add_to_roles($role);
 
 my $oxfordshire_cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Oxfordshire');
+$oxfordshire_cobrand->mock('area_types', sub { [ 'CTY' ] });
 
 $oxfordshire_cobrand->mock('defect_wfs_query', sub {
     return {
@@ -384,13 +389,37 @@ FixMyStreet::override_config {
         $mech->create_contact_ok( body_id => $oxon->id, category => 'Lamp out', email => 'streetlighting', group => 'Street Lighting' );
         $mech->create_contact_ok( body_id => $oxon->id, category => 'Lamp on all day', email => 'streetlighting', group => 'Street Lighting' );
         $mech->create_contact_ok( body_id => $oxon->id, category => 'Lamp leaning', email => 'streetlighting', group => 'Street Lighting' );
-        my @params = (1, $oxon->id, 'Other light', { latitude => $latitude, longitude => $longitude, category => 'Lamp on all day' });
+        my @params = (1, $oxon->id, 'Other light', { latitude => $latitude, longitude => $longitude, category => 'Lamp on all day', cobrand => 'oxfordshire' });
         $mech->create_problems_for_body(@params);
         $params[3]{category} = 'Lamp leaning';
         $mech->create_problems_for_body(@params);
         my $json = $mech->get_ok_json("/around/nearby?latitude=$latitude&longitude=$longitude&filter_category=Lamp+out");
         my $pins = $json->{pins};
         is scalar @$pins, 2, 'other street lighting pins included';
+    };
+
+    subtest "Sends FMS report ID in confirmation emails when user is logged in." => sub {
+        FixMyStreet::Script::Reports::send();
+        $mech->clear_emails_ok;
+
+        my ($report) = $mech->create_problems_for_body( 1, $oxon->id, 'Flooded Gully', {
+            cobrand => 'oxfordshire',
+            category => 'Gullies and Catchpits',
+            user => $user,
+            latitude => 51.754926,
+            longitude => -1.256179,
+        });
+
+        FixMyStreet::Script::Reports::send();
+
+        my $email = $mech->get_email; # tests that there's precisely 1 email in queue
+        my $email_text = $mech->get_text_body_from_email($email);
+        like $email_text, qr/Your report to Oxfordshire County Council has been logged/, "A confirmation email has been received from Oxfordshire CC";
+        like $email_text, qr/The report's reference number is \d+\./, "...with a numerical case ref. in the text part...";
+        my $html_body = $mech->get_html_body_from_email($email);
+        like $html_body, qr/The report's reference number is <strong>\d+/, "...and a numerical case ref. in the HTML part";
+
+        $mech->clear_emails_ok;
     };
 
 };

--- a/templates/email/oxfordshire/_council_reference.html
+++ b/templates/email/oxfordshire/_council_reference.html
@@ -1,0 +1,2 @@
+<p style="[% p_style %]">The report's reference number is <strong>[% problem.id %]</strong>.
+  Please quote this if you need to contact Oxfordshire County Council about this report.</p>

--- a/templates/email/oxfordshire/_council_reference.txt
+++ b/templates/email/oxfordshire/_council_reference.txt
@@ -1,0 +1,2 @@
+The report's reference number is [% problem.id %]. Please quote this if
+you need to contact Oxfordshire County Council about this report.

--- a/templates/web/oxfordshire/tokens/_confirm_problem_council_id.html
+++ b/templates/web/oxfordshire/tokens/_confirm_problem_council_id.html
@@ -1,1 +1,0 @@
-<h2>Your issue is on its way to the council.</h2>


### PR DESCRIPTION
Add FMS ID to confirmation emails asking users to use it if they get in touch with the council. 

Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? 
[skip changelog]

fixes https://github.com/mysociety/societyworks/issues/2548