### PR TITLE
[Bromley] only store payment field when required

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1118,13 +1118,15 @@ sub process_garden_modification : Private {
         $pro_rata = $c->cobrand->waste_get_pro_rata_cost( $new_bins, $c->stash->{garden_form_data}->{end_date});
         $c->set_param('pro_rata', $pro_rata);
     }
+
+    my $payment_method = $c->stash->{garden_form_data}->{payment_method};
     my $payment = $c->cobrand->garden_waste_cost($data->{bins_wanted});
+    $payment = 0 if $payment_method ne 'direct_debit' && $new_bins < 0;
     $c->set_param('payment', $payment);
 
     $c->forward('setup_garden_sub_params', [ $data ]);
     $c->forward('add_report', [ $data, 1 ]) or return;
 
-    my $payment_method = $c->stash->{garden_form_data}->{payment_method};
 
     if ( FixMyStreet->staging_flag('skip_waste_payment') ) {
         $c->stash->{message} = 'Payment skipped on staging';

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -1289,6 +1289,8 @@ FixMyStreet::override_config {
         is $new_report->get_extra_field_value('Container_Instruction_Container_Type'), 44, 'correct container request bin type';
         is $new_report->get_extra_field_value('Container_Instruction_Action'), 2, 'correct container request action';
         is $new_report->get_extra_field_value('Container_Instruction_Quantity'), 1, 'correct container request count';
+        is $new_report->get_extra_field_value('payment'), '', 'no payment if removing bins';
+        is $new_report->get_extra_field_value('pro_rata'), '', 'no pro rata payment if removing bins';
 
         is $sent_params, undef, "no one off payment if reducing bin count";
     };
@@ -1323,6 +1325,8 @@ FixMyStreet::override_config {
         is $new_report->title, 'Garden Subscription - Amend', 'correct title on report';
         is $new_report->get_extra_field_value('payment_method'), 'direct_debit', 'correct payment method on report';
         is $new_report->state, 'unconfirmed', 'report not confirmed';
+        is $new_report->get_extra_field_value('payment'), '4000', 'payment correctly set to future value';
+        is $new_report->get_extra_field_value('pro_rata'), '750', 'pro rata payment correctly set';
 
         is_deeply $dd_sent_params->{one_off_payment}, {
             payer_reference => 'GGW1000000002',
@@ -1356,6 +1360,8 @@ FixMyStreet::override_config {
         is $new_report->category, 'Garden Subscription', 'correct category on report';
         is $new_report->title, 'Garden Subscription - Amend', 'correct title on report';
         is $new_report->get_extra_field_value('payment_method'), 'direct_debit', 'correct payment method on report';
+        is $new_report->get_extra_field_value('payment'), '2000', 'payment correctly set to future value';
+        is $new_report->get_extra_field_value('pro_rata'), '', 'no pro rata payment if removing bins';
         is $new_report->state, 'unconfirmed', 'report not confirmed';
 
         is $dd_sent_params->{one_off_payment}, undef, "no one off payment if reducing bin count";
@@ -2027,6 +2033,8 @@ FixMyStreet::override_config {
         is $new_report->get_extra_field_value('Container_Instruction_Quantity'), 1, 'correct container request count';
         is $new_report->get_extra_metadata('contributed_by'), $staff_user->id;
         is $new_report->get_extra_metadata('contributed_as'), 'anonymous_user';
+        is $new_report->get_extra_field_value('payment'), '', 'no payment if removing bins';
+        is $new_report->get_extra_field_value('pro_rata'), '', 'no pro rata payment if removing bins';
     };
 
     subtest 'cancel staff sub' => sub {


### PR DESCRIPTION
If we're not taking a payment or updating a direct debit amount then
don't store the payment field as it appears in the admin which can be
confusing. This only applies for reducing bins on non direct debit
subscriptions.

Fixes mysociety/societyworks#2448
[skip changelog]