### PR TITLE
[Buckinghamshire] Removes Covid-19 text from report confirmation

### DIFF
--- a/templates/email/buckinghamshire/other-reported.html
+++ b/templates/email/buckinghamshire/other-reported.html
@@ -22,13 +22,6 @@ using the email address associated with the report.</p>
 [% IF cobrand.owns_problem( report ) %]
 [% TRY %][% INCLUDE '_council_reference.html' problem=report %][% CATCH file %][% END %]
 [% END %]
-
-<p style="[% p_style %]">
-Due to COVID 19 restrictions we have reduced capacity and must prioritise work
-based on urgency. We apologise that it might therefore take longer than normal
-to respond to your report.
-</p>
-
   <p style="margin: 20px auto; text-align: center">
   <a style="[% button_style %]" href="[% cobrand.base_url_for_report(report) %][% report.view_url %]">View my report</a>
   </p>

--- a/templates/email/buckinghamshire/other-reported.txt
+++ b/templates/email/buckinghamshire/other-reported.txt
@@ -15,10 +15,6 @@ associated with the report.
 [% TRY %][% INCLUDE '_council_reference.txt' problem=report %][% CATCH file %][% END %]
 [% END %]
 
-Due to COVID 19 restrictions we have reduced capacity and must prioritise work
-based on urgency. We apologise that it might therefore take longer than normal
-to respond to your report.
-
 It is available to view at:
 
 [% cobrand.base_url_for_report(report) %][% report.view_url %]


### PR DESCRIPTION
Removes the Covid-19 text that appears when a report is made that was warning that the time taken to fix reports could be longer due to Covid-19

https://mysocietysupport.freshdesk.com/a/tickets/1657
[skip changelog]
