### PR TITLE
[Merton] save service to extra data to hide spurious service field

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Merton.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton.pm
@@ -62,10 +62,6 @@ sub reopening_disallowed {
 sub open311_extra_data_include {
     my ($self, $row, $h) = @_;
 
-    my $open311_only = [
-        { name => 'service', value => $row->service },
-    ];
-
     # Reports made via FMS.com or the app probably won't have a USRN
     # value because we don't access the USRN layer on those
     # frontends. Instead we'll look up the closest asset from the WFS
@@ -76,7 +72,18 @@ sub open311_extra_data_include {
         }
     }
 
-    return $open311_only;
+    return [];
+}
+
+sub report_new_munge_before_insert {
+    my ($self, $report) = @_;
+
+    # Save the service attribute into extra data as well as in the
+    # problem to avoid having the field appear as blank and required
+    # in the inspector toolbar for users with 'inspect' permissions.
+    if (!$report->get_extra_field_value('service')) {
+        $report->update_extra_field({ name => 'service', value => $report->service });
+    }
 }
 
 sub lookup_site_code_config { {

--- a/perllib/FixMyStreet/Cobrand/Merton.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton.pm
@@ -78,6 +78,11 @@ sub open311_extra_data_include {
 sub report_new_munge_before_insert {
     my ($self, $report) = @_;
 
+    # Workaround for anonymous reports not having a service associated with them.
+    if (!$report->service) {
+        $report->service('unknown');
+    }
+
     # Save the service attribute into extra data as well as in the
     # problem to avoid having the field appear as blank and required
     # in the inspector toolbar for users with 'inspect' permissions.

--- a/t/cobrand/merton.t
+++ b/t/cobrand/merton.t
@@ -191,6 +191,26 @@ FixMyStreet::override_config {
         ok $report, "Found the report";
         is $report->get_extra_field_value("service"), 'desktop', 'origin service recorded in extra data too';
     };
+
+    subtest 'anonymous reports have service "unknown"' => sub {
+        $mech->get_ok('/around');
+        $mech->submit_form_ok( { with_fields => { pc => 'SM4 5DX', } }, "submit location" );
+        $mech->follow_link_ok( { text_regex => qr/skip this step/i, }, "follow 'skip this step' link" );
+        $mech->submit_form_ok(
+            {
+                button => 'report_anonymously',
+                with_fields => {
+                    title => 'Test Report 3',
+                    detail => 'Test report details.',
+                    category => 'Litter',
+                }
+            },
+            "submit report anonymously"
+        );
+        my $report = FixMyStreet::DB->resultset("Problem")->find({ title => 'Test Report 3'});
+        ok $report, "Found the report";
+        is $report->get_extra_field_value("service"), 'unknown', 'origin service recorded in extra data too';
+    };
 };
 
 done_testing;


### PR DESCRIPTION
Hide 'service' input in inspector toolbar which is an artefact of sending service field via Open311 plus endpoint settings. 

To do this, simply save the service field as an additional, albeit redundant extra data field. 

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Are the changes tested for accessibility?
[skip changelog]
