### PR TITLE
[Merton] drop FMS contact form from privacy page

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Merton.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton.pm
@@ -102,4 +102,6 @@ sub lookup_site_code_config { {
 
 sub cut_off_date { '2020-12-06' } # 1 yr prior to FMS Pro go-live
 
+sub abuse_reports_only { 1 }
+
 1;

--- a/templates/web/fixmystreet-uk-councils/about/_sidebar.html
+++ b/templates/web/fixmystreet-uk-councils/about/_sidebar.html
@@ -1,0 +1,14 @@
+<div class="sticky-sidebar">
+    <aside>
+        <ul class="plain-list">
+            <li>[% INCLUDE link h='/faq' t=loc('Frequently Asked Questions') %]</li>
+            <li>[% INCLUDE link h=c.cobrand.privacy_policy_url t=loc('Privacy and cookies') %]</li>
+        </ul>
+    </aside>
+</div>
+
+[% BLOCK link -%]
+<[% IF c.req.uri.path == h %]strong[% ELSE %]a href="[% h %]"[% END %]>
+[%- t -%]
+</[% IF c.req.uri.path == h %]strong[% ELSE %]a[% END %]>
+[%- END %]


### PR DESCRIPTION
- Removed FMS contact form _link_ from privacy policy page.
- Set Merton cobrand to only allow contact form for abuse reports.

fixes mysociety/societyworks/issues/2629

[skip changelog]