### PR TITLE
[Merton] Add nonce attribute to Google Tag Manager script

### DIFF
--- a/templates/web/merton/tracking_code.html
+++ b/templates/web/merton/tracking_code.html
@@ -1,7 +1,9 @@
 <!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+<script nonce="[% csp_nonce %]">
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MTTLXZ4');</script>
+})(window,document,'script','dataLayer','GTM-MTTLXZ4');
+</script>
 <!-- End Google Tag Manager -->


### PR DESCRIPTION
Getting an error on the Merton cobrand:

> Refused to execute inline script because it violates the following Content Security Policy directive: “script-src ‘self’ ‘unsafe-inline’ ‘nonce-ef5d8d05655b1d495b666235f0d57b80’ https://www.googletagmanager.com”. Note that ‘unsafe-inline’ is ignored if either a hash or nonce value is present in the source list.

I believe adding this nonce attribute should fix that.

[skip changelog]