### PR TITLE
[Merton] Run before_insert hook on .com

### DIFF
--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -404,6 +404,7 @@ sub report_new_munge_before_insert {
     $self->SUPER::report_new_munge_before_insert($report);
 
     FixMyStreet::Cobrand::Buckinghamshire::report_new_munge_before_insert($self, $report);
+    FixMyStreet::Cobrand::Merton::report_new_munge_before_insert($self, $report);
 }
 
 around 'munge_sendreport_params' => sub {

--- a/perllib/FixMyStreet/Cobrand/Merton.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton.pm
@@ -78,6 +78,8 @@ sub open311_extra_data_include {
 sub report_new_munge_before_insert {
     my ($self, $report) = @_;
 
+    return unless $report->to_body_named('Merton');
+
     # Workaround for anonymous reports not having a service associated with them.
     if (!$report->service) {
         $report->service('unknown');


### PR DESCRIPTION
This ensures that reports have a service and that the service is persisted to extra data.

[skip changelog]
