### PR TITLE
[UK] Exclude waste/noise/claims from statistics.

### DIFF
--- a/perllib/FixMyStreet/DB/Result/Body.pm
+++ b/perllib/FixMyStreet/DB/Result/Body.pm
@@ -258,6 +258,7 @@ sub calculate_average {
         'me.id' => \"= ($substmt)",
         'me.state' => 'confirmed',
         'problem.state' => [ FixMyStreet::DB::Result::Problem->visible_states() ],
+        'problem.cobrand_data' => { -not_in => ["waste", "noise", "claim"] },
         %cutoff,
     }, {
         select   => [

--- a/perllib/FixMyStreet/Script/UpdateAllReports.pm
+++ b/perllib/FixMyStreet/Script/UpdateAllReports.pm
@@ -135,7 +135,9 @@ sub generate_dashboard {
 
     my %data;
 
-    my $rs = FixMyStreet::DB->resultset('Problem');
+    my $rs = FixMyStreet::DB->resultset('Problem')->search({
+        cobrand_data => { -not_in => ["waste", "noise", "claim"] },
+    });
     $rs = $rs->to_body($body) if $body;
 
     my $rs_c = FixMyStreet::DB->resultset('Comment');

--- a/t/app/controller/reports.t
+++ b/t/app/controller/reports.t
@@ -24,6 +24,7 @@ $mech->create_contact_ok(body_id => $body_fife_id, category => 'Flytipping', ema
 my @edinburgh_problems = $mech->create_problems_for_body(3, $body_edin_id, 'All reports', { category => 'Potholes' });
 my @westminster_problems = $mech->create_problems_for_body(5, $body_west_id, 'All reports', { category => 'Graffiti' });
 my @fife_problems = $mech->create_problems_for_body(15, $body_fife_id, 'All reports', { category => 'Flytipping' });
+$mech->create_problems_for_body(2, $body_edin_id, 'Waste reports', { cobrand_data => 'waste' });
 
 my $west_trans = FixMyStreet::DB->resultset('Translation')->find_or_create({
     tbl => 'body',
@@ -167,7 +168,7 @@ FixMyStreet::override_config {
     $mech->get_ok('/reports/City+of+Edinburgh?status=open');
 };
 $problems = $mech->extract_problem_list;
-is scalar @$problems, 3, 'correct number of open problems displayed';
+is scalar @$problems, 5, 'correct number of open problems displayed';
 
 FixMyStreet::override_config {
     MAPIT_URL => 'http://mapit.uk/',

--- a/t/cobrand/fixmystreet.t
+++ b/t/cobrand/fixmystreet.t
@@ -119,7 +119,7 @@ FixMyStreet::override_config {
         $mech->content_lacks('Where we send Birmingham');
     };
 
-    subtest 'check average fix time respects cobrand cut-off date' => sub {
+    subtest 'check average fix time respects cobrand cut-off date and non-standard reports' => sub {
         $mech->log_in_ok('someone@birmingham.gov.uk');
         my $user = FixMyStreet::DB->resultset('User')->find_or_create({ email => 'counciluser@example.org' });
 
@@ -142,6 +142,21 @@ FixMyStreet::override_config {
             confirmed => DateTime->now->subtract(days => 10),
         });
         $report2->comments->create({
+            user      => $user,
+            name      => 'A User',
+            anonymous => 'f',
+            text      => 'fixed the problem',
+            state     => 'confirmed',
+            mark_fixed => 1,
+            confirmed => DateTime->now,
+        });
+
+        # Another report, created 10 days ago, that was just fixed.
+        my ($report3) = $mech->create_problems_for_body(1, $body->id, 'Title', {
+            confirmed => DateTime->now->subtract(days => 1),
+            cobrand_data => 'waste',
+        });
+        $report3->comments->create({
             user      => $user,
             name      => 'A User',
             anonymous => 'f',


### PR DESCRIPTION
Ignore waste/noise/claims reports from summary dashboard and body averages [skip changelog]
Fixes https://github.com/mysociety/societyworks/issues/2440