### PR TITLE
Allow custom arguments to script/server in Docker config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,11 @@ _Inline/
 *.pyc
 docker-compose.override.yml
 
+# Optional Docker config
+docker/.env
+docker/ssl.crt
+docker/ssl.key
+
 # JS coverage
 /.nyc_output
 /coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
         - Fix link deactivation for privacy policy link on privacy policy page. #3704
     - Development improvements:
         - Default make_css to `web/cobrands` rather than `web`.
+        - Ability to pass custom arguments (eg: SSL config) to server when running via Docker
 
 * v4.0 (3rd December 2021)
     - Front end improvements:

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -27,7 +27,7 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile-development
-    command: script/server
+    command: script/server ${SERVER_ARGUMENTS}
     tty: true
     ports:
       - 3000:3000

--- a/docs/install/docker-develop.md
+++ b/docs/install/docker-develop.md
@@ -22,6 +22,27 @@ Note that the setup step can take a long time the first time, and Docker does
 not output the ongoing logs. While it is running, you can run `docker logs
 docker_setup_1 -f` in another terminal to watch what it is doing.
 
+## Serving with HTTPS
+
+Some client-side features (such as Geolocation API) are only available when
+the site is requested in a secure context (HTTPS). To use these features on
+your development, you’ll need to serve and visit FixMyStreet over HTTPS.
+
+First, generate a self-signed SSL certificate and keyfile with something like:
+
+    openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout docker/ssl.key -out docker/ssl.crt -subj "/CN=My local CA" -days 3650
+
+Create a file at `docker/.env` with the following content:
+
+    SERVER_ARGUMENTS='--listen :3000:ssl --ssl-cert=docker/ssl.crt --ssl-key=docker/ssl.key'
+
+When you next run `docker/compose-dev up`, your custom `$SERVER_ARGUMENTS` will
+be passed to the underlying `script/server` command, and FixMyStreet will be
+accessible, with SSL, on eg: <https://fixmystreet.127.0.0.1.xip.io:3000>.
+
+Note: You will likely need to force your browser to accept the self-signed
+certificate, before it will let you visit the site.
+
 ## Installation complete... now customise
 
 You should then proceed to [customise your installation](/customising/).

--- a/docs/install/manual-install.md
+++ b/docs/install/manual-install.md
@@ -61,6 +61,9 @@ $ port install gettext p5-locale-gettext p5-perlmagick jhead postgresql91-server
 
 ##### ii. HomeBrew
 
+**Note:** perlmagick is no longer included in HomeBrew, so you will need to
+find an alternative way to install ImageMagick.
+
 {% highlight bash %}
 $ brew install gettext perlmagick jhead postgresql
 $ brew link gettext --force


### PR DESCRIPTION
The content of the `SERVER_ARGUMENTS` environment variable (read from `docker/.env`) will be passed as an argument string to `script/server` when run by `docker/compose-dev up`.

If you have generated a self-signed SSL certificate and key, this change means you can pass those filepaths to `script/server`, to serve and access your development version of FixMyStreet over HTTPS.

This is all now documented at Installing > Docker (development).