### PR TITLE
[Merton] Add Merton categories to TfL cleaning categories list

### DIFF
--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -539,6 +539,15 @@ sub _cleaning_categories { [
     'Fly-Tipping',
     'Fly tipping - Enforcement Request',
     'Graffiti and Flyposting', # Bromley
+
+    # Merton want all of their street cleaning categories visible on Red Routes
+    'Abandoned Vehicles',
+    'Clinical Waste on Street',
+    'Dead Animal',
+    'Dog Fouling',
+    'Fly-Posting',
+    'Graffiti',
+    'Litter or Weeds on a Street',
 ] }
 
 sub _cleaning_groups { [ 'Street cleaning', 'Fly-tipping' ] }


### PR DESCRIPTION
Merton want all of their current categories (which they consider to be street cleaning categories) to be available for reporting on Red Routes.

Fixes https://github.com/mysociety/societyworks/issues/2779

[skip changelog]
