### PR TITLE
[Merton] Change domain of anonymous account

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Merton.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton.pm
@@ -36,7 +36,7 @@ sub allow_anonymous_reports { 'button' }
 sub anonymous_account {
     my $self = shift;
     return {
-        email => $self->feature('anonymous_account') . '@' . $self->admin_user_domain,
+        email => $self->feature('anonymous_account') . '@fixmystreet.merton.gov.uk',
         name => 'Anonymous user',
     };
 }

--- a/t/cobrand/merton.t
+++ b/t/cobrand/merton.t
@@ -98,7 +98,7 @@ FixMyStreet::override_config {
 
         is $report->bodies_str, $merton->id;
         is $report->name, 'Anonymous user';
-        is $report->user->email, 'anonymous@merton.gov.uk';
+        is $report->user->email, 'anonymous@fixmystreet.merton.gov.uk';
         is $report->anonymous, 1; # Doesn't change behaviour here, but uses anon account's name always
         is $report->get_extra_metadata('contributed_as'), 'anonymous_user';
 


### PR DESCRIPTION
Merton have asked for the domain of this email address to be changed to avoid reports being incorrectly attributes to a "Client Officer" account in their CRM.

[skip changelog]