### PR TITLE
[UK] Add ability to allow domain access to heatmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     - Front end improvements:
         - Highlight pin on sidebar focus as well as hover.
         - Map page pagination links now styled as links rather than buttons. #3727
+        - Include username in inactive email.
     - Bugfixes:
         - Add ID attributes to change password form inputs.
         - Fix link deactivation for privacy policy link on privacy policy page. #3704

--- a/perllib/FixMyStreet/App/Controller/Dashboard.pm
+++ b/perllib/FixMyStreet/App/Controller/Dashboard.pm
@@ -77,13 +77,16 @@ sub check_page_allowed : Private {
         if ($c->get_param('body')) {
             $body = $c->model('DB::Body')->find({ id => $c->get_param('body') });
         } else {
-            $body = $cobrand_body;
+            return $cobrand_body;
         }
     } elsif ($c->user->from_body && (!$cobrand_body || $cobrand_body->id == $c->user->from_body->id)) {
         $body = $c->user->from_body;
-    } else {
-        $c->detach( '/page_error_404_not_found' )
+    } elsif ($c->action eq 'dashboard/heatmap' && $c->cobrand->feature('heatmap_dashboard_body')) {
+        # Heatmap might be able to be seen by more people
+        $body = $c->cobrand->call_hook('dashboard_body');
+        $body = undef unless $body && $cobrand_body && $body->id == $cobrand_body->id;
     }
+    $c->detach('/page_error_404_not_found') unless $body;
     return $body;
 }
 

--- a/t/script/inactive.t
+++ b/t/script/inactive.t
@@ -100,7 +100,8 @@ subtest 'Anonymization of inactive users' => sub {
     stdout_is { $in->users } "Anonymizing user #" . $user->id . "\nEmailing user #" . $user_inactive->id . "\n", 'users dealt with first time';
 
     my $email = $mech->get_email;
-    like $email->as_string, qr/inactive\@example.com/, 'Inactive email sent';
+    my $user_email = $user_inactive->email;
+    like $email->as_string, qr/Your $user_email/, 'Inactive email sent';
     $mech->clear_emails_ok;
 
     $user->discard_changes;

--- a/templates/email/default/inactive-account.html
+++ b/templates/email/default/inactive-account.html
@@ -12,7 +12,7 @@ INCLUDE '_email_top.html';
 <th style="[% td_style %][% only_column_style %]">
   <h1 style="[% h1_style %]">Your inactive account</h1>
   <p style="[% p_style %]">
-Your account on [% site_name %] has been inactive for [% email_from %]
+Your [% user.username %] account on [% site_name %] has been inactive for [% email_from %]
 [% nget('month', 'months', email_from) %], and we automatically remove
 accounts that have been inactive after [% anonymize_from %]
 [% nget('month', 'months', anonymize_from) %]. If you wish to keep your

--- a/templates/email/default/inactive-account.txt
+++ b/templates/email/default/inactive-account.txt
@@ -2,7 +2,7 @@ Subject: Your inactive account on [% site_name %]
 
 Hello [% user.name %],
 
-Your account on [% site_name %] has been inactive for [% email_from %]
+Your [% user.username %] account on [% site_name %] has been inactive for [% email_from %]
 [% nget('month', 'months', email_from) %], and we automatically remove
 accounts that have been inactive after [% anonymize_from %]
 [% nget('month', 'months', anonymize_from) %]. If you wish to keep your


### PR DESCRIPTION
This brings the ability for logged-in non-staff users with specific email addresses/domains to view `/dashboard/heatmap` in the same way they can view `/reports/<body>/summary`. If a cobrand has the `heatmap_dashboard_body` feature enabled, then the same user-checking code will run when the heatmap is viewed on that cobrand. For example, if enabled for the Bromley cobrand, anyone with a bromley.gov.uk email address will be able to see the heatmap page as well as the summary page they currently can as well.

This PR adds the functionality but doesn't e.g. link to this anywhere, to be determined if given manually, linked, or other.

Fixes https://github.com/mysociety/societyworks/issues/2590 [skip changelog]