### PR TITLE
[Shropshire] Fix missing slash in emails, and improve templates, testing

### DIFF
--- a/bin/archive-old-enquiries
+++ b/bin/archive-old-enquiries
@@ -38,7 +38,6 @@ my ($opts, $usage) = describe_options(
         ['email-cutoff=s',     "Anything before this will be closed with an email sent to the reporter" ],
         ['reports=s',          "csv file with a single column of report ids" ],
     ], required => 1 } ],
-    ['council_name=s', "Name of council for templates", { required => 1 }],
     ['closure-cutoff=s',  "Anything before this will be closed with no email/alert", { required => 1 } ],
     ['closure_file=s',    "path to text file with the message to add to reports" ],
     ['closure_text=s', "text of the message to add to reports" ],

--- a/perllib/FixMyStreet/Script/ArchiveOldEnquiries.pm
+++ b/perllib/FixMyStreet/Script/ArchiveOldEnquiries.pm
@@ -102,7 +102,14 @@ sub get_closure_message {
         chomp(my $message = $file->slurp_utf8);
         return $message;
     } else {
-        my $message = "FixMyStreet is being updated in " . $opts->{council_name} . " to improve how problems get reported.\n\nAs part of this process we are closing all reports made before the update.\n\nAll of your reports will have been received and reviewed by " . $opts->{council_name} . " but, if you believe that this issue has not been resolved, please open a new report on it.\n\nThank you.";
+        my $cobrand;
+        eval {
+            $cobrand = FixMyStreet::Cobrand->get_class_for_moniker($opts->{cobrand})->new()->council_area;
+        };
+        if ($@) {
+            $cobrand = 'your council area';
+        }
+        my $message = "FixMyStreet is being updated in " . $cobrand . " to improve how problems get reported.\n\nAs part of this process we are closing all reports made before the update.\n\nAll of your reports will have been received and reviewed by " . $cobrand . " but, if you believe that this issue has not been resolved, please open a new report on it.\n\nThank you.";
         return $message;
     }
 }
@@ -173,7 +180,6 @@ sub send_email_and_close {
       reports => [@problems],
       report_count => scalar(@problems),
       site_name => $cobrand->moniker,
-      council_name => $opts->{council_name},
       user => $user,
       cobrand => $cobrand,
     );

--- a/templates/email/default/archive-old-enquiries.html
+++ b/templates/email/default/archive-old-enquiries.html
@@ -14,7 +14,7 @@ INCLUDE '_email_top.html';
     Hello [% user.name %],
   </p>
   <p style="[% p_style %]">
-    FixMyStreet is being updated in [% council_name %] to
+    FixMyStreet is being updated in [% cobrand.council_area %] to
     improve how problems get reported.
   </p>
   <p style="[% p_style %]">
@@ -26,7 +26,7 @@ INCLUDE '_email_top.html';
     which we've listed below.
   </p>
   <p style="[% p_style %]">
-    All of your reports will have been received and reviewed by [% council_name %], so if
+    All of your reports will have been received and reviewed by [% cobrand.council_area %], so if
     your report is no longer an issue, you don't need to do anything.
   </p>
   <p style="[% p_style %]">
@@ -40,7 +40,7 @@ INCLUDE '_email_top.html';
       <img style="[% list_item_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="">
     </a>
   [% END %]
-    <h2 style="[% list_item_h2_style %]"><a href="[% cobrand.base_url_for_report( report ) %]report/[% report.id %]">
+    <h2 style="[% list_item_h2_style %]"><a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
       [%~ report.title | html ~%]
     </a></h2>
     <p style="[% list_item_p_style %]">[% report.detail | html %]</p>

--- a/templates/email/default/archive-old-enquiries.txt
+++ b/templates/email/default/archive-old-enquiries.txt
@@ -2,13 +2,13 @@ Subject: Your reports on [% site_name %]
 
 Hello [% user.name %],
 
-FixMyStreet is being updated in [% council_name %] to improve how problems get reported.
+FixMyStreet is being updated in [% cobrand.council_area %] to improve how problems get reported.
 
 As part of this process we are closing all reports made before the update.
 
 We noticed that you have [% report_count %] old [% nget('report', 'reports', report_count) %] on the system, which we've listed below.
 
-All of your reports will have been received and reviewed by [% council_name %], so if your report is no longer an issue, you don't need to do anything.
+All of your reports will have been received and reviewed by [% cobrand.council_area %], so if your report is no longer an issue, you don't need to do anything.
 
 If you believe that the issue has not been resolved you can report it again here: [% cobrand.base_url %]
 
@@ -18,11 +18,11 @@ If you believe that the issue has not been resolved you can report it again here
 
 Reported [% report.time_ago %] ago.
 
-View report: [% cobrand.base_url_for_report( report ) %]report/[% report.id %]
+View report: [% cobrand.base_url_for_report( report ) %]/report/[% report.id %]
 
 ----
 
 [% END %]
 
-The FixMyStreet team and [% council_name %] Council
+The FixMyStreet team and [% cobrand.council_name %]
 


### PR DESCRIPTION
Fix missing slash in emails, and improve templates add testing to archiving old reports script

Adds slash that was missing between base url and 'report' which broke urls in emails

Changes templates to use cobrand variables throughout and remove passing in council name

Adds tests to check urls and templating

[skip changelog]