### PR TITLE
Remove custom styling for /around pagination links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Unreleased
     - Front end improvements:
         - Highlight pin on sidebar focus as well as hover.
+        - Map page pagination links now styled as links rather than buttons. #3727
     - Bugfixes:
         - Add ID attributes to change password form inputs.
         - Fix link deactivation for privacy policy link on privacy policy page. #3704

--- a/templates/web/base/pagination.html
+++ b/templates/web/base/pagination.html
@@ -1,5 +1,5 @@
 [% IF pager AND pager.total_entries > 1 %]
-    <p class="pagination" data-page="[% pager.current_page | html %]">
+    <nav aria-label="Pagination" class="pagination" data-page="[% pager.current_page | html %]">
         [% IF pager.previous_page %]
             <a class="prev" href="[% c.uri_with({ $param => pager.previous_page, ajax => undefined }) %][% '#' _ hash IF hash %]">[% loc('Previous') %]</a>
         [% END %]
@@ -11,5 +11,5 @@
         [% ELSIF page == 'around' AND num_old_reports > 0 AND NOT show_old_reports %]
             <a class="next show_old" href="[% c.uri_with({ $param => pager.current_page, show_old_reports = 1, ajax => undefined }) %][% '#' _ hash IF hash %]">[% loc('Show older') %]</a>
         [% END %]
-    </p>
+    </nav>
 [% END %]

--- a/web/cobrands/buckinghamshire/base.scss
+++ b/web/cobrands/buckinghamshire/base.scss
@@ -125,10 +125,6 @@ dl dt {
     }
 }
 
-.pagination a {
-  color: #fff;
-}
-
 label {
   @extend %bold-font;
 }

--- a/web/cobrands/greenwich/layout.scss
+++ b/web/cobrands/greenwich/layout.scss
@@ -254,17 +254,6 @@ body.mappage {
             text-decoration: underline;
         }
     }
-    // Around page
-    .pagination {
-        .next,
-        .prev {
-            color: $contrast_text;
-            border-radius: 0.25em;
-            &:hover {
-                text-decoration: underline;
-            }
-        }
-    }
 
     .site-footer {
         display: none;

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2401,26 +2401,18 @@ label .muted {
 .pagination {
   text-align: center;
   padding: 0.5em 1em;
+  margin-bottom: 1em;
   background: #eee;
   position: relative;
+
   .prev {
     position: absolute;
     #{$left}: 0.5em;
   }
+
   .next {
     position: absolute;
     #{$right}: 0.5em;
-  }
-  a {
-    @include inline-block;
-    color: $primary_text;
-    background: $primary;
-    padding-#{$left}: 0.5em;
-    padding-#{$right}: 0.5em;
-    &:hover {
-      text-decoration: none;
-      background: $primary/1.1;
-    }
   }
 }
 

--- a/web/cobrands/shropshire/base.scss
+++ b/web/cobrands/shropshire/base.scss
@@ -20,10 +20,6 @@ a:focus,
     outline: solid 3px $shropshire-yellow;
 }
 
-.pagination a {
-    color: #fff;
-}
-
 .olButton:focus {
     z-index: 1; // pull forward, so entire outline is visible
 }

--- a/web/cobrands/tfl/base.scss
+++ b/web/cobrands/tfl/base.scss
@@ -275,19 +275,6 @@ ol.big-numbers>li {
     margin: 0
 }
 
-.pagination a {
-    border-radius: 22.5px;
-    color: #fff;
-    padding: 0.3em 1em;
-    font-size: 14px;
-    &:hover,
-    &:active,
-    &:focus,
-    &:visited {
-        color: #fff;
-    }
-}
-
 /* Safety critical reports */
 .item-list__item--safety-critical {
     background-color: #ffb6b6;


### PR DESCRIPTION
Seminatically, these are links not buttons, so they should look like links, not buttons.

This also avoids the colour contrast issues that we previously had to work around in commits like 5ef5710e06042b4d81207b5d69905096f8a9d89f and 8c595e720763dbcd19228db9921deafb73dc8042.

While I was at it, I also changed the `<p>` to a `<nav>`, to give assistive devices a hint that the links relate to navigation, and an `aria-label` that explains "Next" and "Previous" relate to pagination.

Here’s an example of how it looks, on Merton cobrand:

<img width="548" alt="Screenshot 2021-12-21 at 17 27 55" src="https://user-images.githubusercontent.com/739624/146973913-4dba734a-7847-4aa8-bd73-695eec1d6b70.png">
