### PR TITLE
[Stevenage] Remove left-over Stevenage header_extra template

### DIFF
--- a/templates/web/stevenage/header_extra.html
+++ b/templates/web/stevenage/header_extra.html
@@ -1,1 +1,0 @@
-[% INCLUDE 'tracking_code.html' %]


### PR DESCRIPTION
Oddly, despite @dracos removing lots of files from `/templates/web/stevenage` in c21f766dee71bdce2e1823fc8af2840ef34c5250, I seemed to still have this one hanging around. We’re not keeping it for a reason, are we?

[skip changelog]