### PR TITLE
[Westminster] Correct "Click map" font size on /around page

### DIFF
--- a/web/cobrands/westminster/base.scss
+++ b/web/cobrands/westminster/base.scss
@@ -8,10 +8,7 @@
 
 body.frontpage {
     background-color: #fff; // instead of $westminster_grey
-}
 
-body.frontpage,
-body.mappage {
     h1 {
         font-size: 2.2em;
         font-weight: 600;
@@ -251,11 +248,18 @@ ol.big-numbers > li:before {
 }
 
 body.mappage {
+    h1 {
+        font-weight: 600;
+        letter-spacing: -0.5px;
+        color: $westminster_navy;
+    }
+
     #report-a-problem-main {
         button.btn {
             @include btn-primary
         }
     }
+
     .form-section-preview {
         button.btn {
             @include btn-primary
@@ -267,6 +271,7 @@ body.authpage, body.twothirdswidthpage {
     .form-control {
         outline-color: $westminster_yellow;
     }
+
     #form_sign_in {
         input.btn {
             @include btn-medium-primary

--- a/web/cobrands/westminster/layout.scss
+++ b/web/cobrands/westminster/layout.scss
@@ -1,16 +1,15 @@
 @import "colours";
 @import "../sass/layout";
 
-body.frontpage, body.mappage {
+body.frontpage {
     h1 {
         font-size: 3.3em;
     }
-}
 
-body.frontpage {
     .container {
         max-width: $container-max-width;
     }
+
     #front-main {
         #front-main-container {
             padding: 0 1em;


### PR DESCRIPTION
Somehow a recent commit applied the same massive `font-size: 3.3em` to the map page headings, as to the front page heading. This was particularly unfortunate on the "Click the map…" banner, which is actually a `h1`.

<img width="558" alt="Screenshot 2021-12-21 at 17 54 52" src="https://user-images.githubusercontent.com/739624/146976382-d930e4e8-6139-4cea-8909-7f206c297338.png">

This commit resets `.mappage` headings (including the "Click the map…" banner, and the "Report your problem" heading at the top of the reporting form) to their default font-sizes.

<img width="539" alt="Screenshot 2021-12-21 at 17 53 22" src="https://user-images.githubusercontent.com/739624/146976264-a8ef8680-4af5-4937-9433-0ebd154695bb.png">

Fixes mysociety/societyworks#2557.

[skip changelog]