### PR TITLE
[Bromley] Set payment method to DD for GGW renewals

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -1471,6 +1471,7 @@ sub waste_reconcile_direct_debits {
                     Subscription_Details_Quantity => $self->waste_get_sub_quantity($service),
                     LastPayMethod => $self->bin_payment_types->{direct_debit},
                     PaymentCode => $payer,
+                    payment_method => 'direct_debit',
                 } );
                 $renew->set_extra_metadata('dd_date', $date);
                 $renew->confirm;

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -1625,6 +1625,7 @@ subtest 'check direct debit reconcilliation' => sub {
     is $subsequent_renewal_from_cc_sub->get_extra_field_value('PaymentCode'), "GGW3654321", 'correct echo payment code field';
     is $subsequent_renewal_from_cc_sub->get_extra_field_value('Subscription_Type'), 2, 'Renewal has correct type';
     is $subsequent_renewal_from_cc_sub->get_extra_field_value('LastPayMethod'), 3, 'correct echo payment method field';
+    is $subsequent_renewal_from_cc_sub->get_extra_field_value('payment_method'), 'direct_debit', 'correctly marked as direct debit';
 
     $ad_hoc_orig->discard_changes;
     is $ad_hoc_orig->get_extra_metadata('dd_date'), "01/01/2021", "dd date unchanged ad hoc orig";


### PR DESCRIPTION
This fixes an issue where a report is duplicated once per day if the
original GGW report had a problem with payment.

See https://mysocietysupport.freshdesk.com/a/tickets/1704 for an example

Fixes https://github.com/mysociety/societyworks/issues/2845

[skip changelog]