### PR TITLE
category-specific out-of-hours message

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -548,6 +548,8 @@ sub update_extra_fields : Private {
             my $desc = $c->get_param("metadata[$i].description");
             $meta->{description} = FixMyStreet::Template::sanitize($desc);
             $meta->{disable_form} = $c->get_param("metadata[$i].disable_form") ? 'true' : 'false';
+            $meta->{out_of_hours} = $c->get_param("metadata[$i].out_of_hours") ? 'true' : 'false';
+            $meta->{specific_hours} = $c->get_param("metadata[$i].specific_hours") ? 'true' : 'false';
         } elsif ($behaviour eq 'hidden') {
             $meta->{automated} = 'hidden_field';
         } elsif ($behaviour eq 'server') {

--- a/perllib/FixMyStreet/Cobrand/Bexley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley.pm
@@ -12,6 +12,13 @@ sub council_url { 'bexley' }
 sub get_geocoder { 'Bexley' }
 sub default_map_zoom { 4 }
 
+sub working_hours {
+    return {
+        start => 9,
+        end => 16,
+    };
+}
+
 sub disambiguate_location {
     my $self    = shift;
     my $string  = shift;
@@ -224,7 +231,7 @@ sub open311_post_send {
     push @to, email_list($p1_email_to_use, 'Bexley P1 email') if $p1_email;
     push @to, email_list($emails->{lighting}, 'FixMyStreet Bexley Street Lighting') if $lighting{$row->category};
     push @to, email_list($emails->{flooding}, 'FixMyStreet Bexley Flooding') if $flooding{$row->category};
-    push @to, email_list($emails->{outofhours}, 'Bexley out of hours') if $outofhours_email && _is_out_of_hours();
+    push @to, email_list($emails->{outofhours}, 'Bexley out of hours') if $outofhours_email && $self->_is_out_of_hours();
     if ($contact->email =~ /^Uniform/) {
         push @to, email_list($emails->{eh}, 'FixMyStreet Bexley EH');
         $row->push_extra_fields({ name => 'uniform_id', description => 'Uniform ID', value => $row->external_id });
@@ -248,15 +255,6 @@ sub email_list {
     my @emails = split /,/, $emails;
     my @to = map { [ $_, $name ] } @emails;
     return @to;
-}
-
-sub _is_out_of_hours {
-    my $time = localtime;
-    return 1 if $time->hour > 16 || ($time->hour == 16 && $time->min >= 45);
-    return 1 if $time->hour < 8;
-    return 1 if $time->wday == 1 || $time->wday == 7;
-    return 1 if FixMyStreet::Cobrand::UK::is_public_holiday();
-    return 0;
 }
 
 sub update_anonymous_message {

--- a/t/app/controller/ooh.t
+++ b/t/app/controller/ooh.t
@@ -1,0 +1,92 @@
+use CGI::Simple;
+use Test::MockModule;
+use Test::MockTime qw(:all);
+use FixMyStreet::TestMech;
+use FixMyStreet::Script::Reports;
+use Class::Method::Modifiers;
+use Catalyst::Test 'FixMyStreet::App';
+use FixMyStreet::Cobrand::Bexley;
+use subs (
+    *FixMyStreet::Cobrand::Bexley::opening_hours,
+    *FixMyStreet::Cobrand::Bexley::non_working_days
+);
+set_fixed_time('2019-10-16T17:00:00Z'); # Out of hours
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $body = $mech->create_body_ok(2494, 'London Borough of Bexley', {
+    send_method => 'Open311', api_key => 'key', 'endpoint' => 'e', 'jurisdiction' => 'j' });
+
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => [ 'bexley' ],
+    MAPIT_URL => 'http://mapit.uk/',
+    STAGING_FLAGS => { send_reports => 1, skip_checks => 0 },
+    COBRAND_FEATURES => {
+        open311_email => { bexley => {
+            p1 => 'p1@bexley',
+            p1confirm => 'p1confirm@bexley',
+            lighting => 'thirdparty@notbexley.example.com,another@notbexley.example.com',
+            outofhours => 'outofhours@bexley,ooh2@bexley',
+            flooding => 'flooding@bexley',
+            eh => 'eh@bexley',
+        } },
+        staff_url => { bexley => {
+            'Dead animal' => [ 'message', 'http://public.example.org/dead_animals', 'http://staff.example.org/dead_animals' ],
+            'Missing category' => [ 'message', 'http://public.example.org/dead_animals', 'http://staff.example.org/dead_animals' ]
+        } },
+        category_groups => { bexley => 1 },
+    },
+}, sub {
+
+    my $cobrand = FixMyStreet::Cobrand::Bexley->new;
+    set_fixed_time('2019-10-16T12:00:00Z');
+    is $cobrand->_is_out_of_hours(), 0, 'not out of hours in the day';
+    set_fixed_time('2019-10-16T04:00:00Z');
+    like $cobrand->_is_out_of_hours(), qr/early/, 'out of hours early in the morning';
+    set_fixed_time('2019-10-13T12:00:00Z');
+    like $cobrand->_is_out_of_hours(), qr/non-work day/, 'out of hours at weekends';
+    set_fixed_time('2019-12-25T12:00:00Z');
+    like $cobrand->_is_out_of_hours(), qr/public holiday/, 'out of hours on bank holiday';
+
+};
+
+subtest 'out of unusual hours' => sub {
+
+    {
+        no warnings 'redefine';
+        *FixMyStreet::Cobrand::Bexley::opening_hours = sub {
+            {
+                open   => { h => 10,  m => 45},
+                closed => { h => 14,  m => 30}
+            }
+        };
+
+        *FixMyStreet::Cobrand::Bexley::non_working_days = sub {
+            [4,5]
+        };
+    }
+
+    # change Bexley's OOH times and retest
+    my $bexley = FixMyStreet::Cobrand::Bexley->new;
+
+    ok $bexley->call_hook('opening_hours'), 'Bexley has opening_hours()';
+    ok $bexley->call_hook('non_working_days'), 'Bexley has non_working_days()';
+
+    use DDP;
+    diag 'OPENING HRS.:';
+    diag np $bexley->opening_hours;
+    diag 'NON WKG DAYS:';
+    diag np $bexley->non_working_days;
+
+    set_fixed_time('2021-12-06T12:00:00Z');
+    is $bexley->_is_out_of_hours(), 0, 'still not out of hours at midday';
+
+    set_fixed_time('2021-12-06T10:30:00Z');
+    like $bexley->_is_out_of_hours(), qr/early/, 'out of hours "early" at 10:30am';
+
+    set_fixed_time('2021-12-03T12:00:00Z');
+    like $bexley->_is_out_of_hours(), qr/non-work day/, 'out of hours on new "non-working" Friday' ;
+
+};
+
+done_testing();

--- a/t/cobrand/bexley.t
+++ b/t/cobrand/bexley.t
@@ -341,11 +341,11 @@ EOF
     set_fixed_time('2019-10-16T12:00:00Z');
     is $cobrand->_is_out_of_hours(), 0, 'not out of hours in the day';
     set_fixed_time('2019-10-16T04:00:00Z');
-    is $cobrand->_is_out_of_hours(), 1, 'out of hours early in the morning';
+    like $cobrand->_is_out_of_hours(), qr/early/, 'out of hours early in the morning';
     set_fixed_time('2019-10-13T12:00:00Z');
-    is $cobrand->_is_out_of_hours(), 1, 'out of hours at weekends';
+    like $cobrand->_is_out_of_hours(), qr/non-work day/, 'out of hours at weekends';
     set_fixed_time('2019-12-25T12:00:00Z');
-    is $cobrand->_is_out_of_hours(), 1, 'out of hours on bank holiday';
+    like $cobrand->_is_out_of_hours(), qr/public holiday/, 'out of hours on bank holiday';
 };
 
 

--- a/templates/web/base/admin/extra-metadata-item.html
+++ b/templates/web/base/admin/extra-metadata-item.html
@@ -101,6 +101,12 @@ DEFAULT behaviour = 'question';
             <span class="form-hint" id="metadata[[% i %]]-disable_form-hint">[% loc('If ticked, the form will be disabled and this item’s notice text will be displayed.') %]</span>
         </p>
 
+        <p class="form-check" nonclass="hidden-js" id="metadata-[% i %]-show_out_of_hours-group">
+            <input type="checkbox" name="metadata[[% i %]].show_out_of_hours" value="1" id="metadata-[% i %]-show_out_of_hours" aria-describedby="metadata-[% i %]-show_out_of_hours-hint" [% ' checked' IF meta.show_out_of_hours == 'true' %]>
+            <label for="metadata-[% i %]-show_out_of_hours">[% loc('Only show this notice out of hours') %]</label>
+            <span class="form-hint" id="metadata[[% i %]]-show_out_of_hours-hint">[% loc('If ticked, this notice will only be displayed out of hours (evenings, weekends and bank holidays).') %]</span>
+        </p>
+
         <p class="form-check hidden-js" id="metadata-[% i %]-protected-group">
             <input type="checkbox" name="metadata[[% i %]].protected" value="1" id="metadata-[% i %]-protected" aria-describedby="metadata-[% i %]-protected-hint" [% ' checked' IF meta.protected == 'true' %]>
             <label for="metadata-[% i %]-protected">[% loc('Protect from Open311 changes') %]</label>

--- a/templates/web/base/report/new/_category_extra_field_notice.html
+++ b/templates/web/base/report/new/_category_extra_field_notice.html
@@ -1,0 +1,4 @@
+[%# specifically show category-specific out-of-hours emergency message %]
+[% IF meta.out_of_hours AND meta.description %]
+    <p class="form-hint">[% meta.description %]</p>
+[% END %]

--- a/templates/web/base/report/new/category_extras_fields.html
+++ b/templates/web/base/report/new/category_extras_fields.html
@@ -1,32 +1,34 @@
 [%- FOR meta IN metas %]
   [%- meta_name = meta.code -%]
   [%- x_meta_name = 'x' _ meta.code # For report_meta and field_errors lookup, as TT hides codes starting "_" -%]
-
   [% IF c.cobrand.category_extra_hidden(meta) AND NOT show_hidden %]
 
       <input type="hidden" value="[% report_meta.$x_meta_name.value | html %]" name="[% cat_prefix %][% meta_name %]" id="[% cat_prefix %]form_[% meta_name %]">
-
   [% ELSIF meta.variable != 'false' || NOT hide_notices %]
-
-      <label for="[% cat_prefix %]form_[% meta_name %]">[% (meta.description OR meta.code) | safe %]</label>
+    <label for="[% cat_prefix %]form_[% meta_name %]">[%# (meta.description OR meta.code) | safe %]</label>
+    [% TRY %][% INCLUDE 'report/new/_category_extra_field_notice.html' %][% CATCH file %][% END %]
+    [% IF field_errors.$x_meta_name %]
+    <p class='form-error'>[% field_errors.$x_meta_name %]</p>
+    [% END -%]
+    [% IF meta.variable != 'false' %]
+      [% IF meta.item('values').size %]
+        <select class="form-control" name="[% cat_prefix %][% meta_name %]" id="[% cat_prefix %]form_[% meta_name %]"[% meta.required == 'true' ? ' required' : '' %]>
+          <option value="">[% loc('-- Pick an option --') %]</option>
+          [% FOR option IN meta.values %]
+            <option value="[% option.key %]"[% IF option.key == report_meta.$x_meta_name.value %] selected[% END %]>[% option.name %]</option>
+          [% END %]
+        </select>
+      [% ELSIF meta.datatype == 'text' %]
+        <textarea class="form-control" name="[% cat_prefix %][% meta_name %]" id="[% cat_prefix %]form_[% meta_name %]"[% meta.required == 'true' ? ' required' : '' %]>[% report_meta.$x_meta_name.value %]</textarea>
+      [% ELSE %]
+        <input class="form-control" type="[% meta.fieldtype OR 'text' %]" value="[% report_meta.$x_meta_name.value | html %]" name="[% cat_prefix %][% meta_name %]" id="[% cat_prefix %]form_[% meta_name %]"[% meta.required == 'true' ? ' required' : '' %]>
+      [% END %]
+    [% END %]
+    [% IF (meta.out_of_hours AND c.cobrand.is_out_of_hours) %]
       [% TRY %][% INCLUDE 'report/new/_category_extra_field_notice.html' %][% CATCH file %][% END %]
       [% IF field_errors.$x_meta_name %]
-      <p class='form-error'>[% field_errors.$x_meta_name %]</p>
+        <p class='form-error'>[% field_errors.$x_meta_name %]</p>
       [% END -%]
-      [% IF meta.variable != 'false' %]
-        [% IF meta.item('values').size %]
-          <select class="form-control" name="[% cat_prefix %][% meta_name %]" id="[% cat_prefix %]form_[% meta_name %]"[% meta.required == 'true' ? ' required' : '' %]>
-            <option value="">[% loc('-- Pick an option --') %]</option>
-            [% FOR option IN meta.values %]
-              <option value="[% option.key %]"[% IF option.key == report_meta.$x_meta_name.value %] selected[% END %]>[% option.name %]</option>
-            [% END %]
-          </select>
-        [% ELSIF meta.datatype == 'text' %]
-          <textarea class="form-control" name="[% cat_prefix %][% meta_name %]" id="[% cat_prefix %]form_[% meta_name %]"[% meta.required == 'true' ? ' required' : '' %]>[% report_meta.$x_meta_name.value %]</textarea>
-        [% ELSE %]
-          <input class="form-control" type="[% meta.fieldtype OR 'text' %]" value="[% report_meta.$x_meta_name.value | html %]" name="[% cat_prefix %][% meta_name %]" id="[% cat_prefix %]form_[% meta_name %]"[% meta.required == 'true' ? ' required' : '' %]>
-        [% END %]
-      [% END %]
-
-    [% END %]
+    [% END %] [%# OOH %]
+  [% END %]
 [%- END %]


### PR DESCRIPTION
Show an out-of-hours message for a specific category that appears only out-of-hours, with specificable times on a weekly basis.

for mysociety/societyworks#2570

Please check the following:

- [ ] Whether this PR should include changes to any documentation, or the FAQ;
- [ ] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files; 
- [ ] Are the changes tested for accessibility?
- [ ] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
