### PR TITLE
Include username in inactive email.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     - Front end improvements:
         - Highlight pin on sidebar focus as well as hover.
         - Map page pagination links now styled as links rather than buttons. #3727
+        - Include username in inactive email.
     - Bugfixes:
         - Add ID attributes to change password form inputs.
         - Fix link deactivation for privacy policy link on privacy policy page. #3704

--- a/t/script/inactive.t
+++ b/t/script/inactive.t
@@ -100,7 +100,8 @@ subtest 'Anonymization of inactive users' => sub {
     stdout_is { $in->users } "Anonymizing user #" . $user->id . "\nEmailing user #" . $user_inactive->id . "\n", 'users dealt with first time';
 
     my $email = $mech->get_email;
-    like $email->as_string, qr/inactive\@example.com/, 'Inactive email sent';
+    my $user_email = $user_inactive->email;
+    like $email->as_string, qr/Your $user_email/, 'Inactive email sent';
     $mech->clear_emails_ok;
 
     $user->discard_changes;

--- a/templates/email/default/inactive-account.html
+++ b/templates/email/default/inactive-account.html
@@ -12,7 +12,7 @@ INCLUDE '_email_top.html';
 <th style="[% td_style %][% only_column_style %]">
   <h1 style="[% h1_style %]">Your inactive account</h1>
   <p style="[% p_style %]">
-Your account on [% site_name %] has been inactive for [% email_from %]
+Your [% user.username %] account on [% site_name %] has been inactive for [% email_from %]
 [% nget('month', 'months', email_from) %], and we automatically remove
 accounts that have been inactive after [% anonymize_from %]
 [% nget('month', 'months', anonymize_from) %]. If you wish to keep your

--- a/templates/email/default/inactive-account.txt
+++ b/templates/email/default/inactive-account.txt
@@ -2,7 +2,7 @@ Subject: Your inactive account on [% site_name %]
 
 Hello [% user.name %],
 
-Your account on [% site_name %] has been inactive for [% email_from %]
+Your [% user.username %] account on [% site_name %] has been inactive for [% email_from %]
 [% nget('month', 'months', email_from) %], and we automatically remove
 accounts that have been inactive after [% anonymize_from %]
 [% nget('month', 'months', anonymize_from) %]. If you wish to keep your


### PR DESCRIPTION
This has come up in user support (someone had two accounts, one forwarded to the other, they didn't realise) and I see client support (domain name change causing the same issue), so including the email (or phone number) in the body of the inactive email seems like a sensible thing to do at the least.