### PR TITLE
Add test 'show emails' option to report closure script

### DIFF
--- a/bin/archive-old-enquiries
+++ b/bin/archive-old-enquiries
@@ -44,6 +44,8 @@ my ($opts, $usage) = describe_options(
     ['closure_text=s', "text of the message to add to reports" ],
     ['closed_state=s', "state to set reports to" ],
     ['limit|l=s',      "limit to a certain number of reports/users to be closed"],
+    ['show_emails|s',  "output emails that would be sent to STDOUT and prevent closure. Overrides --commit / -c and exits."],
+    ['show-emails|e',  "alternative to --show_emails with same effects."],
     ['help|h',         "print usage message and exit" ],
 );
 print($usage->text), exit if $opts->help;

--- a/templates/email/default/archive-old-enquiries.html
+++ b/templates/email/default/archive-old-enquiries.html
@@ -26,7 +26,7 @@ INCLUDE '_email_top.html';
     which we've listed below.
   </p>
   <p style="[% p_style %]">
-    All of your reports will have been received and reviewed by [% cobrand.council_area %], so if
+    All of your reports will have been received and reviewed by [% cobrand.council_name %], so if
     your report is no longer an issue, you don't need to do anything.
   </p>
   <p style="[% p_style %]">
@@ -49,6 +49,10 @@ INCLUDE '_email_top.html';
     </p>
   </div>
   [% END %]
+
+  <p style="[% p_style %]">
+  The FixMyStreet team and [% cobrand.council_name %]
+  </p>
 
 </th>
 

--- a/templates/email/default/archive-old-enquiries.txt
+++ b/templates/email/default/archive-old-enquiries.txt
@@ -8,7 +8,7 @@ As part of this process we are closing all reports made before the update.
 
 We noticed that you have [% report_count %] old [% nget('report', 'reports', report_count) %] on the system, which we've listed below.
 
-All of your reports will have been received and reviewed by [% cobrand.council_area %], so if your report is no longer an issue, you don't need to do anything.
+All of your reports will have been received and reviewed by [% cobrand.council_name %], so if your report is no longer an issue, you don't need to do anything.
 
 If you believe that the issue has not been resolved you can report it again here: [% cobrand.base_url %]
 


### PR DESCRIPTION
Added test email output option to old reports closure script.
    - New '--show_emails' option outputs emails instead
      of sending them and does not close reports.
    - Updated templates to use council name to refer to
      council instead of council area.

Also: added signoff to HTML template to match plain text template.

For mysociety/societyworks#2616.

Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [ ] Are the changes tested for accessibility?
[skip changelog]