### PR TITLE
Mark a wait-skipped update as a failure.

### DIFF
--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -254,6 +254,17 @@ sub moderation_filter {
     { problem_id => $self->problem_id };
 }
 
+sub update_send_failed {
+    my $self = shift;
+    my $msg  = shift;
+
+    $self->update( {
+        send_fail_count => $self->send_fail_count + 1,
+        send_fail_timestamp => \'current_timestamp',
+        send_fail_reason => $msg
+    } );
+}
+
 =head2 meta_line
 
 Returns a string to be used on a report update, describing some of the metadata

--- a/t/open311/post-service-request-updates.t
+++ b/t/open311/post-service-request-updates.t
@@ -92,7 +92,8 @@ subtest 'Send comments' => sub {
     $c1->discard_changes;
     is $c1->extra->{title}, "MRS", 'Title set on Bromley update';
     $c2->discard_changes;
-    is $c2->send_fail_count, 0, 'Oxfordshire update skipped entirely';
+    is $c2->send_fail_count, 1, 'Oxfordshire update skipped entirely, still logs as failure';
+    $c2->update({ send_fail_count => 0 });
 
     Open311->_inject_response('/servicerequestupdates.xml', "", 500);
     $oxon_other->update({ email => 'Alloy-OTHER' });


### PR DESCRIPTION
This should prevent the daemon from constantly retrying these updates. [skip changelog]