### PR TITLE
[Bromley] Fix GGW DD subscription amendment.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -395,14 +395,13 @@ sub direct_debit_modify : Path('dd_amend') : Args(0) {
 
     # if reducing bin count then there won't be an ad-hoc payment
     if ( $ad_hoc ) {
-        my $dt = $c->cobrand->waste_get_next_dd_day;
-
         my $one_off_ref = $i->one_off_payment( {
                 # this will be set when the initial payment is confirmed
                 payer_reference => $c->stash->{orig_sub}->get_extra_metadata('payerReference'),
                 amount => sprintf('%.2f', $ad_hoc / 100),
                 reference => $p->id,
                 comments => '',
+                date => $c->cobrand->waste_get_next_dd_day('ad-hoc'),
         } );
     }
 

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -1270,9 +1270,13 @@ sub waste_munge_enquiry_data {
     $self->_set_user_source;
 }
 sub waste_get_next_dd_day {
-    my $self = shift;
+    my ($self, $payment_type) = @_;
 
-    my $dd_delay = 10; # No days to set up a DD
+    # new DD mandates must have a 10-day wait
+    my $dd_delay = 10;
+
+    # ad-hoc payments on an existing mandate only need a 5-day wait
+    if ($payment_type eq 'ad-hoc') { $dd_delay = 5; }
 
     my $dt = DateTime->now->set_time_zone(FixMyStreet->local_time_zone);
     my $wd = FixMyStreet::WorkingDays->new(public_holidays => FixMyStreet::Cobrand::UK::public_holidays());

--- a/perllib/Integrations/Pay360.pm
+++ b/perllib/Integrations/Pay360.pm
@@ -59,7 +59,7 @@ sub one_off_payment {
     my $obj = [
         reference => $args->{payer_reference},
         amountString => $args->{amount},
-        dueDateString => $args->{date}->strftime('%d/%m/%Y'),
+        dueDateString => $args->{date}->strftime('%d-%m-%Y'),
         clientSUN => $self->config->{dd_sun},
         yourRef => $args->{reference},
         comments => $args->{comment}

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -1328,11 +1328,14 @@ FixMyStreet::override_config {
         is $new_report->get_extra_field_value('payment'), '4000', 'payment correctly set to future value';
         is $new_report->get_extra_field_value('pro_rata'), '750', 'pro rata payment correctly set';
 
+        my $ad_hoc_payment_date = '2021-01-15T17:00:00';
+
         is_deeply $dd_sent_params->{one_off_payment}, {
             payer_reference => 'GGW1000000002',
             amount => '7.50',
             reference => $new_report->id,
             comments => '',
+            date => $ad_hoc_payment_date,
         }, "correct direct debit ad hoc payment params sent";
         is_deeply $dd_sent_params->{amend_plan}, {
             payer_reference => 'GGW1000000002',


### PR DESCRIPTION
Fixed amendments to garden waste subscriptions paid for by Direct Debit by adding missing DD due date to hash in call to Integrations::Pay360->one_off_payment.


for https://mysocietysupport.freshdesk.com/a/tickets/1742

[skip changelog]
