### PR TITLE
[Bromley] Assisted collections

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -830,8 +830,9 @@ sub enquiry : Chained('property') : Args(0) {
     }
 
     my $field_list = [];
+    my $staff_form;
     foreach (@{$contact->get_metadata_for_input}) {
-        next if $_->{code} eq 'service_id' || $_->{code} eq 'uprn' || $_->{code} eq 'property_id';
+        $staff_form = 1 if $_->{code} eq 'staff_form';
         next if ($_->{automated} || '') eq 'hidden_field';
         my $type = 'Text';
         $type = 'TextArea' if 'text' eq ($_->{datatype} || '');
@@ -840,6 +841,10 @@ sub enquiry : Chained('property') : Args(0) {
             type => $type, label => $_->{description}, required => $required
         };
     }
+
+    my $staff = $c->user_exists && ($c->user->is_superuser || $c->user->from_body);
+    $c->detach('/auth/redirect') if $staff_form && !$staff;
+    $c->stash->{staff_form} = $staff_form;
 
     # If the contact has no extra fields (e.g. Peterborough) then skip to the
     # "about you" page instead of showing an empty first page.

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -822,13 +822,11 @@ sub enquiry : Chained('property') : Args(0) {
     my $category = $c->get_param('category');
     my $service = $c->get_param('service_id');
     if (!$category || !$service || !$c->stash->{services}{$service}) {
-        $c->res->redirect('/waste/' . $c->stash->{property}{id});
-        $c->detach;
+        $c->detach('property_redirect');
     }
     my ($contact) = grep { $_->category eq $category } @{$c->stash->{contacts}};
     if (!$contact) {
-        $c->res->redirect('/waste/' . $c->stash->{property}{id});
-        $c->detach;
+        $c->detach('property_redirect');
     }
 
     my $field_list = [];
@@ -903,15 +901,8 @@ sub check_if_staff_can_pay : Private {
 sub garden : Chained('property') : Args(0) {
     my ($self, $c) = @_;
 
-    if ($c->stash->{waste_features}->{garden_disabled}) {
-        $c->res->redirect('/waste/' . $c->stash->{property}{id});
-        $c->detach;
-    }
-
-    if ( $c->stash->{services}{$c->cobrand->garden_waste_service_id} ) {
-        $c->res->redirect('/waste/' . $c->stash->{property}{id});
-        $c->detach;
-    }
+    $c->detach('property_redirect') if $c->stash->{waste_features}->{garden_disabled};
+    $c->detach('property_redirect') if $c->stash->{services}{$c->cobrand->garden_waste_service_id};
 
     my $service = $c->cobrand->garden_waste_service_id;
     $c->stash->{garden_form_data} = {
@@ -926,14 +917,8 @@ sub garden : Chained('property') : Args(0) {
 sub garden_modify : Chained('property') : Args(0) {
     my ($self, $c) = @_;
 
-    if ($c->stash->{waste_features}->{garden_disabled}) {
-        $c->res->redirect('/waste/' . $c->stash->{property}{id});
-        $c->detach;
-    }
-
-    unless ( $c->user_exists ) {
-        $c->detach( '/auth/redirect' );
-    }
+    $c->detach('property_redirect') if $c->stash->{waste_features}->{garden_disabled};
+    $c->detach( '/auth/redirect' ) unless $c->user_exists;
 
     $c->forward('get_original_sub');
 
@@ -948,8 +933,7 @@ sub garden_modify : Chained('property') : Args(0) {
     my $max_bins = $c->stash->{quantity_max}->{$service};
     $service = $c->stash->{services}{$service};
     if (!$service || $service->{garden_due}) {
-        $c->res->redirect('/waste/' . $c->stash->{property}{id});
-        $c->detach;
+        $c->detach('property_redirect');
     }
 
     my $payment_method = 'credit_card';
@@ -981,19 +965,9 @@ sub garden_modify : Chained('property') : Args(0) {
 sub garden_cancel : Chained('property') : Args(0) {
     my ($self, $c) = @_;
 
-    if ($c->stash->{waste_features}->{garden_disabled}) {
-        $c->res->redirect('/waste/' . $c->stash->{property}{id});
-        $c->detach;
-    }
-
-    if ( !$c->stash->{services}{$c->cobrand->garden_waste_service_id} ) {
-        $c->res->redirect('/waste/' . $c->stash->{property}{id});
-        $c->detach;
-    }
-
-    unless ( $c->user_exists ) {
-        $c->detach( '/auth/redirect' );
-    }
+    $c->detach('property_redirect') if $c->stash->{waste_features}->{garden_disabled};
+    $c->detach('property_redirect') if !$c->stash->{services}{$c->cobrand->garden_waste_service_id};
+    $c->detach( '/auth/redirect' ) unless $c->user_exists;
 
     $c->forward('get_original_sub');
 
@@ -1008,14 +982,8 @@ sub garden_cancel : Chained('property') : Args(0) {
 sub garden_renew : Chained('property') : Args(0) {
     my ($self, $c) = @_;
 
-    if ($c->stash->{waste_features}->{garden_disabled}) {
-        $c->res->redirect('/waste/' . $c->stash->{property}{id});
-        $c->detach;
-    }
-
-    unless ( $c->user_exists ) {
-        $c->detach( '/auth/redirect' );
-    }
+    $c->detach('property_redirect') if $c->stash->{waste_features}->{garden_disabled};
+    $c->detach( '/auth/redirect' ) unless $c->user_exists;
 
     $c->forward('get_original_sub');
 
@@ -1556,6 +1524,12 @@ sub uprn_redirect : Path('/property') : Args(1) {
     $c->detach( '/page_error_404_not_found', [] ) unless $result;
     $c->res->redirect('/waste/' . $result->{Id});
 }
+
+sub property_redirect : Private {
+    my ($self, $c) = @_;
+    $c->res->redirect('/waste/' . $c->stash->{property}{id});
+}
+
 sub label_for_field {
     my ($form, $field, $key) = @_;
     foreach ($form->field($field)->options) {

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -807,6 +807,9 @@ sub bin_services_for_address {
             }
         }
 
+        my $task_indicator = $servicetask->{TaskIndicatorId} || 0;
+        $self->{c}->stash->{assisted_collection} = 1 if $task_indicator == 84;
+
         my $row = {
             id => $_->{Id},
             service_id => $service_id,

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -1304,7 +1304,7 @@ sub waste_munge_enquiry_data {
     $data->{title} = $data->{category};
 
     my $detail;
-    foreach (grep { /^extra_/ } keys %$data) {
+    foreach (sort grep { /^extra_/ } keys %$data) {
         $detail .= "$data->{$_}\n\n";
     }
     $detail .= $address;

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -60,6 +60,12 @@ create_contact({ category => 'General enquiry', email => 'general@example.org' }
     { code => 'Notes', description => 'Notes', required => 1, datatype => 'text' },
     { code => 'Source', required => 0, automated => 'hidden_field' },
 );
+create_contact({ category => 'Assisted collection add', email => 'assisted' },
+    { code => 'Exact_Location', description => 'Exact location', required => 1, datatype => 'text' },
+    { code => 'Reason', description => 'Reason for request', required => 1, datatype => 'text' },
+    { code => 'staff_form', automated => 'hidden_field' },
+    { code => 'Source', required => 0, automated => 'hidden_field' },
+);
 create_contact({ category => 'Garden Subscription', email => 'garden@example.com'},
         { code => 'Subscription_Type', required => 1, automated => 'hidden_field' },
         { code => 'Subscription_Details_Quantity', required => 1, automated => 'hidden_field' },
@@ -364,6 +370,24 @@ FixMyStreet::override_config {
         is $report->get_extra_field_value('Source'), 9, 'Correct source';
         $staff_user->discard_changes;
         is $staff_user->name, $original_name, 'Staff user name stayed the same';
+    };
+    subtest 'test staff-only assisted collection form' => sub {
+        $mech->get_ok('/waste/12345/enquiry?category=Assisted+collection+add&service_id=531');
+        $mech->submit_form_ok({ with_fields => { extra_Exact_Location => 'Behind the garden gate', extra_Reason => 'Reason' } });
+        $mech->submit_form_ok({ with_fields => { name => "Anne Assist", email => 'anne@example.org' } });
+        $mech->submit_form_ok({ with_fields => { process => 'summary' } });
+        $mech->content_contains('Your enquiry has been submitted');
+        my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+        is $report->get_extra_field_value('Reason'), 'Reason';
+        is $report->detail, "Behind the garden gate\n\nReason\n\n2 Example Street, Bromley, BR1 1AA";
+        is $report->user->email, 'anne@example.org';
+        is $report->name, 'Anne Assist';
+        is $report->get_extra_field_value('Source'), 9, 'Correct source';
+    };
+    subtest 'test staff-only form when logged out' => sub {
+        $mech->log_out_ok;
+        $mech->get_ok('/waste/12345/enquiry?category=Assisted+collection&service_id=531');
+        is $mech->res->previous->code, 302;
     };
     subtest 'Ignores expired services' => sub {
         my $echo = Test::MockModule->new('Integrations::Echo');

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -389,6 +389,33 @@ FixMyStreet::override_config {
         $mech->get_ok('/waste/12345/enquiry?category=Assisted+collection&service_id=531');
         is $mech->res->previous->code, 302;
     };
+    subtest 'test assisted collection display' => sub {
+        $mech->log_in_ok($staff_user->email);
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('Set up for assisted collection');
+        my $echo = Test::MockModule->new('Integrations::Echo');
+        $echo->mock('GetServiceUnitsForObject', sub {
+            return [ {
+                Id => 1003,
+                ServiceId => 531,
+                ServiceName => 'Domestic Refuse Collection',
+                ServiceTasks => { ServiceTask => {
+                    Id => 403,
+                    TaskIndicatorId => 84,
+                    ServiceTaskSchedules => { ServiceTaskSchedule => {
+                        StartDate => { DateTime => '2020-01-01T00:00:00Z' },
+                        EndDate => { DateTime => '2050-01-01T00:00:00Z' },
+                        NextInstance => {
+                            CurrentScheduledDate => { DateTime => '2020-06-03T00:00:00Z' },
+                            OriginalScheduledDate => { DateTime => '2020-06-03T00:00:00Z' },
+                        },
+                    } },
+                } },
+            } ];
+        });
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('This property is set up for assisted collections');
+    };
     subtest 'Ignores expired services' => sub {
         my $echo = Test::MockModule->new('Integrations::Echo');
         $echo->mock('GetServiceUnitsForObject', sub {

--- a/templates/web/base/waste/bin_days.html
+++ b/templates/web/base/waste/bin_days.html
@@ -106,22 +106,7 @@
           </ul>
         </div>
        [% SET show_garden_subscribe = NOT waste_features.garden_disabled AND NOT pending_subscription AND NOT services_available.Garden_Waste.is_active %]
-       [% TRY %][% PROCESS waste/_more_services_sidebar.html %][% CATCH file %]
-        [% IF any_report_allowed OR any_request_allowed OR show_garden_subscribe %]
-            <h3>More services</h3>
-            <ul>
-              [% IF any_report_allowed %]
-                <li><a href="[% c.uri_for_action('waste/report', [ property.id ]) %]">Report a missed collection</a></li>
-              [% END %]
-              [% IF any_request_allowed %]
-                <li><a href="[% c.uri_for_action('waste/request', [ property.id ]) %]">Request a new container</a></li>
-              [% END %]
-              [% IF show_garden_subscribe %]
-                <li><a href="[% c.uri_for_action('waste/garden', [ property.id ]) %]">Subscribe to Green Garden Waste collection</a></li>
-              [% END %]
-            </ul>
-        [% END %]
-       [% END %]
+       [% PROCESS 'waste/_more_services_sidebar.html' %]
       </div>
     </div>
     [% END %]

--- a/templates/web/bromley/waste/_more_services_sidebar.html
+++ b/templates/web/bromley/waste/_more_services_sidebar.html
@@ -1,0 +1,26 @@
+[% IF any_report_allowed OR any_request_allowed OR show_garden_subscribe %]
+    <h3>More services</h3>
+    <ul>
+      [% IF any_report_allowed %]
+        <li><a href="[% c.uri_for_action('waste/report', [ property.id ]) %]">Report a missed collection</a></li>
+      [% END %]
+      [% IF any_request_allowed %]
+        <li><a href="[% c.uri_for_action('waste/request', [ property.id ]) %]">Request a new container</a></li>
+      [% END %]
+      [% IF show_garden_subscribe %]
+        <li><a href="[% c.uri_for_action('waste/garden', [ property.id ]) %]">Subscribe to Green Garden Waste collection</a></li>
+      [% END %]
+    </ul>
+[% END %]
+
+[% IF c.user.from_body OR c.user.is_superuser %]
+    <h3>Assisted collection</h3>
+    <ul>
+    [% IF assisted_collection %]
+        <li>This property is set up for assisted collections.</li>
+        <li><a href="[% c.uri_for_action('waste/enquiry', [ property.id ]) %]?category=Assisted+collection+remove&amp;service_id=531">Remove assisted collection</a></li>
+    [% ELSIF domestic_collection %]
+        <li><a href="[% c.uri_for_action('waste/enquiry', [ property.id ]) %]?category=Assisted+collection+add&amp;service_id=531">Set up for assisted collection</a></li>
+    [% END %]
+    </ul>
+[% END %]


### PR DESCRIPTION
Add the ability to make the enquiry form staff only, and then add display code to show assisted collection status/link to form to set assisted collection on. To have this working, you would create a new category called "Assisted collection" in the "Waste" group, destination 2149, with the normal waste extra fields "uprn" (hidden), "service_id" (hidden), "fixmystreet_id" (hidden"), plus "Exact_Location" (label "Exact location of containers", textarea), "reason" (label "Reason for request", textarea), and "staff_form" (hidden).

At the open311-adapter end, it would need a default in config - "Assisted Action" 1 (Add) - and some code to set "Assisted Start Date" to current date, "Assisted End Date" to 01/01/2050 and "Review Date" to 2 years from current date. Thought that was better there, than attaching to each report as extra data here. Matching PR at https://github.com/mysociety/open311-adapter/pull/212

Fixes https://github.com/mysociety/societyworks/issues/2476 [skip changelog]