### PR TITLE
[Buckinghamshire] Scripts to setup parish councils

### DIFF
--- a/bin/buckinghamshire/add-parish-categories
+++ b/bin/buckinghamshire/add-parish-categories
@@ -1,0 +1,121 @@
+#!/usr/bin/env perl
+#
+# This script adds relevant categories for parishes listed in a CSV file by
+# attempting to match them to the existing parish bodies in FMS.
+#
+# The CSV file needs to have 'name' and 'email' columns with the name of
+# the parish council (which should match the existing body) and the email
+# address that reports should be sent to.
+
+use strict;
+use warnings;
+
+BEGIN {    # set all the paths to the perl code
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use FixMyStreet::DB;
+use Text::CSV;
+
+my $contacts = [
+    { category => 'Hedge problem', extra_metadata => { prefer_if_multiple => 1, group => 'Grass, hedges and weeds' } },
+    { category => 'Fly posting', extra_metadata => { prefer_if_multiple => 1 } },
+    { category => 'Dirty signs', extra_metadata => { prefer_if_multiple => 1 } },
+    {
+        category => 'Grass cutting',
+        extra_metadata => {
+            group => 'Grass, hedges and weeds',
+        },
+        extra_fields => [
+            {
+                code => 'speed_limit',
+                description => 'Is the speed limit on this road 40mph or greater?',
+                datatype => 'singlevaluelist',
+                order => 1,
+                variable => 'true',
+                required => 'true',
+                protected => 'false',
+                values => [
+                    {
+                        key => 'yes',
+                        name => 'Yes',
+                    },
+                    {
+                        key => 'no',
+                        name => 'No',
+                    },
+                    {
+                        key => 'dont_know',
+                        name => "Don't know",
+                    },
+                ],
+            }
+        ],
+    },
+];
+
+my @parishes;
+
+my $csv = Text::CSV->new ({ binary => 1, auto_diag => 1 });
+die "Usage: $0 <csv_file>\n" unless @ARGV;
+open my $fh, "<:encoding(utf8)", $ARGV[0] or die "$ARGV[0]: $!";
+$csv->header($fh);
+
+# Load parishes from supplied CSV file.
+while (my $row = $csv->getline_hr($fh)) {
+    my $name = $row->{name};
+    my $body = FixMyStreet::DB->resultset('Body')->find({ name => $name });
+    if (!$body) {
+        die "Error: Couldn't find body called $name\n";
+    }
+
+    push @parishes, { name => $name, email => $row->{email}, body => $body };
+}
+
+my $db = FixMyStreet::DB->schema->storage;
+$db->txn_do(sub {
+    # Create categories for parishes.
+    foreach my $parish (@parishes) {
+        foreach my $contact (@$contacts) {
+            my $contact_rs = FixMyStreet::DB->resultset('Contact')->search({
+                body_id => $parish->{body}->id,
+                category => $contact->{category},
+            });
+
+            if ($contact_rs->count > 0) {
+                print "Existing contact found...skipping\n";
+                next;
+            }
+
+            print "Creating category $contact->{category} for $parish->{name}...";
+
+            my $new_contact = $contact_rs->create_with_note(
+                "created automatically by script",
+                basename($0),
+                {
+                    email => $parish->{email},
+                    state => 'confirmed',
+                }
+            );
+
+            if ($contact->{extra_metadata}) {
+                $new_contact->set_extra_metadata(%{$contact->{extra_metadata}});
+            }
+
+            if ($contact->{extra_fields}) {
+                $new_contact->set_extra_fields(@{$contact->{extra_fields}});
+            }
+
+            $new_contact->update;
+
+            print "done\n";
+        }
+
+        # Make sure body has correct send method and isn't marked as deleted
+        $parish->{body}->update({ send_method => 'Email', deleted => 0 });
+        print "\n";
+    }
+});

--- a/bin/buckinghamshire/create-parish-bodies
+++ b/bin/buckinghamshire/create-parish-bodies
@@ -1,0 +1,95 @@
+#!/usr/bin/env perl
+#
+# This script creates parish bodies for all parishes covered by Buckinghamshire council.
+
+use strict;
+use warnings;
+
+BEGIN {    # set all the paths to the perl code
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use mySociety::MaPit;
+use FixMyStreet::DB;
+
+# Mapping for parishes that aren't called "$name Parish Council"
+# The key is the mapit name, value is the desired display name.
+# Anything not in this list will default to "$mapit_name Parish Council"
+my $name_mappings = {
+    'Addington' => 'Addington',
+    'Amersham' => 'Amersham Town Council',
+    'Aston Sandford' => 'Aston Sandford',
+    'Aylesbury' => 'Aylesbury Town Council',
+    'Barton Hartshorn' => 'Barton Hartshorn',
+    'Beaconsfield' => 'Beaconsfield Town Council',
+    'Biddlesden' => 'Biddlesden',
+    'Bledlow-cum-Saunderton' => 'Bledlow-Cum-Saunderton Parish Council',
+    'Buckingham' => 'Buckingham Town Council',
+    'Chesham' => 'Chesham Town Council',
+    'Chetwode' => 'Chetwode',
+    'Cholesbury-cum-St Leonards' => 'Cholesbury-Cum-St Leonards Parish Council',
+    'Coldharbour' => 'Coldharbour',
+    'Creslow' => 'Creslow',
+    'Dinton-with-Ford and Upton' => 'Dinton-with-Ford and Upton',
+    'Dorton' => 'Dorton Parish Council',
+    'Drayton Beauchamp' => 'Drayton Beauchamp',
+    'Dunton' => 'Dunton',
+    'Edlesborough' => 'Edlesborough Northall and Dagnall Parish Council',
+    'Gerrards Cross' => 'Gerrards Cross Town Council',
+    'Hedsor' => 'Hedsor',
+    'Hoggeston' => 'Hoggeston',
+    'Kingsey' => 'Kingsey',
+    'Kingswood' => 'Kingswood',
+    'Longwick-cum-Ilmer' => 'Longwick cum Ilmer Parish Council',
+    'Marlow' => 'Marlow Town Council',
+    'Nether Winchendon' => 'Nether Winchendon',
+    'Poundon' => 'Poundon',
+    'Princes Risborough' => 'Princes Risborough Town Council',
+    'Shalstone' => 'Shalstone',
+    'Thornton' => 'Thornton',
+    'Water Stratford' => 'Water Stratford',
+    'Wingrave with Rowsham' => 'Wingrave-with-Rowsham Parish Council',
+    'Winslow' => 'Winslow Town Council',
+    'Wooburn' => 'Wooburn and Bourne End Parish Council',
+    'Woodham' => 'Woodham',
+    'Wotton Underwood' => 'Wotton Underwood',
+};
+
+my $parent_id = "163793"; # Buckinghamshire Council Unitary Authority on Mapit
+
+# Fetch the list of parishes from MapIt
+my $mapit_areas = mySociety::MaPit::call('area', "$parent_id/children", type => 'CPC');
+my @areas = values %$mapit_areas;
+
+my $db = FixMyStreet::DB->schema->storage;
+$db->txn_do(sub {
+    foreach my $area (@areas) {
+        my $id = $area->{id};
+        my $mapped_name = delete $name_mappings->{$area->{name}};
+        my $name = $mapped_name || "$area->{name} Parish Council";
+
+        my $body_rs = FixMyStreet::DB->resultset("Body")->search({
+            name => $name,
+        })->for_areas($id);
+
+        if ($body_rs->count > 0) {
+            print "Existing body found for $name, skipping...\n";
+            next;
+        }
+
+        print "Creating body $name ($id)...";
+
+        my $body = $body_rs->create({ send_method => 'Noop', deleted => 1 });
+        $body->body_areas->find_or_create({ area_id => $id });
+
+        print "done\n";
+    }
+
+    if (%$name_mappings) {
+        my $unused_names = join ', ', keys %$name_mappings;
+        warn "[WARNING] The following name mappings weren't used: $unused_names\n";
+    }
+});

--- a/perllib/FixMyStreet/DB/ResultSet/Contact.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Contact.pm
@@ -90,4 +90,17 @@ sub summary_count {
     );
 }
 
+sub create_with_note {
+    my ( $rs, $note, $editor, $params ) = @_;
+
+    my $new_contact_params = {
+        %$params,
+        note => $note,
+        editor => $editor,
+        whenedited => \'current_timestamp',
+    };
+
+    return $rs->create($new_contact_params);
+}
+
 1;


### PR DESCRIPTION
Adds two scripts for setting up Buckinghamshire parishes as bodies:

1. `bin/buckinghamshire/create-parish-bodies` to pull in all known Buckinghamshire parishes from Mapit and create bodies for them.
2. `bin/buckinghamshire/add-parish-categories` which takes a CSV file with `name` and `email` columns where `name` is the parish body name and creates categories for those parishes which send to the provided email address.

The second script is necessary as Buckinghamshire aren't going to setup categories for all parishes immediately, so we need to be able to control which parishes have the necessary categories.

Fixes https://github.com/mysociety/societyworks/issues/2808

[skip changelog]