### PR TITLE
Remove aria-hidden from parents of #fms_pan_zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - Bugfixes:
         - Add ID attributes to change password form inputs.
         - Fix link deactivation for privacy policy link on privacy policy page. #3704
+        - Make map pan/zoom controls keyboard-accessible. #3751
     - Admin improvements:
         - Admin 'add user' form now always creates staff users
     - Development improvements:

--- a/templates/web/base/maps/noscript_map.html
+++ b/templates/web/base/maps/noscript_map.html
@@ -1,6 +1,6 @@
 [% SET start = c.config.ADMIN_BASE_URL IF admin -%]
 <div class="noscript">
-    <div id="[% nsm_prefix %]drag">
+    <div id="[% nsm_prefix %]drag" aria-hidden="true">
         <[% map.img_type | safe %]
             alt="NW map tile" id="[% nsm_prefix %]t2.2"
             name="tile_[% map.x_tile - 1 %].[% map.y_tile - 1 %]"
@@ -23,6 +23,6 @@
             src="[% map.tiles.3 %]"
             style="top:256px; left:256px;">
     </div>
-    <div id="[% nsm_prefix %]pins">[% FOR pin IN map.pins %][% INCLUDE 'maps/pin.html' %][% END %]</div>
+    <div id="[% nsm_prefix %]pins" aria-hidden="true">[% FOR pin IN map.pins %][% INCLUDE 'maps/pin.html' %][% END %]</div>
     [% INCLUDE 'maps/_compass.html' %]
 </div>

--- a/templates/web/base/maps/noscript_map_base_wmx.html
+++ b/templates/web/base/maps/noscript_map_base_wmx.html
@@ -1,5 +1,5 @@
 <div class="noscript">
-    <div id="[% nsm_prefix %]drag">
+    <div id="[% nsm_prefix %]drag" aria-hidden="true">
         [%- FOR row IN map.tiles -%]
             [%- FOR tile IN row -%]
                 [%- top_px = tile.row_offset * map.tile_size -%]
@@ -13,6 +13,6 @@
             [%- END -%]
         [% END %]
     </div>
-    <div id="[% nsm_prefix %]pins">[% FOR pin IN map.pins %][% INCLUDE 'maps/pin.html' %][% END %]</div>
+    <div id="[% nsm_prefix %]pins" aria-hidden="true">[% FOR pin IN map.pins %][% INCLUDE 'maps/pin.html' %][% END %]</div>
     [% INCLUDE 'maps/_compass.html' %]
 </div>

--- a/templates/web/base/maps/openlayers.html
+++ b/templates/web/base/maps/openlayers.html
@@ -39,7 +39,7 @@
 [%- END -%]
 >
 </div>
-<div id="map_box" aria-hidden="true">
+<div id="map_box">
     [% pre_map %]
     <div id="map">
       [% IF noscript_map_template == 'maps/noscript_map_base_wmx.html' %]

--- a/templates/web/zurich/maps/noscript_map.html
+++ b/templates/web/zurich/maps/noscript_map.html
@@ -1,7 +1,7 @@
 [% IF map.cols %]
 <div class="noscript square-map__outer">
     <div class="square-map__inner">
-        <div id="[% nsm_prefix %]drag">
+        <div id="[% nsm_prefix %]drag" aria-hidden="true">
             [%- FOR row IN map.tiles -%]
                 [%- FOR tile IN row -%]
                     [%- top_px = tile.row_offset * map.tile_size -%]
@@ -16,13 +16,13 @@
                 [%- END -%]
             [% END %]
         </div>
-        <div id="[% nsm_prefix %]pins">[% FOR pin IN map.pins %][% INCLUDE pin %][% END %]</div>
+        <div id="[% nsm_prefix %]pins" aria-hidden="true">[% FOR pin IN map.pins %][% INCLUDE pin %][% END %]</div>
         [% INCLUDE 'maps/_compass.html' %]
     </div>
 </div>
 [% ELSE %]
 <div class="noscript">
-    <div id="[% nsm_prefix %]drag">
+    <div id="[% nsm_prefix %]drag" aria-hidden="true">
         <[% map.img_type | safe %]
             alt="NW map tile" id="[% nsm_prefix %]t2.2"
             name="tile_[% map.x_tile - 1 %].[% map.y_tile - 1 %]"
@@ -45,7 +45,7 @@
             src="[% map.tiles.3 %]"
             style="top:256px; left:256px;">
     </div>
-    <div id="[% nsm_prefix %]pins">[% FOR pin IN map.pins %][% INCLUDE 'maps/pin.html' %][% END %]</div>
+    <div id="[% nsm_prefix %]pins" aria-hidden="true">[% FOR pin IN map.pins %][% INCLUDE 'maps/pin.html' %][% END %]</div>
     [% INCLUDE 'maps/_compass.html' %]
 </div>
 [% END %]

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -830,6 +830,7 @@ $.extend(fixmystreet.utils, {
             });
         }
         fixmystreet.markers = new OpenLayers.Layer.Vector("Pins", pin_layer_options);
+        fixmystreet.markers.div.setAttribute('aria-hidden', 'true');
         fixmystreet.markers.events.register( 'loadstart', null, fixmystreet.maps.loading_spinner.show);
         fixmystreet.markers.events.register( 'loadend', null, fixmystreet.maps.loading_spinner.hide);
         OpenLayers.Request.XMLHttpRequest.onabort = function() {
@@ -989,6 +990,7 @@ $.extend(fixmystreet.utils, {
             } else {
                 layer = new fixmystreet.map_type(fixmystreet.layer_name, layer_options);
             }
+            layer.div.setAttribute('aria-hidden', 'true');
             fixmystreet.map.addLayer(layer);
         }
 
@@ -1035,6 +1037,13 @@ $.extend(fixmystreet.utils, {
 // End maps closure
 })();
 
+OpenLayers.Control.AttributionFMS = OpenLayers.Class(OpenLayers.Control.Attribution, {
+    draw: function(){
+        OpenLayers.Control.Attribution.prototype.draw.apply(this, arguments);
+        this.div.setAttribute('aria-hidden', 'true');
+        return this.div;
+    }
+});
 
 /* Overridding the buttonDown function of PanZoom so that it does
    zoomTo(0) rather than zoomToMaxExtent()

--- a/web/js/map-OpenStreetMap.js
+++ b/web/js/map-OpenStreetMap.js
@@ -1,7 +1,7 @@
 fixmystreet.maps.config = function() {
     fixmystreet.controls = [
         new OpenLayers.Control.ArgParserFMS(),
-        new OpenLayers.Control.Attribution(),
+        new OpenLayers.Control.AttributionFMS(),
         //new OpenLayers.Control.LayerSwitcher(),
         new OpenLayers.Control.Navigation(),
         new OpenLayers.Control.PermalinkFMS('map'),

--- a/web/js/map-bing-ol.js
+++ b/web/js/map-bing-ol.js
@@ -1,6 +1,6 @@
 fixmystreet.maps.config = function() {
     fixmystreet.controls = [
-        new OpenLayers.Control.Attribution(),
+        new OpenLayers.Control.AttributionFMS(),
         new OpenLayers.Control.ArgParserFMS(),
         new OpenLayers.Control.Navigation(),
         new OpenLayers.Control.PermalinkFMS('map'),

--- a/web/js/map-cheshireeast.js
+++ b/web/js/map-cheshireeast.js
@@ -1,6 +1,6 @@
 fixmystreet.maps.config = function() {
     fixmystreet.controls = [
-        new OpenLayers.Control.Attribution(),
+        new OpenLayers.Control.AttributionFMS(),
         new OpenLayers.Control.ArgParserFMS(),
         new OpenLayers.Control.Navigation(),
         new OpenLayers.Control.PermalinkFMS('map'),


### PR DESCRIPTION
Since the `#fms_pan_zoom` map controls are keyboard-navigable (and could conceivably be used by even non-sighted users, wanting to move the map view to reveal new markers in the `#map_sidebar` list) we need to make sure the controls aren’t hidden inside an `aria-hidden` parent.

Removing `aria-hidden` from `#map_box`, however, now exposes a whole load of new elements to assistive devices, including (in order):

1. each of the image tiles
2. each of the pin shadows
3. each of the pins
4. map data attribution at the bottom
5. each of the pan/zoom/other controls

In this commit, I’ve at least hidden the image tiles and pins in the non-JavaScript version(s) of the map. But doing the same thing in the OpenLayers JavaScript is beyond my current understanding!

Perhaps a developer can take a look?

TODO:

- [x] Tell OpenLayers to mark the image tiles and pin shadows as `aria-hidden="true"`
- [x] Decide whether to leave the pins accessible, or mark them as `aria-hidden="true"` as well (given there’s no way to skip over/past them, and there’s a list of all reports in `#map_sidebar` anyway).
