### PR TITLE
[Shropshire] Remove form input focus outline to match branding guidelines

### DIFF
--- a/web/cobrands/shropshire/_colours.scss
+++ b/web/cobrands/shropshire/_colours.scss
@@ -46,6 +46,7 @@ $mappage-header-height: 64px;
     box-shadow: none;
 
     &:focus {
+        outline: none; // hide browser default outline, to match screenshot in branding guidelines
         border: 1px solid #52A8EC;
         box-shadow: 0 1px 3px #000, 0 0 8px #52A8EC;
     }

--- a/web/cobrands/shropshire/base.scss
+++ b/web/cobrands/shropshire/base.scss
@@ -119,9 +119,10 @@ label {
 }
 
 .multi-select-button {
+    // Focus style, copied from shropshire-form-input() mixin
     &:focus {
         outline: none;
-        border-color: #52A8EC;
+        border: 1px solid #52A8EC;
         box-shadow: 0 1px 3px #000, 0 0 8px #52A8EC;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/mysociety/societyworks/issues/2789 (hopefully!)

Hides the browser’s default focus outline on form inputs in the Shropshire cobrand, so that Shropshire’s custom focus (created with a border and box-shadow) shows through, uninterrupted – as requested by their branding guidelines document.

This also means that the multiselect dropdown toggles and the _native_ dropdowns on the `/around` page now match:

Before:

![broken](https://user-images.githubusercontent.com/739624/149988328-b37cb980-64c1-4819-aa58-77bb16f25c3e.gif)

After:

![fixed](https://user-images.githubusercontent.com/739624/149988368-6a7a63a7-bca2-4dde-b972-a397bc5509b0.gif)

[skip changelog]