### PR TITLE
[Shropshire] restrict phone numbers to non-alphabetic characters (0-9, +, space only)

### DIFF
--- a/.cypress/cypress/fixtures/shropshire.xml
+++ b/.cypress/cypress/fixtures/shropshire.xml
@@ -1,0 +1,119 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver https://tilma.staging.mysociety.org:80/mapserver/shropshire?SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=Street_Gazetteer&amp;OUTPUTFORMAT=text/xml;%20subtype=gml/3.1.1  http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+      <gml:boundedBy>
+      	<gml:Envelope srsName="EPSG:27700">
+      		<gml:lowerCorner>350835.000000 328722.000000</gml:lowerCorner>
+      		<gml:upperCorner>351443.000000 328974.000000</gml:upperCorner>
+      	</gml:Envelope>
+      </gml:boundedBy>
+<!-- WARNING: FeatureId item 'fid' not found in typename 'Street_Gazetteer'. -->
+    <gml:featureMember>
+      <ms:Street_Gazetteer>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:27700">
+        		<gml:lowerCorner>351314.000000 328722.000000</gml:lowerCorner>
+        		<gml:upperCorner>351362.000000 328906.000000</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:LineString srsName="EPSG:27700">
+            <gml:posList srsDimension="2">351362.000000 328722.000000 351355.000000 328729.000000 351351.000000 328735.000000 351348.000000 328744.000000 351345.000000 328754.000000 351330.000000 328847.000000 351325.000000 328869.000000 351314.000000 328906.000000 </gml:posList>
+          </gml:LineString>
+        </ms:msGeometry>
+        <ms:SITE_CLASS>PUB</ms:SITE_CLASS>
+        <ms:USRN>28200125</ms:USRN>
+      </ms:Street_Gazetteer>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:Street_Gazetteer>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:27700">
+        		<gml:lowerCorner>351269.000000 328899.000000</gml:lowerCorner>
+        		<gml:upperCorner>351277.000000 328965.000000</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:LineString srsName="EPSG:27700">
+            <gml:posList srsDimension="2">351277.000000 328899.000000 351271.000000 328942.000000 351269.000000 328965.000000 </gml:posList>
+          </gml:LineString>
+        </ms:msGeometry>
+        <ms:SITE_CLASS>PUB</ms:SITE_CLASS>
+        <ms:USRN>28200190</ms:USRN>
+      </ms:Street_Gazetteer>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:Street_Gazetteer>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:27700">
+        		<gml:lowerCorner>350835.000000 328855.000000</gml:lowerCorner>
+        		<gml:upperCorner>351425.000000 328966.000000</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:LineString srsName="EPSG:27700">
+            <gml:posList srsDimension="2">350835.000000 328900.000000 350840.000000 328890.000000 350845.000000 328883.000000 350856.000000 328872.000000 350862.000000 328869.000000 350867.000000 328867.000000 350869.000000 328866.000000 350877.000000 328864.000000 350920.000000 328857.000000 350921.000000 328857.000000 350953.000000 328857.000000 351000.000000 328861.000000 351007.000000 328860.000000 351021.000000 328859.000000 351039.000000 328857.000000 351046.000000 328856.000000 351105.000000 328855.000000 351111.000000 328855.000000 351117.000000 328857.000000 351119.000000 328858.000000 351137.000000 328881.000000 351143.000000 328885.000000 351147.000000 328886.000000 351153.000000 328888.000000 351179.000000 328888.000000 351189.000000 328887.000000 351207.000000 328887.000000 351247.000000 328894.000000 351248.000000 328894.000000 351277.000000 328899.000000 351293.000000 328901.000000 351305.000000 328902.000000 351314.000000 328906.000000 351319.000000 328909.000000 351337.000000 328924.000000 351343.000000 328928.000000 351348.000000 328931.000000 351360.000000 328936.000000 351381.000000 328945.000000 351406.000000 328957.000000 351425.000000 328966.000000 </gml:posList>
+          </gml:LineString>
+        </ms:msGeometry>
+        <ms:SITE_CLASS>PUB</ms:SITE_CLASS>
+        <ms:USRN>28200299</ms:USRN>
+      </ms:Street_Gazetteer>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:Street_Gazetteer>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:27700">
+        		<gml:lowerCorner>351360.000000 328760.000000</gml:lowerCorner>
+        		<gml:upperCorner>351391.000000 328936.000000</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:LineString srsName="EPSG:27700">
+            <gml:posList srsDimension="2">351360.000000 328936.000000 351365.000000 328915.000000 351377.000000 328844.000000 351391.000000 328760.000000 </gml:posList>
+          </gml:LineString>
+        </ms:msGeometry>
+        <ms:SITE_CLASS>PUB</ms:SITE_CLASS>
+        <ms:USRN>28200342</ms:USRN>
+      </ms:Street_Gazetteer>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:Street_Gazetteer>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:27700">
+        		<gml:lowerCorner>351007.000000 328860.000000</gml:lowerCorner>
+        		<gml:upperCorner>351343.000000 328974.000000</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:LineString srsName="EPSG:27700">
+            <gml:posList srsDimension="2">351007.000000 328860.000000 351013.000000 328897.000000 351015.000000 328902.000000 351020.000000 328909.000000 351034.000000 328920.000000 351046.000000 328928.000000 351073.000000 328945.000000 351108.000000 328964.000000 351122.000000 328970.000000 351140.000000 328974.000000 351155.000000 328974.000000 351185.000000 328970.000000 351186.000000 328970.000000 351269.000000 328965.000000 351287.000000 328964.000000 351298.000000 328962.000000 351303.000000 328960.000000 351320.000000 328950.000000 351343.000000 328928.000000 </gml:posList>
+          </gml:LineString>
+        </ms:msGeometry>
+        <ms:SITE_CLASS>PUB</ms:SITE_CLASS>
+        <ms:USRN>28200439</ms:USRN>
+      </ms:Street_Gazetteer>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:Street_Gazetteer>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:27700">
+        		<gml:lowerCorner>351412.000000 328894.000000</gml:lowerCorner>
+        		<gml:upperCorner>351443.000000 328966.000000</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:LineString srsName="EPSG:27700">
+            <gml:posList srsDimension="2">351425.000000 328966.000000 351423.000000 328958.000000 351443.000000 328902.000000 351412.000000 328894.000000 </gml:posList>
+          </gml:LineString>
+        </ms:msGeometry>
+        <ms:SITE_CLASS>PUB</ms:SITE_CLASS>
+        <ms:USRN>34800122</ms:USRN>
+      </ms:Street_Gazetteer>
+    </gml:featureMember>
+</wfs:FeatureCollection>
+

--- a/.cypress/cypress/integration/shropshire.js
+++ b/.cypress/cypress/integration/shropshire.js
@@ -1,0 +1,32 @@
+it('loads the Shropshire FMS Pro front page', function() {
+    cy.visit('http://shropshire.localhost:3001/');
+    cy.contains('Enter a Shropshire postcode');
+});
+it('does not allow typing alphabetic characters in the phone field', function() {
+    cy.server();
+    cy.route('**mapserver/shropshire*Street_Gazetteer*', 'fixture:shropshire.xml').as('salop-roads-layer');
+    cy.visit('http://shropshire.localhost:3001/report/new?latitude=52.855684&longitude=-2.723877');
+    cy.wait('@salop-roads-layer');
+    cy.pickCategory('Flytipping');
+    cy.nextPageReporting();
+    // photos page
+    cy.nextPageReporting();
+    cy.get('input#form_title').type('A case of fly tipping');
+    cy.get('textarea#form_detail').type('Van load of domestic refuse.');
+    cy.nextPageReporting();
+    // about you page
+    cy.get('input#form_name').type('John Smith');
+    var phone_string = "tel no: 0123 4567890";
+    cy.get('input#form_phone').type(phone_string);
+    cy.get('input#form_username_register').type("john.smith@example.com");
+    cy.get('form#mapForm').submit();
+    cy.contains("Please enter a valid UK phone number");
+});
+it('does accept a correctly formatted UK phone number', function() {
+    // carry straight on from above
+    var valid_phone_num = "01234 567890";
+    cy.get('input#form_phone').focus().clear();
+    cy.get('input#form_phone').type(valid_phone_num);
+    cy.get('form#mapForm').submit();
+    cy.contains("Nearly done! Now check your email…");
+});

--- a/bin/browser-tests
+++ b/bin/browser-tests
@@ -25,6 +25,7 @@ BEGIN {
         northamptonshire
         oxfordshire
         peterborough
+        shropshire
         tfl
         westminster
     )];

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -124,7 +124,8 @@ if ($opt->test_fixtures) {
         { area_id => 2566, categories => [ 'General fly tipping', 'Fallen branch', 'Light Out', 'Light Dim', 'Fallen Tree', 'Damaged Tree', 'Pothole' ], name => 'Peterborough City Council' },
         { area_id => 2498, categories => [ 'Incorrect timetable', 'Glass broken', 'Mobile Crane Operation', 'Roadworks' ], name => 'TfL' },
         { area_id => 2237, categories => [ 'Flytipping', 'Roads', 'Parks' ], name => 'Oxfordshire County Council' },
-        { area_id => 2551, categories => [ 'Abandoned vehicles', 'Dog fouling', 'Blocked drain' ], name => 'Bath and North East Somerset Council' }
+        { area_id => 2551, categories => [ 'Abandoned vehicles', 'Dog fouling', 'Blocked drain' ], name => 'Bath and North East Somerset Council' },
+        { area_id => 2238, categories => [ 'Flytipping', 'Roads', 'Parks' ], name => 'Shropshire Council' },
     ) {
         $bodies->{$_->{area_id}} = FixMyStreet::DB::Factory::Body->find_or_create($_);
         my $cats = join(', ', @{$_->{categories}});

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -78,6 +78,7 @@ my @PLACES = (
     [ '?', 51.379009, -2.359276, 2551, 'Bath and North East Somerset Council', 'UTA' ],
     [ 'The Circus', 51.386269, -2.364050, 2551, 'Bath and North East Somerset Council', 'UTA' ],
     [ 'SM4 5DX', 51.400975, -0.19655, 2500, 'Merton Council', 'LBO' ],
+    [ 'SY4 5DL', 52.855684, -2.723877, 2238, 'Shropshire Council', 'UTA' ],
     # Norway
     [ '3290', 59, 10, 709, 'Larvik', 'NKO', 7, 'Vestfold', 'NFY' ],
     [ '0045', "59.9", "10.9", 301, 'Oslo', 'NKO', 3, 'Oslo', 'NFY' ],

--- a/templates/web/base/js/translation_strings.html
+++ b/templates/web/base/js/translation_strings.html
@@ -34,7 +34,8 @@ fixmystreet.password_minimum_length = [% c.cobrand.password_minimum_length %];
             short: '[% tprintf(loc('Please make sure your password is at least %d characters long', "JS"), c.cobrand.password_minimum_length) %]',
         },
         phone: {
-            required: '[% loc('Please enter your phone number', "JS") %]'
+            required: '[% loc('Please enter your phone number', "JS") %]',
+            ukFormat: '[% loc('Please enter a valid UK phone number', "JS") %]'
         },
         fms_extra_title: '[% loc('Please enter your title', "JS") %]',
         first_name: '[% loc('Please enter your first name', "JS") %]',

--- a/web/cobrands/fixmystreet-uk-councils/council_validation_rules.js
+++ b/web/cobrands/fixmystreet-uk-councils/council_validation_rules.js
@@ -63,5 +63,11 @@ body_validation_rules = {
           required: true,
           maxlength: 40
         }
+    },
+    'Shropshire Council': {
+        phone: {
+            validUkPhone: true,
+            maxlength: 20
+        }
     }
 };

--- a/web/cobrands/fixmystreet-uk-councils/js.js
+++ b/web/cobrands/fixmystreet-uk-councils/js.js
@@ -6,6 +6,15 @@
     function valid_name(value, element) {
         return this.optional(element) || value.length > 5 && value.match( /\S/ ) && value.match( /\s/ ) && !value.match( validNamePat );
     }
+    // XXX this fn is duplicated at web/cobrands/fixmystreet.com/js.js
+    function validUkPhone(phone_number, element) {
+        phone_number = phone_number.replace( /\+44\(0\)/g, "+44" );
+        phone_number = phone_number.replace( /\(|\)|\s+|-/g, "" );
+        return this.optional( element ) || phone_number.length > 9 &&
+            phone_number.match( /^(?:(?:00|\+)44|0)[0-9]{9,10}$/ );
+    }
     jQuery.validator.addMethod('validName', valid_name, translation_strings.name.required);
     jQuery.validator.addMethod('validNameU', valid_name, translation_strings.name.required);
+    // validate UK phone numbers
+    jQuery.validator.addMethod('validUkPhone', validUkPhone, translation_strings.phone.ukFormat);
 })();

--- a/web/cobrands/fixmystreet.com/js.js
+++ b/web/cobrands/fixmystreet.com/js.js
@@ -8,8 +8,17 @@
             return this.optional(element) || value.length > 5 && value.match(/\S/) && (value.match(/\s/) || (single && !value.match('.@.'))) && !value.match(validNamePat);
         };
     }
+    // XXX this fn is duplicated at web/cobrands/fixmystreet-uk-councils/js.js
+    function validUkPhone(phone_number, element) {
+        phone_number = phone_number.replace( /\+44\(0\)/g, "+44" );
+        phone_number = phone_number.replace( /\(|\)|\s+|-/g, "" );
+        return this.optional( element ) || phone_number.length > 9 &&
+            phone_number.match( /^(?:(?:00|\+)44|0)[0-9]{9,10}$/ );
+    }
     jQuery.validator.addMethod('validName', valid_name_factory(0), translation_strings.name.required);
     jQuery.validator.addMethod('validNameU', valid_name_factory(1), translation_strings.name.required);
+    // validate UK phone numbers
+    jQuery.validator.addMethod('validUkPhone', validUkPhone, translation_strings.phone.ukFormat);
 
     jQuery('.big-green-banner').on('click', function(){
         if (typeof ga !== 'undefined') {


### PR DESCRIPTION
Restrict phone numbers to non-text characters (0-9, +, space).
Shropshire have asked to be able to match:
+44 1234 567890
and similar phone numbers but not e.g. similar to the following which caused a stuck report:
`Customer - Mrs XXXX - 01746 222 222`
(Where the reporter was reporting on behalf of a resident.)

for https://mysocietysupport.freshdesk.com/a/tickets/1741


Please check the following:

- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [ ] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [ ] Will cobrand-specific changes require additional work to ensure consistent behaviour on www.fixmystreet.com? 🔍 
- [ ] Are the changes tested for accessibility?
[skip changelog]
