### PR TITLE
[Bromley] Fix split postcode BR1 4EY to point to Bromley.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -101,6 +101,14 @@ sub geocode_postcode {
         return $parks_lookup;
     }
 
+    # split postcode with Lewisham
+    if ($s =~ /BR1\s*4EY/i) {
+        return {
+            latitude => 51.4190772,
+            longitude => 0.0117805,
+        };
+    }
+
     return $self->next::method($s);
 }
 


### PR DESCRIPTION
For https://mysocietysupport.freshdesk.com/a/tickets/1752

Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [x] Will cobrand-specific changes require additional work to ensure consistent behaviour on www.fixmystreet.com? 
- [ ] Are the changes tested for accessibility?
[skip changelog]

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
