### PR TITLE
Add prefer_if_multiple setting to contacts

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
@@ -276,7 +276,7 @@ sub update_contact : Private {
     $contact->send_method( $c->get_param('send_method') );
 
     # Set flags in extra to the appropriate values
-    foreach (qw(photo_required open311_protect updates_disallowed reopening_disallowed assigned_users_only anonymous_allowed)) {
+    foreach (qw(photo_required open311_protect updates_disallowed reopening_disallowed assigned_users_only anonymous_allowed prefer_if_multiple)) {
         if ( $c->get_param($_) ) {
             $contact->set_extra_metadata( $_ => 1 );
         } else {

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1202,6 +1202,16 @@ sub contacts_to_bodies : Private {
 
     my @contacts = grep { $_->category eq $category } @{$c->stash->{contacts}};
 
+    # If there are multiple contacts for different bodies then the default
+    # behaviour is to send to all bodies. However if a contact has the
+    # "prefer_if_multiple" checkbox checked then only send reports to that contact.
+    # This is useful for e.g. routing reports to parishes when the parent council
+    # has a contact of the same name.
+    my @preferred_contacts = grep { $_->get_extra_metadata('prefer_if_multiple') } @contacts;
+    if (scalar @preferred_contacts) {
+        @contacts = @preferred_contacts;
+    }
+
     # check that the front end has not indicated that we should not send to a
     # body. This is usually because the asset code thinks it's not near enough
     # to a road.

--- a/t/app/controller/admin/bodies.t
+++ b/t/app/controller/admin/bodies.t
@@ -292,6 +292,16 @@ subtest 'test assigned_users_only setting' => sub {
     is $contact->get_extra_metadata('assigned_users_only'), 1;
 };
 
+subtest 'test prefer_if_multiple setting' => sub {
+    $mech->get_ok('/admin/body/' . $body->id . '/test%20category');
+    $mech->submit_form_ok( { with_fields => {
+        prefer_if_multiple => 1,
+    } } );
+    $mech->content_contains('Values updated');
+    my $contact = $body->contacts->find({ category => 'test category' });
+    is $contact->get_extra_metadata('prefer_if_multiple'), 1;
+};
+
 subtest 'updates disabling' => sub {
     $mech->get_ok('/admin/body/' . $body->id . '/test%20category');
     $mech->submit_form_ok( { with_fields => {

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -510,8 +510,23 @@ foreach my $test (
         extra_fields => { single_body_only => 'National Highways' },
         email_count => 1,
     },
+    {
+        desc => "test prefer_if_multiple only sends to one body",
+        category => 'Street lighting',
+        councils => [ 2326 ],
+        extra_fields => {},
+        email_count => 1,
+        setup => sub {
+            # $contact10 is Cheltenham Borough Council (2326)
+            $contact10->set_extra_metadata(prefer_if_multiple => 1);
+            $contact10->update;
+        },
+    },
 ) {
     subtest $test->{desc} => sub {
+        if ($test->{setup}) {
+            $test->{setup}->();
+        }
 
         # check that the user does not exist
         my $test_email = 'test-2@example.com';

--- a/templates/web/base/admin/bodies/contact-form.html
+++ b/templates/web/base/admin/bodies/contact-form.html
@@ -133,6 +133,12 @@
         <span class='form-hint'>[% loc('Use this if you wish only users assigned to this category to see staff-related features (such as the inspector form) in the front end.') %]</span>
     </p>
 
+    <p class="form-check">
+      <input type="checkbox" name="prefer_if_multiple" value="1" id="prefer_if_multiple" [% ' checked' IF contact.extra.prefer_if_multiple %]>
+      <label for="prefer_if_multiple">[% loc('Prefer this contact if multiple bodies have the same contact') %]</label>
+      <span class='form-hint'>[% loc('Use this if there is a chance that multiple bodies covering the same area that have the same contacts and you want to just send reports to one, rather than multiple bodies') %]</span>
+    </p>
+
   [% IF body.can_be_devolved %]
     <div class="admin-hint">
       <p>


### PR DESCRIPTION
This is for the situation where multiple bodies covering the same area have a contact with the same name. Checking this box indicates that if multiple contacts are found with the same name then the one(s) with this box checked should be preferred.

If no contacts are found with this flag then fall back to the default behaviour of sending to all matching contacts.

If multiple contacts are found with this flag then it will send to all of them.

This is related to the Buckinghamshire parish changes (see #3750), the idea being the parish contacts have this flag on them and therefore only get sent to the parish, rather than to Bucks as well.

[skip changelog]