### PR TITLE
"Can't see the map?" message now is always visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Unreleased
     - Front end improvements:
+        - Skip map link on /around is now always visible below big green banner #3788.
         - Highlight pin on sidebar focus as well as hover.
         - Map page pagination links now styled as links rather than buttons. #3727
         - Include username in inactive email.

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -357,13 +357,10 @@ body.mappage.admin {
 
 #skip-this-step {
   display: block;
-  color: inherit;
-  //margin: 0 -15px;
-  padding: 16px;
-  font-size: 18px;
+  color: #666;
+  padding: 1em;
   line-height: 20px;
-  border-bottom: 1px solid #E7E1C0;
-  background: #FDF4C5;
+  margin: 0 -1em;
 
   em {
     font-style: normal;
@@ -373,19 +370,6 @@ body.mappage.admin {
 
   &:hover {
     text-decoration: none;
-  }
-
-  html.js & {
-    // If javascript is enabled, hide the skip link off-screen,
-    // but keep it visible for screen readers.
-    position: absolute;
-    top: -999px;
-
-    &:focus,
-    &:focus-within {
-      // And show it again if it receives focus (eg: via tab key)
-      position: static;
-    }
   }
 }
 


### PR DESCRIPTION
Moved to the top of the page, below main title. I got rid of the yellow background so it doesn't pop up much on the page,
encouraging users that can see the map to actually keep using it, instead of skipping it.

<img width="1380" alt="Screenshot 2022-02-07 at 15 12 38" src="https://user-images.githubusercontent.com/13790153/152815349-17e59f65-d37d-48ef-bca6-f792f2821914.png">

Fixes part of #1360

