### PR TITLE
[Peterborough] Don't allow duplicate food caddy requests

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -711,20 +711,30 @@ sub bin_services_for_address {
     my $skip_bags = $self->{c}->get_param('skip_bags');
 
     @out = () if $bags_only;
-    my $food_containers = $bags_only ? [ 428 ] : $skip_bags ? [ 424, 423 ] : [ 424, 423, 428 ];
 
-    push @out, {
+    my @food_containers;
+    if ($bags_only) {
+        push(@food_containers, 428) unless $open_requests->{428};
+    } else {
+        unless ( $open_requests->{493} ) { # Both food bins
+            push(@food_containers, 424) unless $open_requests->{424}; # Large food caddy
+            push(@food_containers, 423) unless $open_requests->{423}; # Small food caddy
+        }
+        push(@food_containers, 428) unless $skip_bags || $open_requests->{428};
+    }
+
+    push(@out, {
         id => "FOOD_BINS",
         service_name => "Food bins",
         service_id => "FOOD_BINS",
-        request_containers => $food_containers,
+        request_containers => \@food_containers,
         request_allowed => 1,
         request_max => 1,
         request_only => 1,
         report_only => 1,
-    };
+    }) if @food_containers;
 
-    unless ( $bags_only ) {
+    unless ( $bags_only || $open_requests->{425} ) {
         # We want this one to always appear first
         unshift @out, {
             id => "_ALL_BINS",

--- a/perllib/Integrations/Bartec.pm
+++ b/perllib/Integrations/Bartec.pm
@@ -198,7 +198,7 @@ sub Jobs_Get {
         },
     });
     my $jobs = force_arrayref($res, 'Jobs');
-    @$jobs = sort { $a->{ScheduledDate} cmp $b->{ScheduledDate} } map { $_->{Job} } @$jobs;
+    @$jobs = sort { $a->{ScheduledStart} cmp $b->{ScheduledStart} } map { $_->{Job} } @$jobs;
     return $jobs;
 }
 

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -215,6 +215,22 @@ FixMyStreet::override_config {
         ] });
         $mech->get_ok('/waste/PE1 3NA:100090215480');
         $mech->content_contains('A recycling bin collection has been reported as missed');
+        $b->mock('ServiceRequests_Get', sub { [
+            { ServiceType => { ID => 424 }, ServiceStatus => { Status => "OPEN" } },
+        ] });
+        $mech->get_ok('/waste/PE1 3NA:100090215480/request');
+        $mech->content_lacks('Large food caddy');
+        $b->mock('ServiceRequests_Get', sub { [
+            { ServiceType => { ID => 493 }, ServiceStatus => { Status => "OPEN" } },
+        ] });
+        $mech->get_ok('/waste/PE1 3NA:100090215480/request');
+        $mech->content_lacks('Large food caddy');
+        $mech->content_lacks('Small food caddy');
+        $b->mock('ServiceRequests_Get', sub { [
+            { ServiceType => { ID => 425 }, ServiceStatus => { Status => "OPEN" } },
+        ] });
+        $mech->get_ok('/waste/PE1 3NA:100090215480/request');
+        $mech->content_lacks('All bins');
         $b->mock('ServiceRequests_Get', sub { [ ] }); # reset
     };
     subtest 'Request a new bin' => sub {

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -69,8 +69,8 @@ FixMyStreet::override_config {
         { Token => { TokenString => "TOKEN" } }
     });
     $b->mock('Jobs_Get', sub { [
-        { WorkPack => { Name => 'Waste-R1-010821' }, Name => 'Empty Bin 240L Black', ScheduledDate => '2021-08-01T07:00:00' },
-        { WorkPack => { Name => 'Waste-R1-050821' }, Name => 'Empty Bin Recycling 240l', ScheduledDate => '2021-08-05T07:00:00' },
+        { WorkPack => { Name => 'Waste-R1-010821' }, Name => 'Empty Bin 240L Black', ScheduledStart => '2021-08-01T07:00:00' },
+        { WorkPack => { Name => 'Waste-R1-050821' }, Name => 'Empty Bin Recycling 240l', ScheduledStart => '2021-08-05T07:00:00' },
     ] });
     my $jobs_fsd_get = [
         { JobID => 123, PreviousDate => '2021-08-01T11:11:11Z', NextDate => '2021-08-08T11:11:11Z', JobName => 'Empty Bin 240L Black' },


### PR DESCRIPTION
Prevents requests for new food caddies if there are already open service requests.

For https://github.com/mysociety/societyworks/issues/2878

[skip changelog]