### PR TITLE
Fix colour contrast issues in map page sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
     - Bugfixes:
         - Add ID attributes to change password form inputs.
         - Fix link deactivation for privacy policy link on privacy policy page. #3704
+    - Accessibility improvements:
+        - Improve visual contrast of pagination links. #3794
         - Make map pan/zoom controls keyboard-accessible. #3751
     - Admin improvements:
         - Admin 'add user' form now always creates staff users

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 * Unreleased
     - Front end improvements:
-        - Skip map link on /around is now always visible below big green banner #3788.
         - Highlight pin on sidebar focus as well as hover.
         - Map page pagination links now styled as links rather than buttons. #3727
         - Include username in inactive email.
@@ -10,6 +9,8 @@
         - Add ID attributes to change password form inputs.
         - Fix link deactivation for privacy policy link on privacy policy page. #3704
     - Accessibility improvements:
+        - The "skip map" link on /around now has new wording,
+          and is no longer visible only on focus. #3788 #3794
         - Improve visual contrast of pagination links. #3794
         - Make map pan/zoom controls keyboard-accessible. #3751
     - Admin improvements:

--- a/templates/web/base/around/_report_banner.html
+++ b/templates/web/base/around/_report_banner.html
@@ -1,6 +1,6 @@
 <h1 class="big-green-banner">
     [% loc( 'Click map to report a problem' ) %]
 </h1>
-<a id="skip-this-step" href="[% url_skip %]" rel="nofollow">
-    [% loc("Can't see the map? <em>Skip this step</em>") %]
-</a>
+<p class="map-alternatives">
+    [% tprintf( loc('Can’t use the map? <a href="%s" rel="nofollow">Skip this step.</a>'), url_skip) %]
+</p>

--- a/templates/web/bromley/around/_report_banner.html
+++ b/templates/web/bromley/around/_report_banner.html
@@ -5,6 +5,6 @@
     <h2>[% loc( 'Have you found a problem here?' ) %]</h2>
     <p>Click on the map to report it</p>
 </div>
-<a id="skip-this-step" href="[% url_skip %]" rel="nofollow">
-    [% loc("Can't see the map? <em>Skip this step</em>") %]
-</a>
+<p class="map-alternatives">
+    [% tprintf( loc('Can’t use the map? <a href="%s" rel="nofollow">Skip this step.</a>'), url_skip) %]
+</p>

--- a/templates/web/greenwich/around/_report_banner.html
+++ b/templates/web/greenwich/around/_report_banner.html
@@ -5,6 +5,6 @@
     <h2>[% loc( 'Have you found a problem here?' ) %]</h2>
     <p>Click on the map to report it</p>
 </div>
-<a id="skip-this-step" href="[% url_skip %]" rel="nofollow">
-    [% loc("Can't see the map? <em>Skip this step</em>") %]
-</a>
+<p class="map-alternatives">
+    [% tprintf( loc('Can’t use the map? <a href="%s" rel="nofollow">Skip this step.</a>'), url_skip) %]
+</p>

--- a/templates/web/highwaysengland/around/_report_banner.html
+++ b/templates/web/highwaysengland/around/_report_banner.html
@@ -1,9 +1,9 @@
 <h1 class="big-green-banner">
     Click map to report a problem
 </h1>
-<span id="skip-this-step" tabindex="0">
-    Can’t see the map?
+<p class="map-alternatives">
+    Can’t use the map?
     <a href="[% url_skip %]" rel="nofollow">Skip this step</a>
     or, if you prefer, contact us on
-    <a href="tel:03001235000">0300 123 5000</a>.
-</span>
+    <a href="tel:03001235000" style="white-space: nowrap">0300 123 5000</a>.
+</p>

--- a/templates/web/oxfordshire/around/_report_banner.html
+++ b/templates/web/oxfordshire/around/_report_banner.html
@@ -5,6 +5,6 @@
     <h2>[% loc( 'Have you found a problem here?' ) %]</h2>
     <p>Click on the map to report it</p>
 </div>
-<a id="skip-this-step" href="[% url_skip %]" rel="nofollow">
-    [% loc("Can't see the map? <em>Skip this step</em>") %]
-</a>
+<p class="map-alternatives">
+    [% tprintf( loc('Can’t use the map? <a href="%s" rel="nofollow">Skip this step.</a>'), url_skip) %]
+</p>

--- a/templates/web/shropshire/around/_report_banner.html
+++ b/templates/web/shropshire/around/_report_banner.html
@@ -1,6 +1,0 @@
-<h1 class="big-green-banner">
-    [% loc( 'Click map to report a problem' ) %]
-</h1>
-<a id="skip-this-step" href="[% url_skip %]" rel="nofollow">
-    [% loc("Can’t use the map? <em>Skip this step</em>") %]
-</a>

--- a/web/cobrands/bexley/base.scss
+++ b/web/cobrands/bexley/base.scss
@@ -46,7 +46,9 @@ small {
     font-size: 0.89em;
     line-height: 1.4;
 }
-
+.map-alternatives {
+    font-size: 0.89em;
+}
 .report-list-filters {
     font-size: 0.89em;
     .form-control {

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -865,11 +865,6 @@ $.extend(fixmystreet.set_up, {
     $('.js-multiple').make_multi();
   },
 
-  mobile_ui_tweaks: function() {
-    //move 'skip this step' link on mobile
-    $('.mobile #skip-this-step').addClass('chevron').wrap('<li>').parent().appendTo('#key-tools');
-  },
-
   // Very similar function in front.js for front page
   on_mobile_nav_click: function() {
     var html = document.documentElement;

--- a/web/cobrands/merton/layout.scss
+++ b/web/cobrands/merton/layout.scss
@@ -76,8 +76,3 @@ body.twothirdswidthpage .content {
         top: 0;
     }
 }
-
-#skip-this-step em {
-    color: black;
-}
-

--- a/web/cobrands/oxfordshire/_colours.scss
+++ b/web/cobrands/oxfordshire/_colours.scss
@@ -30,6 +30,7 @@ $col_click_map: $color-oxfordshire-bright-green;
 
 $col_fixed_label: $color-oxfordshire-bright-green;
 
+$pagination_background: #fff;
 $itemlist_item_background: #fff;
 $itemlist_item_background_hover: #e0e2e5;
 

--- a/web/cobrands/oxfordshire/base.scss
+++ b/web/cobrands/oxfordshire/base.scss
@@ -233,11 +233,16 @@ textarea {
 .extra-text {
   padding: 1em;
   margin: 0 -1em;
-  border-bottom: 1px solid $color-oxfordshire-pale-grey-green;
+  border-top: 1px solid $color-oxfordshire-pale-grey-green;
 
   p:last-child {
     margin-bottom: 0;
   }
+}
+
+.report-list-filters-wrapper {
+    border-top-color: $color-oxfordshire-pale-grey-green;
+    border-bottom-color: $color-oxfordshire-pale-grey-green;
 }
 
 .item-list--reports__item {

--- a/web/cobrands/oxfordshire/layout.scss
+++ b/web/cobrands/oxfordshire/layout.scss
@@ -287,39 +287,6 @@ h4.static-with-rule {
     }
 }
 
-#skip-this-step {
-  display: block;
-  color: inherit;
-  margin: 0 -15px;
-  padding: 16px;
-  font-size: 18px;
-  line-height: 20px;
-  border-bottom: 1px solid #E7E1C0;
-  background: #FDF4C5;
-
-  em {
-    font-style: normal;
-    text-decoration: underline;
-    color: $primary;
-  }
-
-  &:hover {
-    text-decoration: none;
-  }
-
-  html.js & {
-    // If javascript is enabled, hide the skip link off-screen,
-    // but keep it visible for screen readers.
-    position: absolute;
-    top: -999px;
-
-    &:focus {
-      // And show it again if it receives focus (eg: via tab key)
-      position: static;
-    }
-  }
-}
-
 .extra-text__image {
     float: left;
     margin-right: 1em;

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -15,6 +15,7 @@ $link-hover-text-decoration: underline !default;
 $primary_link_decoration: underline !default;
 $primary_link_hover_decoration: $primary_link_decoration !default;
 
+$pagination_background: #f6f6f6 !default;
 $itemlist_item_background: #f6f6f6 !default;
 $itemlist_item_background_hover: #e6e6e6 !default;
 $col_big_numbers: #666 !default;
@@ -2402,7 +2403,7 @@ label .muted {
   text-align: center;
   padding: 0.5em 1em;
   margin-bottom: 1em;
-  background: #eee;
+  background: $pagination_background;
   position: relative;
 
   .prev {

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2401,20 +2401,25 @@ label .muted {
 
 .pagination {
   text-align: center;
-  padding: 0.5em 1em;
-  margin-bottom: 1em;
+  padding: 1em;
   background: $pagination_background;
   position: relative;
 
   .prev {
     position: absolute;
-    #{$left}: 0.5em;
+    #{$left}: 1em;
   }
 
   .next {
     position: absolute;
-    #{$right}: 0.5em;
+    #{$right}: 1em;
   }
+}
+
+.map-alternatives {
+  margin: 16px 0;
+  font-size: 14px;
+  color: #666;
 }
 
 // this is a bit of a hack to get some differentation between desk and mobile
@@ -2861,7 +2866,7 @@ a#geolocate_link {
   .olMapViewport,
   .big-green-banner,
   .click-the-map,
-  #skip-this-step,
+  .map-alternatives,
   .my-account-buttons {
     display: none !important;
   }

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -355,24 +355,6 @@ body.mappage.admin {
   text-align: center;
 }
 
-#skip-this-step {
-  display: block;
-  color: #666;
-  padding: 1em;
-  line-height: 20px;
-  margin: 0 -1em;
-
-  em {
-    font-style: normal;
-    text-decoration: underline;
-    color: #0BA7D1;
-  }
-
-  &:hover {
-    text-decoration: none;
-  }
-}
-
 // Only want to capture footers that are inside .content
 // (like the one in base)
 .content {

--- a/web/cobrands/sass/_report_list.scss
+++ b/web/cobrands/sass/_report_list.scss
@@ -1,5 +1,7 @@
 .report-list-filters-wrapper, #bulk-assign-form {
   color: #666;
+  border-top: 1px solid #e5e5e5;
+  border-bottom: 1px solid #e5e5e5;
 
   .mobile-filters-active & {
     position: fixed;
@@ -9,18 +11,18 @@
     right: 0;
     background: #000;
     color: #fff;
+    border: none;
   }
 }
 
 .report-list-filters, #bulk-assign-form {
-  padding: 1em;
-  padding-bottom: 0.75em; // compensate for 0.25em border-top on .item-list__item
+  padding: 16px;
   margin-bottom: 0;
-  font-size: 0.85em;
+  font-size: 14px;
   line-height: 1.8em;
 
   & + & {
-    padding-top: 0.25em;
+    padding-top: 0;
   }
 
   label {


### PR DESCRIPTION
- [x] Lighten pagination element background colour (for mysociety/societyworks#2844)
- [x] Sort out "click map" styling (lots of cobrands hacking this their own way, should really be using `.fake-link`, if at all, maybe wording should also change to "use", instead of "see", across the board?)
- [x] Changelog entry
