### PR TITLE
[Peterborough] Replace '==' with 'eq' for memcached property check

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -539,7 +539,7 @@ sub bin_days : Chained('property') : PathPart('') : Args(0) {
         my $list = Memcached::get($key) || [];
 
         my $id = $c->stash->{property}->{id};
-        return if any { $_ == $id } @$list; # Already visited today
+        return if any { $_ eq $id } @$list; # Already visited today
 
         $c->detach('bin_day_deny') if @$list >= $cfg->{max_properties_per_day};
 


### PR DESCRIPTION
Purely numerical check was not working for Peterborough as its
property IDs are of the form 'postcode:id_no'. So a string
equality check must be used instead.

Fixes https://mysocietysupport.freshdesk.com/a/tickets/1821.

[skip changelog]
