### PR TITLE
[Peterborough] Some bin fixes

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -5,6 +5,7 @@ use utf8;
 use strict;
 use warnings;
 use Integrations::Bartec;
+use List::Util qw(any);
 use Sort::Key::Natural qw(natkeysort_inplace);
 use FixMyStreet::WorkingDays;
 use Utils;
@@ -734,7 +735,9 @@ sub bin_services_for_address {
         report_only => !$open_requests->{252}, # Can report if no open report
     }) if @food_containers;
 
-    unless ( $bags_only || $open_requests->{425} ) {
+    # All bins, black bin, green bin, large black bin, small food caddy, large food caddy, both food bins
+    my $any_open_bin_request = any { $open_requests->{$_} } (425, 419, 420, 422, 423, 424, 493);
+    unless ( $bags_only || $any_open_bin_request ) {
         # We want this one to always appear first
         unshift @out, {
             id => "_ALL_BINS",

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -687,6 +687,8 @@ sub bin_services_for_address {
                 my $is_staff = $self->{c}->user_exists && $self->{c}->user->from_body && $self->{c}->user->from_body->name eq "Peterborough City Council";
                 $row->{report_allowed} = $is_staff ? 1 : 0;
                 $row->{report_locked_out} = [ "ON DAY PRE 5PM" ];
+                # Set a global flag to show things in the sidebar
+                $self->{c}->stash->{on_day_pre_5pm} = 1;
             }
             # But if it has been marked as locked out, show that
             if (my $types = $premise_dates_to_lock_out{$last->ymd}{$container_id}) {

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -118,6 +118,7 @@ FixMyStreet::override_config {
         set_fixed_time('2021-08-05T14:00:00Z');
         $mech->get_ok('/waste/PE1%203NA:100090215480');
         $mech->content_contains('to report a missed recycling bin please call');
+        $mech->content_lacks('Report a missed collection');
 
         $mech->log_in_ok($staff->email);
         $mech->get_ok('/waste/PE1%203NA:100090215480');

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -220,12 +220,14 @@ FixMyStreet::override_config {
         ] });
         $mech->get_ok('/waste/PE1 3NA:100090215480/request');
         $mech->content_lacks('Large food caddy');
+        $mech->content_lacks('All bins');
         $b->mock('ServiceRequests_Get', sub { [
             { ServiceType => { ID => 493 }, ServiceStatus => { Status => "OPEN" } },
         ] });
         $mech->get_ok('/waste/PE1 3NA:100090215480/request');
         $mech->content_lacks('Large food caddy');
         $mech->content_lacks('Small food caddy');
+        $mech->content_lacks('All bins');
         $b->mock('ServiceRequests_Get', sub { [
             { ServiceType => { ID => 425 }, ServiceStatus => { Status => "OPEN" } },
         ] });

--- a/templates/web/peterborough/waste/_more_services_sidebar.html
+++ b/templates/web/peterborough/waste/_more_services_sidebar.html
@@ -1,6 +1,6 @@
 <h3>More services</h3>
 <ul>
-  [% IF any_report_allowed %]
+  [% IF any_report_allowed AND NOT on_day_pre_5pm %]
     <li><a href="[% c.uri_for_action('waste/report', [ property.id ]) %]">Report a missed collection</a></li>
   [% END %]
   [% IF any_request_allowed %]
@@ -21,7 +21,7 @@
           </form>
     </li>
   [% END %]
-  [% IF any_report_allowed %]
+  [% IF any_report_allowed AND NOT on_day_pre_5pm %]
     <li>
         <form method="post" action="[% c.uri_for_action('waste/report', [ property.id ]) %]">
             <input type="hidden" name="token" value="[% csrf_token %]">

--- a/templates/web/peterborough/waste/_more_services_sidebar.html
+++ b/templates/web/peterborough/waste/_more_services_sidebar.html
@@ -3,7 +3,7 @@
   [% IF any_report_allowed AND NOT on_day_pre_5pm %]
     <li><a href="[% c.uri_for_action('waste/report', [ property.id ]) %]">Report a missed collection</a></li>
   [% END %]
-  [% IF any_request_allowed %]
+  [% IF ( NOT waste_features.request_disabled ) AND c.user_exists AND (c.user.is_superuser OR (c.user.from_body AND c.user.from_body.name == "Peterborough City Council")) %]
     <li><a href="[% c.uri_for_action('waste/request', [ property.id ]) %]?skip_bags=1">Request a new bin</a></li>
   [% END %]
   [% IF show_garden_subscribe %]


### PR DESCRIPTION
No all bins option if a bin request; hide sidebar report links pre 5pm; alwas show (to staff at the mo) request bin link.

[skip changelog]
Fixes rest of https://mysocietysupport.freshdesk.com/a/tickets/1827
Fixes https://mysocietysupport.freshdesk.com/a/tickets/1812
Fixes https://mysocietysupport.freshdesk.com/a/tickets/1818

Hopefully last of the dupe issues.