### PR TITLE
Fix dashboard rows for categories with &s.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - Bugfixes:
         - Add ID attributes to change password form inputs.
         - Fix link deactivation for privacy policy link on privacy policy page. #3704
+        - Fix dashboard rows for categories with &s.
     - Accessibility improvements:
         - The "skip map" link on /around now has new wording,
           and is no longer visible only on focus. #3788 #3794

--- a/t/app/controller/dashboard.t
+++ b/t/app/controller/dashboard.t
@@ -30,7 +30,7 @@ my $mech = FixMyStreet::TestMech->new;
 
 my $other_body = $mech->create_body_ok(1234, 'Some Other Council');
 my $body = $mech->create_body_ok(2651, 'City of Edinburgh Council');
-my @cats = ('Litter', 'Other', 'Potholes', 'Traffic lights');
+my @cats = ('Litter', 'Other', 'Potholes', 'Traffic lights & bells');
 for my $contact ( @cats ) {
     my $c = $mech->create_contact_ok(body_id => $body->id, category => $contact, email => "$contact\@example.org");
     if ($contact eq 'Potholes') {
@@ -49,12 +49,12 @@ my $alt_area_id = '62883';
 
 my $last_month = DateTime->now->subtract(months => 2);
 $mech->create_problems_for_body(2, $body->id, 'Title', { areas => ",$area_id,2651,", category => 'Potholes', cobrand => 'no2fat' });
-$mech->create_problems_for_body(3, $body->id, 'Title', { areas => ",$area_id,2651,", category => 'Traffic lights', cobrand => 'no2fa', dt => $last_month });
+$mech->create_problems_for_body(3, $body->id, 'Title', { areas => ",$area_id,2651,", category => 'Traffic lights & bells', cobrand => 'no2fa', dt => $last_month });
 $mech->create_problems_for_body(1, $body->id, 'Title', { areas => ",$alt_area_id,2651,", category => 'Litter', cobrand => 'no2fa' });
 
-my @scheduled_problems = $mech->create_problems_for_body(7, $body->id, 'Title', { areas => ",$area_id,2651,", category => 'Traffic lights', cobrand => 'no2fa' });
+my @scheduled_problems = $mech->create_problems_for_body(7, $body->id, 'Title', { areas => ",$area_id,2651,", category => 'Traffic lights & bells', cobrand => 'no2fa' });
 my @fixed_problems = $mech->create_problems_for_body(4, $body->id, 'Title', { areas => ",$area_id,2651,", category => 'Potholes', cobrand => 'no2fa' });
-my @closed_problems = $mech->create_problems_for_body(3, $body->id, 'Title', { areas => ",$area_id,2651,", category => 'Traffic lights', cobrand => 'no2fa' });
+my @closed_problems = $mech->create_problems_for_body(3, $body->id, 'Title', { areas => ",$area_id,2651,", category => 'Traffic lights & bells', cobrand => 'no2fa' });
 
 my $first_problem_id;
 my $first_update_id;
@@ -148,7 +148,7 @@ FixMyStreet::override_config {
 
     subtest 'The correct categories and totals shown by default' => sub {
         $mech->get_ok("/dashboard");
-        my $expected_cats = [ 'All', 'Litter', 'Other', 'Traffic lights', 'Potholes' ];
+        my $expected_cats = [ 'All', 'Litter', 'Other', 'Traffic lights & bells', 'Potholes' ];
         my $res = $categories->scrape( $mech->content );
         $mech->content_contains('<optgroup label="Road">');
         is_deeply( $res->{cats}, $expected_cats, 'correct list of categories' );

--- a/templates/web/base/dashboard/index.html
+++ b/templates/web/base/dashboard/index.html
@@ -125,7 +125,7 @@
         <th scope="col">[% loc('Total') %]</th>
       [% END %]
     </tr>
-  [% FOR k IN rows %]
+  [% FOR k IN rows %][% k_safe = mark_safe(k) %]
     <tr>
       [% IF group_by == 'state' %]
         <th scope="row">[% prettify_state(k) %]</th>
@@ -133,15 +133,15 @@
         <th scope="row">[% k %]</th>
       [% END %]
       [% IF group_by == 'category+state' %]
-        <td>[% grouped.$k.open OR 0 %]</td>
-        <td>[% grouped.$k.closed OR 0 %]</td>
-        <td>[% grouped.$k.fixed OR 0 %]</td>
-        <td>[% grouped.$k.total OR 0 %]</td>
+        <td>[% grouped.$k_safe.open OR 0 %]</td>
+        <td>[% grouped.$k_safe.closed OR 0 %]</td>
+        <td>[% grouped.$k_safe.fixed OR 0 %]</td>
+        <td>[% grouped.$k_safe.total OR 0 %]</td>
       [% ELSE %]
         [% FOR k2 IN columns.sort %]
-          <td>[% grouped.$k.$k2 OR 0 %]</td>
+          <td>[% grouped.$k_safe.$k2 OR 0 %]</td>
         [% END %]
-        <td>[% grouped.$k.total OR 0 %]</td>
+        <td>[% grouped.$k_safe.total OR 0 %]</td>
       [% END %]
     </tr>
   [% END %]


### PR DESCRIPTION
A hash lookup in a template is escaping the key used, meaning the lookup is failing anywhere we are using a category containing an ampersand as a key. Fixes https://mysocietysupport.freshdesk.com/a/tickets/1840