### PR TITLE
[Lincs] Make asset_item_message for road assets an empty string

### DIFF
--- a/.cypress/cypress/integration/lincolnshire.js
+++ b/.cypress/cypress/integration/lincolnshire.js
@@ -1,0 +1,49 @@
+describe('Lincolnshire cobrand', function(){
+    describe('making a report as a new user', function() {
+        before(function(){
+            cy.server();
+            cy.route('/report/new/ajax*').as('report-ajax');
+
+            cy.visit('http://lincolnshire.localhost:3001/report/new?longitude=-0.502566&latitude=52.656144');
+            cy.contains('Lincolnshire County Council');
+
+            cy.wait('@report-ajax');
+        });
+
+        it('does not display extra message when selecting a "road" category', function(){
+            cy.pickCategory('Damaged/missing cats eye');
+            cy.get(
+                '#category_meta_message_Damagedmissingcatseye'
+            ).should('have.text', '');
+        });
+
+        it('clicks through to photo section', function(){
+            cy.nextPageReporting();
+            cy.contains('Drag photos here').should('be.visible');
+        });
+
+        it('clicks through to public details page', function(){
+            cy.nextPageReporting();
+            cy.contains('Public details').should('be.visible');
+        });
+
+        it('cannot click through to next page without details', function(){
+            cy.nextPageReporting();
+            cy.get('#form_title-error').should('be.visible');
+        });
+
+        it('submits public details form with sufficient details', function(){
+            cy.get('#form_title').type('Missing cat\'s eye');
+            cy.get('#form_detail').type('This cat must be a pirate');
+            cy.nextPageReporting();
+            cy.get('#form_name').should('be.visible');
+        });
+
+        it('submits personal details form with sufficient details', function(){
+            cy.get('#form_name').type('Kitty Wake');
+            cy.get('#form_username_register').type('a@b.com');
+            cy.get('#mapForm').submit();
+            cy.contains('Nearly done! Now check your email…').should('be.visible');
+        });
+    });
+});

--- a/bin/browser-tests
+++ b/bin/browser-tests
@@ -21,6 +21,7 @@ BEGIN {
         highwaysengland
         hounslow
         isleofwight
+        lincolnshire
         northamptonshire
         oxfordshire
         peterborough

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -43,6 +43,7 @@ FixMyStreet::DB::Factories->setup($opt);
 my $categories = [
     'Abandoned vehicles',
     'Bus stops',
+    'Damaged/missing cats eye',
     'Dog fouling',
     'Flyposting',
     'Flytipping',
@@ -120,6 +121,7 @@ if ($opt->test_fixtures) {
         { area_id => 2483, categories => [ 'Potholes', 'Other' ], name => 'Hounslow Borough Council' },
         { area_id => 2508, categories => [ 'Potholes', 'Other' ], name => 'Hackney Council' },
         { area_id => 2636, categories => [ 'Potholes', 'Private', 'Extra' ], name => 'Isle of Wight Council' },
+        { area_id => 2232, categories => ['Damaged/missing cats eye'], name => 'Lincolnshire County Council' },
         { area_id => 2566, categories => [ 'General fly tipping', 'Fallen branch', 'Light Out', 'Light Dim', 'Fallen Tree', 'Damaged Tree', 'Pothole' ], name => 'Peterborough City Council' },
         { area_id => 2498, categories => [ 'Incorrect timetable', 'Glass broken', 'Mobile Crane Operation', 'Roadworks' ], name => 'TfL' },
         { area_id => 2237, categories => [ 'Flytipping', 'Roads', 'Parks' ], name => 'Oxfordshire County Council' },

--- a/templates/web/base/report/new/top_message.html
+++ b/templates/web/base/report/new/top_message.html
@@ -3,7 +3,7 @@
     [% PROCESS 'report/new/unresponsive_body.html' body_id = unresponsive.ALL %]
 [%~ ELSIF bodies_to_list.size == 0 # On a /new page, no bodies ~%]
     <div class="box-warning">[% PROCESS 'report/new/top_message_none.html' %]</div>
-[%~ ELSIF bodies_to_list.size != bodies.size # On a /new page, some missing bodies ~%]
+[%~ ELSIF missing_details_bodies.size # On a /new page, some missing bodies ~%]
     <div class="box-warning">[% PROCESS 'report/new/top_message_some.html' %]</div>
 [%~ END ~%]
 [%~ END ~%]

--- a/web/cobrands/lincolnshire/assets.js
+++ b/web/cobrands/lincolnshire/assets.js
@@ -131,7 +131,7 @@ fixmystreet.assets.add(defaults, {
         "Road surface issue"
     ],
     asset_item: 'road',
-    asset_item_message: null,
+    asset_item_message: '',
     disable_pin_snapping: true,
     stylemap: fixmystreet.assets.stylemap_invisible
 });


### PR DESCRIPTION
Was previously 'null', which was throwing an error in
fixmystreet/assets.js->get_asset_pick_message().

Fixes https://github.com/mysociety/societyworks/issues/2855.

[skip changelog]