### PR TITLE
Switch geocoder files from http to https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
         - Add ID attributes to change password form inputs.
         - Fix link deactivation for privacy policy link on privacy policy page. #3704
         - Fix dashboard rows for categories with &s.
+        - Make calls from Geocoder files to https rather than http
     - Accessibility improvements:
         - The "skip map" link on /around now has new wording,
           and is no longer visible only on focus. #3788 #3794

--- a/perllib/FixMyStreet/Geocode/Bexley.pm
+++ b/perllib/FixMyStreet/Geocode/Bexley.pm
@@ -6,7 +6,7 @@ use strict;
 
 use URI::Escape;
 
-my $base = 'http://tilma.mysociety.org/mapserver/bexley?SERVICE=WFS&VERSION=1.1.0&REQUEST=GetFeature&TYPENAME=Streets&outputFormat=geojson&Filter=%3CFilter%3E%3CPropertyIsLike%20wildcard=%27*%27%20singleChar=%27.%27%20escape=%27!%27%3E%3CPropertyName%3EADDRESS%3C/PropertyName%3E%3CLiteral%3E{{str}}%3C/Literal%3E%3C/PropertyIsLike%3E%3C/Filter%3E';
+my $base = 'https://tilma.mysociety.org/mapserver/bexley?SERVICE=WFS&VERSION=1.1.0&REQUEST=GetFeature&TYPENAME=Streets&outputFormat=geojson&Filter=%3CFilter%3E%3CPropertyIsLike%20wildcard=%27*%27%20singleChar=%27.%27%20escape=%27!%27%3E%3CPropertyName%3EADDRESS%3C/PropertyName%3E%3CLiteral%3E{{str}}%3C/Literal%3E%3C/PropertyIsLike%3E%3C/Filter%3E';
 
 # Data is ALL CAPS
 sub recase {

--- a/perllib/FixMyStreet/Geocode/Bing.pm
+++ b/perllib/FixMyStreet/Geocode/Bing.pm
@@ -33,7 +33,7 @@ sub string {
     $s = FixMyStreet::Geocode::escape($s);
     $s .= '+' . $params->{town} if $params->{town} and $s !~ /$params->{town}/i;
 
-    my $url = "http://dev.virtualearth.net/REST/v1/Locations?q=$s";
+    my $url = "https://dev.virtualearth.net/REST/v1/Locations?q=$s";
     $url .= '&userMapView=' . join(',', @{$params->{bounds}})
         if $params->{bounds};
     $url .= '&userLocation=' . $params->{centre} if $params->{centre};
@@ -105,7 +105,7 @@ sub reverse {
     # Get nearest road-type thing from Bing
     my $key = FixMyStreet->config('BING_MAPS_API_KEY', '');
     if ($key) {
-        my $url = "http://dev.virtualearth.net/REST/v1/Locations/$latitude,$longitude?key=$key";
+        my $url = "https://dev.virtualearth.net/REST/v1/Locations/$latitude,$longitude?key=$key";
         $url .= '&c=' . $bing_culture if $bing_culture;
         my $j = FixMyStreet::Geocode::cache('bing', $url);
         return $j if $j;


### PR DESCRIPTION
Makes Geocoder links be https rather than http - http causing an issue after an upgrade to server and http only to be problematic going forwards.

 Ticket: **Calls from Geocoder files should be https to prevent unexpected failues** mysociety/societyworks#2898 


