### PR TITLE
Added active state to navigation bar

### DIFF
--- a/web/cobrands/borsetshire/layout.scss
+++ b/web/cobrands/borsetshire/layout.scss
@@ -27,6 +27,10 @@
         color: $nav_colour;
     }
 
+    span, span:hover, span.report-a-problem-btn:hover {
+        color: $color-societyworks-pink;
+    }
+
     a {
         &:hover,
         &:focus {
@@ -45,11 +49,6 @@
         &:hover, &:focus {
             background-color: transparent;
         }
-    }
-
-    span.report-a-problem-btn,
-    span.report-a-problem-btn:hover {
-        color: $nav_colour;
     }
 }
 


### PR DESCRIPTION
The current navigation bar is a bit confusing, it doesn't show easily whereabout on the site the user currently is. This fix adds an active state to the current page.

<img width="1905" alt="Screenshot 2022-03-01 at 09 02 53" src="https://user-images.githubusercontent.com/13790153/156138275-eb454e72-4dda-42f4-8733-6d3d81067581.png">

