### PR TITLE
[Buckinghamshire] Added fix to wider selection panel

### DIFF
--- a/web/cobrands/buckinghamshire/layout.scss
+++ b/web/cobrands/buckinghamshire/layout.scss
@@ -165,3 +165,14 @@ body, .content {
   font-size: 1em;
   padding: 20px;
 }
+
+// Adjust the size dropdown button and menu for mappage
+.mappage {
+  .multi-select-button {
+    max-width: 80px;
+  }
+  
+  .multi-select-menu {
+    left: -55px;
+  }
+}


### PR DESCRIPTION
This fix was included on layout.scss because it should only affect wider screen. 
Checked current state on mobile I didn't consider it needed any intervention.

This fix also prevents the changes in the position of the menu when selecting more than one option.

Tested on Edge, IE11, Firefox, Chrome, Opera, Safari.

Fixes: mysociety/societyworks#2905
<img width="516" alt="Screenshot 2022-03-02 at 10 43 58" src="https://user-images.githubusercontent.com/13790153/156346773-2738b84d-f08b-42a9-b653-68c77c4806f5.png">

