### PR TITLE
[Oxfordshire] Remove chevrons from links in updates

### DIFF
--- a/perllib/FixMyStreet/Template.pm
+++ b/perllib/FixMyStreet/Template.pm
@@ -159,8 +159,11 @@ sub html_paragraph_email_factory : FilterFactory('html_para_email') {
 sub sanitize {
     my $text = shift;
 
+    # In case of markdown variant style of <https://www.google.com>
+    $text =~ s/<\s*(https?[^\s>]+)\s*>/$1/g;
+
     $text = $$text if UNIVERSAL::isa($text, 'FixMyStreet::Template::SafeString');
- 
+
     my %allowed_tags = map { $_ => 1 } qw( p ul ol li br b i strong em );
     my $scrubber = HTML::Scrubber->new(
         rules => [

--- a/t/app/controller/alert_new.t
+++ b/t/app/controller/alert_new.t
@@ -936,7 +936,7 @@ subtest 'check staff updates can include sanitized HTML' => sub {
         user => $user1,
     });
 
-    my $update1 = $mech->create_comment_for_problem($report, $user2, 'Staff User', '<p>This is some update text with <strong>HTML</strong> and *italics*.</p> <ul><li>Even a list</li><li>Which might work</li><li>In the <a href="https://www.fixmystreet.com/">text</a> part</li></ul> <script>not allowed</script>', 't', 'confirmed', undef, { confirmed  => $r_dt->clone->add( minutes => 8 ) });
+    my $update1 = $mech->create_comment_for_problem($report, $user2, 'Staff User', '<p>This is some update text with <strong>HTML</strong> and *italics* and <https://www.google.com> remains. </p> <ul><li>Even a list</li><li>Which might work</li><li>In the <a href="https://www.fixmystreet.com/">text</a> part</li></ul> <script>not allowed</script>', 't', 'confirmed', undef, { confirmed  => $r_dt->clone->add( minutes => 8 ) });
     $update1->set_extra_metadata(is_body_user => $user2->from_body->id);
     $update1->set_extra_metadata(something_unicodey => "The cafɇ is here");
     $update1->update;
@@ -956,11 +956,11 @@ subtest 'check staff updates can include sanitized HTML' => sub {
     my $email = $mech->get_email;
     $mech->clear_emails_ok;
     my $plain = $mech->get_text_body_from_email($email);
-    like $plain, qr/This is some update text with \*HTML\* and \*italics\*\.\r\n\r\n\* Even a list\r\n\r\n\* Which might work\r\n\r\n\* In the text \[https:\/\/www.fixmystreet.com\/\] part/, 'plain text part contains no HTML tags from staff update';
+    like $plain, qr/This is some update text with \*HTML\* and \*italics\* and https:\/\/www\.google\.com remains\.\r\n\r\n\* Even a list\r\n\r\n\* Which might work\r\n\r\n\* In the text \[https:\/\/www.fixmystreet.com\/\] part/, 'plain text part contains no HTML tags from staff update';
     like $plain, qr/Public users <i>cannot<\/i> use HTML\./, 'plain text part contains exactly what was entered';
 
     my $html = $mech->get_html_body_from_email($email);
-    like $html, qr{This is some update text with <strong>HTML</strong> and <i>italics</i>\.}, 'HTML part contains HTML tags';
+    like $html, qr{This is some update text with <strong>HTML</strong> and <i>italics</i> and <a href="https://www.google.com">https://www.google.com</a> remains\.}, 'HTML part contains HTML tags';
     unlike $html, qr/<script>/, 'HTML part contains no script tags';
 
     $mech->delete_user( $user1 );


### PR DESCRIPTION
Some officers are using chevrons around links so removing chevrons from around fully qualified urls before sanitization, otherwise they are purged from the displayed update.

https://github.com/mysociety/societyworks/issues/2716

[skip changelog]