### PR TITLE
[Buckinghamshire] Treat parish problems as belonging to the Bucks cobrand

### DIFF
--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -63,7 +63,13 @@ sub cut_off_date { '' }
 sub problems_restriction {
     my ($self, $rs) = @_;
     return $rs if FixMyStreet->staging_flag('skip_checks');
-    $rs = $rs->to_body($self->body);
+
+    my $bodies = $self->body;
+    if ($self->can('problems_restriction_bodies')) {
+        $bodies = $self->problems_restriction_bodies;
+    }
+    $rs = $rs->to_body($bodies);
+
     if (my $date = $self->cut_off_date) {
         my $table = ref $rs eq 'FixMyStreet::DB::ResultSet::Nearby' ? 'problem' : 'me';
         $rs = $rs->search({
@@ -230,6 +236,12 @@ sub recent_photos {
     return $self->problems->recent_photos( $num, $lat, $lon, $dist );
 }
 
+sub area_ids_for_problems {
+    my ($self) = @_;
+
+    return $self->council_area_id;
+}
+
 # Returns true if the cobrand owns the problem.
 sub owns_problem {
     my ($self, $report) = @_;
@@ -243,7 +255,10 @@ sub owns_problem {
     }
     # Want to ignore the TfL body that covers London councils, and HE that is all England
     my %areas = map { %{$_->areas} } grep { $_->name !~ /TfL|National Highways/ } @bodies;
-    return $areas{$self->council_area_id} ? 1 : undef;
+
+    foreach my $area_id ($self->area_ids_for_problems) {
+        return 1 if $areas{$area_id};
+    }
 }
 
 # If the council is two-tier, or e.g. TfL reports,

--- a/t/app/controller/contact.t
+++ b/t/app/controller/contact.t
@@ -535,7 +535,9 @@ for my $test (
         FixMyStreet::override_config {
             ALLOWED_COBRANDS => [ 'buckinghamshire' ],
         }, sub {
-            $mech->get_ok( '/contact?id=' . $problem_main->id, 'can visit for abuse report' );
+            my $bucks = $mech->create_body_ok(2217, 'Buckinghamshire Council');
+            my ($problem) = $mech->create_problems_for_body(1, $bucks->id, 'Test');
+            $mech->get_ok( '/contact?id=' . $problem->id, 'can visit for abuse report' );
             $mech->submit_form_ok( { with_fields => $test->{fields} } );
             is_deeply $mech->page_errors, $test->{page_errors}, 'page errors';
 

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -62,6 +62,7 @@ $contact->set_extra_fields({
     ],
 });
 $contact->update;
+$contact = $mech->create_contact_ok(body_id => $parish->id, category => 'Dirty signs', email => 'signs@example.org', send_method => 'Email');
 
 my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Buckinghamshire');
 $cobrand->mock('lookup_site_code', sub {
@@ -416,7 +417,7 @@ subtest 'sends grass cutting reports on roads under 30mph to the parish' => sub 
             speed_limit_greater_than_30 => 'no', # Is the speed limit greater than 30mph?
         }
     }, "submit details");
-    $mech->content_contains('Thank you for your report');
+    $mech->content_contains('Your issue is on its way to the council');
     my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
     ok $report, "Found the report";
     is $report->title, 'Test grass cutting report 1', 'Got the correct report';
@@ -438,6 +439,26 @@ subtest 'sends grass cutting reports on roads 30mph or more to the council' => s
     ok $report, "Found the report";
     is $report->title, 'Test grass cutting report 2', 'Got the correct report';
     is $report->bodies_str, $body->id, 'Report was sent to council';
+};
+
+subtest 'treats problems sent to parishes as owned by Bucks' => sub {
+    $mech->get_ok('/report/new?latitude=51.615559&longitude=-0.556903');
+    $mech->submit_form_ok({
+        with_fields => {
+            title => "Test Dirty signs report",
+            detail => 'Test report details.',
+            category => 'Dirty signs',
+        }
+    }, "submit details");
+    $mech->content_contains('Your issue is on its way to the council');
+
+    my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+    ok $report, "Found the report";
+    is $report->title, 'Test Dirty signs report', 'Got the correct report';
+
+    # Check that the report can be accessed via the cobrand
+    my $report_id = $report->id;
+    $mech->get_ok("/report/$report_id");
 };
 
 };


### PR DESCRIPTION
Because parishes are setup as separate bodies the default behaviour is to direct people to fixmystreet.com to follow the progress of their report.

Instead we want parish problems to be displayed on the cobrand and treated as cobrand problems. This is achieved by adding some new methods to UKCouncils.pm to make it easier to overrride the bodies/areas that are relevant to a particular cobrand, which will hopefully be useful if/when we add parishes elsewhere in the future.

Part of https://github.com/mysociety/societyworks/issues/2809

[skip changelog]