### PR TITLE
[Bexley] Add warning about personal information to new report/update forms

### DIFF
--- a/t/cobrand/bexley.t
+++ b/t/cobrand/bexley.t
@@ -261,6 +261,12 @@ FixMyStreet::override_config {
         $mech->get_ok('/report/' . $report->id);
         $mech->content_contains('Report ref:&nbsp;' . $report->id);
     };
+
+    subtest 'phishing warning is shown for new reports' => sub {
+        $mech->log_out_ok;
+        $mech->get_ok('/report/new?longitude=0.15356&latitude=51.45556&category=Lamp+post');
+        $mech->content_contains('if asked for personal information, please do not respond');
+    };
 };
 
 subtest 'nearest road returns correct road' => sub {

--- a/t/cobrand/bexley.t
+++ b/t/cobrand/bexley.t
@@ -267,6 +267,11 @@ FixMyStreet::override_config {
         $mech->get_ok('/report/new?longitude=0.15356&latitude=51.45556&category=Lamp+post');
         $mech->content_contains('if asked for personal information, please do not respond');
     };
+
+    subtest 'phishing warning is shown on report pages' => sub {
+        $mech->get_ok('/report/' . $report->id);
+        $mech->content_contains('if asked for personal information, please do not respond');
+    };
 };
 
 subtest 'nearest road returns correct road' => sub {

--- a/templates/web/bexley/report/new/councils_extra_text.html
+++ b/templates/web/bexley/report/new/councils_extra_text.html
@@ -1,0 +1,7 @@
+</p>
+
+<p>
+The London Borough of Bexley and its Contractors will <b>never</b>
+ask for your personal information through the FixMyStreet messaging system.
+Therefore, if asked for personal information, please do not respond.
+Instead, inform the Council immediately by calling 020 8030 7777 to investigate.

--- a/templates/web/bexley/report/updates-sidebar-notes.html
+++ b/templates/web/bexley/report/updates-sidebar-notes.html
@@ -1,0 +1,14 @@
+<p>
+  [% IF NOT problem.updates_sent_to_body %]
+    [% loc( 'Please note that updates are not sent to the council.' ) %]
+  [% END %]
+    [% tprintf( loc( 'Your information will only be used in accordance with our <a href="%s">privacy policy</a>' ), c.cobrand.privacy_policy_url ) %]
+</p>
+
+<p>
+  The London Borough of Bexley and its Contractors will <strong>never</strong>
+  ask for your personal information through the FixMyStreet messaging system.
+  Therefore, if asked for personal information, please do not respond.
+  Instead, inform the Council immediately by calling 020 8030 7777 to investigate.
+</p>
+


### PR DESCRIPTION
Adds anti-phishing warning to top of report form, as well as above the update form.

[skip changelog]

For FD-1036.
Fixes https://github.com/mysociety/societyworks/issues/2776.