### PR TITLE
Issues/public/3168 reports multiple send methods

### DIFF
--- a/bin/update-schema
+++ b/bin/update-schema
@@ -215,6 +215,7 @@ else {
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
     return 'EMPTY' if ! table_exists('problem');
+    return '0078' if column_exists('problem','send_fail_body_ids');
     return '0077' if column_exists('comment', 'send_state');
     return '0076' if index_exists('problem_external_id_idx');
     return '0075' if column_exists('alert', 'parameter3');

--- a/db/downgrade_0078---0077.sql
+++ b/db/downgrade_0078---0077.sql
@@ -1,0 +1,1 @@
+ALTER TABLE problem DROP COLUMN send_fail_bodies;

--- a/db/downgrade_0078---0077.sql
+++ b/db/downgrade_0078---0077.sql
@@ -1,1 +1,1 @@
-ALTER TABLE problem DROP COLUMN send_fail_bodies;
+ALTER TABLE problem DROP COLUMN send_fail_body_ids;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -113,7 +113,7 @@ create table contacts (
     -- last editor
     editor text not null,
     -- time of last change
-    whenedited timestamp not null, 
+    whenedited timestamp not null,
     -- what the last change was for: author's notes
     note text not null,
 
@@ -151,13 +151,13 @@ create table contacts_history (
     -- editor
     editor text not null,
     -- time of entry
-    whenedited timestamp not null, 
+    whenedited timestamp not null,
     -- what the change was for: author's notes
     note text not null
 );
 
 -- Create a trigger to update the contacts history on any update
--- to the contacts table. 
+-- to the contacts table.
 create function contacts_updated()
     returns trigger as '
     begin
@@ -201,7 +201,7 @@ create table problem (
     used_map boolean not null,
 
     -- User's details
-    user_id int references users(id) not null,    
+    user_id int references users(id) not null,
     name text not null,
     anonymous boolean not null,
 
@@ -227,10 +227,11 @@ create table problem (
     response_priority_id int REFERENCES response_priorities(id),
 
     -- logging sending failures (used by webservices)
-    send_fail_count integer not null default 0, 
-    send_fail_reason text, 
+    send_fail_count integer not null default 0,
+    send_fail_reason text,
     send_fail_timestamp timestamp,
-    
+    send_fail_body_ids int array not null default '{}',
+
     -- record send_method used, which can be used to infer usefulness of external_id
     send_method_used text,
 
@@ -467,7 +468,7 @@ create table textmystreet (
 -- Record basic information about edits made through the admin interface
 
 create table admin_log (
-    id serial not null primary key, 
+    id serial not null primary key,
     admin_user text not null,
     object_type text not null check (
       object_type = 'problem'
@@ -486,7 +487,7 @@ create table admin_log (
     user_id int references users(id) null,
     reason text not null default '',
     time_spent int not null default 0
-); 
+);
 
 create table moderation_original_data (
     id serial not null primary key,

--- a/db/schema_0078-problem-add-send_fail_body_ids.sql
+++ b/db/schema_0078-problem-add-send_fail_body_ids.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE problem
+    ADD COLUMN send_fail_body_ids INT ARRAY NOT NULL DEFAULT '{}';
+
+COMMIT;

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -72,7 +72,10 @@ sub index : Path : Args(0) {
 
     my @unsent = $c->cobrand->problems->search( {
         'me.state' => [ FixMyStreet::DB::Result::Problem::open_states() ],
-        whensent => undef,
+        -or => {
+            whensent => undef,
+            send_fail_body_ids => { '!=', '{}' },
+        },
         bodies_str => { '!=', undef },
         # Ignore very recent ones that probably just haven't been sent yet
         confirmed => { '<', \"current_timestamp - '5 minutes'::interval" },

--- a/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
@@ -285,7 +285,8 @@ sub edit : Path('/admin/report_edit') : Args(1) {
     }
     elsif ( $c->get_param('mark_sent') ) {
         $c->forward('/auth/check_csrf_token');
-        $problem->update({ whensent => \'current_timestamp' })->discard_changes;
+        $problem->mark_as_sent;
+        $problem->update->discard_changes;
         $c->stash->{status_message} = _('That problem has been marked as sent.');
         $c->forward( '/admin/log_edit', [ $id, 'problem', 'marked sent' ] );
     }

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -407,7 +407,7 @@ sub link_to_council_cobrand {
         my $url = sprintf("%s%s", $handler->base_url, $problem->url);
         return sprintf("<a href='%s'>%s</a>", $url, $problem->body);
     } else {
-        return $problem->body;
+        return $problem->body( 0, 1 );
     }
 }
 

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -407,7 +407,7 @@ sub link_to_council_cobrand {
         my $url = sprintf("%s%s", $handler->base_url, $problem->url);
         return sprintf("<a href='%s'>%s</a>", $url, $problem->body);
     } else {
-        return $problem->body( 0, 1 );
+        return $problem->body(0);
     }
 }
 

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -744,7 +744,7 @@ sub nearest_address {
 }
 
 sub body {
-    my ( $problem, $link ) = @_;
+    my ( $problem, $link, $successful_send_only ) = @_;
     my $body;
     if ($problem->external_body) {
         if ($problem->cobrand eq 'zurich') {
@@ -754,7 +754,14 @@ sub body {
             $body = FixMyStreet::Template::html_filter($problem->external_body);
         }
     } else {
-        my $bodies = $problem->bodies;
+        my %bodies = %{$problem->bodies};
+
+        # If we only want bodies with successful send methods (in the case of
+        # a problem that has multiple send methods), remove failed
+        if ($successful_send_only) {
+            delete $bodies{$_} for @{ $problem->send_fail_body_ids // [] };
+        }
+
         my @body_names = sort map {
             my $name = $_->name;
             if ($link and FixMyStreet->config('AREA_LINKS_FROM_PROBLEMS')) {
@@ -762,7 +769,7 @@ sub body {
             } else {
                 FixMyStreet::Template::html_filter($name);
             }
-        } values %$bodies;
+        } values %bodies;
         if ( scalar @body_names > 2 ) {
             $body = join( ', ', splice @body_names, 0, -1);
             $body = join( ',' . _(' and '), ($body, $body_names[-1]));
@@ -868,7 +875,8 @@ sub can_display_external_id {
 sub duration_string {
     my $problem = shift;
     my $cobrand = $problem->result_source->schema->cobrand;
-    my $body = $cobrand->call_hook(link_to_council_cobrand => $problem) || $problem->body(1);
+    my $body = $cobrand->call_hook( link_to_council_cobrand => $problem )
+        || $problem->body( 1, 1 );
     my $handler = $cobrand->call_hook(get_body_handler_for_problem => $problem);
     if ( $handler && $handler->call_hook('is_council_with_case_management') ) {
         my $s = sprintf(_('Received by %s moments later'), $body);
@@ -971,6 +979,28 @@ sub has_given_send_fail_body_id {
     my $id   = shift;
 
     return any { $_ == $id } @{ $self->send_fail_body_ids };
+}
+
+sub send_fail_methods {
+    # Deduce from send_fail_body_ids
+    my $self = shift;
+
+    my $bodies = $self->bodies;
+
+    my @send_fail_methods;
+
+    for (@{$self->send_fail_body_ids}) {
+        my $body = $bodies->{$_};
+        push @send_fail_methods, $body->send_method;
+    }
+
+    return \@send_fail_methods;
+}
+
+sub mark_as_sent {
+    my $self = shift;
+    $self->whensent( \'current_timestamp' );
+    $self->send_fail_body_ids( [] );
 }
 
 sub resend {

--- a/t/app/model/problem.t
+++ b/t/app/model/problem.t
@@ -588,6 +588,7 @@ subtest 'check can set multiple emails as a single contact' => sub {
         name => 'Test User',
         cobrand => 'fixmystreet',
         send_fail_count => 0,
+        send_fail_body_ids => [],
     } );
 
     FixMyStreet::override_config $override, sub {

--- a/t/sendreport/multiple-send-methods.t
+++ b/t/sendreport/multiple-send-methods.t
@@ -1,0 +1,240 @@
+use FixMyStreet::TestMech;
+use FixMyStreet::Script::Reports;
+use Test::Deep;
+use Test::MockModule;
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $user = $mech->create_user_ok('user@example.com');
+
+my $body_oxf = $mech->create_body_ok( 2237, 'Oxfordshire County Council' );
+my $body_cherwell
+    = $mech->create_body_ok( 2419, 'Cherwell District Council' );
+
+my $contact_oxf = $mech->create_contact_ok(
+    body_id  => $body_oxf->id,
+    category => 'Other',
+    email    => 'other@oxfordshire.com',
+);
+my $contact_cherwell = $mech->create_contact_ok(
+    body_id  => $body_cherwell->id,
+    category => 'Other',
+    email    => 'other@cherwell.com',
+);
+
+my ($report) = $mech->create_problems_for_body(
+    1,
+    ( join ',', $body_oxf->id, $body_cherwell->id ),
+    'Test',
+    {   cobrand  => 'fixmystreet',
+        category => 'Other',
+        user     => $user,
+    }
+);
+
+$body_oxf->update(
+    {   send_method  => 'Open311',
+        endpoint     => 'http://endpoint.example.com',
+        jurisdiction => 'FMS',
+        api_key      => 'test',
+    },
+);
+
+my $mock_email   = Test::MockModule->new('FixMyStreet::SendReport::Email');
+my $mock_open311 = Test::MockModule->new('FixMyStreet::SendReport::Open311');
+
+subtest '1st attempt - email and Open311 both fail' => sub {
+    $mock_email->mock(
+        'send',
+        sub {
+            shift->error('Email fail');
+            return -1;
+        }
+    );
+    $mock_open311->mock(
+        'send',
+        sub {
+            shift->error('Open311 fail');
+            return -1;
+        }
+    );
+    test_send();
+    $report->discard_changes;
+
+    is $report->whensent,         undef, 'whensent not recorded';
+    is $report->send_method_used, undef, 'send_method_used not recorded';
+    is $report->external_id,      undef, 'Report has no external ID';
+
+    ok $report->send_fail_timestamp, 'send_fail_timestamp recorded';
+    is $report->send_fail_count, 1, 'send_fail_count recorded';
+    like $report->send_fail_reason, qr/Email fail/;
+    like $report->send_fail_reason, qr/Open311 fail/,
+        'send_fail_reason recorded';
+    cmp_bag $report->send_fail_body_ids,
+        [ $body_oxf->id, $body_cherwell->id ],
+        'Failed body ID saved for each body';
+};
+
+subtest '2nd attempt - email and Open311 both fail again' => sub {
+    $mock_email->mock(
+        'send',
+        sub {
+            shift->error('Email fail');
+            return -1;
+        }
+    );
+    $mock_open311->mock(
+        'send',
+        sub {
+            shift->error('Open311 fail');
+            return -1;
+        }
+    );
+    test_send();
+    $report->discard_changes;
+
+    is $report->whensent,         undef, 'whensent not recorded';
+    is $report->send_method_used, undef, 'send_method_used not recorded';
+    is $report->external_id,      undef, 'Report has no external ID';
+
+    is $report->send_fail_count, 2, 'send_fail_count updated';
+    like $report->send_fail_reason, qr/Email fail/;
+    like $report->send_fail_reason, qr/Open311 fail/,
+        'send_fail_reason stays the same';
+    cmp_bag $report->send_fail_body_ids,
+        [ $body_oxf->id, $body_cherwell->id ],
+        'send_fail_body_ids remain the same';
+};
+
+subtest '3rd attempt - email succeeds, Open311 fails' => sub {
+    $mock_email->unmock('send');
+    $mock_open311->mock(
+        'send',
+        sub {
+            shift->error('Open311 fail');
+            return -1;
+        }
+    );
+    test_send();
+    $report->discard_changes;
+
+    ok $report->whensent, 'whensent recorded';
+    is $report->send_method_used, 'Email', 'send_method_used recorded';
+    is $report->external_id,      undef,   'Report has no external ID';
+
+    is $report->send_fail_count, 3, 'send_fail_count incremented';
+    like $report->send_fail_reason, qr/Open311 fail/;
+    unlike $report->send_fail_reason, qr/Email fail/,
+        'email removed from send_fail_reason';
+    cmp_bag $report->send_fail_body_ids,
+        [ $body_oxf->id ],
+        'Failed body ID removed for Cherwell (email)';
+};
+
+subtest '4th attempt - Open311 fails, email set to fail again' => sub {
+    # Since email was successful before, it should not be attempted again
+    $mock_email->mock(
+        'send',
+        sub {
+            shift->error('Email fail');
+            return -1;
+        }
+    );
+    $mock_open311->mock(
+        'send',
+        sub {
+            shift->error('Open311 fail');
+            return -1;
+        }
+    );
+    test_send();
+    $report->discard_changes;
+
+    is $report->send_method_used, 'Email', 'send_method_used unchanged';
+    is $report->external_id,      undef,   'Report has no external ID';
+
+    is $report->send_fail_count, 4, 'send_fail_count incremented';
+    like $report->send_fail_reason, qr/Open311 fail/;
+    unlike $report->send_fail_reason, qr/Email fail/,
+        'email not added to send_fail_reason';
+    cmp_bag $report->send_fail_body_ids,
+        [ $body_oxf->id ],
+        'Failed body ID not added again for Cherwell (email)';
+};
+
+subtest '5th attempt - both methods set to succeed' => sub {
+    $mock_email->unmock('send');
+    $mock_open311->unmock('send');
+    test_send();
+    $report->discard_changes;
+
+    is $report->send_method_used, 'Email,Open311',
+        'send_method_used includes Open311';
+    is $report->external_id, 248, 'Report has external ID';
+
+    is $report->send_fail_count,  4,     'send_fail_count unchanged';
+    is $report->send_fail_reason, undef, 'send_fail_reason unset';
+    cmp_bag $report->send_fail_body_ids, [], 'No send_fail_body_ids';
+};
+
+subtest 'Test resend' => sub {
+    $mock_open311->mock(
+        'send',
+        sub {
+            shift->error('Open311 fail');
+            return -1;
+        }
+    );
+
+    my ($report_for_resend) = $mech->create_problems_for_body(
+        1,
+        ( join ',', $body_oxf->id, $body_cherwell->id ),
+        'Test resend',
+        {   cobrand  => 'fixmystreet',
+            category => 'Other',
+            user     => $user,
+        },
+    );
+
+    # Send report; we expect failure for Open311
+    test_send();
+    $report_for_resend->discard_changes;
+
+    ok $report_for_resend->whensent, 'whensent recorded';
+    is $report_for_resend->send_method_used, 'Email',
+        'send_method_used recorded';
+
+    is $report_for_resend->send_fail_count, 1, 'send_fail_count recorded';
+    is $report_for_resend->send_fail_reason, 'Open311 fail',
+        'send_fail_reason recorded';
+    cmp_bag $report_for_resend->send_fail_body_ids, [ $body_oxf->id ],
+        'Failed body ID recorded';
+
+    # Call 'resend'; we expect certain fields to be unset
+    $report_for_resend->resend;
+    $report_for_resend->update;
+
+    is $report_for_resend->whensent,         undef, 'whensent unset';
+    is $report_for_resend->send_method_used, undef, 'send_method_used unset';
+
+    is $report_for_resend->send_fail_count,  1, 'send_fail_count unmodified';
+    is $report_for_resend->send_fail_reason, 'Open311 fail',
+        'send_fail_reason unmodified';
+    cmp_bag $report_for_resend->send_fail_body_ids, [],
+        'send_fail_body_ids unset';
+};
+
+sub test_send {
+    FixMyStreet::override_config {
+        STAGING_FLAGS    => { send_reports => 1 },
+        ALLOWED_COBRANDS => ['fixmystreet'],
+        MAPIT_URL        => 'http://mapit.uk/',
+        },
+        sub {
+        # Debug mode so we can attempt sending of same report within 5 min
+        # window
+        FixMyStreet::Script::Reports::send( 0, 0, 1 );
+        };
+}
+
+done_testing();

--- a/t/sendreport/two-tier/email-and-open311.t
+++ b/t/sendreport/two-tier/email-and-open311.t
@@ -9,16 +9,17 @@ my $mech = FixMyStreet::TestMech->new;
 
 my $user = $mech->create_user_ok('user@example.com');
 
-my $body_oxf = $mech->create_body_ok( 2237, 'Oxfordshire County Council' );
+my $body_oxf = $mech->create_body_ok( 2237, 'Oxfordshire County Council',
+    {}, { cobrand => 'oxfordshire' } );
 my $body_cherwell
     = $mech->create_body_ok( 2419, 'Cherwell District Council' );
 
-my $contact_oxf = $mech->create_contact_ok(
+$mech->create_contact_ok(
     body_id  => $body_oxf->id,
     category => 'Other',
     email    => 'other@oxfordshire.com',
 );
-my $contact_cherwell = $mech->create_contact_ok(
+$mech->create_contact_ok(
     body_id  => $body_cherwell->id,
     category => 'Other',
     email    => 'other@cherwell.com',
@@ -47,18 +48,16 @@ $report->result_source->schema->cobrand($cobrand);
 
 my $mock_email   = Test::MockModule->new('FixMyStreet::SendReport::Email');
 my $mock_open311 = Test::MockModule->new('FixMyStreet::SendReport::Open311');
-my $mock_log     = Test::MockObject->new;
-$mock_log->mock( debug => sub { } );
-my $mock_catalyst = Test::MockObject->new;
-$mock_catalyst->mock( log => sub {$mock_log} );
 
 subtest '1st attempt - email and Open311 both fail' => sub {
     is $report->duration_string, undef,
         'duration string is undef before any sending attempt';
 
+    my ( $hits_email, $hits_open311 );
     $mock_email->mock(
         'send',
         sub {
+            $hits_email++;
             shift->error('Email fail');
             return -1;
         }
@@ -66,6 +65,7 @@ subtest '1st attempt - email and Open311 both fail' => sub {
     $mock_open311->mock(
         'send',
         sub {
+            $hits_open311++;
             shift->error('Open311 fail');
             return -1;
         }
@@ -73,9 +73,11 @@ subtest '1st attempt - email and Open311 both fail' => sub {
     test_send();
     $report->discard_changes;
 
+    is $hits_email,   1, 'Email sender hit once';
+    is $hits_open311, 1, 'Open311 sender hit once';
+
     is $report->whensent,         undef, 'whensent not recorded';
     is $report->send_method_used, undef, 'send_method_used not recorded';
-    is $report->external_id,      undef, 'Report has no external ID';
 
     ok $report->send_fail_timestamp, 'send_fail_timestamp recorded';
     is $report->send_fail_count, 1, 'send_fail_count recorded';
@@ -86,17 +88,15 @@ subtest '1st attempt - email and Open311 both fail' => sub {
         [ $body_oxf->id, $body_cherwell->id ],
         'Failed body ID saved for each body';
 
-    # I have to assign the $mock_catalyst object to the cobrand anew
-    # after each sending attempt, because the sending logic always resets the
-    # cobrand to one without a catalyst object.
-    $report->result_source->schema->cobrand->{c} = $mock_catalyst;
-    is $report->duration_string, undef, 'duration string is undef';
+    is $report->body(1), '', 'no body for duration_string';
 };
 
 subtest '2nd attempt - email and Open311 both fail again' => sub {
+    my ( $hits_email, $hits_open311 );
     $mock_email->mock(
         'send',
         sub {
+            $hits_email++;
             shift->error('Email fail');
             return -1;
         }
@@ -104,6 +104,7 @@ subtest '2nd attempt - email and Open311 both fail again' => sub {
     $mock_open311->mock(
         'send',
         sub {
+            $hits_open311++;
             shift->error('Open311 fail');
             return -1;
         }
@@ -111,9 +112,11 @@ subtest '2nd attempt - email and Open311 both fail again' => sub {
     test_send();
     $report->discard_changes;
 
+    is $hits_email,   1, 'Email sender hit once';
+    is $hits_open311, 1, 'Open311 sender hit once';
+
     is $report->whensent,         undef, 'whensent not recorded';
     is $report->send_method_used, undef, 'send_method_used not recorded';
-    is $report->external_id,      undef, 'Report has no external ID';
 
     is $report->send_fail_count, 2, 'send_fail_count updated';
     like $report->send_fail_reason, qr/Email fail/;
@@ -123,15 +126,23 @@ subtest '2nd attempt - email and Open311 both fail again' => sub {
         [ $body_oxf->id, $body_cherwell->id ],
         'send_fail_body_ids remain the same';
 
-    $report->result_source->schema->cobrand->{c} = $mock_catalyst;
-    is $report->duration_string, undef, 'duration string is undef';
+    is $report->body(1), '', 'no body for duration_string';
 };
 
 subtest '3rd attempt - email succeeds, Open311 fails' => sub {
-    $mock_email->unmock('send');
+    my ( $hits_email, $hits_open311 );
+    $mock_email->mock(
+        'send',
+        sub {
+            $hits_email++;
+            shift->success(1);
+            return 0;
+        }
+    );
     $mock_open311->mock(
         'send',
         sub {
+            $hits_open311++;
             shift->error('Open311 fail');
             return -1;
         }
@@ -139,9 +150,11 @@ subtest '3rd attempt - email succeeds, Open311 fails' => sub {
     test_send();
     $report->discard_changes;
 
+    is $hits_email,   1, 'Email sender hit once';
+    is $hits_open311, 1, 'Open311 sender hit once';
+
     ok $report->whensent, 'whensent recorded';
     is $report->send_method_used, 'Email', 'send_method_used recorded';
-    is $report->external_id,      undef,   'Report has no external ID';
 
     is $report->send_fail_count, 3, 'send_fail_count incremented';
     like $report->send_fail_reason, qr/Open311 fail/;
@@ -151,18 +164,17 @@ subtest '3rd attempt - email succeeds, Open311 fails' => sub {
         [ $body_oxf->id ],
         'Failed body ID removed for Cherwell (email)';
 
-    $report->result_source->schema->cobrand->{c} = $mock_catalyst;
-    like $report->duration_string, qr/Cherwell District Council/;
-    unlike $report->duration_string,
-        qr/Oxfordshire County Council/,
-        'duration string mentions Cherwell only';
+    is $report->body(1), 'Cherwell District Council',
+        'Cherwell body for duration_string';
 };
 
 subtest '4th attempt - Open311 fails, email set to fail again' => sub {
     # Since email was successful before, it should not be attempted again
+    my ( $hits_email, $hits_open311 );
     $mock_email->mock(
         'send',
         sub {
+            $hits_email++;
             shift->error('Email fail');
             return -1;
         }
@@ -170,6 +182,7 @@ subtest '4th attempt - Open311 fails, email set to fail again' => sub {
     $mock_open311->mock(
         'send',
         sub {
+            $hits_open311++;
             shift->error('Open311 fail');
             return -1;
         }
@@ -177,8 +190,10 @@ subtest '4th attempt - Open311 fails, email set to fail again' => sub {
     test_send();
     $report->discard_changes;
 
+    is $hits_email,   undef, 'Email sender not hit';
+    is $hits_open311, 1,     'Open311 sender hit once';
+
     is $report->send_method_used, 'Email', 'send_method_used unchanged';
-    is $report->external_id,      undef,   'Report has no external ID';
 
     is $report->send_fail_count, 4, 'send_fail_count incremented';
     like $report->send_fail_reason, qr/Open311 fail/;
@@ -188,137 +203,125 @@ subtest '4th attempt - Open311 fails, email set to fail again' => sub {
         [ $body_oxf->id ],
         'Failed body ID not added again for Cherwell (email)';
 
-    $report->result_source->schema->cobrand->{c} = $mock_catalyst;
-    like $report->duration_string, qr/Cherwell District Council/;
-    unlike $report->duration_string,
-        qr/Oxfordshire County Council/,
-        'duration string mentions Cherwell only';
+    is $report->body(1), 'Cherwell District Council',
+        'Cherwell body for duration_string';
 };
 
 subtest '5th attempt - both methods set to succeed' => sub {
-    $mock_email->unmock('send');
-    $mock_open311->unmock('send');
+    my ( $hits_email, $hits_open311 );
+    $mock_email->mock(
+        'send',
+        sub {
+            $hits_email++;
+            shift->success(1);
+            return 0;
+        }
+    );
+    $mock_open311->mock(
+        'send',
+        sub {
+            $hits_open311++;
+            shift->success(1);
+            return 0;
+        }
+    );
     test_send();
     $report->discard_changes;
 
+    is $hits_email,   undef, 'Email sender not hit';      # successful before
+    is $hits_open311, 1,     'Open311 sender hit once';
+
     is $report->send_method_used, 'Email,Open311',
         'send_method_used includes Open311';
-    is $report->external_id, 248, 'Report has external ID';
 
     is $report->send_fail_count, 4, 'send_fail_count unchanged';
     is $report->send_fail_reason, 'Open311 fail',
         'send_fail_reason unchanged';
     cmp_bag $report->send_fail_body_ids, [], 'No send_fail_body_ids';
 
-    $report->result_source->schema->cobrand->{c} = $mock_catalyst;
-    like $report->duration_string,
-        qr/Cherwell District Council and Oxfordshire County Council/,
-        'duration string mentions Cherwell and Oxford';
+    is $report->body(1),
+        'Cherwell District Council and Oxfordshire County Council',
+        'Both bodies for duration_string';
 };
 
 subtest 'Test resend' => sub {
+    # Call 'resend'; we expect certain fields to be unset
+    $report->resend;
+    $report->update;
+
+    is $report->whensent,         undef, 'whensent unset';
+    is $report->send_method_used, undef, 'send_method_used unset';
+
+    is $report->send_fail_count, 4, 'send_fail_count unchanged';
+    is $report->send_fail_reason, 'Open311 fail',
+        'send_fail_reason unchanged';
+    cmp_bag $report->send_fail_body_ids, [], 'send_fail_body_ids unset';
+
+    is $report->body(1),
+        'Cherwell District Council and Oxfordshire County Council',
+        'Both bodies for duration_string';
+
+    my ( $hits_email, $hits_open311 );
+    $mock_email->mock(
+        'send',
+        sub {
+            $hits_email++;
+            shift->success(1);
+            return 0;
+        }
+    );
     $mock_open311->mock(
         'send',
         sub {
-            shift->error('Open311 fail');
-            return -1;
+            $hits_open311++;
+            shift->success(1);
+            return 0;
         }
     );
-
-    my ($report_for_resend) = $mech->create_problems_for_body(
-        1,
-        ( join ',', $body_oxf->id, $body_cherwell->id ),
-        'Test resend',
-        {   cobrand  => 'fixmystreet',
-            category => 'Other',
-            user     => $user,
-        },
-    );
-
-    # Send report; we expect failure for Open311
     test_send();
-    $report_for_resend->discard_changes;
+    $report->discard_changes;
 
-    ok $report_for_resend->whensent, 'whensent recorded';
-    is $report_for_resend->send_method_used, 'Email',
-        'send_method_used recorded';
+    is $hits_email,   1, 'Email sender hit once';
+    is $hits_open311, 1, 'Open311 sender hit once';
 
-    is $report_for_resend->send_fail_count, 1, 'send_fail_count recorded';
-    is $report_for_resend->send_fail_reason, 'Open311 fail',
-        'send_fail_reason recorded';
-    cmp_bag $report_for_resend->send_fail_body_ids, [ $body_oxf->id ],
-        'Failed body ID recorded';
+    is $report->send_method_used, 'Open311,Email',
+        'send_method_used includes both methods';
 
-    # Call 'resend'; we expect certain fields to be unset
-    $report_for_resend->resend;
-    $report_for_resend->update;
+    is $report->send_fail_count, 4, 'send_fail_count unchanged';
+    is $report->send_fail_reason, 'Open311 fail',
+        'send_fail_reason unchanged';
+    cmp_bag $report->send_fail_body_ids, [], 'No send_fail_body_ids';
 
-    is $report_for_resend->whensent,         undef, 'whensent unset';
-    is $report_for_resend->send_method_used, undef, 'send_method_used unset';
-
-    is $report_for_resend->send_fail_count, 1, 'send_fail_count unmodified';
-    is $report_for_resend->send_fail_reason, 'Open311 fail',
-        'send_fail_reason unmodified';
-    cmp_bag $report_for_resend->send_fail_body_ids, [],
-        'send_fail_body_ids unset';
-
-    $report->result_source->schema->cobrand->{c} = $mock_catalyst;
-    like $report->duration_string,
-        qr/Cherwell District Council and Oxfordshire County Council/,
-        'duration string mentions Cherwell and Oxford';
+    is $report->body(1),
+        'Cherwell District Council and Oxfordshire County Council',
+        'Both bodies for duration_string';
 };
 
 subtest 'Test staging send' => sub {
     # Will send with send_reports flag set to 0, so email will be used
     # instead of Open311
 
-    note 'Testing for report with 1 body (Open311)';
+    my ( $hits_email, $hits_open311 );
+    $mock_email->mock(
+        send => sub {
+            my ( $self, undef, $h ) = @_;
+            like $h->{bodies_name}, qr/Cherwell.*Oxfordshire/,
+                'bodies_name for email should contain both bodies';
+            $hits_email++;
+            $self->success(1);
+            return 0;
+        },
+    );
+    $mock_open311->mock(
+        'send',
+        sub {
+            $hits_open311++;
+            shift->error('Open311 fail');
+            return -1;
+        }
+    );
 
     my ($report_for_staging) = $mech->create_problems_for_body(
-        1,
-        $body_oxf->id,
-        'Test staging send',
-        {   cobrand  => 'fixmystreet',
-            category => 'Other',
-            user     => $user,
-        },
-    );
-
-    test_send(0);
-    $report_for_staging->discard_changes;
-
-    like $report_for_staging->send_fail_reason, qr/No recipients/,
-        'send_fail_reason should be for no recipients';
-    is $report_for_staging->send_method_used, undef,
-        'send_method should be undef';
-    cmp_bag $report_for_staging->send_fail_body_ids, [],
-        'there should be no send_fail_body_ids';
-
-    note 'Testing for report with 1 body (email)';
-
-    ($report_for_staging) = $mech->create_problems_for_body(
-        1,
-        $body_cherwell->id,
-        'Test staging send',
-        {   cobrand  => 'fixmystreet',
-            category => 'Other',
-            user     => $user,
-        },
-    );
-
-    test_send(0);
-    $report_for_staging->discard_changes;
-
-    is $report_for_staging->send_fail_reason, undef,
-        'send_fail_reason should be undef';
-    is $report_for_staging->send_method_used, 'Email',
-        'send_method should be email';
-    cmp_bag $report_for_staging->send_fail_body_ids, [],
-        'there should be no send_fail_body_ids';
-
-    note 'Testing for report with multiple bodies (email & Open311)';
-
-    ($report_for_staging) = $mech->create_problems_for_body(
         1,
         ( join ',', $body_oxf->id, $body_cherwell->id ),
         'Test staging send',
@@ -331,9 +334,9 @@ subtest 'Test staging send' => sub {
     test_send(0);
     $report_for_staging->discard_changes;
 
-    # No failure if one of the bodies already has email sending
-    # (for staging, FixMyStreet::Queue::Item::Report->_create_reporters
-    # only preserves bodies with email sending)
+    is $hits_email,   1,     'Email sender hit once';
+    is $hits_open311, undef, 'Open311 sender not hit';
+
     is $report_for_staging->send_fail_reason, undef,
         'send_fail_reason should be undef';
     is $report_for_staging->send_method_used, 'Email',

--- a/t/sendreport/two-tier/email-both.t
+++ b/t/sendreport/two-tier/email-both.t
@@ -1,0 +1,294 @@
+use FixMyStreet::Cobrand;
+use FixMyStreet::Script::Reports;
+use FixMyStreet::TestMech;
+use Test::Deep;
+use Test::MockModule;
+use Test::MockObject;
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $user = $mech->create_user_ok('user@example.com');
+
+my $body_oxf = $mech->create_body_ok( 2237, 'Oxfordshire County Council',
+    {}, { cobrand => 'oxfordshire' } );
+my $body_cherwell
+    = $mech->create_body_ok( 2419, 'Cherwell District Council' );
+
+$mech->create_contact_ok(
+    body_id     => $body_oxf->id,
+    category    => 'Other',
+    email       => 'other@oxfordshire.com',
+    send_method => 'Email::Highways',
+);
+$mech->create_contact_ok(
+    body_id  => $body_cherwell->id,
+    category => 'Other',
+    email    => 'other@cherwell.com',
+);
+
+my ($report) = $mech->create_problems_for_body(
+    1,
+    ( join ',', $body_oxf->id, $body_cherwell->id ),
+    'Test',
+    {   cobrand  => 'fixmystreet',
+        category => 'Other',
+        user     => $user,
+    }
+);
+
+my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker('fixmystreet')->new;
+$report->result_source->schema->cobrand($cobrand);
+
+my $mock_email = Test::MockModule->new('FixMyStreet::SendReport::Email');
+
+subtest '1st attempt - both fail' => sub {
+    is $report->duration_string, undef,
+        'duration string is undef before any sending attempt';
+
+    my $hits = 0;
+    $mock_email->mock(
+        'send',
+        sub {
+            my ( $self, undef, $h ) = @_;
+
+            cmp_bag [ map { $_->id } @{ $self->bodies } ],
+                [ $body_cherwell->id, $body_oxf->id ],
+                'Sender should have both bodies';
+
+            like $h->{bodies_name}, qr/Cherwell.*Oxfordshire/,
+                'bodies_name for email should contain both bodies';
+            $hits++;
+
+            $self->error('Email fail');
+            return -1;
+        }
+    );
+    test_send();
+    $report->discard_changes;
+
+    is $hits, 1, 'Email sender hit once';
+
+    is $report->whensent,         undef, 'whensent not recorded';
+    is $report->send_method_used, undef, 'send_method_used not recorded';
+
+    ok $report->send_fail_timestamp, 'send_fail_timestamp recorded';
+    is $report->send_fail_count,  1,            'send_fail_count recorded';
+    is $report->send_fail_reason, 'Email fail', 'send_fail_reason recorded';
+    cmp_bag $report->send_fail_body_ids,
+        [ $body_oxf->id, $body_cherwell->id ],
+        'Failed body ID saved for each body';
+
+    is $report->body(1), '', 'no body for duration_string';
+};
+
+subtest '2nd attempt - both fail again' => sub {
+    my $hits = 0;
+    $mock_email->mock(
+        'send',
+        sub {
+            my ( $self, undef, $h ) = @_;
+
+            cmp_bag [ map { $_->id } @{ $self->bodies } ],
+                [ $body_cherwell->id, $body_oxf->id ],
+                'Sender should have both bodies';
+
+            like $h->{bodies_name}, qr/Cherwell.*Oxfordshire/,
+                'bodies_name for email should contain both bodies';
+            $hits++;
+
+            $self->error('Email fail');
+            return -1;
+        }
+    );
+    test_send();
+    $report->discard_changes;
+
+    is $hits, 1, 'Email sender hit once';
+
+    is $report->whensent,         undef, 'whensent not recorded';
+    is $report->send_method_used, undef, 'send_method_used not recorded';
+
+    is $report->send_fail_count, 2, 'send_fail_count updated';
+    is $report->send_fail_reason, 'Email fail',
+        'send_fail_reason stays the same';
+    cmp_bag $report->send_fail_body_ids,
+        [ $body_oxf->id, $body_cherwell->id ],
+        'send_fail_body_ids remain the same';
+
+    is $report->body(1), '', 'no body for duration_string';
+};
+
+subtest '3rd attempt - both succeed' => sub {
+    my $hits = 0;
+    $mock_email->mock(
+        'send',
+        sub {
+            my ( $self, undef, $h ) = @_;
+
+            cmp_bag [ map { $_->id } @{ $self->bodies } ],
+                [ $body_cherwell->id, $body_oxf->id ],
+                'Sender should have both bodies';
+
+            like $h->{bodies_name}, qr/Cherwell.*Oxfordshire/,
+                'bodies_name for email should contain both bodies';
+            $hits++;
+
+            $self->success(1);
+            return 0;
+        }
+    );
+    test_send();
+    $report->discard_changes;
+
+    is $hits, 1, 'Email sender hit once';
+
+    ok $report->whensent, 'whensent recorded';
+    is $report->send_method_used, 'Email', 'send_method_used recorded';
+
+    is $report->send_fail_count, 2, 'send_fail_count unchanged';
+    is $report->send_fail_reason, 'Email fail',
+        'send_fail_reason stays the same';
+    cmp_bag $report->send_fail_body_ids, [], 'send_fail_body_ids removed';
+
+    is $report->body(1),
+        'Cherwell District Council and Oxfordshire County Council',
+        'Both bodies for duration_string';
+};
+
+subtest '4th attempt - email set to fail again' => sub {
+    # Expected behaviour:
+    # Since email succeeded previously, its failure here will be
+    # ignored
+
+    my $hits = 0;
+    $mock_email->mock(
+        'send',
+        sub {
+            my $self = shift;
+
+            $hits++;
+
+            $self->error('Email fail');
+            return -1;
+        }
+    );
+    test_send();
+    $report->discard_changes;
+
+    is $hits, 0, 'Email sender not hit';
+
+    is $report->send_method_used, 'Email', 'send_method_used unchanged';
+
+    is $report->send_fail_count,  2,            'send_fail_count unchanged';
+    is $report->send_fail_reason, 'Email fail', 'send_fail_reason unchanged';
+    cmp_bag $report->send_fail_body_ids, [], 'send_fail_body_ids unchanged';
+
+    is $report->body(1),
+        'Cherwell District Council and Oxfordshire County Council',
+        'Bodies for duration_string unchanged';
+};
+
+subtest 'Test resend' => sub {
+    # Call 'resend'; we expect certain fields to be unset
+    $report->resend;
+    $report->update;
+
+    is $report->whensent,         undef, 'whensent unset';
+    is $report->send_method_used, undef, 'send_method_used unset';
+
+    is $report->send_fail_count,  2,            'send_fail_count unmodified';
+    is $report->send_fail_reason, 'Email fail', 'send_fail_reason unmodified';
+    cmp_bag $report->send_fail_body_ids, [], 'send_fail_body_ids unset';
+
+    is $report->body(1),
+        'Cherwell District Council and Oxfordshire County Council',
+        'Both bodies for duration_string';
+
+    my $hits = 0;
+    $mock_email->mock(
+        'send',
+        sub {
+            my $self = shift;
+
+            $hits++;
+
+            $self->success(1);
+            return 0;
+        }
+    );
+    test_send();
+    $report->discard_changes;
+
+    is $hits, 1, 'Email sender hit once';
+
+    is $report->send_method_used, 'Email', 'send_method_used unchanged';
+
+    is $report->send_fail_count,  2,            'send_fail_count unchanged';
+    is $report->send_fail_reason, 'Email fail', 'send_fail_reason unchanged';
+    cmp_bag $report->send_fail_body_ids, [], 'send_fail_body_ids unchanged';
+
+    is $report->body(1),
+        'Cherwell District Council and Oxfordshire County Council',
+        'Both bodies for duration_string';
+};
+
+subtest 'Test staging send' => sub {
+    # Will send with send_reports flag set to 0
+
+    my $hits = 0;
+    $mock_email->mock(
+        send => sub {
+            my ( $self, undef, $h ) = @_;
+
+            cmp_bag [ map { $_->id } @{ $self->bodies } ],
+                [ $body_cherwell->id, $body_oxf->id ],
+                'Sender should have both bodies';
+
+            like $h->{bodies_name}, qr/Cherwell.*Oxfordshire/,
+                'bodies_name for email should contain both bodies';
+
+            $hits++;
+            $self->success(1);
+            return 0;
+        },
+    );
+
+    my ($report_for_staging) = $mech->create_problems_for_body(
+        1,
+        ( join ',', $body_oxf->id, $body_cherwell->id ),
+        'Test staging send',
+        {   cobrand  => 'fixmystreet',
+            category => 'Other',
+            user     => $user,
+        },
+    );
+
+    test_send(0);
+    $report_for_staging->discard_changes;
+
+    is $hits, 1, 'Email sender hit once';
+
+    is $report_for_staging->send_fail_reason, undef,
+        'send_fail_reason should be undef';
+    is $report_for_staging->send_method_used, 'Email',
+        'send_method should be email';
+    cmp_bag $report_for_staging->send_fail_body_ids, [],
+        'there should be no send_fail_body_ids';
+};
+
+sub test_send {
+    my $send_reports = shift // 1;
+
+    FixMyStreet::override_config {
+        STAGING_FLAGS    => { send_reports => $send_reports },
+        ALLOWED_COBRANDS => ['fixmystreet'],
+        MAPIT_URL        => 'http://mapit.uk/',
+        },
+        sub {
+        # Debug mode so we can attempt sending of same report within 5 min
+        # window
+        FixMyStreet::Script::Reports::send( 0, 0, 1 );
+        };
+}
+
+done_testing();

--- a/t/sendreport/two-tier/open311-both.t
+++ b/t/sendreport/two-tier/open311-both.t
@@ -1,0 +1,334 @@
+use FixMyStreet::Cobrand;
+use FixMyStreet::Script::Reports;
+use FixMyStreet::TestMech;
+use Test::Deep;
+use Test::MockModule;
+use Test::MockObject;
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $user = $mech->create_user_ok('user@example.com');
+
+my $body_oxf = $mech->create_body_ok( 2237, 'Oxfordshire County Council',
+    {}, { cobrand => 'oxfordshire' } );
+my $body_cherwell
+    = $mech->create_body_ok( 2419, 'Cherwell District Council' );
+
+$mech->create_contact_ok(
+    body_id  => $body_oxf->id,
+    category => 'Other',
+    email    => 'other@oxfordshire.com',
+);
+$mech->create_contact_ok(
+    body_id  => $body_cherwell->id,
+    category => 'Other',
+    email    => 'other@cherwell.com',
+);
+
+my ($report) = $mech->create_problems_for_body(
+    1,
+    ( join ',', $body_oxf->id, $body_cherwell->id ),
+    'Test',
+    {   cobrand  => 'fixmystreet',
+        category => 'Other',
+        user     => $user,
+    }
+);
+
+$body_oxf->update(
+    {   send_method  => 'Open311',
+        endpoint     => 'http://endpoint1.example.com',
+        jurisdiction => 'FMS',
+        api_key      => 'test',
+    },
+);
+
+$body_cherwell->update(
+    {   send_method  => 'Open311',
+        endpoint     => 'http://endpoint2.example.com',
+        jurisdiction => 'FMS',
+        api_key      => 'test',
+    },
+);
+
+my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker('fixmystreet')->new;
+$report->result_source->schema->cobrand($cobrand);
+
+my $mock_open311 = Test::MockModule->new('FixMyStreet::SendReport::Open311');
+
+subtest '1st attempt - both fail' => sub {
+    is $report->duration_string, undef,
+        'duration string is undef before any sending attempt';
+
+    my $hits = 0;
+    $mock_open311->mock(
+        'send',
+        sub {
+            my $self = shift;
+            is @{ $self->bodies }, 1, '1 body for sender';
+            $hits++;
+            $self->error('Open311 fail');
+            return -1;
+        }
+    );
+    test_send();
+    $report->discard_changes;
+
+    is $hits, 2, 'Sender hit twice';
+
+    is $report->whensent,         undef, 'whensent not recorded';
+    is $report->send_method_used, undef, 'send_method_used not recorded';
+
+    ok $report->send_fail_timestamp, 'send_fail_timestamp recorded';
+    is $report->send_fail_count, 1, 'send_fail_count recorded';
+    is $report->send_fail_reason, 'Open311 fail|Open311 fail',
+        'send_fail_reason recorded';
+    cmp_bag $report->send_fail_body_ids,
+        [ $body_oxf->id, $body_cherwell->id ],
+        'Failed body ID saved for each body';
+
+    is $report->body(1), '', 'no body for duration_string';
+};
+
+subtest '2nd attempt - both fail again' => sub {
+    my $hits = 0;
+    $mock_open311->mock(
+        'send',
+        sub {
+            my $self = shift;
+            is @{ $self->bodies }, 1, '1 body for sender';
+            $hits++;
+            $self->error('Open311 fail');
+            return -1;
+        }
+    );
+    test_send();
+    $report->discard_changes;
+
+    is $hits, 2, 'Sender hit twice';
+
+    is $report->whensent,         undef, 'whensent not recorded';
+    is $report->send_method_used, undef, 'send_method_used not recorded';
+
+    is $report->send_fail_count, 2, 'send_fail_count updated';
+    is $report->send_fail_reason, 'Open311 fail|Open311 fail',
+        'send_fail_reason stays the same';
+    cmp_bag $report->send_fail_body_ids,
+        [ $body_oxf->id, $body_cherwell->id ],
+        'send_fail_body_ids remain the same';
+
+    is $report->body(1), '', 'no body for duration_string';
+};
+
+subtest '3rd attempt - one succeeds, other fails' => sub {
+    my $hits = 0;
+    $mock_open311->mock(
+        'send',
+        sub {
+            my $self = shift;
+            is @{ $self->bodies }, 1, '1 body for sender';
+            $hits++;
+            if ( grep { $_->name =~ /Cherwell/ } @{ $self->bodies } ) {
+                $self->error('Open311 fail');
+                return -1;
+            }
+            else {
+                $self->success(1);
+                return 0;
+            }
+        }
+    );
+    test_send();
+    $report->discard_changes;
+
+    is $hits, 2, 'Sender hit twice';
+
+    ok $report->whensent, 'whensent recorded';
+    is $report->send_method_used, 'Open311', 'send_method_used recorded';
+
+    is $report->send_fail_count, 3, 'send_fail_count incremented';
+    is $report->send_fail_reason, 'Open311 fail',
+        'One error removed from send_fail_reason';
+    cmp_bag $report->send_fail_body_ids,
+        [ $body_cherwell->id ],
+        'Failed body ID removed for Oxfordshire';
+
+    is $report->body(1), 'Oxfordshire County Council',
+        'Oxf body for duration_string';
+};
+
+subtest '4th attempt - both set to fail again' => sub {
+    # Expected behaviour:
+    # Since Oxfordshire succeeded previously, its failure here will be
+    # ignored
+
+    my $hits = 0;
+    $mock_open311->mock(
+        'send',
+        sub {
+            my $self = shift;
+            is @{ $self->bodies }, 1, '1 body for sender';
+            $hits++;
+            $self->error('Open311 fail');
+            return -1;
+        }
+    );
+    test_send();
+    $report->discard_changes;
+
+    is $hits, 1, 'Sender hit once';
+
+    is $report->send_method_used, 'Open311', 'send_method_used unchanged';
+
+    is $report->send_fail_count, 4, 'send_fail_count incremented';
+    is $report->send_fail_reason, 'Open311 fail',
+        'send_fail_reason unchanged';
+    cmp_bag $report->send_fail_body_ids,
+        [ $body_cherwell->id ],
+        'Failed body ID not added again for Oxfordshire';
+
+    is $report->body(1), 'Oxfordshire County Council',
+        'Oxf body for duration_string';
+};
+
+subtest '5th attempt - both set to succeed' => sub {
+    my $hits = 0;
+    $mock_open311->mock(
+        'send',
+        sub {
+            my $self = shift;
+            is @{ $self->bodies }, 1, '1 body for sender';
+            $hits++;
+            $self->success(1);
+            return 0;
+        }
+    );
+    test_send();
+    $report->discard_changes;
+
+    is $hits, 1, 'Sender hit once';
+
+    is $report->send_method_used, 'Open311,Open311',
+        'send_method_used has 2 x Open311';
+
+    is $report->send_fail_count, 4, 'send_fail_count unchanged';
+    is $report->send_fail_reason, 'Open311 fail',
+        'send_fail_reason unchanged';
+    cmp_bag $report->send_fail_body_ids, [], 'No send_fail_body_ids';
+
+    is $report->body(1),
+        'Cherwell District Council and Oxfordshire County Council',
+        'both bodies for duration_string';
+};
+
+subtest 'Test resend' => sub {
+    # Call 'resend'; we expect certain fields to be unset
+    $report->resend;
+    $report->update;
+
+    is $report->whensent,         undef, 'whensent unset';
+    is $report->send_method_used, undef, 'send_method_used unset';
+
+    is $report->send_fail_count, 4, 'send_fail_count unchanged';
+    is $report->send_fail_reason, 'Open311 fail',
+        'send_fail_reason unchanged';
+    cmp_bag $report->send_fail_body_ids, [], 'send_fail_body_ids unset';
+
+    is $report->body(1),
+        'Cherwell District Council and Oxfordshire County Council',
+        'both bodies for duration_string';
+
+    my $hits = 0;
+    $mock_open311->mock(
+        'send',
+        sub {
+            my $self = shift;
+            is @{ $self->bodies }, 1, '1 body for sender';
+            $hits++;
+            $self->success(1);
+            return 0;
+        }
+    );
+    test_send();
+    $report->discard_changes;
+
+    is $hits, 2, 'Sender hit twice';
+
+    is $report->send_method_used, 'Open311,Open311',
+        'send_method_used has 2 x Open311';
+
+    is $report->send_fail_count, 4, 'send_fail_count unchanged';
+    is $report->send_fail_reason, 'Open311 fail',
+        'send_fail_reason unchanged';
+    cmp_bag $report->send_fail_body_ids, [], 'No send_fail_body_ids';
+
+    is $report->body(1),
+        'Cherwell District Council and Oxfordshire County Council',
+        'both bodies for duration_string';
+};
+
+subtest 'Test staging send' => sub {
+    # Will send with send_reports flag set to 0, so email will be used
+    # instead of Open311
+
+    my $mock_email = Test::MockModule->new('FixMyStreet::SendReport::Email');
+    my ( $hits_email, $hits_open311 );
+    $mock_email->mock(
+        send => sub {
+            my ( $self, undef, $h ) = @_;
+            like $h->{bodies_name}, qr/Cherwell.*Oxfordshire/,
+                'bodies_name for email should contain both bodies';
+            $hits_email++;
+            $self->success(1);
+            return 0;
+        },
+    );
+    $mock_open311->mock(
+        'send',
+        sub {
+            $hits_open311++;
+            shift->error('Open311 fail');
+            return -1;
+        }
+    );
+
+    my ($report_for_staging) = $mech->create_problems_for_body(
+        1,
+        ( join ',', $body_oxf->id, $body_cherwell->id ),
+        'Test staging send',
+        {   cobrand  => 'fixmystreet',
+            category => 'Other',
+            user     => $user,
+        },
+    );
+
+    test_send(0);
+    $report_for_staging->discard_changes;
+
+    is $hits_email,   1,     'Email sender hit once';
+    is $hits_open311, undef, 'Open311 sender not hit';
+
+    is $report_for_staging->send_fail_reason, undef,
+        'send_fail_reason should be undef';
+    is $report_for_staging->send_method_used, 'Email',
+        'send_method should be email';
+    cmp_bag $report_for_staging->send_fail_body_ids, [],
+        'there should be no send_fail_body_ids';
+};
+
+sub test_send {
+    my $send_reports = shift // 1;
+
+    FixMyStreet::override_config {
+        STAGING_FLAGS    => { send_reports => $send_reports },
+        ALLOWED_COBRANDS => ['fixmystreet'],
+        MAPIT_URL        => 'http://mapit.uk/',
+        },
+        sub {
+        # Debug mode so we can attempt sending of same report within 5 min
+        # window
+        FixMyStreet::Script::Reports::send( 0, 0, 1 );
+        };
+}
+
+done_testing();

--- a/templates/web/base/admin/problem_row.html
+++ b/templates/web/base/admin/problem_row.html
@@ -37,8 +37,8 @@
         <td>[% prettify_state(problem.state, 1) %]<br><small>
             [% loc('Created') %]:&nbsp;[% PROCESS format_time time=problem.created %]
             <br>[% loc('When sent') %]:&nbsp;[% PROCESS format_time time=problem.whensent %]
-            [%- send_fail_methods = problem.send_fail_methods -%]
-            [%- IF send_fail_methods %]<br>[% loc('Failed send methods:') %]&nbsp;[% send_fail_methods.join(', ') %][% END -%]
+            [%- send_fail_bodies = problem.send_fail_bodies -%]
+            [%- IF send_fail_bodies.size %]<br>[% loc('Failed bodies:') %]&nbsp;[% send_fail_bodies.join(', ') %][% END -%]
             [%- IF problem.is_visible %]<br>[% loc('Confirmed:' ) %]&nbsp;[% PROCESS format_time time=problem.confirmed %][% END -%]
             [%- IF problem.is_fixed %]<br>[% prettify_state('fixed') %]: [% PROCESS format_time time=problem.lastupdate %][% END -%]
             [%- IF problem.is_closed %]<br>[% prettify_state('closed') %]: [% PROCESS format_time time=problem.lastupdate %][% END -%]

--- a/templates/web/base/admin/problem_row.html
+++ b/templates/web/base/admin/problem_row.html
@@ -37,6 +37,8 @@
         <td>[% prettify_state(problem.state, 1) %]<br><small>
             [% loc('Created') %]:&nbsp;[% PROCESS format_time time=problem.created %]
             <br>[% loc('When sent') %]:&nbsp;[% PROCESS format_time time=problem.whensent %]
+            [%- send_fail_methods = problem.send_fail_methods -%]
+            [%- IF send_fail_methods %]<br>[% loc('Failed send methods:') %]&nbsp;[% send_fail_methods.join(', ') %][% END -%]
             [%- IF problem.is_visible %]<br>[% loc('Confirmed:' ) %]&nbsp;[% PROCESS format_time time=problem.confirmed %][% END -%]
             [%- IF problem.is_fixed %]<br>[% prettify_state('fixed') %]: [% PROCESS format_time time=problem.lastupdate %][% END -%]
             [%- IF problem.is_closed %]<br>[% prettify_state('closed') %]: [% PROCESS format_time time=problem.lastupdate %][% END -%]


### PR DESCRIPTION
A report may fall under the jurisdiction of two (or more) bodies, e.g. Cherwell District Council and Oxfordshire County Council. One body may have a send method of (e.g.) email and the other of (e.g.) Open311; if one of these send methods fails, the report is still marked as having been successfully sent, despite the fact that only one body will have received the report. This PR fixes this so that sending is reattempted until all methods have been successful.

Closes https://github.com/mysociety/fixmystreet/issues/3168.

[skip changelog]
