### PR TITLE
[National Highways] Sort NH categories mixed with council categories

### DIFF
--- a/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
+++ b/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
@@ -215,6 +215,7 @@ sub national_highways_cleaning_groups {
             push @{$nh_group->{categories}}, $cat;
         }
     }
+    @{$nh_group->{categories}} = sort {$a->category_display cmp $b->category_display } @{$nh_group->{categories}};
 }
 
 sub report_new_is_on_he_road {


### PR DESCRIPTION
Adds alphabetical sort to the list of mixed NH and council categories, otherwise council categories are at the end of list

[skip changelog]
