### PR TITLE
[Buckinghamshire] Dashboard dropdown for parishes

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Dashboard.pm
+++ b/perllib/FixMyStreet/App/Controller/Dashboard.pm
@@ -81,6 +81,16 @@ sub check_page_allowed : Private {
         }
     } elsif ($c->user->from_body && (!$cobrand_body || $cobrand_body->id == $c->user->from_body->id)) {
         $body = $c->user->from_body;
+
+        my @extra_bodies = $c->cobrand->call_hook('dashboard_extra_bodies');
+        if (@extra_bodies) {
+            $c->stash->{default_body} = $c->user->from_body;
+            $c->stash->{extra_bodies} = \@extra_bodies;
+            if ($c->get_param('body')) {
+                my @found = grep { $_->id == $c->get_param('body') } @extra_bodies;
+                $body = $found[0] if @found;
+            }
+        }
     } elsif ($c->action eq 'dashboard/heatmap' && $c->cobrand->feature('heatmap_dashboard_body')) {
         # Heatmap might be able to be seen by more people
         $body = $c->cobrand->call_hook('dashboard_body');

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -187,6 +187,12 @@ sub dashboard_export_problems_add_columns {
     shift->_dashboard_export_add_columns(@_);
 }
 
+sub dashboard_extra_bodies {
+    my ($self) = @_;
+
+    return $self->parish_bodies->all;
+}
+
 sub _parish_ids {
     # This is a list of all Parish Councils within Buckinghamshire,
     # taken from https://mapit.mysociety.org/area/2217/covers.json?type=CPC
@@ -703,14 +709,20 @@ sub area_ids_for_problems {
     return ($self->council_area_id, @{$self->_parish_ids});
 }
 
+sub parish_bodies {
+    my ($self) = @_;
+
+    return FixMyStreet::DB->resultset('Body')->search(
+        { 'body_areas.area_id' => $self->_parish_ids, },
+        { join => 'body_areas', order_by => 'name' }
+    )->active;
+}
+
 # Show parish problems on the cobrand.
 sub problems_restriction_bodies {
     my ($self) = @_;
 
-    my @parishes = FixMyStreet::DB->resultset('Body')->search(
-        { 'body_areas.area_id' => $self->_parish_ids, },
-        { join => 'body_areas' }
-    )->all;
+    my @parishes = $self->parish_bodies->all;
     my @parish_ids = map { $_->id } @parishes;
 
     return [$self->body->id, @parish_ids];

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -11,6 +11,7 @@ END { FixMyStreet::App->log->enable('info'); }
 my $body = $mech->create_body_ok(2217, 'Buckinghamshire', {
     send_method => 'Open311', api_key => 'key', endpoint => 'endpoint', jurisdiction => 'fms', can_be_devolved => 1 });
 my $parish = $mech->create_body_ok(53822, 'Adstock Parish Council');
+my $other_body = $mech->create_body_ok(1234, 'Some Other Council');
 my $counciluser = $mech->create_user_ok('counciluser@example.com', name => 'Council User', from_body => $body);
 my $publicuser = $mech->create_user_ok('fmsuser@example.org', name => 'Simon Neil');
 
@@ -459,6 +460,20 @@ subtest 'treats problems sent to parishes as owned by Bucks' => sub {
     # Check that the report can be accessed via the cobrand
     my $report_id = $report->id;
     $mech->get_ok("/report/$report_id");
+};
+
+subtest 'body filter on dashboard' => sub {
+    $mech->get_ok('/dashboard');
+    $mech->content_contains('<h1>' . $body->name . '</h1>', 'defaults to Bucks');
+    $mech->content_contains('<select class="form-control" name="body" id="body">', 'extra bodies dropdown is shown');
+    $mech->content_contains('<option value="' . $body->id . '">' . $body->name . '</option>', 'Bucks is shown in the options');
+    $mech->content_contains('<option value="' . $parish->id . '">' . $parish->name . '</option>', 'parish is shown in the options');
+
+    $mech->get_ok('/dashboard?body=' . $parish->id);
+    $mech->content_contains('<h1>' . $parish->name . '</h1>', 'shows parish dashboard');
+
+    $mech->get_ok('/dashboard?body=' . $other_body->id);
+    $mech->content_contains('<h1>' . $body->name . '</h1>', 'defaults to Bucks when body is not permitted');
 };
 
 };

--- a/templates/web/base/dashboard/index.html
+++ b/templates/web/base/dashboard/index.html
@@ -23,7 +23,21 @@
 
 <div class="filters">
   [% IF body %]
+    [% IF extra_bodies %]
+    <p>
+      <label for="body">[% loc('Body:') %]</label>
+      <select class="form-control" name="body" id="body">
+        <option value="[% default_body.id %]">[% default_body.name %]</option>
+        <option disabled>---</option>
+        [% FOR b IN extra_bodies %]
+          <option value="[% b.id %]"[% ' selected' IF b.id == body.id %]>[% b.name %]</option>
+        [% END %]
+      </select>
+    </p>
+    [% ELSE %]
     <input type="hidden" name="body" value="[% body.id | html %]">
+    [% END %]
+
     [% IF NOT c.user.area_ids.size %]
     <p>
         <label for="ward">[% loc('Ward:') %]</label>


### PR DESCRIPTION
This adds an extra "Body" dropdown to the Buckinghamshire dashboard which in addition to Buckinghamshire Council also lists all of the active parishes associated with the Buckinghamshire cobrand. When selected allows viewing the parish bodies stats in the same way as you can with the primary cobrand body.

Fixes https://github.com/mysociety/societyworks/issues/2810

<img width="1184" alt="image" src="https://user-images.githubusercontent.com/22996/157058563-0026ded3-f46d-45ed-9a67-ad1cd0f2aded.png">

[skip changelog]