### PR TITLE
[Peterborough] Remove Covid message

### DIFF
--- a/templates/web/peterborough/front/pre-steps.html
+++ b/templates/web/peterborough/front/pre-steps.html
@@ -1,8 +1,0 @@
-<p class="covid-banner">
-    <strong>Please note:</strong>
-    during the Coronavirus (COVID-19) pandemic it will not be possible for us to
-    action or respond to all reports within regular time-frames. While we are
-    working hard to ensure key services are maintained and focusing on high
-    priority issues, you can
-    <a href="https://www.peterborough.gov.uk/healthcare/public-health/coronavirus/coronavirus-covid-19-overview">find advice and information on our services online</a>.
-</p>


### PR DESCRIPTION
* Remove Covid message so emergency message feature works again

This are requested for staging for the time being.
https://mysocietysupport.freshdesk.com/a/tickets/1865

[skip changelog]