### PR TITLE
[Peterborough] More waste fixes

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -655,10 +655,12 @@ sub bin_services_for_address {
         # Open request for same thing, or for all bins, or for large black bin
         my @request_service_ids_open = grep { $open_requests->{$_} || $open_requests->{425} || ($_ == 419 && $open_requests->{422}) } @$request_service_ids;
 
+        my $last_obj = { date => $last, ordinal => ordinal($last->day) } if $last;
+        my $next_obj = { date => $next, ordinal => ordinal($next->day) } if $next;
         my $row = {
             id => $_->{JobID},
-            last => { date => $last, ordinal => ordinal($last->day) },
-            next => { date => $next, ordinal => ordinal($next->day) },
+            last => $last_obj,
+            next => $next_obj,
             service_name => $service_name_override{$name} || $name,
             schedule => $schedules{$name}->{Frequency},
             service_id => $container_id,
@@ -671,7 +673,7 @@ sub bin_services_for_address {
             # is there already an open bin request for this container?
             request_open => @request_service_ids_open ? 1 : 0,
             # can this collection be reported as having been missed?
-            report_allowed => $self->_waste_report_allowed($last),
+            report_allowed => $last ? $self->_waste_report_allowed($last) : 0,
             # is there already a missed collection report open for this container
             # (or a missed assisted collection for any container)?
             report_open => ( @report_service_ids_open || $open_requests->{492} ) ? 1 : 0,

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -179,6 +179,14 @@ FixMyStreet::override_config {
         $b->unmock('call');
         $b->mock('Jobs_FeatureScheduleDates_Get', sub { $jobs_fsd_get });
     };
+    subtest 'Check no next schedule' => sub {
+        my $alt_jobs_fsd_get = [
+            { JobID => 454, PreviousDate => '2021-08-03T10:10:10Z', NextDate => undef, JobName => 'Empty Bin 240L Black' },
+        ];
+        $b->mock('Jobs_FeatureScheduleDates_Get', sub { $alt_jobs_fsd_get });
+        $mech->get_ok('/waste/PE1%203NA:100090215480');
+        $b->mock('Jobs_FeatureScheduleDates_Get', sub { $jobs_fsd_get });
+    };
     subtest 'Future collection calendar' => sub {
         $mech->get_ok('/waste/PE1 3NA:100090215480/calendar.ics');
         $mech->content_contains('DTSTART;VALUE=DATE:20210808');

--- a/templates/web/peterborough/waste/header.html
+++ b/templates/web/peterborough/waste/header.html
@@ -4,3 +4,10 @@
     version('/cobrands/peterborough/waste.js')
 ] ~%]
 [% INCLUDE header.html %]
+
+[% emergency_message = c.cobrand.emergency_message('waste') %]
+[% IF emergency_message %]
+<div class="emergency-message">
+  [% emergency_message | html_para %]
+</div>
+[% END %]


### PR DESCRIPTION
[skip changelog] My previous fix now breaks if there is a schedule without a next date (e.g. some brown bins at present). And the waste message wasn't displaying because they have their own header (I thought about factoring it out in some way but it's tiny and whatever).