### PR TITLE
[Buckinghamshire] Lookup parishes on .com site for new reports

### DIFF
--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -419,4 +419,17 @@ sub reopening_disallowed {
     return $self->next::method($problem);
 }
 
+# Make sure CPC areas are included in point lookups for new reports
+# This is so that parish bodies (e.g. in Buckinghamshire) are available
+# for reporting to on .com
+sub add_extra_area_types {
+    my ($self, $types) = @_;
+
+    my @types = (
+        @$types,
+        'CPC',
+    );
+    return \@types;
+}
+
 1;


### PR DESCRIPTION
When creating a new report we want .com to be able to route reports to parishes in the same way that the Buckinghamshire cobrand can. In order to achieve this we need to include "CPC" area type from mapit when looking for areas to create a new report in.

Fixes https://github.com/mysociety/societyworks/issues/2944

[skip changelog]