### PR TITLE
[Buckinghamshire] Allow viewing all reports for parishes

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -713,7 +713,7 @@ sub parish_bodies {
     my ($self) = @_;
 
     return FixMyStreet::DB->resultset('Body')->search(
-        { 'body_areas.area_id' => $self->_parish_ids, },
+        { 'body_areas.area_id' => { -in => $self->_parish_ids } },
         { join => 'body_areas', order_by => 'name' }
     )->active;
 }

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -728,4 +728,36 @@ sub problems_restriction_bodies {
     return [$self->body->id, @parish_ids];
 }
 
+# Redirect to .com if not Bucks or a parish
+sub reports_body_check {
+    my ( $self, $c, $code ) = @_;
+
+    my @parishes = $self->parish_bodies->all;
+    my @bodies = ($self->body, @parishes);
+    my $matched = 0;
+    foreach my $body (@bodies) {
+        if ( $body->name =~ /^\Q$code\E/ ) {
+            $matched = 1;
+            last;
+        }
+    }
+
+    if (!$matched) {
+        $c->res->redirect( 'https://www.fixmystreet.com' . $c->req->uri->path_query, 301 );
+        $c->detach();
+    }
+
+    return;
+}
+
+sub about_hook {
+    my ($self) = @_;
+
+    my $c = $self->{c};
+    if ($c->stash->{template} eq 'about/parishes.html') {
+        my @parishes = $self->parish_bodies->all;
+        $c->stash->{parishes} = \@parishes;
+    }
+}
+
 1;

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -419,4 +419,17 @@ sub reopening_disallowed {
     return $self->next::method($problem);
 }
 
+# Make sure CPC areas are included in point lookups for new reports
+# This is so that parish bodies (e.g. in Buckinghamshire) are available
+# for reporting to on .com
+sub add_extra_area_types {
+    my ($self, $types) = @_;
+
+    my @types = (
+        @$types,
+        'CPC',
+    );
+    return \@types;
+}
+
 1;

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -117,7 +117,7 @@ sub short_name {
     return 'Durham+City' if $name eq 'Durham City Council';
 
     $name =~ s/^(Royal|London) Borough of //;
-    $name =~ s/ (Borough|City|District|County) Council$//;
+    $name =~ s/ (Borough|City|District|County|Parish|Town) Council$//;
     $name =~ s/ Council$//;
     $name =~ s/ & / and /;
     $name =~ tr{/}{_};

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -476,6 +476,18 @@ subtest 'body filter on dashboard' => sub {
     $mech->content_contains('<h1>' . $body->name . '</h1>', 'defaults to Bucks when body is not permitted');
 };
 
+subtest 'All reports pages for parishes' => sub {
+    $mech->get_ok('/reports/Buckinghamshire');
+    $mech->content_contains('View reports sent to parishes');
+
+    $mech->get_ok('/about/parishes');
+    $mech->content_contains('Adstock Parish Council');
+
+    $mech->get_ok('/reports/Adstock');
+    $mech->content_contains('Adstock Parish Council');
+    is $mech->uri->path, '/reports/Adstock';
+};
+
 };
 
 done_testing();

--- a/templates/web/buckinghamshire/about/parishes.html
+++ b/templates/web/buckinghamshire/about/parishes.html
@@ -1,0 +1,15 @@
+[% INCLUDE 'header.html', title = loc('All reports for parishes'), bodyclass = 'twothirdswidthpage' %]
+
+<h1>All reports for parishes</h1>
+
+<p><a href="/reports">&larr; Back to All reports for Buckinghamshire Council</a></p>
+
+<p>Choose a parish from the list below to view all reports for that parish.</p>
+
+[% FOREACH parish IN parishes %]
+
+<p><a href="/reports/[% c.cobrand.short_name(parish) %]">[% parish.name %]</a></p>
+
+[% END %]
+
+[% INCLUDE 'footer.html' %]

--- a/templates/web/buckinghamshire/reports/cobrand_stats.html
+++ b/templates/web/buckinghamshire/reports/cobrand_stats.html
@@ -1,0 +1,3 @@
+<div class="parish-all-reports">
+  <p><a class="btn-primary" href="/about/parishes">View reports sent to parishes</a></p>
+</div>

--- a/web/cobrands/buckinghamshire/base.scss
+++ b/web/cobrands/buckinghamshire/base.scss
@@ -151,4 +151,8 @@ label {
   border: none;
 }
 
+.parish-all-reports {
+  margin-top: 1em;
+}
+
 @import "../sass/claims";


### PR DESCRIPTION
This adds a new button to the Buckinghamshire "All reports" page which links to a static page listing all of the parishes with links to the individual parish pages.

Fixes https://github.com/mysociety/societyworks/issues/2939


https://user-images.githubusercontent.com/22996/157831159-5e8b1ec0-f4dc-4168-93a4-df011091115c.mov



[skip changelog]