### PR TITLE
[Buckinghamshire] Show the roads layer for grass cutting categories

### DIFF
--- a/.cypress/cypress/integration/buckinghamshire.js
+++ b/.cypress/cypress/integration/buckinghamshire.js
@@ -60,7 +60,9 @@ describe('buckinghamshire cobrand', function() {
     beforeEach(function() {
       cy.get('#map_box').click(290, 307);
       cy.wait('@report-ajax');
-      cy.pickCategory('Grass cutting');
+      cy.pickCategory('Grass, hedges and weeds');
+      cy.nextPageReporting();
+      cy.pickSubcategory('Grass hedges and weeds', 'Grass cutting');
       cy.wait('@around-ajax');
       cy.nextPageReporting();
     });
@@ -89,7 +91,7 @@ describe('buckinghamshire cobrand', function() {
 });
 
 describe('buckinghamshire roads handling', function() {
-  it('makes you move the pin if not on a road', function() {
+  beforeEach(function() {
     cy.server();
     cy.route('**mapserver/bucks*Whole_Street*', 'fixture:roads.xml').as('roads-layer');
     cy.route('/report/new/ajax*').as('report-ajax');
@@ -101,10 +103,22 @@ describe('buckinghamshire roads handling', function() {
     cy.get('#map_box').click(290, 307);
     cy.wait('@report-ajax');
     cy.get('#mob_ok').should('be.visible').click();
+  });
+
+  it('makes you move the pin if not on a road', function() {
     cy.pickCategory('Roads & Pavements');
     cy.wait('@roads-layer');
     cy.nextPageReporting();
     cy.pickSubcategory('Roads & Pavements', 'Parks');
+    cy.nextPageReporting();
+    cy.contains('Please select a road on which to make a report.').should('be.visible');
+  });
+
+  it('asks you to move the pin for grass cutting reports', function() {
+    cy.pickCategory('Grass, hedges and weeds');
+    cy.wait('@roads-layer');
+    cy.nextPageReporting();
+    cy.pickSubcategory('Grass hedges and weeds', 'Grass cutting');
     cy.nextPageReporting();
     cy.contains('Please select a road on which to make a report.').should('be.visible');
   });

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -115,7 +115,7 @@ if ($opt->test_fixtures) {
         { area_id => 2482, categories => ['Street Lighting and Road Signs'], name => 'Bromley Council' },
         { area_id => 2234, categories => ['Shelter Damaged', 'Very Urgent'], name => 'Northamptonshire Highways' },
         { area_id => 2217, categories => ['Flytipping', 'Roads', 'Parks', 'Snow and ice problem/winter salting', 'Grass cutting'], name => 'Buckinghamshire Council' },
-        { area_id => 53822, categories => [ 'Grass cutting' ], name => 'Adstock Parish Council' }, # Buckinghamshire parish council
+        { area_id => 53822, categories => [ 'Grass cutting', 'Hedge problem' ], name => 'Adstock Parish Council' }, # Buckinghamshire parish council
         { area_id => 2257, categories => ['Flytipping', 'Graffiti'], name => 'Chiltern District Council' },
         { area_id => 2397, categories => [ 'Graffiti' ], name => 'Northampton Borough Council' },
         { area_id => 2483, categories => [ 'Potholes', 'Other' ], name => 'Hounslow Borough Council' },
@@ -198,6 +198,13 @@ if ($opt->test_fixtures) {
     });
     $child_cat->update;
 
+    $child_cat = FixMyStreet::DB->resultset("Contact")->find({
+        body => $bodies->{2217},
+        category => 'Grass cutting',
+    });
+    $child_cat->set_extra_metadata(group => 'Grass, hedges and weeds');
+    $child_cat->update;
+
     for my $cat ('Parks', 'Snow and ice problem/winter salting') {
         $child_cat = FixMyStreet::DB->resultset("Contact")->find({
             body => $bodies->{2217},
@@ -244,6 +251,15 @@ if ($opt->test_fixtures) {
         ],
     });
     $child_cat->update;
+
+    for my $cat_name ('Grass cutting', 'Hedge problem') {
+        $child_cat = FixMyStreet::DB->resultset("Contact")->find({
+            body => $bodies->{53822},
+            category => $cat_name,
+        });
+        $child_cat->set_extra_metadata(group => 'Grass, hedges and weeds');
+        $child_cat->update;
+    }
 
     $child_cat = FixMyStreet::DB->resultset("Contact")->find({
         body => $bodies->{2483},

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -29,7 +29,7 @@ my @PLACES = (
     [ 'BS20 5EE', 51.496194, -2.603439, 2608, 'Borsetshire County Council', 'CTY', 148646, 'Bedminster', 'UTW' ],
     [ 'SL9 0NX', 51.615559, -0.556903, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED', 53822, 'Adstock', 'CPC' ],
     [ '?', 51.615499, -0.556667, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED', 53822, 'Adstock', 'CPC' ],
-    [ '?', 51.615965, -0.556367, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED' ],
+    [ '?', 51.615965, -0.556367, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED', 53822, 'Adstock', 'CPC' ],
     [ '?', 51.615439, -0.558362, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED' ],
     [ 'HP19 8FF', 51.822364, -0.826409, 2217, 'Buckinghamshire Council', 'CTY', 2258, 'Aylesbury Vale District Council', 'DIS', 144545, 'Gatehouse', 'DIW', 143444, 'Aylesbury North-West', 'CED' ],
     [ '?', 51.995, -0.986 , 2217, 'Buckinghamshire Council', 'CTY', 2258, 'Aylesbury Vale District Council', 'DIS', 144539, 'Buckingham South', 'DIW', 143424, 'Buckingham West', 'CED' ],

--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -372,7 +372,8 @@ fixmystreet.assets.add(defaults, {
         'Street Signs',
         'Traffic Lights and crossings',
         'Trees and vegetation',
-        'Trees'
+        'Trees',
+        'Grass, hedges and weeds'
     ],
     actions: {
         found: function(layer, feature) {
@@ -388,7 +389,17 @@ fixmystreet.assets.add(defaults, {
                 return false;
             }, msg_id);
         },
-        not_found: fixmystreet.message_controller.road_not_found
+        not_found: function(layer) {
+            fixmystreet.message_controller.road_not_found(layer, function() {
+                var selected = fixmystreet.reporting.selectedCategory();
+                if (selected.group == 'Grass, hedges and weeds') {
+                    // Want to always show the road not found message.
+                    // This skips the is_only_body check in road_not_found
+                    return true;
+                }
+                return false;
+            });
+        }
     },
     no_asset_msg_id: '#js-not-a-road',
     no_asset_msgs_class: '.js-roads-bucks',

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -1367,14 +1367,14 @@ fixmystreet.message_controller = (function() {
         // If a feature wasn't found at the location they've clicked, it's
         // probably a field or something. Show an error to that effect,
         // unless an asset is selected.
-        road_not_found: function(layer) {
+        road_not_found: function(layer, criterion) {
             // don't show the message if clicking on a National Highways road
             if (fixmystreet.body_overrides.get_only_send() == 'National Highways' || !layer.visibility) {
                 responsibility_off(layer, 'road');
             } else if (fixmystreet.assets.selectedFeature()) {
                 fixmystreet.body_overrides.allow_send(layer.fixmystreet.body);
                 responsibility_off(layer, 'road');
-            } else if (is_only_body(layer.fixmystreet.body)) {
+            } else if (is_only_body(layer.fixmystreet.body) || (criterion && criterion())) {
                 responsibility_on(layer, 'road');
             }
         },


### PR DESCRIPTION
This ensures that grass cutting reports are always made on a road.

Initially I tried simply adding the "Grass, hedges and weeds" category to the `asset_group` array, but that wasn't showing the stopper message because the `road_not_found` function checks for `is_single_body`, but there are actually two bodies in this case, Bucks and the parish, but we still want to show the stopper message. So I've added a `criterion` argument to `road_not_found` which the Bucks road layer then uses to always show the stopper message for the grass cutting categories.

Part of https://github.com/mysociety/societyworks/issues/2809

[skip changelog]