### PR TITLE
Add Cypress method for picking subcategories

### DIFF
--- a/.cypress/cypress/integration/bromley.js
+++ b/.cypress/cypress/integration/bromley.js
@@ -21,7 +21,7 @@ describe('Bromley cobrand', function() {
   it('does not display asset based upon extra question', function() {
     cy.pickCategory('Street Lighting and Road Signs');
     cy.nextPageReporting();
-    cy.pickSubcategory('Non-asset', '#form_service_sub_code');
+    cy.pickSubcatExtraInfo('Non-asset', '#form_service_sub_code');
     // https://stackoverflow.com/questions/47295287/cypress-io-assert-no-xhr-requests-to-url
     cy.on('fail', function(err) {
       expect(err.message).to.include('No request ever occurred.');
@@ -33,7 +33,7 @@ describe('Bromley cobrand', function() {
   it('displays assets based upon extra question', function() {
     cy.pickCategory('Street Lighting and Road Signs');
     cy.nextPageReporting();
-    cy.pickSubcategory('On in day', '#form_service_sub_code');
+    cy.pickSubcatExtraInfo('On in day', '#form_service_sub_code');
     cy.wait('@lights');
     cy.nextPageReporting();
     cy.get('.mobile-map-banner').should('be.visible');

--- a/.cypress/cypress/integration/buckinghamshire.js
+++ b/.cypress/cypress/integration/buckinghamshire.js
@@ -20,7 +20,7 @@ describe('buckinghamshire cobrand', function() {
     cy.pickCategory('Roads & Pavements');
     cy.wait('@roads-layer');
     cy.nextPageReporting();
-    cy.get('#subcategory_RoadsPavements label').contains('Parks').click();
+    cy.pickSubcategory('Roads & Pavements', 'Parks');
     cy.get('[name=site_code]').should('have.value', '7300268');
     cy.nextPageReporting();
     cy.contains('Photo').should('be.visible');
@@ -48,7 +48,7 @@ describe('buckinghamshire cobrand', function() {
     cy.pickCategory('Roads & Pavements');
     cy.wait('@roads-layer');
     cy.nextPageReporting();
-    cy.get('#subcategory_RoadsPavements label').contains('Snow and ice problem/winter salting').click();
+    cy.pickSubcategory('Roads & Pavements', 'Snow and ice problem/winter salting');
     cy.wait('@winter-routes');
     cy.nextPageReporting();
     cy.contains('The road you have selected is on a regular gritting route').should('be.visible');
@@ -72,7 +72,7 @@ describe('buckinghamshire roads handling', function() {
     cy.pickCategory('Roads & Pavements');
     cy.wait('@roads-layer');
     cy.nextPageReporting();
-    cy.get('#subcategory_RoadsPavements label').contains('Parks').click();
+    cy.pickSubcategory('Roads & Pavements', 'Parks');
     cy.nextPageReporting();
     cy.contains('Please select a road on which to make a report.').should('be.visible');
   });

--- a/.cypress/cypress/integration/highways.js
+++ b/.cypress/cypress/integration/highways.js
@@ -31,6 +31,6 @@ describe('National Highways tests', function() {
         cy.get('#js-councils_text').should('contain', 'National Highways');
         cy.get('#single_body_only').should('have.value', 'National Highways');
         cy.nextPageReporting();
-        cy.get('#subcategory_NationalHighways label').contains('Sign issue').click();
+        cy.pickSubcategory('National Highways', 'Sign issue');
     });
 });

--- a/.cypress/cypress/integration/regressions.js
+++ b/.cypress/cypress/integration/regressions.js
@@ -81,7 +81,7 @@ describe('Regression tests', function() {
       cy.wait('@report-ajax');
       cy.pickCategory('Licensing');
       cy.nextPageReporting();
-      cy.get('#subcategory_Licensing label').contains('Skips').click();
+      cy.pickSubcategory('Licensing', 'Skips');
       cy.nextPageReporting();
       cy.get('[name=start_date').type('2019-01-01');
       cy.nextPageReporting();

--- a/.cypress/cypress/integration/westminster.js
+++ b/.cypress/cypress/integration/westminster.js
@@ -19,7 +19,7 @@ describe('Westminster cobrand', function() {
     cy.pickCategory('Signs and bollards');
     cy.get('#form_USRN').should('have.value', 'USRN123');
     cy.nextPageReporting();
-    cy.pickSubcategory('Nameplates', '#form_featuretypecode');
+    cy.pickSubcatExtraInfo('Nameplates', '#form_featuretypecode');
     cy.wait('@nameplates');
     cy.nextPageReporting();
     cy.get('.mobile-map-banner').should('be.visible');
@@ -28,7 +28,7 @@ describe('Westminster cobrand', function() {
   it('checks UPRN fetching', function() {
     cy.pickCategory('Damaged, dirty, or missing bin');
     cy.nextPageReporting();
-    cy.pickSubcategory('Request new bin', '#form_bin_type');
+    cy.pickSubcatExtraInfo('Request new bin', '#form_bin_type');
     cy.wait('@uprn');
     cy.nextPageReporting();
     cy.get('.mobile-map-banner').should('be.visible');

--- a/.cypress/cypress/support/commands.js
+++ b/.cypress/cypress/support/commands.js
@@ -2,7 +2,10 @@
 Cypress.Commands.add('pickCategory', function(option) {
     cy.get('#form_category_fieldset label').contains(option).click();
 });
-Cypress.Commands.add('pickSubcategory', function(option, selector) {
+Cypress.Commands.add('pickSubcategory', function(categoryId, subCategory) {
+    cy.get('#subcategory_' + categoryId.replace(/[^a-zA-Z]+/g, '') + ' label').contains(subCategory).click();
+});
+Cypress.Commands.add('pickSubcatExtraInfo', function(option, selector) {
     cy.get(selector).select(option);
 });
 Cypress.Commands.add('nextPageReporting', function() {


### PR DESCRIPTION
This was originally part of https://github.com/mysociety/fixmystreet/pull/3832, and the code has already been reviewed, but I'm pulling it into a separate PR because I want to use the new pickSubcategory method in https://github.com/mysociety/fixmystreet/pull/3843.

There was already a `cy.pickSubcategory` method, but the name was misleading because it was actually picking a subcategory from within extra data, which isn't how most cobrands work.

This change renames the previous method to pickSubcatExtraInfo to more accurately reflect what it's doing, then the pickSubcategory method has been updated to actually pick a regular subcategory given a category ID and a subcategory label. I've also gone through and updated the obvious places where this pattern was being used to use the new method.

[skip changelog]
