### PR TITLE
Added "Can’t use the map? Skip this step." to report problem here

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -89,10 +89,10 @@ sub open311_extra_data_exclude {
 
 sub lookup_site_code_config { {
     buffer => 50, # metres
-    url => "https://tilma.mysociety.org/mapserver/peterborough",
-    srsname => "urn:ogc:def:crs:EPSG::27700",
-    typename => "highways",
-    property => "Usrn",
+    url => 'https://peterborough.assets/7/query?',
+    type => 'arcgis',
+    outFields => 'USRN',
+    property => "USRN",
     accept_feature => sub { 1 },
     accept_types => { Polygon => 1 },
 } }
@@ -181,12 +181,8 @@ sub get_body_sender {
                 my $road_features = $self->_fetch_features(
                     {
                         buffer => 1, # metres
-                        url => "https://tilma.mysociety.org/mapserver/peterborough",
-                        srsname => "urn:ogc:def:crs:EPSG::27700",
-                        typename => "highways",
-                        property => "Usrn",
-                        accept_feature => sub { 1 },
-                        accept_types => { Polygon => 1 },
+                        type => 'arcgis',
+                        url => 'https://peterborough.assets/7/query?',
                     },
                     $x,
                     $y,
@@ -290,6 +286,7 @@ sub _fetch_features_url {
             outSR => 3857,
             f => "geojson",
             geometry => $cfg->{bbox},
+            outFields => $cfg->{outFields},
         );
         return URI->new(
             'https://tilma.mysociety.org/resource-proxy/proxy.php?' .

--- a/t/cobrand/peterborough.t
+++ b/t/cobrand/peterborough.t
@@ -196,16 +196,13 @@ $mock->mock('_fetch_features', sub {
         # leased out council land
         } elsif ( $x == 552651 && $args->{url} =~ m{3/query} ) {
             return [ { geometry => { type => 'Point' } } ];
-        }
-
-        return [];
-    } else {
         # adopted roads
-        if ( $x == 552721 && $args->{url} =~ m{tilma} ) {
+        } elsif ( $x == 552721 && $args->{url} =~ m{7/query} ) {
             return [ { geometry => { type => 'Point' } } ];
         }
         return [];
     }
+    return [];
 });
 
 for my $test (

--- a/templates/web/base/report/new/fill_in_details_form.html
+++ b/templates/web/base/report/new/fill_in_details_form.html
@@ -5,9 +5,15 @@
 <fieldset>
     <div id="problem_form">
 
-[% IF report.used_map %]
+[% IF report.used_map;
+    url_skip = c.uri_for(
+        '/report/new',
+        { pc = pc, latitude = latitude, longitude = longitude, skipped = 1 }
+    );
+%]
     <ul class="change_location">
         <li class="change_location__map">[% loc('Click the map or drag the pin to adjust the location') %]</li>
+        <li class="screen-reader-only">[% tprintf( loc('Can’t use the map? <a href="%s" rel="nofollow">Skip this step.</a>'), url_skip) %]</li>
         <li class="change_location__search">[% loc('Or <a href="/">search for a different location</a>') %]</li>
     </ul>
 [% END %]

--- a/templates/web/peterborough/front/pre-steps.html
+++ b/templates/web/peterborough/front/pre-steps.html
@@ -1,8 +1,0 @@
-<p class="covid-banner">
-    <strong>Please note:</strong>
-    during the Coronavirus (COVID-19) pandemic it will not be possible for us to
-    action or respond to all reports within regular time-frames. While we are
-    working hard to ensure key services are maintained and focusing on high
-    priority issues, you can
-    <a href="https://www.peterborough.gov.uk/healthcare/public-health/coronavirus/coronavirus-covid-19-overview">find advice and information on our services online</a>.
-</p>

--- a/web/cobrands/peterborough/assets.js
+++ b/web/cobrands/peterborough/assets.js
@@ -35,6 +35,8 @@ var tilma_defaults = $.extend(true, {}, defaults, {
     geometryName: 'msGeometry'
 });
 
+var url_base = 'https://tilma.mysociety.org/resource-proxy/proxy.php?https://peterborough.assets/';
+
 var arcgis_defaults = $.extend(true, {}, defaults, {
     protocol_class: OpenLayers.Protocol.Peterborough,
     format_class: OpenLayers.Format.GeoJSON,
@@ -50,10 +52,11 @@ var arcgis_defaults = $.extend(true, {}, defaults, {
 
 var waste_categories = ['General fly tipping', 'Hazardous fly tipping', 'Offensive graffiti', 'Non offensive graffiti', 'Offensive graffiti - STAFF ONLY' ];
 
-fixmystreet.assets.add(tilma_defaults, {
+fixmystreet.assets.add(arcgis_defaults, {
     http_options: {
+        url: url_base + '7/query?',
         params: {
-            TYPENAME: "highways"
+            outFields: 'USRN',
         }
     },
     nearest_radius: 2,
@@ -61,7 +64,7 @@ fixmystreet.assets.add(tilma_defaults, {
     non_interactive: true,
     always_visible: true,
     usrn: {
-        attribute: 'Usrn',
+        attribute: 'USRN',
         field: 'site_code'
     },
     name: "Adopted Highways"
@@ -191,8 +194,6 @@ fixmystreet.assets.add(light_defaults, {
     disable_pin_snapping: true,
     asset_item_message: ''
 });
-
-var url_base = 'https://tilma.mysociety.org/resource-proxy/proxy.php?https://peterborough.assets/';
 
 var bin_defaults = $.extend(true, {}, arcgis_defaults, {
     http_options: {

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -224,6 +224,22 @@ a,
   margin: 0;
 }
 
+// Visible for screen readers only
+.screen-reader-only {
+  html.js & {
+    // If javascript is enabled, hide the skip link off-screen,
+    // but keep it visible for screen readers.
+    position: absolute;
+    top: -999px;
+
+    &:focus,
+    &:focus-within {
+      // And show it again if it receives focus (eg: via tab key)
+      position: static;
+    }
+  }
+}
+
 // custom type
 .small-print {
   @extend small;
@@ -2917,7 +2933,8 @@ a#geolocate_link {
   .click-the-map,
   .map-alternatives,
   .map-alternatives__display,
-  .my-account-buttons {
+  .my-account-buttons, 
+  .screen-reader-only {
     display: none !important;
   }
 


### PR DESCRIPTION
This PR fixes the issue where users that are on /around page then click on "Report a problem here" on the navigation bar, and there wasn't a "Can’t use the map? Skip this step." button (same that we have implemented on /report/new) causing accessibility issues.

This has been implemented across all cobrands.

This fixes part of: mysociety/societyworks#2787

<img width="461" alt="Screenshot 2022-03-16 at 11 35 52" src="https://user-images.githubusercontent.com/13790153/158581650-0e2bdcf2-46ff-4373-a121-a0f0cc764e67.png">

Do I need to updated the changelog?