### PR TITLE
[Buckinghamshire] Use hard-coded IDs when creating parishes

### DIFF
--- a/bin/buckinghamshire/create-parish-bodies
+++ b/bin/buckinghamshire/create-parish-bodies
@@ -14,6 +14,7 @@ BEGIN {    # set all the paths to the perl code
 
 use mySociety::MaPit;
 use FixMyStreet::DB;
+use FixMyStreet::Cobrand::Buckinghamshire;
 
 # Mapping for parishes that aren't called "$name Parish Council"
 # The key is the mapit name, value is the desired display name.
@@ -58,10 +59,8 @@ my $name_mappings = {
     'Wotton Underwood' => 'Wotton Underwood',
 };
 
-my $parent_id = "163793"; # Buckinghamshire Council Unitary Authority on Mapit
-
 # Fetch the list of parishes from MapIt
-my $mapit_areas = mySociety::MaPit::call('area', "$parent_id/children", type => 'CPC');
+my $mapit_areas = mySociety::MaPit::call('areas', FixMyStreet::Cobrand::Buckinghamshire::_parish_ids);
 my @areas = values %$mapit_areas;
 
 my $db = FixMyStreet::DB->schema->storage;


### PR DESCRIPTION
Previously this was looking up the list of children for the Unitary authority, but this meant that the parishes created were slightly different to the list of parishes in the "Areas covered" dropdown because the dropdown uses the hard-coded list of parishes in the cobrand.

The impact of this is that "Bierton Parish Council" wasn't associated with an area, because the area ID for the new "Bierton" is different to the one in the `_parish_ids` list in Buckinghamshire.pm.

This changes the create-parish-bodies script to use the same list of parish IDs that's used elsewhere, rather than deriving a list from the area children.

Part of https://github.com/mysociety/societyworks/issues/2938

[skip changelog]