### PR TITLE
[Bromley] Don’t protect title dropdown field for staff

### DIFF
--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -102,7 +102,6 @@ fixmystreet.staff_set_up = {
         var $phoneInput = $('input[name=phone]');
         var $showNameCheckbox = $('input[name=may_show_name]');
         var $addAlertCheckbox = $('#form_add_alert');
-        var $extraTitle = $('select#form_fms_extra_title'); // May not be present
         if (val === 'myself') {
             $emailInput.val($emailInput.prop('defaultValue')).prop('disabled', true);
             $emailOptionalLabel.addClass('hidden');
@@ -110,7 +109,6 @@ fixmystreet.staff_set_up = {
             $phoneInput.val($phoneInput.prop('defaultValue')).prop('disabled', true);
             $showNameCheckbox.prop('checked', false).prop('disabled', false);
             $addAlertCheckbox.prop('checked', true).prop('disabled', false);
-            $extraTitle.prop('disabled', true);
         } else if (val === 'another_user') {
             $emailInput.val('').prop('disabled', false);
             if (!$phoneInput.length) {
@@ -125,7 +123,6 @@ fixmystreet.staff_set_up = {
             $phoneInput.val('').prop('disabled', false);
             $showNameCheckbox.prop('checked', false).prop('disabled', true);
             $addAlertCheckbox.prop('checked', true).prop('disabled', false);
-            $extraTitle.prop('disabled', false);
         } else if (val === 'anonymous_user') {
             $emailInput.val('-').prop('disabled', true);
             $emailOptionalLabel.addClass('hidden');
@@ -133,7 +130,6 @@ fixmystreet.staff_set_up = {
             $phoneInput.val('-').prop('disabled', true);
             $showNameCheckbox.prop('checked', false).prop('disabled', true);
             $addAlertCheckbox.prop('checked', false).prop('disabled', true);
-            $extraTitle.prop('disabled', true);
         } else if (val === 'body') {
             $emailInput.val('-').prop('disabled', true);
             $emailOptionalLabel.addClass('hidden');
@@ -141,7 +137,6 @@ fixmystreet.staff_set_up = {
             $phoneInput.val('-').prop('disabled', true);
             $showNameCheckbox.prop('checked', true).prop('disabled', true);
             $addAlertCheckbox.prop('checked', false).prop('disabled', true);
-            $extraTitle.prop('disabled', true);
         }
     });
     $('.js-contribute-as').trigger('change');


### PR DESCRIPTION
This was causing issues because setting `disabled` seemed to stop UAs submitting any value for the title field, which is required for Bromley reports.
`readonly` can’t be used with <select> elements, so just drop these lines entirely.

[skip changelog]