### PR TITLE
[Buckinghamshire] Remove text about emailing reference number

### DIFF
--- a/.cypress/cypress/integration/buckinghamshire.js
+++ b/.cypress/cypress/integration/buckinghamshire.js
@@ -60,7 +60,9 @@ describe('buckinghamshire cobrand', function() {
     beforeEach(function() {
       cy.get('#map_box').click(290, 307);
       cy.wait('@report-ajax');
-      cy.pickCategory('Grass cutting');
+      cy.pickCategory('Grass, hedges and weeds');
+      cy.nextPageReporting();
+      cy.pickSubcategory('Grass hedges and weeds', 'Grass cutting');
       cy.wait('@around-ajax');
       cy.nextPageReporting();
     });
@@ -89,7 +91,7 @@ describe('buckinghamshire cobrand', function() {
 });
 
 describe('buckinghamshire roads handling', function() {
-  it('makes you move the pin if not on a road', function() {
+  beforeEach(function() {
     cy.server();
     cy.route('**mapserver/bucks*Whole_Street*', 'fixture:roads.xml').as('roads-layer');
     cy.route('/report/new/ajax*').as('report-ajax');
@@ -101,10 +103,22 @@ describe('buckinghamshire roads handling', function() {
     cy.get('#map_box').click(290, 307);
     cy.wait('@report-ajax');
     cy.get('#mob_ok').should('be.visible').click();
+  });
+
+  it('makes you move the pin if not on a road', function() {
     cy.pickCategory('Roads & Pavements');
     cy.wait('@roads-layer');
     cy.nextPageReporting();
     cy.pickSubcategory('Roads & Pavements', 'Parks');
+    cy.nextPageReporting();
+    cy.contains('Please select a road on which to make a report.').should('be.visible');
+  });
+
+  it('asks you to move the pin for grass cutting reports', function() {
+    cy.pickCategory('Grass, hedges and weeds');
+    cy.wait('@roads-layer');
+    cy.nextPageReporting();
+    cy.pickSubcategory('Grass hedges and weeds', 'Grass cutting');
     cy.nextPageReporting();
     cy.contains('Please select a road on which to make a report.').should('be.visible');
   });

--- a/.cypress/cypress/integration/buckinghamshire.js
+++ b/.cypress/cypress/integration/buckinghamshire.js
@@ -54,6 +54,38 @@ describe('buckinghamshire cobrand', function() {
     cy.contains('The road you have selected is on a regular gritting route').should('be.visible');
   });
 
+  describe("Parish grass cutting category speed limit question", function() {
+    var speedGreaterThan30 = '#form_speed_limit_greater_than_30';
+
+    beforeEach(function() {
+      cy.get('#map_box').click(290, 307);
+      cy.wait('@report-ajax');
+      cy.pickCategory('Grass cutting');
+      cy.wait('@around-ajax');
+      cy.nextPageReporting();
+    });
+
+    it('displays the parish name if answer is "no"', function() {
+      cy.get(speedGreaterThan30).select('no');
+      cy.nextPageReporting();
+      cy.nextPageReporting();
+      cy.contains('sent to Adstock Parish Council and also published online').should('be.visible');
+    });
+
+    it('displays the council name if answer is "yes"', function() {
+      cy.get(speedGreaterThan30).select('yes');
+      cy.nextPageReporting();
+      cy.nextPageReporting();
+      cy.contains('sent to Buckinghamshire Council and also published online').should('be.visible');
+    });
+
+    it('displays the council name if answer is "dont_know"', function() {
+      cy.get(speedGreaterThan30).select('dont_know');
+      cy.nextPageReporting();
+      cy.nextPageReporting();
+      cy.contains('sent to Buckinghamshire Council and also published online').should('be.visible');
+    });
+  });
 });
 
 describe('buckinghamshire roads handling', function() {

--- a/bin/buckinghamshire/add-parish-categories
+++ b/bin/buckinghamshire/add-parish-categories
@@ -31,8 +31,8 @@ my $contacts = [
         },
         extra_fields => [
             {
-                code => 'speed_limit',
-                description => 'Is the speed limit on this road 40mph or greater?',
+                code => 'speed_limit_greater_than_30',
+                description => 'Is the speed limit greater than 30mph?',
                 datatype => 'singlevaluelist',
                 order => 1,
                 variable => 'true',

--- a/bin/buckinghamshire/add-parish-categories
+++ b/bin/buckinghamshire/add-parish-categories
@@ -80,26 +80,13 @@ $db->txn_do(sub {
     # Create categories for parishes.
     foreach my $parish (@parishes) {
         foreach my $contact (@$contacts) {
-            my $contact_rs = FixMyStreet::DB->resultset('Contact')->search({
+            my $new_contact = FixMyStreet::DB->resultset('Contact')->find_or_new({
                 body_id => $parish->{body}->id,
                 category => $contact->{category},
             });
 
-            if ($contact_rs->count > 0) {
-                print "Existing contact found...skipping\n";
-                next;
-            }
-
-            print "Creating category $contact->{category} for $parish->{name}...";
-
-            my $new_contact = $contact_rs->create_with_note(
-                "created automatically by script",
-                basename($0),
-                {
-                    email => $parish->{email},
-                    state => 'confirmed',
-                }
-            );
+            $new_contact->email($parish->{email});
+            $new_contact->state('confirmed');
 
             if ($contact->{extra_metadata}) {
                 $new_contact->set_extra_metadata(%{$contact->{extra_metadata}});
@@ -109,9 +96,12 @@ $db->txn_do(sub {
                 $new_contact->set_extra_fields(@{$contact->{extra_fields}});
             }
 
-            $new_contact->update;
+            my $action = $new_contact->in_storage ? 'Updated' : 'Created';
 
-            print "done\n";
+            $new_contact->add_note("$action by script", basename($0));
+            $new_contact->update_or_insert;
+
+            print "$action $contact->{category} for $parish->{name}\n";
         }
 
         # Make sure body has correct send method and isn't marked as deleted

--- a/bin/buckinghamshire/create-parish-bodies
+++ b/bin/buckinghamshire/create-parish-bodies
@@ -14,6 +14,7 @@ BEGIN {    # set all the paths to the perl code
 
 use mySociety::MaPit;
 use FixMyStreet::DB;
+use FixMyStreet::Cobrand::Buckinghamshire;
 
 # Mapping for parishes that aren't called "$name Parish Council"
 # The key is the mapit name, value is the desired display name.
@@ -58,10 +59,8 @@ my $name_mappings = {
     'Wotton Underwood' => 'Wotton Underwood',
 };
 
-my $parent_id = "163793"; # Buckinghamshire Council Unitary Authority on Mapit
-
 # Fetch the list of parishes from MapIt
-my $mapit_areas = mySociety::MaPit::call('area', "$parent_id/children", type => 'CPC');
+my $mapit_areas = mySociety::MaPit::call('areas', FixMyStreet::Cobrand::Buckinghamshire::_parish_ids);
 my @areas = values %$mapit_areas;
 
 my $db = FixMyStreet::DB->schema->storage;

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -114,7 +114,8 @@ if ($opt->test_fixtures) {
         { area_id => 2504, categories => ['Damaged, dirty, or missing bin', 'Signs and bollards', 'Busking and Street performance'], name => 'Westminster City Council' },
         { area_id => 2482, categories => ['Street Lighting and Road Signs'], name => 'Bromley Council' },
         { area_id => 2234, categories => ['Shelter Damaged', 'Very Urgent'], name => 'Northamptonshire Highways' },
-        { area_id => 2217, categories => ['Flytipping', 'Roads', 'Parks', 'Snow and ice problem/winter salting'], name => 'Buckinghamshire Council' },
+        { area_id => 2217, categories => ['Flytipping', 'Roads', 'Parks', 'Snow and ice problem/winter salting', 'Grass cutting'], name => 'Buckinghamshire Council' },
+        { area_id => 53822, categories => [ 'Grass cutting' ], name => 'Adstock Parish Council' }, # Buckinghamshire parish council
         { area_id => 2257, categories => ['Flytipping', 'Graffiti'], name => 'Chiltern District Council' },
         { area_id => 2397, categories => [ 'Graffiti' ], name => 'Northampton Borough Council' },
         { area_id => 2483, categories => [ 'Potholes', 'Other' ], name => 'Hounslow Borough Council' },
@@ -214,6 +215,35 @@ if ($opt->test_fixtures) {
         $child_cat->set_extra_metadata(group => 'Roads & Pavements');
         $child_cat->update;
     }
+
+    $child_cat = FixMyStreet::DB->resultset("Contact")->find({
+        body => $bodies->{53822},
+        category => 'Grass cutting',
+    });
+    $child_cat->set_extra_fields({
+        code => 'speed_limit_greater_than_30',
+        description => 'Is the speed limit greater than 30mph?',
+        datatype => 'singlevaluelist',
+        order => 1,
+        variable => 'true',
+        required => 'true',
+        protected => 'false',
+        values => [
+            {
+                key => 'yes',
+                name => 'Yes',
+            },
+            {
+                key => 'no',
+                name => 'No',
+            },
+            {
+                key => 'dont_know',
+                name => "Don't know",
+            },
+        ],
+    });
+    $child_cat->update;
 
     $child_cat = FixMyStreet::DB->resultset("Contact")->find({
         body => $bodies->{2483},

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -115,7 +115,7 @@ if ($opt->test_fixtures) {
         { area_id => 2482, categories => ['Street Lighting and Road Signs'], name => 'Bromley Council' },
         { area_id => 2234, categories => ['Shelter Damaged', 'Very Urgent'], name => 'Northamptonshire Highways' },
         { area_id => 2217, categories => ['Flytipping', 'Roads', 'Parks', 'Snow and ice problem/winter salting', 'Grass cutting'], name => 'Buckinghamshire Council' },
-        { area_id => 53822, categories => [ 'Grass cutting' ], name => 'Adstock Parish Council' }, # Buckinghamshire parish council
+        { area_id => 53822, categories => [ 'Grass cutting', 'Hedge problem' ], name => 'Adstock Parish Council' }, # Buckinghamshire parish council
         { area_id => 2257, categories => ['Flytipping', 'Graffiti'], name => 'Chiltern District Council' },
         { area_id => 2397, categories => [ 'Graffiti' ], name => 'Northampton Borough Council' },
         { area_id => 2483, categories => [ 'Potholes', 'Other' ], name => 'Hounslow Borough Council' },
@@ -198,6 +198,13 @@ if ($opt->test_fixtures) {
     });
     $child_cat->update;
 
+    $child_cat = FixMyStreet::DB->resultset("Contact")->find({
+        body => $bodies->{2217},
+        category => 'Grass cutting',
+    });
+    $child_cat->set_extra_metadata(group => 'Grass, hedges and weeds');
+    $child_cat->update;
+
     for my $cat ('Parks', 'Snow and ice problem/winter salting') {
         $child_cat = FixMyStreet::DB->resultset("Contact")->find({
             body => $bodies->{2217},
@@ -244,6 +251,15 @@ if ($opt->test_fixtures) {
         ],
     });
     $child_cat->update;
+
+    for my $cat_name ('Grass cutting', 'Hedge problem') {
+        $child_cat = FixMyStreet::DB->resultset("Contact")->find({
+            body => $bodies->{53822},
+            category => $cat_name,
+        });
+        $child_cat->set_extra_metadata(group => 'Grass, hedges and weeds');
+        $child_cat->update;
+    }
 
     $child_cat = FixMyStreet::DB->resultset("Contact")->find({
         body => $bodies->{2483},

--- a/perllib/FixMyStreet/App/Controller/Dashboard.pm
+++ b/perllib/FixMyStreet/App/Controller/Dashboard.pm
@@ -81,6 +81,16 @@ sub check_page_allowed : Private {
         }
     } elsif ($c->user->from_body && (!$cobrand_body || $cobrand_body->id == $c->user->from_body->id)) {
         $body = $c->user->from_body;
+
+        my @extra_bodies = $c->cobrand->call_hook('dashboard_extra_bodies');
+        if (@extra_bodies) {
+            $c->stash->{default_body} = $c->user->from_body;
+            $c->stash->{extra_bodies} = \@extra_bodies;
+            if ($c->get_param('body')) {
+                my @found = grep { $_->id == $c->get_param('body') } @extra_bodies;
+                $body = $found[0] if @found;
+            }
+        }
     } elsif ($c->action eq 'dashboard/heatmap' && $c->cobrand->feature('heatmap_dashboard_body')) {
         # Heatmap might be able to be seen by more people
         $body = $c->cobrand->call_hook('dashboard_body');

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1139,7 +1139,7 @@ sub process_report : Private {
             } else {
                 my $contact_options = {};
                 $contact_options->{do_not_send} = [ $c->get_param_list('do_not_send', 1) ];
-                my $bodies = $c->forward('contacts_to_bodies', [ $report->category, $contact_options ]);
+                my $bodies = $c->forward('contacts_to_bodies', [ $report, $contact_options ]);
                 join(',', map { $_->id } @$bodies) || '-1';
             }
         };
@@ -1198,8 +1198,9 @@ sub process_report : Private {
 }
 
 sub contacts_to_bodies : Private {
-    my ($self, $c, $category, $options) = @_;
+    my ($self, $c, $report, $options) = @_;
 
+    my $category = $report->category;
     my @contacts = grep { $_->category eq $category } @{$c->stash->{contacts}};
 
     # If there are multiple contacts for different bodies then the default
@@ -1231,6 +1232,9 @@ sub contacts_to_bodies : Private {
             @contacts = ($contacts[0]);
         }
     }
+
+    $c->cobrand->call_hook(munge_contacts_to_bodies => \@contacts, $report);
+
     [ map { $_->body } @contacts ];
 }
 

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -694,12 +694,15 @@ sub munge_contacts_to_bodies {
     my $greater_than_30 = $report->get_extra_field_value('speed_limit_greater_than_30');
     return unless $greater_than_30;
 
+    # This is called from FixMyStreet.pm as well, so avoid $self.
+    my $area_id = FixMyStreet::Cobrand::Buckinghamshire::council_area_id;
+
     if ($greater_than_30 eq 'no') {
         # Route to the parish
-        @$contacts = grep { !$_->body->areas->{$self->council_area_id} } @$contacts;
+        @$contacts = grep { !$_->body->areas->{$area_id} } @$contacts;
     } else {
         # Route to council
-        @$contacts = grep { $_->body->areas->{$self->council_area_id} } @$contacts;
+        @$contacts = grep { $_->body->areas->{$area_id} } @$contacts;
     }
 }
 

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -187,6 +187,12 @@ sub dashboard_export_problems_add_columns {
     shift->_dashboard_export_add_columns(@_);
 }
 
+sub dashboard_extra_bodies {
+    my ($self) = @_;
+
+    return $self->parish_bodies->all;
+}
+
 sub _parish_ids {
     # This is a list of all Parish Councils within Buckinghamshire,
     # taken from https://mapit.mysociety.org/area/2217/covers.json?type=CPC
@@ -703,14 +709,20 @@ sub area_ids_for_problems {
     return ($self->council_area_id, @{$self->_parish_ids});
 }
 
+sub parish_bodies {
+    my ($self) = @_;
+
+    return FixMyStreet::DB->resultset('Body')->search(
+        { 'body_areas.area_id' => $self->_parish_ids, },
+        { join => 'body_areas', order_by => 'name' }
+    )->active;
+}
+
 # Show parish problems on the cobrand.
 sub problems_restriction_bodies {
     my ($self) = @_;
 
-    my @parishes = FixMyStreet::DB->resultset('Body')->search(
-        { 'body_areas.area_id' => $self->_parish_ids, },
-        { join => 'body_areas' }
-    )->all;
+    my @parishes = $self->parish_bodies->all;
     my @parish_ids = map { $_->id } @parishes;
 
     return [$self->body->id, @parish_ids];

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -670,4 +670,23 @@ around 'report_validation' => sub {
     return $self->$orig($report, $errors);
 };
 
+# Route grass cutting reports to the parish if the user answers 'no' to the
+# question 'Is the speed limit on this road 30mph or greater?'
+sub munge_contacts_to_bodies {
+    my ($self, $contacts, $report) = @_;
+
+    return unless $report->category eq 'Grass cutting';
+
+    my $greater_than_30 = $report->get_extra_field_value('speed_limit_greater_than_30');
+    return unless $greater_than_30;
+
+    if ($greater_than_30 eq 'no') {
+        # Route to the parish
+        @$contacts = grep { !$_->body->areas->{$self->council_area_id} } @$contacts;
+    } else {
+        # Route to council
+        @$contacts = grep { $_->body->areas->{$self->council_area_id} } @$contacts;
+    }
+}
+
 1;

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -713,7 +713,7 @@ sub parish_bodies {
     my ($self) = @_;
 
     return FixMyStreet::DB->resultset('Body')->search(
-        { 'body_areas.area_id' => $self->_parish_ids, },
+        { 'body_areas.area_id' => { -in => $self->_parish_ids } },
         { join => 'body_areas', order_by => 'name' }
     )->active;
 }

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -728,4 +728,36 @@ sub problems_restriction_bodies {
     return [$self->body->id, @parish_ids];
 }
 
+# Redirect to .com if not Bucks or a parish
+sub reports_body_check {
+    my ( $self, $c, $code ) = @_;
+
+    my @parishes = $self->parish_bodies->all;
+    my @bodies = ($self->body, @parishes);
+    my $matched = 0;
+    foreach my $body (@bodies) {
+        if ( $body->name =~ /^\Q$code\E/ ) {
+            $matched = 1;
+            last;
+        }
+    }
+
+    if (!$matched) {
+        $c->res->redirect( 'https://www.fixmystreet.com' . $c->req->uri->path_query, 301 );
+        $c->detach();
+    }
+
+    return;
+}
+
+sub about_hook {
+    my ($self) = @_;
+
+    my $c = $self->{c};
+    if ($c->stash->{template} eq 'about/parishes.html') {
+        my @parishes = $self->parish_bodies->all;
+        $c->stash->{parishes} = \@parishes;
+    }
+}
+
 1;

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -763,4 +763,14 @@ sub about_hook {
     }
 }
 
+sub parish_problem {
+    my ($self, $report) = @_;
+
+    my @contacts = $report->contacts;
+    foreach my $contact (@contacts) {
+        return 1 if $contact->sent_by_open311;
+    }
+    return 0;
+}
+
 1;

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -395,6 +395,13 @@ sub report_new_munge_before_insert {
     FixMyStreet::Cobrand::Merton::report_new_munge_before_insert($self, $report);
 }
 
+sub munge_contacts_to_bodies {
+    my ($self, $contacts, $report) = @_;
+
+    # Make sure Bucks grass cutting reports are routed correctly
+    FixMyStreet::Cobrand::Buckinghamshire::munge_contacts_to_bodies($self, $contacts, $report);
+}
+
 around 'munge_sendreport_params' => sub {
     my ($orig, $self, $row, $h, $params) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -425,4 +425,17 @@ sub reopening_disallowed {
     return $self->next::method($problem);
 }
 
+# Make sure CPC areas are included in point lookups for new reports
+# This is so that parish bodies (e.g. in Buckinghamshire) are available
+# for reporting to on .com
+sub add_extra_area_types {
+    my ($self, $types) = @_;
+
+    my @types = (
+        @$types,
+        'CPC',
+    );
+    return \@types;
+}
+
 1;

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -117,7 +117,7 @@ sub short_name {
     return 'Durham+City' if $name eq 'Durham City Council';
 
     $name =~ s/^(Royal|London) Borough of //;
-    $name =~ s/ (Borough|City|District|County) Council$//;
+    $name =~ s/ (Borough|City|District|County|Parish|Town) Council$//;
     $name =~ s/ Council$//;
     $name =~ s/ & / and /;
     $name =~ tr{/}{_};

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -63,7 +63,13 @@ sub cut_off_date { '' }
 sub problems_restriction {
     my ($self, $rs) = @_;
     return $rs if FixMyStreet->staging_flag('skip_checks');
-    $rs = $rs->to_body($self->body);
+
+    my $bodies = $self->body;
+    if ($self->can('problems_restriction_bodies')) {
+        $bodies = $self->problems_restriction_bodies;
+    }
+    $rs = $rs->to_body($bodies);
+
     if (my $date = $self->cut_off_date) {
         my $table = ref $rs eq 'FixMyStreet::DB::ResultSet::Nearby' ? 'problem' : 'me';
         $rs = $rs->search({
@@ -230,6 +236,12 @@ sub recent_photos {
     return $self->problems->recent_photos( $num, $lat, $lon, $dist );
 }
 
+sub area_ids_for_problems {
+    my ($self) = @_;
+
+    return $self->council_area_id;
+}
+
 # Returns true if the cobrand owns the problem.
 sub owns_problem {
     my ($self, $report) = @_;
@@ -243,7 +255,10 @@ sub owns_problem {
     }
     # Want to ignore the TfL body that covers London councils, and HE that is all England
     my %areas = map { %{$_->areas} } grep { $_->name !~ /TfL|National Highways/ } @bodies;
-    return $areas{$self->council_area_id} ? 1 : undef;
+
+    foreach my $area_id ($self->area_ids_for_problems) {
+        return 1 if $areas{$area_id};
+    }
 }
 
 # If the council is two-tier, or e.g. TfL reports,

--- a/perllib/FixMyStreet/DB/Result/Contact.pm
+++ b/perllib/FixMyStreet/DB/Result/Contact.pm
@@ -204,4 +204,12 @@ sub category_uneditable {
     return 0;
 }
 
+sub add_note {
+  my ( $self, $note, $editor ) = @_;
+
+    $self->note($note);
+    $self->editor($editor);
+    $self->whenedited(\'current_timestamp');
+}
+
 1;

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -29,7 +29,7 @@ my @PLACES = (
     [ 'BS20 5EE', 51.496194, -2.603439, 2608, 'Borsetshire County Council', 'CTY', 148646, 'Bedminster', 'UTW' ],
     [ 'SL9 0NX', 51.615559, -0.556903, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED', 53822, 'Adstock', 'CPC' ],
     [ '?', 51.615499, -0.556667, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED', 53822, 'Adstock', 'CPC' ],
-    [ '?', 51.615965, -0.556367, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED' ],
+    [ '?', 51.615965, -0.556367, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED', 53822, 'Adstock', 'CPC' ],
     [ '?', 51.615439, -0.558362, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED' ],
     [ 'HP19 8FF', 51.822364, -0.826409, 2217, 'Buckinghamshire Council', 'CTY', 2258, 'Aylesbury Vale District Council', 'DIS', 144545, 'Gatehouse', 'DIW', 143444, 'Aylesbury North-West', 'CED' ],
     [ '?', 51.995, -0.986 , 2217, 'Buckinghamshire Council', 'CTY', 2258, 'Aylesbury Vale District Council', 'DIS', 144539, 'Buckingham South', 'DIW', 143424, 'Buckingham West', 'CED' ],

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -27,7 +27,7 @@ my @PLACES = (
     [ 'EH1 1BB', 55.952055, -3.189579, 2651, 'Edinburgh City Council', 'UTA', 20728, 'City Centre', 'UTE' ],
     [ 'BS10 5EE', 51.494885, -2.602237, 2561, 'Bristol City Council', 'UTA', 148646, 'Bedminster', 'UTW' ],
     [ 'BS20 5EE', 51.496194, -2.603439, 2608, 'Borsetshire County Council', 'CTY', 148646, 'Bedminster', 'UTW' ],
-    [ 'SL9 0NX', 51.615559, -0.556903, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED' ],
+    [ 'SL9 0NX', 51.615559, -0.556903, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED', 53822, 'Adstock', 'CPC' ],
     [ '?', 51.615499, -0.556667, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED' ],
     [ '?', 51.615965, -0.556367, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED' ],
     [ '?', 51.615439, -0.558362, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED' ],

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -28,7 +28,7 @@ my @PLACES = (
     [ 'BS10 5EE', 51.494885, -2.602237, 2561, 'Bristol City Council', 'UTA', 148646, 'Bedminster', 'UTW' ],
     [ 'BS20 5EE', 51.496194, -2.603439, 2608, 'Borsetshire County Council', 'CTY', 148646, 'Bedminster', 'UTW' ],
     [ 'SL9 0NX', 51.615559, -0.556903, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED', 53822, 'Adstock', 'CPC' ],
-    [ '?', 51.615499, -0.556667, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED' ],
+    [ '?', 51.615499, -0.556667, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED', 53822, 'Adstock', 'CPC' ],
     [ '?', 51.615965, -0.556367, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED' ],
     [ '?', 51.615439, -0.558362, 2217, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED' ],
     [ 'HP19 8FF', 51.822364, -0.826409, 2217, 'Buckinghamshire Council', 'CTY', 2258, 'Aylesbury Vale District Council', 'DIS', 144545, 'Gatehouse', 'DIW', 143444, 'Aylesbury North-West', 'CED' ],

--- a/t/app/controller/contact.t
+++ b/t/app/controller/contact.t
@@ -535,7 +535,9 @@ for my $test (
         FixMyStreet::override_config {
             ALLOWED_COBRANDS => [ 'buckinghamshire' ],
         }, sub {
-            $mech->get_ok( '/contact?id=' . $problem_main->id, 'can visit for abuse report' );
+            my $bucks = $mech->create_body_ok(2217, 'Buckinghamshire Council');
+            my ($problem) = $mech->create_problems_for_body(1, $bucks->id, 'Test');
+            $mech->get_ok( '/contact?id=' . $problem->id, 'can visit for abuse report' );
             $mech->submit_form_ok( { with_fields => $test->{fields} } );
             is_deeply $mech->page_errors, $test->{page_errors}, 'page errors';
 

--- a/t/app/model/contact.t
+++ b/t/app/model/contact.t
@@ -1,0 +1,17 @@
+use FixMyStreet::Test;
+
+subtest 'add_note() updates note, editor and whenedited', sub {
+    my $contact = FixMyStreet::DB->resultset('Contact')->new({ category => 'Pothole' });
+
+    is $contact->note, undef, 'note starts as empty';
+    is $contact->editor, undef, 'editor starts as empty';
+    is $contact->whenedited, undef, 'whenedited starts as empty';
+
+    $contact->add_note('Test note', 'Mr Tester');
+
+    is $contact->note, 'Test note', 'note is correct';
+    is $contact->editor, 'Mr Tester', 'editor is correct';
+    isnt $contact->whenedited, undef, 'whenedited is set';
+};
+
+done_testing();

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -10,6 +10,7 @@ END { FixMyStreet::App->log->enable('info'); }
 
 my $body = $mech->create_body_ok(2217, 'Buckinghamshire', {
     send_method => 'Open311', api_key => 'key', endpoint => 'endpoint', jurisdiction => 'fms', can_be_devolved => 1 });
+my $parish = $mech->create_body_ok(53822, 'Adstock Parish Council');
 my $counciluser = $mech->create_user_ok('counciluser@example.com', name => 'Council User', from_body => $body);
 my $publicuser = $mech->create_user_ok('fmsuser@example.org', name => 'Simon Neil');
 
@@ -33,6 +34,34 @@ $mech->create_contact_ok(body_id => $body->id, category => 'Car Parks', email =>
 $mech->create_contact_ok(body_id => $body->id, category => 'Graffiti', email => "graffiti\@chiltern", send_method => 'Email');
 $mech->create_contact_ok(body_id => $body->id, category => 'Flytipping (off-road)', email => "districts_flytipping", send_method => 'Email');
 $mech->create_contact_ok(body_id => $body->id, category => 'Barrier problem', email => 'parking@example.org', send_method => 'Email', group => 'Car park issue');
+$mech->create_contact_ok(body_id => $body->id, category => 'Grass cutting', email => 'grass@example.org', send_method => 'Email');
+
+# Create another Grass cutting category for a parish.
+$contact = $mech->create_contact_ok(body_id => $parish->id, category => 'Grass cutting', email => 'grass@example.org', send_method => 'Email');
+$contact->set_extra_fields({
+    code => 'speed_limit_greater_than_30',
+    description => 'Is the speed limit on this road 30mph or greater?',
+    datatype => 'singlevaluelist',
+    order => 1,
+    variable => 'true',
+    required => 'true',
+    protected => 'false',
+    values => [
+        {
+            key => 'yes',
+            name => 'Yes',
+        },
+        {
+            key => 'no',
+            name => 'No',
+        },
+        {
+            key => 'dont_know',
+            name => "Don't know",
+        },
+    ],
+});
+$contact->update;
 
 my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Buckinghamshire');
 $cobrand->mock('lookup_site_code', sub {
@@ -69,14 +98,15 @@ subtest 'cobrand displays council name' => sub {
 
 subtest 'cobrand displays correct categories' => sub {
     my $json = $mech->get_ok_json('/report/new/ajax?latitude=51.615559&longitude=-0.556903');
-    is @{$json->{bodies}}, 1, 'Bucks returned';
+    is @{$json->{bodies}}, 2, 'Bucks and parish returned';
     like $json->{category}, qr/Car Parks/, 'Car Parks displayed';
     like $json->{category}, qr/Flytipping/, 'Flytipping displayed';
     like $json->{category}, qr/Blocked drain/, 'Blocked drain displayed';
     like $json->{category}, qr/Graffiti/, 'Graffiti displayed';
+    like $json->{category}, qr/Grass cutting/, 'Grass cutting displayed';
     unlike $json->{category}, qr/Flytipping \(off-road\)/, 'Flytipping (off-road) not displayed';
     $json = $mech->get_ok_json('/report/new/category_extras?latitude=51.615559&longitude=-0.556903');
-    is @{$json->{bodies}}, 1, 'Still Bucks returned';
+    is @{$json->{bodies}}, 2, 'Still Bucks and parish returned';
 };
 
 my ($report) = $mech->create_problems_for_body(1, $body->id, 'On Road', {
@@ -374,6 +404,40 @@ subtest 'Allows car park reports to be made in a car park' => sub {
         }
     }, "submit details");
     $mech->content_contains('Your issue is on its way to the council');
+};
+
+subtest 'sends grass cutting reports on roads under 30mph to the parish' => sub {
+    $mech->get_ok('/report/new?latitude=51.615559&longitude=-0.556903&category=Grass+cutting');
+    $mech->submit_form_ok({
+        with_fields => {
+            title => "Test grass cutting report 1",
+            detail => 'Test report details.',
+            category => 'Grass cutting',
+            speed_limit_greater_than_30 => 'no', # Is the speed limit greater than 30mph?
+        }
+    }, "submit details");
+    $mech->content_contains('Thank you for your report');
+    my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+    ok $report, "Found the report";
+    is $report->title, 'Test grass cutting report 1', 'Got the correct report';
+    is $report->bodies_str, $parish->id, 'Report was sent to parish';
+};
+
+subtest 'sends grass cutting reports on roads 30mph or more to the council' => sub {
+    $mech->get_ok('/report/new?latitude=51.615559&longitude=-0.556903&category=Grass+cutting');
+    $mech->submit_form_ok({
+        with_fields => {
+            title => "Test grass cutting report 2",
+            detail => 'Test report details.',
+            category => 'Grass cutting',
+            speed_limit_greater_than_30 => 'yes', # Is the speed limit greater than 30mph?
+        }
+    }, "submit details");
+    $mech->content_contains('Your issue is on its way to the council');
+    my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+    ok $report, "Found the report";
+    is $report->title, 'Test grass cutting report 2', 'Got the correct report';
+    is $report->bodies_str, $body->id, 'Report was sent to council';
 };
 
 };

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -11,6 +11,7 @@ END { FixMyStreet::App->log->enable('info'); }
 my $body = $mech->create_body_ok(2217, 'Buckinghamshire', {
     send_method => 'Open311', api_key => 'key', endpoint => 'endpoint', jurisdiction => 'fms', can_be_devolved => 1 });
 my $parish = $mech->create_body_ok(53822, 'Adstock Parish Council');
+my $other_body = $mech->create_body_ok(1234, 'Some Other Council');
 my $counciluser = $mech->create_user_ok('counciluser@example.com', name => 'Council User', from_body => $body);
 my $publicuser = $mech->create_user_ok('fmsuser@example.org', name => 'Simon Neil');
 
@@ -459,6 +460,20 @@ subtest 'treats problems sent to parishes as owned by Bucks' => sub {
     # Check that the report can be accessed via the cobrand
     my $report_id = $report->id;
     $mech->get_ok("/report/$report_id");
+};
+
+subtest 'body filter on dashboard' => sub {
+    $mech->get_ok('/dashboard');
+    $mech->content_contains('<h1>' . $body->name . '</h1>', 'defaults to Bucks');
+    $mech->content_contains('<select class="form-control" name="body" id="body">', 'extra bodies dropdown is shown');
+    $mech->content_contains('<option value="' . $body->id . '">' . $body->name . '</option>', 'Bucks is shown in the options');
+    $mech->content_contains('<option value="' . $parish->id . '">' . $parish->name . '</option>', 'parish is shown in the options');
+
+    $mech->get_ok('/dashboard?body=' . $parish->id);
+    $mech->content_contains('<h1>' . $parish->name . '</h1>', 'shows parish dashboard');
+
+    $mech->get_ok('/dashboard?body=' . $other_body->id);
+    $mech->content_contains('<h1>' . $body->name . '</h1>', 'defaults to Bucks when body is not permitted');
 };
 
 };

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -62,6 +62,7 @@ $contact->set_extra_fields({
     ],
 });
 $contact->update;
+$contact = $mech->create_contact_ok(body_id => $parish->id, category => 'Dirty signs', email => 'signs@example.org', send_method => 'Email');
 
 my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Buckinghamshire');
 $cobrand->mock('lookup_site_code', sub {
@@ -416,7 +417,7 @@ subtest 'sends grass cutting reports on roads under 30mph to the parish' => sub 
             speed_limit_greater_than_30 => 'no', # Is the speed limit greater than 30mph?
         }
     }, "submit details");
-    $mech->content_contains('Thank you for your report');
+    $mech->content_contains('Your issue is on its way to the council');
     my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
     ok $report, "Found the report";
     is $report->title, 'Test grass cutting report 1', 'Got the correct report';
@@ -438,6 +439,26 @@ subtest 'sends grass cutting reports on roads 30mph or more to the council' => s
     ok $report, "Found the report";
     is $report->title, 'Test grass cutting report 2', 'Got the correct report';
     is $report->bodies_str, $body->id, 'Report was sent to council';
+};
+
+subtest 'treats problems sent to parishes as owned by Bucks' => sub {
+    $mech->get_ok('/report/new?latitude=51.615559&longitude=-0.556903');
+    $mech->submit_form_ok({
+        with_fields => {
+            title => "Test Dirty signs report",
+            detail => 'Test report details.',
+            category => 'Dirty signs',
+        }
+    }, "submit details");
+    $mech->content_contains('Your issue is on its way to the council');
+
+    my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+    ok $report, "Found the report";
+    is $report->title, 'Test Dirty signs report', 'Got the correct report';
+
+    # Check that the report can be accessed via the cobrand
+    my $report_id = $report->id;
+    $mech->get_ok("/report/$report_id");
 };
 
 };

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -476,6 +476,18 @@ subtest 'body filter on dashboard' => sub {
     $mech->content_contains('<h1>' . $body->name . '</h1>', 'defaults to Bucks when body is not permitted');
 };
 
+subtest 'All reports pages for parishes' => sub {
+    $mech->get_ok('/reports/Buckinghamshire');
+    $mech->content_contains('View reports sent to parishes');
+
+    $mech->get_ok('/about/parishes');
+    $mech->content_contains('Adstock Parish Council');
+
+    $mech->get_ok('/reports/Adstock');
+    $mech->content_contains('Adstock Parish Council');
+    is $mech->uri->path, '/reports/Adstock';
+};
+
 };
 
 done_testing();

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -488,6 +488,10 @@ subtest 'All reports pages for parishes' => sub {
     is $mech->uri->path, '/reports/Adstock';
 };
 
+subtest 'hides "reference number" text unless report is sent via Open311' => sub {
+
+};
+
 };
 
 done_testing();

--- a/templates/web/base/dashboard/index.html
+++ b/templates/web/base/dashboard/index.html
@@ -23,7 +23,21 @@
 
 <div class="filters">
   [% IF body %]
+    [% IF extra_bodies %]
+    <p>
+      <label for="body">[% loc('Body:') %]</label>
+      <select class="form-control" name="body" id="body">
+        <option value="[% default_body.id %]">[% default_body.name %]</option>
+        <option disabled>---</option>
+        [% FOR b IN extra_bodies %]
+          <option value="[% b.id %]"[% ' selected' IF b.id == body.id %]>[% b.name %]</option>
+        [% END %]
+      </select>
+    </p>
+    [% ELSE %]
     <input type="hidden" name="body" value="[% body.id | html %]">
+    [% END %]
+
     [% IF NOT c.user.area_ids.size %]
     <p>
         <label for="ward">[% loc('Ward:') %]</label>

--- a/templates/web/base/report/new/category_extras.html
+++ b/templates/web/base/report/new/category_extras.html
@@ -15,12 +15,16 @@
     <div class="extra-category-questions">
         [% UNLESS category_extras_notices.$category %]
           <h2 class="visuallyhidden form-section-heading">[% loc('Extra details') %]</h2>
+          [% TRY %]
+            [% INCLUDE 'report/new/_category_extras_header.html' %]
+          [% CATCH file %]
           <p class="form-section-description">
             [% tprintf(
               loc('Help <strong>%s</strong> resolve your problem quicker, by providing some extra detail. This extra information will not be published online.'),
               mark_safe(list_of_names.join( '</strong>' _ loc(' or ') _ '<strong>' ))
             ); %]
           </p>
+          [% END %]
         [% END %]
         [% INCLUDE 'report/new/category_extras_fields.html' metas=category_extras.$category %]
       </div>

--- a/templates/web/buckinghamshire/about/parishes.html
+++ b/templates/web/buckinghamshire/about/parishes.html
@@ -1,0 +1,15 @@
+[% INCLUDE 'header.html', title = loc('All reports for parishes'), bodyclass = 'twothirdswidthpage' %]
+
+<h1>All reports for parishes</h1>
+
+<p><a href="/reports">&larr; Back to All reports for Buckinghamshire Council</a></p>
+
+<p>Choose a parish from the list below to view all reports for that parish.</p>
+
+[% FOREACH parish IN parishes %]
+
+<p><a href="/reports/[% c.cobrand.short_name(parish) %]">[% parish.name %]</a></p>
+
+[% END %]
+
+[% INCLUDE 'footer.html' %]

--- a/templates/web/buckinghamshire/footer_extra_js.html
+++ b/templates/web/buckinghamshire/footer_extra_js.html
@@ -1,1 +1,8 @@
 [% PROCESS 'footer_extra_js_base.html' highways=1 cobrand_js=1 validation=1 roadworks=1 %]
+[%
+IF bodyclass.match('mappage');
+    scripts.push(
+        version('/cobrands/buckinghamshire/js.js')
+    );
+END
+%]

--- a/templates/web/buckinghamshire/report/new/_category_extras_header.html
+++ b/templates/web/buckinghamshire/report/new/_category_extras_header.html
@@ -1,0 +1,7 @@
+[% IF category == 'Grass cutting' %]
+  <p class="form-section-description">
+    Help us to direct your enquiry/report to the right team first time. Some services are provided by the Parish/Town Council, and are dependent on the location/road speed limit.
+  </p>
+[% ELSE %]
+  [% THROW file 'Not found' %]
+[% END %]

--- a/templates/web/buckinghamshire/reports/cobrand_stats.html
+++ b/templates/web/buckinghamshire/reports/cobrand_stats.html
@@ -1,0 +1,3 @@
+<div class="parish-all-reports">
+  <p><a class="btn-primary" href="/about/parishes">View reports sent to parishes</a></p>
+</div>

--- a/templates/web/buckinghamshire/tokens/_confirm_problem_council_id.html
+++ b/templates/web/buckinghamshire/tokens/_confirm_problem_council_id.html
@@ -1,2 +1,5 @@
 <h2>Your issue is on its way to the council.</h2>
-<p>You will receive an email with a reference number for this report soon, please quote it in any enquiries.</p>
+
+[% IF c.cobrand.report_sent_via_open311(report) %]
+  <p>You will receive an email with a reference number for this report soon, please quote it in any enquiries.</p>
+[% END %]

--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -372,7 +372,8 @@ fixmystreet.assets.add(defaults, {
         'Street Signs',
         'Traffic Lights and crossings',
         'Trees and vegetation',
-        'Trees'
+        'Trees',
+        'Grass, hedges and weeds'
     ],
     actions: {
         found: function(layer, feature) {
@@ -388,7 +389,17 @@ fixmystreet.assets.add(defaults, {
                 return false;
             }, msg_id);
         },
-        not_found: fixmystreet.message_controller.road_not_found
+        not_found: function(layer) {
+            fixmystreet.message_controller.road_not_found(layer, function() {
+                var selected = fixmystreet.reporting.selectedCategory();
+                if (selected.group == 'Grass, hedges and weeds') {
+                    // Want to always show the road not found message.
+                    // This skips the is_only_body check in road_not_found
+                    return true;
+                }
+                return false;
+            });
+        }
     },
     no_asset_msg_id: '#js-not-a-road',
     no_asset_msgs_class: '.js-roads-bucks',

--- a/web/cobrands/buckinghamshire/base.scss
+++ b/web/cobrands/buckinghamshire/base.scss
@@ -145,4 +145,8 @@ label {
   border: none;
 }
 
+.parish-all-reports {
+  margin-top: 1em;
+}
+
 @import "../sass/claims";

--- a/web/cobrands/buckinghamshire/js.js
+++ b/web/cobrands/buckinghamshire/js.js
@@ -1,0 +1,31 @@
+(function(){
+
+  if (!fixmystreet.maps) {
+      return;
+  }
+
+  $(function() {
+    $(document).on('change', '#form_speed_limit_greater_than_30', function(e) {
+      var bucks, parish;
+      $.each(fixmystreet.bodies, function(i, body) {
+        if (body === 'Buckinghamshire Council') {
+          bucks = body;
+        } else {
+          parish = body;
+        }
+      });
+      if (!bucks || !parish) {
+        return;
+      }
+
+      if ($(this).val() === 'no') {
+        // Report for the parish
+        fixmystreet.update_public_councils_text($('#js-councils_text').html(), [parish]);
+      } else {
+        // Report for the council
+        fixmystreet.update_public_councils_text($('#js-councils_text').html(), [bucks]);
+      }
+    });
+  });
+
+})();

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -1367,14 +1367,14 @@ fixmystreet.message_controller = (function() {
         // If a feature wasn't found at the location they've clicked, it's
         // probably a field or something. Show an error to that effect,
         // unless an asset is selected.
-        road_not_found: function(layer) {
+        road_not_found: function(layer, criterion) {
             // don't show the message if clicking on a National Highways road
             if (fixmystreet.body_overrides.get_only_send() == 'National Highways' || !layer.visibility) {
                 responsibility_off(layer, 'road');
             } else if (fixmystreet.assets.selectedFeature()) {
                 fixmystreet.body_overrides.allow_send(layer.fixmystreet.body);
                 responsibility_off(layer, 'road');
-            } else if (is_only_body(layer.fixmystreet.body)) {
+            } else if (is_only_body(layer.fixmystreet.body) || (criterion && criterion())) {
                 responsibility_on(layer, 'road');
             }
         },


### PR DESCRIPTION
When sending a report to a non-open311 endpoint, hide the message about sending a reference number.

## Todo

- [ ] Write test to check that text is/isn't present for email/open311 categories

Fixes https://github.com/mysociety/societyworks/issues/2956

[skip changelog]