### PR TITLE
[Bexley] Show report ID in confirmation emails.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley.pm
@@ -272,4 +272,6 @@ sub report_form_extras {
     ( { name => 'private_comments' } )
 }
 
+sub report_sent_confirmation_email { 'id' }
+
 1;

--- a/templates/email/bexley/_council_reference.html
+++ b/templates/email/bexley/_council_reference.html
@@ -1,0 +1,3 @@
+<p style="[% p_style %]">The report's reference number is <strong>[% problem.id %]</strong>.
+  Please quote this if you need to contact the council about this report.</p>
+

--- a/templates/email/bexley/_council_reference.txt
+++ b/templates/email/bexley/_council_reference.txt
@@ -1,0 +1,2 @@
+The report's reference number is [% problem.id %]. Please quote this if
+you need to contact the council about this report.

--- a/templates/email/bexley/_council_reference_alert_update.html
+++ b/templates/email/bexley/_council_reference_alert_update.html
@@ -1,0 +1,2 @@
+<p style="[% p_style %]">The report's reference number is <strong>[% problem.id %]</strong>.
+  Please quote this if you need to contact the council about this report.</p>

--- a/templates/email/bexley/_council_reference_alert_update.txt
+++ b/templates/email/bexley/_council_reference_alert_update.txt
@@ -1,0 +1,2 @@
+The report's reference number is [% problem.id %]. Please quote this if
+you need to contact the council about this report.

--- a/templates/email/bexley/_questionnaire-report-id.html
+++ b/templates/email/bexley/_questionnaire-report-id.html
@@ -1,0 +1,4 @@
+<p style="[% p_style %]">
+  The report's reference number is <strong>[% report.id %]</strong>.
+  Please quote this if you need to contact us about this report.
+</p>

--- a/templates/email/bexley/_questionnaire-report-id.txt
+++ b/templates/email/bexley/_questionnaire-report-id.txt
@@ -1,0 +1,2 @@
+  The report's reference number is [% report.id %].
+  Please quote this if you need to contact us about this report.

--- a/templates/email/default/questionnaire.html
+++ b/templates/email/default/questionnaire.html
@@ -23,8 +23,12 @@ INCLUDE '_email_top.html';
     <a style="[% dontknow_button_style %]" href="[% url %]?been_fixed=Unknown">Don’t know</a>
   </p>
   <p style="[% p_style %]">Thank you! Your feedback is really valuable.</p>
+
+  [% TRY %][% INCLUDE '_questionnaire-report-id.html' %][% CATCH file %][% END %]
+
   [% end_padded_box | safe %]
 </th>
+
 [% WRAPPER '_email_sidebar.html' object = report, url = url %]
     <h2 style="[% h2_style %]">[% title %]</h2>
     [% report.detail | html_para_email(secondary_p_style) %]

--- a/templates/email/default/questionnaire.txt
+++ b/templates/email/default/questionnaire.txt
@@ -20,5 +20,7 @@ Your report was as follows:
 
 [% report.detail %]
 
+[% TRY %][% INCLUDE '_questionnaire-report-id.txt' %][% CATCH file %][% END %]
+
 This email was sent automatically, from an unmonitored email account - so
 please do not reply to it.


### PR DESCRIPTION
As requested by the client, this adds the report ID to the questionnaire email sent to a user about a report, and adds a report logged email so the user gets a report ID from that.

https://github.com/mysociety/societyworks/issues/2775

[skip changelog]