### PR TITLE
[Bucks] Changes for parish-related emails

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -407,7 +407,10 @@ sub should_skip_sending_update {
 
 sub disable_phone_number_entry { 1 }
 
-sub report_sent_confirmation_email { 'external_id' }
+sub report_sent_confirmation_email {
+    my ($self, $report) = @_;
+    return $report->external_id ? 'external_id' : 'id';
+}
 
 sub is_council_with_case_management { 1 }
 

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -205,6 +205,7 @@ subtest 'Ex-district reports are sent to correct emails' => sub {
     $mech->email_count_is(4); # (one for council, one confirmation for user) x 2
     my @email = $mech->get_email;
     is $email[0]->header('To'), 'Buckinghamshire <flytipping@chiltern>';
+    unlike $mech->get_text_body_from_email($email[0]), qr/If there is a/;
 };
 
 my ($report2) = $mech->create_problems_for_body(1, $body->id, 'Drainage problem', {

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -206,6 +206,8 @@ subtest 'Ex-district reports are sent to correct emails' => sub {
     my @email = $mech->get_email;
     is $email[0]->header('To'), 'Buckinghamshire <flytipping@chiltern>';
     unlike $mech->get_text_body_from_email($email[0]), qr/If there is a/;
+
+    like $mech->get_text_body_from_email($email[1]), qr/reference number is/;
 };
 
 my ($report2) = $mech->create_problems_for_body(1, $body->id, 'Drainage problem', {

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -8,7 +8,7 @@ my $mech = FixMyStreet::TestMech->new;
 FixMyStreet::App->log->disable('info');
 END { FixMyStreet::App->log->enable('info'); }
 
-my $body = $mech->create_body_ok(2217, 'Buckinghamshire', {
+my $body = $mech->create_body_ok(2217, 'Buckinghamshire Council', {
     send_method => 'Open311', api_key => 'key', endpoint => 'endpoint', jurisdiction => 'fms', can_be_devolved => 1 });
 my $parish = $mech->create_body_ok(53822, 'Adstock Parish Council');
 my $other_body = $mech->create_body_ok(1234, 'Some Other Council');
@@ -38,7 +38,7 @@ $mech->create_contact_ok(body_id => $body->id, category => 'Barrier problem', em
 $mech->create_contact_ok(body_id => $body->id, category => 'Grass cutting', email => 'grass@example.org', send_method => 'Email');
 
 # Create another Grass cutting category for a parish.
-$contact = $mech->create_contact_ok(body_id => $parish->id, category => 'Grass cutting', email => 'grass@example.org', send_method => 'Email');
+$contact = $mech->create_contact_ok(body_id => $parish->id, category => 'Grass cutting', email => 'grassparish@example.org', send_method => 'Email');
 $contact->set_extra_fields({
     code => 'speed_limit_greater_than_30',
     description => 'Is the speed limit on this road 30mph or greater?',
@@ -204,10 +204,11 @@ subtest 'Ex-district reports are sent to correct emails' => sub {
     FixMyStreet::Script::Reports::send();
     $mech->email_count_is(4); # (one for council, one confirmation for user) x 2
     my @email = $mech->get_email;
-    is $email[0]->header('To'), 'Buckinghamshire <flytipping@chiltern>';
+    is $email[0]->header('To'), '"Buckinghamshire Council" <flytipping@chiltern>';
     unlike $mech->get_text_body_from_email($email[0]), qr/If there is a/;
 
     like $mech->get_text_body_from_email($email[1]), qr/reference number is/;
+    unlike $mech->get_text_body_from_email($email[1]), qr/please contact Buckinghamshire/;
 };
 
 my ($report2) = $mech->create_problems_for_body(1, $body->id, 'Drainage problem', {
@@ -412,6 +413,8 @@ subtest 'Allows car park reports to be made in a car park' => sub {
 };
 
 subtest 'sends grass cutting reports on roads under 30mph to the parish' => sub {
+    FixMyStreet::Script::Reports::send();
+    $mech->clear_emails_ok;
     $mech->get_ok('/report/new?latitude=51.615559&longitude=-0.556903&category=Grass+cutting');
     $mech->submit_form_ok({
         with_fields => {
@@ -426,6 +429,9 @@ subtest 'sends grass cutting reports on roads under 30mph to the parish' => sub 
     ok $report, "Found the report";
     is $report->title, 'Test grass cutting report 1', 'Got the correct report';
     is $report->bodies_str, $parish->id, 'Report was sent to parish';
+    FixMyStreet::Script::Reports::send();
+    my @email = $mech->get_email;
+    like $mech->get_text_body_from_email($email[1]), qr/please contact Adstock Parish Council at grassparish\@example.org/;
 };
 
 subtest 'sends grass cutting reports on roads 30mph or more to the council' => sub {

--- a/templates/email/buckinghamshire/_council_reference.html
+++ b/templates/email/buckinghamshire/_council_reference.html
@@ -1,4 +1,7 @@
 [% IF problem.external_id ~%]
 <p style="[% p_style %]">The report's reference number is <strong>[% problem.external_id %]</strong>.
   Please quote this if you need to contact the council about this report.</p>
+[% ELSE %]
+<p style="[% p_style %]">The report's reference number is <strong>[% problem.id %]</strong>.
+</p>
 [%~ END %]

--- a/templates/email/buckinghamshire/_council_reference.html
+++ b/templates/email/buckinghamshire/_council_reference.html
@@ -3,5 +3,9 @@
   Please quote this if you need to contact the council about this report.</p>
 [% ELSE %]
 <p style="[% p_style %]">The report's reference number is <strong>[% problem.id %]</strong>.
+ [% IF problem.body != cobrand.council_name %]
+  For any further enquiries regarding this report, please contact [% problem.body %]
+  [%~ IF problem.contact.email %] at [% problem.contact.email %][% END %].
+ [% END %]
 </p>
 [%~ END %]

--- a/templates/email/buckinghamshire/_council_reference.txt
+++ b/templates/email/buckinghamshire/_council_reference.txt
@@ -1,4 +1,8 @@
 [% IF problem.external_id %]The report's reference number is [% problem.external_id %]. Please quote this if
 you need to contact the council about this report.
 [%~ ELSE %]The report's reference number is [% problem.id %].
+  [% IF problem.body != cobrand.council_name %]
+    For any further enquiries regarding this report, please contact [% problem.body %]
+    [%~ IF problem.contact.email %] at [% problem.contact.email %][% END %].
+  [% END %]
 [%~ END %]

--- a/templates/email/buckinghamshire/_council_reference.txt
+++ b/templates/email/buckinghamshire/_council_reference.txt
@@ -1,2 +1,4 @@
 [% IF problem.external_id %]The report's reference number is [% problem.external_id %]. Please quote this if
-you need to contact the council about this report.[% END %]
+you need to contact the council about this report.
+[%~ ELSE %]The report's reference number is [% problem.id %].
+[%~ END %]

--- a/templates/email/buckinghamshire/submit.html
+++ b/templates/email/buckinghamshire/submit.html
@@ -1,7 +1,7 @@
 [%
 
 email_summary = "A new problem in your area has been reported by a " _ site_name _ " user.";
-email_footer = "If there is a more appropriate email address for messages about " _ category_footer _ ", please let us know. This will help improve the service for local people. We also welcome any other feedback you may have.";
+email_footer = "";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/buckinghamshire/submit.txt
+++ b/templates/email/buckinghamshire/submit.txt
@@ -45,7 +45,3 @@ View OpenStreetMap of this location: [% osm_url %]
 Replies to this email will go to the user who submitted the problem.
 
 [% signature %]
-
-If there is a more appropriate email address for messages about
-[% category_footer %], please let us know. This will help improve the
-service for local people. We also welcome any other feedback you may have.


### PR DESCRIPTION
[skip changelog]
Fixes https://github.com/mysociety/societyworks/issues/2958
Fixes https://github.com/mysociety/societyworks/issues/2957
Does the opposite of https://github.com/mysociety/societyworks/issues/2956 in that it starts to include the FMS ID in the logged email if no external ID.
