### PR TITLE
[Cheshire East] Inspector tool amendments

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
@@ -53,6 +53,8 @@ sub index : Path {
 
     my $problems = $c->cobrand->problems;
 
+    $c->stash->{assignees} = $c->cobrand->call_hook('get_list_of_report_assignees' => $problems);
+
     if (my $search = $c->get_param('search')) {
         $search = $self->trim($search);
 
@@ -152,7 +154,11 @@ sub index : Path {
             $c->stash->{updates} = [ $updates->all ];
             $c->stash->{updates_pager} = $updates->pager;
         }
-
+    } elsif (my $assignee = $c->get_param('assignee')) {
+        my $problems = $c->cobrand->call_hook('filter_problems_by_assignee' => $problems, $assignee, $order, $p_page);
+        $c->stash->{selected_assignee} = $assignee;
+        $c->stash->{problems} = [ $problems->all ] if $problems;
+        $c->stash->{problems_pager} = $problems->pager if $problems;
     } else {
 
         $problems = $problems->search(

--- a/t/cobrand/bexley.t
+++ b/t/cobrand/bexley.t
@@ -118,6 +118,22 @@ FixMyStreet::override_config {
         $mech->content_lacks('Odour');
     };
 
+    subtest 'not opted in cobrand does not show assignee filter on admin/reports page' => sub {
+        my $bexley = $mech->create_body_ok(2494, 'London Borough of Bexley');
+        my $admin_user = $mech->create_user_ok('adminuser@example.com', name => 'An admin user', from_body => $bexley, is_superuser => 1);
+        $mech->create_problems_for_body( 1, $bexley->id, 'Assignee', {
+        category => 'Zebra Crossing',
+        extra => {
+            contributed_as => 'another_user',
+            contributed_by => $admin_user->id,
+            },
+        });
+        $mech->log_in_ok($admin_user->email);
+        $mech->get_ok('/admin/reports');
+        $mech->content_lacks('Assignee</option>');
+        $mech->delete_problems_for_body($bexley->id);
+    };
+
     my $report;
     foreach my $test (
         { category => 'Abandoned and untaxed vehicles', email => ['p1confirm'], code => 'ConfirmABAN',

--- a/templates/web/base/admin/problem_row.html
+++ b/templates/web/base/admin/problem_row.html
@@ -44,6 +44,10 @@
             [%- IF problem.is_closed %]<br>[% prettify_state('closed') %]: [% PROCESS format_time time=problem.lastupdate %][% END -%]
             [%- IF problem.is_open AND problem.lastupdate != problem.whensent %]<br>[% loc('Last&nbsp;update:') %] [% PROCESS format_time time=problem.lastupdate %][% END -%]
         </small></td>
+        [% TRY %]
+            [% INCLUDE admin/_problem_row_assigned.html %]
+        [% CATCH %]
+        [% END %]
         <td>
             [% IF c.user.has_permission_to('report_edit', problem.bodies_str_ids) %]
                 <a href="[% c.uri_for_action( '/admin/reports/edit', [ problem.id ] ) %]">[% loc('Edit') %]</a>

--- a/templates/web/base/admin/reports/index.html
+++ b/templates/web/base/admin/reports/index.html
@@ -14,6 +14,10 @@
         <th>[% loc('Name') %]</th>
         <th>[% loc('Body') %]</th>
         <th>[% loc('State') %]</th>
+        [% TRY %]
+            [% INCLUDE 'admin/reports/_index_col_assigned.html' %]
+        [% CATCH %]
+        [% END %]
         <th>*</th>
     </tr>
     [% INCLUDE 'admin/problem_row.html' %]

--- a/templates/web/cheshireeast/admin/_problem_row_assigned.html
+++ b/templates/web/cheshireeast/admin/_problem_row_assigned.html
@@ -1,0 +1,5 @@
+[% IF c.req.uri.path == '/admin/reports' %]
+<td>
+    [%- problem.shortlisted_user.name OR problem.shortlisted_user.username OR loc('Unassigned') -%]
+</td>
+[% END %]

--- a/templates/web/cheshireeast/admin/reports/_index_col_assigned.html
+++ b/templates/web/cheshireeast/admin/reports/_index_col_assigned.html
@@ -1,0 +1,12 @@
+<th>
+    <form method="get" action="reports" enctype="application/x-www-form-urlencoded" accept-charset="utf-8">
+    <select name="assignee" onchange="this.form.submit()">
+        [% IF !selected_assignee %]<option disabled selected>Assignee</option>[% END %]
+        <option value="All" [%~ IF selected_assignee == 'All' ~%]selected[% END %]>All</option>
+        <option value="Unassigned" [%~ IF selected_assignee == 'Unassigned' ~%]selected[% END %]>Unassigned</option>
+        [% FOR assignee IN assignees ~%]
+            <option value="[%~ assignee.key ~%]" [%~ IF selected_assignee == assignee.key ~%]selected[% END %]>[%~ assignee.value ~%]</option>
+        [% END %]
+    </select>
+    </form>
+</th>


### PR DESCRIPTION
* Moves 'assignee' information on /admin/reports page into separate column
* Adds dropdown with list of assignees for filtering
* Includes filters 'Unassigned', 'All' and any assignees for the body
* Does not interact with search - search searches all reports unfiltered
* Adds tests to check functionality
* Adds test to check doesn't appear for another cobrand

https://github.com/mysociety/societyworks/issues/2777

[skip changelog]