### PR TITLE
Moved "Not maintained..." message right above the "continue" button

### DIFF
--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1975,3 +1975,6 @@ function setup_popstate() {
         });
     }, 0);
 }
+
+// Move the message "Not maintained..." message right above the "continue" button
+$('#js-roads-responsibility').insertBefore('.js-reporting-page--category .js-reporting-page--next');

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1977,4 +1977,6 @@ function setup_popstate() {
 }
 
 // Move the message "Not maintained..." message right above the "continue" button
-$('#js-roads-responsibility').insertBefore('.js-reporting-page--category .js-reporting-page--next');
+if (!$("html").hasClass("mobile")) { 
+    $('#js-roads-responsibility').insertBefore('.js-reporting-page--category .js-reporting-page--next');
+}


### PR DESCRIPTION
This issue was originated from the following issue:
https://trello.com/c/mCNc3WaY

This fix should improve that some users might get frustrated that the continue button doesn’t appear to work because they have not noticed the message ("Not maintained by...") has appeared at the top.

I had some issues trying to replicate the problem, as @bekkileaver mentioned when creating the ticket. @dracos I was wondering if you know how to trigger this message locally (I tried reporting a problem in a different council or in the same street that Becki provide as an example, but no results). So far I have been able to check that the message is where Becky wants, but I have no idea if this message is also shown in other pages and me moving it has cause an effect on them.

Would we want to implement this on every cobrand or only in "Buckinghamshire" (I'll add the commit name if it's only for this cobrand)?
Instead of using Jquery, would it better to move the 
`[% TRY %][% INCLUDE 'report/new/roads_message.html' %][% CATCH file %][% END %]` to another file, at the moment is in `fill_in_details_form.html`?

Thanks for your feedback
