### PR TITLE
Add send_state column to updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
         - Add an --exclude option to bin/fetch.
         - Add an index on problem(external_id) to speed up bin/fetch --updates
         - Upgrade Net::DNS and libwww to deal with IPv6 issues.
+        - Add send_state column to updates. #3865
     - Open311 improvements:
         - Increase default timeout.
 

--- a/bin/update-schema
+++ b/bin/update-schema
@@ -215,6 +215,7 @@ else {
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
     return 'EMPTY' if ! table_exists('problem');
+    return '0077' if column_exists('comment', 'send_state');
     return '0076' if index_exists('problem_external_id_idx');
     return '0075' if column_exists('alert', 'parameter3');
     return '0074' if index_exists('users_fulltext_idx');

--- a/db/downgrade_0077---0076.sql
+++ b/db/downgrade_0077---0076.sql
@@ -1,0 +1,3 @@
+begin;
+alter table comment drop send_state;
+commit;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -358,6 +358,12 @@ create table comment (
     -- and should be highlighted in the display?
     external_id text,
     extra text,
+    send_state text not null default 'unprocessed' check (
+        send_state = 'unprocessed'
+        or send_state = 'processed'
+        or send_state = 'skipped'
+        or send_state = 'sent'
+    ),
     send_fail_count integer not null default 0,
     send_fail_reason text,
     send_fail_timestamp timestamp,
@@ -367,6 +373,7 @@ create table comment (
 create index comment_user_id_idx on comment(user_id);
 create index comment_problem_id_idx on comment(problem_id);
 create index comment_problem_id_created_idx on comment(problem_id, created);
+create index comment_state_send_state_idx on comment(state, send_state);
 create index comment_fulltext_idx on comment USING GIN(
     to_tsvector(
         'english',

--- a/db/schema_0077-add-comment-send-state.sql
+++ b/db/schema_0077-add-comment-send-state.sql
@@ -1,0 +1,8 @@
+alter table comment add send_state text not null default 'processed' check (
+    send_state = 'unprocessed'
+    or send_state = 'processed'
+    or send_state = 'skipped'
+    or send_state = 'sent'
+);
+alter table comment alter column send_state set default 'unprocessed';
+create index concurrently comment_state_send_state_idx on comment(state, send_state);

--- a/perllib/FixMyStreet/App/Controller/Admin/Triage.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Triage.pm
@@ -136,6 +136,7 @@ sub update : Private {
             problem_state => $problem->state,
             extra => $extra,
             whensent => \'current_timestamp',
+            send_state => 'processed',
         } );
 
         my @alerts = FixMyStreet::DB->resultset('Alert')->search( {

--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -35,9 +35,8 @@ __PACKAGE__->add_columns(
   "created",
   {
     data_type     => "timestamp",
-    default_value => \"current_timestamp",
+    default_value => \"CURRENT_TIMESTAMP",
     is_nullable   => 0,
-    original      => { default_value => \"now()" },
   },
   "confirmed",
   { data_type => "timestamp", is_nullable => 1 },
@@ -71,6 +70,8 @@ __PACKAGE__->add_columns(
   { data_type => "timestamp", is_nullable => 1 },
   "whensent",
   { data_type => "timestamp", is_nullable => 1 },
+  "send_state",
+  { data_type => "text", default_value => "unprocessed", is_nullable => 0 },
 );
 __PACKAGE__->set_primary_key("id");
 __PACKAGE__->has_many(
@@ -93,8 +94,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2019-04-25 12:06:39
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:CozqNY621I8G7kUPXi5RoQ
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2022-03-29 14:20:23
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:x+v4WPYnfPF/ac+UBsPW9g
 #
 
 __PACKAGE__->load_components("+FixMyStreet::DB::RABXColumn");

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -117,7 +117,7 @@ subtest 'Check updates not sent for staff with no text' => sub {
 
     $comment->discard_changes;
     is $comment->send_fail_count, 0, "comment sending not attempted";
-    is $comment->get_extra_metadata('cobrand_skipped_sending'), 1, "skipped sending comment";
+    is $comment->send_state, 'skipped', "skipped sending comment";
 };
 
 subtest 'Updates from staff with no text but with private comments are sent' => sub {
@@ -132,7 +132,7 @@ subtest 'Updates from staff with no text but with private comments are sent' => 
         confirmed  => 'now()',
         anonymous  => 'f',
     } );
-    $comment->unset_extra_metadata('cobrand_skipped_sending');
+    $comment->send_state('unprocessed');
     $comment->set_extra_metadata(private_comments => 'This comment has secret notes');
     $comment->update;
     FixMyStreet::override_config {
@@ -145,7 +145,7 @@ subtest 'Updates from staff with no text but with private comments are sent' => 
 
         $comment->discard_changes;
         ok $comment->whensent, "comment was sent";
-        ok !$comment->get_extra_metadata('cobrand_skipped_sending'), "didn't skip sending comment";
+        is $comment->send_state, 'sent', "didn't skip sending comment";
 
         my $req = Open311->test_req_used;
         my $c = CGI::Simple->new($req->content);

--- a/t/cobrand/northamptonshire.t
+++ b/t/cobrand/northamptonshire.t
@@ -79,11 +79,11 @@ subtest 'Check updates not sent for defects' => sub {
 
     $comment->discard_changes;
     is $comment->send_fail_count, 0, "comment sending not attempted";
-    is $comment->get_extra_metadata('cobrand_skipped_sending'), 1, "skipped sending comment";
+    is $comment->send_state, 'skipped', "skipped sending comment";
 };
 
 $report->update({ user => $user });
-$comment->update({ extra => undef });
+$comment->update({ send_state => 'unprocessed' });
 subtest 'check updates sent for non defects' => sub {
     FixMyStreet::override_config {
         ALLOWED_COBRANDS=> 'northamptonshire',

--- a/t/cobrand/peterborough.t
+++ b/t/cobrand/peterborough.t
@@ -133,9 +133,10 @@ subtest "no update sent to Bartec" => sub {
             problem_state => 'fixed - council', state => 'confirmed', mark_fixed => 0,
             confirmed => DateTime->now(),
         });
+        $c->discard_changes; # to get defaults
         $o->process_update($peterborough, $c);
         $c->discard_changes;
-        is $c->get_extra_metadata("cobrand_skipped_sending"), 1;
+        is $c->send_state, 'skipped';
     };
 };
 


### PR DESCRIPTION
This adds a sending state column to the comment table that the daemon can use for finding what updates still need processing. The schema change sets the default to 'processed' then changes it to 'unprocessed' so that all existing entries are set as processed.

This also means we no longer need workaround such as sticking -1 in the external_id column to stop an unsendable comment being processed, we can set the send_state to `processed` or `skipped` instead.

The daemon will fetch all `unprocessed` confirmed updates on sent reports. Any that lack an external_id or weren't sent via the Open311 send method will be marked as `processed`. Any that the cobrand says should be skipped will be marked as `skipped`. Any remainder will be sent, marked as `sent` if successful, left as `unprocessed` if not (and the send_fail_timestamp backoff should work as normal).

Before:
```
bci=# explain analyze SELECT me.* FROM "comment" "me"
JOIN "problem" "problem" ON "problem"."id" = "me"."problem_id" 
WHERE ( ( ( ( "me"."send_fail_count" = 0 OR "me"."send_fail_timestamp" < current_timestamp - '30 minutes'::interval )
AND regexp_split_to_array(bodies_str, ',') && ARRAY[...] )
AND "me"."external_id" IS NULL
AND ( "me"."extra" IS NULL OR "me"."extra" NOT LIKE '%cobrand_skipped_sending%' )
AND "me"."state" = 'confirmed'
AND "me"."whensent" IS NULL
AND "problem"."external_id" IS NOT NULL
AND "problem"."send_method_used" LIKE '%Open311%'
AND "problem"."whensent" IS NOT NULL ) ) LIMIT 1 ;
                                                                                                                                            QUERY PLAN

--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.43..25.60 rows=1 width=768) (actual time=16435.834..16435.836 rows=0 loops=1)
   ->  Nested Loop  (cost=0.43..1721053.65 rows=68374 width=768) (actual time=16435.832..16435.834 rows=0 loops=1)
         ->  Seq Scan on problem  (cost=0.00..553852.70 rows=219810 width=4) (actual time=0.016..4779.016 rows=1269011 loops=1)
               Filter: ((external_id IS NOT NULL) AND (whensent IS NOT NULL) AND (send_method_used ~~ '%Open311%'::text) AND (regexp_split_to_array(bodies_str, ','::text) && '{...}'::text[]))
               Rows Removed by Filter: 2154465
         ->  Index Scan using comment_problem_id_idx on comment me  (cost=0.43..5.30 rows=1 width=768) (actual time=0.009..0.009 rows=0 loops=1269011)
               Index Cond: (problem_id = problem.id)
               Filter: ((external_id IS NULL) AND (whensent IS NULL) AND ((extra IS NULL) OR (extra !~~ '%cobrand_skipped_sending%'::text)) AND (state = 'confirmed'::text) AND ((send_fail_count = 0) OR (send_fail_timestamp < (CURRENT_TIMESTAMP - '00:30:00'::interval))))
               Rows Removed by Filter: 4
 Planning Time: 0.507 ms
 Execution Time: 16435.873 ms
```

After:

```
bci=# explain analyze SELECT me.* FROM "comment" "me"
JOIN "problem" "problem" ON "problem"."id" = "me"."problem_id" 
WHERE ( ( ( ( "me"."send_fail_count" = 0 OR "me"."send_fail_timestamp" < current_timestamp - '30 minutes'::interval )
AND regexp_split_to_array(bodies_str, ',') && ARRAY[...] )
AND "me"."state" = 'confirmed'
AND me.send_state = 'unprocessed'
AND "problem"."whensent" IS NOT NULL ) ) LIMIT 1 ;
                                                                                                                                            QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.99..15.96 rows=1 width=599) (actual time=0.025..0.025 rows=0 loops=1)
   ->  Nested Loop  (cost=0.99..15.96 rows=1 width=599) (actual time=0.024..0.024 rows=0 loops=1)
         ->  Index Scan using comment_state_send_state_idx on comment me  (cost=0.56..7.50 rows=1 width=599) (actual time=0.024..0.024 rows=0 loops=1)
               Index Cond: ((state = 'confirmed'::text) AND (send_state = 'unprocessed'::text))
               Filter: ((send_fail_count = 0) OR (send_fail_timestamp < (now() - '00:30:00'::interval)))
         ->  Index Scan using problem_pkey on problem  (cost=0.43..8.46 rows=1 width=4) (never executed)
               Index Cond: (id = me.problem_id)
               Filter: ((whensent IS NOT NULL) AND (regexp_split_to_array(bodies_str, ','::text) && '{...}'::text[]))
 Planning time: 0.885 ms
 Execution time: 0.130 ms
```

