### PR TITLE
Make test for time in email a pattern match for confirming time is in email

### DIFF
--- a/t/cobrand/hackney.t
+++ b/t/cobrand/hackney.t
@@ -168,7 +168,7 @@ subtest "sends branded alert emails" => sub {
     ok $email, "got an email";
     my $text = $mech->get_text_body_from_email($email);
     like $text, qr/Hackney Council/, "emails are branded";
-    like $text, qr/13:00 today/, "date is included";
+    like $text, qr/\d\d:\d\d today/, "date is included";
 };
 
 


### PR DESCRIPTION
As test is not about what the time is, make the time a pattern match to confirm the time is in the email.

Previous test was failing as the timezone on my local server was changing the time by an hour after British Summertime clock changes.

Fixes: Test failing due to timezone issues #3868 

[skip changelog]