### PR TITLE
staff_with_permission list returns list of users unique by id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
         - Fix link deactivation for privacy policy link on privacy policy page. #3704
         - Fix dashboard rows for categories with &s.
         - Make calls from Geocoder files to https rather than http
+        - Inspector dropdown list only shows name once even if permissions repeated #3870
     - Accessibility improvements:
         - The "skip map" link on /around now has new wording. #3794
         - Improve visual contrast of pagination links. #3794

--- a/perllib/FixMyStreet/DB/Result/Body.pm
+++ b/perllib/FixMyStreet/DB/Result/Body.pm
@@ -295,6 +295,7 @@ sub staff_with_permission {
         { permissions => \"@> ARRAY['$permission']" }
     ], {
         join => [ 'user_body_permissions', { "user_roles" => "role" } ],
+        distinct => 1,
         order_by => { '-asc' => ['name'] },
     });
 }


### PR DESCRIPTION
staff_with_permission has been collating user names if permissions repeated through assignment to multiple roles.

This filters the list to return unique users.

https://github.com/mysociety/fixmystreet/issues/3870