### PR TITLE
Pop up "Browse photos" button when reporting incident

### DIFF
--- a/web/cobrands/bexley/base.scss
+++ b/web/cobrands/bexley/base.scss
@@ -105,3 +105,21 @@ ol.big-numbers > li:before {
 #postcodeForm .form-hint {
 //    color: $white;
 }
+
+.dropzone {
+    border-color: $primary_b;
+    background: mix($primary_b, $white, 15%);
+}
+
+.dz-clickable {
+    .dz-message u {
+        background-color: $primary_b;
+        color: $white;
+        border: 1px solid $primary_b;
+
+        &:hover {
+            background-color: $white ;
+            color: $primary_b;
+        }
+    }
+}

--- a/web/cobrands/centralbedfordshire/base.scss
+++ b/web/cobrands/centralbedfordshire/base.scss
@@ -123,4 +123,23 @@ html.js .form-section-preview {
     text-transform: none;
 }
 
+.dropzone {
+    border-color: $central-beds-fuschia;
+    background: mix($central-beds-fuschia, #fff, 15%);
+}
+
+.dz-clickable {
+    .dz-message u {
+        background-color: $central-beds-fuschia;
+        color: #fff;
+        border: 1px solid $central-beds-fuschia;
+
+        &:hover {
+            background-color: #fff;
+            color: $central-beds-fuschia;
+            border-color: $central-beds-fuschia; 
+        }
+    }
+}
+
 @import "../fixmystreet-uk-councils/societyworks-footer";

--- a/web/cobrands/cheshireeast/base.scss
+++ b/web/cobrands/cheshireeast/base.scss
@@ -161,3 +161,21 @@ a#geolocate_link {
     background-color: $white;
     color: $link-color;
 }
+
+.dropzone {
+    border-color: $primary_b;
+    background: mix($primary_b, $white, 15%);
+}
+
+.dz-clickable {
+    .dz-message u {
+        background-color: $primary_b;
+        color: $white;
+        border: 1px solid $primary_b;
+
+        &:hover {
+            background-color: $white ;
+            color: $primary_b;
+        }
+    }
+}

--- a/web/cobrands/eastherts/base.scss
+++ b/web/cobrands/eastherts/base.scss
@@ -157,3 +157,21 @@ button:focus {
         display: none;
     }
 }
+
+.dropzone {
+    border-color: $eh_green;
+    background: mix($eh_green, $eh_light_grey, 15%);
+}
+
+.dz-clickable {
+    .dz-message u {
+        background-color: $eh_green;
+        color: $eh_light_grey;
+        border: 1px solid $eh_green;
+
+        &:hover {
+            background-color: $eh_light_grey;
+            color: $eh_green;
+        }
+    }
+}

--- a/web/cobrands/fixmystreet.com/base.scss
+++ b/web/cobrands/fixmystreet.com/base.scss
@@ -432,3 +432,12 @@ html.lazyload .js-lazyload {
         margin-bottom: 0;
     }
 }
+
+.dz-clickable {
+  .dz-message u {
+    color: $primary_text;
+    &:hover {
+      color: $primary_text;
+    }
+  }
+}

--- a/web/cobrands/hackney/base.scss
+++ b/web/cobrands/hackney/base.scss
@@ -188,14 +188,6 @@ select.form-error {
   background-color: rgba(164, 214, 94, 0.5);
 }
 
-.dz-clickable:hover, .dz-drag-hover {
-  border-color: $light-green;
-}
-
-.dz-clickable:hover .dz-message u, .dz-drag-hover .dz-message u {
-  color: $green;
-}
-
 .sso-staff-sign-in {
   font-size: 0.9em;
   margin: 1em 0;
@@ -239,6 +231,29 @@ select.form-error {
 .lbh-container {
     margin-left: auto;
     margin-right: auto;
+}
+
+.dropzone {
+  border-color: $dark_green;
+  background: mix($dark_green, $pale_green, 15%);
+
+  &:hover {
+    border-color: $alt_green;
+    background: mix($dark_green, $pale_green, 30%);
+  }
+}
+
+.dz-clickable {
+  .dz-message u {
+      background-color: $dark_green;
+      color: $pale_green;
+      border: 1px solid $dark_green;
+
+      &:hover {
+          background-color: $pale_green;
+          color: $dark_green;
+      }
+  }
 }
 
 @import "../fixmystreet-uk-councils/societyworks-footer";

--- a/web/cobrands/hart/base.scss
+++ b/web/cobrands/hart/base.scss
@@ -110,4 +110,16 @@ a#geolocate_link {
     color: #000;
 }
 
+  .dz-clickable {
+    .dz-message u {
+        color: $primary_b;
+
+        &:hover {
+            color: #fff;
+            background-color: #4a725d;
+            border-color: #4a725d;
+        }
+    }
+  }
+
 @import "../fixmystreet-uk-councils/societyworks-footer";

--- a/web/cobrands/lincolnshire/base.scss
+++ b/web/cobrands/lincolnshire/base.scss
@@ -151,3 +151,9 @@ body.mappage .big-green-banner {
 .admin-hint {
   background-color: $lincs-link-focus;
 }
+
+.dz-clickable {
+  .dz-message u {
+      color: $lincs-text;
+  }
+}

--- a/web/cobrands/oxfordshire/base.scss
+++ b/web/cobrands/oxfordshire/base.scss
@@ -343,5 +343,19 @@ textarea {
     }
 }
 
+.dz-clickable {
+    .dz-message u {
+        background-color: $primary_b;
+        color: $primary_text;
+        border: 1px solid $primary_b;
+
+        &:hover {
+            background-color: $primary_text;
+            color: $primary_b;
+            border-color: $primary_b;
+        }
+    }
+}
+
 @import "oxfordshire-footer";
 @import "oxfordshire-cookiepopup";

--- a/web/cobrands/peterborough/base.scss
+++ b/web/cobrands/peterborough/base.scss
@@ -78,10 +78,6 @@ h1, h2 {
     font-weight: 700;
 }
 
-.dz-clickable .dz-message u {
-    color: $link-color;
-}
-
 .big-green-banner {
     text-transform: none;
 }

--- a/web/cobrands/rutland/base.scss
+++ b/web/cobrands/rutland/base.scss
@@ -16,4 +16,14 @@
     margin-top: 2em;
 }
 
+.dz-clickable {
+    .dz-message u {
+        color: $primary_text;
+
+        &:hover {
+            color: $primary_text;
+        }
+    }
+}
+
 @import "../fixmystreet-uk-councils/societyworks-footer";

--- a/web/cobrands/sass/_dropzone.scss
+++ b/web/cobrands/sass/_dropzone.scss
@@ -39,12 +39,22 @@ $dropzone-background-color--full: mix($dropzone-border-color--full, $dropzone-ba
   }
 
   .dz-message u {
-    //color: $dropzone-link-color;
-    @extend .btn-primary;
+    padding: 0.75em 1em;
+    text-decoration: none;
     display: inline;
     vertical-align: baseline;
     margin-left: 3px;
     font-weight: 400;
+    border-radius: 4px;
+    background: $primary;
+    color: #fff;
+    border: 1px solid $primary;
+
+    &:hover, &:focus {
+      background: #fff;
+      color: $primary;
+      border-color: $primary;
+    }
   }
 }
 
@@ -56,10 +66,6 @@ $dropzone-background-color--full: mix($dropzone-border-color--full, $dropzone-ba
   .dz-remove,
   .dz-cancel {
     border-color: $dropzone-background-color--awakened;
-  }
-
-  .dz-message u {
-    color: $dropzone-link-color--awakened;
   }
 }
 

--- a/web/cobrands/sass/_dropzone.scss
+++ b/web/cobrands/sass/_dropzone.scss
@@ -2,7 +2,7 @@ $dropzone-link-color: $link-color;
 $dropzone-link-color--awakened: $link-hover-color;
 $dropzone-border-color--awakened: $dropzone-link-color--awakened;
 $dropzone-border-color--full: #bf002a;
-$dropzone-background-color: #fff;
+$dropzone-background-color: transparentize($primary, 0.85);
 $dropzone-background-color--awakened: mix($dropzone-link-color, $dropzone-background-color, 10%);
 $dropzone-background-color--full: mix($dropzone-border-color--full, $dropzone-background-color, 10%);
 
@@ -12,11 +12,15 @@ $dropzone-background-color--full: mix($dropzone-border-color--full, $dropzone-ba
 }
 
 .dropzone {
-  @extend .form-control;
+  //@extend .form-control;
   @include clearfix;
   background-color: $dropzone-background-color;
   padding: 1.5em;
+  margin-bottom: 0.5em;
   text-align: center;
+  border-color: $primary;
+  border-style: dashed;
+  border-radius: 4px;
 }
 
 .dz-clickable {
@@ -31,10 +35,16 @@ $dropzone-background-color--full: mix($dropzone-border-color--full, $dropzone-ba
   .dz-remove,
   .dz-cancel {
     cursor: pointer;
+    font-weight: 600;
   }
 
   .dz-message u {
-    color: $dropzone-link-color;
+    //color: $dropzone-link-color;
+    @extend .btn-primary;
+    display: inline;
+    vertical-align: baseline;
+    margin-left: 3px;
+    font-weight: 400;
   }
 }
 

--- a/web/cobrands/warwickshire/base.scss
+++ b/web/cobrands/warwickshire/base.scss
@@ -157,3 +157,22 @@ a#geolocate_link {
         font-size: 0.875em;
     }
 }
+
+.dropzone {
+    border-color: $warwickshire-green;
+    background: mix($warwickshire-green, $warwickshire-light-grey, 15%);
+}
+
+.dz-clickable {
+    .dz-message u {
+        background-color: $warwickshire-green;
+        color: $warwickshire-light-grey;
+        border: 1px solid $warwickshire-green;
+
+        &:hover {
+            background-color: $warwickshire-light-grey;
+            color: $warwickshire-green;
+            border-color: $warwickshire-green;
+        }
+    }
+}

--- a/web/cobrands/westminster/base.scss
+++ b/web/cobrands/westminster/base.scss
@@ -290,3 +290,10 @@ body.alertpage, body.authpage, body.twothirdswidthpage {
         @include btn-medium-primary
     }
 }
+
+.dz-clickable {
+    .dz-message u {
+        @include btn-primary;
+        padding: 0.5em 1em;
+    }
+}


### PR DESCRIPTION
The dropzone and link inside the drop zone area were too subtle. This fix should draw more attention to both elements.
Peterborough raised this incident; however, this has been implemented for all cobrands because they all had a similar issue.

Some cobrand needed special treatment because the default solution was accessible (contrast issues).
There is only one cobrand that I couldn't test, which was "highwaysengland."

Desktop view:
<img width="460" alt="Screenshot 2022-04-07 at 13 25 26" src="https://user-images.githubusercontent.com/13790153/162198526-488d357d-84b9-4e75-9fef-888cbab0f638.png">

Mobile view:
<img width="366" alt="Screenshot 2022-04-07 at 13 27 29" src="https://user-images.githubusercontent.com/13790153/162198626-a07869ec-21ef-419f-b392-b4b6362dd19d.png">

Fixes: mysociety/societyworks#2579

