### PR TITLE
undef body if user is anonymised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
         - Fix dashboard rows for categories with &s.
         - Make calls from Geocoder files to https rather than http
         - Inspector dropdown list only shows name once even if permissions repeated #3870
+        - Inspector dropdown list doesn't show anonymised users, removing blank options #3873
     - Accessibility improvements:
         - The "skip map" link on /around now has new wording. #3794
         - Improve visual contrast of pagination links. #3794

--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -607,6 +607,7 @@ sub anonymize_account {
         twitter_id => undef,
         facebook_id => undef,
         oidc_ids => undef,
+        from_body => undef,
     });
 }
 


### PR DESCRIPTION
An anonymised user loses their name, phone, verified status and now their affiliation with a body.

This will stop the user being picked up by 'id' in body permission code.

For issue: https://github.com/mysociety/fixmystreet/issues/3873
