### PR TITLE
Add CORS header for requests from iOS app

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -344,6 +344,7 @@ the map. Used via /around?ajax=1 but also available at /ajax for mobile app.
 sub ajax : Path('/ajax') {
     my ( $self, $c ) = @_;
 
+    $c->forward('/set_app_cors_header');
     my $ret = $c->forward('/location/determine_location_from_bbox');
     unless ($ret) {
         $c->res->status(404);
@@ -411,6 +412,7 @@ sub location_autocomplete : Path('/ajax/geocode') {
 sub location_lookup : Path('/ajax/lookup_location') {
     my ( $self, $c ) = @_;
     $c->res->content_type('application/json; charset=utf-8');
+    $c->forward('/set_app_cors_header');
     unless ( $c->get_param('term') ) {
         $c->res->status(404);
         $c->res->body('');

--- a/perllib/FixMyStreet/App/Controller/Auth.pm
+++ b/perllib/FixMyStreet/App/Controller/Auth.pm
@@ -496,6 +496,7 @@ sub common_password : Local : Args(0) {
 
     my $body = JSON->new->utf8->allow_nonref->encode($return);
     $c->res->content_type('application/json; charset=utf-8');
+    $c->forward('/set_app_cors_header');
     $c->res->body($body);
 }
 
@@ -585,6 +586,7 @@ sub ajax_sign_in : Path('ajax/sign_in') {
 
     my $body = encode_json($return);
     $c->res->content_type('application/json; charset=utf-8');
+    $c->forward('/set_app_cors_header');
     $c->res->body($body);
 
     return 1;
@@ -597,6 +599,7 @@ sub ajax_sign_out : Path('ajax/sign_out') {
 
     my $body = encode_json( { signed_out => 1 } );
     $c->res->content_type('application/json; charset=utf-8');
+    $c->forward('/set_app_cors_header');
     $c->res->body($body);
 
     return 1;
@@ -615,6 +618,7 @@ sub ajax_check_auth : Path('ajax/check_auth') {
 
     my $body = encode_json($data);
     $c->res->content_type('application/json; charset=utf-8');
+    $c->forward('/set_app_cors_header');
     $c->res->code($code);
     $c->res->body($body);
 

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -68,6 +68,7 @@ sub ajax : Path('ajax') : Args(1) {
     my ( $self, $c, $id ) = @_;
 
     $c->stash->{ajax} = 1;
+    $c->forward('/set_app_cors_header');
     $c->forward('load_problem_or_display_error', [ $id ]);
     $c->forward('display');
 }

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -134,6 +134,7 @@ sub report_new_ajax : Path('mobile') : Args(0) {
 
     # create the report - loading a partial if available
     $c->forward('initialize_report');
+    $c->forward('/set_app_cors_header');
 
     unless ( $c->forward('determine_location') ) {
         $c->stash->{ json_response } = { errors => 'Unable to determine location' };
@@ -180,6 +181,7 @@ sub send_json_response : Private {
 sub report_form_ajax : Path('ajax') : Args(0) {
     my ( $self, $c ) = @_;
 
+    $c->forward('/set_app_cors_header');
     $c->forward('initialize_report');
 
     # work out the location for this report and do some checks

--- a/perllib/FixMyStreet/App/Controller/Root.pm
+++ b/perllib/FixMyStreet/App/Controller/Root.pm
@@ -185,6 +185,12 @@ sub check_password_expiry : Private {
     $c->detach;
 }
 
+sub set_app_cors_header : Private {
+    my ($self, $c) = @_;
+    my $origin = $c->req->header('Origin') || '';
+    $c->response->header('Access-Control-Allow-Origin' => 'app://localhost') if $origin eq 'app://localhost';
+}
+
 =head2 end
 
 Attempt to render a view, if needed.


### PR DESCRIPTION
[Recent changes](https://github.com/mysociety/fixmystreet-mobile/pull/298) to the iOS app mean that requests to FMS now include an `Origin: app://localhost` header, so we need to return the corresponding header in the response.

[skip changelog]