### PR TITLE
[Greenwich] Improve accesibility for button element

### DIFF
--- a/web/cobrands/greenwich/base.scss
+++ b/web/cobrands/greenwich/base.scss
@@ -124,14 +124,14 @@ button,
 .btn,
 .green-btn {
     border: none;
-    color: white;
+    color: white !important;
     background: $greenwich_red;
 
     &:hover {
         border: none;
         text-decoration: underline;
-        color: white;
-        background: lighten($greenwich_red, 2%);
+        color: white !important;
+        background: mix($greenwich_red, white, 85%);
     }
 }
 


### PR DESCRIPTION
Primary button is having contrast issues between the colour and background colour, also the hover effect on the background is too subtle to be noticed, especially for someone with visual impairment.

This PR fixes both issues, by adding white colour to the buttons, and also make the background colour lighter on hover.

### Current state
<img width="455" alt="Screenshot 2022-04-11 at 08 08 25" src="https://user-images.githubusercontent.com/13790153/162683520-1e7a6571-638c-4fe8-bea3-caf85d05d9ae.png">

<img width="455" alt="Screenshot 2022-04-11 at 08 05 32" src="https://user-images.githubusercontent.com/13790153/162683512-3386f522-81ee-4568-9970-6efda43555ab.png">

### Solution
<img width="455" alt="Screenshot 2022-04-11 at 08 05 10" src="https://user-images.githubusercontent.com/13790153/162683605-28b56973-b98a-4eaf-8a36-538856d5a91b.png">

