### PR TITLE
[Buckinghamshire] Fixed font inconsistency in claim form

### DIFF
--- a/web/cobrands/buckinghamshire/base.scss
+++ b/web/cobrands/buckinghamshire/base.scss
@@ -145,4 +145,6 @@ label {
   border: none;
 }
 
+input[type="text"], input[type="email"], textarea { @extend %normal-font;}
+
 @import "../sass/claims";

--- a/web/cobrands/sass/_claims.scss
+++ b/web/cobrands/sass/_claims.scss
@@ -15,7 +15,7 @@ body.formflow {
       max-width: 20ex;
     }
 
-    input[type="text"].govuk-input, input[type="time"].govuk-input {
+    input[type="text"].govuk-input, input[type="time"].govuk-input, input[type="email"].govuk-input {
       font-size: 16px;
       font-size: 1rem;
       line-height: 1.25;


### PR DESCRIPTION
Added minor UI fix that prevents inconsistency in the claims forms.
The current fix uses "Helvetica" just like the rest of the website.

<img width="497" alt="Screenshot 2022-04-14 at 09 25 13" src="https://user-images.githubusercontent.com/13790153/163345547-78f7261f-e815-4529-a24d-8abda3f9691c.png">

Fixes: mysociety/societyworks#2930