### PR TITLE
Added fix that enables buttons from having a full clickable area.

### DIFF
--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1647,6 +1647,10 @@ input.final-submit {
     left: 0px;
 }
 
+.fancybox-bg {
+  pointer-events: none;
+}
+
 .problem-back {
   display: block;
   font-size: 1em;


### PR DESCRIPTION
This will prevent the ".fancybox-bg-s" element from taking over the clickable area from the button.

This fixes: mysociety/societyworks#2935

