### PR TITLE
Enable Light version only for emails

### DIFF
--- a/templates/email/default/_email_settings.html
+++ b/templates/email/default/_email_settings.html
@@ -77,7 +77,6 @@ wrapper_table = table_reset
 link_style = "color: $link_text_color;"
 link_hover_style = "text-decoration: none; color: $link_hover_text_color;"
 link_style_dark_mode = "color: $link_text_color !important;"
-link_hover_style_dark_mode = "text-decoration: none; color: $link_hover_text_color;"
 
 td_style = "font-family: $body_font_family; font-size: 16px; line-height: 21px; font-weight: normal; text-align: left;"
 
@@ -96,9 +95,7 @@ header_style = "padding: $header_padding; background: $header_background_color; 
 
 only_column_style = "padding: ${ column_padding }px; vertical-align: top; background-color: $primary_column_background_color; color: $primary_column_text_color;"
 primary_column_style = "vertical-align: top; width: 50%; background-color: $primary_column_background_color; color: $primary_column_text_color;"
-primary_column_style_dark_mode = "vertical-align: top; width: 50%; background-color: $primary_column_background_color_dark_mode !important; color: $primary_column_text_color_dark_mode !important;"
 secondary_column_style = "vertical-align: top; width: 50%; background-color: $secondary_column_background_color; color: $secondary_column_text_color; border-left: 1px solid $column_divider_color;"
-secondary_column_style_dark_mode = "vertical-align: top; width: 50%; background-color: $secondary_column_background_color_dark_mode !important; color: $secondary_column_text_color_dark_mode !important; border-left: 1px solid $column_divider_color;"
 
 # Use these to add padding inside primary and secondary columns.
 start_padded_box = '<table cellspacing="0" cellpadding="' _ column_padding _ '" border="0" width="100%"><tr><th style="' _ td_style _ '">'
@@ -115,9 +112,7 @@ map_image_style = "display: block; width: 100%; height: auto;"
 list_item_style = "padding-bottom: 20px; margin-bottom: 20px; border-bottom: $list_item_border_bottom;"
 list_item_h2_style = "margin: 0 0 16px 0; font-size: 21px; line-height: 24px;"
 list_item_p_style = "margin: 0 0 16px 0;"
-list_item_p_style_dark_mode = "margin: 0 0 16px 0;"
 list_item_date_style = "font-size: 14px; line-height: 20px; margin: 0; color: $color_gunmetal_light;"
-list_item_date_style_dark_mode = "color: $color_blue_pale !important;"
 list_item_photo_style = "float: right; margin: 0 0 1em 1em; border: none;"
 
 contact_meta_style = "padding: 15px ${ column_padding }px; vertical-align: top; background-color: $secondary_column_background_color; border-bottom: 1px solid $column_divider_color;"

--- a/templates/email/default/_email_top.html
+++ b/templates/email/default/_email_top.html
@@ -15,8 +15,8 @@
 <head>
   <title>[% rss_title | safe %]</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta name="color-scheme" content="light dark" />
-  <meta name="supported-color-schemes" content="light dark" />
+  <meta name="color-scheme" content="only" />
+  <meta name="supported-color-schemes" content="only" />
   <style type="text/css">
   [%~ # Styles here will be applied by everything except Gmail.com %]
   a { [% link_style %] }
@@ -46,22 +46,6 @@
       background-color: [% body_background_color %];
     }
   }
-
-  @media (prefers-color-scheme: dark ) {
-    a { [% link_style_dark_mode %] }
-    a:hover { [% link_hover_style_dark_mode %] }
-    #secondary_column { [% secondary_column_style_dark_mode %] }
-    #primary_column { [% primary_column_style_dark_mode %] }
-    #primary_column p { [% list_item_p_style_dark_mode %] }
-    #primary_column p.user-name { [% list_item_date_style_dark_mode %] }
-  }
-
-  [data-ogsc] a { [% link_style_dark_mode %] }
-  [data-ogsc] a:hover { [% link_hover_style_dark_mode %] }
-  [data-ogsc] #secondary_column { [% secondary_column_style_dark_mode %] }
-  [data-ogsc] #primary_column { [% primary_column_style_dark_mode %] }
-  [data-ogsc] #primary_column p { [% list_item_p_style_dark_mode %] }
-  [data-ogsc] #primary_column p.user-name { [% list_item_date_style_dark_mode %] }
   </style>
 </head>
 <body style="[% body_style %]">


### PR DESCRIPTION
I'll give a little bit of context, a few weeks ago, we implemented dark mode styling for emails, preventing the contrast issue found in #3643. This solution worked well, but while working on the Peabody cobrand. I noticed that the buttons had contrast issues on the emails.

The ideal solution would have been to keep the dark mode on. But unfortunately, all windows products were causing issues when reversing the colours and, of course, not respecting the CSS rules. In addition, some elements in certain templates were having issues with some Apple products. 

-Contrast colour on buttons (windows products)
-Black font color against black background color on apple email app

So fixing, testing and maintaining a solution keeping Dark mode enabled will probably take more than we expected during the design sprint. Assuming having dark mode is important? And if so, we could allocate some time for a future sprint.

In the meantime, this Pull request enables Light mode only, which solves the problems on Apple and Windows. The rest of the products also look fine on Litmus. The "only" attribute only applies for apple products, as you can see Windows products will still have a dark version.

Fixes: #3886 

Apple mail 15 Dark mode
![Apple Mail 15 Dark](https://user-images.githubusercontent.com/13790153/164168295-9ab94819-8b06-468c-acbf-51090adabcfa.png)

![Apple Mail ](https://user-images.githubusercontent.com/13790153/164168331-e013b902-b454-4b2e-ae22-6d293ec571b1.png)

Windows 11 Mail dark
![Windows 11 Mail Dark](https://user-images.githubusercontent.com/13790153/164168565-d621149e-0631-4329-b2ef-d3c3474a73aa.png)

Office 365 on Mac
![Office 365](https://user-images.githubusercontent.com/13790153/164168653-5fe1a150-64c4-4190-b169-8925e4f21ac8.png)

Gmail app 
![Gmail App dark](https://user-images.githubusercontent.com/13790153/164168678-c5f4db60-8cec-4880-93f4-d968cfc514d7.png)

