### PR TITLE
[Waste] Do not reuse CSC payment method on modify.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -956,7 +956,8 @@ sub garden_modify : Chained('property') : Args(0) {
     my $billing_address;
     if ( $c->stash->{orig_sub} ) {
         my $orig_sub = $c->stash->{orig_sub};
-        $payment_method = $orig_sub->get_extra_field_value('payment_method') if $orig_sub->get_extra_field_value('payment_method');
+        my $orig_payment_method = $orig_sub->get_extra_field_value('payment_method');
+        $payment_method = $orig_payment_method if $orig_payment_method && $orig_payment_method ne 'csc';
         $billing_address = $orig_sub->get_extra_field_value('billing_address');
     }
 

--- a/perllib/FixMyStreet/App/Form/Waste/Garden/Modify.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Garden/Modify.pm
@@ -80,7 +80,7 @@ has_page summary => (
             $data->{phone} ||= $c->user->phone;
         }
         my $button_text = 'Continue to payment';
-        if ( $data->{payment_method} eq 'credit_card' ) {
+        if ( $data->{payment_method} eq 'credit_card' || $data->{payment_method} eq 'csc' ) {
             if ( $new_bins <= 0 ) {
                 $button_text = 'Confirm changes';
             }

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -1267,6 +1267,9 @@ FixMyStreet::override_config {
         $mech->content_like(qr#/waste/12345">Show upcoming#, "contains link to bin page");
     };
 
+    $p->update_extra_field({ name => 'payment_method', value => 'csc' }); # Originally done by staff
+    $p->update;
+
     subtest 'check modify sub credit card payment reducing bin count' => sub {
         set_fixed_time('2021-01-09T17:00:00Z'); # After sample data collection
         $sent_params = undef;


### PR DESCRIPTION
If the original payment was made by CSC, this payment method was being copied across to modifications made by normal users. It is already re-set to CSC if CSC is used for the modification so default to credit card in the usual case. Also fix button text for such a payment. Fixes https://github.com/mysociety/societyworks/issues/2865 [skip changelog]