### PR TITLE
Added function that prevents orphaned labels and includes aria-label

### DIFF
--- a/templates/web/base/js/translation_strings.html
+++ b/templates/web/base/js/translation_strings.html
@@ -78,6 +78,7 @@ fixmystreet.password_minimum_length = [% c.cobrand.password_minimum_length %];
         upload_default_message_mobile: '[% loc('<u>Take or choose existing photo</u>', "JS") %]',
         upload_cancel_confirmation: '[% loc('Are you sure you want to cancel this upload?', "JS") %]',
         upload_invalid_file_type: '[% loc('Please upload an image only', "JS") %]',
+        upload_aria_label: '[% loc('You can add an optional photo', "JS") %]',
 
         [% IF c.cobrand.sms_authentication ~%]
         login_with_email: '[% loc('Log in with email/text', "JS") %]',

--- a/templates/web/base/report/form/photo_upload.html
+++ b/templates/web/base/report/form/photo_upload.html
@@ -1,6 +1,6 @@
 [% IF c.cobrand.allow_photo_upload %]
     <input type="hidden" name="upload_fileid" value="[% upload_fileid %]">
-    <label for="form_photo">
+    <label id="photo-upload-label" for="form_photo">
         <span data-singular="[% loc('Photo') %]" data-plural="[% loc('Photos') %]">[% loc('Photo') %]</span>
         [% IF c.cobrand.moniker == 'zurich' %][% loc('(Defect &amp; location of defect)') %][% END %]
         [% loc('(optional)') %]

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -873,6 +873,16 @@ $.extend(fixmystreet.set_up, {
     update_label('#filter_categories', translation_strings.select_category_aria_label);
   },
 
+  label_accessibility_update: function() {
+    // Replace unnecessary labels with a span and include a 
+    // proper aria-label to improve accessibility.
+    function replace_label(id, sibling_class, sibling_child, str) {
+        $(id).siblings(sibling_class).children(sibling_child).attr('aria-label', str);
+        $(id).replaceWith(function(){ return $('<span>' + this.innerHTML + '</span>'); });
+    }
+    replace_label('#photo-upload-label','.dropzone.dz-clickable', '.dz-default.dz-message', translation_strings.upload_aria_label);
+  },
+
   // Very similar function in front.js for front page
   on_mobile_nav_click: function() {
     var html = document.documentElement;


### PR DESCRIPTION
This function will allow replacing unnecessary labels with a span element that won't get read on a screen reader.
This fix will also prevent orphaned labels.

To improve accessibility, this function also allows to includes an aria-label.

I think we should try not to overwhelm the screen reader and visually impaired user, by not repeating information that has
already been provided.

For example:
Label("Photos(optiona)")-> Div("Browse or drag photos"),
instead -> Div(Aria-label("You can add optional photos"))

I tested this solution using VoiceOver.
Fixes: mysociety/societyworks#3024
And is related to mysociety/societyworks#2785
