### PR TITLE
Tidy up behaviour around unassigned reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
         - Make calls from Geocoder files to https rather than http
         - Inspector dropdown list only shows name once even if permissions repeated #3870
         - Inspector dropdown list doesn't show anonymised users, removing blank options #3873
+        - Fix report unassignment so it works for users who did not create the report #3903
     - Accessibility improvements:
         - The "skip map" link on /around now has new wording. #3794
         - Improve visual contrast of pagination links. #3794

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
         - Include username in inactive email.
         - Update document title on client-side new report page transition.
         - Disable staff phone and name fields to avoid accidental overwriting.
+        - Hide 'Assigned to' text if a report is not assigned to anyone
+        - Hide 'Assign to' dropdown if no available assignees
     - Bugfixes:
         - Add ID attributes to change password form inputs.
         - Fix link deactivation for privacy policy link on privacy policy page. #3704

--- a/docs/_includes/admin-tasks-content.md
+++ b/docs/_includes/admin-tasks-content.md
@@ -454,9 +454,9 @@ they are in a practical order for your route or priorities.
 
 <span class="admin-task__permissions">Permissions required: User must be marked as staff and 'Assign problem reports to users' must be ticked.</span>
 
-Managers of teams of inspectors can assign reports to the shortlists of inspectors (i.e. staff with the 'Markup problem details' permission). The assignment dropdown appears when editing reports with the inspector tool.
+Managers of teams of inspectors can assign reports to the shortlists of inspectors (i.e. staff with the 'Markup problem details' permission). The assignment dropdown appears when editing reports with the inspector tool, but only if there are any users available to be assigned.
 
-Reports can also be assigned in bulk from the 'All reports' page, where inspector managers can see at a glance which reports are assigned to which inspectors, as well as which are unassigned.
+Reports can also be assigned in bulk from the 'All reports' page, where inspector managers can see at a glance which reports are assigned to which inspectors.
 
 Assigned users can also be viewed on the Reports list page in the Admin area, as well as when editing a report in that list by clicking its 'Edit' link.
 
@@ -464,7 +464,7 @@ Assigned users can also be viewed on the Reports list page in the Admin area, as
 
 <span class="admin-task__permissions">Permissions required: User must be marked as staff and 'Markup problem details' must be ticked.</span>
 
-In addition to seeing their own shortlist, inspectors can, like inspector managers, see which reports are assigned to other inspectors and which are unassigned both in the individual report webpage and in the 'All reports' list.
+In addition to seeing their own shortlist, inspectors can, like inspector managers, see which reports are assigned to other inspectors, both in the individual report webpage and in the 'All reports' list.
 
 #### Viewing navigation routes
 

--- a/perllib/FixMyStreet/App/Controller/My.pm
+++ b/perllib/FixMyStreet/App/Controller/My.pm
@@ -286,7 +286,9 @@ sub bulk_assign : Path('planned/bulk_assign') {
             # take off shortlist
             my @problems = $c->model('DB::Problem')->search({ id => { -in => [ @bulk_reports ]} });
             foreach my $problem (@problems) {
-                $problem->user->remove_from_planned_reports($problem);
+                my $current_assignee = $problem->shortlisted_user;
+                $current_assignee->remove_from_planned_reports($problem)
+                    if $current_assignee;
             }
         } else {
             # add to shortlist

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -526,7 +526,9 @@ sub inspect : Private {
         my $assigned = ($c->get_param('assignment'));
         if ($assigned && $assigned eq 'unassigned') {
             # take off shortlist
-            $problem->user->remove_from_planned_reports($problem);
+            my $current_assignee = $problem->shortlisted_user;
+            $current_assignee->remove_from_planned_reports($problem)
+                if $current_assignee;
         } elsif ($assigned) {
             my $assignee = $c->model('DB::User')->find({ id => $assigned });
             $assignee->add_to_planned_reports($problem);

--- a/t/app/controller/my_assigned.t
+++ b/t/app/controller/my_assigned.t
@@ -109,6 +109,34 @@ FixMyStreet::override_config {
         for (0..2) {
             like($assigned_to[$_], qr/Inspector Ian/, 'Report ' . ($_ + 1) . ' assigned to Ian');
         }
+
+        # unassign reports
+        $mech->form_name('bulk-assign-form');
+        # HTML::Form does not seem to find external form inputs :(
+        # So, copy the checkboxes to inside the form, then tick them.
+        $bulk_form = $mech->current_form;
+        @tickboxes = $root->find('input.bulk-assign');
+        for my $box (@tickboxes) {
+            $bulk_form->push_input('checkbox', {
+                name  => $box->attr('name'),
+                id    => $box->id,
+                value => $box->attr('value'),
+            });
+        }
+
+        $mech->form_name('bulk-assign-form');
+        $mech->select('inspector', 'unassigned');
+        $mech->tick('bulk-assign-reports', $report_id);
+        $mech->tick('bulk-assign-reports', $report2_id);
+        $mech->tick('bulk-assign-reports', $report3_id);
+        $mech->click;
+
+        # check reports are now unassigned
+        $root = HTML::TreeBuilder->new_from_content($mech->content());
+        @assigned_to = $get_assignees->();
+        for (0..2) {
+            is($assigned_to[$_], undef, 'Report ' . ($_ + 1) . ' unassigned from Ian');
+        }
     };
 };
 

--- a/t/app/controller/my_assigned.t
+++ b/t/app/controller/my_assigned.t
@@ -52,8 +52,7 @@ FixMyStreet::override_config {
             my @span = $root->find('li div.assigned-to span.assignee');
             return map {map { s/ ^ \s+ | \s+ $ //grx } $_->content_list} @span;
         };
-        my @all_match_unassigned = qw((unassigned) (unassigned) (unassigned));
-        is_deeply([$get_assignees->()], \@all_match_unassigned, 'all reports correctly unassigned');
+        is_deeply([$get_assignees->()], [], 'all reports correctly unassigned');
 
         $mech->form_name('bulk-assign-form');
         # HTML::Form does not seem to find external form inputs :(
@@ -80,7 +79,7 @@ FixMyStreet::override_config {
         $root = HTML::TreeBuilder->new_from_content($mech->content());
         my @assigned_to = $get_assignees->();
         for (0..2) {
-            like($assigned_to[$_], qr/unassigned/, 'Report ' . ($_ + 1) . ' still unassigned');
+            is($assigned_to[$_], undef, 'Report ' . ($_ + 1) . ' still unassigned');
         }
 
         $mech->form_name('bulk-assign-form');

--- a/t/app/controller/report_inspect.t
+++ b/t/app/controller/report_inspect.t
@@ -711,12 +711,13 @@ FixMyStreet::override_config {
             $mech->click();
             $mech->get_ok("/reports");
             $root = HTML::TreeBuilder->new_from_content($mech->content());
-            @assigned_to = $root->find("li#report-$report_id div.assigned-to span.assignee")->content_list;
+            my $elem = $root->find("li#report-$report_id div.assigned-to span.assignee");
+            @assigned_to = $elem ? $elem->content_list : ();
         };
         $toggle_shortlist->();
         like($assigned_to[0], qr/Body User/, 'assignment by shortlist-add button still works' );
         $toggle_shortlist->();
-        like($assigned_to[0], qr/unassigned/, 'unassignment by shortlist-remove button still works' );
+        is($assigned_to[0], undef, 'unassignment by shortlist-remove button still works' );
     };
     $user->user_body_permissions->delete;
 };

--- a/t/app/controller/report_inspect.t
+++ b/t/app/controller/report_inspect.t
@@ -691,6 +691,13 @@ FixMyStreet::override_config {
 
         $mech->submit_form_ok({ button => 'save', with_fields => { include_update => 0, assignment => $ian->id } });
         $mech->content_contains('Shortlisted by Inspector Ian');
+
+        $mech->submit_form_ok({ button => 'save', with_fields => { include_update => 0, assignment => 'unassigned' } });
+        $mech->get_ok("/report/$report_id");
+        $mech->content_lacks('Shortlisted by', 'Unassignment of user who did not raise report works');
+
+        # Reassign in prep for following tests
+        $mech->submit_form_ok({ button => 'save', with_fields => { include_update => 0, assignment => $ian->id } });
     };
 
     $ian->remove_from_roles($role_a);

--- a/templates/web/base/admin/_report-assignment.html
+++ b/templates/web/base/admin/_report-assignment.html
@@ -1,11 +1,9 @@
 [%  IF c.user.has_permission_to('report_inspect', problem.bodies_str_ids ) OR c.user.has_permission_to('assign_report_to_user', problem.bodies_str_ids) %]
     [%# see report's assigned user %]
-    <span>[% loc('Assigned to:') %]</span>
-    <span class="assignee">
-        [% IF problem.shortlisted_user %]
+    [% IF problem.shortlisted_user %]
+        <span>[% loc('Assigned to:') %]</span>
+        <span class="assignee">
             [% problem.shortlisted_user.name OR problem.shortlisted_user.username %]
-        [% ELSE %]
-            [% loc('(unassigned)') %]
-        [% END %]
-    </span>
+        </span>
+    [% END %]
 [% END %]

--- a/templates/web/base/admin/problem_row.html
+++ b/templates/web/base/admin/problem_row.html
@@ -30,10 +30,14 @@
             [%- END -%]
             <br>[% problem.cobrand %]<br>[% problem.cobrand_data | html %]
             <br>
-            [% IF c.user.has_body_permission_to('assign_report_to_user') %] [%# see report's assigned user %]
+            [% assigned_user = problem.shortlisted_user.name OR problem.shortlisted_user.username %]
+            [%
+                IF c.user.has_body_permission_to('assign_report_to_user')
+                && assigned_user
+            %] [%# see report's assigned user %]
                 <span>[% loc('Assigned to') %]: </span>
                 <span>
-                    [%- problem.shortlisted_user.name OR problem.shortlisted_user.username OR loc('unassigned') -%]
+                    [%- assigned_user -%]
                 </span>
             [%- END -%]
         </td>

--- a/templates/web/base/report/inspect/_assignment-options.html
+++ b/templates/web/base/report/inspect/_assignment-options.html
@@ -1,4 +1,4 @@
-[% FOR user IN body.staff_with_permission('report_inspect')  %]
+[% FOR user IN inspectors %]
     <option value='[% user.id %]'
     [%- IF problem AND (user.id == problem.shortlisted_user.id) -%]
         selected="selected"
@@ -9,4 +9,3 @@
 <option value='unassigned'
 [%- UNLESS problem.shortlisted_user -%] selected="selected"[%- END -%]
 >[% loc('unassigned') %]</option>
-

--- a/templates/web/base/report/inspect/assignment.html
+++ b/templates/web/base/report/inspect/assignment.html
@@ -1,4 +1,7 @@
-[% IF c.user.has_permission_to('assign_report_to_user', problem.bodies_str_ids) %]
+[%
+    IF c.user.has_permission_to('assign_report_to_user', problem.bodies_str_ids)
+        && c.user.from_body.staff_with_permission('report_inspect')
+%]
     <p>
     <label for="assignment">[% loc('Assign to:') %]</label>
     <select class="form-control" name="assignment" id="assignment">

--- a/templates/web/base/report/inspect/assignment.html
+++ b/templates/web/base/report/inspect/assignment.html
@@ -1,11 +1,12 @@
+[% inspectors = c.user.from_body.staff_with_permission('report_inspect') %]
 [%
     IF c.user.has_permission_to('assign_report_to_user', problem.bodies_str_ids)
-        && c.user.from_body.staff_with_permission('report_inspect')
+        && inspectors
 %]
     <p>
     <label for="assignment">[% loc('Assign to:') %]</label>
     <select class="form-control" name="assignment" id="assignment">
-        [% INCLUDE 'report/inspect/_assignment-options.html' body = c.user.from_body %]
+        [% INCLUDE 'report/inspect/_assignment-options.html' %]
     </select>
     </p>
 [% END %]

--- a/templates/web/base/reports/_bulk-assign.html
+++ b/templates/web/base/reports/_bulk-assign.html
@@ -1,6 +1,7 @@
+[% inspectors = c.user.from_body.staff_with_permission('report_inspect') %]
 [%
     IF c.user.has_body_permission_to('assign_report_to_user')
-        && body.staff_with_permission('report_inspect')
+        && inspectors
 %]
 <form id='bulk-assign-form' name='bulk-assign-form' method='post' action='/my/planned/bulk_assign'>
     <label for='inspector'>[% loc('Assign to') %]</label>

--- a/templates/web/base/reports/_bulk-assign.html
+++ b/templates/web/base/reports/_bulk-assign.html
@@ -1,4 +1,7 @@
-[%  IF c.user.has_body_permission_to('assign_report_to_user') %]
+[%
+    IF c.user.has_body_permission_to('assign_report_to_user')
+        && body.staff_with_permission('report_inspect')
+%]
 <form id='bulk-assign-form' name='bulk-assign-form' method='post' action='/my/planned/bulk_assign'>
     <label for='inspector'>[% loc('Assign to') %]</label>
     <input type="hidden" name="token" value="[% csrf_token %]">


### PR DESCRIPTION
This PR hides 'assigned to' text if there is no assignee for a report.
It also fixes buggy behaviour around unassigning reports.

Fixes https://github.com/mysociety/fixmystreet/issues/3646.
Fixes https://github.com/mysociety/fixmystreet/issues/3903.

Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
