### PR TITLE
[Thamesmead] Changes after testing part 1

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Thamesmead.pm
+++ b/perllib/FixMyStreet/Cobrand/Thamesmead.pm
@@ -68,6 +68,15 @@ sub base_url { FixMyStreet::Cobrand::UKCouncils::base_url($_[0]) }
 
 sub default_map_zoom { 6 }
 
+sub enter_postcode_text {
+    my ( $self ) = @_;
+    return _("Enter a road name or postcode adjacent to the area you want to report on or the name of the area");
+}
+
+sub example_places {
+    return [ 'Glendale Way', 'Manorway Green' ];
+}
+
 sub munge_report_new_bodies {
     my ($self, $bodies) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/Thamesmead.pm
+++ b/perllib/FixMyStreet/Cobrand/Thamesmead.pm
@@ -64,6 +64,8 @@ sub problems_sql_restriction { FixMyStreet::Cobrand::UKCouncils::problems_sql_re
 sub users_restriction { FixMyStreet::Cobrand::UKCouncils::users_restriction($_[0], $_[1]) }
 sub updates_restriction { FixMyStreet::Cobrand::UKCouncils::updates_restriction($_[0], $_[1]) }
 
+sub base_url { FixMyStreet::Cobrand::UKCouncils::base_url($_[0]) }
+
 sub default_map_zoom { 6 }
 
 sub munge_report_new_bodies {

--- a/perllib/FixMyStreet/Cobrand/Thamesmead.pm
+++ b/perllib/FixMyStreet/Cobrand/Thamesmead.pm
@@ -77,6 +77,10 @@ sub example_places {
     return [ 'Glendale Way', 'Manorway Green' ];
 }
 
+sub get_body_handler_for_problem {
+    return $_[0];
+}
+
 sub munge_report_new_bodies {
     my ($self, $bodies) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -374,6 +374,9 @@ sub get_body_handler_for_problem {
     if ($row->to_body_named('TfL')) {
         return FixMyStreet::Cobrand::TfL->new;
     }
+    if ($row->to_body_named('Thamesmead')) {
+        return FixMyStreet::Cobrand::Thamesmead->new;
+    }
     # Do not do anything for National Highways here, as we don't want it to
     # treat this as a cobrand for e.g. submit report emails made on .com
 

--- a/templates/web/thamesmead/around/intro.html
+++ b/templates/web/thamesmead/around/intro.html
@@ -1,2 +1,2 @@
-<h1>Report a Problem on a street/road</h1>
-<h2>Report a problem on street/road in Thamesmead or track the progress of reported issues</h2>
+<h1>Report a problem on parks, public open green spaces and canals and waterways in Thamesmead</h1>
+<h2>Report a problem in Thamesmead or track the progress of reported issues</h2>

--- a/templates/web/thamesmead/report/form/private_details.html
+++ b/templates/web/thamesmead/report/form/private_details.html
@@ -1,0 +1,21 @@
+<!-- private_details.html -->
+<h2 class="form-section-heading form-section-heading--private">[% loc('Tell us about you') %]</h2>
+
+[% UNLESS c.user_exists %]
+<p class="hidden-nojs js-new-report-sign-in-hidden">
+    <a class="js-new-report-show-sign-in" href="#">[% loc('Or sign in with password to prefill this information.') %]</a>
+</p>
+[% END %]
+
+[% IF type == 'report' %]
+<p class="form-section-description js-new-report-sign-in-hidden" id="js-councils_text_private">
+  [% IF js %]
+    [% loc('These details will be sent to Peabody, but will never be shown online without your permission.') %]
+    (<a href="[% c.cobrand.privacy_policy_url %]">[% loc('See our privacy policy') %]</a>.)
+  [% ELSE %]
+    [% PROCESS 'report/new/councils_text_private.html' %]
+  [% END %]
+</p>
+[% END %]
+
+<!-- /private_details.html -->

--- a/templates/web/thamesmead/report/new/councils_text_private.html
+++ b/templates/web/thamesmead/report/new/councils_text_private.html
@@ -1,0 +1,9 @@
+[% FILTER collapse %]
+[% category = mark_safe(category) %]
+[% IF unresponsive.$category OR unresponsive.ALL OR bodies_to_list.size == 0 %]
+    [% loc('These details will never be shown online without your permission.') %]
+[% ELSE %]
+    [% loc('These details will be sent to Peabody, but will never be shown online without your permission.') %]
+[% END %]
+(<a href="[% c.cobrand.privacy_policy_url %]">[% loc('See our privacy policy') %]</a>.)
+[% END -%]


### PR DESCRIPTION
1) Confirmation of report refers to it going to a council rather than Peabody
https://3.basecamp.com/4020879/buckets/26382066/todos/4906247418
https://3.basecamp.com/4020879/buckets/26382066/todos/4910559283

2) Content text for page when entering your details, refers to 'Council' and should refer to Peabody
https://3.basecamp.com/4020879/buckets/26382066/todos/4915678385

3) Update home page text to reflect Thamesmead locations
https://3.basecamp.com/4020879/buckets/26382066/todos/4911842219

4) Site going through to FMS.com after confirming a report rather than back to Peabody cobrand
https://3.basecamp.com/4020879/buckets/26382066/todos/4902033447

[skip changelog]