### PR TITLE
[Thamesmead] Change geocoder to OSM and use OSM mapping methods

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Thamesmead.pm
+++ b/perllib/FixMyStreet/Cobrand/Thamesmead.pm
@@ -91,4 +91,31 @@ sub privacy_policy_url {
     'https://www.thamesmeadnow.org.uk/terms-and-conditions/privacy-statement/'
 }
 
+sub get_geocoder { 'OSM' }
+
+sub disambiguate_location {
+    my $self    = shift;
+    my $string  = shift;
+
+    my $town = 'Thamesmead';
+
+    my $results = {
+        %{ $self->SUPER::disambiguate_location() },
+        centre => 51.4981168,0.1054538,
+        string => $string,
+        town => $town,
+    };
+
+    return $results;
+}
+
+sub geocoder_munge_results {
+    my $self = shift;
+    my ($result) = @_;
+    if ($result->{display_name} !~ /Greenwich|Bexley|Thamesmead/) {
+        $result->{display_name} = '';
+    }
+
+}
+
 1;


### PR DESCRIPTION
1) Southmere drive not in Crayford - OSM doesn't show it as such so changing to OSM removes Crayford
https://3.basecamp.com/4020879/buckets/26382066/todos/4906047321

2) Claridge Way not coming up in search - OSM shows Claridge Way
https://3.basecamp.com/4020879/buckets/26382066/todos/4906653404

3) Holstein and Lensbury way don't show on map and have Crayford in title - OSM removes Crayford. Lensbury way seems to show up but Holstein too small for the map? 
https://3.basecamp.com/4020879/buckets/26382066/todos/4906718571

4) Some locations not found and taken to an area outside of Thamesmead - remove not area search results.
https://3.basecamp.com/4020879/buckets/26382066/todos/4898005285

[skip changelog]