### PR TITLE
Permit control over database connection SSL mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
         - Add an index on problem(external_id) to speed up bin/fetch --updates
         - Upgrade Net::DNS and libwww to deal with IPv6 issues.
         - Add send_state column to updates. #3865
+    - Security
+        - Permit control over database connection `sslmode` via $FMS_DB_SSLMODE
     - Open311 improvements:
         - Increase default timeout.
 

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -19,6 +19,7 @@ FMS_DB_PORT: '5432'
 FMS_DB_NAME: 'fms'
 FMS_DB_USER: 'fms'
 FMS_DB_PASS: ''
+FMS_DB_SSLMODE: 'prefer'
 
 # The base URL of the install.
 BASE_URL: 'http://www.example.org'

--- a/docs/customising/config.md
+++ b/docs/customising/config.md
@@ -40,8 +40,9 @@ The following are all the configuration settings that you can change in `conf/ge
 * <code><a href="#fms_db_host">FMS_DB_HOST</a></code>,
 <code><a href="#fms_db_port">FMS_DB_PORT</a></code>,
 <code><a href="#fms_db_name">FMS_DB_NAME</a></code>,
-<code><a href="#fms_db_user">FMS_DB_USER</a></code>, and
-<code><a href="#fms_db_pass">FMS_DB_PASS</a></code>
+<code><a href="#fms_db_user">FMS_DB_USER</a></code>,
+<code><a href="#fms_db_pass">FMS_DB_PASS</a></code> and
+<code><a href="#fms_db_sslmode">FMS_DB_SSLMODE</a></code>
 
 ### Site settings and behaviour
 
@@ -141,8 +142,9 @@ The following are all the configuration settings that you can change in `conf/ge
     <a name="fms_db_host"><code>FMS_DB_HOST</code></a>,
     <a name="fms_db_port"><code>FMS_DB_PORT</code></a>,
     <a name="fms_db_name"><code>FMS_DB_NAME</code></a>,
-    <a name="fms_db_user"><code>FMS_DB_USER</code></a> &amp;
-    <a name="fms_db_pass"><code>FMS_DB_PASS</code></a>
+    <a name="fms_db_user"><code>FMS_DB_USER</code></a>,
+    <a name="fms_db_pass"><code>FMS_DB_PASS</code></a> &amp;
+    <a name="fms_db_sslmode"><code>FMS_DB_SSLMODE</code></a>
   </dt>
   <dd>
     These are the PostgreSQL database details for FixMyStreet.
@@ -156,6 +158,7 @@ The following are all the configuration settings that you can change in `conf/ge
             FMS_DB_NAME: 'fms'<br>
             FMS_DB_USER: 'fmsuser'<br>
             FMS_DB_PASS: 'aSecretWord'
+            FMS_DB_SSLMODE: 'require'
             </code>
         </li>
       </ul>

--- a/perllib/FixMyStreet.pm
+++ b/perllib/FixMyStreet.pm
@@ -142,15 +142,16 @@ Most of the values are read from the config file and others are hordcoded here.
 # we use the one that is most similar to DBI's connect.
 
 sub dbic_connect_info {
-    my $class  = shift;
-    my $config = $class->config;
+    my $class   = shift;
+    my $config  = $class->config;
+    my $sslmode = $config->{FMS_DB_SSLMODE} || "prefer";
 
     my $dsn = "dbi:Pg:dbname=" . $config->{FMS_DB_NAME};
     $dsn .= ";host=$config->{FMS_DB_HOST}"
       if $config->{FMS_DB_HOST};
     $dsn .= ";port=$config->{FMS_DB_PORT}"
       if $config->{FMS_DB_PORT};
-    $dsn .= ";sslmode=allow";
+    $dsn .= ";sslmode=$sslmode";
 
     my $user     = $config->{FMS_DB_USER} || undef;
     my $password = $config->{FMS_DB_PASS} || undef;


### PR DESCRIPTION
This adds a new configuration variable, `FMS_DB_SSLMODE`, can be used to override the default `sslmode` setting FMS uses when connecting to its PostgreSQL database and changes the default from `allow` to `prefer`.

The previous value for `sslmode` used was hardcoded to `allow` which will at first try an unencrypted connection before trying an encrypted one if the database server enforces SSL. This is an insecure default behaviour and also results in large numbers of FATAL connection errors on database servers that enforce SSL connections.

This nows default to `prefer` if the variable isn't present in the configuration file. This is backwards-compatible with the previous default in that it will allow unsecure connections, but only after first trying an encrypted connection, reversing the previous behaviour.

We recommend setting this to at least `require` and ensuring that your database server is configured to only accept encrypted connections.

Please check the following:

- [x] Whether this PR should include changes to any documentation, or the FAQ;
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [ ] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Will cobrand-specific changes require additional work to ensure consistent behaviour on www.fixmystreet.com? 
- [x] Are the changes tested for accessibility?
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
