### PR TITLE
[Kingston] Changed font size and colour for h1, h2, p

### DIFF
--- a/web/cobrands/kingston/base.scss
+++ b/web/cobrands/kingston/base.scss
@@ -13,10 +13,14 @@
 body {
     font-family: $body-font;
     color: $black;
+    background-color: #eef1e6;
 }
 
 .content {
     color: $black !important;
+    background: #fff;
+    padding: 0.75rem 1.5rem;
+    margin-top: 1em;
 }
 
 .visually-hidden {

--- a/web/cobrands/kingston/base.scss
+++ b/web/cobrands/kingston/base.scss
@@ -12,7 +12,11 @@
 
 body {
     font-family: $body-font;
-    color: $primary_b;
+    color: $black;
+}
+
+.content {
+    color: $black !important;
 }
 
 .visually-hidden {
@@ -119,10 +123,16 @@ h1, h2, h3, .h1, .h2, .h3 {
     font-family: $body-font;
 }
 
-h1 {
-    font-size: 2em;
+h1, h1.govuk-heading-xl {
+    font-size: 2.375em;
     line-height: 1.25em;
-    font-weight: bold;
+    font-weight: 600;
+    color: $blue;
+}
+
+h2, h2.govuk-heading-l {
+    color: $black;
+    font-size: 1.75em;
 }
 
 label {

--- a/web/cobrands/kingston/layout.scss
+++ b/web/cobrands/kingston/layout.scss
@@ -88,10 +88,6 @@
     padding: 4%;
 }
 
-h1 {
-    font-size: 2.5em;
-}
-
 input.form-error,
 textarea.form-error {
     border-radius: 4px;


### PR DESCRIPTION
Updated fonts styles to the ones https://www.kingston.gov.uk/.
I have also fixed some spacing issues I found on mobile. These changes should make it look similar to Kingston website.

It fixes: https://3.basecamp.com/4020879/buckets/26876928/todos/4935216341