### PR TITLE
[Peterborough] Small improvements to bin day & missed collection messages

### DIFF
--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -127,6 +127,8 @@ FixMyStreet::override_config {
         ] });
         $mech->get_ok('/waste/PE1%203NA:100090215480');
         $mech->content_contains('There was a problem with your bin collection, please call');
+        $mech->content_contains('quoting your collection address in the subject line');
+        $mech->content_contains('mailto:ask&#64;peterborough.gov.uk?subject=1 Pope Way, Peterborough, PE1 3NA - missed bin');
 
         $b->mock('Premises_Events_Get', sub { [] }); # reset
 

--- a/templates/web/peterborough/waste/services.html
+++ b/templates/web/peterborough/waste/services.html
@@ -1,3 +1,4 @@
+[% USE date(format = c.cobrand.bin_day_format) %]
 [% SET pboro_staff_request = ( NOT waste_features.request_disabled ) AND c.user_exists AND (c.user.is_superuser OR (c.user.from_body AND c.user.from_body.name == "Peterborough City Council")) %]
 
 [% UNLESS waste_features.report_disabled %]
@@ -40,7 +41,11 @@
       <input type="submit" value="Report a [% unit.service_name FILTER lower %] collection as missed" class="waste-service-descriptor waste-service-link">
     </form>
   [% ELSE %]
-    <span class="waste-service-descriptor">Please note that missed collections can only be reported within 2&frac12; working days of your collection day (including the collection day).</span>
+    [% IF unit.next AND unit.next.date.ymd == date.format(date.now, "%Y-%m-%d") %]
+      <span class="waste-service-descriptor">The crew have not recorded your street as complete and may still be planning to attend. You will not be able to report a missed bin at this time.</span>
+    [% ELSE %]
+      <span class="waste-service-descriptor">Please note that missed collections can only be reported within 2&frac12; working days of your collection day (including the collection day).</span>
+    [% END %]
   [% END %]
 [% END %]
 

--- a/templates/web/peterborough/waste/services.html
+++ b/templates/web/peterborough/waste/services.html
@@ -27,7 +27,7 @@
     [%~ IF c.user.from_body OR c.user.is_superuser %]
         ([% unit.report_locked_out.join(', ') %])
     [%~ END %], please call 01733 74 74 74 or email us at
-        <a href="mailto:ask&#64;peterborough.gov.uk">ask&#64;peterborough.gov.uk</a>.<br />
+        <a href="mailto:ask&#64;peterborough.gov.uk?subject=[% property.address %] - missed bin">ask&#64;peterborough.gov.uk</a>, quoting your collection address in the subject line.<br />
         <small>Please note: we will not return to collect bins that have been recorded
         by the crew as overweight, contaminated or bin not presented. For more
         information please visit


### PR DESCRIPTION
 - On the day of collection a more specific message is shown to prevent user confusion. For FD-2046
 - The email link displayed in the "There was a problem with the collection, please email" message now prepopulates the user's address in the subject line. For FD-2040.

[skip changelog]