### PR TITLE
[Kingston] Variety of waste changes

### DIFF
--- a/bin/fixmystreet.com/kingston-fetch-waste
+++ b/bin/fixmystreet.com/kingston-fetch-waste
@@ -11,7 +11,8 @@ BEGIN {
 }
 
 use Getopt::Long::Descriptive;
-use FixMyStreet::Cobrand::Bromley;
+use FixMyStreet::Cobrand; # Without this, you get a method 'look_up_property' is not found in the inheritance hierarchy error
+use FixMyStreet::Cobrand::Kingston;
 
 my ($opts, $usage) = describe_options(
     '%c %o',
@@ -20,8 +21,8 @@ my ($opts, $usage) = describe_options(
 );
 $usage->die if $opts->help;
 
-my $cobrand = FixMyStreet::Cobrand::Bromley->new;
+my $cobrand = FixMyStreet::Cobrand::Kingston->new;
 $cobrand->waste_fetch_events({
     verbose => $opts->verbose,
-    devolved => 1,
+    devolved => 0,
 });

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -923,7 +923,9 @@ sub process_user : Private {
     if ( $c->user_exists ) { {
         my $user = $c->user->obj;
 
-        if ($c->stash->{contributing_as_another_user}) {
+        # WasteWorks can set a flag to treat the user as if not logged in if username differs
+        my $same_user = $user->username eq $params{username};
+        if ($c->stash->{contributing_as_another_user} || ($c->stash->{ignore_logged_in_user} && !$same_user)) {
             if ($params{username} || $params{phone}) {
                 # Act as if not logged in (and it will be auto-confirmed later on)
                 $report->user(undef);

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -983,7 +983,7 @@ sub garden : Chained('garden_setup') : Args(0) {
     if ($c->stash->{garden_sacks}) {
         $c->stash->{form_class} = 'FixMyStreet::App::Form::Waste::Garden::Sacks';
     } else {
-        my $service = $c->cobrand->garden_bin_service_id;
+        my $service = $c->cobrand->garden_service_id;
         $c->stash->{garden_form_data} = {
             max_bins => $c->stash->{quantity_max}->{$service}
         };
@@ -1018,7 +1018,7 @@ sub garden_modify : Chained('garden_setup') : Args(0) {
 
         $c->forward('get_original_sub', ['user']);
 
-        my $service_id = $c->cobrand->garden_bin_service_id;
+        my $service_id = $c->cobrand->garden_service_id;
         my $max_bins = $c->stash->{quantity_max}->{$service_id};
 
         my $payment_method = 'credit_card';
@@ -1085,7 +1085,7 @@ sub garden_renew : Chained('garden_setup') : Args(0) {
     if ($c->stash->{garden_sacks}) {
         $c->stash->{form_class} = 'FixMyStreet::App::Form::Waste::Garden::Sacks::Renew';
     } else {
-        my $service = $c->cobrand->garden_bin_service_id;
+        my $service = $c->cobrand->garden_service_id;
         my $max_bins = $c->stash->{quantity_max}->{$service};
         $service = $c->stash->{services}{$service};
         $c->stash->{garden_form_data} = {
@@ -1183,10 +1183,8 @@ sub setup_garden_sub_params : Private {
     my $service_id;
     if (my $service = $c->cobrand->garden_current_subscription) {
         $service_id = $service->{service_id};
-    } elsif ($c->stash->{garden_sacks}) {
-        $service_id = $c->cobrand->garden_bag_service_id;
     } else {
-        $service_id = $c->cobrand->garden_bin_service_id;
+        $service_id = $c->cobrand->garden_service_id;
     }
     $c->set_param('service_id', $service_id);
     $c->set_param('client_reference', 'GGW' . $c->stash->{property}->{uprn});

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1378,13 +1378,17 @@ sub add_report : Private {
     };
 
     # Don’t let staff inadvertently change their name when making reports
-    my $original_name = $c->user->name if $c->user_exists && $c->user->from_body && $c->user->email eq $data->{email};
+    my $original_name = $c->user->name if $c->user_exists && $c->user->from_body && $c->user->email eq ($data->{email} || '');
 
-    # XXX Is this best way to do this?
-    if ($c->user_exists && $c->user->from_body && !$data->{email} && !$data->{phone}) {
-        $c->set_param('form_as', 'anonymous_user');
-    } elsif ($c->user_exists && $c->user->from_body && $c->user->email ne $data->{email}) {
-        $c->set_param('form_as', 'another_user');
+    # We want to take what has been entered in the form, even if someone is logged in
+    $c->stash->{ignore_logged_in_user} = 1;
+
+    if ($c->user_exists) {
+        if ($c->user->from_body && !$data->{email} && !$data->{phone}) {
+            $c->set_param('form_as', 'anonymous_user');
+        } elsif ($c->user->from_body && $c->user->email ne $data->{email}) {
+            $c->set_param('form_as', 'another_user');
+        }
         $c->set_param('username', $data->{email} || $data->{phone});
     } else {
         $c->set_param('username_register', $data->{email} || $data->{phone});

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -539,7 +539,7 @@ sub property : Chained('/') : PathPart('waste') : CaptureArgs(1) {
     }
 
     my $property = $c->stash->{property} = $c->cobrand->call_hook(look_up_property => $id);
-    $c->detach( '/page_error_404_not_found', [] ) unless $property;
+    $c->detach( '/page_error_404_not_found', [] ) unless $property && $property->{id};
 
     $c->stash->{latitude} = Utils::truncate_coordinate( $property->{latitude} );
     $c->stash->{longitude} = Utils::truncate_coordinate( $property->{longitude} );

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -224,6 +224,7 @@ sub pay : Path('pay') : Args(0) {
         ref => 'GGW' . $uprn,
         request_id => $p->id,
         description => $p->title,
+        name => $p->name,
         email => $p->user->email,
         uprn => $uprn,
         address1 => shift @parts,

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -558,9 +558,8 @@ sub image_for_service {
 }
 
 use constant GARDEN_WASTE_SERVICE_ID => 545;
-sub garden_bin_service_id { GARDEN_WASTE_SERVICE_ID }
+sub garden_service_id { GARDEN_WASTE_SERVICE_ID }
 sub garden_current_subscription { shift->{c}->stash->{services}{+GARDEN_WASTE_SERVICE_ID} }
-sub garden_current_bin_subscription { shift->garden_current_subscription }
 sub get_current_garden_bins { shift->garden_current_subscription->{garden_bins} }
 sub garden_subscription_type_field { 'Subscription_Type' }
 sub garden_subscription_container_field { 'Subscription_Details_Container_Type' }

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -539,8 +539,9 @@ sub clear_cached_lookups_property {
     delete $self->{c}->session->{$key};
 }
 
-sub image_for_service {
-    my ($self, $service_id) = @_;
+sub image_for_unit {
+    my ($self, $unit) = @_;
+    my $service_id = $unit->{service_id};
     my $base = '/cobrands/bromley/images/container-images';
     my $images = {
         531 => "$base/refuse-black-sack",

--- a/perllib/FixMyStreet/Cobrand/Kingston.pm
+++ b/perllib/FixMyStreet/Cobrand/Kingston.pm
@@ -168,15 +168,19 @@ around look_up_property => sub {
     return $data;
 };
 
-sub image_for_service {
-    my ($self, $service_id) = @_;
+sub image_for_unit {
+    my ($self, $unit) = @_;
     my $base = '/cobrands/kingston/container-images';
+    if (my $container = $unit->{garden_container}) {
+        return "$base/garden-waste-bin" if $container == 26;
+        return "";
+    }
+    my $service_id = $unit->{service_id};
     my $images = {
         1906 => "$base/black-bin-blue-lid", # paper and card
         1903 => "$base/black-bin", # refuse
         1908 => "$base/brown-bin", # food
         1909 => "$base/green-bin", # dry mixed
-        2247 => "$base/garden-waste-bin",
     };
     return $images->{$service_id};
 }
@@ -337,6 +341,7 @@ sub bin_services_for_address {
 
             my $garden = 0;
             my $garden_bins;
+            my $garden_container;
             my $garden_cost = 0;
             my $garden_due = $self->waste_sub_due($schedules->{end_date});
             my $garden_overdue = $expired{$service_id};
@@ -344,10 +349,10 @@ sub bin_services_for_address {
                 $garden = 1;
                 my $data = Integrations::Echo::force_arrayref($task->{Data}, 'ExtensibleDatum');
                 foreach (@$data) {
-                    next unless $_->{DatatypeName} eq 'SLWP - Containers'; # DatatypeId 3346
+                    next unless $_->{DatatypeName} eq $self->garden_echo_container_name; # DatatypeId 3346
                     my $moredata = Integrations::Echo::force_arrayref($_->{ChildData}, 'ExtensibleDatum');
                     foreach (@$moredata) {
-                        # $container = $_->{Value} if $_->{DatatypeName} eq 'Container Type'; # should be 26 or 28
+                        $garden_container = $_->{Value} if $_->{DatatypeName} eq 'Container Type'; # should be 26 or 28
                         if ( $_->{DatatypeName} eq 'Quantity' ) {
                             $garden_bins = $_->{Value};
                             $garden_cost = $self->garden_waste_cost_pa($garden_bins) / 100;
@@ -366,6 +371,7 @@ sub bin_services_for_address {
                 service_id => $service_id,
                 service_name => $service_name,
                 garden_waste => $garden,
+                garden_container => $garden_container,
                 garden_bins => $garden_bins,
                 garden_cost => $garden_cost,
                 garden_due => $garden_due,

--- a/perllib/FixMyStreet/Cobrand/Kingston.pm
+++ b/perllib/FixMyStreet/Cobrand/Kingston.pm
@@ -7,6 +7,8 @@ use utf8;
 use DateTime::Format::W3CDTF;
 use Integrations::Echo;
 use FixMyStreet::WorkingDays;
+use JSON::MaybeXS;
+use LWP::Simple;
 use Moo;
 with 'FixMyStreet::Roles::CobrandEcho';
 with 'FixMyStreet::Roles::Bottomline';
@@ -150,6 +152,21 @@ sub clear_cached_lookups_property {
     $key = "kingston:echo:bin_services_for_address:$id";
     delete $self->{c}->session->{$key};
 }
+
+around look_up_property => sub {
+    my ($orig, $self, $id) = @_;
+    my $data = $orig->($self, $id);
+    my $cfg = $self->feature('echo');
+    if ($cfg->{nlpg} && $data->{uprn}) {
+        my $uprn_data = get(sprintf($cfg->{nlpg}, $data->{uprn}));
+        $uprn_data = JSON::MaybeXS->new->decode($uprn_data);
+        if ($uprn_data->{Addresses}[0]{AdministrativeArea} ne 'KINGSTON UPON THAMES') {
+            $self->{c}->stash->{template} = 'waste/missing.html';
+            $self->{c}->detach;
+        }
+    }
+    return $data;
+};
 
 sub image_for_service {
     my ($self, $service_id) = @_;

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -492,8 +492,9 @@ sub look_up_property {
     return $premises{$uprn};
 }
 
-sub image_for_service {
-    my ($self, $service_id) = @_;
+sub image_for_unit {
+    my ($self, $unit) = @_;
+    my $service_id = $unit->{service_id};
     my $base = '/cobrands/peterborough/images';
     my $images = {
         6533 => "$base/black-bin",

--- a/perllib/FixMyStreet/Roles/CobrandEcho.pm
+++ b/perllib/FixMyStreet/Roles/CobrandEcho.pm
@@ -25,7 +25,9 @@ sub bin_addresses_for_postcode {
         value => $_->{Id},
         label => FixMyStreet::Template::title($_->{Description}),
     } } @$points ];
-    natkeysort_inplace { $_->{label} } @$data;
+    if ($self->moniker eq 'bromley') {
+        natkeysort_inplace { $_->{label} } @$data;
+    }
     return $data;
 }
 

--- a/perllib/Integrations/SCP.pm
+++ b/perllib/Integrations/SCP.pm
@@ -124,6 +124,7 @@ sub pay {
         },
         'scpbase:billing' => {
             'scpbase:cardHolderDetails' => ixhash(
+                'scpbase:cardHolderName' => $args->{name},
                 'scpbase:address' => ixhash(
                     'scpbase:address1' => $args->{address1},
                     'scpbase:address2' => $args->{address2},

--- a/t/app/controller/waste_kingston.t
+++ b/t/app/controller/waste_kingston.t
@@ -170,6 +170,54 @@ FixMyStreet::override_config {
     ALLOWED_COBRANDS => 'kingston',
     MAPIT_URL => 'http://mapit.uk/',
     COBRAND_FEATURES => {
+        echo => { kingston => { url => 'http://example.org', nlpg => 'https://example.com/%s' } },
+        waste => { kingston => 1 },
+    },
+}, sub {
+    my $lwp = Test::MockModule->new('LWP::UserAgent');
+    $lwp->mock('get', sub {
+        my ($ua, $url) = @_;
+        return $lwp->original('get')->(@_) unless $url =~ /example.com/;
+        my ($uprn, $area) = (1000000002, "KINGSTON UPON THAMES");
+        ($uprn, $area) = (1000000004, "SUTTON") if $url =~ /1000000004/;
+        my $j = '{ "Addresses": [ { "Uprn": ' . $uprn . ', "AdministrativeArea": "' . $area . '" } ] }';
+        return HTTP::Response->new(200, 'OK', [], $j);
+    });
+    my $echo = Test::MockModule->new('Integrations::Echo');
+    $echo->mock('GetEventsForObject', sub { [] });
+    $echo->mock('FindPoints', sub { [
+        { Description => '2 Example Street, Kingston, KT1 1AA', Id => '12345', SharedRef => { Value => { anyType => 1000000002 } } },
+        { Description => '3 Example Street, Sutton, KT1 1AA', Id => '14345', SharedRef => { Value => { anyType => 1000000004 } } },
+    ] });
+    $echo->mock('GetPointAddress', sub {
+        my ($self, $id) = @_;
+        return {
+            Id => $id,
+            SharedRef => { Value => { anyType => $id == 14345 ? '1000000004' : '1000000002' } },
+            PointType => 'PointAddress',
+            PointAddressType => { Name => 'House' },
+            Coordinates => { GeoPoint => { Latitude => 51.408688, Longitude => -0.304465 } },
+            Description => '2/3 Example Street, Sutton, KT1 1AA',
+        };
+    });
+    $echo->mock('GetServiceUnitsForObject', \&garden_waste_one_bin);
+
+    subtest 'Look up of address not in correct borough' => sub {
+        $mech->get_ok('/waste');
+        $mech->submit_form_ok({ with_fields => { postcode => 'KT1 1AA' } });
+        $mech->submit_form_ok({ with_fields => { address => '14345' } });
+        $mech->content_contains('No address on record');
+        $mech->get_ok('/waste');
+        $mech->submit_form_ok({ with_fields => { postcode => 'KT1 1AA' } });
+        $mech->submit_form_ok({ with_fields => { address => '12345' } });
+        $mech->content_lacks('No address on record');
+    };
+};
+
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => 'kingston',
+    MAPIT_URL => 'http://mapit.uk/',
+    COBRAND_FEATURES => {
         echo => { kingston => { url => 'http://example.org' } },
         waste => { kingston => 1 },
         payment_gateway => { kingston => {

--- a/t/app/controller/waste_kingston.t
+++ b/t/app/controller/waste_kingston.t
@@ -130,7 +130,6 @@ sub _garden_waste_service_units {
     my ($bin_count, $type) = @_;
 
     my $bin_type_id = $type eq 'sack' ? 28 : 26;
-    my $task_type_id = $type eq 'sack' ? 1915 : 1914;
 
     return [ {
         Id => 1002,
@@ -138,7 +137,7 @@ sub _garden_waste_service_units {
         ServiceName => 'Garden waste collection',
         ServiceTasks => { ServiceTask => {
             Id => 405,
-            TaskTypeId => $task_type_id,
+            TaskTypeId => 2247,
             Data => { ExtensibleDatum => [ {
                 DatatypeName => 'SLWP - Containers',
                 ChildData => { ExtensibleDatum => [ {

--- a/t/app/controller/waste_kingston.t
+++ b/t/app/controller/waste_kingston.t
@@ -656,7 +656,7 @@ FixMyStreet::override_config {
             current_bins => 1,
             bins_wanted => 2,
             payment_method => 'credit_card',
-            name => 'Test McTest',
+            name => 'New McTest',
             email => 'test@example.net',
         } });
         $mech->content_contains('40.00');
@@ -664,6 +664,7 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { tandc => 1 } });
         is $sent_params->{items}[0]{amount}, 4000, 'correct amount used';
         is $sent_params->{items}[1]{amount}, 1500, 'correct amount used';
+        is $call_params->{'scpbase:billing'}{'scpbase:cardHolderDetails'}{'scpbase:cardHolderName'}, 'New McTest', 'Correct name';
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
@@ -933,6 +934,8 @@ FixMyStreet::override_config {
 
         $mech->submit_form_ok({ with_fields => { tandc => 1 } });
         is $call_params->{'scpbase:panEntryMethod'}, 'CNP', 'Correct cardholder-not-present flag';
+        is $call_params->{'scpbase:billing'}{'scpbase:cardHolderDetails'}{'scpbase:cardHolderName'}, 'a user', 'Correct name';
+        is $call_params->{'scpbase:billing'}{'scpbase:cardHolderDetails'}{'scpbase:contact'}{'scpbase:email'}, 'a_user@example.net', 'Correct name';
         is $sent_params->{items}[0]{amount}, 2000, 'correct amount used';
         is $sent_params->{items}[1]{amount}, undef, 'correct amount used';
 

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -24,6 +24,7 @@ my $params = {
 my $body = $mech->create_body_ok(2566, 'Peterborough City Council', $params);
 my $user = $mech->create_user_ok('test@example.net', name => 'Normal User');
 my $staff = $mech->create_user_ok('staff@example.net', name => 'Staff User', from_body => $body->id);
+$staff->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_another_user' });
 
 sub create_contact {
     my ($params, $group, @extra) = @_;
@@ -254,7 +255,7 @@ FixMyStreet::override_config {
         $mech->log_in_ok($user->email);
         $mech->get_ok('/waste/PE1 3NA:100090215480/request');
         $mech->submit_form_ok({ with_fields => { 'container-425' => 1, 'request_reason' => 'cracked' }});
-        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => 'email@example.org' }});
+        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
         $mech->submit_form_ok({ with_fields => { process => 'summary' } });
         $mech->content_contains('Request sent');
         $mech->content_like(qr/If your bin is not received two working days before scheduled collection\s+please call 01733 747474 to discuss alternative arrangements./);
@@ -265,10 +266,9 @@ FixMyStreet::override_config {
         is $report->title, 'Request new All bins';
     };
     subtest 'Report a cracked bin raises a bin delivery request' => sub {
-        $mech->log_in_ok($user->email);
         $mech->get_ok('/waste/PE1 3NA:100090215480/problem');
         $mech->submit_form_ok({ with_fields => { 'service-420' => 1 } });
-        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => 'email@example.org' }});
+        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
         $mech->content_contains('The bin is cracked', "Cracked category found");
         $mech->submit_form_ok({ with_fields => { process => 'summary' } });
         $mech->content_contains('Damaged bin reported');
@@ -280,7 +280,6 @@ FixMyStreet::override_config {
         is $report->title, 'Request new 240L Green';
     };
     subtest 'Staff-only request reason shown correctly' => sub {
-        $mech->log_in_ok($user->email);
         $mech->get_ok('/waste/PE1 3NA:100090215480/request');
         $mech->content_lacks("(Other - PD STAFF)");
         $mech->log_in_ok($staff->email);
@@ -318,7 +317,7 @@ FixMyStreet::override_config {
         $mech->get_ok('/waste/PE1 3NA:100090215480');
         $mech->submit_form_ok({ with_fields => { 'container-428' => 1 } });
         $mech->content_contains('About you');
-        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => 'email@example.org' }});
+        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
         $mech->content_contains('Request food bags');
         $mech->content_contains('Submit food bags request');
         $mech->content_lacks('Request new bins');

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -711,7 +711,7 @@ subtest 'updating of waste reports' => sub {
 
         $report->update({ external_id => 'waste-15001-' });
         stdout_like {
-            $cobrand->waste_fetch_events(1);
+            $cobrand->waste_fetch_events({ verbose => 1 });
         } qr/Fetching data for report/;
         $report->discard_changes;
         is $report->comments->count, 0, 'No new update';
@@ -719,7 +719,7 @@ subtest 'updating of waste reports' => sub {
 
         $report->update({ external_id => 'waste-15003-' });
         stdout_like {
-            $cobrand->waste_fetch_events(1);
+            $cobrand->waste_fetch_events({ verbose => 1 });
         } qr/Updating report to state action scheduled, Allocated to Crew/;
         $report->discard_changes;
         is $report->comments->count, 1, 'A new update';
@@ -729,7 +729,7 @@ subtest 'updating of waste reports' => sub {
 
         $report->update({ external_id => 'waste-15003-' });
         stdout_like {
-            $cobrand->waste_fetch_events(1);
+            $cobrand->waste_fetch_events({ verbose => 1 });
         } qr/Latest update matches fetched state/;
         $report->discard_changes;
         is $report->comments->count, 1, 'No new update';
@@ -737,7 +737,7 @@ subtest 'updating of waste reports' => sub {
 
         $report->update({ external_id => 'waste-15004-201' });
         stdout_like {
-            $cobrand->waste_fetch_events(1);
+            $cobrand->waste_fetch_events({ verbose => 1 });
         } qr/Updating report to state fixed - council, Completed/;
         $report->discard_changes;
         is $report->comments->count, 2, 'A new update';
@@ -745,12 +745,12 @@ subtest 'updating of waste reports' => sub {
 
         $reports[1]->update({ state => 'fixed - council' });
         stdout_like {
-            $cobrand->waste_fetch_events(1);
+            $cobrand->waste_fetch_events({ verbose => 1 });
         } qr/^$/, 'No open reports';
 
         $report->update({ external_id => 'waste-15005-205', state => 'confirmed' });
         stdout_like {
-            $cobrand->waste_fetch_events(1);
+            $cobrand->waste_fetch_events({ verbose => 1 });
         } qr/Updating report to state unable to fix, Inclement Weather/;
         $report->discard_changes;
         is $report->comments->count, 3, 'A new update';

--- a/t/cobrand/kingston.t
+++ b/t/cobrand/kingston.t
@@ -48,7 +48,7 @@ FixMyStreet::override_config {
                     ServiceId => 409,
                     ServiceName => 'Garden waste collection',
                     ServiceTasks => { ServiceTask => {
-                        TaskTypeId => 1914,
+                        TaskTypeId => 2247,
                         Id => 405,
                         ScheduleDescription => 'every other Monday',
                         Data => { ExtensibleDatum => [ {
@@ -85,7 +85,7 @@ FixMyStreet::override_config {
                     ServiceId => 409,
                     ServiceName => 'Garden waste collection',
                     ServiceTasks => { ServiceTask => {
-                        TaskTypeId => 1914,
+                        TaskTypeId => 2247,
                         Id => 405,
                         ScheduleDescription => 'every other Monday',
                         Data => { ExtensibleDatum => [ {
@@ -705,7 +705,7 @@ FixMyStreet::override_config {
         is $renewal_from_cc_sub->get_extra_field_value('PaymentCode'), "GGW1654321", 'correct echo payment code field';
         is $renewal_from_cc_sub->get_extra_field_value('Request_Type'), 2, 'From CC Renewal has correct type';
         is $renewal_from_cc_sub->get_extra_field_value('Subscription_Details_Containers'), 26, 'From CC Renewal has correct container type';
-        is $renewal_from_cc_sub->get_extra_field_value('service_id'), 1914, 'Renewal has correct service id';
+        is $renewal_from_cc_sub->get_extra_field_value('service_id'), 2247, 'Renewal has correct service id';
         is $renewal_from_cc_sub->get_extra_field_value('LastPayMethod'), 3, 'correct echo payment method field';
 
         my $subsequent_renewal_from_cc_sub = FixMyStreet::DB->resultset('Problem')->search({
@@ -721,7 +721,7 @@ FixMyStreet::override_config {
         is $subsequent_renewal_from_cc_sub->get_extra_field_value('PaymentCode'), "GGW3654321", 'correct echo payment code field';
         is $subsequent_renewal_from_cc_sub->get_extra_field_value('Request_Type'), 2, 'Subsequent Renewal has correct type';
         is $subsequent_renewal_from_cc_sub->get_extra_field_value('Subscription_Details_Containers'), 26, 'Subsequent Renewal has correct container type';
-        is $subsequent_renewal_from_cc_sub->get_extra_field_value('service_id'), 1914, 'Subsequent Renewal has correct service id';
+        is $subsequent_renewal_from_cc_sub->get_extra_field_value('service_id'), 2247, 'Subsequent Renewal has correct service id';
         is $subsequent_renewal_from_cc_sub->get_extra_field_value('LastPayMethod'), 3, 'correct echo payment method field';
         is $subsequent_renewal_from_cc_sub->get_extra_field_value('payment_method'), 'direct_debit', 'correctly marked as direct debit';
 
@@ -761,7 +761,7 @@ FixMyStreet::override_config {
         is $p->get_extra_field_value('Subscription_Details_Quantity'), 2, "renewal has correct number of bins";
         is $p->get_extra_field_value('Request_Type'), 2, "renewal has correct type";
         is $p->get_extra_field_value('Subscription_Details_Containers'), 26, 'renewal has correct container type';
-        is $p->get_extra_field_value('service_id'), 1914, 'renewal has correct service id';
+        is $p->get_extra_field_value('service_id'), 2247, 'renewal has correct service id';
         is $p->get_extra_field_value('LastPayMethod'), 3, 'correct echo payment method field';
         is $p->state, 'confirmed';
 
@@ -883,7 +883,7 @@ sub setup_dd_test_report {
         user => $user,
     });
 
-    $extras->{service_id} ||= 1914;
+    $extras->{service_id} ||= 2247;
     $extras->{Subscription_Details_Containers} ||= 26;
 
     my @extras = map { { name => $_, value => $extras->{$_} } } keys %$extras;

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -702,7 +702,7 @@ for my $host ( 'www.fixmystreet.com', 'tfl.fixmystreet.com' ) {
 subtest 'TfL staff can access TfL admin' => sub {
     $mech->log_in_ok( $staffuser->email );
     $mech->get_ok('/admin');
-    $mech->content_contains( 'This is the administration interface for' );
+    $mech->content_contains( 'Search Reports' );
 };
 
 subtest 'TLRN categories cannot be renamed' => sub {
@@ -1142,7 +1142,7 @@ FixMyStreet::override_config {
 subtest 'Bromley staff can access Bromley admin' => sub {
     $mech->log_in_ok( $bromleyuser->email );
     $mech->get_ok('/admin');
-    $mech->content_contains( 'This is the administration interface for' );
+    $mech->content_contains( 'Search Reports' );
     $mech->log_out_ok;
 };
 

--- a/templates/web/base/admin/_index_intro.html
+++ b/templates/web/base/admin/_index_intro.html
@@ -1,0 +1,10 @@
+<div class="fms-admin-info fms-admin-floated">
+This is the administration interface for [% site_name %]. If you
+need any help or guidance, there is <a href="https://fixmystreet.org/">plenty of
+online documentation</a>. The FixMyStreet Platform is
+<a href="https://github.com/mysociety/fixmystreet">actively supported</a> by
+its developers, and has a community of people using or working on the code.
+Please <a href="https://fixmystreet.org/community/">sign up to the mailing list
+or get in touch</a> to let us know about your use of the FixMyStreet Platform,
+and to receive notices of updates.
+</div>

--- a/templates/web/base/admin/index.html
+++ b/templates/web/base/admin/index.html
@@ -29,6 +29,8 @@
     </div>
 </form>
 
+[% TRY %][% PROCESS 'admin/_index_extra_search.html' %][% CATCH file %][% END %]
+
 [% IF c.user.is_superuser %]
 <form method="get" action="[% c.uri_for('bodies') %]">
     <label for="search_body">[% loc('Edit body details') %]</label>

--- a/templates/web/base/admin/index.html
+++ b/templates/web/base/admin/index.html
@@ -1,16 +1,7 @@
 [% INCLUDE 'admin/header.html' title=loc('Summary') -%]
 [% PROCESS 'admin/report_blocks.html' %]
 
-<div class="fms-admin-info fms-admin-floated">
-This is the administration interface for [% site_name %]. If you
-need any help or guidance, there is <a href="https://fixmystreet.org/">plenty of
-online documentation</a>. The FixMyStreet Platform is
-<a href="https://github.com/mysociety/fixmystreet">actively supported</a> by
-its developers, and has a community of people using or working on the code.
-Please <a href="https://fixmystreet.org/community/">sign up to the mailing list
-or get in touch</a> to let us know about your use of the FixMyStreet Platform,
-and to receive notices of updates.
-</div>
+[% PROCESS 'admin/_index_intro.html' %]
 
 [% IF bodies.size == 0 %]
   <p class="fms-admin-info">

--- a/templates/web/base/waste/bin_days.html
+++ b/templates/web/base/waste/bin_days.html
@@ -18,7 +18,7 @@
 [% UNLESS unit.request_only %]
   <h3 class="govuk-heading-m waste-service-name">[% unit.service_name %]</h3>
   <div class="govuk-grid-row">
-  [% SET image = c.cobrand.image_for_service(unit.service_id) ~%]
+  [% SET image = c.cobrand.image_for_unit(unit) ~%]
   [% IF image %]
     <div class="govuk-grid-column-one-quarter text-centered">
       <img src="[% image %].png" srcset="[% image %].png 1x, [% image %]@2x.png 2x" alt="" class="waste-service-image">

--- a/templates/web/base/waste/missing.html
+++ b/templates/web/base/waste/missing.html
@@ -16,7 +16,11 @@
 
 <ul class="govuk-list govuk-list--bullet">
     <li>Check your address details and <a href="[% c.uri_for_action('waste/index') %]">search again</a>
+  [% IF c.cobrand.moniker == 'bromley' %]
     <li>Call our customer service team on 0800 647 7836 who will be pleased to assist you
+  [% ELSIF c.cobrand.moniker == 'kingston' %]
+    <li>Call our customer service team on 020 8547 5002 who will be pleased to assist you
+  [% END %]
 </ul>
 
 [% INCLUDE footer.html %]

--- a/templates/web/kingston/admin/_index_extra_search.html
+++ b/templates/web/kingston/admin/_index_extra_search.html
@@ -1,0 +1,7 @@
+<form method="post" action="/waste">
+ <label for="search_postcode">Property postcode:</label>
+    <div class="form-txt-submit-box">
+        <input type="text" class="form-control" name="postcode"  size="10" id="search_postcode" value="">
+        <input type="submit" class="btn" value="Go">
+    </div>
+</form>

--- a/templates/web/kingston/main_nav_items.html
+++ b/templates/web/kingston/main_nav_items.html
@@ -13,5 +13,6 @@
 [%~ END ~%]
 
 [%~ IF c.user_exists AND c.cobrand.admin_allow_user(c.user) ~%]
+  [%~ INCLUDE navitem uri='/waste' label='Property lookup' ~%]
   [%~ INCLUDE navitem uri='/admin' label=loc('Admin') ~%]
 [%~ END ~%]

--- a/templates/web/kingston/site-name.html
+++ b/templates/web/kingston/site-name.html
@@ -1,0 +1,1 @@
+Kingston WasteWorks


### PR DESCRIPTION
The commit I really need reviewing is the last one, "[Waste] Use provided details, even if logged in." as that would affect current existing sites, the rest don't/shouldn't.

The two before that - "Only one garden task type ID" and "Different image lookup" - are due to me misunderstanding how data was stored, thinking there were two service tasks (one for bins, one for sacks), but looks like there is only one with different data contained within. So switching code that was already checking for two to only checking one. Then image lookup is based on service task so that needs updating to work for container (and they don't want an image for sacks at present).

The rest are smaller tweaks, can be split up as follows:

Admin improvements for Kingston:
* Add property admin search (easier to get from admin to front end)
* Add site name (hide "FixMyStreet")

Admin improvements for all:
* Factor out admin intro box (confusing to be shown)

Front end improvements for Kingston:
* Add property admin area check (prevent Sutton postcodes being looked up in Kingston, as both are in Echo)
* Don't re-sort postcode results - they're in a better order as-is (not sure about Bromley, so left that alone)

Front end improvements for all:
* Fix 404 not showing on bad ID
* Pass name to credit card processor (email/address was, just name wasn't being)

Backend for Kingston:
* Update fetching script (refactor Bromley to do same job but not with devolved contacts)

[skip changelog]