### PR TITLE
[Hackney] Only allow 256 chars in report description

### DIFF
--- a/.cypress/cypress/integration/hackney.js
+++ b/.cypress/cypress/integration/hackney.js
@@ -16,4 +16,25 @@ describe('When you look at the Hackney site', function() {
     cy.pickCategory('Potholes');
     cy.contains('sent to Hackney Council');
   });
+
+  it('only allows 256 chars in description', function() {
+    cy.get('#map_box').click();
+    cy.wait('@report-ajax');
+    cy.pickCategory('Potholes');
+    cy.contains('sent to Hackney Council');
+    cy.nextPageReporting();
+    // photos page
+    cy.nextPageReporting();
+    cy.get('#form_detail').type('a'.repeat(260));
+    cy.get('#form_detail').invoke('val').then(function(val){
+        expect(val.length).to.be.at.most(256);
+    });
+    cy.get('#form_detail').invoke('val', 'a'.repeat(260));
+    cy.get('#form_detail').invoke('val').then(function(val){
+        expect(val.length).to.equal(260);
+    });
+    cy.nextPageReporting();
+    cy.contains("Reports are limited to 256 characters in length. Please shorten your report");
+
+  });
 });

--- a/perllib/FixMyStreet/Cobrand/Hackney.pm
+++ b/perllib/FixMyStreet/Cobrand/Hackney.pm
@@ -316,6 +316,16 @@ sub validate_contact_email {
     return 1 if is_valid_email_list(join(",", @emails));
 }
 
+sub report_validation {
+    my ($self, $report, $errors) = @_;
+
+    if ( length( $report->detail ) > 256 ) {
+        $errors->{detail} = sprintf( _('Reports are limited to %s characters in length. Please shorten your report'), 256 );
+    }
+
+    return $errors;
+}
+
 sub dashboard_export_problems_add_columns {
     my ($self, $csv) = @_;
 

--- a/t/app/controller/report_new_errors.t
+++ b/t/app/controller/report_new_errors.t
@@ -41,6 +41,7 @@ for my $body (
     { area_id => 2600, name => 'Rutland County Council' },
     { area_id => 2234, name => 'Northamptonshire Highways' },
     { area_id => 2566, name => 'Peterborough City Council' },
+    { area_id => 2508, name => 'Hackney Council' },
 ) {
     my $body_obj = $mech->create_body_ok($body->{area_id}, $body->{name});
     $body_ids{$body->{area_id}} = $body_obj->id;
@@ -96,6 +97,11 @@ $mech->create_contact_ok(
     body_id => $body_ids{2566}, # Peterborough
     category => 'Trees',
     email => 'trees-2566@example.com',
+);
+$mech->create_contact_ok(
+    body_id => $body_ids{2508}, # Hackney
+    category => 'Trees',
+    email => 'trees-2508@example.com',
 );
 
 # test that the various bit of form get filled in and errors correctly
@@ -538,6 +544,27 @@ foreach my $test (
         errors => [ 'Please enter a subject', 'Reports are limited to 1700 characters in length. Please shorten your report' ],
     },
     {
+        msg    => 'Hackney long detail',
+        pc     => 'E8 1DY',
+        fields => {
+            title         => '',
+            detail        => 'X' . 'x' x 256,
+            photo1        => '',
+            photo2        => '',
+            photo3        => '',
+            name          => 'Bob Example',
+            may_show_name => '1',
+            username_register => 'bob@example.com',
+            username      => '',
+            phone         => '',
+            category      => 'Trees',
+            password_sign_in => '',
+            password_register => '',
+        },
+        changes => { },
+        errors => [ 'Please enter a subject', 'Reports are limited to 256 characters in length. Please shorten your report' ],
+    },
+    {
         msg    => 'Lincolnshire long phone',
         pc     => 'PE9 2GX',
         fields => {
@@ -670,7 +697,7 @@ foreach my $test (
 
         # submit initial pc form
         FixMyStreet::override_config {
-            ALLOWED_COBRANDS => [ { fixmystreet => '.' }, 'bromley', 'oxfordshire', 'rutland', 'lincolnshire', 'buckinghamshire', 'northamptonshire', 'peterborough' ],
+            ALLOWED_COBRANDS => [ { fixmystreet => '.' }, 'bromley', 'oxfordshire', 'rutland', 'lincolnshire', 'buckinghamshire', 'northamptonshire', 'peterborough', 'hackney' ],
             MAPIT_URL => 'http://mapit.uk/',
         }, sub {
             $mech->submit_form_ok( { with_fields => { pc => $test->{pc} } },

--- a/web/cobrands/fixmystreet-uk-councils/council_validation_rules.js
+++ b/web/cobrands/fixmystreet-uk-councils/council_validation_rules.js
@@ -22,6 +22,12 @@ body_validation_rules = {
     },
     'Buckinghamshire Council': confirm_validation_rules,
     'Cheshire East Council': confirm_validation_rules,
+    'Hackney Council': {
+        detail: {
+          required: true,
+          maxlength: 256
+        }
+    },
     'Hounslow Borough Council': confirm_validation_rules,
     'Isle of Wight Council': confirm_validation_rules,
     'Island Roads': confirm_validation_rules,


### PR DESCRIPTION
Technically the limit doesn't need to be applied to email categories, but it seemed simplest/quickest to do it this way.

Fixes https://github.com/mysociety/societyworks/issues/3056

[skip changelog]