### PR TITLE
[Lincolnshire] Update district categories list

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
@@ -65,8 +65,9 @@ sub categories_restriction {
 
         # District categories:
         'me.category' => { -in => [
+            'Litter',
             'Street nameplates',
-            'Bench/cycle rack/litter bin/planter',
+            'Bench', 'Cycle rack', 'Litter bin', 'Planter',
         ] },
     ] } );
 }


### PR DESCRIPTION
This code was originally written back in March but was accidentally overlooked when it came to putting the changes live. Opening this pull request so we don't forget to complete this task.

## Todo

- [ ] Add the new categories for all districts under Lincolnshire on the live site

Part of https://github.com/mysociety/societyworks/issues/3057

[skip changelog]