### PR TITLE
[Sutton] WW front-end

### DIFF
--- a/templates/web/base/waste/bin_days.html
+++ b/templates/web/base/waste/bin_days.html
@@ -1,7 +1,9 @@
 [% USE date(format = c.cobrand.bin_day_format) %]
 [% PROCESS 'waste/header.html' %]
 
+[% IF c.cobrand.moniker != 'sutton' %]
 <h1 class="govuk-heading-xl">Your bin days</h1>
+[% END %]
 
 [% INCLUDE 'waste/_address_display.html' %]
 <div class="waste__collections">

--- a/templates/web/sutton/header_logo.html
+++ b/templates/web/sutton/header_logo.html
@@ -1,2 +1,2 @@
-<a href="https://www.kingston.gov.uk/" id="site-logo">[% site_name %]</a>
+<a href="https://www.sutton.gov.uk/" id="site-logo">[% site_name %]</a>
 <a href="/waste" id="report-cta" title="[%- loc('Report a problem') -%]">[%- loc('Report') -%]</a>

--- a/templates/web/sutton/header_site.html
+++ b/templates/web/sutton/header_site.html
@@ -1,8 +1,14 @@
 <header id="site-header" role="banner">
     <div class="container">
         [% INCLUDE 'header_logo.html' %]
+        <label id="nav-link" for="main-nav-btn" aria-expanded="false">[% loc('Main Navigation') %]</label>
     </div>
 </header>
+<div class="nav-wrapper">
+    <div class="container">
+        [% INCLUDE 'main_nav.html' %]
+    </div>
+</div>
 
 <div class="sutton-gradient">
     <div class="container page-title-wrapper">

--- a/templates/web/sutton/header_site.html
+++ b/templates/web/sutton/header_site.html
@@ -1,0 +1,11 @@
+<header id="site-header" role="banner">
+    <div class="container">
+        [% INCLUDE 'header_logo.html' %]
+    </div>
+</header>
+
+<div class="sutton-gradient">
+    <div class="container page-title-wrapper">
+        <h1>Garden waste collection</h1>
+    </div>
+</div>

--- a/web/cobrands/sutton/base.scss
+++ b/web/cobrands/sutton/base.scss
@@ -74,6 +74,10 @@ a,
     padding-top: 1em;
 }
 
+.sutton-gradient {
+    background: linear-gradient(45deg,$green 5%,#00715a 20%,$green 60%,$green-l2);
+}
+
 // HEADER
 
 #site-header {
@@ -104,6 +108,15 @@ a,
 }
 
 // GENERAL
+
+.page-title-wrapper {
+    padding: 1em 1em;
+    h1 {
+        color: $white;
+        margin-bottom: 0;
+        margin-top: 0;
+    }
+}
 
 .olButton:focus {
     z-index: 1; // pull forward, so entire outline is visible
@@ -381,7 +394,7 @@ body.twothirdswidthpage .content .sticky-sidebar {
     text-align: center;
 }
 
-//WASTEWORKS
+// WASTEWORKS
 .waste {
     .content[role="main"] {
         background-color: $white;
@@ -405,6 +418,7 @@ body.twothirdswidthpage .content .sticky-sidebar {
     }
 
     form.waste {
+        display: flex;
         flex-direction: row;
         align-items: end;
 
@@ -449,9 +463,4 @@ input[type="text"], input[type="email"], textarea {
     li {
         list-style: none;
     }
-}
-
-form.waste {
-    display: flex;
-    flex-direction: column;
 }

--- a/web/cobrands/sutton/layout.scss
+++ b/web/cobrands/sutton/layout.scss
@@ -2,7 +2,7 @@
 @import "../sass/layout";
 
 body {
-    background: linear-gradient(45deg,#00856a 5%,#00715a 20%,#00856a 60%,#40a360);
+    background-color: $white;
 }
 
 #site-header {
@@ -69,7 +69,6 @@ body {
         max-width: none;
         background: $white;
         padding: 4%;
-        border-top: 4px solid $green;
     }
 
     #postcodeForm {


### PR DESCRIPTION
## Added styling for Sutton cobrand

- Colours
- Form components
- Footer
- Header
- Emails

I'd like to give a proper cross browser testing once the developer have started/finish working on this cobrand.

## Screenshots

<img width="1429" alt="Screenshot 2022-06-06 at 06 30 04" src="https://user-images.githubusercontent.com/13790153/172100608-fae2e5df-3180-48b6-897d-930b84bcbf28.png">

<img width="352" alt="Screenshot 2022-06-06 at 06 33 35" src="https://user-images.githubusercontent.com/13790153/172100973-bcfc5178-8416-4e22-b27b-2972948e7766.png">

<img width="578" alt="Screenshot 2022-06-06 at 06 34 21" src="https://user-images.githubusercontent.com/13790153/172101078-859b50f5-30d0-4821-bcf2-cc5d2de5b353.png">

