### PR TITLE
[Kingston] Improved focus state links and navbar

### DIFF
--- a/web/cobrands/kingston/_colours.scss
+++ b/web/cobrands/kingston/_colours.scss
@@ -67,22 +67,24 @@ $container-max-width: 1024px;
     padding: $padding;
     border-radius: 25px;
     border: 4px solid $primary;
-    background: $primary !important;
-    color: $white !important;
+    background: $primary;
+    color: $white;
+    text-decoration: none;
 
     // This gets rid of the .govuk-button box-shadow
     box-shadow: none;
 
     &:hover, &:focus {
+        // Overrides .govuk-button:focus:not(:active):not(:hover)
         background: $white !important;
         color: $primary !important;
-        border-color: $primary;
+        border-color: $primary !important;
         outline:none;
         text-decoration: none;
     }
 
     &:focus {
-        text-decoration: underline !important;
+        text-decoration: underline;
     }
 
     &.govuk-button:focus:not(:active):not(:hover) {

--- a/web/cobrands/kingston/base.scss
+++ b/web/cobrands/kingston/base.scss
@@ -81,6 +81,18 @@ a,
     }
 }
 
+.nav-menu a {
+    text-decoration: none;
+    &:focus {
+        color: $white;
+        text-decoration: underline;
+    }
+}
+
+#report-cta {
+    @include kingston-button-primary;
+}
+
 .olButton:focus {
     z-index: 1; // pull forward, so entire outline is visible
 }

--- a/web/cobrands/kingston/base.scss
+++ b/web/cobrands/kingston/base.scss
@@ -45,13 +45,20 @@ body {
 
 a,
 .fake-link {
+    text-decoration: underline;
+
     &:hover,
     &:active {
-        color: $link-color;
+        color: $link-hover-color;
     }
+
     &:focus {
         background-color: $link-color;
-        color: $white !important;
+        color: $white;
+
+        small {
+            color: transparentize($color: $white, $amount: 0.3)
+        }
     }
 }
 
@@ -59,7 +66,19 @@ a,
 #nav-link.focussed,
 .olButton:focus {
     text-decoration: underline;
-    
+}
+
+.item-list--reports__item a,
+.item-list--wards__item a {
+    @extend .fake-link;
+    text-decoration: none;
+
+    &:focus {
+        text-decoration: none;
+        small {
+            color: transparentize($color: $white, $amount: 0.3)
+        }
+    }
 }
 
 .olButton:focus {

--- a/web/cobrands/kingston/layout.scss
+++ b/web/cobrands/kingston/layout.scss
@@ -9,6 +9,11 @@
         width: 3.43rem;
         height: 4rem;
     }
+
+    &:focus {
+        outline: 2px solid $blue;
+        background-color: $white;
+    }
 }
 
 .nav-wrapper {
@@ -23,40 +28,23 @@
     a.report-a-problem-btn {
         border-radius: 0;
         margin: 0;
-
-        &:hover {
-            background-color: $nav_hover_background_colour;
-        }
+        @include kingston-button-primary;
     }
 
     a,
     span,
-    a.report-a-problem-btn,
     span.report-a-problem-btn {
         padding: 0.5em 0.75em;
         font-size: 18px;
         font-weight: 700;
         text-decoration: none;
-
-        &, &:hover {
-            color: $nav_colour;
-        }
     }
 
-    // underlines for clickable nav items
-    a,
-    a.report-a-problem-btn {
-        &:hover {
-            color: $primary;
+    a {
+        &:hover, &:focus {
+            background-color: $blue;
+            color: $white;
             text-decoration: underline;
-        }
-    }
-
-    // darken background for selected nav item
-    span,
-    span.report-a-problem-btn {
-        &, &:hover {
-            background-color: $nav_hover_background_colour;
         }
     }
 }


### PR DESCRIPTION
This PR contains some changes that fixes the focus state on the navigation bar and other interactive links making them accessible.

<img width="1157" alt="Screenshot 2022-06-06 at 14 49 28" src="https://user-images.githubusercontent.com/13790153/172173801-8c4da82a-5990-40c7-a14e-f0a36c9cdffc.png">
<img width="1157" alt="Screenshot 2022-06-06 at 14 49 37" src="https://user-images.githubusercontent.com/13790153/172173827-4242823b-07f7-4f99-8734-92d3dbef5dce.png">
<img width="480" alt="Screenshot 2022-06-06 at 14 50 04" src="https://user-images.githubusercontent.com/13790153/172173911-5e696cec-2939-477c-972a-8061ec1576f1.png">
<img width="355" alt="Screenshot 2022-06-06 at 15 02 19" src="https://user-images.githubusercontent.com/13790153/172176148-6330152d-5520-4709-86f5-e8402ad3adc2.png">

