### PR TITLE
[Thamesmead] Replaces Thamesmead in staff comments with Peabody

### DIFF
--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -308,6 +308,8 @@ sub meta_line {
                 $body = 'Hounslow Highways';
             } elsif ($body eq 'Isle of Wight Council') {
                 $body = 'Island Roads';
+            } elsif ($body eq 'Thamesmead') {
+               $body = 'Peabody';
             }
         }
         my $cobrand_always_view_body_user = $cobrand->call_hook(always_view_body_contribute_details => $contributed_as);

--- a/templates/web/thamesmead/footer_extra_js.html
+++ b/templates/web/thamesmead/footer_extra_js.html
@@ -9,6 +9,7 @@ IF bodyclass.match('mappage');
     scripts.push(
         version('/vendor/OpenLayers.Projection.OrdnanceSurvey.js'),
     );
+    scripts.push( version('/cobrands/thamesmead/js.js') );
 END;
 IF bodyclass.match('frontpage');
     scripts.push(

--- a/web/cobrands/thamesmead/js.js
+++ b/web/cobrands/thamesmead/js.js
@@ -1,0 +1,4 @@
+(function(){
+translation_strings.name.validName = 'Please enter your full name, Peabody needs this information – if you do not wish your name to be shown on the site, untick the box below';
+})();
+


### PR DESCRIPTION
When staff user comments, body should report as Peabody.

https://github.com/mysociety/societyworks/issues/3063
Ticket created from
https://3.basecamp.com/4020879/buckets/26382066/todos/4948834882

[skip changelog]