### PR TITLE
[Thamesmead] Text requesting full user name should be from Peabody

### DIFF
--- a/templates/web/thamesmead/footer_extra_js.html
+++ b/templates/web/thamesmead/footer_extra_js.html
@@ -9,6 +9,7 @@ IF bodyclass.match('mappage');
     scripts.push(
         version('/vendor/OpenLayers.Projection.OrdnanceSurvey.js'),
     );
+    scripts.push( version('/cobrands/thamesmead/js.js') );
 END;
 IF bodyclass.match('frontpage');
     scripts.push(

--- a/web/cobrands/thamesmead/js.js
+++ b/web/cobrands/thamesmead/js.js
@@ -1,0 +1,4 @@
+(function(){
+translation_strings.name.validName = 'Please enter your full name, Peabody needs this information – if you do not wish your name to be shown on the site, untick the box below';
+})();
+


### PR DESCRIPTION
When filling in the form to make a report, a user is asked for their full name if they only enter one name.
    
This text usually says that councils require this text. We want it to say that Peabody requires this.

https://github.com/mysociety/societyworks/issues/3064
(created from https://3.basecamp.com/4020879/buckets/26382066/todos/4952095715)

[skip changelog]