### PR TITLE
[Oxfordshire] Minor inspector tool changes

### DIFF
--- a/templates/web/oxfordshire/report/inspect/_extra_details_field.html
+++ b/templates/web/oxfordshire/report/inspect/_extra_details_field.html
@@ -9,6 +9,9 @@
         <br>[% c.user.email %] <span id="js-defect-prefix"></span> &hellip;
     </span>
     <textarea rows="2" name="detailed_information" id="detailed_information" class="form-control"
+        [% IF problem.get_extra_metadata('defect_item_category') %]
+            disabled
+        [% END %]
         [% IF max_detailed_info_length %]data-max-length="[% max_detailed_info_length %]"[% END %]>[% problem.get_extra_metadata('detailed_information') | html %]</textarea>
 </p>
 

--- a/templates/web/oxfordshire/report/inspect/_raise_defect.html
+++ b/templates/web/oxfordshire/report/inspect/_raise_defect.html
@@ -59,13 +59,10 @@
         <label for="defect_item_type">Defect type</label>
         <select id="defect_item_type" name="defect_item_type" class="form-control" required>
             <option value="">-- Pick a type --</option>
-            <optgroup class="defect-fill-options defect-minor-carriageway-options defect-non-kerb-options defect-non-drainage-options" label="Minor Carriageway/ Footway/ Cycleway">
-                <option>Sweep &amp; Fill</option>
             <optgroup class="defect-pothole-options defect-non-fill-options defect-non-cluster-options defect-minor-carriageway-options defect-non-kerb-options defect-non-drainage-options" label="Minor Carriageway/ Footway/ Cycleway">
                 <option>Pothole (Permanent)</option>
-            </optgroup>
-            <optgroup class="defect-cluster-options defect-non-pothole-options defect-non-fill-options defect-minor-carriageway-options defect-non-kerb-options defect-non-drainage-options" label="Minor Carriageway/ Footway/ Cycleway">
-                <option>Pothole Cluster (Permanent)</option>
+            <optgroup class="defect-fill-options defect-minor-carriageway-options defect-non-kerb-options defect-non-drainage-options" label="Minor Carriageway/ Footway/ Cycleway">
+                <option>Sweep &amp; Fill</option>
             </optgroup>
             <optgroup class="defect-kerb-options defect-non-fill-options defect-non-minor-carriageway-options defect-non-drainage-options" label="Kerbing">
                 <option>Damaged</option>
@@ -84,8 +81,8 @@
             <optgroup class="defect-fill-options defect-minor-carriageway-options defect-non-cluster-options defect-non-pothole-options defect-non-kerb-options defect-non-drainage-options"
                 data-show="defect-fill-options" data-hide="defect-non-fill-options"
                 label="Sweep &amp; Fill">
-                <option>Pothole Sweep &amp; Fill 0-1m&sup2;</option>
-                <option>Pothole Cluster Sweep &amp; Fill 1-2m&sup2;</option>
+                <option>0-1m&sup2;</option>
+                <option>1-2m&sup2;</option>
             </optgroup>
             <optgroup class="defect-pothole-options defect-minor-carriageway-options defect-non-cluster-options defect-non-fill-options defect-non-kerb-options defect-non-drainage-options"
                 data-show="defect-pothole-options" data-hide="defect-non-pothole-options"
@@ -110,7 +107,7 @@
         <label for="traffic_information">[% loc('Traffic management required?') %]</label>
         [% traffic_info = problem.get_extra_metadata('traffic_information') %]
         <select id="traffic_information" name="traffic_information" class="form-control">
-            <option value=""[% ' selected' IF NOT traffic_info %]>-</option>
+            <option value=""[% ' selected' IF NOT traffic_info %]>&nbsp;</option>
             [% FOREACH option IN ['Signs and Cones', 'Stop and Go Boards'] %]
                 <option value='[% option %]'[% ' selected' IF traffic_info == option %]>[% option %]</option>
             [% END %]

--- a/templates/web/oxfordshire/report/inspect/extra_details.html
+++ b/templates/web/oxfordshire/report/inspect/extra_details.html
@@ -1,0 +1,17 @@
+<p>
+    <label for="problem_priority">[% loc('Priority') %]</label>
+    <select name="priority" id="problem_priority" class="form-control"
+    [% IF problem.get_extra_metadata('defect_item_category') %]
+        disabled
+    [% END %]
+    >
+        <option value="" [% 'selected' UNLESS problem.response_priority_id OR has_default_priority %]>-</option>
+        [% FOREACH priority IN problem.response_priorities %]
+        <option value="[% priority.id %]" [% 'selected' IF problem.response_priority_id == priority.id OR (NOT problem.response_priority_id AND priority.is_default) %]>[% priority.name | html %]</option>
+        [% END %]
+    </select>
+</p>
+
+[% IF permissions.report_inspect %]
+    [% INCLUDE 'report/inspect/_extra_details_field.html' %]
+[% END %]


### PR DESCRIPTION
* Pothole (permanent) should be the default above Sweep and Fill
* Removes Pothole Cluster from defect type dropdown
* Changes the pothole detail when Sweep and Fill is selected
* Replaces '-' with a space in dropdown selection
* Once issue raised, disables priority and extra_priority fields so they can't be changed

https://github.com/mysociety/societyworks/issues/3067
https://mysocietysupport.freshdesk.com/a/tickets/2113

[skip changelog]
