### PR TITLE
[Bromley] Erased 'Coronavirus update' navitem from navbar

### DIFF
--- a/templates/web/bromley/main_nav_items.html
+++ b/templates/web/bromley/main_nav_items.html
@@ -1,4 +1,3 @@
-[%~ INCLUDE navitem uri='https://www.bromley.gov.uk/info/200154/coronavirus_covid-19' label='Coronavirus update' ~%]
 
 [%~ IF bodyclass == 'waste' OR (problem AND problem.cobrand_data == 'waste') ~%]
     [%~ IF c.user_exists ~%]


### PR DESCRIPTION
Bromley council has requested to remove the coronavirus update from the navigation bar.

<img width="1042" alt="Screenshot 2022-06-13 at 12 04 01" src="https://user-images.githubusercontent.com/13790153/173340437-7eb6579c-c1f6-4351-a110-817592911810.png">

[skip changelog]


