### PR TITLE
[Peterborough] Suppress certain emails for graffiti and fly-tipping

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -236,6 +236,9 @@ sub open311_post_send {
     $row->unset_extra_metadata('pcc_witness');
     return unless $send_email;
 
+    # P'bro do not want to be emailed about graffiti on public land
+    return if $row->category =~ /graffiti/i;
+
     # P'bro do not want to be emailed about smaller incident sizes
     return if _is_small_flytipping_incident($row);
 

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -233,7 +233,8 @@ sub open311_post_send {
     my ($self, $row, $h) = @_;
 
     # Check Open311 was successful
-    my $send_email = $row->external_id || _witnessed_general_flytipping($row);
+    my $witnessed_flytipping = _witnessed_general_flytipping($row);
+    my $send_email = $row->external_id || $witnessed_flytipping;
     # Unset here because check above used it
     $row->unset_extra_metadata('pcc_witness');
     return unless $send_email;
@@ -242,10 +243,12 @@ sub open311_post_send {
     return if $row->category =~ /graffiti/i;
 
     # P'bro do not want to be emailed about smaller incident sizes or staff
-    # reports
+    # reports - with the exception of witnessed flytipping, as this won't
+    # have been sent by Open311
     return
-        if _is_small_flytipping_incident($row)
-        || _is_raised_by_staff($row);
+        if !$witnessed_flytipping
+        && ( _is_small_flytipping_incident($row)
+        || _is_raised_by_staff($row) );
 
     my $emails = $self->feature('open311_email');
     my %flytipping_cats = map { $_ => 1 } @{ $self->_flytipping_categories };

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -194,9 +194,11 @@ sub get_body_sender {
         if ( $emails->{flytipping} ) {
             $problem->set_extra_metadata('flytipping_email' => $emails->{flytipping});
 
-            # P'bro do not want to be notified of smaller incident sizes
+            # P'bro do not want to be notified of smaller incident sizes. They
+            # also do not want email for reports raised by staff.
             return { method => 'Blackhole' }
-                if _is_small_flytipping_incident($problem);
+                if _is_small_flytipping_incident($problem)
+                || _is_raised_by_staff($problem);
 
             my $contact = $self->SUPER::get_body_sender($body, $problem)->{contact};
             return { method => 'Email', contact => $contact};
@@ -239,8 +241,11 @@ sub open311_post_send {
     # P'bro do not want to be emailed about graffiti on public land
     return if $row->category =~ /graffiti/i;
 
-    # P'bro do not want to be emailed about smaller incident sizes
-    return if _is_small_flytipping_incident($row);
+    # P'bro do not want to be emailed about smaller incident sizes or staff
+    # reports
+    return
+        if _is_small_flytipping_incident($row)
+        || _is_raised_by_staff($row);
 
     my $emails = $self->feature('open311_email');
     my %flytipping_cats = map { $_ => 1 } @{ $self->_flytipping_categories };
@@ -375,6 +380,12 @@ sub _is_small_flytipping_incident {
 
     return ( $problem->get_extra_field_value('Incident_Size') // '' )
         =~ /$single_black_bag|$single_item/;
+}
+
+sub _is_raised_by_staff {
+    my $problem = shift;
+
+    return $problem->user && $problem->user->body eq council_name();
 }
 
 # We can resend reports upon category change

--- a/t/cobrand/peterborough.t
+++ b/t/cobrand/peterborough.t
@@ -568,6 +568,140 @@ for my $test (
     };
 }
 
+for my $test (
+    { desc => 'Offensive graffiti' },
+    { desc => 'Non offensive graffiti' },
+    )
+{
+    my $contact = $mech->create_contact_ok(
+        body_id  => $peterborough->id,
+        category => $test->{desc},
+        email    => 'GRAF',
+    );
+
+    subtest $test->{desc} => sub {
+        subtest "on PCC land is sent by open311 only" => sub {
+            FixMyStreet::override_config {
+                STAGING_FLAGS    => { send_reports => 1 },
+                MAPIT_URL        => 'http://mapit.uk/',
+                ALLOWED_COBRANDS => 'peterborough',
+                COBRAND_FEATURES => {
+                    open311_email => {
+                        peterborough =>
+                            { flytipping => 'flytipping@example.org' }
+                    }
+                },
+                },
+                sub {
+                $mech->clear_emails_ok;
+
+                my ($p) = $mech->create_problems_for_body(
+                    1,
+                    $peterborough->id,
+                    'Title',
+                    {   category  => $test->{desc},
+                        latitude  => 52.5708,
+                        longitude => 0.2505,
+                        cobrand   => 'peterborough',
+                        geocode   => {
+                            resourceSets => [
+                                {   resources => [
+                                        {   name    => '12 A Street, XX1 1SZ',
+                                            address => {
+                                                addressLine => '12 A Street',
+                                                postalCode  => 'XX1 1XZ'
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        extra => {
+                            _fields =>
+                                [ { name => 'site_code', value => '999' }, ],
+                        },
+                    },
+                );
+
+                FixMyStreet::Script::Reports::send();
+                $p->discard_changes;
+                ok $p->whensent, 'Report marked as sent';
+                is $p->get_extra_metadata('sent_to'), undef,
+                    'sent_to extra metadata is not set';
+                is $p->state,           'confirmed', 'report state unchanged';
+                is $p->comments->count, 0,           'no comment added';
+                my $cgi = CGI::Simple->new( Open311->test_req_used->content );
+                is $cgi->param('service_code'), 'GRAF',
+                    'service code is correct';
+
+                $mech->email_count_is(0);
+                };
+        };
+
+        subtest "on non PCC land is emailed only" => sub {
+            FixMyStreet::override_config {
+                STAGING_FLAGS    => { send_reports => 1 },
+                MAPIT_URL        => 'http://mapit.uk/',
+                ALLOWED_COBRANDS => 'peterborough',
+                COBRAND_FEATURES => {
+                    open311_email => {
+                        peterborough =>
+                            { flytipping => 'flytipping@example.org' }
+                    }
+                },
+                },
+                sub {
+                $mech->clear_emails_ok;
+
+                my ($p) = $mech->create_problems_for_body(
+                    1,
+                    $peterborough->id,
+                    'Title',
+                    {   category  => $test->{desc},
+                        latitude  => 52.5608,
+                        longitude => 0.2405,
+                        cobrand   => 'peterborough',
+                        geocode   => {
+                            resourceSets => [
+                                {   resources => [
+                                        {   name    => '12 A Street, XX1 1SZ',
+                                            address => {
+                                                addressLine => '12 A Street',
+                                                postalCode  => 'XX1 1XZ'
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        extra => {
+                            _fields =>
+                                [ { name => 'site_code', value => '999' }, ],
+                        },
+                    }
+                );
+
+                FixMyStreet::Script::Reports::send();
+                $p->discard_changes;
+                ok $p->whensent, 'Report marked as sent';
+                is $p->get_extra_metadata('flytipping_email'), undef,
+                    'flytipping_email extra metadata unset';
+                is $p->get_extra_metadata('sent_to')->[0],
+                    'flytipping@example.org', 'sent_to extra metadata set';
+                is $p->state, 'closed',    'report closed having sent email';
+                is $p->comments->count, 1, 'comment added';
+                like $p->comments->first->text, qr/As this is private land/,
+                    'correct comment text';
+                ok !Open311->test_req_used, 'no open311 sent';
+
+                $mech->email_count_is(1);
+                my $email = $mech->get_email;
+                ok $email, "got an email";
+                };
+        };
+    };
+}
+
 subtest 'Dashboard CSV extra columns' => sub {
     $report->update({
         state => 'unable to fix',

--- a/t/cobrand/peterborough.t
+++ b/t/cobrand/peterborough.t
@@ -299,7 +299,7 @@ subtest "flytipping on PCC land is sent by open311 and email" => sub {
     };
 };
 
-subtest "flytipping on PCC land witnessed is only sent by email" => sub {
+subtest "flytipping on PCC land (witnessed) is only sent by email" => sub {
     FixMyStreet::override_config {
         STAGING_FLAGS => { send_reports => 1 },
         MAPIT_URL => 'http://mapit.uk/',
@@ -346,17 +346,6 @@ subtest "flytipping on non PCC land is emailed" => sub {
             latitude => 52.5608,
             longitude => 0.2405,
             cobrand => 'peterborough',
-            geocode => {
-                resourceSets => [ {
-                    resources => [ {
-                        name => '12 A Street, XX1 1SZ',
-                        address => {
-                            addressLine => '12 A Street',
-                            postalCode => 'XX1 1XZ'
-                        }
-                    } ]
-                } ]
-            },
             extra => {
                 _fields => [
                     { name => 'site_code', value => '12345', },
@@ -420,20 +409,7 @@ for my $test (
                         latitude  => 52.5708,
                         longitude => 0.2505,
                         cobrand   => 'peterborough',
-                        geocode   => {
-                            resourceSets => [
-                                {   resources => [
-                                        {   name    => '12 A Street, XX1 1SZ',
-                                            address => {
-                                                addressLine => '12 A Street',
-                                                postalCode  => 'XX1 1XZ'
-                                            }
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        extra => {
+                        extra     => {
                             _fields => [
                                 { name => 'site_code', value => '999' },
                                 $test->{extra_field},
@@ -457,51 +433,52 @@ for my $test (
                 };
         };
 
-  # TODO What is expected here?
-  #
-  # subtest "flytipping on PCC land witnessed is only sent by email" => sub {
-  #     FixMyStreet::override_config {
-  #         STAGING_FLAGS    => { send_reports => 1 },
-  #         MAPIT_URL        => 'http://mapit.uk/',
-  #         ALLOWED_COBRANDS => 'peterborough',
-  #         COBRAND_FEATURES => {
-  #             open311_email => {
-  #                 peterborough => { flytipping => 'flytipping@example.org' }
-  #             }
-  #         },
-  #         },
-  #         sub {
-  #         $mech->clear_emails_ok;
+        subtest "flytipping on PCC land (witnessed) is only sent by email" =>
+            sub {
+            FixMyStreet::override_config {
+                STAGING_FLAGS    => { send_reports => 1 },
+                MAPIT_URL        => 'http://mapit.uk/',
+                ALLOWED_COBRANDS => 'peterborough',
+                COBRAND_FEATURES => {
+                    open311_email => {
+                        peterborough =>
+                            { flytipping => 'flytipping@example.org' }
+                    }
+                },
+                },
+                sub {
+                $mech->clear_emails_ok;
 
-       #         my ($p) = $mech->create_problems_for_body(
-       #             1,
-       #             $peterborough->id,
-       #             'Title',
-       #             {   category  => 'General fly tipping',
-       #                 latitude  => 52.5708,
-       #                 longitude => 0.2505,
-       #                 cobrand   => 'peterborough',
-       #                 extra     => {
-       #                     _fields => [
-       #                         { name => 'site_code',   value => '12345', },
-       #                         { name => 'pcc-witness', value => 'yes', },
-       #                     ],
-       #                 },
-       #             }
-       #         );
+                my ($p) = $mech->create_problems_for_body(
+                    1,
+                    $peterborough->id,
+                    'Title',
+                    {   category  => 'General fly tipping',
+                        latitude  => 52.5708,
+                        longitude => 0.2505,
+                        cobrand   => 'peterborough',
+                        extra     => {
+                            _fields => [
+                                { name => 'site_code',   value => '12345', },
+                                { name => 'pcc-witness', value => 'yes', },
+                                $test->{extra_field},
+                            ],
+                        },
+                    }
+                );
 
-        #         my $test_data = FixMyStreet::Script::Reports::send();
-        #         $p->discard_changes;
-        #         ok !$test_data->{test_req_used}, 'open311 not sent';
+                my $test_data = FixMyStreet::Script::Reports::send();
+                $p->discard_changes;
+                ok !$test_data->{test_req_used}, 'open311 not sent';
 
-        #         $mech->email_count_is(1);
-        #         my $email = $mech->get_email;
-        #         ok $email, "got an email";
-        #         is $email->header('To'),
-        #             '"Environmental Services" <flytipping@example.org>',
-        #             'email sent to correct address';
-        #         };
-        # };
+                $mech->email_count_is(1);
+                my $email = $mech->get_email;
+                ok $email, "got an email";
+                is $email->header('To'),
+                    '"Environmental Services" <flytipping@example.org>',
+                    'email sent to correct address';
+                };
+            };
 
         subtest "flytipping on non PCC land is not sent at all" => sub {
             FixMyStreet::override_config {
@@ -526,20 +503,7 @@ for my $test (
                         latitude  => 52.5608,
                         longitude => 0.2405,
                         cobrand   => 'peterborough',
-                        geocode   => {
-                            resourceSets => [
-                                {   resources => [
-                                        {   name    => '12 A Street, XX1 1SZ',
-                                            address => {
-                                                addressLine => '12 A Street',
-                                                postalCode  => 'XX1 1XZ'
-                                            }
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        extra => {
+                        extra     => {
                             _fields => [
                                 { name => 'site_code', value => '999' },
                                 $test->{extra_field},
@@ -603,19 +567,6 @@ for my $test (
                         latitude  => 52.5708,
                         longitude => 0.2505,
                         cobrand   => 'peterborough',
-                        geocode   => {
-                            resourceSets => [
-                                {   resources => [
-                                        {   name    => '12 A Street, XX1 1SZ',
-                                            address => {
-                                                addressLine => '12 A Street',
-                                                postalCode  => 'XX1 1XZ'
-                                            }
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
                         extra => {
                             _fields =>
                                 [ { name => 'site_code', value => '999' }, ],
@@ -661,19 +612,6 @@ for my $test (
                         latitude  => 52.5608,
                         longitude => 0.2405,
                         cobrand   => 'peterborough',
-                        geocode   => {
-                            resourceSets => [
-                                {   resources => [
-                                        {   name    => '12 A Street, XX1 1SZ',
-                                            address => {
-                                                addressLine => '12 A Street',
-                                                postalCode  => 'XX1 1XZ'
-                                            }
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
                         extra => {
                             _fields =>
                                 [ { name => 'site_code', value => '999' }, ],
@@ -740,21 +678,6 @@ subtest 'Staff user:' => sub {
                             latitude  => 52.5708,
                             longitude => 0.2505,
                             cobrand   => 'peterborough',
-                            geocode   => {
-                                resourceSets => [
-                                    {   resources => [
-                                            {   name =>
-                                                    '12 A Street, XX1 1SZ',
-                                                address => {
-                                                    addressLine =>
-                                                        '12 A Street',
-                                                    postalCode => 'XX1 1XZ'
-                                                }
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
                             extra => {
                                 _fields => [
                                     { name => 'site_code', value => '999' },
@@ -803,21 +726,6 @@ subtest 'Staff user:' => sub {
                             latitude  => 52.5608,
                             longitude => 0.2405,
                             cobrand   => 'peterborough',
-                            geocode   => {
-                                resourceSets => [
-                                    {   resources => [
-                                            {   name =>
-                                                    '12 A Street, XX1 1SZ',
-                                                address => {
-                                                    addressLine =>
-                                                        '12 A Street',
-                                                    postalCode => 'XX1 1XZ'
-                                                }
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
                             extra => {
                                 _fields => [
                                     { name => 'site_code', value => '999' },
@@ -881,21 +789,6 @@ subtest 'Staff user:' => sub {
                             latitude  => 52.5708,
                             longitude => 0.2505,
                             cobrand   => 'peterborough',
-                            geocode   => {
-                                resourceSets => [
-                                    {   resources => [
-                                            {   name =>
-                                                    '12 A Street, XX1 1SZ',
-                                                address => {
-                                                    addressLine =>
-                                                        '12 A Street',
-                                                    postalCode => 'XX1 1XZ'
-                                                }
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
                             extra => {
                                 _fields => [
                                     { name => 'site_code', value => '999' },
@@ -991,21 +884,6 @@ subtest 'Staff user:' => sub {
                             latitude  => 52.5608,
                             longitude => 0.2405,
                             cobrand   => 'peterborough',
-                            geocode   => {
-                                resourceSets => [
-                                    {   resources => [
-                                            {   name =>
-                                                    '12 A Street, XX1 1SZ',
-                                                address => {
-                                                    addressLine =>
-                                                        '12 A Street',
-                                                    postalCode => 'XX1 1XZ'
-                                                }
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
                             extra => {
                                 _fields => [
                                     { name => 'site_code', value => '999' },

--- a/t/cobrand/peterborough.t
+++ b/t/cobrand/peterborough.t
@@ -381,6 +381,193 @@ subtest "flytipping on non PCC land is emailed" => sub {
     };
 };
 
+for my $test (
+    {   desc        => 'Flytipping: incident_size = single item',
+        extra_field => {
+            name  => 'Incident_Size',
+            value => 'Single Item - S01',
+        },
+    },
+    {   desc        => 'Flytipping: incident_size = single black bag',
+        extra_field => {
+            name  => 'Incident_Size',
+            value => 'Single Black Bag - S00',
+        },
+    },
+    )
+{
+    subtest $test->{desc} => sub {
+        subtest "flytipping on PCC land is sent by open311 only" => sub {
+            FixMyStreet::override_config {
+                STAGING_FLAGS    => { send_reports => 1 },
+                MAPIT_URL        => 'http://mapit.uk/',
+                ALLOWED_COBRANDS => 'peterborough',
+                COBRAND_FEATURES => {
+                    open311_email => {
+                        peterborough =>
+                            { flytipping => 'flytipping@example.org' }
+                    }
+                },
+                },
+                sub {
+                $mech->clear_emails_ok;
+
+                my ($p) = $mech->create_problems_for_body(
+                    1,
+                    $peterborough->id,
+                    'Title',
+                    {   category  => 'General fly tipping',
+                        latitude  => 52.5708,
+                        longitude => 0.2505,
+                        cobrand   => 'peterborough',
+                        geocode   => {
+                            resourceSets => [
+                                {   resources => [
+                                        {   name    => '12 A Street, XX1 1SZ',
+                                            address => {
+                                                addressLine => '12 A Street',
+                                                postalCode  => 'XX1 1XZ'
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        extra => {
+                            _fields => [
+                                { name => 'site_code', value => '999' },
+                                $test->{extra_field},
+                            ],
+                        },
+                    },
+                );
+
+                FixMyStreet::Script::Reports::send();
+                $p->discard_changes;
+                ok $p->whensent, 'Report marked as sent';
+                is $p->get_extra_metadata('sent_to'), undef,
+                    'sent_to extra metadata is not set';
+                is $p->state,           'confirmed', 'report state unchanged';
+                is $p->comments->count, 0,           'no comment added';
+                my $cgi = CGI::Simple->new( Open311->test_req_used->content );
+                is $cgi->param('service_code'), 'FLY',
+                    'service code is correct';
+
+                $mech->email_count_is(0);
+                };
+        };
+
+  # TODO What is expected here?
+  #
+  # subtest "flytipping on PCC land witnessed is only sent by email" => sub {
+  #     FixMyStreet::override_config {
+  #         STAGING_FLAGS    => { send_reports => 1 },
+  #         MAPIT_URL        => 'http://mapit.uk/',
+  #         ALLOWED_COBRANDS => 'peterborough',
+  #         COBRAND_FEATURES => {
+  #             open311_email => {
+  #                 peterborough => { flytipping => 'flytipping@example.org' }
+  #             }
+  #         },
+  #         },
+  #         sub {
+  #         $mech->clear_emails_ok;
+
+       #         my ($p) = $mech->create_problems_for_body(
+       #             1,
+       #             $peterborough->id,
+       #             'Title',
+       #             {   category  => 'General fly tipping',
+       #                 latitude  => 52.5708,
+       #                 longitude => 0.2505,
+       #                 cobrand   => 'peterborough',
+       #                 extra     => {
+       #                     _fields => [
+       #                         { name => 'site_code',   value => '12345', },
+       #                         { name => 'pcc-witness', value => 'yes', },
+       #                     ],
+       #                 },
+       #             }
+       #         );
+
+        #         my $test_data = FixMyStreet::Script::Reports::send();
+        #         $p->discard_changes;
+        #         ok !$test_data->{test_req_used}, 'open311 not sent';
+
+        #         $mech->email_count_is(1);
+        #         my $email = $mech->get_email;
+        #         ok $email, "got an email";
+        #         is $email->header('To'),
+        #             '"Environmental Services" <flytipping@example.org>',
+        #             'email sent to correct address';
+        #         };
+        # };
+
+        subtest "flytipping on non PCC land is not sent at all" => sub {
+            FixMyStreet::override_config {
+                STAGING_FLAGS    => { send_reports => 1 },
+                MAPIT_URL        => 'http://mapit.uk/',
+                ALLOWED_COBRANDS => 'peterborough',
+                COBRAND_FEATURES => {
+                    open311_email => {
+                        peterborough =>
+                            { flytipping => 'flytipping@example.org' }
+                    }
+                },
+                },
+                sub {
+                $mech->clear_emails_ok;
+
+                my ($p) = $mech->create_problems_for_body(
+                    1,
+                    $peterborough->id,
+                    'Title',
+                    {   category  => 'General fly tipping',
+                        latitude  => 52.5608,
+                        longitude => 0.2405,
+                        cobrand   => 'peterborough',
+                        geocode   => {
+                            resourceSets => [
+                                {   resources => [
+                                        {   name    => '12 A Street, XX1 1SZ',
+                                            address => {
+                                                addressLine => '12 A Street',
+                                                postalCode  => 'XX1 1XZ'
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        extra => {
+                            _fields => [
+                                { name => 'site_code', value => '999' },
+                                $test->{extra_field},
+                            ],
+                        },
+                    }
+                );
+
+                FixMyStreet::Script::Reports::send();
+
+                $p->discard_changes;
+                ok $p->whensent, 'Report marked as sent';
+                is $p->get_extra_metadata('flytipping_email'), undef,
+                    'flytipping_email extra metadata unset';
+                is $p->get_extra_metadata('sent_to'), undef,
+                    'sent_to extra metadata not set';
+                is $p->state,           'closed', 'report marked as closed';
+                is $p->comments->count, 1,        'comment added';
+                like $p->comments->first->text, qr/As this is private land/,
+                    'correct comment text';
+                ok !Open311->test_req_used, 'no open311 sent';
+
+                $mech->email_count_is(0);
+                };
+        };
+    };
+}
+
 subtest 'Dashboard CSV extra columns' => sub {
     $report->update({
         state => 'unable to fix',

--- a/t/cobrand/peterborough.t
+++ b/t/cobrand/peterborough.t
@@ -702,6 +702,341 @@ for my $test (
     };
 }
 
+subtest 'Staff user:' => sub {
+    $mech->log_in_ok( $staffuser->email );
+
+    for my $test (
+        { desc => 'Offensive graffiti' },
+        { desc => 'Non offensive graffiti' },
+        )
+    {
+        my $contact = $mech->create_contact_ok(
+            body_id  => $peterborough->id,
+            category => $test->{desc},
+            email    => 'GRAF',
+        );
+
+        subtest $test->{desc} => sub {
+            subtest "on PCC land is sent by open311 only" => sub {
+                FixMyStreet::override_config {
+                    STAGING_FLAGS    => { send_reports => 1 },
+                    MAPIT_URL        => 'http://mapit.uk/',
+                    ALLOWED_COBRANDS => 'peterborough',
+                    COBRAND_FEATURES => {
+                        open311_email => {
+                            peterborough =>
+                                { flytipping => 'flytipping@example.org' }
+                        }
+                    },
+                    },
+                    sub {
+                    $mech->clear_emails_ok;
+
+                    my ($p) = $mech->create_problems_for_body(
+                        1,
+                        $peterborough->id,
+                        'Title',
+                        {   category  => $test->{desc},
+                            latitude  => 52.5708,
+                            longitude => 0.2505,
+                            cobrand   => 'peterborough',
+                            geocode   => {
+                                resourceSets => [
+                                    {   resources => [
+                                            {   name =>
+                                                    '12 A Street, XX1 1SZ',
+                                                address => {
+                                                    addressLine =>
+                                                        '12 A Street',
+                                                    postalCode => 'XX1 1XZ'
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            extra => {
+                                _fields => [
+                                    { name => 'site_code', value => '999' },
+                                ],
+                            },
+                            user => $staffuser,
+                        },
+                    );
+
+                    FixMyStreet::Script::Reports::send();
+                    $p->discard_changes;
+                    ok $p->whensent, 'Report marked as sent';
+                    is $p->get_extra_metadata('sent_to'), undef,
+                        'sent_to extra metadata is not set';
+                    is $p->state, 'confirmed', 'report state unchanged';
+                    is $p->comments->count, 0, 'no comment added';
+                    my $cgi
+                        = CGI::Simple->new( Open311->test_req_used->content );
+                    is $cgi->param('service_code'), 'GRAF',
+                        'service code is correct';
+
+                    $mech->email_count_is(0);
+                    };
+            };
+
+            subtest "on non PCC land is not sent at all" => sub {
+                FixMyStreet::override_config {
+                    STAGING_FLAGS    => { send_reports => 1 },
+                    MAPIT_URL        => 'http://mapit.uk/',
+                    ALLOWED_COBRANDS => 'peterborough',
+                    COBRAND_FEATURES => {
+                        open311_email => {
+                            peterborough =>
+                                { flytipping => 'flytipping@example.org' }
+                        }
+                    },
+                    },
+                    sub {
+                    $mech->clear_emails_ok;
+
+                    my ($p) = $mech->create_problems_for_body(
+                        1,
+                        $peterborough->id,
+                        'Title',
+                        {   category  => $test->{desc},
+                            latitude  => 52.5608,
+                            longitude => 0.2405,
+                            cobrand   => 'peterborough',
+                            geocode   => {
+                                resourceSets => [
+                                    {   resources => [
+                                            {   name =>
+                                                    '12 A Street, XX1 1SZ',
+                                                address => {
+                                                    addressLine =>
+                                                        '12 A Street',
+                                                    postalCode => 'XX1 1XZ'
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            extra => {
+                                _fields => [
+                                    { name => 'site_code', value => '999' },
+                                ],
+                            },
+                            user => $staffuser,
+                        }
+                    );
+
+                    FixMyStreet::Script::Reports::send();
+
+                    $p->discard_changes;
+                    ok $p->whensent, 'Report marked as sent';
+                    is $p->get_extra_metadata('flytipping_email'), undef,
+                        'flytipping_email extra metadata unset';
+                    is $p->get_extra_metadata('sent_to'), undef,
+                        'sent_to extra metadata not set';
+                    is $p->state, 'closed',    'report marked as closed';
+                    is $p->comments->count, 1, 'comment added';
+                    like $p->comments->first->text,
+                        qr/As this is private land/,
+                        'correct comment text';
+                    ok !Open311->test_req_used, 'no open311 sent';
+
+                    $mech->email_count_is(0);
+                    };
+            };
+        };
+    }
+
+    for my $test (
+        {   desc        => 'Flytipping: incident_size = car boot load',
+            extra_field => {
+                name  => 'Incident_Size',
+                value => 'Car Boot Load or Less - S02',
+            },
+        },
+        )
+    {
+        subtest $test->{desc} => sub {
+            subtest "flytipping on PCC land is sent by open311 only" => sub {
+                FixMyStreet::override_config {
+                    STAGING_FLAGS    => { send_reports => 1 },
+                    MAPIT_URL        => 'http://mapit.uk/',
+                    ALLOWED_COBRANDS => 'peterborough',
+                    COBRAND_FEATURES => {
+                        open311_email => {
+                            peterborough =>
+                                { flytipping => 'flytipping@example.org' }
+                        }
+                    },
+                    },
+                    sub {
+                    $mech->clear_emails_ok;
+
+                    my ($p) = $mech->create_problems_for_body(
+                        1,
+                        $peterborough->id,
+                        'Title',
+                        {   category  => 'General fly tipping',
+                            latitude  => 52.5708,
+                            longitude => 0.2505,
+                            cobrand   => 'peterborough',
+                            geocode   => {
+                                resourceSets => [
+                                    {   resources => [
+                                            {   name =>
+                                                    '12 A Street, XX1 1SZ',
+                                                address => {
+                                                    addressLine =>
+                                                        '12 A Street',
+                                                    postalCode => 'XX1 1XZ'
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            extra => {
+                                _fields => [
+                                    { name => 'site_code', value => '999' },
+                                    $test->{extra_field},
+                                ],
+                            },
+                            user => $staffuser,
+                        },
+                    );
+
+                    FixMyStreet::Script::Reports::send();
+                    $p->discard_changes;
+                    ok $p->whensent, 'Report marked as sent';
+                    is $p->get_extra_metadata('sent_to'), undef,
+                        'sent_to extra metadata is not set';
+                    is $p->state, 'confirmed', 'report state unchanged';
+                    is $p->comments->count, 0, 'no comment added';
+                    my $cgi
+                        = CGI::Simple->new( Open311->test_req_used->content );
+                    is $cgi->param('service_code'), 'FLY',
+                        'service code is correct';
+
+                    $mech->email_count_is(0);
+                    };
+            };
+
+  # TODO What is expected here?
+  #
+  # subtest "flytipping on PCC land witnessed is only sent by email" => sub {
+  #     FixMyStreet::override_config {
+  #         STAGING_FLAGS    => { send_reports => 1 },
+  #         MAPIT_URL        => 'http://mapit.uk/',
+  #         ALLOWED_COBRANDS => 'peterborough',
+  #         COBRAND_FEATURES => {
+  #             open311_email => {
+  #                 peterborough => { flytipping => 'flytipping@example.org' }
+  #             }
+  #         },
+  #         },
+  #         sub {
+  #         $mech->clear_emails_ok;
+
+       #         my ($p) = $mech->create_problems_for_body(
+       #             1,
+       #             $peterborough->id,
+       #             'Title',
+       #             {   category  => 'General fly tipping',
+       #                 latitude  => 52.5708,
+       #                 longitude => 0.2505,
+       #                 cobrand   => 'peterborough',
+       #                 extra     => {
+       #                     _fields => [
+       #                         { name => 'site_code',   value => '12345', },
+       #                         { name => 'pcc-witness', value => 'yes', },
+       #                     ],
+       #                 },
+       #             }
+       #         );
+
+            #         my $test_data = FixMyStreet::Script::Reports::send();
+            #         $p->discard_changes;
+            #         ok !$test_data->{test_req_used}, 'open311 not sent';
+
+            #         $mech->email_count_is(1);
+            #         my $email = $mech->get_email;
+            #         ok $email, "got an email";
+            #         is $email->header('To'),
+            #             '"Environmental Services" <flytipping@example.org>',
+            #             'email sent to correct address';
+            #         };
+            # };
+
+            subtest "flytipping on non PCC land is not sent at all" => sub {
+                FixMyStreet::override_config {
+                    STAGING_FLAGS    => { send_reports => 1 },
+                    MAPIT_URL        => 'http://mapit.uk/',
+                    ALLOWED_COBRANDS => 'peterborough',
+                    COBRAND_FEATURES => {
+                        open311_email => {
+                            peterborough =>
+                                { flytipping => 'flytipping@example.org' }
+                        }
+                    },
+                    },
+                    sub {
+                    $mech->clear_emails_ok;
+
+                    my ($p) = $mech->create_problems_for_body(
+                        1,
+                        $peterborough->id,
+                        'Title',
+                        {   category  => 'General fly tipping',
+                            latitude  => 52.5608,
+                            longitude => 0.2405,
+                            cobrand   => 'peterborough',
+                            geocode   => {
+                                resourceSets => [
+                                    {   resources => [
+                                            {   name =>
+                                                    '12 A Street, XX1 1SZ',
+                                                address => {
+                                                    addressLine =>
+                                                        '12 A Street',
+                                                    postalCode => 'XX1 1XZ'
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            extra => {
+                                _fields => [
+                                    { name => 'site_code', value => '999' },
+                                    $test->{extra_field},
+                                ],
+                            },
+                            user => $staffuser,
+                        }
+                    );
+
+                    FixMyStreet::Script::Reports::send();
+                    $p->discard_changes;
+                    ok $p->whensent, 'Report marked as sent';
+                    is $p->get_extra_metadata('flytipping_email'), undef,
+                        'flytipping_email extra metadata unset';
+                    is $p->get_extra_metadata('sent_to'), undef,
+                        'sent_to extra metadata not set';
+                    is $p->state, 'closed',    'report marked as closed';
+                    is $p->comments->count, 1, 'comment added';
+                    like $p->comments->first->text,
+                        qr/As this is private land/,
+                        'correct comment text';
+                    ok !Open311->test_req_used, 'no open311 sent';
+
+                    $mech->email_count_is(0);
+                    };
+            };
+        };
+    }
+};
+
 subtest 'Dashboard CSV extra columns' => sub {
     $report->update({
         state => 'unable to fix',


### PR DESCRIPTION
As requested in https://mysocietysupport.freshdesk.com/a/tickets/1332, this PR:

- stops emails being sent for graffiti reported on public land
- stops emails being sent for fly-tipping, on both public and private land, for incident sizes of
    - 'Single Black Bag'
    - 'Single Item'
- stops emails being sent for graffiti and fly-tipping reports raised by Peterborough staff

Fixes https://github.com/mysociety/societyworks/issues/2529.

Should be deployed before https://github.com/mysociety/fixmystreet/pull/3985.

[skip changelog]
