### PR TITLE
Abort browser-test script if fixture script fails

### DIFF
--- a/bin/browser-tests
+++ b/bin/browser-tests
@@ -163,7 +163,7 @@ sub run {
             '--cobrand', $body_cobrand,
             '--area-id', $area_id,
             '--commit'
-        );
+        ) == 0 or die("Failed to run fixture script");
     }
 
     my $pid;


### PR DESCRIPTION
On more than one occasion I have edited the fixture script and left a
syntax error in there by accident, and then been confused about why the
browser tests are all failing.

To avoid this problem check the exit status of the fixture script before
running the browser test interface.

[skip changelog]