### PR TITLE
[Buckinghamshire] Make it clear when reports are sent to the parish

### DIFF
--- a/.cypress/cypress/integration/buckinghamshire.js
+++ b/.cypress/cypress/integration/buckinghamshire.js
@@ -112,6 +112,42 @@ describe("Parish grass cutting category speed limit question", function() {
   });
 });
 
+describe("Correct body showing depending on category", function() {
+  beforeEach(function() {
+    cy.server();
+    cy.route('**mapserver/bucks*Whole_Street*', 'fixture:roads.xml').as('roads-layer');
+    cy.route('**mapserver/bucks*WinterRoutes*', 'fixture:roads.xml').as('winter-routes');
+    cy.route('/report/new/ajax*').as('report-ajax');
+    cy.route('/around\?ajax*').as('update-results');
+    cy.route('/around/nearby*').as('around-ajax');
+    cy.visit('http://buckinghamshire.localhost:3001/');
+    cy.contains('Buckinghamshire');
+    cy.get('[name=pc]').type('SL9 0NX');
+    cy.get('[name=pc]').parents('form').submit();
+    cy.wait('@update-results');
+    cy.get('#map_box').click(290, 307);
+    cy.wait('@report-ajax');
+  });
+
+  it('displays only the parish name for other parish categories', function() {
+    cy.pickCategory('Grass, hedges and weeds');
+    cy.nextPageReporting();
+    cy.pickSubcategory('Grass, hedges and weeds', 'Hedge problem');
+    cy.wait('@around-ajax');
+    cy.nextPageReporting();
+    cy.nextPageReporting();
+    cy.contains('These will be sent to Adstock Parish Council and also published online');
+  });
+
+  it("doesn't show the parish name for Buckinghamshire categories", function() {
+    cy.pickCategory('Roads');
+    cy.wait('@around-ajax');
+    cy.nextPageReporting();
+    cy.nextPageReporting();
+    cy.contains('These will be sent to Buckinghamshire Council and also published online');
+  });
+});
+
 describe('buckinghamshire roads handling', function() {
   beforeEach(function() {
     cy.server();

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -122,7 +122,7 @@ if ($opt->test_fixtures) {
         { area_id => 2504, categories => ['Damaged, dirty, or missing bin', 'Signs and bollards', 'Busking and Street performance'], name => 'Westminster City Council', cobrand => 'westminster' },
         { area_id => 2482, categories => ['Lamp Column Damaged', 'Sign Light Not Working'], name => 'Bromley Council', cobrand => 'bromley' },
         { area_id => 164186, categories => ['Shelter Damaged', 'Very Urgent'], name => 'Northamptonshire Highways', cobrand => 'northamptonshire' },
-        { area_id => 163793, categories => ['Flytipping', 'Roads', 'Parks', 'Snow and ice problem/winter salting', 'Grass cutting'], name => 'Buckinghamshire Council', cobrand => 'buckinghamshire' },
+        { area_id => 163793, categories => ['Flytipping', 'Roads', 'Parks', 'Snow and ice problem/winter salting', 'Grass cutting', 'Hedge problem'], name => 'Buckinghamshire Council', cobrand => 'buckinghamshire' },
         { area_id => 53822, categories => [ 'Grass cutting', 'Hedge problem' ], name => 'Adstock Parish Council' }, # Buckinghamshire parish council
         { area_id => 2257, categories => ['Flytipping', 'Graffiti'], name => 'Chiltern District Council' },
         { area_id => 164186, categories => [ 'Graffiti' ], name => 'West Northamptonshire Council' },
@@ -240,6 +240,13 @@ if ($opt->test_fixtures) {
     }
 
     $child_cat = FixMyStreet::DB->resultset("Contact")->find({
+        body => $bodies->{163793},
+        category => 'Hedge problem',
+    });
+    $child_cat->set_extra_metadata(group => 'Grass, hedges and weeds');
+    $child_cat->update;
+
+    $child_cat = FixMyStreet::DB->resultset("Contact")->find({
         body => $bodies->{53822},
         category => 'Grass cutting',
     });
@@ -261,6 +268,9 @@ if ($opt->test_fixtures) {
             category => $cat_name,
         });
         $child_cat->set_extra_metadata(group => 'Grass, hedges and weeds');
+        if ($cat_name eq 'Hedge problem') {
+            $child_cat->set_extra_metadata(prefer_if_multiple => 1);
+        }
         $child_cat->update;
     }
 

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -124,7 +124,6 @@ if ($opt->test_fixtures) {
         { area_id => 164186, categories => ['Shelter Damaged', 'Very Urgent'], name => 'Northamptonshire Highways', cobrand => 'northamptonshire' },
         { area_id => 163793, categories => ['Flytipping', 'Roads', 'Parks', 'Snow and ice problem/winter salting', 'Grass cutting', 'Hedge problem'], name => 'Buckinghamshire Council', cobrand => 'buckinghamshire' },
         { area_id => 53822, categories => [ 'Grass cutting', 'Hedge problem' ], name => 'Adstock Parish Council' }, # Buckinghamshire parish council
-        { area_id => 2257, categories => ['Flytipping', 'Graffiti'], name => 'Chiltern District Council' },
         { area_id => 164186, categories => [ 'Graffiti' ], name => 'West Northamptonshire Council' },
         { area_id => 2483, categories => [ 'Potholes', 'Other' ], name => 'Hounslow Borough Council', cobrand => 'hounslow' },
         { area_id => 2508, categories => [ 'Potholes', 'Other' ], name => 'Hackney Council', cobrand => 'hackney' },

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -36,6 +36,7 @@ $mech->create_contact_ok(body_id => $body->id, category => 'Graffiti', email => 
 $mech->create_contact_ok(body_id => $body->id, category => 'Flytipping (off-road)', email => "districts_flytipping", send_method => 'Email');
 $mech->create_contact_ok(body_id => $body->id, category => 'Barrier problem', email => 'parking@example.org', send_method => 'Email', group => 'Car park issue');
 $mech->create_contact_ok(body_id => $body->id, category => 'Grass cutting', email => 'grass@example.org', send_method => 'Email');
+$mech->create_contact_ok(body_id => $body->id, category => 'Hedge problem', email => 'hedges@example.org', send_method => 'Email');
 
 # Create another Grass cutting category for a parish.
 $contact = $mech->create_contact_ok(body_id => $parish->id, category => 'Grass cutting', email => 'grassparish@example.org', send_method => 'Email');
@@ -51,6 +52,11 @@ $contact->set_extra_fields({
 });
 $contact->update;
 $contact = $mech->create_contact_ok(body_id => $parish->id, category => 'Dirty signs', email => 'signs@example.org', send_method => 'Email');
+
+# Create a parish "Hedge problem" category with prefer_if_multiple.
+$contact = $mech->create_contact_ok(body_id => $parish->id, category => 'Hedge problem', email => 'hedges-parish@example.org', send_method => 'Email');
+$contact->set_extra_metadata(prefer_if_multiple => 1);
+$contact->update;
 
 my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Buckinghamshire');
 $cobrand->mock('lookup_site_code', sub {
@@ -586,6 +592,12 @@ subtest 'Reports to parishes are closed by default' => sub {
 
     my $json = $mech->get_ok_json( "/around/nearby?filter_category=Dirty+signs&latitude=51.615559&longitude=-0.556903" );
     like $json->{reports_list}, qr/Test Dirty signs report 2/;
+};
+
+subtest "Only the contact with prefer_if_multiple is returned for the Hedge Problem category" => sub {
+    my $json = $mech->get_ok_json('/report/new/ajax?latitude=51.615559&longitude=-0.556903');
+    is scalar @{$json->{by_category}->{'Hedge problem'}->{bodies}}, 1, "Only one contact returned";
+    is $json->{by_category}->{'Hedge problem'}->{bodies}->[0], 'Adstock Parish Council', "Correct contact returned";
 };
 
 };


### PR DESCRIPTION
Rather than the text during the reporting process saying "These will be sent to Adstock Parish Council or Buckinghamshire Council and also published online" we instead want it to just say the parish name. This is because parish categories have the `prefer_if_multiple` flag, so the reports will only go to those contacts.

Part of https://github.com/mysociety/societyworks/issues/2809

## Todo

- [x] Fix Cypress test that's intermittently failing because there are three bodies but the code expects there to be two (Bucks and the parish)

[skip changelog]