### PR TITLE
[Buckinghamshire] Show sign assets for parish Dirty signs category

### DIFF
--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -199,8 +199,12 @@ fixmystreet.assets.add(labeled_defaults, {
     asset_category: [
           'Sign light not working',
           'Sign problem',
+          'Dirty signs'
         ],
-    asset_item: 'sign'
+    asset_item: 'sign',
+
+    // Want to show signs for the parish "Dirty signs" categories, so skip body checks.
+    body: null
 });
 
 // When the auto-asset selection of a layer occurs, the data for inspections


### PR DESCRIPTION
This disables the body check for the sign assets so that it shows for
all of the (100+) parishes in Buckinghamshire to allow asset selection
for the "Dirty signs" category.

Part of https://github.com/mysociety/societyworks/issues/2809

[skip changelog]