### PR TITLE
[Bathnes] Accessibility colour improvement

### DIFF
--- a/templates/web/bathnes/around/_postcode_form_post.html
+++ b/templates/web/bathnes/around/_postcode_form_post.html
@@ -1,3 +1,5 @@
-<h2 style='margin-top:1em'><a href="https://www.bathnes.gov.uk/reportit">Report other issues or make enquiries</a></h2>
-<h2>Report emergencies on 01225 39 40 41 (option 9).</h2>
-<h2 style="max-width: 30em; margin-right: auto; margin-left: auto; margin-top: 0.5em;">For issues with parking, please contact Parking Services by phone on <a href="tel:01225 477133">01225 477133</a> or by email at <a href="email:parking@bathnes.gov.uk">parking@bathnes.gov.uk</a></h3>
+<div class="front-main-other-issues-wrapper">
+    <h4 style='margin-top:0.8em'><a href="https://www.bathnes.gov.uk/reportit">Report other issues or make enquiries</a></h4>
+    <h4>Report emergencies on 01225 39 40 41 (option 9).</h4>
+    <h4 style="max-width: 30em; margin-right: auto; margin-left: auto; margin-top: 0.5em;">For issues with parking, please contact Parking Services by phone on <a href="tel:01225 477133">01225 477133</a> or by email at <a href="email:parking@bathnes.gov.uk">parking@bathnes.gov.uk</a></h4>
+</div>

--- a/web/cobrands/bathnes/_colours.scss
+++ b/web/cobrands/bathnes/_colours.scss
@@ -24,10 +24,12 @@ $primary_text: #fff;
 $primary_link_color: $primary_text;
 $primary_link_hover_color: rgba($primary_text, 0.8);
 
-$base_bg: white;
+$base_bg: $bathnes-white;
 $base_fg: #0b0c0c;
 
-$nav_background_colour: #fff;
+$stats-colour: $bathnes-navy;
+
+$nav_background_colour: $bathnes-white;
 $nav_colour: #000;
 $nav_hover_background_colour: #eee;
 

--- a/web/cobrands/bathnes/base.scss
+++ b/web/cobrands/bathnes/base.scss
@@ -8,6 +8,15 @@
 @import "pattern-lib/navigation";
 @import "pattern-lib/footer";
 
+// Links
+
+a, .fake-link {
+    &:focus {
+        background-color: $bathnes-yellow;
+        outline: 3px solid $bathnes-yellow;
+    }
+}
+
 // Header
 
 #site-header {

--- a/web/cobrands/bathnes/base.scss
+++ b/web/cobrands/bathnes/base.scss
@@ -68,7 +68,22 @@
 
 #front-main #postcodeForm {
     margin-top: 1em;
+
     label {
-        color: #fff;
+        color: $primary_b;
     }
+
+    .form-hint {
+        color: #313131;
+    }
+}
+
+// Stats homepage
+
+ol.big-numbers>li:before {
+    color: $stats-colour;
+}
+
+#front_stats {
+    background: $stats-colour;
 }

--- a/web/cobrands/bathnes/base.scss
+++ b/web/cobrands/bathnes/base.scss
@@ -64,6 +64,19 @@
         margin: 0;
         font-size: 1.1em;
     }
+
+    #geolocate_link {
+        background-color: $bathnes-white;
+
+        &:hover {
+            background-color:  lighten($bathnes-primary, 45%);
+            color: lighten($bathnes-black, 15%);
+        }
+
+        &:focus {
+            background-color: $bathnes-yellow;
+        }
+    }
 }
 
 #front-main #postcodeForm {

--- a/web/cobrands/bathnes/layout.scss
+++ b/web/cobrands/bathnes/layout.scss
@@ -44,7 +44,7 @@
     padding: 2em 1em;
     background-color: $front_main_background;
 
-    h1, h2 {
+    h1, h4 {
         color: $primary_b;
     }
     h1 {
@@ -62,6 +62,20 @@
 
     a {
         color: $primary_b;
+    }
+
+    .front-main-other-issues-wrapper {
+        padding: 1em;
+        background: $bathens-cyan;
+        max-width: 500px;
+        margin: 1em auto;
+
+        a {
+            &:hover {
+                color: $bathnes-navy;
+                text-decoration: none;
+            }
+        }
     }
 }
 

--- a/web/cobrands/bathnes/layout.scss
+++ b/web/cobrands/bathnes/layout.scss
@@ -42,8 +42,9 @@
 
 #front-main {
     background-color: $front_main_background;
+
     h1, h2 {
-        color: #fff;
+        color: $primary_b;
     }
     h1 {
         font-weight: bold;
@@ -56,6 +57,10 @@
     #postcodeForm {
         margin-top: 0;
         padding: 0;
+    }
+
+    a {
+        color: $primary_b;
     }
 }
 
@@ -79,4 +84,14 @@ body.mappage {
 
 body.twothirdswidthpage .content .sticky-sidebar aside {
     top: 12em;
+}
+
+// Stats homepage
+
+#front_stats {
+    border-color: $stats-colour;
+
+    big {
+        color: $stats-colour;
+    }
 }

--- a/web/cobrands/bathnes/layout.scss
+++ b/web/cobrands/bathnes/layout.scss
@@ -41,6 +41,7 @@
 // Front page
 
 #front-main {
+    padding: 2em 1em;
     background-color: $front_main_background;
 
     h1, h2 {

--- a/web/cobrands/bathnes/pattern-lib/_colours.scss
+++ b/web/cobrands/bathnes/pattern-lib/_colours.scss
@@ -6,7 +6,8 @@ $bathnes-primary-ally: #00728F;
 $bathnes-secondary: #00b259;
 $bathnes-secondary-ally: #00663D;
 $mainstream-brand: $bathnes-primary;
-
+$bathnes-navy: #003078;
+$bathens-cyan: #daf1f8;
 
 // Standard palette, colours
 $bathnes-purple: #5261AC;


### PR DESCRIPTION
This PR fixes issues found by the design team[ here on this Trello ticket](https://trello.com/c/HLfN7G5Q)
There were a couple of accessibility issues:

- Focus state for links too subtle. I made them match the focus state on Bathnes website.
- The contrast of the white text against the light blue of the #front-main element wasn't high enough.
- The #front-main element felt cluttered, so I added some space.
- Reduced the size of the report other issues message on the #front-main element, so the page is easier to scan and clearer which elements are more important than others.
- The colour of the stats on the homepage was changed to navy, so they passed the contrast test.

https://user-images.githubusercontent.com/13790153/175244106-fbb2ad7f-1edc-4e18-ad34-528b7764798a.mov



https://user-images.githubusercontent.com/13790153/175244070-277d1851-d925-474f-b096-ed43091054d4.mov



https://user-images.githubusercontent.com/13790153/175244250-41b07d33-ac0e-49eb-b148-d16a7a0fd791.mov


Let me know if there is any feedback.

[skip changelog]

