### PR TITLE
Parse incoming email for subject code

### DIFF
--- a/bin/handlemail
+++ b/bin/handlemail
@@ -5,12 +5,9 @@
 #
 # This script should be invoked through the .forward mechanism. It
 # processes bounce messages and replies and deals with them accordingly.
-#
-# Copyright (c) 2016 UK Citizens Online Democracy. All rights reserved.
 
-use strict;
+use v5.14;
 use warnings;
-require 5.8.0;
 
 BEGIN {
     use File::Basename qw(dirname);
@@ -20,12 +17,7 @@ BEGIN {
 }
 
 use Getopt::Long;
-use Path::Tiny;
-use FixMyStreet;
-use FixMyStreet::Cobrand;
-use FixMyStreet::DB;
-use FixMyStreet::Email;
-use mySociety::HandleMail;
+use FixMyStreet::Email::Incoming;
 use mySociety::SystemMisc qw(print_log);
 
 # Don't print diagnostics to standard error, as this can result in bounce
@@ -41,200 +33,10 @@ my $bouncemgr = FixMyStreet->config('CONTACT_EMAIL');
 GetOptions ("cobrand=s" => \$cobrand,
             "bouncemgr=s" => \$bouncemgr);
 
-my %data = mySociety::HandleMail::get_message();
-my @lines = @{$data{lines}};
-my $token = get_envelope_token();
-my $verp = $token !~ /DO-NOT-REPLY/i;
-my ($type, $object) = get_object_from_token();
-
-if ($data{is_bounce_message}) {
-    if ($object) {
-        handle_bounce_to_verp_address();
-    } else {
-        print_log('info', "bounce received for don't-care email");
-    }
-} else {
-    # This is not a bounce message. If it's to a VERP address, pass it on to
-    # the message sender; otherwise send an auto-reply
-    if ($object) {
-        handle_non_bounce_to_verp_address();
-    } else {
-        handle_non_bounce_to_null_address();
-    }
-}
+my $incoming = FixMyStreet::Email::Incoming->new({
+    cobrand => $cobrand,
+    bouncemgr => $bouncemgr,
+});
+$incoming->process;
 
 exit(0);
-
-# ---
-
-sub get_envelope_token {
-    my $m = $data{message};
-
-    # If we have a special suffix header for the local part suffix, use that.
-    # This is set by our exim so we have access to it through the domain name
-    # forwarding and routers.
-    my $suffix = $m->head()->get("X-Delivered-Suffix");
-    if ($suffix) {
-        chomp $suffix;
-        return substr($suffix, 1);
-    }
-
-    # Otherwise, fall back to To header
-    my $a = mySociety::HandleMail::get_bounce_recipient($m);
-
-    my $token = mySociety::HandleMail::get_token($a,
-        'fms-', FixMyStreet->config('EMAIL_DOMAIN')
-    );
-    exit 0 unless $token; # Don't care unless we have a token
-
-    return $token;
-}
-
-sub get_object_from_token {
-    return unless $verp;
-
-    my ($type, $id) = FixMyStreet::Email::check_verp_token($token);
-    exit 0 unless $type;
-
-    my $rs;
-    if ($type eq 'report') {
-        $rs = FixMyStreet::DB->resultset('Problem');
-    } elsif ($type eq 'alert') {
-        $rs = FixMyStreet::DB->resultset('Alert');
-    }
-
-    my $object = $rs->find({ id => $id });
-    exit(0) unless $object;
-
-    return ($type, $object);
-}
-
-sub handle_permanent_bounce {
-    if ($type eq 'alert') {
-        print_log('info', "Received bounce for alert " . $object->id . ", unsubscribing");
-        $object->disable();
-    } elsif ($type eq 'report') {
-        print_log('info', "Received bounce for report " . $object->id . ", forwarding to support");
-        forward_on_to($bouncemgr);
-    }
-}
-
-sub is_out_of_office {
-    my (%attributes) = @_;
-    return 1 if $attributes{problem} && $attributes{problem} == mySociety::HandleMail::ERR_OUT_OF_OFFICE;
-    my $head = $data{message}->head();
-    return 1 if $head->get('X-Autoreply') || $head->get('X-Autorespond');
-    my $mc = $head->get('X-POST-MessageClass') || '';
-    return 1 if $mc eq '9; Autoresponder';
-    my $auto_submitted = $head->get("Auto-Submitted") || '';
-    return 1 if $auto_submitted && $auto_submitted !~ /no/;
-    my $precedence = $head->get("Precedence") || '';
-    return 1 if $precedence =~ /auto_reply/;
-    my $subject = $head->get("Subject");
-    return 1 if $subject =~ /Auto(matic|mated)?[ -_]?(reply|response|responder)|Thank[ _]you[ _]for[ _](your[ _]email|contacting)|Out of (the )?Office|away from the office|This office is closed until|^Re: (Problem Report|New updates)|^Auto: |^E-Mail Response$|^Message Received:|have received your email|Acknowledgement of your email|away from my desk|We got your email/i;
-    return 0;
-}
-
-sub handle_bounce_to_verp_address {
-    my %attributes = mySociety::HandleMail::parse_bounce(\@lines);
-    my $info = '';
-    if ($attributes{is_dsn}) {
-        # If permanent failure, but not mailbox full
-        return handle_permanent_bounce() if $attributes{status} =~ /^5\./ && $attributes{status} ne '5.2.2';
-        $info = ", Status $attributes{status}";
-    } elsif ($attributes{problem}) {
-        my $err_type = mySociety::HandleMail::error_type($attributes{problem});
-        return handle_permanent_bounce() if $err_type == mySociety::HandleMail::ERR_TYPE_PERMANENT;
-        $info = ", Bounce type $attributes{problem}";
-    }
-
-    # Check if the Subject looks like an auto-reply rather than a delivery bounce.
-    # If so, treat as if it were a normal email
-    if (is_out_of_office(%attributes)) {
-        print_log('info', "Treating bounce for $type " . $object->id . " as auto-reply to sender");
-        handle_non_bounce_to_verp_address();
-    } elsif (!$info) {
-        print_log('info', "Unparsed bounce received for $type " . $object->id . ", forwarding to support");
-        forward_on_to($bouncemgr);
-    } else {
-        print_log('info', "Ignoring bounce received for $type " . $object->id . $info);
-    }
-}
-
-sub handle_non_bounce_to_verp_address {
-    if ($type eq 'alert' && !is_out_of_office()) {
-        print_log('info', "Received non-bounce for alert " . $object->id . ", forwarding to support");
-        forward_on_to($bouncemgr);
-    } elsif ($type eq 'report') {
-        my $contributed_as = $object->get_extra_metadata('contributed_as') || '';
-        if ($contributed_as eq 'body' || $contributed_as eq 'anonymous_user') {
-            print_log('info', "Received non-bounce for report " . $object->id . " to anon report, dropping");
-        } else {
-            print_log('info', "Received non-bounce for report " . $object->id . ", forwarding to report creator");
-            forward_on_to($object->user->email);
-        }
-    }
-}
-
-sub handle_non_bounce_to_null_address {
-    # Don't send a reply to out of office replies...
-    if (is_out_of_office()) {
-        print_log('info', "Received non-bounce auto-reply to null address, ignoring");
-        return;
-    }
-
-    # Send an automatic response
-    print_log('info', "Received non-bounce to null address, auto-replying");
-
-    my ( $cobrand, $from_addr, $from_name ) = get_config_for_autoresponse();
-
-    my $template = path(FixMyStreet->path_to("templates", "email", $cobrand, 'reply-autoresponse'))->slurp_utf8;
-
-    # We generate this as a bounce.
-    my ($rp) = $data{return_path} =~ /^\s*<(.*)>\s*$/;
-    my $mail = FixMyStreet::Email::construct_email({
-        'Auto-Submitted' => 'auto-replied',
-        From => [ $from_addr, $from_name ],
-        To => $rp,
-        _body_ => $template,
-    });
-    send_mail($mail, $rp);
-}
-
-# Based on the address the incoming message was sent to, we might want to
-# use a cobrand's own reply-autoresponse template.
-sub get_config_for_autoresponse {
-    # cobrand might have been set from command line, so prefer that if so.
-    if ( defined $cobrand ) {
-        return ( $cobrand, FixMyStreet->config('CONTACT_EMAIL'), FixMyStreet->config('CONTACT_NAME') );
-    }
-
-    # Try and find a matching email address in the COBRAND_FEATURES config
-    my $recipient = mySociety::HandleMail::get_bounce_recipient($data{message})->address;
-    my $features = FixMyStreet->config('COBRAND_FEATURES') || {};
-    my $cobrands = $features->{do_not_reply_email} || {};
-    for my $moniker ( keys %$cobrands ) {
-        if ( $cobrands->{$moniker} eq $recipient ) {
-            my $cb = FixMyStreet::Cobrand->get_class_for_moniker($moniker)->new();
-            return ( $moniker, $cb->contact_email, $cb->contact_name );
-        }
-    }
-
-    # No match found, so use default cobrand
-    return ( "default", FixMyStreet->config('CONTACT_EMAIL'), FixMyStreet->config('CONTACT_NAME') );
-}
-
-sub forward_on_to {
-    my $recipient = shift;
-    my $text = join("\n", @lines) . "\n";
-    send_mail($text, $recipient);
-}
-
-sub send_mail {
-    my ($email, $recipient) = @_;
-    unless (FixMyStreet::Email::Sender->try_to_send(
-        $email, { from => '<>', to => $recipient }
-    )) {
-        exit(75);
-    }
-}

--- a/cpanfile
+++ b/cpanfile
@@ -188,6 +188,7 @@ requires 'Test::LongString';
 requires 'Test::MockTime';
 requires 'Test::More', '0.88';
 requires 'Test::Output';
+requires 'Test::Trap';
 requires 'Test::Warn';
 requires 'Test::WWW::Mechanize::Catalyst', '0.62';
 requires 'Web::Scraper';

--- a/perllib/FixMyStreet/App/Controller/Admin/Templates.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Templates.pm
@@ -105,7 +105,8 @@ sub edit : Path : Args(2) {
             $ext_code ||= $c->get_param('external_status_code');
             $template->external_status_code($ext_code);
 
-            if ( $template->state && $template->external_status_code ) {
+            # Bucks can set both state and external state for the special 'email-in' templates
+            if ( $template->state && $template->external_status_code && $c->cobrand->moniker ne 'buckinghamshire' ) {
                 $c->stash->{errors} ||= {};
                 $c->stash->{errors}->{state} = _("State and external status code cannot be used simultaneously.");
                 $c->stash->{errors}->{external_status_code} = _("State and external status code cannot be used simultaneously.");

--- a/perllib/FixMyStreet/App/Controller/Admin/Templates.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Templates.pm
@@ -116,14 +116,14 @@ sub edit : Path : Args(2) {
             if ($template->auto_response) {
                 my @check_contact_ids = @new_contact_ids;
                 # If the new template has not specific categories (i.e. it
-                # applies to all categories) then we need to check each of those
-                # category ids for existing auto-response templates.
+                # applies to all categories) then we only need to check for
+                # other any-category auto-response templates.
                 if (!scalar @check_contact_ids) {
-                    @check_contact_ids = @live_contact_ids;
+                    @check_contact_ids = (undef);
                 }
                 my $query = {
                     'auto_response' => 1,
-                    'contact.id' => [ @check_contact_ids, undef ],
+                    'contact.id' => [ @check_contact_ids ],
                     -or => {
                         $template->state ? ('me.state' => $template->state) : (),
                         $template->external_status_code ? ('me.external_status_code' => $template->external_status_code) : (),

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -467,6 +467,9 @@ sub _lookup_site_name {
 around 'munge_sendreport_params' => sub {
     my ($orig, $self, $row, $h, $params) = @_;
 
+    # Do not want the user's email to be the Reply-To
+    delete $params->{'Reply-To'};
+
     if ($row->category eq 'Claim') {
         # Update subject
         my $type = $row->get_extra_metadata('what');

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -419,6 +419,8 @@ sub disable_phone_number_entry { 1 }
 
 sub report_sent_confirmation_email { 'external_id' }
 
+sub handle_email_status_codes { 1 }
+
 sub is_council_with_case_management { 1 }
 
 # Try OSM for Bucks as it provides better disamiguation descriptions.

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -838,15 +838,14 @@ sub response_template_for {
     my $ext_code_changed = $ext_code && $ext_code ne $old_ext_code;
     my $template;
     if ($state_changed || $ext_code_changed) {
-        my $order;
-        my $state_params = {};
+        # make sure that empty string/nulls come last.
+        my $order = { order_by => \"me.external_status_code DESC NULLS LAST" };
+        my $state_params = [];
         if ($state_changed) {
-            $state_params->{'me.state'} = $state;
+            push @$state_params, { 'me.state' => $state, 'me.external_status_code' => ["", undef] };
         }
         if ($ext_code_changed) {
-            $state_params->{'me.external_status_code'} = $ext_code;
-            # make sure that empty string/nulls come last.
-            $order = { order_by => \"me.external_status_code DESC NULLS LAST" };
+            push @$state_params, { 'me.state' => '', 'me.external_status_code' => $ext_code };
         };
 
         $template = $self->response_templates->search({

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -838,8 +838,8 @@ sub response_template_for {
     my $ext_code_changed = $ext_code && $ext_code ne $old_ext_code;
     my $template;
     if ($state_changed || $ext_code_changed) {
-        # make sure that empty string/nulls come last.
-        my $order = { order_by => \"me.external_status_code DESC NULLS LAST" };
+        # make sure that empty string/nulls come last, and templates for a category come earlier.
+        my $order = { order_by => \"me.external_status_code DESC NULLS LAST, contact.category" };
         my $state_params = [];
         if ($state_changed) {
             push @$state_params, { 'me.state' => $state, 'me.external_status_code' => ["", undef] };

--- a/perllib/FixMyStreet/Email/Incoming.pm
+++ b/perllib/FixMyStreet/Email/Incoming.pm
@@ -1,0 +1,247 @@
+package FixMyStreet::Email::Incoming;
+
+use Moo;
+use Path::Tiny;
+use FixMyStreet;
+use FixMyStreet::Cobrand;
+use FixMyStreet::DB;
+use FixMyStreet::Email;
+use mySociety::HandleMail;
+use mySociety::SystemMisc qw(print_log);
+
+has cobrand => ( is => 'ro' );
+has bouncemgr => ( is => 'ro' );
+
+has data => ( is => 'lazy' );
+has lines => ( is => 'lazy' );
+has token => ( is => 'lazy' );
+has token_parts => ( is => 'lazy' );
+has type => ( is => 'lazy' );
+has object => ( is => 'lazy' );
+
+sub _build_data {
+    my %data = mySociety::HandleMail::get_message();
+    return \%data;
+}
+
+sub _build_lines { $_[0]->data->{lines} }
+
+sub process {
+    my $self = shift;
+
+    if ($self->data->{is_bounce_message}) {
+        if ($self->object) {
+            $self->handle_bounce_to_verp_address();
+        } else {
+            print_log('info', "bounce received for don't-care email");
+        }
+    } else {
+        # This is not a bounce message. If it's to a VERP address, pass it on to
+        # the message sender; otherwise send an auto-reply
+        if ($self->object) {
+            $self->handle_non_bounce_to_verp_address();
+        } else {
+            $self->handle_non_bounce_to_null_address();
+        }
+    }
+}
+
+sub _build_token {
+    my $self = shift;
+    my $m = $self->data->{message};
+
+    # If we have a special suffix header for the local part suffix, use that.
+    # This is set by our exim so we have access to it through the domain name
+    # forwarding and routers.
+    my $suffix = $m->head()->get("X-Delivered-Suffix");
+    if ($suffix) {
+        chomp $suffix;
+        return substr($suffix, 1);
+    }
+
+    # Otherwise, fall back to To header
+    my $a = mySociety::HandleMail::get_bounce_recipient($m);
+
+    my $token = mySociety::HandleMail::get_token($a,
+        'fms-', FixMyStreet->config('EMAIL_DOMAIN')
+    );
+    exit 0 unless $token; # Don't care unless we have a token
+
+    return $token;
+}
+
+sub _build_token_parts {
+    my $self = shift;
+
+    my $verp = $self->token !~ /DO-NOT-REPLY/i;
+    if (!$verp) {
+        return { verp => 0 };
+    }
+
+    my ($type, $id) = FixMyStreet::Email::check_verp_token($self->token);
+    exit 0 unless $type;
+
+    return { verp => 1, type => $type, id => $id };
+}
+
+sub _build_type { $_[0]->token_parts->{type} }
+
+sub _build_object {
+    my $self = shift;
+
+    my $token_parts = $self->token_parts;
+    return unless $token_parts->{verp};
+
+    my $rs;
+    if ($self->type eq 'report') {
+        $rs = FixMyStreet::DB->resultset('Problem');
+    } elsif ($self->type eq 'alert') {
+        $rs = FixMyStreet::DB->resultset('Alert');
+    }
+
+    my $id = $token_parts->{id};
+    my $object = $rs->find({ id => $id });
+    exit(0) unless $object;
+
+    return $object;
+}
+
+sub handle_permanent_bounce {
+    my $self = shift;
+    if ($self->type eq 'alert') {
+        print_log('info', "Received bounce for alert " . $self->object->id . ", unsubscribing");
+        $self->object->disable();
+    } elsif ($self->type eq 'report') {
+        print_log('info', "Received bounce for report " . $self->object->id . ", forwarding to support");
+        $self->forward_on_to($self->bouncemgr);
+    }
+}
+
+sub is_out_of_office {
+    my $self = shift;
+    my (%attributes) = @_;
+    return 1 if $attributes{problem} && $attributes{problem} == mySociety::HandleMail::ERR_OUT_OF_OFFICE;
+    my $head = $self->data->{message}->head();
+    return 1 if $head->get('X-Autoreply') || $head->get('X-Autorespond');
+    my $mc = $head->get('X-POST-MessageClass') || '';
+    return 1 if $mc eq '9; Autoresponder';
+    my $auto_submitted = $head->get("Auto-Submitted") || '';
+    return 1 if $auto_submitted && $auto_submitted !~ /no/;
+    my $precedence = $head->get("Precedence") || '';
+    return 1 if $precedence =~ /auto_reply/;
+    my $subject = $head->get("Subject");
+    return 1 if $subject =~ /Auto(matic|mated)?[ -_]?(reply|response|responder)|Thank[ _]you[ _]for[ _](your[ _]email|contacting)|Out of (the )?Office|away from the office|This office is closed until|^Re: (Problem Report|New updates)|^Auto: |^E-Mail Response$|^Message Received:|have received your email|Acknowledgement of your email|away from my desk|We got your email/i;
+    return 0;
+}
+
+sub handle_bounce_to_verp_address {
+    my $self = shift;
+    my %attributes = mySociety::HandleMail::parse_bounce($self->lines);
+    my $info = '';
+    if ($attributes{is_dsn}) {
+        # If permanent failure, but not mailbox full
+        return $self->handle_permanent_bounce() if $attributes{status} =~ /^5\./ && $attributes{status} ne '5.2.2';
+        $info = ", Status $attributes{status}";
+    } elsif ($attributes{problem}) {
+        my $err_type = mySociety::HandleMail::error_type($attributes{problem});
+        return $self->handle_permanent_bounce() if $err_type == mySociety::HandleMail::ERR_TYPE_PERMANENT;
+        $info = ", Bounce type $attributes{problem}";
+    }
+
+    # Check if the Subject looks like an auto-reply rather than a delivery bounce.
+    # If so, treat as if it were a normal email
+    my $type = $self->type;
+    if ($self->is_out_of_office(%attributes)) {
+        print_log('info', "Treating bounce for $type " . $self->object->id . " as auto-reply to sender");
+        $self->handle_non_bounce_to_verp_address();
+    } elsif (!$info) {
+        print_log('info', "Unparsed bounce received for $type " . $self->object->id . ", forwarding to support");
+        $self->forward_on_to($self->bouncemgr);
+    } else {
+        print_log('info', "Ignoring bounce received for $type " . $self->object->id . $info);
+    }
+}
+
+sub handle_non_bounce_to_verp_address {
+    my $self = shift;
+    if ($self->type eq 'alert' && !$self->is_out_of_office()) {
+        print_log('info', "Received non-bounce for alert " . $self->object->id . ", forwarding to support");
+        $self->forward_on_to($self->bouncemgr);
+    } elsif ($self->type eq 'report') {
+        my $contributed_as = $self->object->get_extra_metadata('contributed_as') || '';
+        if ($contributed_as eq 'body' || $contributed_as eq 'anonymous_user') {
+            print_log('info', "Received non-bounce for report " . $self->object->id . " to anon report, dropping");
+        } else {
+            print_log('info', "Received non-bounce for report " . $self->object->id . ", forwarding to report creator");
+            $self->forward_on_to($self->object->user->email);
+        }
+    }
+}
+
+sub handle_non_bounce_to_null_address {
+    my $self = shift;
+    # Don't send a reply to out of office replies...
+    if ($self->is_out_of_office()) {
+        print_log('info', "Received non-bounce auto-reply to null address, ignoring");
+        return;
+    }
+
+    # Send an automatic response
+    print_log('info', "Received non-bounce to null address, auto-replying");
+
+    my ( $cobrand, $from_addr, $from_name ) = $self->get_config_for_autoresponse();
+
+    my $template = path(FixMyStreet->path_to("templates", "email", $cobrand, 'reply-autoresponse'))->slurp_utf8;
+
+    # We generate this as a bounce.
+    my ($rp) = $self->data->{return_path} =~ /^\s*<(.*)>\s*$/;
+    my $mail = FixMyStreet::Email::construct_email({
+        'Auto-Submitted' => 'auto-replied',
+        From => [ $from_addr, $from_name ],
+        To => $rp,
+        _body_ => $template,
+    });
+    send_mail($mail, $rp);
+}
+
+# Based on the address the incoming message was sent to, we might want to
+# use a cobrand's own reply-autoresponse template.
+sub get_config_for_autoresponse {
+    my $self = shift;
+    # cobrand might have been set from command line, so prefer that if so.
+    if ( $self->cobrand ) {
+        return ( $self->cobrand, FixMyStreet->config('CONTACT_EMAIL'), FixMyStreet->config('CONTACT_NAME') );
+    }
+
+    # Try and find a matching email address in the COBRAND_FEATURES config
+    my $recipient = mySociety::HandleMail::get_bounce_recipient($self->data->{message})->address;
+    my $features = FixMyStreet->config('COBRAND_FEATURES') || {};
+    my $cobrands = $features->{do_not_reply_email} || {};
+    for my $moniker ( keys %$cobrands ) {
+        if ( $cobrands->{$moniker} eq $recipient ) {
+            my $cb = FixMyStreet::Cobrand->get_class_for_moniker($moniker)->new();
+            return ( $moniker, $cb->contact_email, $cb->contact_name );
+        }
+    }
+
+    # No match found, so use default cobrand
+    return ( "default", FixMyStreet->config('CONTACT_EMAIL'), FixMyStreet->config('CONTACT_NAME') );
+}
+
+sub forward_on_to {
+    my $self = shift;
+    my $recipient = shift;
+    my $text = join("\n", @{$self->lines}) . "\n";
+    send_mail($text, $recipient);
+}
+
+sub send_mail {
+    my ($email, $recipient) = @_;
+    unless (FixMyStreet::Email::Sender->try_to_send(
+        $email, { from => '<>', to => $recipient }
+    )) {
+        exit(75);
+    }
+}
+
+1;

--- a/perllib/FixMyStreet/Queue/Item/Report.pm
+++ b/perllib/FixMyStreet/Queue/Item/Report.pm
@@ -332,7 +332,8 @@ sub _add_confirmed_update {
             blank_updates_permitted => 1,
         );
 
-        my $description = $updates->comment_text_for_request({}, $problem, 'confirmed', 'dummy', '', '');
+        my $template = $problem->response_template_for('confirmed', 'dummy', '', '');
+        my $description = $updates->comment_text_for_request($template, {}, $problem);
         next unless $description;
 
         my $request = {

--- a/perllib/FixMyStreet/SendReport/Email.pm
+++ b/perllib/FixMyStreet/SendReport/Email.pm
@@ -92,14 +92,10 @@ sub send {
         To => $self->to,
     };
 
-    $cobrand->call_hook(munge_sendreport_params => $row, $h, $params);
-
     $params->{Bcc} = $self->bcc if @{$self->bcc};
 
     my $sender = $self->envelope_sender($row);
-    if ($params->{From}) {
-        # Don't do anything if something has been included already
-    } elsif ($row->user->email && $row->user->email_verified) {
+    if ($row->user->email && $row->user->email_verified) {
         $params->{From} = $self->send_from( $row );
     } else {
         my $name = sprintf(_("On behalf of %s"), @{ $self->send_from($row) }[1]);
@@ -115,6 +111,8 @@ sub send {
         $params->{'Reply-To'} = [ $params->{From} ];
         $params->{From} = [ $sender, $params->{From}[1] ];
     }
+
+    $cobrand->call_hook(munge_sendreport_params => $row, $h, $params);
 
     my $result = FixMyStreet::Email::send_cron($row->result_source->schema,
         $self->get_template($row), {

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -48,7 +48,7 @@ FixMyStreet::override_config {
     COBRAND_FEATURES => {
         open311_email => {
             buckinghamshire => {
-                flytipping => 'flytipping@example.org',
+                flytipping => 'flytipping@example.com',
                 flood => 'floods@example.org',
             }
         },
@@ -89,7 +89,8 @@ my ($report) = $mech->create_problems_for_body(1, $body->id, 'On Road', {
 subtest 'flytipping on road sent to extra email' => sub {
     FixMyStreet::Script::Reports::send();
     my @email = $mech->get_email;
-    is $email[0]->header('To'), 'TfB <flytipping@example.org>';
+    is $email[0]->header('To'), 'TfB <flytipping@example.com>';
+    is $email[0]->header('Reply-To'), undef, 'No reply-to header';
     like $mech->get_text_body_from_email($email[1]), qr/report's reference number/;
     $report->discard_changes;
     is $report->external_id, 248, 'Report has right external ID';

--- a/t/email/incoming.t
+++ b/t/email/incoming.t
@@ -1,0 +1,223 @@
+use Test::Trap;
+use FixMyStreet::TestMech;
+use_ok 'FixMyStreet::Email::Incoming';
+use FixMyStreet::Email;
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $body = $mech->create_body_ok(2217, 'Buckinghamshire Council');
+my ($p) = $mech->create_problems_for_body(1, $body->id, 'Title');
+my $alert = FixMyStreet::DB->resultset("Alert")->create({
+    alert_type => 'new_updates',
+    user_id => $p->user_id,
+});
+my $id = $p->id;
+my $alert_id = $alert->id;
+my $token_report = FixMyStreet::Email::generate_verp_token('report', $id);
+my $token_alert = FixMyStreet::Email::generate_verp_token('alert', $alert_id);
+
+# For testing, want to turn this back on and see what we get
+mySociety::SystemMisc::log_to_stderr(1);
+
+sub email_from_template {
+    my %params = @_;
+    $params{RETURNPATH} = $params{RETURNPATH} ? 'from@council.example.net': '';
+    my $email = <<'EOF';
+Return-Path: <RETURNPATH>
+From: someone@example.org
+To: fms-TOKEN@example.com
+Subject: SUBJECT Re: Problem report
+Message-ID: <ABCDEF@GHIJKL>
+HEADERS
+
+This is the contents of the message.
+EOF
+    foreach (keys %params) {
+        $email =~ s/$_/$params{$_}/g;
+    }
+    return $email;
+}
+
+sub process {
+    my $email = shift;
+    open my $stdin, '<', \$email;
+    local *STDIN = $stdin;
+    my $e = FixMyStreet::Email::Incoming->new( bouncemgr => 'contact@example.org' );
+    trap { $e->process };
+}
+
+FixMyStreet::override_config {
+    EMAIL_DOMAIN => 'example.com',
+    ALLOWED_COBRANDS => ['buckinghamshire', 'fixmystreet', 'tfl'],
+    COBRAND_FEATURES => {
+        do_not_reply_email =>  {
+            tfl => 'fms-tfl-do-not-reply@example.com'
+        },
+    },
+}, sub {
+    subtest 'A bad token email' => sub {
+        my $email = email_from_template(TOKEN => "bad");
+        process($email);
+        is $trap->exit, 0, 'exited with 0';
+    };
+
+    subtest 'A bounce to the do-not-reply address' => sub {
+        my $email = email_from_template(RETURNPATH => 0, TOKEN => "DO-NOT-REPLY");
+        process($email);
+        is $trap->stderr, "incoming.t: bounce received for don't-care email\n";
+    };
+
+    subtest 'An email to the do-not-reply address' => sub {
+        my $email = email_from_template(RETURNPATH => 1, HEADERS => "X-Delivered-Suffix: -DO-NOT-REPLY");
+        process($email);
+        is $trap->stderr, "incoming.t: Received non-bounce to null address, auto-replying\n";
+        like $mech->get_text_body_from_email, qr/This is an automatic response/;
+    };
+
+    subtest 'An email to the cobrand specific do-not-reply address' => sub {
+        my $email = email_from_template(RETURNPATH => 1, TOKEN => 'tfl-do-not-reply');
+        process($email);
+        is $trap->stderr, "incoming.t: Received non-bounce to null address, auto-replying\n";
+        like $mech->get_text_body_from_email, qr/from TfL Street Care/;
+    };
+
+    subtest 'An OOO email to the do-not-reply address' => sub {
+        my $email = email_from_template(RETURNPATH => 1, TOKEN => "DO-NOT-REPLY", SUBJECT => "Out of Office");
+        process($email);
+        is $trap->stderr, "incoming.t: Received non-bounce auto-reply to null address, ignoring\n";
+        $mech->email_count_is(0);
+    };
+
+    subtest 'A bounce to a VERP address' => sub {
+        my $email = email_from_template(RETURNPATH => 0, TOKEN => $token_report);
+        process($email);
+        is $trap->stderr, "incoming.t: Unparsed bounce received for report $id, forwarding to support\n";
+        my $env = $mech->get_email_envelope;
+        is $env->{to}[0], 'contact@example.org';
+        $email = $mech->get_email;
+        like $email->as_string, qr/This is the contents/;
+        $mech->clear_emails_ok;
+    };
+
+    subtest 'An OOO bounce to a VERP address' => sub {
+        my $email = email_from_template(RETURNPATH => 0, TOKEN => $token_report, HEADERS => "X-Autoreply: true");
+        process($email);
+        is $trap->stderr, "incoming.t: Treating bounce for report $id as auto-reply to sender\nincoming.t: Received non-bounce for report $id, forwarding to report creator\n";
+        my $env = $mech->get_email_envelope;
+        is $env->{to}[0], $p->user->email;
+        $email = $mech->get_email;
+        like $email->as_string, qr/This is the contents/;
+        $mech->clear_emails_ok;
+    };
+
+    subtest 'An email to a VERP address' => sub {
+        my $email = email_from_template(RETURNPATH => 1, TOKEN => $token_report);
+        process($email);
+        is $trap->stderr, "incoming.t: Received non-bounce for report $id, forwarding to report creator\n";
+        my $env = $mech->get_email_envelope;
+        is $env->{to}[0], $p->user->email;
+        $email = $mech->get_email;
+        like $email->as_string, qr/This is the contents/;
+        $mech->clear_emails_ok;
+    };
+
+    subtest 'An email to a VERP address, report made as body' => sub {
+        $p->set_extra_metadata(contributed_as => 'body');
+        $p->update;
+        my $email = email_from_template(RETURNPATH => 1, TOKEN => $token_report);
+        process($email);
+        is $trap->stderr, "incoming.t: Received non-bounce for report $id to anon report, dropping\n";
+        $mech->email_count_is(0);
+        $p->unset_extra_metadata('contributed_as');
+        $p->update;
+    };
+
+    subtest 'An email to an alert VERP address' => sub {
+        my $email = email_from_template(RETURNPATH => 1, TOKEN => $token_alert);
+        process($email);
+        is $trap->stderr, "incoming.t: Received non-bounce for alert $alert_id, forwarding to support\n";
+        my $env = $mech->get_email_envelope;
+        is $env->{to}[0], 'contact@example.org';
+        $email = $mech->get_email;
+        like $email->as_string, qr/This is the contents/;
+        $mech->clear_emails_ok;
+    };
+
+    subtest 'An OOO email to an alert VERP address' => sub {
+        my $email = email_from_template(RETURNPATH => 1, TOKEN => $token_alert, HEADERS => "Auto-Submitted: yes");
+        process($email);
+        is $trap->stderr, '';
+        $mech->email_count_is(0);
+    };
+
+    subtest 'A DSN' => sub {
+        my $email = <<EOF;
+Return-path: <>
+Date: Thu, 11 Sep 2008 05:00:33 -0500
+From: someone\@example.org
+Message-Id: <message-id\@somewhere.example.org>
+To: fms-$token_report\@example.com
+Content-Type: multipart/report; report-type=delivery-status;
+	boundary="1221127233-13870"
+Subject: Returned mail: User unknown
+
+This is a MIME-encapsulated message
+
+--1221127233-13870
+Content-type: text/plain; charset=US-ASCII
+
+The original message was received Thu, 11 Sep 2008 05:00:32 -0500
+from -
+
+   ----- The following address(es) had permanent fatal errors -----
+<anon>; originally to anon (unrecoverable error)
+  	The recipient 'anon' is unknown
+
+--1221127233-13870
+Content-type: message/delivery-status
+
+Arrival-Date: Thu, 11 Sep 2008 05:00:32 -0500
+
+Original-Recipient: anon
+Final-Recipient: anon
+Action: failed
+Status: 5.0.0
+--1221127233-13870
+Content-type: message/rfc822
+
+
+-- Message body has been omitted --
+
+--1221127233-13870--
+EOF
+        process($email);
+        is $trap->stderr, "incoming.t: Received bounce for report $id, forwarding to support\n";
+        my $env = $mech->get_email_envelope;
+        is $env->{to}[0], 'contact@example.org';
+        $email = $mech->get_email;
+        $mech->clear_emails_ok;
+    };
+
+    subtest 'A remote host bounce to an alert VERP address' => sub {
+        my $email = <<EOF;
+Return-path: <>
+Date: Thu, 11 Sep 2008 05:00:33 -0500
+From: someone\@example.org
+Message-Id: <message-id\@somewhere.example.org>
+To: fms-$token_alert\@example.com
+Subject: Returned mail: User unknown
+
+This server does not like recipient.
+
+Remote host said: 500 User does not exist - <@>
+
+EOF
+        process($email);
+        is $trap->stderr, "incoming.t: Received bounce for alert $alert_id, unsubscribing\n";
+        $alert->discard_changes;
+        isnt $alert->whendisabled, undef;
+    };
+
+};
+
+done_testing;

--- a/t/email/incoming.t
+++ b/t/email/incoming.t
@@ -5,7 +5,8 @@ use FixMyStreet::Email;
 
 my $mech = FixMyStreet::TestMech->new;
 
-my $body = $mech->create_body_ok(2217, 'Buckinghamshire Council');
+my $user = $mech->create_user_ok('systemuser@example.org');
+my $body = $mech->create_body_ok(2217, 'Buckinghamshire Council', { comment_user => $user, send_extended_statuses => 1 }, { cobrand => 'buckinghamshire' });
 my ($p) = $mech->create_problems_for_body(1, $body->id, 'Title');
 my $alert = FixMyStreet::DB->resultset("Alert")->create({
     alert_type => 'new_updates',
@@ -218,6 +219,61 @@ EOF
         isnt $alert->whendisabled, undef;
     };
 
+    $p->update({ cobrand => 'buckinghamshire' });
+
+    subtest 'Bucks bad status code' => sub {
+        my $email = email_from_template(RETURNPATH => 1, SUBJECT => "SC101", TOKEN => $token_report);
+        process($email);
+        is $trap->stderr, "incoming.t: Report #$id, email subject had bad code SC101\n";
+        $p->discard_changes;
+        is $p->state, 'confirmed';
+        is $p->comments->count, 0;
+        $email = $mech->get_email;
+        $mech->clear_emails_ok;
+        is $email->header('Subject'), "Report #$id, email subject had bad code SC101";
+    };
+
+    subtest 'Bucks status code, fixed default' => sub {
+        FixMyStreet::DB->resultset("ResponseTemplate")->create({
+            body => $body,
+            auto_response => 1,
+            external_status_code => '123',
+            title => '123 fixed',
+            text => 'Text of template',
+        });
+        my $email = email_from_template(RETURNPATH => 1, SUBJECT => "SC123", TOKEN => $token_report);
+        process($email);
+        is $trap->stderr, "incoming.t: Received SC code in subject, updating report\n";
+        $mech->email_count_is(0);
+        $p->discard_changes;
+        is $p->state, 'fixed - council';
+        is $p->comments->count, 1;
+        is $p->comments->first->text, "Text of template";
+        is $p->comments->first->problem_state, "fixed - council";
+        $p->comments->delete;
+    };
+
+    $p->update({ cobrand => 'fixmystreet' });
+
+    subtest 'Bucks status code, closed status' => sub {
+        FixMyStreet::DB->resultset("ResponseTemplate")->create({
+            body => $body,
+            auto_response => 1,
+            external_status_code => '456',
+            state => 'closed',
+            title => '456 closed',
+            text => 'Text of template',
+        });
+        my $email = email_from_template(RETURNPATH => 1, SUBJECT => "SC456", TOKEN => $token_report);
+        process($email);
+        is $trap->stderr, "incoming.t: Received SC code in subject, updating report\n";
+        $mech->email_count_is(0);
+        $p->discard_changes;
+        is $p->state, 'closed';
+        is $p->comments->count, 1;
+        is $p->comments->first->text, "Text of template";
+        is $p->comments->first->problem_state, "closed";
+    };
 };
 
 done_testing;

--- a/templates/email/buckinghamshire/submit.html
+++ b/templates/email/buckinghamshire/submit.html
@@ -50,6 +50,7 @@ of a local problem that they believe might require your attention.</p>
 [%- IF report.category == 'Claim' %]
     <p style="[% secondary_p_style %]">Confirm reference: [% report.external_id | html %]</p>
 [% END -%]
+    <p style="[% secondary_p_style %]">Report ID: [% report.id %]</p>
     <p style="[% secondary_p_style %]">[% report.category | html %]</p>
     [% report.detail | html_para_email(secondary_p_style) %]
   [% IF report.get_extra_fields %]

--- a/templates/email/buckinghamshire/submit.html
+++ b/templates/email/buckinghamshire/submit.html
@@ -42,7 +42,10 @@ of a local problem that they believe might require your attention.</p>
       </tr>
     [%~ END %]
   </table>
-  <p style="[% p_style %] margin-top: 0.5em;">Replies to this message will go directly to [% report.name | html %], the user who reported the problem.</p>
+  <p style="[% p_style %] margin-top: 0.5em;">
+    Replies to this email will go to FixMyStreet and updated according to the
+    SC code used in the Subject line.
+  </p>
   [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]

--- a/templates/email/buckinghamshire/submit.txt
+++ b/templates/email/buckinghamshire/submit.txt
@@ -42,7 +42,8 @@ View OpenStreetMap of this location: [% osm_url %]
 
 [% closest_address %]----------
 
-Replies to this email will go to the user who submitted the problem.
+Replies to this email will go to FixMyStreet and updated according to the SC
+code used in the Subject line.
 
 [% signature %]
 


### PR DESCRIPTION
This PR first refactors handlemail so that the various aspects of it can be tested. And then adds some new functionality to look for a code in the subject and mark report fixed/use a response template like it was an Open311-fetched update.
Fixes https://github.com/mysociety/societyworks/issues/2820. [skip changelog]