### PR TITLE
[Buckinghamshire] Mark parish reports as internal referral after sending

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -48,6 +48,11 @@ sub geocoder_munge_results {
 
 sub on_map_default_status { ('open', 'fixed') }
 
+sub around_nearby_filter {
+    my ($self, $params) = @_;
+    $params->{states}->{'internal referral'} = 1;
+}
+
 sub pin_colour {
     my ( $self, $p, $context ) = @_;
     # updated to match Oxon CC

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -144,6 +144,21 @@ sub report_new_munge_before_insert {
     $report->category('Flytipping (off-road)');
 }
 
+sub post_report_sent {
+    my ($self, $report) = @_;
+
+    my @parishes = $self->parish_bodies->all;
+    my @parish_ids = map { $_->id } @parishes;
+
+    foreach my $body_id (@{$report->bodies_str_ids}) {
+        if (grep { $body_id == $_ } @parish_ids) {
+            # Report is to a Bucks parish, mark as internal referral by default
+            $report->state('internal referral');
+            $report->update;
+        }
+    }
+}
+
 sub filter_report_description {
     my ($self, $description) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -388,6 +388,14 @@ sub munge_contacts_to_bodies {
     FixMyStreet::Cobrand::Buckinghamshire::munge_contacts_to_bodies($self, $contacts, $report);
 }
 
+sub post_report_sent {
+    my ($self, $report) = @_;
+
+    # Run Buckinghamshire-specific code
+    my $bucks = FixMyStreet::Cobrand::Buckinghamshire->new;
+    $bucks->post_report_sent($report);
+}
+
 around 'munge_sendreport_params' => sub {
     my ($orig, $self, $row, $h, $params) = @_;
 

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -514,6 +514,9 @@ subtest 'Reports to parishes are closed by default' => sub {
     ok $report, "Found the report";
     is $report->title, 'Test Dirty signs report 2', 'Got the correct report';
     is $report->state, 'internal referral', 'parish report is automatically marked as closed';
+
+    my $json = $mech->get_ok_json( "/around/nearby?filter_category=Dirty+signs&latitude=51.615559&longitude=-0.556903" );
+    like $json->{reports_list}, qr/Test Dirty signs report 2/;
 };
 
 };

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -497,6 +497,25 @@ subtest 'All reports pages for parishes' => sub {
     is $mech->uri->path, '/reports/Adstock';
 };
 
+subtest 'Reports to parishes are closed by default' => sub {
+    $mech->get_ok('/report/new?latitude=51.615559&longitude=-0.556903');
+    $mech->submit_form_ok({
+        with_fields => {
+            title => "Test Dirty signs report 2",
+            detail => 'Test report details.',
+            category => 'Dirty signs',
+        }
+    }, "submit details");
+    $mech->content_contains('Your issue is on its way to the council');
+
+    FixMyStreet::Script::Reports::send();
+
+    my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+    ok $report, "Found the report";
+    is $report->title, 'Test Dirty signs report 2', 'Got the correct report';
+    is $report->state, 'internal referral', 'parish report is automatically marked as closed';
+};
+
 };
 
 done_testing();


### PR DESCRIPTION
Adds a `post_report_sent` hook to Bucks which checks if any of the receiving bodies are a know Bucks parish and if so marks the report as internal referral.

Fixes https://github.com/mysociety/societyworks/issues/3075

[skip changelog]