### PR TITLE
[Waste] truncate some SCP fields which have limits

### DIFF
--- a/perllib/Integrations/SCP.pm
+++ b/perllib/Integrations/SCP.pm
@@ -80,6 +80,10 @@ sub pay {
     my $credentials = $self->credentials($args);
     my $entry_method = $args->{staff} ? 'CNP' : 'ECOM';
 
+    for my $field( qw/name address1 address2/ ) {
+        $args->{$field} = substr($args->{$field}, 0, 50) if $args->{$field};
+    }
+
     my @items;
     my $total = 0;
     foreach (@{$args->{items}}) {


### PR DESCRIPTION
name and address fields are limited to 50 characters in the SCP api so
truncate these before sending.

[skip changelog]