### PR TITLE
[Bucks] Fix stopper message for 'Grass. hedges...' category for private roads

### DIFF
--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -1362,7 +1362,13 @@ fixmystreet.message_controller = (function() {
                 responsibility_off(layer, 'road');
             } else {
                 fixmystreet.body_overrides.do_not_send(layer.fixmystreet.body);
+                var selected = fixmystreet.reporting.selectedCategory();
                 if (is_only_body(layer.fixmystreet.body)) {
+                    responsibility_on(layer, 'road', msg_id);
+                }
+                else if (layer.fixmystreet.body == 'Buckinghamshire Council' &&
+                    selected.group == 'Grass, hedges and weeds') {
+                    // Special case for Bucks' 'Grass' layer
                     responsibility_on(layer, 'road', msg_id);
                 }
             }
@@ -1378,7 +1384,7 @@ fixmystreet.message_controller = (function() {
             } else if (fixmystreet.assets.selectedFeature()) {
                 fixmystreet.body_overrides.allow_send(layer.fixmystreet.body);
                 responsibility_off(layer, 'road');
-            } else if (is_only_body(layer.fixmystreet.body) || (criterion && criterion())) {
+            } else if ( (criterion && criterion()) || is_only_body(layer.fixmystreet.body) ) {
                 responsibility_on(layer, 'road');
             }
         },


### PR DESCRIPTION
Fixes https://github.com/mysociety/societyworks/issues/3076.

The bug is on the `bucks-parishes-reviewed` branch.

The 'Grass, hedges and weeds' category was showing 'The location you have selected doesn't appear to be on a road' msg when a (private) road was selected. This PR fixes that so that the correct 'The selected road is not maintained by Buckinghamshire Council' msg is shown.

[skip changelog]
