### PR TITLE
[Kingston] Fix variable clash.

### DIFF
--- a/perllib/FixMyStreet/App/Form/Waste/Garden/Kingston/Subscribe.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Garden/Kingston/Subscribe.pm
@@ -12,11 +12,11 @@ has_page intro => (
         my $form = shift;
         my $c = $form->{c};
         my $data = $form->saved_data;
-        $data->{garden_sacks} = $c->stash->{garden_sacks};
+        $data->{_garden_sacks} = $c->stash->{garden_sacks};
         return {};
     },
     next => sub {
-        return 'choice' if $_[0]->{garden_sacks};
+        return 'choice' if $_[0]->{_garden_sacks};
         'existing';
     }
 );


### PR DESCRIPTION
The subscribe form intro page was setting a variable for use in deciding
what step to go to next; the form processing code later on was using the
same variable to decide whether to give someone sacks or not.
[skip changelog]