### PR TITLE
[Open311] Check for identical latest update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
         - Permit control over database connection `sslmode` via $FMS_DB_SSLMODE
     - Open311 improvements:
         - Increase default timeout.
+        - Check for an identical latest update when adding a new one.
 
 * v4.0 (3rd December 2021)
     - Front end improvements:

--- a/perllib/FixMyStreet/Cobrand/Merton.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton.pm
@@ -90,19 +90,6 @@ sub open311_extra_data_include {
     return [];
 }
 
-sub open311_get_update_munging {
-    my ($self, $comment) = @_;
-
-    my $latest = $comment->problem->comments->search({ state => 'confirmed' }, {
-        order_by => [ { -desc => 'confirmed' }, { -desc => 'id' } ],
-        rows => 1,
-    })->first;
-    # If last update has same text and is the system user, hide it
-    if ($latest && $latest->text eq $comment->text && $latest->user_id == $comment->user_id) {
-        $comment->state('hidden');
-    }
-}
-
 sub report_new_munge_before_insert {
     my ($self, $report) = @_;
 

--- a/perllib/Open311/UpdatesBase.pm
+++ b/perllib/Open311/UpdatesBase.pm
@@ -217,6 +217,15 @@ sub process_update {
     $comment->state('hidden') unless $comment->text || $comment->photo
         || ($comment->problem_state && $state ne $old_state);
 
+    # Hide if the new comment is the same as the latest comment
+    my $latest = $comment->problem->comments->search({ state => 'confirmed' }, {
+        order_by => [ { -desc => 'confirmed' }, { -desc => 'id' } ],
+        rows => 1,
+    })->first;
+    if ($latest && $latest->text eq $comment->text && $latest->user_id == $comment->user_id && $latest->problem_state eq $comment->problem_state) {
+        $comment->state('hidden');
+    }
+
     my $cobrand = $body->get_cobrand_handler;
     $cobrand->call_hook(open311_get_update_munging => $comment)
         if $cobrand;


### PR DESCRIPTION
This already existed for Merton, but it seemed like a good thing to have in general - could help with e.g. Bucks duplicate updates on occasion (though we've hidden some status codes there as a different solution).