### PR TITLE
Scroll responsibility message into view.

### DIFF
--- a/.cypress/cypress/integration/oxfordshire.js
+++ b/.cypress/cypress/integration/oxfordshire.js
@@ -11,12 +11,15 @@ describe("Oxfordshire cobrand", function() {
     cy.pickCategory('Lamp Out of Light');
     cy.wait('@street-lights-layer');
     cy.wait('@empty-street-lights-layer');
+    cy.get('#map_sidebar').scrollTo('bottom');
     cy.get('.js-reporting-page--next:visible').should('be.disabled');
     cy.get('circle').eq(1).click(); // Click a public light
     cy.get("#category_meta_message_LampOutofLight").should('not.contain', 'private street light asset');
+    cy.get('#map_sidebar').scrollTo('bottom');
     cy.get('.js-reporting-page--next:visible').should('not.be.disabled');
     cy.get('circle').eq(0).click(); // Click a private light
     cy.get("#category_meta_message_LampOutofLight").should('contain', 'private street light asset');
+    cy.get('#map_sidebar').scrollTo('bottom');
     cy.get('.js-reporting-page--next:visible').should('be.disabled');
   });
 

--- a/templates/web/base/report/new/fill_in_details_form.html
+++ b/templates/web/base/report/new/fill_in_details_form.html
@@ -1,6 +1,8 @@
 [% PROCESS 'report/new/form_heading.html' %]
 
+<div id="js-roads-responsibility" class="box-warning hidden" aria-live="polite">
 [% TRY %][% INCLUDE 'report/new/roads_message.html' %][% CATCH file %][% END %]
+</div>
 
 <fieldset>
     <div id="problem_form">

--- a/templates/web/bathnes/report/new/roads_message.html
+++ b/templates/web/bathnes/report/new/roads_message.html
@@ -1,4 +1,3 @@
-<div id="js-roads-responsibility" class="box-warning hidden">
     <strong>Not maintained by Bath &amp; North East Somerset Council</strong>
     <div id="js-not-a-road" class="hidden js-responsibility-message">
         <p>The location you have selected doesn't appear to be on <span class="js-roads-asset" data-original="a road">a road</span> that Bath &amp; North East Somerset Council maintain.</p>
@@ -10,5 +9,3 @@
         <p>The location you have selected is maintained by Curo Group.</p>
         <p>You can report this issue to Curo Group directly by emailing <span class="js-roads-asset"></span>.</p>
     </div>
-
-</div>

--- a/templates/web/buckinghamshire/report/new/roads_message.html
+++ b/templates/web/buckinghamshire/report/new/roads_message.html
@@ -1,4 +1,3 @@
-<div id="js-roads-responsibility" class="box-warning hidden">
     <div id="js-not-council-road" class="hidden js-responsibility-message js-roads-bucks">
         <strong>Not maintained by Buckinghamshire Council</strong>
         <p>The selected road is not maintained by Buckinghamshire Council;
@@ -31,4 +30,3 @@
     <div id="js-not-an-asset" class="hidden js-responsibility-message">
         <p>Please select <span class="js-roads-asset" data-original="an item">an item</span> from the map on which to make a report.</p>
     </div>
-</div>

--- a/templates/web/centralbedfordshire/report/new/roads_message.html
+++ b/templates/web/centralbedfordshire/report/new/roads_message.html
@@ -1,4 +1,3 @@
-<div id="js-roads-responsibility" class="box-warning hidden">
     <strong>Not maintained by Central Bedfordshire Council</strong>
     <div id="js-not-council-road" class="hidden js-responsibility-message js-roads-centralbeds">
         <p>The selected road is not maintained by Central Bedfordshire Council;
@@ -25,4 +24,3 @@
         </p>
         <p>This road may be the responsibility of the developer or builder.</p>
     </div>
-</div>

--- a/templates/web/cheshireeast/report/new/roads_message.html
+++ b/templates/web/cheshireeast/report/new/roads_message.html
@@ -1,4 +1,3 @@
-<div id="js-roads-responsibility" class="box-warning hidden">
     <strong>Not maintained by Cheshire East Highways</strong>
     <div id="js-not-a-road" class="hidden js-responsibility-message">
         <p>Cheshire East Highways is not responsible for this location;
@@ -6,5 +5,3 @@
         <a href="https://www.gov.uk/search-property-information-land-registry">https://www.gov.uk/search-property-information-land-registry</a>.
         </p>
     </div>
-</div>
-

--- a/templates/web/fixmystreet-uk-councils/report/new/roads_message.html
+++ b/templates/web/fixmystreet-uk-councils/report/new/roads_message.html
@@ -1,5 +1,3 @@
-<div id="js-roads-responsibility" class="box-warning hidden">
     <div id="js-not-an-asset" class="hidden js-responsibility-message">
         <p>Please select <span class="js-roads-asset" data-original="an item">an item</span> from the map on which to make a report.</p>
     </div>
-</div>

--- a/templates/web/fixmystreet.com/report/new/roads_message.html
+++ b/templates/web/fixmystreet.com/report/new/roads_message.html
@@ -1,4 +1,3 @@
-<div id="js-roads-responsibility" class="box-warning hidden">
     <div id="js-not-council-road" class="hidden js-responsibility-message js-roads-bucks js-roads-centralbeds js-roads-shropshire">
         <p>The selected road is not maintained by the council;
         to find out who owns this land/road please contact the Land Registry at
@@ -37,4 +36,3 @@
     <p>
     [% INCLUDE 'report/new/flytipping_text.html' %]
     </p>
-</div>

--- a/templates/web/highwaysengland/report/new/roads_message.html
+++ b/templates/web/highwaysengland/report/new/roads_message.html
@@ -1,4 +1,3 @@
-<div id="js-roads-responsibility" class="box-warning hidden">
     <div id="js-not-he-road" class="hidden js-responsibility-message js-roads-he">
         <strong>Not maintained by us</strong>
         <p>The selected location is not maintained by us.
@@ -13,4 +12,3 @@
         <a class="js-update-coordinates" href="https://www.fixmystreet.com/report/new?latitude=[% latitude %]&amp;longitude=[% longitude %]">FixMyStreet</a> to continue reporting your issue.
         </p>
     </div>
-</div>

--- a/templates/web/northamptonshire/report/new/roads_message.html
+++ b/templates/web/northamptonshire/report/new/roads_message.html
@@ -1,4 +1,3 @@
-<div id="js-roads-responsibility" class="box-warning hidden">
     <div id="js-not-an-asset" class="hidden js-responsibility-message">
         <p>Please select <span class="js-roads-asset" data-original="an item">an item</span> from the map on which to make a report.</p>
     </div>
@@ -7,4 +6,3 @@
         Highways and therefore we are unable to accept reports in
         this area / street.</p>
     </div>
-</div>

--- a/templates/web/oxfordshire/report/new/roads_message.html
+++ b/templates/web/oxfordshire/report/new/roads_message.html
@@ -1,4 +1,3 @@
-<div id="js-roads-responsibility" class="box-warning hidden">
     <div id="js-not-a-road" class="hidden js-responsibility-message">
         <p>This area is not under the responsibility of Oxfordshire
         County Council and therefore we are unable to accept reports in
@@ -16,4 +15,3 @@
             <a href="https://publicrightsofway.oxfordshire.gov.uk/web/standardmap.aspx">this page</a>.
         </p>
     </div>
-</div>

--- a/templates/web/peterborough/report/new/roads_message.html
+++ b/templates/web/peterborough/report/new/roads_message.html
@@ -1,4 +1,3 @@
-<div id="js-roads-responsibility" class="box-warning hidden">
     <div id="js-not-an-asset" class="hidden js-responsibility-message">
         <p>Please select <span class="js-roads-asset" data-original="an item">an item</span> from the map on which to make a report.</p>
     </div>
@@ -7,4 +6,3 @@
     <p>
     [% INCLUDE 'report/new/flytipping_text.html' %]
     </p>
-</div>

--- a/templates/web/shropshire/report/new/roads_message.html
+++ b/templates/web/shropshire/report/new/roads_message.html
@@ -1,4 +1,3 @@
-<div id="js-roads-responsibility" class="box-warning hidden">
     <strong>Not maintained by Shropshire Council</strong>
     <div id="js-not-a-road" class="hidden js-responsibility-message js-roads-shropshire">
         <p>The location you have selected doesn't appear to be on <span class="js-roads-asset" data-original="a road">a public road</span> that Shropshire Council maintain.</p>
@@ -7,4 +6,3 @@
     <div id="js-not-council-road" class="js-responsibility-message hidden js-roads-shropshire">
         <p>The road you have selected is a <strong>Private road</strong> and not maintained by Shropshire Council</p>
     </div>
-</div>

--- a/templates/web/tfl/report/new/roads_message.html
+++ b/templates/web/tfl/report/new/roads_message.html
@@ -1,4 +1,3 @@
-<div id="js-roads-responsibility" class="box-warning hidden">
     <div id="js-not-tfl-road" class="hidden js-responsibility-message">
         <p>Transport for London does not maintain this road. Please use
         <a class="js-not-tfl-link" href="https://www.fixmystreet.com/report/new?latitude=[% latitude | html %]&amp;longitude=[% longitude | html %]">FixMyStreet.com</a> to report it
@@ -14,4 +13,3 @@
         Please <a id="a13dbfolink" href="mailto:SMBA13DBFOTeamRd@tfl.gov.uk,Enquiries@rmsa13.com?subject=A13 DBFO Streetcare report&body=">email</a>
         the A13 DBFO team <strong>SMBA13DBFOTeamRd@tfl.gov.uk</strong> and RMS central queries <strong>Enquiries@rmsa13.com</strong> to report it</p>
     </div>
-</div>

--- a/templates/web/thamesmead/report/new/roads_message.html
+++ b/templates/web/thamesmead/report/new/roads_message.html
@@ -1,4 +1,3 @@
-<div id="js-roads-responsibility" class="box-warning hidden">
     <strong>Not maintained by Thamesmead</strong>
     <div id="js-not-a-road" class="hidden js-responsibility-message js-roads-shropshire">
         <p>The location you have selected doesn't appear to be on <span class="js-roads-asset" data-original="a road">a public road</span> that Thamesmead maintain.</p>
@@ -7,4 +6,3 @@
     <div id="js-not-council-road" class="js-responsibility-message hidden js-roads-shropshire">
         <p>The road you have selected is a <strong>Private road</strong> and not maintained by Thamesmead</p>
     </div>
-</div>

--- a/templates/web/westminster/report/new/roads_message.html
+++ b/templates/web/westminster/report/new/roads_message.html
@@ -1,5 +1,3 @@
-<div id="js-roads-responsibility" class="box-warning hidden">
     <div id="js-not-an-asset" class="hidden js-responsibility-message">
         <p>Please select <span class="js-roads-asset" data-original="an item">an item</span> from the map on which to make a report.</p>
     </div>
-</div>

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -1204,6 +1204,7 @@ fixmystreet.message_controller = (function() {
             $div.appendTo('#map_box');
         } else {
             $("#js-roads-responsibility").removeClass("hidden");
+            $("#js-roads-responsibility")[0].scrollIntoView();
         }
         $(id).removeClass("hidden");
     }


### PR DESCRIPTION
If the pin was moved and the message shown, it was being scrolled into view by update_pin, but this was not happening if the message was shown after category selection. [skip changelog]