### PR TITLE
[Buckinghamshire] Use speed limit asset layer to route Grass cutting reports

### DIFF
--- a/.cypress/cypress/fixtures/bucks_speed_limits_30.xml
+++ b/.cypress/cypress/fixtures/bucks_speed_limits_30.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:wfs="http://www.opengis.net/wfs"
+  xmlns:gml="http://www.opengis.net/gml"
+  xmlns:OS_Highways_Speed="https://maps.buckscc.gov.uk/arcgis/services/OS_Highways_Speed/MapServer/WFSServer"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" timeStamp="2022-07-18T16:53:44Z" numberOfFeatures="123" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/gml.xsd https://maps.buckscc.gov.uk/arcgis/services/OS_Highways_Speed/MapServer/WFSServer https://maps.buckscc.gov.uk/arcgis/services/Transport/OS_Highways_Speed/MapServer/WFSServer?service=wfs%26version=1.1.0%26request=DescribeFeatureType">
+  <gml:boundedBy>
+    <gml:Envelope srsName="urn:ogc:def:crs:EPSG::27700">
+      <gml:lowerCorner>0.00000000 0.00000000</gml:lowerCorner>
+      <gml:upperCorner>0.00000000 0.00000000</gml:upperCorner>
+    </gml:Envelope>
+  </gml:boundedBy>
+  <gml:featureMember>
+    <OS_Highways_Speed:CORPGIS.CORPORATE.OS_Highways_Speed gml:id="CORPGIS.CORPORATE.OS_Highways_Speed.111">
+      <OS_Highways_Speed:OBJECTID>111</OS_Highways_Speed:OBJECTID>
+      <OS_Highways_Speed:speed>30.00000000</OS_Highways_Speed:speed>
+      <OS_Highways_Speed:Shape>
+        <gml:MultiCurve srsName="EPSG:27700">
+            <gml:curveMember>
+              <gml:LineString>
+                <gml:posList srsDimension="2">499991.980000 191715.960000 500000.000000 191720.020000 500004.960000 191721.000000 500008.960000 191721.970000 500019.990000 191724.970000 500028.010000 191729.030000 500032.990000 191733.020000 500035.030000 191734.950000 500039.020000 191743.030000 500039.990000 191746.950000 500040.000000 191749.950000 500040.010000 191755.960000 500035.180000 191772.660000 </gml:posList>
+              </gml:LineString>
+            </gml:curveMember>
+            <gml:curveMember>
+              <gml:LineString>
+                <gml:posList srsDimension="2">500035.180000 191772.660000 500025.070000 191769.020000 </gml:posList>
+              </gml:LineString>
+            </gml:curveMember>
+            <gml:curveMember>
+              <gml:LineString>
+                <gml:posList srsDimension="2">500035.180000 191772.660000 500027.000000 191800.990000 500019.980000 191819.980000 500008.590000 191849.680000 500005.380000 191858.080000 </gml:posList>
+              </gml:LineString>
+            </gml:curveMember>
+          </gml:MultiCurve>
+      </OS_Highways_Speed:Shape>
+      <OS_Highways_Speed:Shape.STLength__>23.17721240</OS_Highways_Speed:Shape.STLength__>
+    </OS_Highways_Speed:CORPGIS.CORPORATE.OS_Highways_Speed>
+  </gml:featureMember>
+</wfs:FeatureCollection>

--- a/.cypress/cypress/fixtures/bucks_speed_limits_60.xml
+++ b/.cypress/cypress/fixtures/bucks_speed_limits_60.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:wfs="http://www.opengis.net/wfs"
+  xmlns:gml="http://www.opengis.net/gml"
+  xmlns:OS_Highways_Speed="https://maps.buckscc.gov.uk/arcgis/services/OS_Highways_Speed/MapServer/WFSServer"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" timeStamp="2022-07-18T16:53:44Z" numberOfFeatures="123" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/gml.xsd https://maps.buckscc.gov.uk/arcgis/services/OS_Highways_Speed/MapServer/WFSServer https://maps.buckscc.gov.uk/arcgis/services/Transport/OS_Highways_Speed/MapServer/WFSServer?service=wfs%26version=1.1.0%26request=DescribeFeatureType">
+  <gml:boundedBy>
+    <gml:Envelope srsName="urn:ogc:def:crs:EPSG::27700">
+      <gml:lowerCorner>0.00000000 0.00000000</gml:lowerCorner>
+      <gml:upperCorner>0.00000000 0.00000000</gml:upperCorner>
+    </gml:Envelope>
+  </gml:boundedBy>
+  <gml:featureMember>
+    <OS_Highways_Speed:CORPGIS.CORPORATE.OS_Highways_Speed gml:id="CORPGIS.CORPORATE.OS_Highways_Speed.111">
+      <OS_Highways_Speed:OBJECTID>111</OS_Highways_Speed:OBJECTID>
+      <OS_Highways_Speed:speed>60.00000000</OS_Highways_Speed:speed>
+      <OS_Highways_Speed:Shape>
+        <gml:MultiCurve srsName="EPSG:27700">
+            <gml:curveMember>
+              <gml:LineString>
+                <gml:posList srsDimension="2">499991.980000 191715.960000 500000.000000 191720.020000 500004.960000 191721.000000 500008.960000 191721.970000 500019.990000 191724.970000 500028.010000 191729.030000 500032.990000 191733.020000 500035.030000 191734.950000 500039.020000 191743.030000 500039.990000 191746.950000 500040.000000 191749.950000 500040.010000 191755.960000 500035.180000 191772.660000 </gml:posList>
+              </gml:LineString>
+            </gml:curveMember>
+            <gml:curveMember>
+              <gml:LineString>
+                <gml:posList srsDimension="2">500035.180000 191772.660000 500025.070000 191769.020000 </gml:posList>
+              </gml:LineString>
+            </gml:curveMember>
+            <gml:curveMember>
+              <gml:LineString>
+                <gml:posList srsDimension="2">500035.180000 191772.660000 500027.000000 191800.990000 500019.980000 191819.980000 500008.590000 191849.680000 500005.380000 191858.080000 </gml:posList>
+              </gml:LineString>
+            </gml:curveMember>
+          </gml:MultiCurve>
+      </OS_Highways_Speed:Shape>
+      <OS_Highways_Speed:Shape.STLength__>23.17721240</OS_Highways_Speed:Shape.STLength__>
+    </OS_Highways_Speed:CORPGIS.CORPORATE.OS_Highways_Speed>
+  </gml:featureMember>
+</wfs:FeatureCollection>

--- a/.cypress/cypress/fixtures/bucks_speed_limits_none.xml
+++ b/.cypress/cypress/fixtures/bucks_speed_limits_none.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:wfs="http://www.opengis.net/wfs"
+  xmlns:gml="http://www.opengis.net/gml"
+  xmlns:OS_Highways_Speed="https://maps.buckscc.gov.uk/arcgis/services/OS_Highways_Speed/MapServer/WFSServer"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" timeStamp="2022-07-18T16:53:44Z" numberOfFeatures="123" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/gml.xsd https://maps.buckscc.gov.uk/arcgis/services/OS_Highways_Speed/MapServer/WFSServer https://maps.buckscc.gov.uk/arcgis/services/Transport/OS_Highways_Speed/MapServer/WFSServer?service=wfs%26version=1.1.0%26request=DescribeFeatureType">
+  <gml:boundedBy>
+    <gml:Envelope srsName="urn:ogc:def:crs:EPSG::27700">
+      <gml:lowerCorner>0.00000000 0.00000000</gml:lowerCorner>
+      <gml:upperCorner>0.00000000 0.00000000</gml:upperCorner>
+    </gml:Envelope>
+  </gml:boundedBy>
+</wfs:FeatureCollection>

--- a/bin/buckinghamshire/add-parish-categories
+++ b/bin/buckinghamshire/add-parish-categories
@@ -47,25 +47,12 @@ my $contacts = [
             {
                 code => 'speed_limit_greater_than_30',
                 description => 'Is the speed limit greater than 30mph?',
-                datatype => 'singlevaluelist',
+                datatype => 'string',
                 order => 1,
                 variable => 'true',
                 required => 'true',
                 protected => 'false',
-                values => [
-                    {
-                        key => 'yes',
-                        name => 'Yes',
-                    },
-                    {
-                        key => 'no',
-                        name => 'No',
-                    },
-                    {
-                        key => 'dont_know',
-                        name => "Don't know",
-                    },
-                ],
+                automated => 'hidden_field',
             }
         ],
     },

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -246,25 +246,12 @@ if ($opt->test_fixtures) {
     $child_cat->set_extra_fields({
         code => 'speed_limit_greater_than_30',
         description => 'Is the speed limit greater than 30mph?',
-        datatype => 'singlevaluelist',
+        datatype => 'string',
         order => 1,
         variable => 'true',
         required => 'true',
         protected => 'false',
-        values => [
-            {
-                key => 'yes',
-                name => 'Yes',
-            },
-            {
-                key => 'no',
-                name => 'No',
-            },
-            {
-                key => 'dont_know',
-                name => "Don't know",
-            },
-        ],
+        automated => 'hidden_field',
     });
     $child_cat->update;
 

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -627,6 +627,48 @@ sub council_rss_alert_options {
 sub car_park_wfs_query {
     my ($self, $row) = @_;
 
+    my $uri = URI->new("https://maps.buckscc.gov.uk/arcgis/services/Transport/BC_Car_Parks/MapServer/WFSServer");
+    $uri->query_form(
+        REQUEST => "GetFeature",
+        SERVICE => "WFS",
+        SRSNAME => "urn:ogc:def:crs:EPSG::27700",
+        TYPENAME => "BC_CAR_PARKS",
+        VERSION => "1.1.0",
+        propertyName => 'OBJECTID,Shape',
+    );
+
+    try {
+        return $self->_get($self->_wfs_uri($row, $uri));
+    } catch {
+        # Ignore WFS errors.
+        return {};
+    };
+}
+
+sub speed_limit_wfs_query {
+    my ($self, $row) = @_;
+
+    my $uri = URI->new("https://maps.buckscc.gov.uk/arcgis/services/Transport/OS_Highways_Speed/MapServer/WFSServer");
+    $uri->query_form(
+        REQUEST => "GetFeature",
+        SERVICE => "WFS",
+        SRSNAME => "urn:ogc:def:crs:EPSG::27700",
+        TYPENAME => "OS_Highways_Speed:CORPGIS.CORPORATE.OS_Highways_Speed",
+        VERSION => "1.1.0",
+        propertyName => 'OBJECTID,Shape,speed',
+    );
+
+    try {
+        return $self->_get($self->_wfs_uri($row, $uri));
+    } catch {
+        # Ignore WFS errors.
+        return {};
+    };
+}
+
+sub _wfs_uri {
+    my ($self, $row, $base_uri) = @_;
+
     my ($x, $y) = $row->local_coords;
     my $buffer = 50; # metres
     my ($w, $s, $e, $n) = ($x-$buffer, $y-$buffer, $x+$buffer, $y+$buffer);
@@ -643,30 +685,14 @@ sub car_park_wfs_query {
     </ogc:Filter>";
     $filter =~ s/\n\s+//g;
 
-    my $uri = URI->new("https://maps.buckscc.gov.uk/arcgis/services/Transport/BC_Car_Parks/MapServer/WFSServer");
-    $uri->query_form(
-        REQUEST => "GetFeature",
-        SERVICE => "WFS",
-        SRSNAME => "urn:ogc:def:crs:EPSG::27700",
-        TYPENAME => "BC_CAR_PARKS",
-        VERSION => "1.1.0",
-        propertyName => 'OBJECTID,Shape',
-    );
-
     # URI encodes ' ' as '+' but arcgis wants it to be '%20'
     # Putting %20 into the filter string doesn't work because URI then escapes
     # the '%' as '%25' so you get a double encoding issue.
     #
-    # Avoid all of that and just put the filter on the end of the $uri
+    # Avoid all of that and just put the filter on the end of the $base_uri
     $filter = URI::Escape::uri_escape_utf8($filter);
-    $uri = "$uri&filter=$filter";
 
-    try {
-        return $self->_get($uri);
-    } catch {
-        # Ignore WFS errors.
-        return {};
-    };
+    return "$base_uri&filter=$filter";
 }
 
 # Wrapper around LWP::Simple::get to make mocking in tests easier.
@@ -702,17 +728,27 @@ around 'report_validation' => sub {
 };
 
 # Route grass cutting reports to the parish if the user answers 'no' to the
-# question 'Is the speed limit on this road 30mph or greater?'
+# question 'Is the speed limit greater than 30mph?'
 sub munge_contacts_to_bodies {
     my ($self, $contacts, $report) = @_;
 
     return unless $report->category eq 'Grass cutting';
 
     my $greater_than_30 = $report->get_extra_field_value('speed_limit_greater_than_30');
-    return unless $greater_than_30;
 
-    # This is called from FixMyStreet.pm as well, so avoid $self.
-    my $area_id = FixMyStreet::Cobrand::Buckinghamshire::council_area_id;
+    if (!$greater_than_30) {
+        # Look up the report's location on the speed limit WFS server
+        my $speed_limit_xml = $self->speed_limit_wfs_query($report);
+        my $speed_limit = $1 if $speed_limit_xml =~ /<OS_Highways_Speed:speed>([\.\d]+)<\/OS_Highways_Speed:speed>/;
+
+        if ($speed_limit) {
+            $greater_than_30 = $speed_limit > 30 ? 'yes' : 'no';
+        } else {
+            $greater_than_30 = 'dont_know';
+        }
+    }
+
+    my $area_id = $self->council_area_id;
 
     if ($greater_than_30 eq 'no') {
         # Route to the parish

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -384,8 +384,13 @@ sub report_new_munge_before_insert {
 sub munge_contacts_to_bodies {
     my ($self, $contacts, $report) = @_;
 
-    # Make sure Bucks grass cutting reports are routed correctly
-    FixMyStreet::Cobrand::Buckinghamshire::munge_contacts_to_bodies($self, $contacts, $report);
+    my %bodies = map { $_->body->name => 1 } @$contacts;
+
+    if ($bodies{'Buckinghamshire Council'}) {
+        # Make sure Bucks grass cutting reports are routed correctly
+        my $bucks = FixMyStreet::Cobrand::Buckinghamshire->new;
+        $bucks->munge_contacts_to_bodies($contacts, $report);
+    }
 }
 
 sub get_body_handler_for_problem {

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -41,26 +41,13 @@ $mech->create_contact_ok(body_id => $body->id, category => 'Grass cutting', emai
 $contact = $mech->create_contact_ok(body_id => $parish->id, category => 'Grass cutting', email => 'grassparish@example.org', send_method => 'Email');
 $contact->set_extra_fields({
     code => 'speed_limit_greater_than_30',
-    description => 'Is the speed limit on this road 30mph or greater?',
-    datatype => 'singlevaluelist',
+    description => 'Is the speed limit greater than 30mph?',
+    datatype => 'string',
     order => 1,
     variable => 'true',
     required => 'true',
     protected => 'false',
-    values => [
-        {
-            key => 'yes',
-            name => 'Yes',
-        },
-        {
-            key => 'no',
-            name => 'No',
-        },
-        {
-            key => 'dont_know',
-            name => "Don't know",
-        },
-    ],
+    automated => 'hidden_field',
 });
 $contact->update;
 $contact = $mech->create_contact_ok(body_id => $parish->id, category => 'Dirty signs', email => 'signs@example.org', send_method => 'Email');
@@ -472,6 +459,61 @@ subtest 'sends grass cutting reports on roads 30mph or more to the council' => s
     my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
     ok $report, "Found the report";
     is $report->title, 'Test grass cutting report 2', 'Got the correct report';
+    is $report->bodies_str, $body->id, 'Report was sent to council';
+};
+
+subtest "server side speed limit lookup for council grass cutting report" => sub {
+    $bucks->mock('_get', sub { "<OS_Highways_Speed:speed>60.00000000</OS_Highways_Speed:speed>" });
+
+    $mech->get_ok('/report/new?latitude=51.615559&longitude=-0.556903&category=Grass+cutting');
+    $mech->submit_form_ok({
+        with_fields => {
+            title => "Test grass cutting report 3",
+            detail => 'Test report details.',
+            category => 'Grass cutting',
+            speed_limit_greater_than_30 => '',
+        }
+    }, "submit details");
+    $mech->content_contains('Your issue is on its way to the council') or diag $mech->content;
+    my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+    ok $report, "Found the report";
+    is $report->title, 'Test grass cutting report 3', 'Got the correct report';
+    is $report->bodies_str, $body->id, 'Report was sent to council';
+};
+
+subtest "server side speed limit lookup for parish grass cutting report" => sub {
+    $bucks->mock('_get', sub { "<OS_Highways_Speed:speed>30.00000000</OS_Highways_Speed:speed>" });
+
+    $mech->get_ok('/report/new?latitude=51.615559&longitude=-0.556903&category=Grass+cutting');
+    $mech->submit_form_ok({
+        with_fields => {
+            title => "Test grass cutting report 4",
+            detail => 'Test report details.',
+            category => 'Grass cutting',
+        }
+    }, "submit details");
+    $mech->content_contains('Your issue is on its way to the council');
+    my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+    ok $report, "Found the report";
+    is $report->title, 'Test grass cutting report 4', 'Got the correct report';
+    is $report->bodies_str, $parish->id, 'Report was sent to parish';
+};
+
+subtest "server side speed limit lookup with unknown speed limit" => sub {
+    $bucks->mock('_get', sub { '' });
+
+    $mech->get_ok('/report/new?latitude=51.615559&longitude=-0.556903&category=Grass+cutting');
+    $mech->submit_form_ok({
+        with_fields => {
+            title => "Test grass cutting report 5",
+            detail => 'Test report details.',
+            category => 'Grass cutting',
+        }
+    }, "submit details");
+    $mech->content_contains('Your issue is on its way to the council');
+    my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+    ok $report, "Found the report";
+    is $report->title, 'Test grass cutting report 5', 'Got the correct report';
     is $report->bodies_str, $body->id, 'Report was sent to council';
 };
 

--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -505,4 +505,43 @@ fixmystreet.assets.add(defaults, {
     protocol_class: OpenLayers.Protocol.BuckinghamshireHTTP
 });
 
+// The maximum speed for reports to be sent to the parish council.
+var parish_speed_threshold = 30;
+
+fixmystreet.assets.add(defaults, {
+    http_options: {
+        url: 'https://maps.buckscc.gov.uk/arcgis/services/Transport/OS_Highways_Speed/MapServer/WFSServer',
+        params: {
+            propertyName: 'speed,shape',
+            TYPENAME: "OS_Highways_Speed:CORPGIS.CORPORATE.OS_Highways_Speed"
+        }
+    },
+    actions: {
+        found: function(layer, feature, criterion, msg_id) {
+            // Answer speed limit question based on speed limit of the road.
+            var $question = $('#form_speed_limit_greater_than_30');
+            if (feature.attributes.speed && feature.attributes.speed <= parish_speed_threshold) {
+                $question.val('no');
+            } else {
+                $question.val('yes');
+            }
+            // Fire the change event so the council text is updated.
+            $question.trigger('change');
+        },
+        not_found: function(layer) {
+            $('#form_speed_limit_greater_than_30').val('dont_know').trigger('change');
+        }
+    },
+    no_asset_msg_id: '#js-not-a-road',
+    asset_category: "Grass cutting",
+    non_interactive: true,
+    road: true,
+    asset_item: 'road',
+    asset_type: 'road',
+    stylemap: fixmystreet.assets.stylemap_invisible,
+
+    // Want to use this for parish categories as well as Bucks, so skip body checks.
+    body: null
+});
+
 })();


### PR DESCRIPTION
This uses the same code that was already in place for this, but the
question is now a hidden field which gets auto-populated by the values
in the asset layer.

[skip changelog]

Fixes https://github.com/mysociety/societyworks/issues/2812