### PR TITLE
[Bucks] Fixes after MapIt generation update

### DIFF
--- a/t/app/controller/contact.t
+++ b/t/app/controller/contact.t
@@ -535,7 +535,7 @@ for my $test (
         FixMyStreet::override_config {
             ALLOWED_COBRANDS => [ 'buckinghamshire' ],
         }, sub {
-            my $bucks = $mech->create_body_ok(2217, 'Buckinghamshire Council');
+            my $bucks = $mech->create_body_ok(2217, 'Buckinghamshire Council', {}, { cobrand => 'buckinghamshire' });
             my ($problem) = $mech->create_problems_for_body(1, $bucks->id, 'Test');
             $mech->get_ok( '/contact?id=' . $problem->id, 'can visit for abuse report' );
             $mech->submit_form_ok( { with_fields => $test->{fields} } );

--- a/t/app/controller/report_new_staff.t
+++ b/t/app/controller/report_new_staff.t
@@ -8,11 +8,11 @@ my $mech = FixMyStreet::TestMech->new;
 
 my %body_ids;
 for my $body (
-    { area_id => 2651, name => 'City of Edinburgh Council' },
-    { area_id => 2482, name => 'Bromley Council' },
-    { area_id => 2237, name => 'Oxfordshire County Council' },
+    { area_id => 2651, name => 'City of Edinburgh Council', cobrand => undef },
+    { area_id => 2482, name => 'Bromley Council', cobrand => 'bromley' },
+    { area_id => 2237, name => 'Oxfordshire County Council', cobrand => 'oxfordshire' },
 ) {
-    my $body_obj = $mech->create_body_ok($body->{area_id}, $body->{name});
+    my $body_obj = $mech->create_body_ok($body->{area_id}, $body->{name}, {}, { cobrand => $body->{cobrand} });
     $body_ids{$body->{area_id}} = $body_obj->id;
 }
 


### PR DESCRIPTION
Restores the correct functionality for Parishes after the MapIt generation update (#3933).

NB when you come to rebase the Bucks parishes work over `master`, you'll need to replace the `2217` area IDs with `163793`.