### PR TITLE
[Buckinghamshire] Have cobrand own parish bodies.

### DIFF
--- a/perllib/FixMyStreet/Queue/Item/Report.pm
+++ b/perllib/FixMyStreet/Queue/Item/Report.pm
@@ -97,6 +97,7 @@ sub _create_vars {
     my %h = map { $_ => $row->$_ } qw/id title detail name category latitude longitude used_map/;
     $h{report} = $row;
     $h{cobrand} = $self->cobrand;
+    $h{cobrand_handler} = $self->cobrand_handler;
     map { $h{$_} = $row->user->$_ || '' } qw/email phone/;
     $h{confirmed} = DateTime::Format::Pg->format_datetime( $row->confirmed->truncate (to => 'second' ) )
         if $row->confirmed;

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -434,6 +434,30 @@ subtest 'sends grass cutting reports on roads under 30mph to the parish' => sub 
     like $mech->get_text_body_from_email($email[1]), qr/please contact Adstock Parish Council at grassparish\@example.org/;
 };
 
+subtest '.com reports get the logged email too' => sub {
+    ok $mech->host("www.fixmystreet.com"), "change host to www";
+    $mech->clear_emails_ok;
+    $mech->get_ok('/report/new?latitude=51.615559&longitude=-0.556903&category=Grass+cutting');
+    $mech->submit_form_ok({
+        with_fields => {
+            title => "Test grass cutting report 1b",
+            detail => 'Test report details.',
+            category => 'Grass cutting',
+            speed_limit_greater_than_30 => 'no', # Is the speed limit greater than 30mph?
+        }
+    }, "submit details");
+    $mech->content_contains('Thank you for reporting');
+    my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+    ok $report, "Found the report";
+    is $report->title, 'Test grass cutting report 1b', 'Got the correct report';
+    is $report->bodies_str, $parish->id, 'Report was sent to parish';
+    FixMyStreet::Script::Reports::send();
+    my @email = $mech->get_email;
+    $mech->email_count_is(2);
+    like $mech->get_text_body_from_email($email[1]), qr/please contact Adstock Parish Council at grassparish\@example.org/;
+    ok $mech->host("buckinghamshire.fixmystreet.com"), "change host to bucks";
+};
+
 subtest 'sends grass cutting reports on roads 30mph or more to the council' => sub {
     $mech->get_ok('/report/new?latitude=51.615559&longitude=-0.556903&category=Grass+cutting');
     $mech->submit_form_ok({

--- a/templates/email/fixmystreet.com/_council_reference.html
+++ b/templates/email/fixmystreet.com/_council_reference.html
@@ -2,3 +2,10 @@
 <p style="[% p_style %]">The report's reference number is <strong>[% sent_confirm_id_ref %]</strong>.
   Please quote this if you need to contact the council about this report.</p>
 [%~ END %]
+
+[% IF cobrand_handler.moniker == 'buckinghamshire' AND problem.body != 'Buckinghamshire Council' %]
+<p style="[% p_style %]">
+  For any further enquiries regarding this report, please contact [% problem.body %]
+  [%~ IF problem.contact.email %] at [% problem.contact.email %][% END %].
+</p>
+[% END %]

--- a/templates/email/fixmystreet.com/_council_reference.txt
+++ b/templates/email/fixmystreet.com/_council_reference.txt
@@ -2,3 +2,8 @@
 The report's reference number is [% sent_confirm_id_ref %]. Please quote this
 if you need to contact the council about this report.
 [%~ END %]
+
+[% IF cobrand_handler.moniker == 'buckinghamshire' AND problem.body != 'Buckinghamshire Council' %]
+For any further enquiries regarding this report, please contact [% problem.body %]
+[%~ IF problem.contact.email %] at [% problem.contact.email %][% END %].
+[%~ END %]


### PR DESCRIPTION
This means a parish report made on .com will get a report logged email,
plus no need for a special post_report_sent function in FixMyStreet.pm.
[skip changelog]
Should fix FD-2186.