### PR TITLE
[Bromley] Don’t munge Open311 update params for waste reports

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -282,6 +282,11 @@ sub open311_post_send_updates {
 
 sub open311_munge_update_params {
     my ($self, $params, $comment, $body) = @_;
+
+    # Waste reports are sent to our Open311 endpoint, not Bromley's,
+    # and we don't want to make changes to parameters in that case.
+    return if $comment->problem->cobrand_data eq 'waste';
+
     delete $params->{update_id};
     $params->{public_anonymity_required} = $comment->anonymous ? 'TRUE' : 'FALSE',
     $params->{update_id_ext} = $comment->id;


### PR DESCRIPTION
Our open311-adapter doesn’t need these params munging in the same way
as the Bromley endpoint.

[skip changelog]