### PR TITLE
[Cheshire East] Untick ‘Save with a public update’ box on inspector form by default

### DIFF
--- a/perllib/FixMyStreet/Cobrand/CheshireEast.pm
+++ b/perllib/FixMyStreet/Cobrand/CheshireEast.pm
@@ -227,4 +227,6 @@ sub open311_post_send {
     $row->detail($h->{ce_original_detail});
 }
 
+sub public_update_default_checked { 0 }
+
 1;

--- a/t/cobrand/cheshireeast.t
+++ b/t/cobrand/cheshireeast.t
@@ -167,7 +167,7 @@ FixMyStreet::override_config {
     ok $mech->host("cheshireeast.fixmystreet.com"), "change host to cheshireeast";
     $mech->log_in_ok($staff_user->email);
 
-    $report->comments->delete_all;
+    ($report) = $mech->create_problems_for_body( 1, $body->id, 'Test', { category => 'Zebra Crossing' } );
 
     subtest 'inspector form defaults to not creating a public update on CE cobrand', sub {
         $mech->get_ok('/report/' . $report->id);

--- a/templates/web/base/report/inspect/public_update.html
+++ b/templates/web/base/report/inspect/public_update.html
@@ -1,5 +1,9 @@
 [% IF NOT public_update_defaulted.defined %]
+  [% IF c.cobrand.can('public_update_default_checked') %]
+    [% public_update_defaulted = c.cobrand.public_update_default_checked %]
+  [% ELSE %]
     [% public_update_defaulted = 1 %]
+  [% END %]
 [% END %]
           <p>
             <label class="label-containing-checkbox">


### PR DESCRIPTION
For FD-2247

[skip changelog]