### PR TITLE
[Bromley] Skip email_alerts_requested param for waste report updates

### DIFF
--- a/perllib/Open311.pm
+++ b/perllib/Open311.pm
@@ -461,7 +461,7 @@ sub _populate_service_request_update_params {
     }
 
     # The following will only set by UK in Bromley/Bromley cobrands
-    if ( $comment->extra && $comment->extra->{title} ) {
+    if ( $comment->extra && $comment->extra->{title} && ( $comment->problem->cobrand_data || '' ) ne 'waste' ) {
         $params->{'email_alerts_requested'}
             = $comment->extra->{email_alerts_requested} ? 'TRUE' : 'FALSE';
         $params->{'title'} = $comment->extra->{title};

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -361,6 +361,7 @@ subtest 'Updates on waste reports don\'t have munged params' => sub {
         is $c->param('update_id_ext'), undef;
         is $c->param('service_request_id_ext'), undef;
         is $c->param('public_anonymity_required'), undef;
+        is $c->param('email_alerts_requested'), undef;
 
         $report->update({ cobrand_data => '' });
     };


### PR DESCRIPTION
Missed this in previous fix (765bfb0146b09132b653494c2da063ea1ae304c1)

[skip changelog]