### PR TITLE
[Thamesmead] Goes to own report page and reports own stats

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Thamesmead.pm
+++ b/perllib/FixMyStreet/Cobrand/Thamesmead.pm
@@ -57,6 +57,8 @@ sub problems_on_map_restriction { $_[0]->problems_restriction($_[1]) }
 sub problems_sql_restriction { FixMyStreet::Cobrand::UKCouncils::problems_sql_restriction($_[0], $_[1]) }
 sub users_restriction { FixMyStreet::Cobrand::UKCouncils::users_restriction($_[0], $_[1]) }
 sub updates_restriction { FixMyStreet::Cobrand::UKCouncils::updates_restriction($_[0], $_[1]) }
+sub site_key { FixMyStreet::Cobrand::UKCouncils::site_key($_[0], $_[1]) }
+sub all_reports_single_body { FixMyStreet::Cobrand::UKCouncils::all_reports_single_body($_[0], $_[1]) }
 
 sub base_url { FixMyStreet::Cobrand::UKCouncils::base_url($_[0]) }
 


### PR DESCRIPTION
* Thamesmead uses own stats for front page stat reporting like a council
* Thamesmead /reports goes to its own reports page like a council

Two parts out of three on this ticket https://github.com/mysociety/societyworks/issues/3074

[skip changelog]