### PR TITLE
[Buckinghamshire] Match parish/town councils for all reports page

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -254,7 +254,7 @@ sub rss_area_ward : Path('/rss/area') : Args(2) {
         ($c->stash->{area}) = values %$areas;
     } else {
         foreach (keys %$areas) {
-            if (lc($areas->{$_}->{name}) eq lc($area) || $areas->{$_}->{name} =~ /^\Q$area\E (Borough|City|District|County) Council$/i) {
+            if (lc($areas->{$_}->{name}) eq lc($area) || $areas->{$_}->{name} =~ /^\Q$area\E (Borough|City|District|County|Parish|Town) Council$/i) {
                 $c->stash->{area} = $areas->{$_};
             }
         }
@@ -365,13 +365,16 @@ sub body_find : Private {
     my ($self, $c, $q_body) = @_;
 
     # We must now have a string to check
-    my @bodies = $c->model('DB::Body')->search( { name => { -like => "$q_body%" } } )->all;
+    my @bodies = $c->model('DB::Body')->search(
+        { name => { -like => "$q_body%" } },
+        { order_by => 'deleted' } # Prefer active over deleted
+    )->all;
 
     if (@bodies == 1) {
         return $bodies[0];
     } else {
         foreach (@bodies) {
-            if (lc($_->name) eq lc($q_body) || $_->name =~ /^\Q$q_body\E (Borough|City|District|County) Council$/i) {
+            if (lc($_->name) eq lc($q_body) || $_->name =~ /^\Q$q_body\E (Borough|City|District|County|Parish|Town) Council$/i) {
                 return $_;
             }
         }

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -11,7 +11,10 @@ END { FixMyStreet::App->log->enable('info'); }
 my $body = $mech->create_body_ok(163793, 'Buckinghamshire Council', {
     send_method => 'Open311', api_key => 'key', endpoint => 'endpoint', jurisdiction => 'fms', can_be_devolved => 1 }, { cobrand => 'buckinghamshire' });
 my $parish = $mech->create_body_ok(53822, 'Adstock Parish Council');
-my $other_body = $mech->create_body_ok(1234, 'Some Other Council');
+my $parish2 = $mech->create_body_ok(58815, 'Aylesbury Town Council');
+my $deleted_parish = $mech->create_body_ok(58815, 'Aylesbury Parish Council');
+$deleted_parish->update({ deleted => 1 });
+my $other_body = $mech->create_body_ok(1234, 'Aylesbury Vale District Council');
 my $counciluser = $mech->create_user_ok('counciluser@example.com', name => 'Council User', from_body => $body);
 my $publicuser = $mech->create_user_ok('fmsuser@example.org', name => 'Simon Neil');
 
@@ -570,6 +573,10 @@ subtest 'All reports pages for parishes' => sub {
     $mech->get_ok('/reports/Adstock');
     $mech->content_contains('Adstock Parish Council');
     is $mech->uri->path, '/reports/Adstock';
+
+    $mech->get_ok('/reports/Aylesbury');
+    $mech->content_contains('Aylesbury Town Council');
+    is $mech->uri->path, '/reports/Aylesbury';
 };
 
 subtest 'Reports to parishes are closed by default' => sub {


### PR DESCRIPTION
On the staging site the Buckinghamshire parish councils were originally
loaded in by simply appending "Parish Council" to the area name in
mapit.

However as part of the Buckinghamshire parish project we got a
more accurate list of parish and town council names to use. [1]

This means we have database entries for e.g. "Aylesbury Parish Council"
(from the original import) and "Aylesbury Town Council" (from the more
recent import). There are many other examples like this.

The unused entries from the original import should all be marked as
deleted, however the code that maps URLs like /reports/Aylesbury
to a body wasn't filtering for active bodies, so the deleted bodies were
being returned.

There was also a separate bug where if there's a third body, in this
case "Aylesbury Vale District Council", the regex wasn't matching for
Parish/Town councils so it would still fail.

[1] `bin/buckinghamshire/create-parish-bodies` has a list of the place names
    that aren't simply "$name Parish Council".

Fixes https://github.com/mysociety/societyworks/issues/2939

[skip changelog]