### PR TITLE
[Bucks] Triage parish fixes

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
@@ -376,47 +376,65 @@ Returns 1 if category changed, 0 if no change.
 sub edit_category : Private {
     my ($self, $c, $problem, $no_comment) = @_;
 
-    if ((my $category = $c->get_param('category')) ne $problem->category) {
-        my $force_resend = $c->cobrand->call_hook('category_change_force_resend', $problem->category, $category);
-        my $disable_resend = $c->cobrand->call_hook('disable_resend');
-        my $category_old = $problem->category;
-        $problem->category($category);
-        my @contacts = grep { $_->category eq $problem->category } @{$c->stash->{contacts}};
-        my @new_body_ids = map { $_->body_id } @contacts;
-        # If the report has changed bodies (and not to a subset!) we need to resend it
-        my %old_map = map { $_ => 1 } @{$problem->bodies_str_ids};
-        if (!$disable_resend && grep !$old_map{$_}, @new_body_ids) {
-            $problem->resend;
-        }
-        # If the send methods of the old/new contacts differ we need to resend the report
-        my @new_send_methods = uniq map {
-            ( $_->body->can_be_devolved && $_->send_method ) ?
-            $_->send_method : $_->body->send_method
-                ? $_->body->send_method
-                : $c->cobrand->_fallback_body_sender()->{method};
-        } @contacts;
-        my %old_send_methods = map { $_ => 1 } split /,/, ($problem->send_method_used || "Email");
-        if (!$disable_resend && grep !$old_send_methods{$_}, @new_send_methods) {
-            $problem->resend;
-        }
-        if ($force_resend) {
-            $problem->resend;
-        }
+    my $category = $c->get_param('category');
+    return 0 if $category eq $problem->category;
 
-        $problem->bodies_str(join( ',', @new_body_ids ));
-        my $update_text = '*' . sprintf(_('Category changed from ‘%s’ to ‘%s’'), $category_old, $category) . '*';
-        if ($no_comment) {
-            $c->stash->{update_text} = $update_text;
-        } else {
-            $problem->add_to_comments({
-                text => $update_text,
-                user => $c->user->obj,
-            });
-        }
-        $c->forward( '/admin/log_edit', [ $problem->id, 'problem', 'category_change' ] );
-        return 1;
+    my $category_old = $problem->category;
+    $problem->category($category);
+
+    my @contacts = grep { $_->category eq $problem->category } @{$c->stash->{contacts}};
+
+    check_resend($c, $category_old, $problem, \@contacts);
+
+    my @new_body_ids = map { $_->body_id } @contacts;
+    $problem->bodies_str(join( ',', @new_body_ids ));
+
+    my $update_text = '*' . sprintf(_('Category changed from ‘%s’ to ‘%s’'), $category_old, $category) . '*';
+    if ($no_comment) {
+        $c->stash->{update_text} = $update_text;
+    } else {
+        $problem->add_to_comments({
+            text => $update_text,
+            user => $c->user->obj,
+        });
     }
-    return 0;
+
+    $c->forward( '/admin/log_edit', [ $problem->id, 'problem', 'category_change' ] );
+    return 1;
+}
+
+sub check_resend {
+    my ($c, $category_old, $problem, $contacts) = @_;
+
+    my $force_resend = $c->cobrand->call_hook('category_change_force_resend', $category_old, $problem->category);
+    if ($force_resend) {
+        $problem->resend;
+        return;
+    }
+
+    my $disable_resend = $c->cobrand->call_hook('disable_resend');
+    return if $disable_resend;
+
+    # If the report has changed bodies (and not to a subset!) we need to resend it
+    my %old_map = map { $_ => 1 } @{$problem->bodies_str_ids};
+    my @new_body_ids = map { $_->body_id } @$contacts;
+    if (grep !$old_map{$_}, @new_body_ids) {
+        $problem->resend;
+        return;
+    }
+
+    # If the send methods of the old/new contacts differ we need to resend the report
+    my @new_send_methods = uniq map {
+        ( $_->body->can_be_devolved && $_->send_method ) ?
+        $_->send_method : $_->body->send_method
+            ? $_->body->send_method
+            : $c->cobrand->_fallback_body_sender()->{method};
+    } @$contacts;
+    my %old_send_methods = map { $_ => 1 } split /,/, ($problem->send_method_used || "Email");
+    if (grep !$old_send_methods{$_}, @new_send_methods) {
+        $problem->resend;
+        return;
+    }
 }
 
 =head2 edit_location

--- a/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
@@ -374,15 +374,26 @@ Returns 1 if category changed, 0 if no change.
 =cut
 
 sub edit_category : Private {
-    my ($self, $c, $problem, $no_comment) = @_;
+    my ($self, $c, $problem, $no_comment, $contact) = @_;
 
-    my $category = $c->get_param('category');
-    return 0 if $category eq $problem->category;
+    my $category;
+    if ($contact) {
+        $category = $contact->category;
+        return 0 if $contact->id == $problem->contact->id;
+    } else {
+        $category = $c->get_param('category');
+        return 0 if $category eq $problem->category;
+    }
 
     my $category_old = $problem->category;
     $problem->category($category);
 
-    my @contacts = grep { $_->category eq $problem->category } @{$c->stash->{contacts}};
+    my @contacts;
+    if ($contact) {
+        @contacts = ($contact);
+    } else {
+        @contacts = grep { $_->category eq $problem->category } @{$c->stash->{contacts}};
+    }
 
     check_resend($c, $category_old, $problem, \@contacts);
 

--- a/perllib/FixMyStreet/App/Controller/Admin/Triage.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Triage.pm
@@ -112,9 +112,9 @@ sub update : Private {
     my $problem = $c->stash->{problem};
 
     my $current_category = $problem->category;
-    my $new_category = $c->get_param('category');
+    my $new_category_id = $c->get_param('category');
 
-    if (!$new_category) {
+    if (!$new_category_id) {
         my $errors = $c->stash->{errors} || [];
         push @$errors, _"Please choose a category";
         $c->stash->{errors} = $errors;
@@ -122,7 +122,10 @@ sub update : Private {
         $c->detach;
     }
 
-    my $changed = $c->forward('/admin/reports/edit_category', [ $problem, 1 ] );
+    my $contact = FixMyStreet::DB->resultset("Contact")->find($new_category_id);
+    my $new_category = $contact->category;
+
+    my $changed = $c->forward('/admin/reports/edit_category', [ $problem, 1, $contact ] );
 
     if ( $changed ) {
         $c->stash->{problem}->update( { state => 'confirmed' } );

--- a/perllib/FixMyStreet/App/Controller/Admin/Triage.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Triage.pm
@@ -89,10 +89,7 @@ sub setup_categories : Private {
     my ( $self, $c ) = @_;
 
     if ( $c->stash->{problem}->state eq 'for triage' ) {
-        $c->stash->{holding_options} = [ grep { $_->send_method && $_->send_method eq 'Triage' } @{$c->stash->{category_options}} ];
-        $c->stash->{holding_categories} = { map { $_->category => 1 } @{$c->stash->{holding_options}} };
-        $c->stash->{end_options} = [ grep { !$_->send_method || $_->send_method ne 'Triage' } @{$c->stash->{category_options}} ];
-        $c->stash->{end_categories} = { map { $_->category => 1 } @{$c->stash->{end_options}} };
+        $c->stash->{end_options} = [ grep { !$_->send_method || $_->send_method ne 'Triage' } @{$c->stash->{contacts}} ];
         delete $c->stash->{categories_hash};
         my %category_groups = ();
         for my $category (@{$c->stash->{end_options}}) {

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -85,6 +85,22 @@ sub available_permissions {
     return $perms;
 }
 
+=head2 permission_body_override
+
+If a parish body ID is provided, return our body ID instead.
+This is so Bucks staff users have permissions on parish reports.
+
+=cut
+
+sub permission_body_override {
+    my ($self, $body_ids) = @_;
+
+    my %parish_ids = map { $_->id => 1 } $self->parish_bodies->all;
+    my @out = map { $parish_ids{$_} ? $self->body->id : $_ } @$body_ids;
+
+    return \@out;
+}
+
 # Assume that any category change means the report should be resent
 sub category_change_force_resend { 1 }
 
@@ -821,7 +837,7 @@ sub owns_problem {
 sub parish_bodies {
     my ($self) = @_;
 
-    return FixMyStreet::DB->resultset('Body')->search(
+    return $self->{parish_bodies} //= FixMyStreet::DB->resultset('Body')->search(
         { 'body_areas.area_id' => { -in => $self->_parish_ids } },
         { join => 'body_areas', order_by => 'name' }
     )->active;

--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -387,7 +387,7 @@ sub moderating_user_name {
 
     $belongs_to_body = $user->belongs_to_body( $bodies );
 
-Returns true if the user belongs to the comma seperated list of body ids passed in
+Returns true if the user belongs to the arrayref or comma seperated list of body ids passed in
 
 =cut
 
@@ -397,7 +397,8 @@ sub belongs_to_body {
 
     return 0 unless $bodies && $self->from_body;
 
-    my %bodies = map { $_ => 1 } split ',', $bodies;
+    $bodies = [ split ',', $bodies ] unless ref $bodies eq 'ARRAY';
+    my %bodies = map { $_ => 1 } @$bodies;
 
     return 1 if $bodies{ $self->from_body->id };
     return 0;
@@ -481,7 +482,8 @@ sub permissions {
         return { map { %$_ } values %$perms };
     }
 
-    my $body_id = $problem->bodies_str;
+    my $body_id = $problem->bodies_str_ids;
+    $body_id = $cobrand->call_hook(permission_body_override => $body_id) || $body_id;
 
     return {} unless $self->belongs_to_body($body_id);
 
@@ -502,8 +504,9 @@ sub has_permission_to {
     return 1 if $self->is_superuser;
     return 0 if !$body_ids || (ref $body_ids eq 'ARRAY' && !@$body_ids);
     $body_ids = [ $body_ids ] unless ref $body_ids eq 'ARRAY';
-    my %body_ids = map { $_ => 1 } @$body_ids;
+    $body_ids = $cobrand->call_hook(permission_body_override => $body_ids) || $body_ids;
 
+    my %body_ids = map { $_ => 1 } @$body_ids;
     foreach (@{$self->body_permissions}) {
         return 1 if $_->{permission} eq $permission_type && $body_ids{$_->{body_id}};
     }

--- a/t/app/controller/admin/triage.t
+++ b/t/app/controller/admin/triage.t
@@ -18,7 +18,7 @@ my $iow_contact = $mech->create_contact_ok(
     email       => 'potholes@example.com',
     send_method => 'Triage'
 );
-$mech->create_contact_ok(
+my $traffic_lights = $mech->create_contact_ok(
     body_id  => $iow->id,
     category => 'Traffic lights',
     email    => 'lights@example.com'
@@ -111,7 +111,7 @@ FixMyStreet::override_config {
 
         $mech->submit_form_ok( {
                 with_fields => {
-                    category => 'Traffic lights',
+                    category => $traffic_lights->id,
                     include_update => 0,
                 }
             },

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -437,6 +437,8 @@ subtest 'Can triage parish reports' => sub {
     $report->update({ state => 'for triage' });
     $mech->get_ok('/admin/triage');
     $mech->content_contains('Test grass cutting report 1');
+    $mech->get_ok('/report/' . $report->id);
+    $mech->content_contains('value="Grass cutting"');
     $report->update({ state => 'confirmed' });
 };
 

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -39,7 +39,7 @@ $mech->create_contact_ok(body_id => $body->id, category => 'Car Parks', email =>
 $mech->create_contact_ok(body_id => $body->id, category => 'Graffiti', email => "graffiti\@chiltern", send_method => 'Email');
 $mech->create_contact_ok(body_id => $body->id, category => 'Flytipping (off-road)', email => "districts_flytipping", send_method => 'Email');
 $mech->create_contact_ok(body_id => $body->id, category => 'Barrier problem', email => 'parking@example.org', send_method => 'Email', group => 'Car park issue');
-$mech->create_contact_ok(body_id => $body->id, category => 'Grass cutting', email => 'grass@example.org', send_method => 'Email');
+my $grass_bucks = $mech->create_contact_ok(body_id => $body->id, category => 'Grass cutting', email => 'grass@example.org', send_method => 'Email');
 $mech->create_contact_ok(body_id => $body->id, category => 'Hedge problem', email => 'hedges@example.org', send_method => 'Email');
 
 # Create another Grass cutting category for a parish.
@@ -440,7 +440,8 @@ subtest 'Can triage parish reports' => sub {
     $mech->get_ok('/report/' . $report->id);
     $mech->content_contains('Grass cutting (grass@example.org)');
     $mech->content_contains('Grass cutting (grassparish@example.org)');
-    $report->update({ state => 'confirmed' });
+    $mech->submit_form_ok({ with_fields => { category => $grass_bucks->id } });
+    $report->update({ whensent => \'current_timestamp' });
 };
 
 subtest '.com reports get the logged email too' => sub {

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -438,7 +438,8 @@ subtest 'Can triage parish reports' => sub {
     $mech->get_ok('/admin/triage');
     $mech->content_contains('Test grass cutting report 1');
     $mech->get_ok('/report/' . $report->id);
-    $mech->content_contains('value="Grass cutting"');
+    $mech->content_contains('Grass cutting (grass@example.org)');
+    $mech->content_contains('Grass cutting (grassparish@example.org)');
     $report->update({ state => 'confirmed' });
 };
 

--- a/t/cobrand/isleofwight.t
+++ b/t/cobrand/isleofwight.t
@@ -363,7 +363,7 @@ subtest "comment recording triage details is not sent" => sub {
         $mech->get_ok($report_url);
         $mech->submit_form_ok( {
                 with_fields => {
-                    category => 'Potholes',
+                    category => $contact->id,
                     include_update => 0,
                 }
             },

--- a/templates/web/base/admin/triage/_inspect.html
+++ b/templates/web/base/admin/triage/_inspect.html
@@ -10,14 +10,14 @@
                     [% IF group_select == 0 AND problem.category == group.name %]
                         [% selected = 1; group_select = 1 %]
                     [% END %]
-                    <option value="[% cat_op.category | html %]"[% ' selected' IF selected OR problem.category == cat_op.category %]>[% cat_op.category_display | html %] ([% cat_op.email | html %])</option>
+                    <option value="[% cat_op.id %]"[% ' selected' IF selected OR problem.category == cat_op.category %]>[% cat_op.category_display %] ([% cat_op.email %])</option>
                     [% selected = 0 %]
                 [%~ END ~%]
                 [% IF group.name %]</optgroup>[% END %]
             [%~ END =%]
         [% ELSE %]
               [% FOREACH cat IN category_options %]
-                <option value="[% cat.category | html %]"[% ' selected' IF problem.category == cat.category %]>[% cat.category_display | html %]</option>
+                <option value="[% cat.id %]"[% ' selected' IF problem.category == cat.category %]>[% cat.category_display %]</option>
               [% END %]
       [% END %]
   [% END %]
@@ -68,7 +68,7 @@
           [% NEXT IF field.name == 'urgent' %]
           <p>
               <label for="[% field.name %]">[% field.description %]</label>
-              <input class="form-control" name="[% field.name %]" type="text" value="[% field.value | html %]" disabled>
+              <input class="form-control" name="[% field.name %]" type="text" value="[% field.value %]" disabled>
           </p>
           [% END %]
 

--- a/templates/web/base/admin/triage/_inspect.html
+++ b/templates/web/base/admin/triage/_inspect.html
@@ -56,7 +56,7 @@
                 New category
               [%~ END ~%]
           </label>
-          [% PROCESS category_list category_groups=end_groups field_name="category" categories_hash=end_categories category_options=end_options %]
+          [% PROCESS category_list category_groups=end_groups field_name="category" category_options=end_options %]
         </p>
 
       </div>


### PR DESCRIPTION
[skip changelog] Fixes https://github.com/mysociety/societyworks/issues/3138

This turned out to need multiple steps - firstly fixing the triage list page to show all cobranded reports rather than just the cobrand body's. Next to allow Bucks staff as if they had their staff permissions on all parish bodies (so that viewing a parish report page would show the triage form). Then instead of using the unique-name dropdown, show all contacts, and update the triage server form to deal with contact IDs rather than category name. Don't think this should affect any usage (and may well need extending at some point if same thing applies to e.g. normal admin report edit page).