### PR TITLE
Peterborough bulky goods: check availability of collection slots (core behaviour)

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Form.pm
+++ b/perllib/FixMyStreet/App/Controller/Form.pm
@@ -65,6 +65,8 @@ sub form : Private {
 
     $c->forward('pre_form');
 
+    # XXX This double form load means double API calls in
+    # Cobrand/Peterborough.pm, for example
     my $form = $self->load_form($c);
     if ($c->get_param('process') && !$c->stash->{override_no_process}) {
         # A claim form will quite possibly have people logging in part-way

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -517,7 +517,7 @@ sub property : Chained('/') : PathPart('waste') : CaptureArgs(1) {
     $c->forward('/auth/get_csrf_token');
 
     # clear this every time they visit this page to stop stale content.
-    if ( $c->req->path =~ m#^waste/[:\w ]+$#i ) {
+    if ( $c->req->path =~ m#^waste/[:\w %]+$#i ) {
         $c->cobrand->call_hook( clear_cached_lookups_property => $id );
     }
 

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -27,7 +27,7 @@ has_page about_you => (
 with 'FixMyStreet::App::Form::Waste::AboutYou';
 
 has_page choose_date => (
-    fields => ['continue', 'chosen_date'],
+    fields => [ 'continue', 'chosen_date' ],
     title => 'Choose date for collection',
     next => 'add_items',
 );
@@ -106,8 +106,14 @@ has_field chosen_date => (
             )
         };
 
-        # XXX Display message if no options
         # XXX Hide additional dates with JS(?)
+
+        # XXX Do we want to let the user know there are no available dates
+        # much earlier in the journey?
+        if ( !@dates ) {
+            $self->inactive(1);
+            $self->form->field('continue')->inactive(1);
+        }
 
         return \@dates;
     },

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -21,17 +21,36 @@ has_page residency_check => (
 has_page about_you => (
     fields => ['name', 'email', 'phone', 'continue'],
     title => 'About you',
-    next => 'choose_date',
+    next => 'choose_date_earlier',
 );
 
 with 'FixMyStreet::App::Form::Waste::AboutYou';
 
-has_page choose_date => (
-    fields => [ 'continue', 'chosen_date', 'show_later_dates' ],
+has_page choose_date_earlier => (
+    fields => [
+        'continue',         'chosen_date',
+        'show_later_dates',
+        ],
     title => 'Choose date for collection',
     template => 'waste/bulky/choose_date.html',
     next => sub {
-        $_[0]->{continue} ? 'add_items' : 'choose_date';
+        ( $_[1]->{later_dates} )
+            ? 'choose_date_later'
+            : 'add_items';
+    },
+);
+
+has_page choose_date_later => (
+    fields => [
+        'continue',         'chosen_date',
+        'show_earlier_dates',
+        ],
+    title => 'Choose date for collection',
+    template => 'waste/bulky/choose_date.html',
+    next => sub {
+        ( $_[1]->{earlier_dates} )
+            ? 'choose_date_earlier'
+            : 'add_items';
     },
 );
 
@@ -64,7 +83,10 @@ has_page done => (
 has_field continue => (
     type => 'Submit',
     value => 'Continue',
-    element_attr => { class => 'govuk-button' },
+    element_attr => {
+        class      => 'govuk-button',
+        formaction => '?',
+    },
     order => 999,
 );
 
@@ -87,53 +109,106 @@ has_field resident => (
 );
 
 has_field chosen_date => (
-    type           => 'Select',
-    widget         => 'RadioGroup',
-    label          => 'Available dates',
+    type                 => 'Select',
+    widget               => 'RadioGroup',
+    label                => 'Available dates',
+    no_option_validation => 1,
     options_method => sub {
         my $self = shift;
-        my $c    = $self->form->c;
+        my $form = $self->form;
+        my $c    = $form->c;
 
-        my $parser = DateTime::Format::Strptime->new( pattern => '%FT%T' );
-
-        my @dates = grep {$_} map {
-            my $dt = $parser->parse_datetime( $_->{date} );
-            $dt
-                ? {
-                label => $dt->strftime('%d %B'),
-                value => $_->{date},
-                }
-                : undef
-            } @{
-            $c->cobrand->call_hook(
-                'find_available_bulky_slots', $c->stash->{property},
-                $c->stash->{start_date},
-            )
-            };
-
-        # XXX Do we want to let the user know there are no available dates
-        # much earlier in the journey?
-        if ( !@dates ) {
-            $self->inactive(1);
-            $self->form->field('continue')->inactive(1);
-            $self->form->field('show_later_dates')->inactive(1);
-        }
-        elsif ( !$c->stash->{start_date} ) {
-            $c->stash->{start_date} = $dates[-1]{value};
+        my @dates;
+        if ($form->current_page->name eq 'choose_date_later') {
+            @dates = _get_dates( $c, $c->stash->{last_earlier_date} );
         } else {
-            $self->form->field('show_later_dates')->inactive(1);
+            @dates = _get_dates($c);
+            $c->stash->{last_earlier_date} = $dates[-1]{value} if @dates;
         }
 
         return \@dates;
     },
 );
 
+sub _get_dates {
+    my ( $c, $last_earlier_date ) = @_;
+
+    my $parser = DateTime::Format::Strptime->new( pattern => '%FT%T' );
+    my @dates  = grep {$_} map {
+        my $dt = $parser->parse_datetime( $_->{date} );
+        $dt
+            ? {
+            label => $dt->strftime('%d %B'),
+            value => $_->{date},
+            }
+            : undef
+        } @{
+        $c->cobrand->call_hook(
+            'find_available_bulky_slots', $c->stash->{property},
+            $last_earlier_date,
+        )
+        };
+
+    return @dates;
+}
+
 has_field show_later_dates => (
-    type => 'Submit',
-    value => 'Show later dates',
-    element_attr => { class => 'govuk-button' },
+    type         => 'Submit',
+    value        => 'Show later dates',
+    element_attr => {
+        class          => 'govuk-button',
+        formaction     => '?later_dates=1',
+    },
     order => 998,
 );
+
+has_field show_earlier_dates => (
+    type         => 'Submit',
+    value        => 'Show earlier dates',
+    element_attr => {
+        class          => 'govuk-button',
+        formaction     => '?earlier_dates=1',
+    },
+    order => 998,
+);
+
+sub validate {
+    my $self = shift;
+
+    if ( $self->current_page->name =~ /choose_date/ ) {
+        my $next_page
+            = $self->current_page->next->( undef, $self->c->req->params );
+
+        if ( $next_page eq 'add_items' ) {
+            $self->field('chosen_date')
+                ->add_error('Available dates field is required')
+                if !$self->field('chosen_date')->value;
+        }
+    }
+}
+
+after 'process' => sub {
+    my $self = shift;
+
+    # XXX Do we want to let the user know there are no available dates
+    # much earlier in the journey?
+
+    # Hide certain fields if no date options
+    if ( $self->current_page->name eq 'choose_date_earlier'
+        && !@{ $self->field('chosen_date')->options } )
+    {
+        $self->field('chosen_date')->inactive(1);
+        $self->field('show_later_dates')->inactive(1);
+        $self->field('continue')->inactive(1);
+    }
+
+    if ( $self->current_page->name eq 'choose_date_later'
+        && !@{ $self->field('chosen_date')->options } )
+    {
+        $self->field('chosen_date')->inactive(1);
+        $self->field('continue')->inactive(1);
+    }
+};
 
 has_field tandc => (
     type => 'Checkbox',
@@ -204,12 +279,5 @@ has_field item2 => item_field(2);
 has_field item3 => item_field(3);
 has_field item4 => item_field(4);
 has_field item5 => item_field(5);
-
-sub validate {
-   my $self = shift;
-   $self->field('chosen_date')->add_error('Available dates field is required')
-       if( $self->field('continue')->input &&
-           !$self->field('chosen_date')->has_value);
-}
 
 1;

--- a/perllib/FixMyStreet/App/Form/Wizard.pm
+++ b/perllib/FixMyStreet/App/Form/Wizard.pm
@@ -50,7 +50,10 @@ sub next {
     my $self = shift;
     my $next = $self->current_page->next;
     if (ref $next eq 'CODE') {
-        $next = $next->($self->saved_data);
+        $next = $next->(
+            $self->saved_data,
+            $self->c->req->params,
+        );
     }
     return $next;
 }

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -447,8 +447,12 @@ sub clear_cached_lookups_property {
     foreach ( qw/look_up_property bin_services_for_address property_attributes/ ) {
         delete $self->{c}->session->{"peterborough:bartec:$_:$uprn"};
     }
-}
 
+    for (qw/earlier later/) {
+        delete $self->{c}
+            ->session->{"peterborough:bartec:available_bulky_slots:$_:$uprn"};
+    }
+}
 
 sub bin_addresses_for_postcode {
     my $self = shift;
@@ -511,6 +515,12 @@ sub image_for_unit {
 # Check if collection is free or chargeable
 sub find_available_bulky_slots {
     my ( $self, $property, $last_earlier_date_str ) = @_;
+
+    my $key
+        = 'peterborough:bartec:available_bulky_slots:'
+        . ( $last_earlier_date_str ? 'later' : 'earlier' ) . ':'
+        . $property->{uprn};
+    return $self->{c}->session->{$key} if $self->{c}->session->{$key};
 
     my $bartec = $self->feature('bartec');
     $bartec = Integrations::Bartec->new(%$bartec);
@@ -612,6 +622,8 @@ sub find_available_bulky_slots {
             if !$last_earlier_date_str
             && @available_slots == max_bulky_collection_dates();
     }
+
+    $self->{c}->session->{$key} = \@available_slots;
 
     return \@available_slots;
 }

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -444,6 +444,9 @@ sub clear_cached_lookups_postcode {
 sub clear_cached_lookups_property {
     my ($self, $uprn) = @_;
 
+    # might be prefixed with postcode if it's come straight from the URL
+    $uprn =~ s/^.+\://g;
+
     foreach ( qw/look_up_property bin_services_for_address property_attributes/ ) {
         delete $self->{c}->session->{"peterborough:bartec:$_:$uprn"};
     }

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -44,6 +44,7 @@ sub service_name_override {
     };
 }
 
+# XXX Use config to set max daily slots etc.
 sub bulky_collection_window_days     {90}
 sub max_daily_bulky_collection_slots {40}
 sub bulky_workpack_name {
@@ -501,7 +502,7 @@ sub image_for_unit {
     return $images->{$service_id};
 }
 
-# TODO
+# XXX
 # Error handling
 # Holidays, bank holidays?
 # Monday limit, Tuesday limit etc.?
@@ -562,15 +563,12 @@ sub find_available_bulky_slots {
         # workpacks for the same date, we only take the first into account
         next if $workpack->{WorkPackDate} eq ( $last_workpack_date // '' );
 
+        my %jobs_per_uprn;
         my $workpacks_for_day
             = $bartec->WorkPacks_Get( $workpack->{WorkPackDate} );
-
         my $workpack_dt = $workpack_date_parser->parse_datetime(
             $workpack->{WorkPackDate} );
 
-        my $jobs_total = 0;
-
-        my %jobs_per_uprn;
         for my $wpfd (@$workpacks_for_day) {
             next if $wpfd->{Name} !~ bulky_workpack_name();
 

--- a/perllib/Integrations/Bartec.pm
+++ b/perllib/Integrations/Bartec.pm
@@ -197,6 +197,27 @@ sub Premises_FutureWorkpacks_Get {
     return $workpacks;
 }
 
+sub WorkPacks_Get {
+    my ( $self, $date ) = @_;
+
+    my $res = $self->call(
+        'WorkPacks_Get',
+        token => $self->token,
+        Date  => {
+            MinimumDate => {
+                attr  => { xmlns => "http://www.bartec-systems.com" },
+                value => $date,
+            },
+            MaximumDate => {
+                attr  => { xmlns => "http://www.bartec-systems.com" },
+                value => $date,
+            },
+        },
+    );
+
+    return force_arrayref( $res, 'WorkPack' );
+}
+
 sub Jobs_Get {
     my ($self, $uprn) = @_;
 
@@ -222,6 +243,18 @@ sub Jobs_Get {
     my $jobs = force_arrayref($res, 'Jobs');
     @$jobs = sort { $a->{ScheduledStart} cmp $b->{ScheduledStart} } map { $_->{Job} } @$jobs;
     return $jobs;
+}
+
+sub Jobs_Get_for_workpack {
+    my ( $self, $workpack_id ) = @_;
+
+    my $res = $self->call(
+        'Jobs_Get',
+        token      => $self->token,
+        WorkPackID => $workpack_id,
+    );
+
+    return force_arrayref( $res, 'Jobs' );
 }
 
 sub Jobs_FeatureScheduleDates_Get {

--- a/perllib/Integrations/Bartec.pm
+++ b/perllib/Integrations/Bartec.pm
@@ -178,6 +178,25 @@ sub Premises_Get {
     return \@premises;
 }
 
+sub Premises_FutureWorkpacks_Get {
+    my ( $self, %args ) = @_;
+
+    my $res = $self->call(
+        'Premises_FutureWorkpacks_Get',
+        token    => $self->token,
+        UPRN     => $args{uprn},
+        DateFrom => $args{date_from},
+        DateTo   => $args{date_to},
+    );
+
+    # Already seem to be returned from Bartec in date ascending order, but
+    # we'll sort just in case
+    my $workpacks = force_arrayref( $res, 'Premises_FutureWorkPack' );
+    @$workpacks
+        = sort { $a->{WorkPackDate} cmp $b->{WorkPackDate} } @$workpacks;
+    return $workpacks;
+}
+
 sub Jobs_Get {
     my ($self, $uprn) = @_;
 

--- a/perllib/Integrations/Bartec.pm
+++ b/perllib/Integrations/Bartec.pm
@@ -198,7 +198,7 @@ sub Premises_FutureWorkpacks_Get {
 }
 
 sub WorkPacks_Get {
-    my ( $self, $date ) = @_;
+    my ( $self, %args ) = @_;
 
     my $res = $self->call(
         'WorkPacks_Get',
@@ -206,11 +206,11 @@ sub WorkPacks_Get {
         Date  => {
             MinimumDate => {
                 attr  => { xmlns => "http://www.bartec-systems.com" },
-                value => $date,
+                value => $args{date_from},
             },
             MaximumDate => {
                 attr  => { xmlns => "http://www.bartec-systems.com" },
-                value => $date,
+                value => $args{date_to},
             },
         },
     );

--- a/perllib/Integrations/Bartec.pm
+++ b/perllib/Integrations/Bartec.pm
@@ -245,6 +245,7 @@ sub Jobs_Get {
     return $jobs;
 }
 
+# TODO Merge with Jobs_Get() above
 sub Jobs_Get_for_workpack {
     my ( $self, $workpack_id ) = @_;
 

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -704,8 +704,7 @@ FixMyStreet::override_config {
             $mech->content_contains('12 August');
             $mech->content_contains('19 August');
             $mech->content_contains('26 August');
-            $mech->content_contains('02 September');
-            $mech->content_lacks('31 February');
+            $mech->content_lacks('02 September'); # Max of 4 dates fetched
             $mech->submit_form_ok(
                 { with_fields => { chosen_date => '2022-08-26T00:00:00' } } );
         };
@@ -895,10 +894,6 @@ sub _future_workpacks {
                 { 'Action' => { 'ActionName' => 'Empty Bin 240L Black' } },
         },
         {   'WorkPackDate' => '2022-09-02T00:00:00',
-            'Actions'      =>
-                { 'Action' => { 'ActionName' => 'Empty Bin 240L Black' } },
-        },
-        {   'WorkPackDate' => '2022-02-31T00:00:00', # Invalid date
             'Actions'      =>
                 { 'Action' => { 'ActionName' => 'Empty Bin 240L Black' } },
         },

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -700,11 +700,14 @@ FixMyStreet::override_config {
         subtest 'Choose date page' => sub {
             $mech->content_contains('Choose date for collection');
             $mech->content_contains('Available dates');
-            $mech->content_contains('2022-08-25');
-            $mech->content_contains('2022-08-26');
-            $mech->content_contains('2022-08-27');
-            $mech->content_contains('2022-08-28');
-            $mech->submit_form_ok({ with_fields => { chosen_date => '20220828' }});
+            $mech->content_contains('05 August');
+            $mech->content_contains('12 August');
+            $mech->content_contains('19 August');
+            $mech->content_contains('26 August');
+            $mech->content_contains('02 September');
+            $mech->content_lacks('31 February');
+            $mech->submit_form_ok(
+                { with_fields => { chosen_date => '2022-08-26T00:00:00' } } );
         };
 
         subtest 'Add items page' => sub {
@@ -835,7 +838,7 @@ FixMyStreet::override_config {
 
 
 sub shared_bartec_mocks {
-        my $b = Test::MockModule->new('Integrations::Bartec');
+    my $b = Test::MockModule->new('Integrations::Bartec');
     $b->mock('Authenticate', sub {
         { Token => { TokenString => "TOKEN" } }
     });
@@ -866,8 +869,40 @@ sub shared_bartec_mocks {
     $b->mock('Streets_Events_Get', sub { [
         # No open events at present
     ] });
+    $b->mock( 'Premises_FutureWorkpacks_Get', &_future_workpacks );
+    $b->mock( 'WorkPacks_Get',                [] );
+    $b->mock( 'Jobs_Get_for_workpack',        [] );
 
     return $b, $jobs_fsd_get;
+}
+
+sub _future_workpacks {
+    [   {   'WorkPackDate' => '2022-08-05T00:00:00',
+            'Actions'      => {
+                'Action' => [ { 'ActionName' => 'Empty Bin 240L Black' } ],
+            },
+        },
+        {   'WorkPackDate' => '2022-08-12T00:00:00',
+            'Actions'      =>
+                { 'Action' => { 'ActionName' => 'Empty Black 240l Bin' } },
+        },
+        {   'WorkPackDate' => '2022-08-19T00:00:00',
+            'Actions'      =>
+                { 'Action' => { 'ActionName' => 'Empty Bin 240L Black' } },
+        },
+        {   'WorkPackDate' => '2022-08-26T00:00:00',
+            'Actions'      =>
+                { 'Action' => { 'ActionName' => 'Empty Bin 240L Black' } },
+        },
+        {   'WorkPackDate' => '2022-09-02T00:00:00',
+            'Actions'      =>
+                { 'Action' => { 'ActionName' => 'Empty Bin 240L Black' } },
+        },
+        {   'WorkPackDate' => '2022-02-31T00:00:00', # Invalid date
+            'Actions'      =>
+                { 'Action' => { 'ActionName' => 'Empty Bin 240L Black' } },
+        },
+    ];
 }
 
 done_testing;

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -706,7 +706,10 @@ FixMyStreet::override_config {
             $mech->content_contains('26 August');
             $mech->content_lacks('02 September'); # Max of 4 dates fetched
             $mech->submit_form_ok(
-                { with_fields => { chosen_date => '2022-08-26T00:00:00' } } );
+                {   with_fields =>
+                        { chosen_date => '2022-08-26T00:00:00' }
+                }
+            );
         };
 
         subtest 'Add items page' => sub {

--- a/t/cobrand/peterborough/bulky-goods/available-slots.t
+++ b/t/cobrand/peterborough/bulky-goods/available-slots.t
@@ -86,7 +86,7 @@ subtest 'find_available_bulky_slots' => sub {
             FixMyStreet::Cobrand::Peterborough->find_available_bulky_slots(
                 $dummy_property, '17-09-22' )
         },
-        qr/Invalid start date/,
+        qr/Invalid date provided/,
     );
 };
 

--- a/t/cobrand/peterborough/bulky-goods/available-slots.t
+++ b/t/cobrand/peterborough/bulky-goods/available-slots.t
@@ -26,8 +26,9 @@ subtest 'find_available_bulky_slots' => sub {
     $mock_bartec->mock(
         'WorkPacks_Get',
         sub {
-            my ( undef, $date ) = @_;
-            return _workpacks_by_date()->{$date};
+            my ( undef, %args ) = @_;
+            my $wp = _workpacks_by_date()->{ $args{date_from} };
+            return $wp ? $wp : _workpacks_by_date()->{ $args{date_to} };
         },
     );
     $mock_bartec->mock(

--- a/t/cobrand/peterborough/bulky-goods/available-slots.t
+++ b/t/cobrand/peterborough/bulky-goods/available-slots.t
@@ -57,6 +57,9 @@ subtest 'find_available_bulky_slots' => sub {
             {   date        => '2022-09-30T00:00:00',
                 workpack_id => 75500,
             },
+            {   date        => '2022-10-07T00:00:00',
+                workpack_id => 75600,
+            },
         ],
     );
 };
@@ -68,18 +71,8 @@ sub _future_workpacks {
         {   'id'           => 57127,
             'WorkPackDate' => '2022-07-29T00:00:00',
             'WorkPackName' => 'Waste-Round 2 Garden-290722',
-            'Actions'      => {
-                'Action' => {
-                    'Action' => {
-                        'ActionID'      => '5016',
-                        'ActionName'    => 'Empty Bin 240L Brown',
-                        'JobsCount'     => '679',
-                        'JobsVolume'    => '0.000',
-                        'JobsWeight'    => '65184.000',
-                        'PremisesCount' => '641',
-                    },
-                },
-            },
+            'Actions'      =>
+                { 'Action' => { 'ActionName' => 'Empty Bin 240L Brown' } },
         },
 
         {   'id'           => 75474,
@@ -87,21 +80,8 @@ sub _future_workpacks {
             'WorkPackName' => 'Waste-Round 16-050822',
             'Actions'      => {
                 'Action' => [
-                    {   'ActionID'      => '4998',
-                        'ActionName'    => 'Empty 1100l Refuse',
-                        'JobsCount'     => '2',
-                        'JobsVolume'    => '0.000',
-                        'JobsWeight'    => '0.000',
-                        'PremisesCount' => '1',
-                    },
-
-                    {   'ActionID'      => '4722',
-                        'ActionName'    => 'Empty Bin 240L Black',
-                        'JobsCount'     => '1788',
-                        'JobsVolume'    => '0.000',
-                        'JobsWeight'    => '171648.000',
-                        'PremisesCount' => '1785',
-                    }
+                    { 'ActionName' => 'Empty 1100l Refuse' },
+                    { 'ActionName' => 'Empty Bin 240L Black' }
                 ],
             },
         },
@@ -109,121 +89,73 @@ sub _future_workpacks {
         {   'id'           => 75481,
             'WorkPackDate' => '2022-08-12T00:00:00',
             'WorkPackName' => 'Waste-Round 16-120822',
-            'Actions'      => {
-                'Action' => {
-                    'ActionID'      => '4722',
-                    'ActionName'    => 'Empty Black 240l Bin',
-                    'JobsCount'     => '1788',
-                    'JobsVolume'    => '0.000',
-                    'JobsWeight'    => '171648.000',
-                    'PremisesCount' => '1785',
-                },
-            },
+            'Actions'      => [
+                { 'ActionName' => 'Empty 1100l Refuse' },
+                { 'ActionName' => 'Empty Bin 240L Black' }
+            ],
         },
 
         {   'id'           => 75488,
             'WorkPackDate' => '2022-08-19T00:00:00',
             'WorkPackName' => 'Waste-Round 16-190822',
-            'Actions'      => {
-                'Action' => {
-                    'ActionID'      => '4722',
-                    'ActionName'    => 'Empty Bin 240L Black',
-                    'JobsCount'     => '1788',
-                    'JobsVolume'    => '0.000',
-                    'JobsWeight'    => '171648.000',
-                    'PremisesCount' => '1785',
-                },
-            },
+            'Actions'      =>
+                { 'Action' => { 'ActionName' => 'Empty Bin 240L Black' } },
         },
 
         {   'id'           => 75495,
             'WorkPackDate' => '2022-08-26T23:59:59',
             'WorkPackName' => 'Waste-Round 16-260822',
-            'Actions'      => {
-                'Action' => {
-                    'ActionID'      => '4722',
-                    'ActionName'    => 'Empty Bin 240L Black',
-                    'JobsCount'     => '1788',
-                    'JobsVolume'    => '0.000',
-                    'JobsWeight'    => '171648.000',
-                    'PremisesCount' => '1785',
-                },
-            },
+            'Actions'      =>
+                { 'Action' => { 'ActionName' => 'Empty Bin 240L Black' } },
         },
 
         {   'id'           => 75496,
             'WorkPackDate' => '2022-09-02T00:00:00',
             'WorkPackName' => 'Waste-Round 16-020922',
-            'Actions'      => {
-                'Action' => {
-                    'ActionID'      => '4722',
-                    'ActionName'    => 'Empty Bin 240L Black',
-                    'JobsCount'     => '1788',
-                    'JobsVolume'    => '0.000',
-                    'JobsWeight'    => '171648.000',
-                    'PremisesCount' => '1785',
-                },
-            },
+            'Actions'      => { 'ActionName' => 'Empty Bin 240L Black' },
         },
 
         {   'id'           => 75497,
             'WorkPackDate' => '2022-09-09T00:00:00',
             'WorkPackName' => 'Waste-Round 16-090922',
-            'Actions'      => {
-                'Action' => {
-                    'ActionID'      => '4722',
-                    'ActionName'    => 'Empty Bin 240L Black',
-                    'JobsCount'     => '1788',
-                    'JobsVolume'    => '0.000',
-                    'JobsWeight'    => '171648.000',
-                    'PremisesCount' => '1785',
-                },
-            },
+            'Actions'      =>
+                { 'Action' => { 'ActionName' => 'Empty Bin 240L Black' } },
         },
 
         {   'id'           => 75498,
             'WorkPackDate' => '2022-09-16T00:00:00',
             'WorkPackName' => 'Waste-Round 16-160922',
-            'Actions'      => {
-                'Action' => {
-                    'ActionID'      => '4722',
-                    'ActionName'    => 'Empty Bin 240L Black',
-                    'JobsCount'     => '1788',
-                    'JobsVolume'    => '0.000',
-                    'JobsWeight'    => '171648.000',
-                    'PremisesCount' => '1785',
-                },
-            },
+            'Actions'      =>
+                { 'Action' => { 'ActionName' => 'Empty Bin 240L Black' } },
         },
 
         {   'id'           => 75499,
             'WorkPackDate' => '2022-09-23T00:00:00',
             'WorkPackName' => 'Waste-Round 16-230922',
-            'Actions'      => {
-                'Action' => {
-                    'ActionID'      => '4722',
-                    'ActionName'    => 'Empty Bin 240L Black',
-                    'JobsCount'     => '1788',
-                    'JobsVolume'    => '0.000',
-                    'JobsWeight'    => '171648.000',
-                    'PremisesCount' => '1785',
-                },
-            },
+            'Actions'      =>
+                { 'Action' => { 'ActionName' => 'Empty Bin 240L Black' } },
         },
 
         {   'id'           => 75500,
             'WorkPackDate' => '2022-09-30T00:00:00',
             'WorkPackName' => 'Waste-Round 16-300922',
-            'Actions'      => {
-                'Action' => {
-                    'ActionID'      => '4722',
-                    'ActionName'    => 'Empty Bin 240L Black',
-                    'JobsCount'     => '1788',
-                    'JobsVolume'    => '0.000',
-                    'JobsWeight'    => '171648.000',
-                    'PremisesCount' => '1785',
-                },
-            },
+            'Actions'      =>
+                { 'Action' => { 'ActionName' => 'Empty Bin 240L Black' } },
+        },
+
+        # In reality this shouldn't happen, but test for two black bin WPs
+        # for the same day
+        {   'id'           => 75600,
+            'WorkPackDate' => '2022-10-07T00:00:00',
+            'WorkPackName' => 'Waste-Round 16-071022',
+            'Actions'      =>
+                { 'Action' => { 'ActionName' => 'Empty Bin 240L Black' } },
+        },
+        {   'id'           => 75700,
+            'WorkPackDate' => '2022-10-07T00:00:00',
+            'WorkPackName' => 'Waste-Round 17-071022',
+            'Actions'      =>
+                { 'Action' => { 'ActionName' => 'Empty Bin 240L Black' } },
         },
     ];
 }
@@ -325,6 +257,13 @@ sub _workpacks_by_date {
                 'RecordStamp' => {},
             },
         ],
+
+        '2022-10-07T00:00:00' => [
+            {   'ID'          => '710221',
+                'Name'        => 'Waste-BULKY WASTE-071022',
+                'RecordStamp' => {},
+            },
+        ],
     };
 }
 
@@ -341,7 +280,7 @@ sub _jobs_by_workpack_id {
 
         # 'WHITES' & 'BULKY WASTE' that together make max jobs
         2608221 => _jobs_arrayref(10),
-        2608222 => _jobs_arrayref(30),
+        2608222 => _jobs_arrayref( 30, 20001 ),
 
         # Connected to faulty workpack names so limit ignored
         209221 => _jobs_arrayref(40),
@@ -350,18 +289,21 @@ sub _jobs_by_workpack_id {
 
         # Limit not reached:
 
-        909221 => _jobs_arrayref(39),
+        # Same UPRN for all jobs so counts as single bulky collection
+        909221 => [ ( { Job => { UPRN => 10001 } } ) x 40 ],
 
         1609221 => _jobs_arrayref(39),
 
-        3009221 => _jobs_arrayref(24),
-        3009222 => _jobs_arrayref(15),
+        3009221 => _jobs_arrayref(25),
+        # Same UPRN for all jobs so counts as single bulky collection
+        3009222 => [ ( { Job => { UPRN => 10001 } } ) x 15 ],
     };
 }
 
 sub _jobs_arrayref {
-    my $job_count = shift;
-    [ ( { Job => {} } ) x $job_count ];
+    my ( $job_count, $uprn ) = @_;
+    $uprn //= 10001;
+    return [ map { { Job => { UPRN => $uprn++ } } } 1 .. $job_count ];
 }
 
 done_testing;

--- a/t/cobrand/peterborough/bulky-goods/available-slots.t
+++ b/t/cobrand/peterborough/bulky-goods/available-slots.t
@@ -1,0 +1,367 @@
+use FixMyStreet::Cobrand::Peterborough;
+use Test::MockModule;
+use Test::MockTime 'set_fixed_time';
+use Test::More;
+
+# TODO Mocked time not being picked up on, why?
+
+# Friday, 31 December 2021 23:59:59 GMT
+# set_fixed_time(1640995199);
+
+# subtest '_bulky_collection_window' => sub {
+#     is_deeply(
+#         FixMyStreet::Cobrand::Peterborough->_bulky_collection_window(),
+#         {   date_from => '2021-12-31',
+#             date_to   => '2022-03-29',
+#         },
+#     );
+# };
+
+subtest 'find_available_bulky_slots' => sub {
+    my $dummy_property = { uprn => 123456789 };
+    my $mock_bartec    = Test::MockModule->new('Integrations::Bartec');
+    $mock_bartec->mock( 'Premises_FutureWorkpacks_Get', &_future_workpacks );
+    $mock_bartec->mock(
+        'WorkPacks_Get',
+        sub {
+            my ( undef, $date ) = @_;
+            return _workpacks_by_date()->{$date};
+        },
+    );
+    $mock_bartec->mock(
+        'Jobs_Get_for_workpack',
+        sub {
+            my ( undef, $workpack_id ) = @_;
+            return _jobs_by_workpack_id()->{$workpack_id};
+        },
+    );
+
+    is_deeply(
+        FixMyStreet::Cobrand::Peterborough->find_available_bulky_slots(
+            $dummy_property),
+        [   {   date        => '2022-08-05T00:00:00',
+                workpack_id => 75474,
+            },
+            {   date        => '2022-09-02T00:00:00',
+                workpack_id => 75496,
+            },
+            {   date        => '2022-09-09T00:00:00',
+                workpack_id => 75497,
+            },
+            {   date        => '2022-09-16T00:00:00',
+                workpack_id => 75498,
+            },
+            {   date        => '2022-09-23T00:00:00',
+                workpack_id => 75499,
+            },
+            {   date        => '2022-09-30T00:00:00',
+                workpack_id => 75500,
+            },
+        ],
+    );
+};
+
+# For Premises_FutureWorkpacks_Get() calls
+sub _future_workpacks {
+    [
+        # No black bin - ignored
+        {   'id'           => 57127,
+            'WorkPackDate' => '2022-07-29T00:00:00',
+            'WorkPackName' => 'Waste-Round 2 Garden-290722',
+            'Actions'      => {
+                'Action' => {
+                    'Action' => {
+                        'ActionID'      => '5016',
+                        'ActionName'    => 'Empty Bin 240L Brown',
+                        'JobsCount'     => '679',
+                        'JobsVolume'    => '0.000',
+                        'JobsWeight'    => '65184.000',
+                        'PremisesCount' => '641',
+                    },
+                },
+            },
+        },
+
+        {   'id'           => 75474,
+            'WorkPackDate' => '2022-08-05T00:00:00',
+            'WorkPackName' => 'Waste-Round 16-050822',
+            'Actions'      => {
+                'Action' => [
+                    {   'ActionID'      => '4998',
+                        'ActionName'    => 'Empty 1100l Refuse',
+                        'JobsCount'     => '2',
+                        'JobsVolume'    => '0.000',
+                        'JobsWeight'    => '0.000',
+                        'PremisesCount' => '1',
+                    },
+
+                    {   'ActionID'      => '4722',
+                        'ActionName'    => 'Empty Bin 240L Black',
+                        'JobsCount'     => '1788',
+                        'JobsVolume'    => '0.000',
+                        'JobsWeight'    => '171648.000',
+                        'PremisesCount' => '1785',
+                    }
+                ],
+            },
+        },
+
+        {   'id'           => 75481,
+            'WorkPackDate' => '2022-08-12T00:00:00',
+            'WorkPackName' => 'Waste-Round 16-120822',
+            'Actions'      => {
+                'Action' => {
+                    'ActionID'      => '4722',
+                    'ActionName'    => 'Empty Black 240l Bin',
+                    'JobsCount'     => '1788',
+                    'JobsVolume'    => '0.000',
+                    'JobsWeight'    => '171648.000',
+                    'PremisesCount' => '1785',
+                },
+            },
+        },
+
+        {   'id'           => 75488,
+            'WorkPackDate' => '2022-08-19T00:00:00',
+            'WorkPackName' => 'Waste-Round 16-190822',
+            'Actions'      => {
+                'Action' => {
+                    'ActionID'      => '4722',
+                    'ActionName'    => 'Empty Bin 240L Black',
+                    'JobsCount'     => '1788',
+                    'JobsVolume'    => '0.000',
+                    'JobsWeight'    => '171648.000',
+                    'PremisesCount' => '1785',
+                },
+            },
+        },
+
+        {   'id'           => 75495,
+            'WorkPackDate' => '2022-08-26T23:59:59',
+            'WorkPackName' => 'Waste-Round 16-260822',
+            'Actions'      => {
+                'Action' => {
+                    'ActionID'      => '4722',
+                    'ActionName'    => 'Empty Bin 240L Black',
+                    'JobsCount'     => '1788',
+                    'JobsVolume'    => '0.000',
+                    'JobsWeight'    => '171648.000',
+                    'PremisesCount' => '1785',
+                },
+            },
+        },
+
+        {   'id'           => 75496,
+            'WorkPackDate' => '2022-09-02T00:00:00',
+            'WorkPackName' => 'Waste-Round 16-020922',
+            'Actions'      => {
+                'Action' => {
+                    'ActionID'      => '4722',
+                    'ActionName'    => 'Empty Bin 240L Black',
+                    'JobsCount'     => '1788',
+                    'JobsVolume'    => '0.000',
+                    'JobsWeight'    => '171648.000',
+                    'PremisesCount' => '1785',
+                },
+            },
+        },
+
+        {   'id'           => 75497,
+            'WorkPackDate' => '2022-09-09T00:00:00',
+            'WorkPackName' => 'Waste-Round 16-090922',
+            'Actions'      => {
+                'Action' => {
+                    'ActionID'      => '4722',
+                    'ActionName'    => 'Empty Bin 240L Black',
+                    'JobsCount'     => '1788',
+                    'JobsVolume'    => '0.000',
+                    'JobsWeight'    => '171648.000',
+                    'PremisesCount' => '1785',
+                },
+            },
+        },
+
+        {   'id'           => 75498,
+            'WorkPackDate' => '2022-09-16T00:00:00',
+            'WorkPackName' => 'Waste-Round 16-160922',
+            'Actions'      => {
+                'Action' => {
+                    'ActionID'      => '4722',
+                    'ActionName'    => 'Empty Bin 240L Black',
+                    'JobsCount'     => '1788',
+                    'JobsVolume'    => '0.000',
+                    'JobsWeight'    => '171648.000',
+                    'PremisesCount' => '1785',
+                },
+            },
+        },
+
+        {   'id'           => 75499,
+            'WorkPackDate' => '2022-09-23T00:00:00',
+            'WorkPackName' => 'Waste-Round 16-230922',
+            'Actions'      => {
+                'Action' => {
+                    'ActionID'      => '4722',
+                    'ActionName'    => 'Empty Bin 240L Black',
+                    'JobsCount'     => '1788',
+                    'JobsVolume'    => '0.000',
+                    'JobsWeight'    => '171648.000',
+                    'PremisesCount' => '1785',
+                },
+            },
+        },
+
+        {   'id'           => 75500,
+            'WorkPackDate' => '2022-09-30T00:00:00',
+            'WorkPackName' => 'Waste-Round 16-300922',
+            'Actions'      => {
+                'Action' => {
+                    'ActionID'      => '4722',
+                    'ActionName'    => 'Empty Bin 240L Black',
+                    'JobsCount'     => '1788',
+                    'JobsVolume'    => '0.000',
+                    'JobsWeight'    => '171648.000',
+                    'PremisesCount' => '1785',
+                },
+            },
+        },
+    ];
+}
+
+# For WorkPacks_Get() calls
+sub _workpacks_by_date {
+    {
+        # No bulky workpacks; i.e. no booked bulky collections
+        '2022-08-05T00:00:00' => [
+            {   'ID'          => '508221',
+                'Name'        => 'Waste-R5 Ref-050822',
+                'RecordStamp' => {},                      # Not relevant
+            },
+        ],
+
+        # Workpacks with jobs that exceed the bulky limit:
+
+        # 'WHITES' (bulky) workpack
+        '2022-08-12T00:00:00' => [
+            {   'ID'          => '1208221',
+                'Name'        => 'Waste-WHITES-120822',
+                'RecordStamp' => {},
+            },
+        ],
+
+        # 'BULKY WASTE' workpack
+        '2022-08-19T00:00:00' => [
+            {   'ID'          => '1908221',
+                'Name'        => 'Waste-BULKY WASTE-190822',
+                'RecordStamp' => {},
+            },
+        ],
+
+        # Both 'WHITES' & 'BULKY WASTE'
+        '2022-08-26T23:59:59' => [
+            {   'ID'          => '2608221',
+                'Name'        => 'Waste-BULKY WASTE-260822',
+                'RecordStamp' => {},
+            },
+            {   'ID'          => '2608222',
+                'Name'        => 'Waste-WHITES-260822',
+                'RecordStamp' => {},
+            },
+        ],
+
+        # Both 'WHITES' & 'BULKY WASTE' but wrong/bad date in 'Name' - so
+        # job counts for these collections are ignored
+        '2022-09-02T00:00:00' => [
+            {   'ID'   => '209221',
+                'Name' => 'Waste-BULKY WASTE-010122',    # Non-matching date
+                'RecordStamp' => {},
+            },
+            {   'ID'          => '209222',
+                'Name'        => 'Waste-WHITES-20922',    # Bad format
+                'RecordStamp' => {},
+            },
+            {   'ID'          => '209223',
+                'Name'        => 'Waste-WHITES-311322',    # Impossible date
+                'RecordStamp' => {},
+            },
+        ],
+
+        # Workpacks with jobs that do not exceed the bulky limit:
+
+        '2022-09-09T00:00:00' => [
+            {   'ID'          => '909221',
+                'Name'        => 'Waste-BULKY WASTE-090922',
+                'RecordStamp' => {},
+            },
+        ],
+
+        '2022-09-16T00:00:00' => [
+            {   'ID'          => '1609221',
+                'Name'        => 'Waste-WHITES-160922',
+                'RecordStamp' => {},
+            },
+        ],
+
+        '2022-09-23T00:00:00' => [
+            {   'ID'          => '2309221',
+                'Name'        => 'Waste-BULKY WASTE-230922',
+                'RecordStamp' => {},
+            },
+            {   'ID'          => '2309222',
+                'Name'        => 'Waste-WHITES-230922',
+                'RecordStamp' => {},
+            },
+        ],
+
+        # Workpacks with no jobs:
+
+        '2022-09-30T00:00:00' => [
+            {   'ID'          => '3009221',
+                'Name'        => 'Waste-BULKY WASTE-300922',
+                'RecordStamp' => {},
+            },
+            {   'ID'          => '3009222',
+                'Name'        => 'Waste-WHITES-300922',
+                'RecordStamp' => {},
+            },
+        ],
+    };
+}
+
+sub _jobs_by_workpack_id {
+    {
+        # Not a bulky workpack so limit ignored
+        508221 => _jobs_arrayref(40),
+
+        # 'WHITES' - max jobs
+        1208221 => _jobs_arrayref(40),
+
+        # 'BULKY WASTE' - max jobs
+        1908221 => _jobs_arrayref(40),
+
+        # 'WHITES' & 'BULKY WASTE' that together make max jobs
+        2608221 => _jobs_arrayref(10),
+        2608222 => _jobs_arrayref(30),
+
+        # Connected to faulty workpack names so limit ignored
+        209221 => _jobs_arrayref(40),
+        209222 => _jobs_arrayref(40),
+        209223 => _jobs_arrayref(40),
+
+        # Limit not reached:
+
+        909221 => _jobs_arrayref(39),
+
+        1609221 => _jobs_arrayref(39),
+
+        3009221 => _jobs_arrayref(24),
+        3009222 => _jobs_arrayref(15),
+    };
+}
+
+sub _jobs_arrayref {
+    my $job_count = shift;
+    [ ( { Job => {} } ) x $job_count ];
+}
+
+done_testing;

--- a/templates/web/base/waste/bulky/choose_date.html
+++ b/templates/web/base/waste/bulky/choose_date.html
@@ -10,9 +10,14 @@
   [% END %]
 <form class="waste" method="post">
   [% PROCESS form %]
-  [% IF NOT form.field('chosen_date').options.size %]
+  [% IF form.current_page.name == 'choose_date_earlier' && !form.field('chosen_date').options.size %]
     <p>
       There are no slots available in the next 90 days. Please refer to information regarding and link to information about taking waste to the local <a href='https://www.peterborough.gov.uk/residents/rubbish-and-recycling/household-recycling-centre'>Household Waste Recycling Centre</a>.
+    </p>
+  [% END %]
+  [% IF form.current_page.name == 'choose_date_later' && !form.field('chosen_date').options.size %]
+    <p>
+      No later dates found.
     </p>
   [% END %]
 </form>

--- a/templates/web/base/waste/bulky/choose_date.html
+++ b/templates/web/base/waste/bulky/choose_date.html
@@ -1,0 +1,20 @@
+[% SET title = form.title ~%]
+[% PROCESS 'waste/header.html' %]
+
+  [% PROCESS 'govuk/fields.html' %]
+  [% PROCESS back %]
+  [% PROCESS errors %]
+  [% PROCESS title %]
+  [% IF property %]
+    [% INCLUDE 'waste/_address_display.html' %]
+  [% END %]
+<form class="waste" method="post">
+  [% PROCESS form %]
+  [% IF NOT form.field('chosen_date').options.size %]
+    <p>
+      There are no slots available in the next 90 days. Please refer to information regarding and link to information about taking waste to the local <a href='https://www.peterborough.gov.uk/residents/rubbish-and-recycling/household-recycling-centre'>Household Waste Recycling Centre</a>.
+    </p>
+  [% END %]
+</form>
+
+[% INCLUDE footer.html %]


### PR DESCRIPTION
Core behaviour for fetching & displaying viable bulky good collection slots to a user.

Closes https://github.com/mysociety/societyworks/issues/3215.

[skip changelog]