### PR TITLE
Make sure staff permissions removed when anonymized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
         - Make map pan/zoom controls keyboard-accessible. #3751
     - Admin improvements:
         - Admin 'add user' form now always creates staff users
+	- Make sure staff permissions removed when anonymized.
     - Development improvements:
         - Default make_css to `web/cobrands` rather than `web`.
         - Ability to pass custom arguments (eg: SSL config) to server when running via Docker

--- a/perllib/FixMyStreet/App/Controller/Admin/Users.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Users.pm
@@ -32,13 +32,11 @@ sub index :Path : Args(0) {
         my $user_rs = FixMyStreet::DB->resultset("User")->search({ id => \@uids });
         if ( $c->get_param('remove-staff') ) {
             foreach my $user ($user_rs->all) {
+                $user->remove_staff;
                 $user->update({
-                    from_body => undef,
                     email_verified => 0,
                     phone_verified => 0,
                 });
-                $user->user_roles->delete;
-                $user->admin_user_body_permissions->delete;
             }
         } else {
             my @role_ids = $c->get_param_list('roles');
@@ -349,9 +347,7 @@ sub edit : Chained('user') : PathPart('') : Args(0) {
 
         if (!$user->from_body) {
             # Non-staff users aren't allowed any permissions or to be in an area
-            $user->admin_user_body_permissions->delete;
-            $user->user_roles->delete;
-            $user->area_ids(undef);
+            $user->remove_staff;
             delete $c->stash->{areas};
             delete $c->stash->{roles};
             delete $c->stash->{fetched_areas_body_id};

--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -421,6 +421,14 @@ sub split_name {
     return { first => $first || '', last => $last || '' };
 }
 
+sub remove_staff {
+    my $self = shift;
+    $self->user_roles->delete;
+    $self->admin_user_body_permissions->delete;
+    $self->from_body(undef);
+    $self->area_ids(undef);
+}
+
 sub can_moderate {
     my ($self, $object, $perms) = @_;
 
@@ -597,6 +605,7 @@ sub anonymize_account {
     $self->comments->update({ anonymous => 1, name => '' });
     $self->alerts->update({ whendisabled => \'current_timestamp' });
     $self->password('', 1);
+    $self->remove_staff;
     $self->update({
         email => 'removed-' . $self->id . '@' . FixMyStreet->config('EMAIL_DOMAIN'),
         email_verified => 0,
@@ -607,7 +616,6 @@ sub anonymize_account {
         twitter_id => undef,
         facebook_id => undef,
         oidc_ids => undef,
-        from_body => undef,
     });
 }
 

--- a/t/script/inactive.t
+++ b/t/script/inactive.t
@@ -20,6 +20,7 @@ my $comment_user = $mech->create_user_ok('commentuser@example.com');
 $comment_user->last_active($t);
 $comment_user->update;
 my $body = $mech->create_body_ok(2237, 'Oxfordshire Council', { comment_user_id => $comment_user->id });
+$user->update({ from_body => $body });
 
 my @problems;
 for (my $m = 1; $m <= 12; $m++) {
@@ -106,6 +107,7 @@ subtest 'Anonymization of inactive users' => sub {
 
     $user->discard_changes;
     is $user->email, 'removed-' . $user->id . '@example.org', 'User has been anonymized';
+    is $user->from_body, undef;
 
     stdout_is { $in->users } '', 'No output second time';
 

--- a/templates/web/base/my/my.html
+++ b/templates/web/base/my/my.html
@@ -76,7 +76,7 @@ li .my-account-buttons a {
     </p>
 </li>
 [% current_pref = c.user.get_extra_metadata('alert_notify') %]
-<li>[% loc('Receive alert notifications by') %]:
+<li>[% loc('Receive local alert notifications by') %]:
     <p class="segmented-control segmented-control--radio">
       [% IF c.user.email_verified %]
         <input type="radio" name="alert_notify" id="alert_notify_email" value="email"[% ' checked' IF current_pref == 'email' OR NOT current_pref %]>


### PR DESCRIPTION
Fixes https://github.com/mysociety/societyworks/issues/2991. Fixes https://github.com/mysociety/societyworks/issues/3027 - carries on from https://github.com/mysociety/fixmystreet/pull/3874, makes sure permissions are removed along with the from_body. Existing entries in db will need updating to match, I think.