### PR TITLE
Fix intermittently failing public_asset_ids.t

### DIFF
--- a/t/cobrand/public_asset_ids.t
+++ b/t/cobrand/public_asset_ids.t
@@ -14,7 +14,7 @@ my %problem_params = (
 my ($problem_pbro_tree)
     = $mech->create_problems_for_body( 1, $pbro_body->id,
     'Tree problem', \%problem_params, );
-$problem_pbro_tree->external_id('0123');
+$problem_pbro_tree->external_id('€0123');
 $problem_pbro_tree->set_extra_metadata( customer_reference => 'TREE123' );
 $problem_pbro_tree->update_extra_field(
     { name => 'tree_code', value => 101 } );
@@ -24,7 +24,7 @@ $problem_pbro_tree->update;
 my ($problem_pbro_bin)
     = $mech->create_problems_for_body( 1, $pbro_body->id,
     'Bin problem', \%problem_params, );
-$problem_pbro_bin->external_id('0234');
+$problem_pbro_bin->external_id('€0234');
 $problem_pbro_bin->set_extra_metadata( customer_reference => 'BIN234' );
 $problem_pbro_bin->update_extra_field(
     { name => 'central_asset_id', value => 201 }, );
@@ -34,7 +34,7 @@ $problem_pbro_bin->update;
 my ($problem_pbro_other)
     = $mech->create_problems_for_body( 1, $pbro_body->id, 'Other problem',
     \%problem_params, );
-$problem_pbro_other->external_id('0345');
+$problem_pbro_other->external_id('€0345');
 $problem_pbro_other->set_extra_metadata( customer_reference => 'OTH345' );
 $problem_pbro_other->update_extra_field( { name => 'other_id', value => 301 },
 );
@@ -147,7 +147,7 @@ subtest 'Multiple public asset IDs defined' => sub {
                     = $mech->create_problems_for_body( 1, $pbro_body->id,
                     'We have a problem',
                     \%problem_params );
-                $problem_pbro_conflict->external_id('0987');
+                $problem_pbro_conflict->external_id('€0987');
                 $problem_pbro_conflict->set_extra_metadata(
                     customer_reference => 'CON987' );
                 $problem_pbro_conflict->update_extra_field(


### PR DESCRIPTION
Possibly was failing due to original external ID strings (0123,
0234, etc.) also sometimes matching the randomly generated CSRF
token or CSP nonce in the HTML. So external IDs are now prefixed
with the non-base64 char €.

Fixes https://github.com/mysociety/societyworks/issues/3153.

[skip changelog]