### PR TITLE
[Northamptonshire] Include report's external ID in CSV export

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
@@ -121,4 +121,20 @@ sub staff_ignore_form_disable_form {
         && $c->user->belongs_to_body( $self->body->id );
 }
 
+sub dashboard_export_problems_add_columns {
+    my ($self, $csv) = @_;
+
+    $csv->add_csv_columns(
+        external_id => 'External ID',
+    );
+
+    $csv->csv_extra_data(sub {
+        my $report = shift;
+
+        return {
+            external_id => $report->external_id,
+        };
+    });
+}
+
 1;


### PR DESCRIPTION
This adds an extra "External ID" column to the dashboard CSV export which Northamptonshire have requested so they can map updates to reports in their new system.

Part of https://github.com/mysociety/societyworks/issues/3131

[skip changelog]
