### PR TITLE
For CSV export, fetch children of all generations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
         - Trim whitespace on extra status codes for response templates
         - The permission default_to_body now also affects updates. #3317
         - Decouple the permission to manage shortlist from default_to_body. #3317
+	- For CSV export, fetch children of all generations.
     - Accessibility improvements:
         - The "skip map" link on /around now has new wording. #3794
         - Improve visual contrast of pagination links. #3794

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -810,10 +810,11 @@ cobrand's area_types_children type.
 =cut
 
 sub fetch_area_children {
-    my ($self, $area_id) = @_;
+    my ($self, $area_id, $all_generations) = @_;
 
     return FixMyStreet::MapIt::call('area/children', $area_id,
-        type => $self->area_types_children
+        type => $self->area_types_children,
+        $all_generations ? (min_generation => 1) : (),
     );
 }
 

--- a/perllib/FixMyStreet/DB/Result/Body.pm
+++ b/perllib/FixMyStreet/DB/Result/Body.pm
@@ -186,14 +186,14 @@ sub areas {
 }
 
 sub first_area_children {
-    my ( $self ) = @_;
+    my ( $self, $all_generations ) = @_;
 
     my $body_area = $self->body_areas->first;
     return unless $body_area;
 
     my $cobrand = $self->result_source->schema->cobrand;
 
-    return $cobrand->fetch_area_children($body_area->area_id);
+    return $cobrand->fetch_area_children($body_area->area_id, $all_generations);
 }
 
 =head2 get_cobrand_handler

--- a/perllib/FixMyStreet/Reporting.pm
+++ b/perllib/FixMyStreet/Reporting.pm
@@ -263,7 +263,7 @@ sub generate_csv {
 
     my %asked_for = map { $_ => 1 } @{$self->csv_columns};
 
-    my $children = $self->body ? $self->body->first_area_children : {};
+    my $children = $self->body ? $self->body->first_area_children(1) : {};
 
     my $objects = $self->objects_rs;
     while ( my $obj = $objects->next ) {

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -186,8 +186,8 @@ sub dispatch_request {
         }
     },
 
-    sub (GET + /area/*/children) {
-        my ($self, $area) = @_;
+    sub (GET + /area/*/children + ?*) {
+        my ($self, $area, $query) = @_;
         if ($area eq '2514') {
             return $self->output({
                 151907 => {parent_area => 2514, id => 151907, name => "Bordesley & Highgate", type => "MTW"},
@@ -204,6 +204,9 @@ sub dispatch_request {
             "60705" => { "parent_area" => 2245, "generation_high" => 25, "all_names" => { }, "id" => 60705, "codes" => { "ons" => "00HY226", "gss" => "E04011842", "unit_id" => "17101" }, "name" => "Trowbridge", "country" => "E", "type_name" => "Civil parish/community", "generation_low" => 12, "country_name" => "England", "type" => "CPC" },
             "62883" => { "parent_area" => 2245, "generation_high" => 25, "all_names" => { }, "id" => 62883, "codes" => { "ons" => "00HY026", "gss" => "E04011642", "unit_id" => "17205" }, "name" => "Bradford-on-Avon", "country" => "E", "type_name" => "Civil parish/community", "generation_low" => 12, "country_name" => "England", "type" => "CPC" },
         };
+        if ($query->{min_generation}) {
+            $response->{"58805"} = { "parent_area" => 2245, "generation_high" => 10, "id" => 58805, "name" => "Bishops Cannings", "generation_low" => 1, "type" => "CPC" };
+        }
         return $self->output($response);
     },
 

--- a/t/app/controller/dashboard.t
+++ b/t/app/controller/dashboard.t
@@ -46,6 +46,7 @@ my $normaluser = $mech->create_user_ok('normaluser@example.com', name => 'Normal
 my $body_id = $body->id;
 my $area_id = '60705';
 my $alt_area_id = '62883';
+my $old_area_id = '58805';
 
 my $last_month = DateTime->now->subtract(months => 2);
 $mech->create_problems_for_body(2, $body->id, 'Title', { areas => ",$area_id,2651,", category => 'Potholes', cobrand => 'no2fat' });
@@ -183,7 +184,7 @@ FixMyStreet::override_config {
         $mech->create_problems_for_body(1, $body->id, 'Title', {
             detail => "this report\nis split across\nseveral lines",
             category => 'Problem one',
-            areas => ",$alt_area_id,2651,",
+            areas => ",$old_area_id,2651,",
         });
         $mech->get_ok('/dashboard?export=1');
         my @rows = $mech->content_as_csv;
@@ -221,6 +222,7 @@ FixMyStreet::override_config {
         is $rows[5]->[15], 'Trowbridge', 'Ward column is name not ID';
         is $rows[5]->[16], '529025', 'Correct Easting conversion';
         is $rows[5]->[17], '179716', 'Correct Northing conversion';
+        is $rows[18]->[15], 'Bishops Cannings', 'Can see old ward';
     };
 
     subtest 'export updates as csv' => sub {


### PR DESCRIPTION
Fixes https://github.com/mysociety/societyworks/issues/3156

Area IDs are stored on a report at creation; if the areas in MapIt change, due to boundary changes, those IDs no longer match against the data in the current MapIt generation. So fetch all generations of children so old ward information is included.