### PR TITLE
Check asset layer body visibility at creation.

### DIFF
--- a/.cypress/cypress/integration/highwaysengland.js
+++ b/.cypress/cypress/integration/highwaysengland.js
@@ -8,20 +8,22 @@ describe('National Highways cobrand tests', function() {
         cy.get('[name=pc]').type(Cypress.env('postcode'));
         cy.get('[name=pc]').parents('form').submit();
         cy.url().should('include', '/around');
-        cy.wait('@highways-tilma');
     });
     it('does not allow reporting on non-road', function() {
         cy.get('#map_box').click(280, 249);
+        cy.wait('@highways-tilma');
         cy.wait('@report-ajax');
         cy.contains('The selected location is not maintained by us.').should('be.visible');
     });
     it('does not allow reporting on DBFO roads', function() {
         cy.get('#map_box').click(200, 249);
+        cy.wait('@highways-tilma');
         cy.wait('@report-ajax');
         cy.contains('report on roads directly maintained').should('be.visible');
     });
     it('allows reporting on other HE roads', function() {
         cy.get('#map_box').click(240, 249);
+        cy.wait('@highways-tilma');
         cy.wait('@report-ajax');
         cy.pickCategory('Fallen sign');
         cy.nextPageReporting();
@@ -40,8 +42,8 @@ describe('National Highways cobrand mobile tests', function() {
         cy.get('[name=pc]').type(Cypress.env('postcode'));
         cy.get('[name=pc]').parents('form').submit();
         cy.url().should('include', '/around');
-        cy.wait('@highways-tilma');
         cy.get('#map_box').click(80, 249);
+        cy.wait('@highways-tilma');
         cy.wait('@report-ajax');
         cy.contains('report on roads directly maintained').should('be.visible');
     });

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -955,7 +955,8 @@ fixmystreet.assets = {
 
         fixmystreet.assets.layers.push(asset_layer);
         if (options.always_visible) {
-            asset_layer.setVisibility(true);
+            var visibility = fixmystreet.bodies && options.body ? fixmystreet.bodies.indexOf(options.body) != -1 : true;
+            asset_layer.setVisibility(visibility);
         }
         return asset_layer;
     },


### PR DESCRIPTION
Previously always_visible layers were set to visible at setup, but then when the layer was initialized update_layer_visibility was called which would set the visibility to false if the body did not match. However by then a layer data request would already have been made.
[skip changelog]
