### PR TITLE
[UK] Tidy up closed-to-update messaging.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -521,9 +521,9 @@ if the report's category has its "updates_disallowed" flag set.
 
 sub updates_disallowed {
     my ($self, $problem) = @_;
-    return 1 if $problem->get_extra_metadata('closed_updates');
-    return 1 if $problem->contact && $problem->contact->get_extra_metadata('updates_disallowed');
-    return 0;
+    return 'problem-closed' if $problem->get_extra_metadata('closed_updates');
+    return 'category-closed' if $problem->contact && $problem->contact->get_extra_metadata('updates_disallowed');
+    return '';
 }
 
 =item reopening_disallowed

--- a/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
+++ b/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
@@ -96,13 +96,6 @@ sub anonymous_account {
     };
 }
 
-sub updates_disallowed {
-    my ($self, $problem) = @_;
-    return 1 if $problem->is_fixed || $problem->is_closed;
-    return 1 if $problem->get_extra_metadata('closed_updates');
-    return 0;
-}
-
 # Bypass photo requirement, we have none
 sub recent_photos {
     my ( $self, $area, $num, $lat, $lon, $dist ) = @_;

--- a/perllib/FixMyStreet/Cobrand/IsleOfWight.pm
+++ b/perllib/FixMyStreet/Cobrand/IsleOfWight.pm
@@ -41,14 +41,6 @@ sub disambiguate_location {
     };
 }
 
-sub updates_disallowed {
-    my ($self, $problem) = @_;
-
-    my $c = $self->{c};
-    return 0 if $c->user_exists && $c->user->id eq $problem->user->id;
-    return 1;
-}
-
 # Island Roads don't want any reports made before their go-live date visible on
 # their cobrand at all.
 sub cut_off_date { '2019-09-30' }

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -542,24 +542,28 @@ sub updates_disallowed {
     my ($problem) = @_;
     my $c = $self->{c};
 
+    # If closed due to problem/category closure, want that to take precedence
+    my $parent = $self->next::method(@_);
+    return $parent if $parent;
+
     my $cfg = $self->feature('updates_allowed') || '';
     if ($cfg eq 'none') {
-        return 1;
+        return $cfg;
     } elsif ($cfg eq 'staff') {
         # Only staff and superusers can leave updates
         my $staff = $c->user_exists && $c->user->from_body && $c->user->from_body->name eq $self->council_name;
         my $superuser = $c->user_exists && $c->user->is_superuser;
-        return 1 unless $staff || $superuser;
+        return $cfg unless $staff || $superuser;
     }
 
     if ($cfg =~ /reporter/) {
-        return 1 if !$c->user_exists || $c->user->id != $problem->user->id;
+        return $cfg if !$c->user_exists || $c->user->id != $problem->user->id;
     }
     if ($cfg =~ /open/) {
-        return 1 if $problem->is_fixed || $problem->is_closed;
+        return $cfg if $problem->is_fixed || $problem->is_closed;
     }
 
-    return $self->next::method(@_);
+    return '';
 }
 
 # Report if cobrand denies updates by user

--- a/t/cobrand/isleofwight.t
+++ b/t/cobrand/isleofwight.t
@@ -107,16 +107,35 @@ subtest "only original reporter can comment" => sub {
         ALLOWED_COBRANDS => 'isleofwight',
         COBRAND_FEATURES => { updates_allowed => { isleofwight => 'reporter' } },
     }, sub {
+        my $category = $reports[0]->category;
+        $reports[0]->update({ category => 'Potholes' });
+
         $mech->get_ok('/report/' . $reports[0]->id);
         $mech->content_contains('Only the original reporter may leave updates');
+
+        $contact->set_extra_metadata(updates_disallowed => 1);
+        $contact->update;
+        $mech->get_ok('/report/' . $reports[0]->id);
+        $mech->content_lacks('Only the original reporter may leave updates');
+        $mech->content_contains('closed to updates');
+        $contact->unset_extra_metadata('updates_disallowed');
+        $contact->update;
 
         $mech->log_in_ok('user@example.org');
         $mech->get_ok('/report/' . $reports[0]->id);
         $mech->content_lacks('Only the original reporter may leave updates');
+
+        $contact->set_extra_metadata(updates_disallowed => 1);
+        $contact->update;
+        $mech->get_ok('/report/' . $reports[0]->id);
+        $mech->content_lacks('Only the original reporter may leave updates');
+        $mech->content_contains('closed to updates');
+        $contact->unset_extra_metadata('updates_disallowed');
+        $contact->update;
     };
 };
 
-subtest "only original reporter can comment" => sub {
+subtest "only original reporter can comment (.com)" => sub {
     FixMyStreet::override_config {
         MAPIT_URL => 'http://mapit.uk/',
         ALLOWED_COBRANDS => 'fixmystreet',

--- a/t/cobrand/northamptonshire.t
+++ b/t/cobrand/northamptonshire.t
@@ -116,7 +116,7 @@ subtest 'check updates sent for non defects' => sub {
 my $cobrand = FixMyStreet::Cobrand::Northamptonshire->new;
 
 subtest 'check updates disallowed correctly' => sub {
-    is $cobrand->updates_disallowed($report), 0;
+    is $cobrand->updates_disallowed($report), '';
     $report->update({ state => 'closed' });
     is $cobrand->updates_disallowed($report), 1;
     $report->update({ state => 'confirmed', user => $counciluser });

--- a/templates/web/base/report/display.html
+++ b/templates/web/base/report/display.html
@@ -51,12 +51,6 @@
 
 [% IF problem.duplicate_of %]
     [% INCLUDE 'report/duplicate-no-updates.html' %]
-[% ELSIF problem.extra.closed_updates %]
-    <p>[% loc('This report is now closed to updates.') %]
-       [% tprintf(loc('You can <a href="%s">make a new report in the same location</a>.'),
-              c.uri_for( '/report/new', { longitude => longitude, latitude => latitude } )
-          ) %]
-    </p>
 [% ELSIF problem.cobrand_data == 'noise' %]
     <p>[% loc('This report is now closed to updates.') %]</p>
 [% ELSIF NOT shown_form  %]

--- a/templates/web/base/report/update-form-wrapper.html
+++ b/templates/web/base/report/update-form-wrapper.html
@@ -1,4 +1,5 @@
-[% UNLESS c.cobrand.updates_disallowed(problem) %]
+[% disallowed = c.cobrand.updates_disallowed(problem) %]
+[% UNLESS disallowed %]
 
   [% IF NOT c.user_exists AND problem.non_public # Came via other-reported token or similar %]
     <p>[% tprintf(loc('To provide an update, please <a href="%s">sign in</a>.'), '/auth?r=report/' _ problem.id) %]</p>
@@ -17,5 +18,5 @@
   [% END %]
 
 [% ELSE %]
-    [% TRY %][% INCLUDE 'report/_updates_disallowed_message.html' %][% CATCH file %][% END %]
+    [% INCLUDE 'report/_updates_disallowed_message.html' %]
 [% END %]

--- a/templates/web/fixmystreet-uk-councils/report/_updates_disallowed_message.html
+++ b/templates/web/fixmystreet-uk-councils/report/_updates_disallowed_message.html
@@ -1,5 +1,4 @@
-[% cfg = c.cobrand.feature("updates_allowed") ~%]
-[% IF cfg.match('reporter') AND (NOT cfg.match('open') OR problem.is_open) %]
+[% IF disallowed.match('reporter') AND (NOT disallowed.match('open') OR problem.is_open) %]
     <p>
         Only the original reporter may leave updates.
         [% IF NOT c.user_exists %]

--- a/templates/web/fixmystreet.com/report/_updates_disallowed_message.html
+++ b/templates/web/fixmystreet.com/report/_updates_disallowed_message.html
@@ -1,5 +1,4 @@
-[% cfg = c.cobrand.per_body_config('updates_allowed', problem).0 ~%]
-[% IF cfg.match('reporter') AND (NOT cfg.match('open') OR problem.is_open) %]
+[% IF disallowed.match('reporter') AND (NOT disallowed.match('open') OR problem.is_open) %]
     <p>
         Only the original reporter may leave updates.
         [% IF NOT c.user_exists %]


### PR DESCRIPTION
If a report is closed to updates, directly or because of its category, a
closed-to-updates message should be shown, even if the cobrand eg allows
updates for reporters. Also take out a couple of cobrand functions where
the same behaviour is achieved through config. [skip changelog]
Fixes https://github.com/mysociety/societyworks/issues/3081