### PR TITLE
[Waste] DD uniqueness, renewal cobrand_data, New dd_date, auto-internal created time

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -396,7 +396,7 @@ sub populate_dd_details : Private {
     my $payment_details = $c->cobrand->feature('payment_gateway');
     $c->stash->{payment_details} = $payment_details;
     $c->stash->{amount} = sprintf( '%.2f', $payment / 100 );
-    $c->stash->{reference} = $c->cobrand->call_hook( 'waste_dd_payment_ref' => $p ) || 'GGW' . $c->stash->{property}{uprn};
+    $c->stash->{reference} = substr($c->cobrand->waste_payment_ref_council_code . '-' . $p->id . '-' . $c->stash->{property}{uprn}, 0, 18);
     $c->stash->{lookup} = $reference;
     $c->stash->{payment_date} = $dt;
     $c->stash->{start_date} = $dt->ymd;

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -863,6 +863,8 @@ sub garden_waste_cost_pa {
 
 sub garden_waste_new_bin_admin_fee { 0 }
 
+sub waste_payment_ref_council_code { "LBB" }
+
 sub admin_templates_external_status_code_hook {
     my ($self) = @_;
     my $c = $self->{c};

--- a/perllib/FixMyStreet/Cobrand/Kingston.pm
+++ b/perllib/FixMyStreet/Cobrand/Kingston.pm
@@ -723,12 +723,6 @@ sub garden_waste_dd_complete {
     $report->update();
 }
 
-sub waste_dd_payment_ref {
-    my ($self, $p) = @_;
-
-    return substr($self->waste_payment_ref_council_code . '-' . $p->id . '-' . $p->get_extra_field_value('uprn'), 0, 18);
-}
-
 sub admin_templates_external_status_code_hook {
     my ($self) = @_;
     my $c = $self->{c};

--- a/perllib/FixMyStreet/Queue/Item/Report.pm
+++ b/perllib/FixMyStreet/Queue/Item/Report.pm
@@ -2,6 +2,7 @@ package FixMyStreet::Queue::Item::Report;
 
 use Moo;
 use DateTime::Format::Pg;
+use Time::HiRes;
 
 use Utils::OpenStreetMap;
 
@@ -339,10 +340,7 @@ sub _add_confirmed_update {
         my $request = {
             service_request_id => $problem->id,
             update_id => 'auto-internal',
-            # Add a second so it is definitely later than problem confirmed timestamp,
-            # which uses current_timestamp (and thus microseconds) whilst this update
-            # is rounded down to the nearest second
-            comment_time => DateTime->now->add( seconds => 1 ),
+            comment_time => DateTime->from_epoch( epoch => Time::HiRes::time ),
             email_text => $email_text,
             status => 'open',
             description => $description,

--- a/perllib/FixMyStreet/Roles/Bottomline.pm
+++ b/perllib/FixMyStreet/Roles/Bottomline.pm
@@ -96,33 +96,4 @@ sub waste_payment_type {
     return ($category, $sub_type);
 }
 
-sub _process_reference {
-    my ($self, $payer) = @_;
-
-    my ($id, $uprn) = $payer =~ /^@{[$self->waste_payment_ref_council_code()]}-(\d+)-(\d+)/;
-
-    return (undef, undef) unless $id;
-    my $origin = FixMyStreet::DB->resultset('Problem')->find($id);
-
-    if ( !$origin ) {
-        $self->log("no matching origin sub for id $id");
-        return (undef, undef);
-    }
-
-    $uprn = $origin->get_extra_field_value('uprn');
-    my $len = length($payer);
-    $self->log( "extra query is " . '%payerReference,T' . $len . ':'. $payer . '%' );
-    my $rs = FixMyStreet::DB->resultset('Problem')->search({
-        -or => [
-            id => $id,
-            extra => { like => '%payerReference,T' . $len . ':'. $payer . '%' },
-        ]
-    },
-    {
-            order_by => { -desc => 'created' }
-    })->to_body( $self->body );
-
-    return ($uprn, $rs);
-}
-
 1;

--- a/perllib/FixMyStreet/Roles/DDProcessor.pm
+++ b/perllib/FixMyStreet/Roles/DDProcessor.pm
@@ -302,6 +302,7 @@ sub _duplicate_waste_report {
         anonymous => $report->anonymous,
         state => 'unconfirmed',
         non_public => 1,
+        cobrand_data => 'waste',
     });
 
     $extra->{$self->garden_subscription_container_field} ||= $report->get_extra_field_value($self->garden_subscription_container_field);

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -1324,7 +1324,8 @@ FixMyStreet::override_config {
     $p->category('Garden Subscription');
     $p->title('Garden Subscription - New');
     $p->update_extra_field({ name => 'payment_method', value => 'direct_debit' });
-    $p->set_extra_metadata('payerReference', 'GGW1000000002');
+    my $dd_ref = 'LBB-' . $p->id . '-1000000002';
+    $p->set_extra_metadata('payerReference', $dd_ref);
     $p->update;
 
     subtest 'check modify sub direct debit payment' => sub {
@@ -1357,14 +1358,14 @@ FixMyStreet::override_config {
         my $ad_hoc_payment_date = '2021-01-15T17:00:00';
 
         is_deeply $dd_sent_params->{one_off_payment}, {
-            payer_reference => 'GGW1000000002',
+            payer_reference => $dd_ref,
             amount => '7.50',
             reference => $new_report->id,
             comments => '',
             date => $ad_hoc_payment_date,
         }, "correct direct debit ad hoc payment params sent";
         is_deeply $dd_sent_params->{amend_plan}, {
-            payer_reference => 'GGW1000000002',
+            payer_reference => $dd_ref,
             amount => '40.00',
         }, "correct direct debit amendment params sent";
         $new_report->delete;
@@ -1397,7 +1398,7 @@ FixMyStreet::override_config {
 
         is $dd_sent_params->{one_off_payment}, undef, "no one off payment if reducing bin count";
         is_deeply $dd_sent_params->{amend_plan}, {
-            payer_reference => 'GGW1000000002',
+            payer_reference => $dd_ref,
             amount => '20.00',
         }, "correct direct debit amendment params sent";
     };
@@ -1454,7 +1455,7 @@ FixMyStreet::override_config {
         is $new_report->state, 'unconfirmed', 'report confirmed';
 
         is_deeply $dd_sent_params->{cancel_plan}, {
-            payer_reference => 'GGW1000000002',
+            payer_reference => $dd_ref,
         }, "correct direct debit cancellation params sent";
 
         $mech->get_ok('/waste/12345');

--- a/t/app/controller/waste_kingston.t
+++ b/t/app/controller/waste_kingston.t
@@ -1626,7 +1626,7 @@ FixMyStreet::override_config {
     $p->category('Garden Subscription');
     $p->title('Garden Subscription - New');
     $p->update_extra_field({ name => 'payment_method', value => 'direct_debit' });
-    $p->set_extra_metadata('payerReference', 'GGW1000000002');
+    $p->set_extra_metadata('payerReference', 'RBK-' . $p->id . '1000000002');
     $p->set_extra_metadata('dd_mandate_id', '100');
     $p->set_extra_metadata('dd_contact_id', '101');
     $p->update;

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -1740,6 +1740,7 @@ subtest 'check direct debit reconcilliation' => sub {
     is $p->get_extra_field_value('Subscription_Details_Container_Type'), 44, 'renewal has correct container type';
     is $p->get_extra_field_value('service_id'), 545, 'renewal has correct service id';
     is $p->get_extra_field_value('LastPayMethod'), 3, 'correct echo payment method field';
+    is $p->cobrand_data, 'waste';
     is $p->state, 'confirmed';
 
     my $renewal_too_recent = FixMyStreet::DB->resultset('Problem')->search({

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -1743,6 +1743,12 @@ subtest 'check direct debit reconcilliation' => sub {
     is $p->cobrand_data, 'waste';
     is $p->state, 'confirmed';
 
+    # Assume that this has now had to go through as New, rather than Renewal
+    # Should not be any extra warning output later on
+    $p->update_extra_field({ name => "Subscription_Type", value => 1 });
+    $p->title("Garden Subscription - New");
+    $p->update;
+
     my $renewal_too_recent = FixMyStreet::DB->resultset('Problem')->search({
             extra => { like => '%uprn,T5:value,I6:654329%' }
         },


### PR DESCRIPTION
Fixes https://github.com/mysociety/societyworks/issues/3169 - This makes the Kingston DD reference code the general code, so replaces Bromley's existing. Leave the old GGW handling for any DDs that come in overlap.
Fixes https://github.com/mysociety/societyworks/issues/3114 - make sure the renewals set the correct cobrand_data
Fixes https://github.com/mysociety/societyworks/issues/3149 - deal with the cron output
Fixes https://github.com/mysociety/societyworks/issues/3171 - fix the update order issue (I think)
[skip changelog]
