### PR TITLE
[Peterborough] Change missed collection timeframe from 2.5 days to 1.5 days

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -375,7 +375,7 @@ sub category_change_force_resend {
 
 Functions specific to the waste product & Bartec integration.
 
-=cut 
+=cut
 
 sub _premises_for_postcode {
     my $self = shift;
@@ -640,7 +640,7 @@ sub bin_services_for_address {
             report_open => ( @report_service_ids_open || $open_requests->{492} ) ? 1 : 0,
         };
         if ($row->{report_allowed}) {
-            # We only get here if we're within the 2.5 day window after the collection.
+            # We only get here if we're within the 1.5 day window after the collection.
             # Set this so missed food collections can always be reported, as they don't
             # have their own collection event.
             $self->{c}->stash->{any_report_allowed} = 1;
@@ -673,7 +673,7 @@ sub bin_services_for_address {
 
     # Some need to be added manually as they don't appear in Bartec responses
     # as they're not "real" collection types (e.g. requesting all bins)
-    
+
     my $bags_only = $self->{c}->get_param('bags_only');
     my $skip_bags = $self->{c}->get_param('skip_bags');
 
@@ -739,7 +739,7 @@ sub _waste_report_allowed {
     #  A bin not collected on Thursday can be rung through up to noon Monday
 
     my $wd = FixMyStreet::WorkingDays->new(public_holidays => FixMyStreet::Cobrand::UK::public_holidays());
-    $dt = $wd->add_days($dt, 2);
+    $dt = $wd->add_days($dt, 1);
     $dt->set( hour => 12, minute => 0, second => 0 );
     my $now = DateTime->now->set_time_zone(FixMyStreet->local_time_zone);
     return $now <= $dt;

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -72,7 +72,7 @@ FixMyStreet::override_config {
         $mech->content_contains('can’t find your address', "Missing message found");
     };
     subtest 'Address lookup' => sub {
-        set_fixed_time('2021-08-06T10:00:00Z');
+        set_fixed_time('2021-08-05T21:00:00Z');
         $mech->get_ok('/waste');
         $mech->submit_form_ok({ with_fields => { postcode => 'PE1 3NA' } });
         $mech->content_contains('1 Pope Way, Peterborough, PE1 3NA');
@@ -81,10 +81,10 @@ FixMyStreet::override_config {
         $mech->content_contains('Every two weeks');
         $mech->content_contains('Thursday, 5th August 2021');
         $mech->content_contains('Report a recycling bin collection as missed');
-        set_fixed_time('2021-08-09T10:00:00Z');
+        set_fixed_time('2021-08-06T10:00:00Z');
         $mech->get_ok('/waste/PE1%203NA:100090215480');
         $mech->content_contains('Report a recycling bin collection as missed');
-        set_fixed_time('2021-08-09T14:00:00Z');
+        set_fixed_time('2021-08-06T14:00:00Z');
         $mech->get_ok('/waste/PE1%203NA:100090215480');
         $mech->content_lacks('Report a recycling bin collection as missed');
     };

--- a/templates/web/peterborough/waste/services.html
+++ b/templates/web/peterborough/waste/services.html
@@ -44,7 +44,7 @@
     [% IF unit.next AND unit.next.date.ymd == date.format(date.now, "%Y-%m-%d") %]
       <span class="waste-service-descriptor">The crew have not recorded your street as complete and may still be planning to attend. You will not be able to report a missed bin at this time.</span>
     [% ELSE %]
-      <span class="waste-service-descriptor">Please note that missed collections can only be reported within 2&frac12; working days of your collection day (including the collection day).</span>
+      <span class="waste-service-descriptor">Please note that missed bin collections can only be reported until midday the next working day after your scheduled collection.</span>
     [% END %]
   [% END %]
 [% END %]


### PR DESCRIPTION
The rules on missed collections have changed. Missed collections can now only be reported until noon the next working day.


Fixes https://github.com/mysociety/societyworks/issues/3183

<!-- [skip changelog] -->
