### PR TITLE
Check report body for category on incoming email.

### DIFF
--- a/perllib/FixMyStreet/Email/Incoming.pm
+++ b/perllib/FixMyStreet/Email/Incoming.pm
@@ -200,9 +200,17 @@ sub check_for_status_code {
         current_body => $body,
         blank_updates_permitted => 1,
     );
+
+    my %body_ids = map { $_ => 1 } @{$problem->bodies_str_ids};
+    my $categories = [ $problem->category, undef ];
+    if (!$body_ids{$body->id}) {
+        # Not to the body we're using for templates, so don't match on a category
+        $categories = undef;
+    }
+
     my $templates = FixMyStreet::DB->resultset("ResponseTemplate")->search({
         'me.body_id' => $body->id,
-        'contact.category' => [ $problem->category, undef ],
+        'contact.category' => $categories,
     }, {
         order_by => 'contact.category', # So nulls are last
         join => { 'contact_response_templates' => 'contact' },


### PR DESCRIPTION
If an incoming email concerns a report for a body other than the one we are using to look up a response template, do not match on categories, as they should only apply to reports for that body. This is so e.g. if a category exists for both Bucks and a parish, a reply to a parish report will not use a matching Bucks template. [skip changelog]