### PR TITLE
[Bromley] Add "Street Cleansing" to red route groups

### DIFF
--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -547,7 +547,7 @@ sub _cleaning_categories { [
     'Litter or Weeds on a Street',
 ] }
 
-sub _cleaning_groups { [ 'Street cleaning', 'Fly-tipping' ] }
+sub _cleaning_groups { [ 'Street cleaning', 'Street Cleansing', 'Fly-tipping' ] }
 
 sub _tfl_council_categories { [
     'General Litter / Rubbish Collection',


### PR DESCRIPTION
Bromley have recently switched to using proper groups. As a result they
have a new "Street Cleansing" group that should be displayed on red
routes, but wasn't being handled by the code.

Fixes https://github.com/mysociety/societyworks/issues/3193

[skip changelog]