### PR TITLE
CSV export, instantantiate cobrand class.

### DIFF
--- a/bin/csv-export
+++ b/bin/csv-export
@@ -52,7 +52,7 @@ if ($use_stdout) {
     $fh = $file->openw_utf8;
 }
 
-my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker($opts->cobrand);
+my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker($opts->cobrand)->new;
 FixMyStreet::DB->schema->cobrand($cobrand);
 
 my $user = FixMyStreet::DB->resultset("User")->find($opts->user) if $opts->user;


### PR DESCRIPTION
Until recently, nothing tried to use the class as an instance, only call simple functions, but the Buckinghamshire parish_bodies call caches the fetched bodies on the cobrand. [skip changelog]
Fixes https://mysocietysupport.freshdesk.com/a/tickets/2342