### PR TITLE
[Waste] Remove hardcoded ‘GGW’ references

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -218,20 +218,20 @@ sub pay : Path('pay') : Args(0) {
         amount => $amount,
         reference => $payment->config->{customer_ref},
         description => $p->title,
-        lineId => $c->cobrand->call_hook(waste_cc_payment_line_item_ref => $p) || "GGW$uprn",
+        lineId => $c->cobrand->waste_cc_payment_line_item_ref($p),
     });
     if ($admin_fee) {
         push @items, {
             amount => $admin_fee,
             reference => $payment->config->{customer_ref_admin_fee},
             description => 'Admin fee',
-            lineId => $c->cobrand->call_hook(waste_cc_payment_admin_fee_line_item_ref => $p) || "GGW$uprn",
+            lineId => $c->cobrand->waste_cc_payment_admin_fee_line_item_ref($p),
         };
     }
     my $result = $payment->pay({
         returnUrl => $c->uri_for('pay_complete', $p->id, $redirect_id ) . '',
         backUrl => $backUrl,
-        ref => 'GGW' . $uprn,
+        ref => $c->cobrand->waste_cc_payment_sale_ref($p),
         request_id => $p->id,
         description => $p->title,
         name => $p->name,
@@ -1237,7 +1237,6 @@ sub setup_garden_sub_params : Private {
         $service_id = $c->cobrand->garden_service_id;
     }
     $c->set_param('service_id', $service_id);
-    $c->set_param('client_reference', 'GGW' . $c->stash->{property}->{uprn});
     $c->set_param('current_containers', $data->{current_bins});
     $c->set_param('new_containers', $data->{new_bins});
     # Either the user picked in the form, or it was staff and so will be credit card (or overridden to csc if that used)

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -865,6 +865,21 @@ sub garden_waste_new_bin_admin_fee { 0 }
 
 sub waste_payment_ref_council_code { "LBB" }
 
+sub waste_cc_payment_line_item_ref {
+    my ($self, $p) = @_;
+    return "GGW" . $p->get_extra_field_value('uprn');
+}
+
+sub waste_cc_payment_admin_fee_line_item_ref {
+    my ($self, $p) = @_;
+    return "GGW" . $p->get_extra_field_value('uprn');
+}
+
+sub waste_cc_payment_sale_ref {
+    my ($self, $p) = @_;
+    return "GGW" . $p->get_extra_field_value('uprn');
+}
+
 sub admin_templates_external_status_code_hook {
     my ($self) = @_;
     my $c = $self->{c};

--- a/perllib/FixMyStreet/Cobrand/Kingston.pm
+++ b/perllib/FixMyStreet/Cobrand/Kingston.pm
@@ -637,6 +637,11 @@ sub _waste_cc_line_item_ref {
     return "$id-$name-$str";
 }
 
+sub waste_cc_payment_sale_ref {
+    my ($self, $p) = @_;
+    return "GGW" . $p->get_extra_field_value('uprn');
+}
+
 sub waste_payment_ref_council_code { "RBK" }
 
 sub garden_waste_dd_munge_form_details {

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -75,7 +75,6 @@ create_contact({ category => 'Garden Subscription', email => 'garden@example.com
         { code => 'payment_method', required => 1, automated => 'hidden_field' },
         { code => 'pro_rata', required => 0, automated => 'hidden_field' },
         { code => 'payment', required => 1, automated => 'hidden_field' },
-        { code => 'client_reference', required => 1, automated => 'hidden_field' },
         { code => 'Source', required => 0, automated => 'hidden_field' },
 );
 create_contact({ category => 'Cancel Garden Subscription', email => 'garden_renew@example.com'},
@@ -83,7 +82,6 @@ create_contact({ category => 'Cancel Garden Subscription', email => 'garden_rene
         { code => 'Container_Instruction_Quantity', required => 1, automated => 'hidden_field' },
         { code => 'Container_Instruction_Action', required => 1, automated => 'hidden_field' },
         { code => 'Container_Instruction_Container_Type', required => 1, automated => 'hidden_field' },
-        { code => 'client_reference', required => 1, automated => 'hidden_field' },
         { code => 'payment_method', required => 1, automated => 'hidden_field' },
         { code => 'Source', required => 0, automated => 'hidden_field' },
 );
@@ -1043,7 +1041,6 @@ FixMyStreet::override_config {
 
         is $new_report->category, 'Garden Subscription', 'correct category on report';
         is $new_report->title, 'Garden Subscription - New', 'correct title on report';
-        is $new_report->get_extra_field_value('client_reference'), 'GGW1000000002', 'correct client reference on report';
         is $new_report->get_extra_field_value('payment_method'), 'credit_card', 'correct payment method on report';
         is $new_report->get_extra_field_value('Subscription_Details_Quantity'), 1, 'correct bin count';
         is $new_report->get_extra_field_value('Subscription_Details_Container_Type'), 44, 'correct bin type';
@@ -2156,7 +2153,6 @@ FixMyStreet::override_config {
 
         is $report->category, 'Garden Subscription', 'correct category on report';
         is $report->title, 'Garden Subscription - New', 'correct title on report';
-        is $report->get_extra_field_value('client_reference'), 'GGW1000000002', 'correct client reference on report';
         is $report->get_extra_field_value('payment_method'), 'csc', 'correct payment method on report';
         is $report->get_extra_field_value('Subscription_Details_Quantity'), 1, 'correct bin count';
         is $report->get_extra_field_value('Subscription_Details_Container_Type'), 44, 'correct bin type';
@@ -2246,7 +2242,6 @@ FixMyStreet::override_config {
 
         is $report->category, 'Garden Subscription', 'correct category on report';
         is $report->title, 'Garden Subscription - New', 'correct title on report';
-        is $report->get_extra_field_value('client_reference'), 'GGW1000000002', 'correct client reference on report';
         is $report->get_extra_field_value('payment_method'), 'csc', 'correct payment method on report';
         is $report->get_extra_field_value('Subscription_Details_Quantity'), 1, 'correct bin count';
         is $report->get_extra_field_value('Subscription_Details_Container_Type'), 44, 'correct bin type';


### PR DESCRIPTION
Just a bit of tidying to make it easier for non-GGW modules to use payments code.

[skip changelog]