### PR TITLE
[Peterborough Bulky Goods] Basic implementation of booking wizard & admin config editor

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Waste.pm
@@ -1,0 +1,116 @@
+package FixMyStreet::App::Controller::Admin::Waste;
+
+use JSON::MaybeXS;
+use Moose;
+use Try::Tiny;
+use namespace::autoclean;
+
+BEGIN { extends 'Catalyst::Controller'; }
+
+=head1 NAME
+
+FixMyStreet::App::Controller::Admin::Waste - Catalyst Controller
+
+=head1 DESCRIPTION
+
+Admin pages for configuring WasteWorks parameters
+
+=head1 METHODS
+
+=cut
+
+sub index : Path : Args(0) {
+    my ( $self, $c ) = @_;
+
+    my $user = $c->user;
+
+    if ($user->is_superuser) {
+        $c->forward('fetch_wasteworks_bodies');
+    } elsif ( $user->from_body ) {
+        $c->forward('load_wasteworks_body', [ $user->from_body->id ]);
+        $c->res->redirect( $c->uri_for_action( 'admin/waste/edit', $c->stash->{body}->id ) );
+    } else {
+        $c->detach( '/page_error_404_not_found', [] );
+    }
+}
+
+sub edit : Path : Args(1) {
+    my ( $self, $c, $body_id ) = @_;
+
+    foreach (qw(status_message)) {
+        $c->stash->{$_} = $c->flash->{$_} if $c->flash->{$_};
+    }
+
+    $c->forward('load_wasteworks_body', [ $body_id ]);
+    $c->forward('stash_body_config_json');
+    $c->forward('/auth/get_csrf_token');
+
+    if ($c->req->method eq 'POST') {
+        $c->forward('/auth/check_csrf_token');
+
+        my $new_cfg;
+        try {
+            $new_cfg = JSON->new->utf8(1)->allow_nonref(0)->decode($c->get_param("body_config"));
+        } catch {
+            $c->stash->{errors} ||= {};
+            my $e = $_;
+            $e =~ s/ at \/.*$//; # trim the filename/lineno
+            $c->stash->{errors}->{body_config} = sprintf(_("Not a valid JSON string: %s"), $e);
+            $c->detach;
+        };
+        if (ref $new_cfg ne 'HASH') {
+            $c->stash->{errors} ||= {};
+            $c->stash->{errors}->{body_config} = _("Config must be a JSON object literal, not array.");
+            $c->detach;
+        }
+        $c->stash->{body}->set_extra_metadata("wasteworks_config", $new_cfg);
+        $c->stash->{body}->update;
+        $c->flash->{status_message} = _("Updated!");
+        $c->res->redirect( $c->uri_for_action( '/admin/waste/edit', $c->stash->{body}->id ) );
+    }
+}
+
+sub fetch_wasteworks_bodies : Private {
+    my ( $self, $c ) = @_;
+
+    my @bodies = $c->model('DB::Body')->search(undef, {
+        columns => [ "id", "name", "extra" ],
+    })->active;
+
+    @bodies = grep {
+        $_->get_cobrand_handler &&
+        $_->get_cobrand_handler->feature('waste_features') &&
+        $_->get_cobrand_handler->feature('waste_features')->{admin_config_enabled}
+    } @bodies;
+    $c->stash->{bodies} = \@bodies;
+}
+
+sub stash_body_config_json : Private {
+    my ($self, $c) = @_;
+
+    if ( my $new_cfg = $c->get_param("body_config") ) {
+        $c->stash->{body_config_json} = $new_cfg;
+    } else {
+        my $cfg = $c->stash->{body}->get_extra_metadata("wasteworks_config", {});
+        $c->stash->{body_config_json} = JSON->new->utf8(1)->pretty->canonical->encode($cfg);
+    }
+}
+
+sub load_wasteworks_body : Private {
+    my ($self, $c, $body_id) = @_;
+
+    unless ( $c->user->has_body_permission_to('wasteworks_config', $body_id) ) {
+        $c->detach( '/page_error_404_not_found', [] );
+    }
+
+    # Regular users can only view their own body's config
+    if ( !$c->user->is_superuser && $body_id ne $c->user->from_body->id ) {
+        $c->res->redirect( $c->uri_for_action( '/admin/waste/edit', $c->user->from_body->id ) );
+    }
+
+    $c->stash->{body} = $c->model('DB::Body')->find($body_id)
+        or $c->detach( '/page_error_404_not_found', [] );
+}
+
+
+1;

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -14,6 +14,7 @@ use FixMyStreet::App::Form::Waste::Request::Peterborough;
 use FixMyStreet::App::Form::Waste::Report;
 use FixMyStreet::App::Form::Waste::Problem;
 use FixMyStreet::App::Form::Waste::Enquiry;
+use FixMyStreet::App::Form::Waste::Bulky;
 use FixMyStreet::App::Form::Waste::Garden;
 use FixMyStreet::App::Form::Waste::Garden::Modify;
 use FixMyStreet::App::Form::Waste::Garden::Cancel;
@@ -981,6 +982,24 @@ sub check_if_staff_can_pay : Private {
 
     return 1;
 }
+
+sub bulky_setup : Chained('property') : PathPart('') : CaptureArgs(0) {
+    my ($self, $c) = @_;
+
+    unless ($c->stash->{waste_features}->{bulky_enabled}) {
+        $c->res->redirect('/waste/' . $c->stash->{property}{id});
+        $c->detach;
+    }
+}
+
+sub bulky : Chained('bulky_setup') : Args(0) {
+    my ($self, $c) = @_;
+
+    $c->stash->{first_page} = 'intro';
+    $c->stash->{form_class} = 'FixMyStreet::App::Form::Waste::Bulky';
+    $c->forward('form');
+}
+
 
 sub garden_setup : Chained('property') : PathPart('') : CaptureArgs(0) {
     my ($self, $c) = @_;

--- a/perllib/FixMyStreet/App/Form/Page/Simple.pm
+++ b/perllib/FixMyStreet/App/Form/Page/Simple.pm
@@ -5,6 +5,9 @@ extends 'HTML::FormHandler::Page';
 # What page to go to after successful submission of this page
 has next => ( is => 'ro', isa => 'Str|CodeRef' );
 
+# Optional template to display at the top of this page
+has intro => ( is => 'ro', isa => 'Str' );
+
 # A function that will be called to generate an update_field_list parameter
 has update_field_list => (
     is => 'ro',

--- a/perllib/FixMyStreet/App/Form/Page/Wizard.pm
+++ b/perllib/FixMyStreet/App/Form/Page/Wizard.pm
@@ -5,9 +5,6 @@ extends 'FixMyStreet::App::Form::Page::Simple';
 # Title to use for this page
 has title => ( is => 'ro', isa => 'Str' );
 
-# Optional template to display at the top of this page
-has intro => ( is => 'ro', isa => 'Str' );
-
 # Special template to use in preference to the default
 has template => ( is => 'ro', isa => 'Str' );
 

--- a/perllib/FixMyStreet/App/Form/Waste.pm
+++ b/perllib/FixMyStreet/App/Form/Waste.pm
@@ -18,6 +18,7 @@ before _process_page_array => sub {
 # Add some functions to the form to pass through to the current page
 has '+current_page' => (
     handles => {
+        intro_template => 'intro',
         title => 'title',
         template => 'template',
     }

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -1,0 +1,127 @@
+package FixMyStreet::App::Form::Waste::Bulky;
+
+use utf8;
+use HTML::FormHandler::Moose;
+extends 'FixMyStreet::App::Form::Waste';
+
+has_page intro => (
+    title => 'Book bulky goods collection',
+    intro => 'bulky/intro.html',
+    fields => ['continue'],
+    next => 'residency_check',
+);
+
+has_page residency_check => (
+    title => 'Book bulky goods collection',
+    fields => ['resident', 'continue'],
+    next => 'about_you',
+);
+
+has_page about_you => (
+    fields => ['name', 'email', 'phone', 'continue'],
+    title => 'About you',
+    next => 'choose_date',
+);
+
+with 'FixMyStreet::App::Form::Waste::AboutYou';
+
+has_page choose_date => (
+    fields => ['continue', 'chosen_date'],
+    title => 'Choose date for collection',
+    next => 'add_items',
+);
+
+has_page add_items => (
+    fields => ['continue', 'item1', 'item2', 'item3', 'item4', 'item5'], # XXX build list dynamically
+    title => 'Add items for collection',
+    next => 'summary',
+);
+
+
+has_page summary => (
+    fields => ['submit', 'tandc'],
+    title => 'Submit collection booking',
+    template => 'waste/bulky/summary.html',
+    next => 'done',
+);
+
+has_page done => (
+    title => 'Collection booked',
+    template => 'waste/bulky/confirmation.html',
+);
+
+
+has_field continue => (
+    type => 'Submit',
+    value => 'Continue',
+    element_attr => { class => 'govuk-button' },
+    order => 999,
+);
+
+has_field submit => (
+    type => 'Submit',
+    value => 'Continue to payment',
+    element_attr => { class => 'govuk-button' },
+    order => 999,
+);
+
+has_field resident => (
+    type => 'Select',
+    widget => 'RadioGroup',
+    required => 1,
+    label => 'Are you the resident of this property or booking on behalf of the property resident?',
+    options => [
+        { label => 'Yes', value => 'Yes' },
+        { label => 'No', value => 'No' },
+    ],
+);
+
+has_field chosen_date => (
+    type => 'Select',
+    widget => 'RadioGroup',
+    required => 1,
+    label => 'Available dates',
+    options => [
+        # XXX look these up dynamically
+        { value => '20220825', label => '2022-08-25' },
+        { value => '20220826', label => '2022-08-26' },
+        { value => '20220827', label => '2022-08-27' },
+        { value => '20220828', label => '2022-08-28' },
+    ],
+);
+
+has_field tandc => (
+    type => 'Checkbox',
+    required => 1,
+    label => 'Terms and conditions',
+    option_label => FixMyStreet::Template::SafeString->new(
+        'I agree to the <a href="/about/bulky_terms" target="_blank">terms and conditions</a>',
+    ),
+);
+
+
+# XXX yuck
+sub item_field {
+    (
+        type => 'Select',
+        widget => 'Select',
+        label => 'Item ' . shift,
+        tags => { last_differs => 1, small => 1, autocomplete => 1 },
+        options => [
+            # XXX look these up dynamically
+            { value => 'chair', label => 'Armchair' },
+            { value => 'sofa', label => 'Sofa' },
+            { value => 'table', label => 'Table' },
+            { value => 'fridge', label => 'Fridge' },
+        ],
+    )
+}
+
+# XXX yuck yuck
+has_field item1 => item_field(1);
+has_field item2 => item_field(2);
+has_field item3 => item_field(3);
+has_field item4 => item_field(4);
+has_field item5 => item_field(5);
+
+1;

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -728,6 +728,9 @@ sub admin_pages {
     if ( $user->has_body_permission_to('emergency_message_edit') ) {
         $pages->{emergencymessage} = [ _('Emergency message'), 12 ];
     }
+    if ( $user->has_body_permission_to('wasteworks_config') ) {
+        $pages->{waste} = [ _('WasteWorks config'), 14];
+    }
 
     return $pages;
 }

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -1083,4 +1083,17 @@ sub _format_address {
 
 sub bin_day_format { '%A, %-d~~~ %B %Y' }
 
+sub available_permissions {
+    my $self = shift;
+
+    my $perms = $self->next::method();
+
+    my $features = $self->feature('waste_features') || {};
+    if ( $features->{admin_config_enabled} ) {
+        $perms->{Waste}->{wasteworks_config} = "Can edit WasteWorks configuration";
+    }
+
+    return $perms;
+}
+
 1;

--- a/templates/web/base/admin/waste/edit.html
+++ b/templates/web/base/admin/waste/edit.html
@@ -1,0 +1,31 @@
+[% INCLUDE 'admin/header.html' title=tprintf(loc('WasteWorks Configuration for %s'), body.name) -%]
+[% PROCESS 'admin/report_blocks.html' %]
+
+[% INCLUDE status_message %]
+
+<form method="post">
+    [% IF errors %]
+        <p class="error">[% loc('Please correct the errors below') %]</p>
+    [% END %]
+
+    <p>
+        <label for="body_config">JSON:</label>
+        <small>Use <code>0</code>/<code>1</code> instead of <code>false</code>/<code>true</code>.</small>
+        [% IF errors.body_config %]
+            <div class="form-error">[% errors.body_config %]</div>
+        [% END %]
+        <textarea cols="80" rows="15" required name="body_config" class="code">
+            [%~ body_config_json ~%]
+        </textarea>
+    </p>
+    <p>
+        <input type="hidden" name="token" value="[% csrf_token %]" >
+        <input type="submit" class="btn" value="Save changes" />
+    </p>
+</form>
+
+<p>
+    <a href="[% c.uri_for_action('admin/waste/index') %]">[% loc("&larr; Back") %]</a>
+</p>
+
+[% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/admin/waste/index.html
+++ b/templates/web/base/admin/waste/index.html
@@ -1,0 +1,11 @@
+[% INCLUDE 'admin/header.html' title=loc('WasteWorks Configuration') -%]
+
+<ul>
+    [% FOR body IN bodies %]
+        <li>
+            <a href="[% c.uri_for_action('admin/waste/edit', [ body.id ]) %]">[% body.name %]</a>
+        </li>
+    [% END %]
+</ul>
+
+[% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/waste/bulky/confirmation.html
+++ b/templates/web/base/waste/bulky/confirmation.html
@@ -1,0 +1,20 @@
+[% SET title = form.title ~%]
+[% PROCESS 'waste/header.html' %]
+
+<div class="govuk-panel govuk-panel--confirmation">
+    <h1 class="govuk-panel__title">
+        [% title %]
+    </h1>
+    <div class="govuk-panel__body">
+        <p>Your [% title | lower %];
+          [% IF report.user.email && report.get_extra_metadata('contributed_as') != 'anonymous_user' %]
+            a copy has been sent to your email address, [% report.user.email %].
+          [% END %]
+        </p>
+        <p>
+          [% INCLUDE 'waste/_report_ids.html' %]
+        </p>
+    </div>
+</div>
+
+[% INCLUDE footer.html %]

--- a/templates/web/base/waste/bulky/intro.html
+++ b/templates/web/base/waste/bulky/intro.html
@@ -1,0 +1,9 @@
+<h3>Before you start your booking</h3>
+<ol>
+    <li>Requesting a bulky waste collection usually takes approximately <strong>X minutes</strong></li>
+    <li>You can request up to <strong>5 items per collection</strong></li>
+    <li>In order to help us with your collection, we will ask you to optionally add pictures of the items to be collected and the location</li>
+    <li>Before confirming your booking, check all the info provided is correct</li>
+    <li>You can cancel your booking anytime up until 23:55 the day before the collection is scheduled</li>
+    <li><strong>Cancellations made more than 24 hours</strong> before collection is scheduled are entitled to a refund.</li>
+</ol>

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -1,0 +1,20 @@
+[%
+title = 'Submit bulky goods collection booking';
+thing = 'bulky goods collection booking';
+summary_title = 'Bulky goods collection';
+step1 = 'report';
+%]
+
+[% BLOCK answers %]
+  [% FOR item IN data.keys.grep('^item') %]
+    [% NEXT UNLESS data.$item %]
+    <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key govuk-summary-list__key--sub">[% item %]</dt>
+        <dd class="govuk-summary-list__value">
+          [%~ data.$item ~%]
+        </dd>
+    </div>
+  [% END %]
+[% END %]
+
+[% PROCESS waste/summary.html %]

--- a/templates/web/base/waste/index.html
+++ b/templates/web/base/waste/index.html
@@ -8,6 +8,9 @@
   [% IF property %]
     [% INCLUDE 'waste/_address_display.html' %]
   [% END %]
+
+  [% IF form.intro_template %][% PROCESS "waste/${form.intro_template}" %][% END %]
+
 <form class="waste" method="post">
   [% PROCESS form %]
 </form>

--- a/templates/web/peterborough/waste/_more_services_sidebar.html
+++ b/templates/web/peterborough/waste/_more_services_sidebar.html
@@ -34,6 +34,11 @@
           </form>
     </li>
   [% END %]
+  [% IF waste_features.bulky_enabled %]
+    <li>
+        <a href="[% c.uri_for_action('waste/bulky', [ property.id ]) %]">Book bulky goods collection</a>
+    </li>
+  [% END %]
 </ul>
 
 <h3>Help</h3>

--- a/templates/web/peterborough/waste/index.html
+++ b/templates/web/peterborough/waste/index.html
@@ -4,6 +4,7 @@
   [% PROCESS back %]
   [% PROCESS errors %]
   [% PROCESS title %]
+
   [% IF form.current_page.name == 'about_you' %]
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
@@ -15,9 +16,13 @@
       </div>
     </div>
   [% END %]
+
   [% IF property %]
     [% INCLUDE 'waste/_address_display.html' %]
   [% END %]
+
+  [% IF form.intro_template %][% PROCESS "waste/${form.intro_template}" %][% END %]
+
   <form class="waste" method="post">
     [% UNLESS property %]
     <div class="govuk-grid-row">

--- a/web/cobrands/sass/_admin.scss
+++ b/web/cobrands/sass/_admin.scss
@@ -323,3 +323,8 @@ $button_bg_col: #a1a1a1;  // also search bar (tables)
     max-height: initial;
   }
 }
+
+textarea.code {
+    font-family: monospace;
+    max-width: initial;
+}


### PR DESCRIPTION
This implements the basic wizard for booking a bulky collection, albeit with lots of hardcoded values and behaviour that is not yet correct according to the tech spec.

It's behind a feature flag that must be enabled:

```
COBRAND_FEATURES:
  waste_features:
    peterborough:
      bulky_enabled: 1
```

There is also an config editor for admins that will allow certain aspects of the bulky goods system to be controlled. This was reviewed in https://github.com/mysociety/fixmystreet/pull/4090 (though I've moved the new permission from `Default::available_permissions` to `Peterborough::available_permissions` and put it behind the feature flag). This also needs a feature flag to be active:

```
COBRAND_FEATURES:
  waste_features:
    peterborough:
      admin_config_enabled: 1
```

Per recent discussion I thought having this merged to master will make collaborating on subsequent features easier and reduce the code review burden ahead of go-live.

[skip changelog]