### PR TITLE
[UK] Fix crash on /admin/config for cobrands that don’t define report_sent_confirmation_email

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -451,6 +451,7 @@ sub disable_phone_number_entry { 1 }
 
 sub report_sent_confirmation_email {
     my ($self, $report) = @_;
+    return 'FMS ID if emailed, external ID otherwise' unless $report; # for /admin/config
     return $report->external_id ? 'external_id' : 'id';
 }
 

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -321,6 +321,7 @@ sub social_auth_disabled { 1 }
 # only for Waste reports
 sub report_sent_confirmation_email {
     my ($self, $report) = @_;
+    return 'Report ID if WasteWorks report' unless $report; # no report passed when called from /admin/config template
     my $contact = $report->contact or return;
     return 'id' if $report->contact->get_extra_metadata('type', '') eq 'waste';
     return '';


### PR DESCRIPTION
e.g. Peterborough

[skip changelog]