### PR TITLE
Peterborough bulky goods: implement form for item selection

### DIFF
--- a/perllib/FixMyStreet/App/Form/Field/FileIdPhoto.pm
+++ b/perllib/FixMyStreet/App/Form/Field/FileIdPhoto.pm
@@ -20,7 +20,7 @@ sub validate {
     my $field = $self->linked_field;
     $self->form->process_photo($field);
     my $value = $self->form->saved_data->{$field};
-    my @parts = split(/,/, $value);
+    my @parts = split /,/, ( $value // '' );
     if ($self->num_photos_required && scalar @parts != $self->num_photos_required) {
         my $num = $self->num_photos_required;
         my $word = NUMWORDS($num);

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -5,6 +5,8 @@ use DateTime::Format::Strptime;
 use HTML::FormHandler::Moose;
 extends 'FixMyStreet::App::Form::Waste';
 
+use constant MAX_ITEMS => 5;
+
 has_page intro => (
     title => 'Book bulky goods collection',
     intro => 'bulky/intro.html',
@@ -55,9 +57,10 @@ has_page choose_date_later => (
 );
 
 has_page add_items => (
-    fields => ['continue', 'item1', 'item2', 'item3', 'item4', 'item5'], # XXX build list dynamically
-    title => 'Add items for collection',
-    next => 'location',
+    fields   => [ 'continue', map {"item_$_"} ( 1 .. MAX_ITEMS ) ],
+    template => 'waste/bulky/items.html',
+    title    => 'Add items for collection',
+    next     => 'location',
 );
 
 has_page location => (
@@ -65,7 +68,6 @@ has_page location => (
     fields => ['location', 'location_photo', 'location_photo_fileid', 'continue'],
     next => 'summary',
 );
-
 
 has_page summary => (
     fields => ['submit', 'tandc'],
@@ -182,43 +184,125 @@ has_field show_earlier_dates => (
     order => 998,
 );
 
-sub validate {
-    my $self = shift;
+# Item selection code
 
-    if ( $self->current_page->name =~ /choose_date/ ) {
-        my $next_page
-            = $self->current_page->next->( undef, $self->c->req->params );
+# List as fetched from cobrand, before munging
+has items_master_list => (
+    is      => 'ro',
+    isa     => 'ArrayRef',
+    lazy    => 1,
+    builder => '_build_items_master_list',
+);
 
-        if ( $next_page eq 'add_items' ) {
-            $self->field('chosen_date')
-                ->add_error('Available dates field is required')
-                if !$self->field('chosen_date')->value;
-        }
-    }
+sub _build_items_master_list {
+    $_[0]->c->cobrand->call_hook('bulky_items_master_list');
 }
 
-after 'process' => sub {
+has items_by_category => (
+    is      => 'ro',
+    isa     => 'HashRef',
+    lazy    => 1,
+    builder => '_build_items_by_category',
+);
+
+sub _build_items_by_category {
     my $self = shift;
 
-    # XXX Do we want to let the user know there are no available dates
-    # much earlier in the journey?
+    my %hash;
+    for my $item ( @{ $self->items_master_list } ) {
+        push @{ $hash{ $item->{category} } }, $item->{name};
+    }
+    return \%hash;
+}
 
-    # Hide certain fields if no date options
-    if ( $self->current_page->name eq 'choose_date_earlier'
-        && !@{ $self->field('chosen_date')->options } )
-    {
-        $self->field('chosen_date')->inactive(1);
-        $self->field('show_later_dates')->inactive(1);
-        $self->field('continue')->inactive(1);
+# Hash of item names mapped to extra text
+has items_extra_text => (
+    is      => 'ro',
+    isa     => 'HashRef',
+    lazy    => 1,
+    builder => '_build_items_extra_text',
+);
+
+sub _build_items_extra_text {
+    my $self = shift;
+
+    my %hash;
+    for my $item ( @{ $self->items_master_list } ) {
+        $hash{ $item->{name} } = $item->{message} if $item->{message};
+    }
+    return \%hash;
+}
+
+sub format_item_string {
+    my ( $self, $str ) = @_;
+    return lc $str =~ s/\W+/_/gr;
+}
+
+sub field_list {
+    my $self = shift;
+
+    my @field_list;
+
+    for my $num ( 1 .. MAX_ITEMS ) {
+        push @field_list,
+            "item_$num" => {
+            type     => 'Compound',
+            id       => "item_$num",
+            };
+
+        push @field_list, "item_$num.item" => {
+            type           => 'Select',
+            label          => "Item $num",
+            id             => "item_$num.item",
+            empty_select   => 'Please select an item',
+            options_method => sub {
+                my $field = shift;
+
+                # JS autocomplete ignores optgroups, but we want them in case
+                # a user has JS disabled.
+                # In order to display under optgroups, we have to build
+                # data structures like the following:
+                # {   group   => 'First Group',
+                #     options => [
+                #         { value => 1, label => 'One' },
+                #         { value => 2, label => 'Two' },
+                #         { value => 3, label => 'Three' },
+                #     ],
+                # },
+                my @option_groups;
+
+                for my $cat ( sort keys %{ $field->form->items_by_category } )
+                {
+                    my @options;
+
+                    for my $name (
+                        @{ $field->form->items_by_category->{$cat} } )
+                    {
+                        push @options => {
+                            label => $name,
+                            value => $name,
+                        };
+                    }
+
+                    push @option_groups => {
+                        group   => $cat,
+                        options => \@options,
+                    };
+                }
+
+                return \@option_groups;
+            },
+        };
+
+        push @field_list,
+            "item_$num.image" => {
+            type  => 'Upload',
+            label => 'Upload image (optional)',
+            };
     }
 
-    if ( $self->current_page->name eq 'choose_date_later'
-        && !@{ $self->field('chosen_date')->options } )
-    {
-        $self->field('chosen_date')->inactive(1);
-        $self->field('continue')->inactive(1);
-    }
-};
+    return \@field_list;
+}
 
 has_field tandc => (
     type => 'Checkbox',
@@ -264,30 +348,54 @@ has_field location_photo => (
     label => 'Help us by attaching a photo of where the items will be left for collection.',
 );
 
-# XXX yuck
-sub item_field {
-    my $i = shift;
-    (
-        type => 'Select',
-        widget => 'Select',
-        label => 'Item ' . $i,
-        required => $i == 1 ? 1 : 0,
-        tags => { last_differs => 1, small => 1, autocomplete => 1 },
-        options => [
-            # XXX look these up dynamically
-            { value => 'chair', label => 'Armchair' },
-            { value => 'sofa', label => 'Sofa' },
-            { value => 'table', label => 'Table' },
-            { value => 'fridge', label => 'Fridge' },
-        ],
-    )
+sub validate {
+    my $self = shift;
+
+    if ( $self->current_page->name =~ /choose_date/ ) {
+        my $next_page
+            = $self->current_page->next->( undef, $self->c->req->params );
+
+        if ( $next_page eq 'add_items' ) {
+            $self->field('chosen_date')
+                ->add_error('Available dates field is required')
+                if !$self->field('chosen_date')->value;
+        }
+    }
+
+    if ( $self->current_page->name eq 'add_items' ) {
+        for my $num ( 1 .. MAX_ITEMS ) {
+            my $base_field = $self->field("item_$num");
+
+            # Make sure at least item_1 has input
+            $base_field->add_error('Please select an item')
+                if $num == 1 && !$base_field->field('item')->value;
+
+            # XXX Image upload
+        }
+    }
 }
 
-# XXX yuck yuck
-has_field item1 => item_field(1);
-has_field item2 => item_field(2);
-has_field item3 => item_field(3);
-has_field item4 => item_field(4);
-has_field item5 => item_field(5);
+after 'process' => sub {
+    my $self = shift;
+
+    # XXX Do we want to let the user know there are no available dates
+    # much earlier in the journey?
+
+    # Hide certain fields if no date options
+    if ( $self->current_page->name eq 'choose_date_earlier'
+        && !@{ $self->field('chosen_date')->options } )
+    {
+        $self->field('chosen_date')->inactive(1);
+        $self->field('show_later_dates')->inactive(1);
+        $self->field('continue')->inactive(1);
+    }
+
+    if ( $self->current_page->name eq 'choose_date_later'
+        && !@{ $self->field('chosen_date')->options } )
+    {
+        $self->field('chosen_date')->inactive(1);
+        $self->field('continue')->inactive(1);
+    }
+};
 
 1;

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -255,6 +255,7 @@ sub field_list {
             label          => "Item $num",
             id             => "item_$num.item",
             empty_select   => 'Please select an item',
+            tags           => { autocomplete => 1 },
             options_method => sub {
                 my $field = shift;
 

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -295,11 +295,20 @@ sub field_list {
             },
         };
 
-        push @field_list,
-            "item_$num.image" => {
-            type  => 'Upload',
-            label => 'Upload image (optional)',
-            };
+        push @field_list => (
+            "item_$num.photo" => {
+                type  => 'Photo',
+                label => 'Upload image (optional)',
+                tags  => { max_photos => 1 },
+                # XXX Limit to JPG etc.
+                # XXX Save to DB
+            },
+            "item_$num.photo_fileid" => {
+                type                => 'FileIdPhoto',
+                num_photos_required => 0,
+                linked_field        => "item_$num.photo",
+            },
+        );
     }
 
     return \@field_list;

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -5,6 +5,7 @@ use DateTime::Format::Strptime;
 use HTML::FormHandler::Moose;
 extends 'FixMyStreet::App::Form::Waste';
 
+# XXX Remove hardcoded number & fetch from config
 use constant MAX_ITEMS => 5;
 
 has_page intro => (

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -672,53 +672,11 @@ sub _bulky_collection_window {
 }
 
 sub bulky_items_master_list {
-    # XXX Need to fetch from DB
-    return [
-        {   bartec_id => '1001',
-            category  => 'Audio / Visual Elec. equipment',
-            message   => '',
-            name      => 'Amplifiers',
-            price     => '',
-        },
-        {   bartec_id => '1001',
-            category  => 'Audio / Visual Elec. equipment',
-            message   => '',
-            name      => 'DVD/BR Video players',
-            price     => '',
-        },
-        {   bartec_id => '1001',
-            category  => 'Audio / Visual Elec. equipment',
-            message   => '',
-            name      => 'HiFi Stereos',
-            price     => '',
-        },
+    my $self = shift;
 
-        {   bartec_id => '1002',
-            category  => 'Baby / Toddler',
-            message   => '',
-            name      => 'Childs bed / cot',
-            price     => '',
-        },
-        {   bartec_id => '1002',
-            category  => 'Baby / Toddler',
-            message   => '',
-            name      => 'High chairs',
-            price     => '',
-        },
+    my $cfg  = $self->body->get_extra_metadata( 'wasteworks_config', {} );
 
-        {   bartec_id => '1003',
-            category  => 'Bedroom',
-            message   => '',
-            name      => 'Chest of drawers',
-            price     => '',
-        },
-        {   bartec_id => '1003',
-            category  => 'Bedroom',
-            message   => 'Please dismantle',
-            name      => 'Wardrobes',
-            price     => '',
-        },
-    ];
+    return $cfg->{item_list} || [];
 }
 
 sub bin_services_for_address {
@@ -1140,11 +1098,11 @@ sub waste_munge_bulky_data {
     $data->{extra_DATE} = $data->{chosen_date};
 
     # XXX loop here, plus might be more than 5 in future
-    $data->{extra_ITEM_01} = $data->{item1};
-    $data->{extra_ITEM_02} = $data->{item2};
-    $data->{extra_ITEM_03} = $data->{item3};
-    $data->{extra_ITEM_04} = $data->{item4};
-    $data->{extra_ITEM_05} = $data->{item5};
+    $data->{extra_ITEM_01} = $data->{item_1}{item};
+    $data->{extra_ITEM_02} = $data->{item_2}{item};
+    $data->{extra_ITEM_03} = $data->{item_3}{item};
+    $data->{extra_ITEM_04} = $data->{item_4}{item};
+    $data->{extra_ITEM_05} = $data->{item_5}{item};
 
     $data->{extra_CHARGEABLE} = 'CHARGED'; # XXX not necessarily true
 

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -671,6 +671,56 @@ sub _bulky_collection_window {
     };
 }
 
+sub bulky_items_master_list {
+    # XXX Need to fetch from DB
+    return [
+        {   bartec_id => '1001',
+            category  => 'Audio / Visual Elec. equipment',
+            message   => '',
+            name      => 'Amplifiers',
+            price     => '',
+        },
+        {   bartec_id => '1001',
+            category  => 'Audio / Visual Elec. equipment',
+            message   => '',
+            name      => 'DVD/BR Video players',
+            price     => '',
+        },
+        {   bartec_id => '1001',
+            category  => 'Audio / Visual Elec. equipment',
+            message   => '',
+            name      => 'HiFi Stereos',
+            price     => '',
+        },
+
+        {   bartec_id => '1002',
+            category  => 'Baby / Toddler',
+            message   => '',
+            name      => 'Childs bed / cot',
+            price     => '',
+        },
+        {   bartec_id => '1002',
+            category  => 'Baby / Toddler',
+            message   => '',
+            name      => 'High chairs',
+            price     => '',
+        },
+
+        {   bartec_id => '1003',
+            category  => 'Bedroom',
+            message   => '',
+            name      => 'Chest of drawers',
+            price     => '',
+        },
+        {   bartec_id => '1003',
+            category  => 'Bedroom',
+            message   => 'Please dismantle',
+            name      => 'Wardrobes',
+            price     => '',
+        },
+    ];
+}
+
 sub bin_services_for_address {
     my $self = shift;
     my $property = shift;

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -683,6 +683,58 @@ FixMyStreet::override_config {
 }, sub {
     my ($b, $jobs_fsd_get) = shared_bartec_mocks();
 
+    $body->set_extra_metadata(
+        wasteworks_config => {
+            item_list => [
+                {   bartec_id => '1001',
+                    category  => 'Audio / Visual Elec. equipment',
+                    message   => '',
+                    name      => 'Amplifiers',
+                    price     => '',
+                },
+                {   bartec_id => '1001',
+                    category  => 'Audio / Visual Elec. equipment',
+                    message   => '',
+                    name      => 'DVD/BR Video players',
+                    price     => '',
+                },
+                {   bartec_id => '1001',
+                    category  => 'Audio / Visual Elec. equipment',
+                    message   => '',
+                    name      => 'HiFi Stereos',
+                    price     => '',
+                },
+
+                {   bartec_id => '1002',
+                    category  => 'Baby / Toddler',
+                    message   => '',
+                    name      => 'Childs bed / cot',
+                    price     => '',
+                },
+                {   bartec_id => '1002',
+                    category  => 'Baby / Toddler',
+                    message   => '',
+                    name      => 'High chairs',
+                    price     => '',
+                },
+
+                {   bartec_id => '1003',
+                    category  => 'Bedroom',
+                    message   => '',
+                    name      => 'Chest of drawers',
+                    price     => '',
+                },
+                {   bartec_id => '1003',
+                    category  => 'Bedroom',
+                    message   => 'Please dismantle',
+                    name      => 'Wardrobes',
+                    price     => '',
+                },
+            ],
+        },
+    );
+    $body->update;
+
     subtest 'Bulky goods collection booking' => sub {
         # XXX NB Currently, these tests do not describe the correct
         # behaviour of the system. They are here to remind us to update them as
@@ -789,9 +841,9 @@ FixMyStreet::override_config {
             is $report->get_extra_field_value('DATE'), '2022-08-26T00:00:00';
             is $report->get_extra_field_value('CREW NOTES'), 'behind the hedge in the front garden';
             is $report->get_extra_field_value('CHARGEABLE'), 'CHARGED';
-            is $report->get_extra_field_value('ITEM_01'), '';
-            is $report->get_extra_field_value('ITEM_02'), '';
-            is $report->get_extra_field_value('ITEM_03'), '';
+            is $report->get_extra_field_value('ITEM_01'), 'Amplifiers';
+            is $report->get_extra_field_value('ITEM_02'), 'High chairs';
+            is $report->get_extra_field_value('ITEM_03'), 'Wardrobes';
             is $report->get_extra_field_value('ITEM_04'), '';
             is $report->get_extra_field_value('ITEM_05'), '';
         };
@@ -817,6 +869,8 @@ FixMyStreet::override_config {
         }
     },
 }, sub {
+    $body->set_extra_metadata( wasteworks_config => undef );
+    $body->update;
 
     subtest 'WasteWorks configuration editing' => sub {
         ok $mech->host('peterborough.fixmystreet.com');

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -735,14 +735,21 @@ FixMyStreet::override_config {
             $mech->content_contains('Item 3');
             $mech->content_contains('Item 4');
             $mech->content_contains('Item 5');
-            $mech->content_contains('<option value="chair">Armchair</option>');
-            $mech->submit_form_ok({ with_fields => {
-                item1 => 'fridge',
-                item2 => 'chair',
-                item3 => 'sofa',
-                item4 => 'table',
-                item5 => 'fridge',
-            }});
+            $mech->content_like(
+                qr/<option value="Amplifiers".*>Amplifiers<\/option>/);
+
+            $mech->submit_form_ok;
+            $mech->content_contains(
+                'Please select an item');
+
+            $mech->submit_form_ok(
+                {   with_fields => {
+                        'item_1.item' => 'Amplifiers',
+                        'item_2.item' => 'High chairs',
+                        'item_3.item' => 'Wardrobes',
+                    },
+                },
+            );
         };
 
         subtest 'Location details page' => sub {
@@ -756,7 +763,12 @@ FixMyStreet::override_config {
             $mech->content_contains('Submit bulky goods collection booking');
             $mech->content_contains('Please review the information');
             $mech->content_contains('provided before you submit your bulky goods collection booking.');
-            $mech->content_contains('<dd class="govuk-summary-list__value">table</dd>');
+            $mech->content_contains('Please review the information you’ve provided before you submit your bulky goods collection booking.');
+            $mech->content_like(qr/<dd class="govuk-summary-list__value">.*Amplifiers/s);
+            $mech->content_like(qr/<dd class="govuk-summary-list__value">.*High chairs/s);
+            $mech->content_like(qr/<dd class="govuk-summary-list__value">.*Wardrobes/s);
+            # Extra text for wardrobes
+            $mech->content_like(qr/Please dismantle/s);
             $mech->submit_form_ok({ with_fields => { tandc => 1 } });
         };
 
@@ -777,11 +789,11 @@ FixMyStreet::override_config {
             is $report->get_extra_field_value('DATE'), '2022-08-26T00:00:00';
             is $report->get_extra_field_value('CREW NOTES'), 'behind the hedge in the front garden';
             is $report->get_extra_field_value('CHARGEABLE'), 'CHARGED';
-            is $report->get_extra_field_value('ITEM_01'), 'fridge';
-            is $report->get_extra_field_value('ITEM_02'), 'chair';
-            is $report->get_extra_field_value('ITEM_03'), 'sofa';
-            is $report->get_extra_field_value('ITEM_04'), 'table';
-            is $report->get_extra_field_value('ITEM_05'), 'fridge';
+            is $report->get_extra_field_value('ITEM_01'), '';
+            is $report->get_extra_field_value('ITEM_02'), '';
+            is $report->get_extra_field_value('ITEM_03'), '';
+            is $report->get_extra_field_value('ITEM_04'), '';
+            is $report->get_extra_field_value('ITEM_05'), '';
         };
 
     };

--- a/t/forms/waste/bulky.t
+++ b/t/forms/waste/bulky.t
@@ -1,0 +1,28 @@
+use FixMyStreet::App::Form::Waste::Bulky;
+use FixMyStreet::Cobrand::Peterborough;
+use Test::MockObject;
+use Test::More;
+
+my $req = Test::MockObject->new;
+$req->mock( params => sub { {} } );
+
+my $c = Test::MockObject->new;
+$c->mock( req => sub {$req} );
+
+# Peterborough
+my $cobrand = FixMyStreet::Cobrand::Peterborough->new;
+$c->mock( cobrand => sub {$cobrand} );
+my $form = FixMyStreet::App::Form::Waste::Bulky->new(
+    c         => $c,
+    page_name => 'add_items',
+);
+
+is_deeply $form->items_by_category => {
+    'Audio / Visual Elec. equipment' =>
+        [ 'Amplifiers', 'DVD/BR Video players', 'HiFi Stereos' ],
+    'Baby / Toddler' => [ 'Childs bed / cot', 'High chairs' ],
+    'Bedroom'        => [ 'Chest of drawers', 'Wardrobes' ]
+};
+is_deeply $form->items_extra_text => { 'Wardrobes' => 'Please dismantle' };
+
+done_testing;

--- a/t/forms/waste/bulky.t
+++ b/t/forms/waste/bulky.t
@@ -1,7 +1,10 @@
 use FixMyStreet::App::Form::Waste::Bulky;
 use FixMyStreet::Cobrand::Peterborough;
+use FixMyStreet::TestMech;
 use Test::MockObject;
 use Test::More;
+
+my $mech = FixMyStreet::TestMech->new;
 
 my $req = Test::MockObject->new;
 $req->mock( params => sub { {} } );
@@ -10,6 +13,61 @@ my $c = Test::MockObject->new;
 $c->mock( req => sub {$req} );
 
 # Peterborough
+my $body = $mech->create_body_ok(
+    2566,
+    'Peterborough City Council',
+    {},
+    {   cobrand           => 'peterborough',
+        wasteworks_config => {
+            item_list => [
+                {   bartec_id => '1001',
+                    category  => 'Audio / Visual Elec. equipment',
+                    message   => '',
+                    name      => 'Amplifiers',
+                    price     => '',
+                },
+                {   bartec_id => '1001',
+                    category  => 'Audio / Visual Elec. equipment',
+                    message   => '',
+                    name      => 'DVD/BR Video players',
+                    price     => '',
+                },
+                {   bartec_id => '1001',
+                    category  => 'Audio / Visual Elec. equipment',
+                    message   => '',
+                    name      => 'HiFi Stereos',
+                    price     => '',
+                },
+
+                {   bartec_id => '1002',
+                    category  => 'Baby / Toddler',
+                    message   => '',
+                    name      => 'Childs bed / cot',
+                    price     => '',
+                },
+                {   bartec_id => '1002',
+                    category  => 'Baby / Toddler',
+                    message   => '',
+                    name      => 'High chairs',
+                    price     => '',
+                },
+
+                {   bartec_id => '1003',
+                    category  => 'Bedroom',
+                    message   => '',
+                    name      => 'Chest of drawers',
+                    price     => '',
+                },
+                {   bartec_id => '1003',
+                    category  => 'Bedroom',
+                    message   => 'Please dismantle',
+                    name      => 'Wardrobes',
+                    price     => '',
+                },
+            ],
+        },
+    },
+);
 my $cobrand = FixMyStreet::Cobrand::Peterborough->new;
 $c->mock( cobrand => sub {$cobrand} );
 my $form = FixMyStreet::App::Form::Waste::Bulky->new(

--- a/templates/web/base/govuk/fields.html
+++ b/templates/web/base/govuk/fields.html
@@ -301,7 +301,7 @@
         <span class="govuk-visually-hidden">Error:</span> [% error %]
     </span>
   [% END %]
-  <div id="form_photos" data-upload-field="[% field.id %]_fileid">
+  <div class="js-photo-fields" data-upload-field="[% field.id %]_fileid" data-max-photos="[% field.get_tag('max_photos') %]">
   [% IF field.fif %]
         [% FOREACH id IN field.fif.split(',') %]
         <img align="right" src="/photo/temp.[% id %]" alt="">

--- a/templates/web/base/govuk/fields.html
+++ b/templates/web/base/govuk/fields.html
@@ -274,7 +274,15 @@
   <select class="govuk-select[% ' js-autocomplete' IF field.get_tag('autocomplete') %]" id="[% field.id %]" name="[% field.html_name %]"[% IF field.required %] required[% END %]>
     [% '<option value=""></option>' IF field.get_tag('autocomplete') %]
     [% FOR item IN field.options %]
-      <option value="[% item.value %]"[% ' selected' IF field.fif == item.value %]>[% item.label %]</option>
+      [% # Select options may be optgrouped %]
+      [% IF item.group %]
+        <optgroup label="[% item.group %]"></optgroup>
+        [% FOR opt IN item.options %]
+          <option value="[% opt.value %]"[% ' selected' IF field.fif == opt.value %]>[% opt.label %]</option>
+        [% END %]
+      [% ELSE  %]
+        <option value="[% item.value %]"[% ' selected' IF field.fif == item.value %]>[% item.label %]</option>
+      [% END %]
 	[% END %]
   </select>
 [% END %]

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -15,7 +15,14 @@
     [% base_field = 'item_' _ num %]
     [% item = base_field _ '.item' %]
     [% PROCESS form override_fields = [ item ] %]
-    [% form.field(base_field).field('image').render | safe %]
+
+    [% # XXX Use override_fields instead of .render %]
+    [% form.field(base_field).field('photo').render | safe %]
+    [% form.field(base_field).field('photo_fileid').render | safe %]
+    [% # photo = base_field _ '.photo' %]
+    [% # photo_fileid = base_field _ '.photo_fileid' %]
+    [% # PROCESS form override_fields = [ item, photo, photo_fileid ] %]
+
     [% PROCESS extra_text num = num %]
     <hr>
   [% END %]

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -11,8 +11,11 @@
 
 <form class="waste" method="post" enctype="multipart/form-data">
   [% FOR num IN [ 1 .. form.MAX_ITEMS ] %]
-    [% form.field( 'item_' _ num ).field('item').renderx( 'element_class', 'js-autocomplete') | safe %]
-    [% form.field( 'item_' _ num ).field('image').render | safe %]
+    [% # Building names beforehand because override_fields does not seem to like them being built inside its arg list %]
+    [% base_field = 'item_' _ num %]
+    [% item = base_field _ '.item' %]
+    [% PROCESS form override_fields = [ item ] %]
+    [% form.field(base_field).field('image').render | safe %]
     [% PROCESS extra_text num = num %]
     <hr>
   [% END %]

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -1,0 +1,30 @@
+[% SET title = form.title ~%]
+[% PROCESS 'waste/header.html' %]
+
+[% PROCESS 'govuk/fields.html' %]
+[% PROCESS back %]
+[% PROCESS errors %]
+[% PROCESS title %]
+[% IF property %]
+  [% INCLUDE 'waste/_address_display.html' %]
+[% END %]
+
+<form class="waste" method="post" enctype="multipart/form-data">
+  [% FOR num IN [ 1 .. form.MAX_ITEMS ] %]
+    [% form.field( 'item_' _ num ).field('item').renderx( 'element_class', 'js-autocomplete') | safe %]
+    [% form.field( 'item_' _ num ).field('image').render | safe %]
+    [% PROCESS extra_text num = num %]
+    <hr>
+  [% END %]
+  [% PROCESS form override_fields = [ 'continue', 'saved_data', 'token', 'process', 'unique_id' ] %]
+</form>
+
+[% # XXX If JS enabled, hide unless relevant item selected %]
+[% BLOCK extra_text %]
+  [% FOR item_desc IN form.items_extra_text.keys %]
+    [% id = 'item_' _ num _ '.' _ form.format_item_string(item_desc) _ '.extra_text' %]
+    <div id="[% id %]"><b>[% item_desc %]: [% form.items_extra_text.$item_desc %]</b></div>
+  [% END %]
+[% END %]
+
+[% INCLUDE footer.html %]

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -14,14 +14,10 @@
     [% # Building names beforehand because override_fields does not seem to like them being built inside its arg list %]
     [% base_field = 'item_' _ num %]
     [% item = base_field _ '.item' %]
-    [% PROCESS form override_fields = [ item ] %]
 
-    [% # XXX Use override_fields instead of .render %]
-    [% form.field(base_field).field('photo').render | safe %]
-    [% form.field(base_field).field('photo_fileid').render | safe %]
-    [% # photo = base_field _ '.photo' %]
-    [% # photo_fileid = base_field _ '.photo_fileid' %]
-    [% # PROCESS form override_fields = [ item, photo, photo_fileid ] %]
+    [% photo = base_field _ '.photo' %]
+    [% photo_fileid = base_field _ '.photo_fileid' %]
+    [% PROCESS form override_fields = [ item, photo, photo_fileid ] %]
 
     [% PROCESS extra_text num = num %]
     <hr>

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -17,7 +17,9 @@ step1 = 'report';
             Notes: [% extra_text %]
             <br>
           [% END %]
-          Image: TODO
+          [% IF item.photo_fileid %]
+          <img src="/photo/temp.[% item.photo_fileid %]" />
+          [% END %]
         </dd>
     </div>
   [% END %]

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -6,12 +6,18 @@ step1 = 'report';
 %]
 
 [% BLOCK answers %]
-  [% FOR item IN data.keys.grep('^item') %]
-    [% NEXT UNLESS data.$item %]
+  [% FOR item_key IN data.keys.grep('^item').sort %]
+    [% item = data.$item_key; NEXT UNLESS item %]
     <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key govuk-summary-list__key--sub">[% item %]</dt>
+        <dt class="govuk-summary-list__key govuk-summary-list__key--sub">[% item_key.ucfirst.replace( '_', ' ' )  %]</dt>
         <dd class="govuk-summary-list__value">
-          [%~ data.$item ~%]
+          [% item.item %]
+          <br>
+          [% extra_text = form.items_extra_text.${item.item}; IF extra_text %]
+            Notes: [% extra_text %]
+            <br>
+          [% END %]
+          Image: TODO
         </dd>
     </div>
   [% END %]

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -754,106 +754,110 @@ $.extend(fixmystreet.set_up, {
       // Internal $context is the individual form with the photo upload inside
       var $context = $(this);
       var $originalLabel = $('[for="form_photo"], .js-photo-label', $context);
-      var $originalInput = $('#form_photos, .js-photo-fields', $context);
-      var $dropzone = $('<div tabindex=0>').addClass('dropzone');
-      var $fileid_input = $originalInput.data('upload-field') || 'upload_fileid';
+      var $originalInputs = $('#form_photos, .js-photo-fields', $context);
+      $originalInputs.each(function() {
+        var $originalInput = $(this);
+        var $dropzone = $('<div tabindex=0>').addClass('dropzone');
+        var $fileid_input = $originalInput.data('upload-field') || 'upload_fileid';
+        var max_photos = !isNaN($originalInput.data('max-photos')) ? $originalInput.data('max-photos') : 3;
 
-      $originalLabel.removeAttr('for');
-      $('[data-plural]', $originalLabel).text(
-          $('[data-plural]', $originalLabel).attr('data-plural')
-      );
-      $originalInput.hide();
+        $originalLabel.removeAttr('for');
+        $('[data-plural]', $originalLabel).text(
+            $('[data-plural]', $originalLabel).attr('data-plural')
+        );
+        $originalInput.hide();
 
-      $dropzone.insertAfter($originalInput);
-      var default_message = translation_strings.upload_default_message;
-      if ($("html").hasClass("mobile")) {
-        default_message = translation_strings.upload_default_message_mobile;
-      }
-      var photodrop = new Dropzone($dropzone[0], {
-        url: '/photo/upload',
-        paramName: 'photo',
-        maxFiles: 3,
-        addRemoveLinks: true,
-        thumbnailHeight: 150,
-        thumbnailWidth: 150,
-        resizeWidth: 2048,
-        resizeHeight: 2048,
-        resizeQuality: 0.6,
-        acceptedFiles: 'image/jpeg,image/pjpeg,image/gif,image/tiff,image/png,.png,.tiff,.tif,.gif,.jpeg,.jpg',
-        dictDefaultMessage: default_message,
-        dictCancelUploadConfirmation: translation_strings.upload_cancel_confirmation,
-        dictInvalidFileType: translation_strings.upload_invalid_file_type,
-        dictMaxFilesExceeded: translation_strings.upload_max_files_exceeded,
-
-        fallback: function() {
-          $dropzone.remove();
-          $originalLabel.attr('for', 'form_photo');
-          $('[data-singular]', $originalLabel).text(
-              $('[data-singular]', $originalLabel).attr('data-singular')
-          );
-          $originalInput.show();
-        },
-        init: function() {
-          this.on("addedfile", function(file) {
-            $('input[type=submit]', $context).prop("disabled", true).removeClass('green-btn');
-          });
-          this.on("queuecomplete", function() {
-            $('input[type=submit]', $context).prop('disabled', false).addClass('green-btn');
-          });
-          this.on("success", function(file, xhrResponse) {
-            var $upload_fileids = $('input[name=' + $fileid_input + ']', $context);
-            var ids = [];
-            // only split if it has a value otherwise you get a spurious empty string
-            // in the array as split returns the whole string if no match
-            if ( $upload_fileids.val() ) {
-                ids = $upload_fileids.val().split(',');
-            }
-            var id = (file.server_id = xhrResponse.id),
-                l = ids.push(id);
-            newstr = ids.join(',');
-            $upload_fileids.val(newstr);
-          });
-          this.on("error", function(file, errorMessage, xhrResponse) {
-          });
-          this.on("removedfile", function(file) {
-            var $upload_fileids = $('input[name=' + $fileid_input + ']', $context);
-            var ids = $upload_fileids.val().split(','),
-                newstr = $.grep(ids, function(n) { return (n!=file.server_id); }).join(',');
-            $upload_fileids.val(newstr);
-          });
-          this.on("maxfilesexceeded", function(file) {
-            this.removeFile(file);
-            var $message = $('<div class="dz-message dz-error-message">');
-            $message.text(translation_strings.upload_max_files_exceeded);
-            $message.prependTo(this.element);
-            setTimeout(function() {
-              $message.slideUp(250, function() {
-                $message.remove();
-              });
-            }, 2000);
-          });
+        $dropzone.insertAfter($originalInput);
+        var default_message = translation_strings.upload_default_message;
+        if ($("html").hasClass("mobile")) {
+            default_message = translation_strings.upload_default_message_mobile;
         }
-      });
+        var photodrop = new Dropzone($dropzone[0], {
+            url: '/photo/upload',
+            paramName: 'photo',
+            maxFiles: max_photos,
+            addRemoveLinks: true,
+            thumbnailHeight: 150,
+            thumbnailWidth: 150,
+            resizeWidth: 2048,
+            resizeHeight: 2048,
+            resizeQuality: 0.6,
+            acceptedFiles: 'image/jpeg,image/pjpeg,image/gif,image/tiff,image/png,.png,.tiff,.tif,.gif,.jpeg,.jpg',
+            dictDefaultMessage: default_message,
+            dictCancelUploadConfirmation: translation_strings.upload_cancel_confirmation,
+            dictInvalidFileType: translation_strings.upload_invalid_file_type,
+            dictMaxFilesExceeded: translation_strings.upload_max_files_exceeded,
 
-      $dropzone.on('keydown', function(e) {
-          if (e.keyCode === 13 || e.keyCode === 32) {
-              $dropzone.trigger('click');
-          }
-      });
-
-      $.each($('input[name=' + $fileid_input + ']', $context).val().split(','), function(i, f) {
-        if (!f) {
-            return;
-        }
-        var mockFile = { name: f, server_id: f, dataURL: '/photo/temp.' + f };
-        photodrop.emit("addedfile", mockFile);
-        photodrop.createThumbnailFromUrl(mockFile,
-            photodrop.options.thumbnailWidth, photodrop.options.thumbnailHeight,
-            photodrop.options.thumbnailMethod, true, function(thumbnail) {
-                photodrop.emit('thumbnail', mockFile, thumbnail);
+            fallback: function() {
+            $dropzone.remove();
+            $originalLabel.attr('for', 'form_photo');
+            $('[data-singular]', $originalLabel).text(
+                $('[data-singular]', $originalLabel).attr('data-singular')
+            );
+            $originalInput.show();
+            },
+            init: function() {
+            this.on("addedfile", function(file) {
+                $('input[type=submit]', $context).prop("disabled", true).removeClass('green-btn');
             });
-        photodrop.emit("complete", mockFile);
-        photodrop.options.maxFiles -= 1;
+            this.on("queuecomplete", function() {
+                $('input[type=submit]', $context).prop('disabled', false).addClass('green-btn');
+            });
+            this.on("success", function(file, xhrResponse) {
+                var $upload_fileids = $('input[name="' + $fileid_input + '"]', $context);
+                var ids = [];
+                // only split if it has a value otherwise you get a spurious empty string
+                // in the array as split returns the whole string if no match
+                if ( $upload_fileids.val() ) {
+                    ids = $upload_fileids.val().split(',');
+                }
+                var id = (file.server_id = xhrResponse.id),
+                    l = ids.push(id);
+                newstr = ids.join(',');
+                $upload_fileids.val(newstr);
+            });
+            this.on("error", function(file, errorMessage, xhrResponse) {
+            });
+            this.on("removedfile", function(file) {
+                var $upload_fileids = $('input[name="' + $fileid_input + '"]', $context);
+                var ids = $upload_fileids.val().split(','),
+                    newstr = $.grep(ids, function(n) { return (n!=file.server_id); }).join(',');
+                $upload_fileids.val(newstr);
+            });
+            this.on("maxfilesexceeded", function(file) {
+                this.removeFile(file);
+                var $message = $('<div class="dz-message dz-error-message">');
+                $message.text(translation_strings.upload_max_files_exceeded);
+                $message.prependTo(this.element);
+                setTimeout(function() {
+                $message.slideUp(250, function() {
+                    $message.remove();
+                });
+                }, 2000);
+            });
+            }
+        });
+
+        $dropzone.on('keydown', function(e) {
+            if (e.keyCode === 13 || e.keyCode === 32) {
+                $dropzone.trigger('click');
+            }
+        });
+
+        $.each($('input[name="' + $fileid_input + '"]', $context).val().split(','), function(i, f) {
+            if (!f) {
+                return;
+            }
+            var mockFile = { name: f, server_id: f, dataURL: '/photo/temp.' + f };
+            photodrop.emit("addedfile", mockFile);
+            photodrop.createThumbnailFromUrl(mockFile,
+                photodrop.options.thumbnailWidth, photodrop.options.thumbnailHeight,
+                photodrop.options.thumbnailMethod, true, function(thumbnail) {
+                    photodrop.emit('thumbnail', mockFile, thumbnail);
+                });
+            photodrop.emit("complete", mockFile);
+            photodrop.options.maxFiles -= 1;
+        });
       });
     });
   },


### PR DESCRIPTION
Closes https://github.com/mysociety/societyworks/issues/3245.

Items for selection are fetched from the database (admin can provide item list via `/admin/waste/<pbro_body_id>`); user can  select up to 5 items (one item per dropdown), as well as optionally upload one image per item.

This PR does not handle saving booking details to the database - see https://github.com/mysociety/fixmystreet/pull/4127.

<img width="537" alt="Screenshot 2022-10-18 at 11 28 21" src="https://user-images.githubusercontent.com/11098355/196406217-9358bc55-ed79-4f5c-8769-3445881fb07d.png">

[skip changelog]