### PR TITLE
[Peterborough] Speed up WasteWorks by calling Bartec API in parallel

### DIFF
--- a/bin/fixmystreet.com/call-wasteworks-backend
+++ b/bin/fixmystreet.com/call-wasteworks-backend
@@ -29,7 +29,7 @@ my ($opts, $usage) = describe_options(
     ['help|h', "print usage message and exit" ],
 );
 $usage->die if $opts->help;
-$usage->die unless $opts->cobrand && $opts->out && $opts->calls && $opts->backend;
+$usage->die unless $opts->cobrand && $opts->calls && $opts->backend;
 
 my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker($opts->cobrand)->new;
 my $cfg = $cobrand->feature($opts->backend);
@@ -39,4 +39,8 @@ my $integration = $class->new(%$cfg);
 
 my $calls = decode_json($opts->calls);
 $calls = $integration->_parallel_api_calls(@$calls);
-Storable::store($calls, $opts->out);
+if ($opts->out) {
+    Storable::store($calls, $opts->out);
+} else {
+    print encode_json($calls);
+}

--- a/bin/fixmystreet.com/call-wasteworks-backend
+++ b/bin/fixmystreet.com/call-wasteworks-backend
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
-# call-echo
-# Call the Echo API in parallel
+# call-wasteworks-backend
+# Call the Echo or Bartec API in parallel
 
 use v5.14;
 use warnings;
@@ -17,22 +17,26 @@ use Getopt::Long::Descriptive;
 use JSON::MaybeXS;
 use Storable;
 use Integrations::Echo;
+use Integrations::Bartec;
 use FixMyStreet::Cobrand;
 
 my ($opts, $usage) = describe_options(
     '%c %o',
     ['cobrand=s', 'which cobrand configuration to use'],
+    ['backend=s', 'which backend type (echo/bartec)'],
     ['out=s', 'where to output data'],
     ['calls=s', 'JSON of what API calls to make'],
     ['help|h', "print usage message and exit" ],
 );
 $usage->die if $opts->help;
-$usage->die unless $opts->cobrand && $opts->out && $opts->calls;
+$usage->die unless $opts->cobrand && $opts->out && $opts->calls && $opts->backend;
 
 my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker($opts->cobrand)->new;
-my $cfg = $cobrand->feature('echo');
-my $echo = Integrations::Echo->new(%$cfg);
+my $cfg = $cobrand->feature($opts->backend);
+
+my $class = $opts->backend eq 'echo' ? 'Integrations::Echo' : 'Integrations::Bartec';
+my $integration = $class->new(%$cfg);
 
 my $calls = decode_json($opts->calls);
-$calls = $echo->_parallel_api_calls(@$calls);
+$calls = $integration->_parallel_api_calls(@$calls);
 Storable::store($calls, $opts->out);

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -581,7 +581,7 @@ sub property : Chained('/') : PathPart('waste') : CaptureArgs(1) {
     $c->forward('/auth/get_csrf_token');
 
     # clear this every time they visit this page to stop stale content.
-    if ( $c->req->path =~ m#^waste/\d+$# ) {
+    if ( $c->req->path =~ m#^waste/[:\w ]+$#i ) {
         $c->cobrand->call_hook( clear_cached_lookups_property => $id );
     }
 

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -414,6 +414,15 @@ sub clear_cached_lookups_postcode {
     delete $self->{c}->session->{$key};
 }
 
+sub clear_cached_lookups_property {
+    my ($self, $uprn) = @_;
+
+    foreach ( qw/look_up_property bin_services_for_address property_attributes/ ) {
+        delete $self->{c}->session->{"peterborough:bartec:$_:$uprn"};
+    }
+}
+
+
 sub bin_addresses_for_postcode {
     my $self = shift;
     my $pc = shift;

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -782,6 +782,9 @@ sub open_service_requests_for_uprn {
 sub property_attributes {
     my ($self, $uprn, $bartec) = @_;
 
+    my $key = "peterborough:bartec:property_attributes:$uprn";
+    return $self->{c}->session->{$key} if !FixMyStreet->test_mode && $self->{c}->session->{$key};
+
     unless ($bartec) {
         $bartec = $self->feature('bartec');
         $bartec = Integrations::Bartec->new(%$bartec);
@@ -789,6 +792,8 @@ sub property_attributes {
 
     my $attributes = $bartec->Premises_Attributes_Get($uprn);
     my %attribs = map { $_->{AttributeDefinition}->{Name} => 1 } @$attributes;
+
+    $self->{c}->session->{$key} = \%attribs;
 
     return \%attribs;
 }

--- a/perllib/FixMyStreet/Roles/ParallelAPI.pm
+++ b/perllib/FixMyStreet/Roles/ParallelAPI.pm
@@ -1,0 +1,71 @@
+package FixMyStreet::Roles::ParallelAPI;
+use Moo::Role;
+use JSON::MaybeXS;
+use Parallel::ForkManager;
+use Storable;
+use Time::HiRes;
+
+# ---
+# Calling things in parallel
+
+sub call_api {
+    # Shifting because the remainder of @_ is passed along further down
+    my ($self, $c, $cobrand, $key) = (shift, shift, shift, shift);
+
+    my $type = $self->backend_type;
+    $key = "$cobrand:$type:$key";
+    return $c->session->{$key} if !FixMyStreet->test_mode && $c->session->{$key};
+
+    my $tmp = File::Temp->new;
+    my @cmd = (
+        FixMyStreet->path_to('bin/fixmystreet.com/call-wasteworks-backend'),
+        '--cobrand', $cobrand,
+        '--backend', $type,
+        '--out', $tmp,
+        '--calls', encode_json(\@_),
+    );
+    my $start = Time::HiRes::time();
+
+    # We cannot fork directly under mod_fcgid, so
+    # call an external script that calls back in.
+    my $data;
+    # uncoverable branch false
+    if (FixMyStreet->test_mode || $self->sample_data) {
+        $data = $self->_parallel_api_calls(@_);
+    } else {
+        # uncoverable statement
+        system(@cmd);
+        $data = Storable::fd_retrieve($tmp);
+    }
+    $c->session->{$key} = $data;
+    my $time = Time::HiRes::time() - $start;
+    $c->log->info("[$cobrand] call_api $key took $time seconds");
+    return $data;
+}
+
+sub _parallel_api_calls {
+    my $self = shift;
+
+    my %calls;
+    # uncoverable branch false
+    my $pm = Parallel::ForkManager->new(FixMyStreet->test_mode || $self->sample_data ? 0 : 10);
+    $pm->run_on_finish(sub {
+        my ($pid, $exit_code, $ident, $exit_signal, $core_dump, $data) = @_;
+        %calls = ( %calls, %$data );
+    });
+
+    while (@_) {
+        my $call = shift;
+        my $args = shift;
+        $pm->start and next;
+        my $result = $self->$call(@$args);
+        my $key = "$call @$args";
+        $key = $call if $call eq 'GetTasks';
+        $pm->finish(0, { $key => $result });
+    }
+    $pm->wait_all_children;
+
+    return \%calls;
+}
+
+1;

--- a/perllib/FixMyStreet/Roles/ParallelAPI.pm
+++ b/perllib/FixMyStreet/Roles/ParallelAPI.pm
@@ -60,7 +60,7 @@ sub _parallel_api_calls {
         $pm->start and next;
         my $result = $self->$call(@$args);
         my $key = "$call @$args";
-        $key = $call if $call eq 'GetTasks';
+        $key = $call if ( $call eq 'GetTasks' && $self->backend_type eq 'echo' );
         $pm->finish(0, { $key => $result });
     }
     $pm->wait_all_children;

--- a/perllib/Integrations/Bartec.pm
+++ b/perllib/Integrations/Bartec.pm
@@ -9,6 +9,7 @@ use Moo;
 use FixMyStreet;
 
 with 'FixMyStreet::Roles::SOAPIntegration';
+with 'FixMyStreet::Roles::ParallelAPI';
 
 has attr => ( is => 'ro', default => 'http://bartec-systems.com/' );
 has action => ( is => 'lazy', default => sub { $_[0]->attr . "/Service/" } );
@@ -55,6 +56,8 @@ has token => (
         return $token;
     },
 );
+
+has backend_type => ( is => 'ro', default => 'bartec' );
 
 sub call {
     my ($self, $method, @params) = @_;

--- a/perllib/Integrations/Echo.pm
+++ b/perllib/Integrations/Echo.pm
@@ -4,12 +4,10 @@ use Moo;
 use strict;
 use warnings;
 with 'FixMyStreet::Roles::SOAPIntegration';
+with 'FixMyStreet::Roles::ParallelAPI';
 
 use DateTime;
 use File::Temp;
-use JSON::MaybeXS;
-use Parallel::ForkManager;
-use Storable;
 use FixMyStreet;
 
 has attr => ( is => 'ro', default => 'http://www.twistedfish.com/xmlns/echo/api/v1' );
@@ -50,6 +48,8 @@ has security => (
         );
     },
 );
+
+has backend_type => ( is => 'ro', default => 'echo' );
 
 sub action_hdr {
     my ($self, $method) = @_;
@@ -455,67 +455,6 @@ sub dt_to_hash {
         'dataContract:OffsetMinutes' => $dt->offset / 60,
     );
     return $dt;
-}
-
-# ---
-# Calling things in parallel
-
-sub call_api {
-    # Shifting because the remainder of @_ is passed along further down
-    my ($self, $c, $cobrand, $key) = (shift, shift, shift, shift);
-
-    $key = "$cobrand:echo:$key";
-    return $c->session->{$key} if !FixMyStreet->test_mode && $c->session->{$key};
-
-    my $tmp = File::Temp->new;
-    my @cmd = (
-        FixMyStreet->path_to('bin/fixmystreet.com/call-echo'),
-        '--cobrand', $cobrand,
-        '--out', $tmp,
-        '--calls', encode_json(\@_),
-    );
-    my $start = time();
-
-    # We cannot fork directly under mod_fcgid, so
-    # call an external script that calls back in.
-    my $data;
-    # uncoverable branch false
-    if (FixMyStreet->test_mode || $self->sample_data) {
-        $data = $self->_parallel_api_calls(@_);
-    } else {
-        # uncoverable statement
-        system(@cmd);
-        $data = Storable::fd_retrieve($tmp);
-    }
-    $c->session->{$key} = $data;
-    my $time = time() - $start;
-    $c->log->info("[$cobrand] call_api $key took $time seconds");
-    return $data;
-}
-
-sub _parallel_api_calls {
-    my $self = shift;
-
-    my %calls;
-    # uncoverable branch false
-    my $pm = Parallel::ForkManager->new(FixMyStreet->test_mode || $self->sample_data ? 0 : 10);
-    $pm->run_on_finish(sub {
-        my ($pid, $exit_code, $ident, $exit_signal, $core_dump, $data) = @_;
-        %calls = ( %calls, %$data );
-    });
-
-    while (@_) {
-        my $call = shift;
-        my $args = shift;
-        $pm->start and next;
-        my $result = $self->$call(@$args);
-        my $key = "$call @$args";
-        $key = $call if $call eq 'GetTasks';
-        $pm->finish(0, { $key => $result });
-    }
-    $pm->wait_all_children;
-
-    return \%calls;
 }
 
 1;


### PR DESCRIPTION
WasteWorks was making 6 sequential calls to the Bartec API on every page load which made the process feel quite sluggish - often taking up to 3 or 4 seconds for each page.

This PR factors out the existing Echo parallel API code into a `Role` which the Bartec module then uses. The Peterborough cobrand takes advantage of this which also has the side effect of caching results in the user's session, making page loads effectively instant.

[skip changelog]