### PR TITLE
[Highways England] Update text for roads where HE not responsible for litter

### DIFF
--- a/.cypress/cypress/fixtures/highways_a_road.xml
+++ b/.cypress/cypress/fixtures/highways_a_road.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver https://tilma.mysociety.org:80/mapserver/highways?SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=Highways&amp;OUTPUTFORMAT=text/xml;%20subtype=gml/3.1.1  http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+   <gml:featureMember>
+      <ms:Highways>
+        <ms:msGeometry>
+          <gml:LineString srsName="EPSG:3857">
+            <gml:posList srsDimension="2">-289674.87858928 6709851.5161992 -289916.13295977 6709311.679687 -289885.08041704 6709302.1250585 -289636.66007514 6709882.5687419</gml:posList>
+          </gml:LineString>
+        </ms:msGeometry>
+        <ms:ROA_NUMBER>A6</ms:ROA_NUMBER>
+        <ms:area_name>Area 7</ms:area_name>
+      </ms:Highways>
+   </gml:featureMember>
+</wfs:FeatureCollection>

--- a/.cypress/cypress/fixtures/highways_litter.xml
+++ b/.cypress/cypress/fixtures/highways_litter.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver https://tilma.mysociety.org:80/mapserver/highways?SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=Highways_litter_pick&amp;OUTPUTFORMAT=text/xml;%20subtype=gml/3.1.1  http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+   <gml:boundedBy>
+      <gml:Null>missing</gml:Null>
+   </gml:boundedBy>
+</wfs:FeatureCollection>

--- a/.cypress/cypress/integration/highwaysengland.js
+++ b/.cypress/cypress/integration/highwaysengland.js
@@ -13,12 +13,14 @@ describe('National Highways cobrand tests', function() {
         cy.get('#map_box').click(280, 249);
         cy.wait('@highways-tilma');
         cy.wait('@report-ajax');
+        cy.contains('Report a maintenance issue').should('be.visible');
         cy.contains('The selected location is not maintained by us.').should('be.visible');
     });
     it('does not allow reporting on DBFO roads', function() {
         cy.get('#map_box').click(200, 249);
         cy.wait('@highways-tilma');
         cy.wait('@report-ajax');
+        cy.contains('Report a maintenance issue').should('be.visible');
         cy.contains('report on roads directly maintained').should('be.visible');
     });
     it('allows reporting on other HE roads', function() {
@@ -27,6 +29,30 @@ describe('National Highways cobrand tests', function() {
         cy.wait('@report-ajax');
         cy.pickCategory('Fallen sign');
         cy.nextPageReporting();
+        cy.contains('Report a maintenance issue').should('be.visible');
+    });
+});
+
+describe('National Highways litter picking test', function() {
+    beforeEach(function() {
+        cy.server();
+        cy.route('POST', '**/mapserver/highways', 'fixture:highways_a_road.xml').as('highways-tilma');
+        cy.route('POST', '**/mapserver/highways?litter', 'fixture:highways_litter.xml').as('highways-tilma-litter');
+        cy.route('**/report/new/ajax*').as('report-ajax');
+        cy.visit('http://highwaysengland.localhost:3001/');
+        cy.contains('Go');
+        cy.get('[name=pc]').type(Cypress.env('postcode'));
+        cy.get('[name=pc]').parents('form').submit();
+        cy.url().should('include', '/around');
+    });
+    it('stops litter reporting on roads where HE not responsible', function() {
+        cy.get('#map_box').click(240, 249);
+        cy.wait('@report-ajax');
+        cy.wait('@highways-tilma');
+        cy.wait('@highways-tilma-litter');
+        cy.pickCategory('Litter');
+        cy.contains('Report a litter issue').should('be.visible');
+        cy.contains('litter issues on this road are handled by the local council').should('be.visible');
     });
 });
 

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -123,7 +123,7 @@ if ($opt->test_fixtures) {
     my $params = {
         name => 'National Highways',
         area_id => 2608,
-        categories => ['Fallen sign', 'Driver on phone']
+        categories => ['Fallen sign', 'Driver on phone', 'Litter (NH)']
     };
     $bodies->{HE} = FixMyStreet::DB::Factory::Body->find_or_create($params);
     $bodies->{HE}->set_extra_metadata(cobrand => 'highwaysengland');

--- a/templates/web/highwaysengland/report/new/form_heading.html
+++ b/templates/web/highwaysengland/report/new/form_heading.html
@@ -1,2 +1,3 @@
-<h1>Report a maintenance issue on our road network</h1>
+<h1 id="he_maintenance_heading">Report a maintenance issue on our road network</h1>
+<h1 id="he_litter_heading" hidden="">Report a litter issue on our road network</h1>
 

--- a/templates/web/highwaysengland/report/new/roads_message.html
+++ b/templates/web/highwaysengland/report/new/roads_message.html
@@ -12,3 +12,10 @@
         <a class="js-update-coordinates" href="https://www.fixmystreet.com/report/new?latitude=[% latitude %]&amp;longitude=[% longitude %]">FixMyStreet</a> to continue reporting your issue.
         </p>
     </div>
+
+    <div id="js-not-litter-pick-road" class="hidden js-responsibility-message js-roads-he">
+        The road selected is maintained by National Highways, but litter issues on this road are handled by the local council.
+        Please follow this link to
+        <a class="js-update-coordinates" href="https://www.fixmystreet.com/report/new?latitude=[% latitude %]&amp;longitude=[% longitude %]">FixMyStreet</a> to continue reporting your issue.
+        </p>
+    </div>

--- a/web/cobrands/highwaysengland/assets.js
+++ b/web/cobrands/highwaysengland/assets.js
@@ -74,16 +74,19 @@ fixmystreet.assets.add(defaults, {
                     return false;
                 }
             }, '#js-dbfo-road');
+            change_header('maintenance');
         },
         not_found: function(layer) {
-          fixmystreet.message_controller.road_not_found(layer);
-          $('#js-top-message').hide();
-          $('.js-reporting-page--category').addClass('hidden-js');
+            fixmystreet.message_controller.road_not_found(layer);
+            $('#js-top-message').hide();
+            $('.js-reporting-page--category').addClass('hidden-js');
+            change_header('maintenance');
         }
     }
 });
 
 fixmystreet.assets.add(defaults, {
+    wfs_url: "https://tilma.mysociety.org/mapserver/highways?litter",
     wfs_feature: "Highways_litter_pick",
     stylemap: highways_stylemap,
     always_visible: true,
@@ -91,7 +94,7 @@ fixmystreet.assets.add(defaults, {
     road: true,
     nearest_radius: 50,
     asset_type: 'road',
-    no_asset_msg_id: '#js-not-he-road',
+    no_asset_msg_id: '#js-not-litter-pick-road',
     no_asset_msgs_class: '.js-roads-he',
     all_categories: true,
     actions: {
@@ -103,6 +106,7 @@ fixmystreet.assets.add(defaults, {
                     return true;
                 });
             }
+            change_header('maintenance');
         },
         not_found: function(layer) {
             if (fixmystreet.assets.layers[0].selected_feature) {
@@ -113,12 +117,26 @@ fixmystreet.assets.add(defaults, {
                         fixmystreet.message_controller.road_not_found(layer);
                         $('#js-top-message').hide();
                         $('.js-reporting-page--category').addClass('hidden-js');
+                        change_header('litter');
+                    } else {
+                        $('.js-reporting-page--category').removeClass('hidden-js');
+                        change_header('maintenance');
                     }
                 }
             }
         }
     }
 });
+
+function change_header(header) {
+    if (header === 'maintenance') {
+        $('#he_maintenance_heading').show();
+        $('#he_litter_heading').hide();
+    } else if (header === 'litter') {
+        $('#he_maintenance_heading').hide();
+        $('#he_litter_heading').show();
+    }
+}
 
 })();
 


### PR DESCRIPTION
* Changes the headline where HE not responsible for litter
* Changes the text where HE not responsible for litter
* Adds tests

https://github.com/mysociety/societyworks/issues/3158

[skip changelog]

Below part of the comment from WIP - left so comment below makes some sense:

@davea  Could you give me a hand in understanding how to create the cypress test for this. I'm a bit confused as nationalhighways seems to be the only one that actually uses a route of 'PUSH' to the WFS - for example, tfl uses a route that lets you put in the map layer that's being targeted.

So I can't work out how I can get both asset layers to get called separately - or how to combine them into one file. Not sure that using two `<featureCollections>` is legitimate.
