### PR TITLE
[Highways England] NHW035 Personal Details in Free Text 'Detail' Field

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1657,6 +1657,7 @@ sub save_user_and_report : Private {
     $c->cobrand->call_hook(report_new_munge_before_insert => $report);
 
     $report->update_or_insert;
+    $c->cobrand->call_hook(report_new_munge_after_insert => $report);
 
     # tidy up
     if ( my $token = $c->stash->{partial_token} ) {

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -425,6 +425,11 @@ sub report_new_munge_before_insert {
     FixMyStreet::Cobrand::Merton::report_new_munge_before_insert($self, $report);
 }
 
+sub report_new_munge_after_insert {
+    my ($self, $report) = @_;
+    $self->SUPER::report_new_munge_after_insert($report);
+}
+
 sub munge_contacts_to_bodies {
     my ($self, $contacts, $report) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -427,6 +427,14 @@ sub report_new_munge_before_insert {
     }
 }
 
+sub report_new_munge_after_insert {
+    my ($self, $report) = @_;
+
+    if ($report->to_body_named('National Highways')) {
+        FixMyStreet::Cobrand::HighwaysEngland::report_new_munge_after_insert($self, $report);
+    }
+}
+
 # Allow cobrands to disallow updates on some things.
 # Note this only ever locks down more than the default.
 sub updates_disallowed {

--- a/templates/web/highwaysengland/header_extra.html
+++ b/templates/web/highwaysengland/header_extra.html
@@ -1,4 +1,5 @@
 <link rel="stylesheet" href="https://use.typekit.net/lgn8iyw.css">
+<link rel="stylesheet" href="/vendor/govuk-frontend/forms.css">
 <link rel="shortcut icon" href="/cobrands/highwaysengland/HE_Fav-144x144.jpg">
 
 [% INCLUDE 'tracking_code.html' %]

--- a/templates/web/highwaysengland/report/new/councils_text_all.html
+++ b/templates/web/highwaysengland/report/new/councils_text_all.html
@@ -1,17 +1,13 @@
-<p>
+<p class="highwaysengland-warning">
 [% category = mark_safe(category) %]
-[% UNLESS non_public_categories.$category;
+[% UNLESS non_public_categories.$category %]
 
-    tprintf(
-        'Anything you include in your report will be published online for others to see. Please take care not to include personal information, such as your contact details. Find out more in our <a href="%s">privacy policy</a>.',
-        c.cobrand.privacy_policy_url
-    );
+    <b>Anything you include in your report will be published online for others to see. Please take care not to include personal information, such as your contact details.</b>
+    Find out more in our <a href="[% c.cobrand.privacy_policy_url %]">privacy policy</a>.
 
-ELSE;
+[% ELSE %]
 
-    'These will be sent to us but not published online.';
+    These will be sent to us but not published online.
 
-END %]
-
-[% TRY %][% INCLUDE 'report/new/councils_extra_text.html' %][% CATCH file %][% END %]
+[% END %]
 </p>

--- a/templates/web/highwaysengland/report/new/inline-tips.html
+++ b/templates/web/highwaysengland/report/new/inline-tips.html
@@ -24,3 +24,13 @@
 <option value="National Highways correspondence"[% ' selected' IF 'National Highways correspondence' == where_hear %]>National Highways correspondence</option>
 <option value="Other"[% ' selected' IF 'Other' == where_hear %]>Other</option>
 </select>
+
+    <div class="govuk-checkboxes" style="margin-top:2em">
+      <div class="govuk-checkboxes__item">
+        <input required type="checkbox" class="form-control govuk-checkboxes__input" id="form_confirm_no_personal" name="confirm_no_personal" value="1">
+        <label style="margin-top:0;padding-top:0" class="govuk-label govuk-checkboxes__label" for="form_confirm_no_personal">
+            Please tick this box to confirm that you have not entered any
+            personal information on this page
+        </label>
+      </div>
+    </div>

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -441,7 +441,8 @@ $.extend(fixmystreet.set_up, {
         errorElement: 'div',
         errorClass: 'form-error',
         errorPlacement: function( error, element ) {
-            if (element.attr('type') == 'radio') {
+            var typ = element.attr('type');
+            if (typ == 'radio' || typ == 'checkbox') {
                 element.parent().before( error );
             } else {
                 element.before( error );


### PR DESCRIPTION
This is part 1 of a series of requirements for HE to highlight to users that personal information should not be put into the text field.

* Highlights existing wording warning about personal details

https://github.com/mysociety/societyworks/issues/3098

[skip changelog]