### PR TITLE
import-export-data script includes email_text from templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
         - The permission default_to_body now also affects updates. #3317
         - Decouple the permission to manage shortlist from default_to_body. #3317
         - Fix issue with sanitizing missing attributes.
+        - Include email_text from templates in export-import-data script. #4084
 	- For CSV export, fetch children of all generations.
     - Accessibility improvements:
         - The "skip map" link on /around now has new wording. #3794

--- a/bin/export-import-data
+++ b/bin/export-import-data
@@ -73,6 +73,7 @@ sub export {
         push @{$out{templates}}, {
             title => $_->title,
             text => $_->text,
+            email_text => $_->email_text,
             state => $_->state,
             categories => [ sort map { $_->category } $_->contacts->all ],
             auto_response => $_->auto_response,
@@ -141,6 +142,7 @@ sub import {
         my $template = $body->response_templates->update_or_new({
             title => $_->{title},
             text => $_->{text},
+            email_text => $_->{email_text},
             state => $_->{state},
             auto_response => $_->{auto_response},
             external_status_code => $_->{external_status_code},


### PR DESCRIPTION
Adds email_text field from templates to import-export-data script so it is included in imports and exports

https://github.com/mysociety/fixmystreet/issues/4084
