### PR TITLE
[Lincolnshire] Pull in user information via Open311 so customers can receive updates

### DIFF
--- a/docs/_layouts/pro.html
+++ b/docs/_layouts/pro.html
@@ -29,41 +29,14 @@
           <ul id="menu-main-menu" class="menu js-dropdown-sub-menus">
             <li id="menu-item-1801" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1801"><a href="https://www.societyworks.org/services/">Services</a>
               <ul class="sub-menu">
-                <li id="menu-item-1803" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1803"><a href="https://www.societyworks.org/services/highways/">Streets and highways</a></li>
-                <li id="menu-item-1805" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1805"><a href="https://www.societyworks.org/services/waste/">Bins and waste</a></li>
-                <li id="menu-item-1804" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1804"><a href="https://www.societyworks.org/services/noise/">Noise and social complaints</a></li>
-                <li id="menu-item-1808" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1808"><a href="https://www.societyworks.org/services/green-spaces/">Parks, trees and green spaces</a></li>
-                <li id="menu-item-1802" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1802"><a href="https://www.societyworks.org/services/licensing/">Licence applications</a></li>
-                <li id="menu-item-1817" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1817"><a href="https://www.societyworks.org/features/housing/">Estate maintenance</a></li>
-                <li id="menu-item-1806" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1806"><a href="https://www.societyworks.org/services/foi/">FOI</a></li>
+                <li id="menu-item-1803" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1803"><a href="https://www.societyworks.org/services/highways/">FixMyStreet Pro</a></li>
+                <li id="menu-item-1805" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1805"><a href="https://www.societyworks.org/services/waste/">WasteWorks</a></li>
+                <li id="menu-item-1802" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1802"><a href="https://www.societyworks.org/services/licensing/">ApplyWorks</a></li>
+                <li id="menu-item-1806" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1806"><a href="https://www.societyworks.org/services/foi/">FOIWorks</a></li>
                 <li id="menu-item-1807" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1807"><a href="https://www.societyworks.org/services/discovery/">Service transformation</a></li>
               </ul>
             </li>
             <li id="menu-item-537" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-537"><a href="https://www.societyworks.org/case-studies/">Case Studies</a>
-              <ul class="sub-menu">
-                <li id="menu-item-1065" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1065"><a href="https://www.societyworks.org/case-studies/banes/">Bath &#038; North East Somerset District Council</a></li>
-                <li id="menu-item-538" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-538"><a href="https://www.societyworks.org/case-studies/bristol/">Bristol Council</a></li>
-                <li id="menu-item-1272" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1272"><a href="https://www.societyworks.org/case-studies/bromley-borough-council/">Bromley Borough Council</a></li>
-                <li id="menu-item-588" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-588"><a href="https://www.societyworks.org/case-studies/ground-control/">Ground Control</a></li>
-                <li id="menu-item-1077" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1077"><a href="https://www.societyworks.org/case-studies/lincolnshire-county-council/">Lincolnshire County Council</a></li>
-                <li id="menu-item-539" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-539"><a href="https://www.societyworks.org/case-studies/oxfordshire/">Oxfordshire County Council</a></li>
-                <li id="menu-item-947" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-947"><a href="https://www.societyworks.org/case-studies/rutland-county-council/">Rutland County Council</a></li>
-                <li id="menu-item-1080" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1080"><a href="https://www.societyworks.org/case-studies/buckinghamshire/">Buckinghamshire Council</a></li>
-              </ul>
-            </li>
-            <li id="menu-item-30" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-30"><a href="https://www.societyworks.org/features/">Features</a>
-              <ul class="sub-menu">
-                <li id="menu-item-1813" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1813"><a href="https://www.societyworks.org/features/reporting/">Reporting</a></li>
-                <li id="menu-item-1812" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1812"><a href="https://www.societyworks.org/features/customer-contact/">Customer contact</a></li>
-                <li id="menu-item-1816" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1816"><a href="https://www.societyworks.org/features/inspections/">Inspections</a></li>
-                <li id="menu-item-1815" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1815"><a href="https://www.societyworks.org/features/case-management/">Case management</a></li>
-                <li id="menu-item-32" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-32"><a href="https://www.societyworks.org/features/fully-integrated/">Integrations</a></li>
-                <li id="menu-item-1814" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1814"><a href="https://www.societyworks.org/features/data-assets/">Data and assets</a></li>
-                <li id="menu-item-33" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-33"><a href="https://www.societyworks.org/features/hosted-secure/">Secure hosting</a></li>
-                <li id="menu-item-34" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-34"><a href="https://www.societyworks.org/features/open-standards/">Open standards</a></li>
-                <li id="menu-item-28" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-28"><a href="https://www.societyworks.org/training/">Training and onboarding</a></li>
-                <li id="menu-item-35" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-35"><a href="https://www.societyworks.org/features/accessible/">Accessibilty</a></li>
-              </ul>
             </li>
             <li id="menu-item-36" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-36"><a href="https://www.societyworks.org/how-to-buy/">How to buy</a></li>
             <li id="menu-item-1800" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1800"><a href="https://www.societyworks.org/blog/">Blog</a></li>

--- a/docs/_layouts/wasteworks.html
+++ b/docs/_layouts/wasteworks.html
@@ -29,41 +29,14 @@
           <ul id="menu-main-menu" class="menu js-dropdown-sub-menus">
             <li id="menu-item-1801" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1801"><a href="https://www.societyworks.org/services/">Services</a>
               <ul class="sub-menu">
-                <li id="menu-item-1803" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1803"><a href="https://www.societyworks.org/services/highways/">Streets and highways</a></li>
-                <li id="menu-item-1805" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1805"><a href="https://www.societyworks.org/services/waste/">Bins and waste</a></li>
-                <li id="menu-item-1804" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1804"><a href="https://www.societyworks.org/services/noise/">Noise and social complaints</a></li>
-                <li id="menu-item-1808" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1808"><a href="https://www.societyworks.org/services/green-spaces/">Parks, trees and green spaces</a></li>
-                <li id="menu-item-1802" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1802"><a href="https://www.societyworks.org/services/licensing/">Licence applications</a></li>
-                <li id="menu-item-1817" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1817"><a href="https://www.societyworks.org/features/housing/">Estate maintenance</a></li>
-                <li id="menu-item-1806" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1806"><a href="https://www.societyworks.org/services/foi/">FOI</a></li>
+                <li id="menu-item-1803" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1803"><a href="https://www.societyworks.org/services/highways/">FixMyStreet Pro</a></li>
+                <li id="menu-item-1805" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1805"><a href="https://www.societyworks.org/services/waste/">WasteWorks</a></li>
+                <li id="menu-item-1802" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1802"><a href="https://www.societyworks.org/services/licensing/">ApplyWorks</a></li>
+                <li id="menu-item-1806" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1806"><a href="https://www.societyworks.org/services/foi/">FOIWorks</a></li>
                 <li id="menu-item-1807" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1807"><a href="https://www.societyworks.org/services/discovery/">Service transformation</a></li>
               </ul>
             </li>
             <li id="menu-item-537" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-537"><a href="https://www.societyworks.org/case-studies/">Case Studies</a>
-              <ul class="sub-menu">
-                <li id="menu-item-1065" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1065"><a href="https://www.societyworks.org/case-studies/banes/">Bath &#038; North East Somerset District Council</a></li>
-                <li id="menu-item-538" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-538"><a href="https://www.societyworks.org/case-studies/bristol/">Bristol Council</a></li>
-                <li id="menu-item-1272" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1272"><a href="https://www.societyworks.org/case-studies/bromley-borough-council/">Bromley Borough Council</a></li>
-                <li id="menu-item-588" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-588"><a href="https://www.societyworks.org/case-studies/ground-control/">Ground Control</a></li>
-                <li id="menu-item-1077" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1077"><a href="https://www.societyworks.org/case-studies/lincolnshire-county-council/">Lincolnshire County Council</a></li>
-                <li id="menu-item-539" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-539"><a href="https://www.societyworks.org/case-studies/oxfordshire/">Oxfordshire County Council</a></li>
-                <li id="menu-item-947" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-947"><a href="https://www.societyworks.org/case-studies/rutland-county-council/">Rutland County Council</a></li>
-                <li id="menu-item-1080" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1080"><a href="https://www.societyworks.org/case-studies/buckinghamshire/">Buckinghamshire Council</a></li>
-              </ul>
-            </li>
-            <li id="menu-item-30" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-30"><a href="https://www.societyworks.org/features/">Features</a>
-              <ul class="sub-menu">
-                <li id="menu-item-1813" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1813"><a href="https://www.societyworks.org/features/reporting/">Reporting</a></li>
-                <li id="menu-item-1812" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1812"><a href="https://www.societyworks.org/features/customer-contact/">Customer contact</a></li>
-                <li id="menu-item-1816" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1816"><a href="https://www.societyworks.org/features/inspections/">Inspections</a></li>
-                <li id="menu-item-1815" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1815"><a href="https://www.societyworks.org/features/case-management/">Case management</a></li>
-                <li id="menu-item-32" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-32"><a href="https://www.societyworks.org/features/fully-integrated/">Integrations</a></li>
-                <li id="menu-item-1814" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1814"><a href="https://www.societyworks.org/features/data-assets/">Data and assets</a></li>
-                <li id="menu-item-33" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-33"><a href="https://www.societyworks.org/features/hosted-secure/">Secure hosting</a></li>
-                <li id="menu-item-34" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-34"><a href="https://www.societyworks.org/features/open-standards/">Open standards</a></li>
-                <li id="menu-item-28" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-28"><a href="https://www.societyworks.org/training/">Training and onboarding</a></li>
-                <li id="menu-item-35" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-35"><a href="https://www.societyworks.org/features/accessible/">Accessibilty</a></li>
-              </ul>
             </li>
             <li id="menu-item-36" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-36"><a href="https://www.societyworks.org/how-to-buy/">How to buy</a></li>
             <li id="menu-item-1800" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1800"><a href="https://www.societyworks.org/blog/">Blog</a></li>

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -494,6 +494,20 @@ sub confirm {
     return 1;
 }
 
+sub send_logged_email {
+    my ($self, $h, $nomail, $cobrand) = @_;
+    FixMyStreet::Email::send_cron(
+        $self->result_source->schema,
+        'confirm_report_sent.txt',
+        $h,
+        { To => $self->user->email },
+        undef,
+        $nomail,
+        $cobrand,
+        $self->lang,
+    );
+}
+
 sub category_display {
     my $self = shift;
     my $contact = $self->contact;

--- a/perllib/FixMyStreet/Queue/Item/Report.pm
+++ b/perllib/FixMyStreet/Queue/Item/Report.pm
@@ -358,18 +358,7 @@ sub _send_report_sent_email {
     my $contributed_as = $self->report->get_extra_metadata('contributed_as') || '';
     return if $contributed_as eq 'body' || $contributed_as eq 'anonymous_user';
 
-    FixMyStreet::Email::send_cron(
-        $self->report->result_source->schema,
-        'confirm_report_sent.txt',
-        $self->h,
-        {
-            To => $self->report->user->email,
-        },
-        undef,
-        $self->nomail,
-        $self->cobrand,
-        $self->report->lang,
-    );
+    $self->report->send_logged_email($self->h, $self->nomail, $self->cobrand);
 }
 
 sub log {


### PR DESCRIPTION
Lincolnshire have requested that reports pulled in via Open311's
GetServiceRequests are created using the user information stored in
their backend system.

This is so that the reports created in FixMyStreet are associated with
the email address of the original reporter so they can receive updates
on reports.

Open311 adapter change to add the user data is here: https://github.com/mysociety/open311-adapter/pull/228

Part of https://github.com/mysociety/societyworks/issues/3079

[skip changelog]