### PR TITLE
[PCC] Added reusable UI elements for Bulky waste request form

### DIFF
--- a/web/cobrands/peterborough/base.scss
+++ b/web/cobrands/peterborough/base.scss
@@ -37,6 +37,105 @@ h1, h2 {
     color: $alt-green;
 }
 
+.btn-primary,
+.green-btn,
+.btn--primary, .btn-secondary {
+    border: 0.2em solid $primary;
+    padding: 0.55em 1em;
+    border-radius: 0.25em;
+    text-decoration: none !important;
+    font-weight: bold;
+    line-height: 100%;
+    font-size: 1em;
+
+    &:focus {
+        box-shadow: #4c9aff 0px 0px 0px 3px;
+        outline: none;
+    }
+}
+
+@mixin next-back-button($orientation) {
+    padding-#{$orientation}: 2em;
+    background-size: 9px auto;
+    background-position: center $orientation 1em;
+    background-repeat: no-repeat;
+
+    &.is--disabled, &:disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
+        text-decoration: none;
+        pointer-events: none
+    }
+}
+
+.btn-primary,
+.green-btn,
+.btn--primary {
+    background: $primary;
+
+    &:hover,
+    &:active {
+        background: darken($green, 5%);
+        border-color: darken($green, 5%);
+    }
+
+    &:focus {
+        color: $primary_text;
+        background: $primary;
+    }
+
+    &.is--next {
+        @include svg-background-image('/cobrands/peterborough/images/chevron-next-white');
+        @include next-back-button(right);
+    }
+
+    &.is--back {
+        @include svg-background-image('/cobrands/peterborough/images/chevron-back-white');
+        @include next-back-button(left);
+    }
+}
+
+.btn-secondary, input.btn-secondary {
+    color: $primary ;
+    background-color: $primary_text;
+
+    &:hover,
+    &:active {
+        color: $primary_text ;
+        background-color: $primary ;
+        border-color: $primary ;
+    }
+
+    &:focus {
+        color: $primary !important;
+    }
+
+    &.is--disabled, &:disabled {
+        color: $primary !important;
+        border: 0.2em solid $primary;
+    }
+
+    &.is--next {
+        @include svg-background-image('/cobrands/peterborough/images/chevron-next-green');
+        @include next-back-button(right);
+
+        &:hover,
+        &:active {
+            @include svg-background-image('/cobrands/peterborough/images/chevron-next-white');
+        }
+    }
+
+    &.is--back {
+        @include svg-background-image('/cobrands/peterborough/images/chevron-back-green');
+        @include next-back-button(left);
+
+        &:hover,
+        &:active {
+            @include svg-background-image('/cobrands/peterborough/images/chevron-back-white');
+        }
+    }
+}
+
 #front-main {
     h2 {
         font-style: normal;
@@ -53,18 +152,6 @@ h1, h2 {
     label,
     .form-hint {
         color: $primary_b;
-    }
-}
-
-.btn-primary,
-.green-btn,
-.btn--primary {
-    border: none;
-    background: $green;
-
-    &:hover,
-    &:active {
-        background: lighten($green, 5%);
     }
 }
 

--- a/web/cobrands/peterborough/images/chevron-back-green.svg
+++ b/web/cobrands/peterborough/images/chevron-back-green.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="15" viewBox="0 0 10 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.5 13L3 7.5L8.5 2" stroke="#337B1C" stroke-width="3"/>
+</svg>

--- a/web/cobrands/peterborough/images/chevron-back-white.svg
+++ b/web/cobrands/peterborough/images/chevron-back-white.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="15" viewBox="0 0 10 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 13L2.5 7.5L8 2" stroke="white" stroke-width="3"/>
+</svg>

--- a/web/cobrands/peterborough/images/chevron-next-green.svg
+++ b/web/cobrands/peterborough/images/chevron-next-green.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="15" viewBox="0 0 10 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 2L7.5 7.5L2 13" stroke="#337B1C" stroke-width="3"/>
+</svg>

--- a/web/cobrands/peterborough/images/chevron-next-white.svg
+++ b/web/cobrands/peterborough/images/chevron-next-white.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="15" viewBox="0 0 10 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 2L7.5 7.5L2 13" stroke="white" stroke-width="3"/>
+</svg>


### PR DESCRIPTION
This PR includes elements that improves the user journey:

- Added secondary button, which has less emphasis than the primary one. It's good to use it next to the primary one so it 
- Added a secondary button with less emphasis than the primary one. It's good to use it next to the primary one so it doesn't draw as much attention, but it's still fairly obvious is there. You can also use it on its own; when you want to show there is an action available but is not the most important part of the page.
- Added "Next" and "Back" buttons, which help with the page's scannability.
- Added an info message based on the GOVUK warning message. It can be used to provide non-vital information to the user, so if they decide to omit it, there won't be a big consequence. For example: "If you are a landlord, call this number". For instance, when NOT to use it, "You need to dismantle this item before collection". In this case, if the user ignores this message, there will be a consequence, the item won't get picked up.

Fixes: https://github.com/mysociety/societyworks/issues/3231
