### PR TITLE
[National Highways] Forward council litter responsibilities to FMS

### DIFF
--- a/.cypress/cypress/integration/highwaysengland.js
+++ b/.cypress/cypress/integration/highwaysengland.js
@@ -56,7 +56,22 @@ describe('National Highways litter picking test', function() {
     });
 });
 
-describe('National Highways cobrand mobile tests', function() {
+describe('National Highways litter picking test', function() {
+    beforeEach(function() {
+        cy.server();
+        cy.route('**/mapserver/highways*', 'fixture:highways_a_road.xml').as('highways-tilma');
+        cy.route('**/report/new/ajax*', 'fixture:highways-ajax.json').as('report-ajax');
+    });
+    it('filters to litter options on FMS', function() {
+        cy.visit('http://fixmystreet.localhost:3001/report/new?longitude=-2.6030503&latitude=51.4966133&he_referral=1');
+        cy.wait('@report-ajax');
+        cy.wait('@highways-tilma');
+        cy.contains('most appropriate option for the litter or flytipping');
+        cy.contains('National Highways: Subcategory');
+        });
+});
+
+ describe('National Highways cobrand mobile tests', function() {
     it('does not allow reporting on DBFO roads on mobile either', function() {
         cy.server();
         cy.route('POST', '**/mapserver/highways', 'fixture:highways.xml').as('highways-tilma');

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -82,6 +82,7 @@ sub report_new : Path : Args(0) {
 
     # create the report - loading a partial if available
     $c->forward('initialize_report');
+
     $c->forward('/auth/get_csrf_token');
 
     my @shortlist = grep { /^shortlist-(add|remove)-(\d+)$/ } keys %{$c->req->params};
@@ -180,6 +181,10 @@ sub send_json_response : Private {
 
 sub report_form_ajax : Path('ajax') : Args(0) {
     my ( $self, $c ) = @_;
+
+    if ($c->req->params->{he_referral}) {
+        $c->stash->{he_referral} = 1;
+    };
 
     $c->forward('/set_app_cors_header');
     $c->forward('initialize_report');

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -168,6 +168,7 @@ sub munge_unmixed_category_groups {
 
 sub munge_mixed_category_groups {
     my ($self, $list) = @_;
+
     my $nh = FixMyStreet::Cobrand::HighwaysEngland->new({ c => $self->{c} });
     $nh->national_highways_cleaning_groups($list);
 }

--- a/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
+++ b/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
@@ -193,8 +193,11 @@ sub national_highways_cleaning_groups {
     return unless $not_he_litter;
 
     # NH do not want flytipping or litter reports on these roads, take them out
-    @{$nh_group->{categories}} = grep { $_->category_display !~ /Flytipping|Litter/ } @{$nh_group->{categories}};
-
+    if (defined $c->stash->{he_referral}) {
+        @{$nh_group->{categories}} = ();
+    } else {
+        @{$nh_group->{categories}} = grep { $_->category_display !~ /Flytipping|Litter/ } @{$nh_group->{categories}};
+    }
     # Put any council street cleaning categories we can find into the NH group,
     # so they'll still appear if "on the HE road" is picked
     my %cleaning_cats = map { $_ => 1 } @{ $self->_cleaning_categories };

--- a/t/cobrand/fixmystreet.t
+++ b/t/cobrand/fixmystreet.t
@@ -409,6 +409,15 @@ FixMyStreet::override_config {
         $mech->content_contains('Potholes');
         $mech->content_contains('Trees');
         $mech->content_contains('Flytipping');
+
+        # A-road where NH not responsible for litter, referred to FMS from National Highways
+        # ajax call filters NH category to contain only litter related council subcategories
+        mock_road("A34", 0);
+        my $j = $mech->get_ok_json("/report/new/ajax?w=1&longitude=-0.912160&latitude=51.015143&he_referral=1");
+        my $tree = HTML::TreeBuilder->new_from_content($j->{subcategories});
+        my @elements = $tree->find('input');
+        is @elements, 1, 'Only one subcategory in National Highways category';
+        is $elements[0]->attr('value') eq 'Flytipping', 1, 'Subcategory is Flytipping';
     };
 };
 

--- a/templates/web/highwaysengland/report/new/roads_message.html
+++ b/templates/web/highwaysengland/report/new/roads_message.html
@@ -16,6 +16,10 @@
     <div id="js-not-litter-pick-road" class="hidden js-responsibility-message js-roads-he">
         The road selected is maintained by National Highways, but litter issues on this road are handled by the local council.
         Please follow this link to
-        <a class="js-update-coordinates" href="https://www.fixmystreet.com/report/new?latitude=[% latitude %]&amp;longitude=[% longitude %]">FixMyStreet</a> to continue reporting your issue.
+        [% IF c.config.STAGING_SITE %]
+         <a class="js-update-coordinates" href="https://staging.fixmystreet.com/report/new?latitude=[% latitude %]&amp;longitude=[% longitude %]&amp;he_referral=1">FixMyStreet</a> to continue reporting your issue.
+        [% ELSE %]
+         <a class="js-update-coordinates" href="https://www.fixmystreet.com/report/new?latitude=[% latitude %]&amp;longitude=[% longitude %]&amp;he_referral=1">FixMyStreet</a> to continue reporting your issue.
+        [% END %]
         </p>
     </div>

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -1202,13 +1202,18 @@ fixmystreet.message_controller = (function() {
             asset_strings.html(asset_strings.data('original'));
         }
         $('.js-update-coordinates').attr('href', function(i, href) {
+            var he_arg;
             if (href.indexOf('?') != -1) {
+                he_arg = href.indexOf('&he_referral=1');
                 href = href.substring(0, href.indexOf('?'));
             }
             href += '?' + OpenLayers.Util.getParameterString({
                 latitude: $('#fixmystreet\\.latitude').val(),
                 longitude: $('#fixmystreet\\.longitude').val()
             });
+            if (he_arg != -1) {
+                href += '&he_referral=1';
+            }
             return href;
         });
         if ($('html').hasClass('mobile')) {

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1491,10 +1491,13 @@ function re_select(group, category) {
 
 // On the new report form, does this by asking for details from the server.
 fixmystreet.fetch_reporting_data = function() {
+    var he_arg = window.location.href.indexOf('&he_referral=1');
+    he_arg = he_arg === -1 ? 0 : 1;
     $.getJSON('/report/new/ajax', {
         w: 1,
         latitude: $('#fixmystreet\\.latitude').val(),
-        longitude: $('#fixmystreet\\.longitude').val()
+        longitude: $('#fixmystreet\\.longitude').val(),
+        he_referral: he_arg
     }, function(data) {
         if (data.error) {
             if (!$('#side-form-error').length) {

--- a/web/cobrands/highways/assets.js
+++ b/web/cobrands/highways/assets.js
@@ -112,6 +112,14 @@ function he_selected() {
     fixmystreet.body_overrides.allow_send('National Highways');
     regenerate_category(true);
     $(fixmystreet).trigger('report_new:highways_change');
+    if (window.location.href.indexOf('&he_referral=1') != -1) {
+        $('#problem_form .js-reporting-page--next').click();
+        var message = "<div class='box-warning' id='national-highways-referral'>Please select the local council's most appropriate option for the litter or flytipping issue you would like to report.</div>";
+        $('#js-top-message').append(message);
+        $('.js-reporting-page--next').on('click', function() {
+            $('#national-highways-referral').remove();
+        });
+    }
 }
 
 function he_council_litter_cat_selected() {


### PR DESCRIPTION
* Adds a parameter 'he_referral' when directing to cooridinates on FMS
* When 'he_referral' is present:
	- filters highways category to only contain council litter categories
	- triggers automatic selection of highways category
	- adds message to say to choose one of the councils litter categories
	- adds cypress test

https://github.com/mysociety/societyworks/issues/3159

[skip changelog]