### PR TITLE
Option to read asset layers from configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
         - Upgrade Net::DNS and libwww to deal with IPv6 issues.
         - Add send_state column to updates. #3865
         - Enable alternative response from templates to be emailed to issue reporter. #4001
+        - Option to read asset layers from configuration.
     - Security
         - Permit control over database connection `sslmode` via $FMS_DB_SSLMODE
     - Open311 improvements:

--- a/bin/browser-tests
+++ b/bin/browser-tests
@@ -148,6 +148,27 @@ sub run {
             COBRAND_FEATURES => {
                 category_groups => { map { $_ => 1 } @$cobrand },
                 suggest_duplicates => { map { $_ => 1 } @$cobrand },
+                asset_layers => {
+                    lincolnshire => [
+                        {
+                            wfs_url => "https://tilma.staging.mysociety.org/mapserver/lincs",
+                            geometryName => 'msGeometry',
+                            srsName => "EPSG:3857",
+                            body => "Lincolnshire County Council"
+                        },
+                        {
+                            wfs_feature => "Carriageway",
+                            asset_category => [
+                                "Damaged/missing cats eye",
+                                "Pothole on road/cycleway",
+                            ],
+                            asset_item => 'road',
+                            asset_item_message => '',
+                            disable_pin_snapping => 1,
+                            stylemap => 'fixmystreet.assets.stylemap_invisible'
+                        },
+                    ],
+                },
             }
         });
         $ENV{FMS_OVERRIDE_CONFIG} = $config_out;

--- a/perllib/FixMyStreet/App/Controller/Develop.pm
+++ b/perllib/FixMyStreet/App/Controller/Develop.pm
@@ -3,6 +3,7 @@ use Moose;
 use namespace::autoclean;
 
 use File::Basename;
+use YAML;
 
 BEGIN { extends 'Catalyst::Controller'; }
 
@@ -284,6 +285,12 @@ sub report_new_preview : Path('/_dev/report_new') : Args(0) {
     my ( $self, $c ) = @_;
     $c->stash->{template}   = 'email_sent.html';
     $c->stash->{email_type} = $c->get_param('email_type');
+}
+
+sub asset_layers : Path('/_dev/asset_layers') : Args(0) {
+    my ( $self, $c ) = @_;
+    my $cobrands = $c->config->{COBRAND_FEATURES}->{asset_layers};
+    $c->stash->{config} = YAML::Dump($cobrands);
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/perllib/FixMyStreet/App/Controller/JS.pm
+++ b/perllib/FixMyStreet/App/Controller/JS.pm
@@ -1,5 +1,6 @@
 package FixMyStreet::App::Controller::JS;
 use Moose;
+use JSON::MaybeXS;
 use namespace::autoclean;
 
 BEGIN { extends 'Catalyst::Controller'; }
@@ -24,6 +25,41 @@ sub translation_strings : LocalRegex('^translation_strings\.(.*?)\.js$') : Args(
         FixMyStreet->path_to('locale')->stringify
     );
     $c->res->content_type( 'application/javascript' );
+}
+
+sub asset_layers : Path('asset_layers.js') : Args(0) {
+    my ( $self, $c ) = @_;
+
+    $c->res->content_type( 'application/javascript' );
+
+    if ($c->cobrand->moniker eq 'fixmystreet') {
+        # Combine all the layers together for .com
+        my $features = FixMyStreet->config('COBRAND_FEATURES') || {};
+        my $cobrands = $features->{asset_layers} || {};
+        my $layers = $c->stash->{asset_layers} = [];
+        for my $moniker ( keys %$cobrands ) {
+            my @layers = @{ $cobrands->{$moniker} };
+            push @$layers, _add_layer($moniker, @layers);
+        }
+    } else {
+        my @layers = @{ $c->cobrand->feature('asset_layers') || [] };
+        return unless @layers;
+        $c->stash->{asset_layers} = [ _add_layer($c->cobrand->moniker, @layers) ];
+    }
+}
+
+sub _add_layer {
+    my ($moniker, @layers) = @_;
+    my $default = shift @layers;
+    return {
+        moniker => $moniker,
+        default => encode_json($default),
+        layers => [ map {
+            my $json = encode_json($_);
+            $json =~ s/("stylemap":)"(.*?)"/$1$2/;
+            $json;
+        } @layers ],
+    };
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/t/app/controller/js.t
+++ b/t/app/controller/js.t
@@ -1,0 +1,34 @@
+use JSON::MaybeXS;
+use FixMyStreet::TestMech;
+my $mech = FixMyStreet::TestMech->new;
+
+subtest "check translation endpoint" => sub {
+    $mech->get_ok('/js/translation_strings.en-gb.js');
+    $mech->content_contains('translation_strings');
+};
+
+subtest "check asset layer endpoint" => sub {
+    $mech->get_ok('/js/asset_layers.js');
+    $mech->content_is('var fixmystreet = fixmystreet || {}; (function(){ if (!fixmystreet.maps) { return; } fixmystreet.asset_layers = {}; var defaults; })();' . "\n");
+
+    my $defaults = { wfs_url => 'http://example.org', geometryName => 'msGeometry', srsName => 'EPSG:3857' };
+    my $bridges = { wfs_feature => 'Bridges', asset_item => 'bridge', asset_category => 'Bridges' };
+
+    foreach ('fixmystreet', 'lincolnshire') {
+        FixMyStreet::override_config {
+            ALLOWED_COBRANDS => $_,
+            COBRAND_FEATURES => { asset_layers => { lincolnshire => [ $defaults, $bridges ] } },
+        }, sub {
+            $mech->get_ok('/js/asset_layers.js');
+            my $content = $mech->encoded_content;
+            $content =~ /fixmystreet\.asset_layers\.lincolnshire_defaults = (\{.*?\})/;
+            my $json = decode_json($1);
+            is_deeply $json, $defaults;
+            $content =~ /fixmystreet\.assets\.add\(defaults, (\{.*?\})\);/;
+            $json = decode_json($1);
+            is_deeply $json, $bridges;
+        };
+    }
+};
+
+done_testing();

--- a/templates/web/base/develop/asset_layers.html
+++ b/templates/web/base/develop/asset_layers.html
@@ -1,0 +1,9 @@
+[% INCLUDE 'header.html' %]
+[% USE Dumper %]
+
+<h1>Configured asset layers</h1>
+
+<pre>[% config %]</pre>
+
+[% INCLUDE 'footer.html' %]
+

--- a/templates/web/base/js/asset_layers.html
+++ b/templates/web/base/js/asset_layers.html
@@ -1,0 +1,23 @@
+[% FILTER collapse %]
+
+var fixmystreet = fixmystreet || {};
+
+(function(){
+
+if (!fixmystreet.maps) {
+    return;
+}
+
+fixmystreet.asset_layers = {};
+var defaults;
+
+[% FOR cobrand IN asset_layers %]
+    defaults = fixmystreet.asset_layers.[% cobrand.moniker %]_defaults = [% cobrand.default | safe %];
+    [% FOR layer IN cobrand.layers %]
+        fixmystreet.assets.add(defaults, [% layer | safe %]);
+    [% END %]
+[% END %]
+
+})();
+
+[% END %]

--- a/templates/web/fixmystreet-uk-councils/footer_extra_js_base.html
+++ b/templates/web/fixmystreet-uk-councils/footer_extra_js_base.html
@@ -35,6 +35,9 @@ IF bodyclass.match('mappage') AND NOT bodyclass.match('formflow');
             version('/cobrands/thamesmead/assets.js'),
         );
     END;
+    scripts.push(
+        version('../conf/general.yml', '/js/asset_layers.js')
+    );
 END;
 IF bodyclass.match('mappage') AND bodyclass.match('formflow');
     scripts.push(

--- a/templates/web/fixmystreet.com/footer_extra_js.html
+++ b/templates/web/fixmystreet.com/footer_extra_js.html
@@ -26,6 +26,7 @@ IF bodyclass.match('mappage');
     scripts.push( version('/cobrands/merton/assets.js') );
     scripts.push( version('/cobrands/tfl/assets.js') );
     scripts.push( version('/cobrands/highways/assets.js') );
+    scripts.push( version('../conf/general.yml', '/js/asset_layers.js') );
     scripts.push( version('/cobrands/fixmystreet-uk-councils/council_validation_rules.js') );
     scripts.push(
         version('/vendor/OpenLayers.Projection.OrdnanceSurvey.js'),

--- a/templates/web/highwaysengland/footer_extra_js.html
+++ b/templates/web/highwaysengland/footer_extra_js.html
@@ -2,6 +2,7 @@
 IF bodyclass.match('mappage');
     scripts.push( version('/cobrands/fixmystreet/assets.js') );
     scripts.push( version('/cobrands/highwaysengland/assets.js') );
+    scripts.push( version('../conf/general.yml', '/js/asset_layers.js') );
     scripts.push(
         version('/vendor/OpenLayers.Projection.OrdnanceSurvey.js'),
     );

--- a/templates/web/thamesmead/footer_extra_js.html
+++ b/templates/web/thamesmead/footer_extra_js.html
@@ -5,6 +5,7 @@ scripts.push(
 IF bodyclass.match('mappage');
     scripts.push( version('/cobrands/fixmystreet/assets.js') );
     scripts.push( version('/cobrands/thamesmead/assets.js') );
+    scripts.push( version('../conf/general.yml', '/js/asset_layers.js') );
     scripts.push( version('/cobrands/fixmystreet-uk-councils/council_validation_rules.js') );
     scripts.push(
         version('/vendor/OpenLayers.Projection.OrdnanceSurvey.js'),

--- a/web/cobrands/bathnes/assets.js
+++ b/web/cobrands/bathnes/assets.js
@@ -19,7 +19,6 @@ fixmystreet.maps.banes_defaults = {
     },
     format_class: OpenLayers.Format.GeoJSON,
     format_options: {ignoreExtraDims: true},
-    strategy_class: OpenLayers.Strategy.FixMyStreet,
     asset_category: "",
     asset_item: "asset",
     asset_type: 'spot',

--- a/web/cobrands/bexley/assets.js
+++ b/web/cobrands/bexley/assets.js
@@ -5,15 +5,7 @@ if (!fixmystreet.maps) {
 }
 
 var defaults = {
-    http_options: {
-        url: "https://tilma.mysociety.org/mapserver/bexley",
-        params: {
-            SERVICE: "WFS",
-            VERSION: "1.1.0",
-            REQUEST: "GetFeature",
-            SRSNAME: "urn:ogc:def:crs:EPSG::3857"
-        }
-    },
+    http_wfs_url: "https://tilma.mysociety.org/mapserver/bexley",
     max_resolution: 4.777314267158508,
     geometryName: 'msGeometry',
     srsName: "EPSG:3857",
@@ -48,11 +40,7 @@ var road_defaults = $.extend(true, {}, defaults, {
 });
 
 fixmystreet.assets.add(road_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Streets",
-        }
-    },
+    wfs_feature: "Streets",
     nearest_radius: 100,
     usrn: [
         {
@@ -71,12 +59,7 @@ fixmystreet.assets.add(road_defaults, {
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        url: "https://tilma.mysociety.org/mapserver/bexley",
-        params: {
-            TYPENAME: "Trees"
-        }
-    },
+    wfs_feature: "Trees",
     asset_id_field: 'central_as',
     attributes: {
         central_asset_id: 'central_as',
@@ -88,33 +71,21 @@ fixmystreet.assets.add(defaults, {
 });
 
 fixmystreet.assets.add(labeled_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Bollards"
-        }
-    },
+    wfs_feature: "Bollards",
     asset_category: ["Traffic bollard"],
     asset_item_message: 'Select the <b class="asset-spot"></b> on the map to pinpoint the exact location of a damaged traffic bollard.',
     asset_item: 'bollard'
 });
 
 fixmystreet.assets.add(labeled_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Lighting"
-        }
-    },
+    wfs_feature: "Lighting",
     asset_category: ["Lamp post", "Light in park or open space", "Underpass light", "Light in multi-storey car park", "Light in outside car park"],
     asset_item_message: 'Please pinpoint the exact location for the street lighting fault.',
     asset_item: 'street light'
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Toilets"
-        }
-    },
+    wfs_feature: "Toilets",
     asset_type: 'spot',
     asset_category: ["Public toilets"],
     asset_item: 'public toilet'

--- a/web/cobrands/bexley/assets.js
+++ b/web/cobrands/bexley/assets.js
@@ -17,8 +17,7 @@ var defaults = {
     max_resolution: 4.777314267158508,
     geometryName: 'msGeometry',
     srsName: "EPSG:3857",
-    body: "London Borough of Bexley",
-    strategy_class: OpenLayers.Strategy.FixMyStreet
+    body: "London Borough of Bexley"
 };
 
 var streetlight_stylemap = new OpenLayers.StyleMap({

--- a/web/cobrands/bristol/assets.js
+++ b/web/cobrands/bristol/assets.js
@@ -48,7 +48,6 @@ var parkOptions = $.extend(true, {}, base_options, {
     asset_id_field: 'SITE_CODE',
     srsName: "EPSG:3857",
     stylemap: park_style_map,
-    strategy_class: OpenLayers.Strategy.FixMyStreet,
     road: true,
     non_interactive: true,
     actions: {

--- a/web/cobrands/bromley/assets.js
+++ b/web/cobrands/bromley/assets.js
@@ -20,8 +20,7 @@ var defaults = {
     asset_id_field: 'CENTRAL_AS',
     geometryName: 'msGeometry',
     srsName: "EPSG:3857",
-    body: "Bromley Council",
-    strategy_class: OpenLayers.Strategy.FixMyStreet
+    body: "Bromley Council"
 };
 
 fixmystreet.assets.add(defaults, {

--- a/web/cobrands/bromley/assets.js
+++ b/web/cobrands/bromley/assets.js
@@ -6,15 +6,7 @@ if (!fixmystreet.maps) {
 
 var domain = fixmystreet.staging ? "https://tilma.staging.mysociety.org" : "https://tilma.mysociety.org";
 var defaults = {
-    http_options: {
-        url: domain + "/mapserver/bromley_wfs",
-        params: {
-            SERVICE: "WFS",
-            VERSION: "1.1.0",
-            REQUEST: "GetFeature",
-            SRSNAME: "urn:ogc:def:crs:EPSG::3857"
-        }
-    },
+    http_wfs_url: domain + "/mapserver/bromley_wfs",
     asset_type: 'spot',
     max_resolution: 4.777314267158508,
     asset_id_field: 'CENTRAL_AS',
@@ -24,11 +16,7 @@ var defaults = {
 };
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Streetlights"
-        }
-    },
+    wfs_feature: "Streetlights",
     asset_id_field: 'FEATURE_ID',
     attributes: {
         feature_id: 'FEATURE_ID'
@@ -38,11 +26,7 @@ fixmystreet.assets.add(defaults, {
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Bins"
-        }
-    },
+    wfs_feature: "Bins",
     asset_category: ["Overflowing litter/dog bin", "Public Litter Bin"],
     asset_item: 'park bin',
     asset_item_message: 'For our parks, pick a <b class="asset-spot">bin</b> from the map &raquo;'
@@ -58,11 +42,7 @@ var parks_stylemap = new OpenLayers.StyleMap({
 });
 
 var parks_defaults = $.extend(true, {}, defaults, {
-    http_options: {
-        params: {
-            TYPENAME: 'Parks_Open_Spaces'
-        }
-    },
+    wfs_feature: 'Parks_Open_Spaces',
     stylemap: parks_stylemap,
     asset_type: 'area',
     asset_item: 'park',
@@ -86,11 +66,7 @@ var prow_stylemap = new OpenLayers.StyleMap({
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "PROW"
-        }
-    },
+    wfs_feature: "PROW",
     stylemap: prow_stylemap,
     always_visible: true,
     non_interactive: true,
@@ -107,7 +83,7 @@ fixmystreet.assets.add(defaults, {
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: { params: { TYPENAME: "Drains" } },
+    wfs_feature: "Drains",
     asset_id_field: 'node_id',
     attributes: {
         feature_id: 'node_id'

--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -21,15 +21,7 @@ var tilma_url = "https://" + wfs_host + "/mapserver/bucks";
 var drains_proxy_url = "https://" + wfs_host + "/proxy/bcc/drains/wfs";
 
 var defaults = {
-    http_options: {
-        url: tilma_url,
-        params: {
-            SERVICE: "WFS",
-            VERSION: "1.1.0",
-            REQUEST: "GetFeature",
-            SRSNAME: "urn:ogc:def:crs:EPSG::27700"
-        }
-    },
+    http_wfs_url: tilma_url,
     asset_type: 'spot',
     max_resolution: 4.777314267158508,
     asset_id_field: 'central_as',
@@ -43,11 +35,7 @@ var defaults = {
 };
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Grit_Bins"
-        }
-    },
+    wfs_feature: "Grit_Bins",
     asset_category: ["Salt bin damaged", "Salt bin refill"],
     asset_item: 'grit bin'
 });
@@ -85,11 +73,7 @@ var labeled_defaults = $.extend(true, {}, defaults, {
 });
 
 fixmystreet.assets.add(labeled_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "StreetLights_Union"
-        }
-    },
+    wfs_feature: "StreetLights_Union",
     class: OpenLayers.Layer.VectorAssetMove,
     asset_category: [
         'Light on during the day',
@@ -121,31 +105,19 @@ fixmystreet.assets.add(labeled_defaults, {
 });
 
 fixmystreet.assets.add(labeled_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "IlluminatedBollards"
-        }
-    },
+    wfs_feature: "IlluminatedBollards",
     asset_category: ["Bollard light not working"],
     asset_item: 'bollard'
 });
 
 fixmystreet.assets.add(labeled_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Bollards"
-        }
-    },
+    wfs_feature: "Bollards",
     asset_category: ["Bollards or railings"],
     asset_item: 'bollard'
 });
 
 fixmystreet.assets.add(labeled_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Beacons"
-        }
-    },
+    wfs_feature: "Beacons",
     asset_category: [
           'Belisha Beacon broken',
         ],
@@ -153,11 +125,7 @@ fixmystreet.assets.add(labeled_defaults, {
 });
 
 fixmystreet.assets.add(labeled_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Beacon_Column"
-        }
-    },
+    wfs_feature: "Beacon_Column",
     asset_category: [
           'Belisha Beacon broken',
         ],
@@ -165,11 +133,7 @@ fixmystreet.assets.add(labeled_defaults, {
 });
 
 fixmystreet.assets.add(labeled_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Crossings"
-        }
-    },
+    wfs_feature: "Crossings",
     asset_category: [
           'Traffic lights & crossings problems with buttons, beep or lamps',
           'Traffic lights & crossings problems with timings',
@@ -178,11 +142,7 @@ fixmystreet.assets.add(labeled_defaults, {
 });
 
 fixmystreet.assets.add(labeled_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Signs_Union"
-        }
-    },
+    wfs_feature: "Signs_Union",
     asset_category: [
           'Sign light not working',
           'Sign problem',
@@ -195,11 +155,7 @@ fixmystreet.assets.add(labeled_defaults, {
 });
 
 fixmystreet.assets.add(labeled_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "BusStops"
-        }
-    },
+    wfs_feature: "BusStops",
     asset_group: "Bus stop/shelter issue",
     construct_asset_name: null,
     asset_item: 'bus stop',
@@ -367,12 +323,8 @@ $(fixmystreet).on('report_new:highways_change', function() {
 
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            propertyName: 'msGeometry,site_code,feature_ty',
-            TYPENAME: "Whole_Street"
-        }
-    },
+    wfs_feature: "Whole_Street",
+    propertyNames: ['msGeometry', 'site_code', 'feature_ty'],
     stylemap: new OpenLayers.StyleMap({
         'default': highways_style
     }),
@@ -429,11 +381,7 @@ fixmystreet.assets.add(defaults, {
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "WinterRoutes"
-        }
-    },
+    wfs_feature: "WinterRoutes",
     asset_category: "Snow and ice problem/winter salting",
     asset_item: "road",
     asset_type: "road",
@@ -464,12 +412,8 @@ fixmystreet.assets.add(defaults, {
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        url: 'https://maps.buckscc.gov.uk/arcgis/services/Transport/BC_Car_Parks/MapServer/WFSServer',
-        params: {
-            TYPENAME: "BC_CAR_PARKS"
-        }
-    },
+    http_wfs_url: 'https://maps.buckscc.gov.uk/arcgis/services/Transport/BC_Car_Parks/MapServer/WFSServer',
+    wfs_feature: "BC_CAR_PARKS",
     class: OpenLayers.Layer.VectorAssetMove,
     select_action: true,
     actions: {
@@ -496,13 +440,9 @@ fixmystreet.assets.add(defaults, {
 var parish_speed_threshold = 30;
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        url: 'https://maps.buckscc.gov.uk/arcgis/services/Transport/OS_Highways_Speed/MapServer/WFSServer',
-        params: {
-            propertyName: 'speed,shape',
-            TYPENAME: "OS_Highways_Speed:CORPGIS.CORPORATE.OS_Highways_Speed"
-        }
-    },
+    http_wfs_url: 'https://maps.buckscc.gov.uk/arcgis/services/Transport/OS_Highways_Speed/MapServer/WFSServer',
+    wfs_feature: "OS_Highways_Speed:CORPGIS.CORPORATE.OS_Highways_Speed",
+    propertyNames: ['speed', 'shape'],
     actions: {
         found: function(layer, feature, criterion, msg_id) {
             // Answer speed limit question based on speed limit of the road.

--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -39,8 +39,7 @@ var defaults = {
     },
     geometryName: 'msGeometry',
     srsName: "EPSG:27700",
-    body: "Buckinghamshire Council",
-    strategy_class: OpenLayers.Strategy.FixMyStreet
+    body: "Buckinghamshire Council"
 };
 
 fixmystreet.assets.add(defaults, {

--- a/web/cobrands/centralbedfordshire/assets.js
+++ b/web/cobrands/centralbedfordshire/assets.js
@@ -6,15 +6,7 @@ if (!fixmystreet.maps) {
 
 var domain = fixmystreet.staging ? "https://tilma.staging.mysociety.org" : "https://tilma.mysociety.org";
 var defaults = {
-    http_options: {
-        url: domain + "/mapserver/centralbeds",
-        params: {
-            SERVICE: "WFS",
-            VERSION: "1.1.0",
-            REQUEST: "GetFeature",
-            SRSNAME: "urn:ogc:def:crs:EPSG::3857"
-        }
-    },
+    http_wfs_url: domain + "/mapserver/centralbeds",
     asset_type: 'spot',
     max_resolution: 9.554628534317017,
     geometryName: 'msGeometry',
@@ -70,11 +62,7 @@ function hide_non_stopper_message() {
 }
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Highways"
-        }
-    },
+    wfs_feature: "Highways",
     stylemap: fixmystreet.assets.stylemap_invisible,
     non_interactive: true,
     always_visible: true,
@@ -135,22 +123,14 @@ var labeled_defaults = $.extend(true, {}, defaults, {
 });
 
 fixmystreet.assets.add(labeled_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "StreetLighting"
-        }
-    },
+    wfs_feature: "StreetLighting",
     max_resolution: 2.388657133579254,
     asset_category: ["Street Lights"],
     asset_item: 'street light'
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Gullies"
-        }
-    },
+    wfs_feature: "Gullies",
     max_resolution: 1.194328566789627,
     asset_category: ["Surface cover", "Drains/Ditches Blocked"],
     asset_item: 'drain or manhole'

--- a/web/cobrands/centralbedfordshire/assets.js
+++ b/web/cobrands/centralbedfordshire/assets.js
@@ -19,8 +19,7 @@ var defaults = {
     max_resolution: 9.554628534317017,
     geometryName: 'msGeometry',
     srsName: "EPSG:3857",
-    body: "Central Bedfordshire Council",
-    strategy_class: OpenLayers.Strategy.FixMyStreet
+    body: "Central Bedfordshire Council"
 };
 var proxy_defaults = $.extend(true, {}, defaults, {
     http_options: {

--- a/web/cobrands/cheshireeast/assets.js
+++ b/web/cobrands/cheshireeast/assets.js
@@ -16,8 +16,7 @@ var defaults = {
     },
     geometryName: 'msGeometry',
     srsName: "EPSG:27700",
-    body: "Cheshire East Council",
-    strategy_class: OpenLayers.Strategy.FixMyStreet
+    body: "Cheshire East Council"
 };
 
 var streetlight_stylemap = new OpenLayers.StyleMap({

--- a/web/cobrands/fixmystreet-uk-councils/roadworks.js
+++ b/web/cobrands/fixmystreet-uk-councils/roadworks.js
@@ -12,7 +12,6 @@ var roadworks_defaults = {
     },
     srsName: "EPSG:27700",
     format_class: OpenLayers.Format.GeoJSON,
-    strategy_class: OpenLayers.Strategy.FixMyStreet,
     stylemap: fixmystreet.assets.stylemap_invisible,
     non_interactive: true,
     always_visible: true,

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -287,7 +287,7 @@ OpenLayers.Layer.VectorNearest = OpenLayers.Class(OpenLayers.Layer.VectorBase, {
         var feature = this.getFeatureAtPoint(point);
         if (feature == null) {
             // The click wasn't directly over a road, try and find one nearby
-            var nearest = this.getFeaturesWithinDistance(point, this.fixmystreet.nearest_radius || 10);
+            var nearest = this.getFeaturesWithinDistance(point, parseFloat(this.fixmystreet.nearest_radius) || 10);
             feature = nearest.length ? nearest[0] : null;
         }
         this.selected_feature = feature;
@@ -682,7 +682,9 @@ function construct_layer_options(options, protocol) {
 
     var max_resolution = options.max_resolution;
     if (typeof max_resolution === 'object') {
-        max_resolution = max_resolution[fixmystreet.cobrand];
+        max_resolution = parseFloat(max_resolution[fixmystreet.cobrand]);
+    } else {
+        max_resolution = parseFloat(max_resolution);
     }
 
     var layer_options = {

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -662,7 +662,7 @@ function construct_protocol_class(options) {
 }
 
 function construct_layer_options(options, protocol) {
-    var StrategyClass = options.strategy_class || OpenLayers.Strategy.BBOX;
+    var StrategyClass = options.strategy_class || OpenLayers.Strategy.FixMyStreet;
 
     var max_resolution = options.max_resolution;
     if (typeof max_resolution === 'object') {

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -624,6 +624,22 @@ function get_fault_stylemap() {
 
 function construct_protocol_options(options) {
     var protocol_options;
+    if (options.http_wfs_url) {
+        var srsname = options.srsName.replace(':', '::');
+        options.http_options = {
+            url: options.http_wfs_url,
+            params: {
+                SERVICE: "WFS",
+                VERSION: "1.1.0",
+                REQUEST: "GetFeature",
+                SRSNAME: "urn:ogc:def:crs:" + srsname,
+                TYPENAME: options.wfs_feature
+            }
+        };
+        if (options.propertyNames) {
+            options.http_options.params.propertyName = options.propertyNames.join(',');
+        }
+    }
     if (options.http_options !== undefined) {
         protocol_options = options.http_options;
         OpenLayers.Util.applyDefaults(options, {

--- a/web/cobrands/hackney/assets.js
+++ b/web/cobrands/hackney/assets.js
@@ -21,7 +21,6 @@ var wfs_defaults = {
   attributes: {},
   geometryName: 'geom',
   srsName: "EPSG:27700",
-  strategy_class: OpenLayers.Strategy.FixMyStreet,
   body: "Hackney Council",
   asset_item: "item"
 };
@@ -133,7 +132,6 @@ var hackney_defaults = $.extend(true, {}, {
   format_class: OpenLayers.Format.GeoJSON,
   srsName: "EPSG:4326",
   class: OpenLayers.Layer.VectorAssetMove,
-  strategy_class: OpenLayers.Strategy.FixMyStreet,
   non_interactive: false,
   body: "Hackney Council",
   attributes: {

--- a/web/cobrands/hackney/assets.js
+++ b/web/cobrands/hackney/assets.js
@@ -6,15 +6,7 @@ if (!fixmystreet.maps) {
 
 /** These layers are from the Hackney WFS feed, for non-Alloy categories: */
 var wfs_defaults = {
-  http_options: {
-    url: 'https://map2.hackney.gov.uk/geoserver/ows',
-    params: {
-        SERVICE: "WFS",
-        VERSION: "1.1.0",
-        REQUEST: "GetFeature",
-        SRSNAME: "urn:ogc:def:crs:EPSG::27700"
-    }
-},
+  http_wfs_url: 'https://map2.hackney.gov.uk/geoserver/ows',
   asset_type: 'spot',
   max_resolution: 2.388657133579254,
   asset_id_field: 'id',
@@ -27,21 +19,13 @@ var wfs_defaults = {
 
 
 fixmystreet.assets.add(wfs_defaults, {
-  http_options: {
-      params: {
-          TYPENAME: "parking:inventory_pay_and_display_machine",
-      }
-  },
+  wfs_feature: "parking:inventory_pay_and_display_machine",
   asset_category: "Pay & Display Machines",
   attributes: {}
 });
 
 fixmystreet.assets.add(wfs_defaults, {
-  http_options: {
-      params: {
-          TYPENAME: "transport:bike_hangar",
-      }
-  },
+  wfs_feature: "transport:bike_hangar",
   asset_category: "Cycle Hangars",
   attributes: {}
 });

--- a/web/cobrands/hampshire/assets.js
+++ b/web/cobrands/hampshire/assets.js
@@ -8,26 +8,14 @@ var wfs_host = fixmystreet.staging ? 'tilma.staging.mysociety.org' : 'tilma.myso
 var tilma_url = "https://" + wfs_host + "/mapserver/hampshire";
 
 var defaults = {
-    http_options: {
-        url: tilma_url,
-        params: {
-            SERVICE: "WFS",
-            VERSION: "1.1.0",
-            REQUEST: "GetFeature",
-            SRSNAME: "urn:ogc:def:crs:EPSG::27700"
-        }
-    },
+    http_wfs_url: tilma_url,
     geometryName: 'msGeometry',
     srsName: "EPSG:27700",
     body: "Hampshire County Council"
 };
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Road_Sections"
-        }
-    },
+    wfs_feature: "Road_Sections",
     usrn: [
         {
         attribute: 'SITE_CODE',
@@ -56,11 +44,7 @@ fixmystreet.assets.add(defaults, {
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "salt_bins"
-        }
-    },
+    wfs_feature: "salt_bins",
     asset_id_field: 'Asset_ID',
     asset_type: 'spot',
     asset_category: ["Salt Bin"],

--- a/web/cobrands/hampshire/assets.js
+++ b/web/cobrands/hampshire/assets.js
@@ -19,8 +19,7 @@ var defaults = {
     },
     geometryName: 'msGeometry',
     srsName: "EPSG:27700",
-    body: "Hampshire County Council",
-    strategy_class: OpenLayers.Strategy.FixMyStreet
+    body: "Hampshire County Council"
 };
 
 fixmystreet.assets.add(defaults, {

--- a/web/cobrands/highways/assets.js
+++ b/web/cobrands/highways/assets.js
@@ -5,28 +5,16 @@ if (!fixmystreet.maps) {
 }
 
 var defaults = {
-    http_options: {
-        url: "https://tilma.mysociety.org/mapserver/highways",
-        params: {
-            SERVICE: "WFS",
-            VERSION: "1.1.0",
-            REQUEST: "GetFeature",
-            SRSNAME: "urn:ogc:def:crs:EPSG::3857"
-        }
-    },
+    http_wfs_url: "https://tilma.mysociety.org/mapserver/highways",
     asset_type: 'area',
     // this covers zoomed right out on Cumbrian sections of
     // the M6
     max_resolution: 20,
-    srsName: "EPSG:900913"
+    srsName: "EPSG:3857"
 };
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Highways"
-        }
-    },
+    wfs_feature: "Highways",
     stylemap: fixmystreet.assets.stylemap_invisible,
     always_visible: true,
 

--- a/web/cobrands/highways/assets.js
+++ b/web/cobrands/highways/assets.js
@@ -18,8 +18,7 @@ var defaults = {
     // this covers zoomed right out on Cumbrian sections of
     // the M6
     max_resolution: 20,
-    srsName: "EPSG:900913",
-    strategy_class: OpenLayers.Strategy.FixMyStreet
+    srsName: "EPSG:900913"
 };
 
 fixmystreet.assets.add(defaults, {

--- a/web/cobrands/highwaysengland/assets.js
+++ b/web/cobrands/highwaysengland/assets.js
@@ -26,7 +26,6 @@ var defaults = {
     max_resolution: 40,
     min_resolution: 0.0001,
     srsName: "EPSG:3857",
-    strategy_class: OpenLayers.Strategy.FixMyStreet,
     body: 'National Highways'
 };
 

--- a/web/cobrands/hounslow/assets.js
+++ b/web/cobrands/hounslow/assets.js
@@ -5,15 +5,7 @@ if (!fixmystreet.maps) {
 }
 
 var defaults = {
-    http_options: {
-        url: "https://tilma.mysociety.org/mapserver/hounslow",
-        params: {
-            SERVICE: "WFS",
-            VERSION: "1.1.0",
-            REQUEST: "GetFeature",
-            SRSNAME: "urn:ogc:def:crs:EPSG::27700"
-        }
-    },
+    http_wfs_url: "https://tilma.mysociety.org/mapserver/hounslow",
     asset_type: 'spot',
     max_resolution: 1.194328566789627,
     asset_id_field: 'CentralAssetId',
@@ -27,11 +19,7 @@ var defaults = {
 };
 
 fixmystreet.assets.add($.extend(true, {}, defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "bins"
-        }
-    },
+    wfs_feature: "bins",
     asset_category: "Litter Bins",
     asset_item: 'bin'
 }));
@@ -39,11 +27,7 @@ fixmystreet.assets.add($.extend(true, {}, defaults, {
 // Disabled for now as the data is quite out of date and causing problems
 // sending reports.
 // fixmystreet.assets.add($.extend(true, {}, defaults, {
-//     http_options: {
-//         params: {
-//             TYPENAME: "trees"
-//         }
-//     },
+//     wfs_feature: "trees",
 //     asset_id_field: 'central_asset_id',
 //     attributes: {
 //         central_asset_id: 'central_asset_id',
@@ -74,11 +58,7 @@ fixmystreet.assets.add($.extend(true, {}, defaults, {
 // }));
 
 fixmystreet.assets.add($.extend(true, {}, defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "signs"
-        }
-    },
+    wfs_feature: "signs",
     asset_category: [
         "Sign Obstructed: Vegetation",
         "Missing sign",
@@ -95,11 +75,7 @@ fixmystreet.assets.add($.extend(true, {}, defaults, {
 //  confident that the inventory is accurate."
 // https://3.basecamp.com/4020879/buckets/10951425/todos/1780668464
 // fixmystreet.assets.add($.extend(true, {}, defaults, {
-//     http_options: {
-//         params: {
-//             TYPENAME: "gulleys"
-//         }
-//     },
+//     wfs_feature: "gulleys",
 //     asset_category: [
 //         "Bad smell",
 //         "Flooding",
@@ -146,11 +122,7 @@ var labeled_defaults = $.extend(true, {}, defaults, {
 });
 
 fixmystreet.assets.add($.extend(true, {}, labeled_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "lighting"
-        }
-    },
+    wfs_feature: "lighting",
     asset_category: [
         "Damage to paintwork",
         "Damage to paintwork/ column",
@@ -173,11 +145,7 @@ fixmystreet.assets.add($.extend(true, {}, labeled_defaults, {
 }));
 
 fixmystreet.assets.add($.extend(true, {}, defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "streets"
-        }
-    },
+    wfs_feature: "streets",
     max_resolution: 4.777314267158508,
     always_visible: true,
     non_interactive: true,

--- a/web/cobrands/hounslow/assets.js
+++ b/web/cobrands/hounslow/assets.js
@@ -23,7 +23,6 @@ var defaults = {
     },
     geometryName: 'msGeometry',
     srsName: "EPSG:27700",
-    strategy_class: OpenLayers.Strategy.FixMyStreet,
     body: "Hounslow Borough Council"
 };
 

--- a/web/cobrands/isleofwight/assets.js
+++ b/web/cobrands/isleofwight/assets.js
@@ -22,7 +22,6 @@ var defaults = {
     asset_id_field: 'asset_id',
     geometryName: 'msGeometry',
     srsName: "EPSG:27700",
-    strategy_class: OpenLayers.Strategy.FixMyStreet,
     body: "Isle of Wight Council"
 };
 

--- a/web/cobrands/isleofwight/assets.js
+++ b/web/cobrands/isleofwight/assets.js
@@ -5,15 +5,7 @@ if (!fixmystreet.maps) {
 }
 
 var defaults = {
-    http_options: {
-        url: fixmystreet.staging ? "https://tilma.staging.mysociety.org/mapserver/iow": "https://tilma.mysociety.org/mapserver/iow",
-        params: {
-            SERVICE: "WFS",
-            VERSION: "1.1.0",
-            REQUEST: "GetFeature",
-            SRSNAME: "urn:ogc:def:crs:EPSG::27700"
-        }
-    },
+    http_wfs_url: fixmystreet.staging ? "https://tilma.staging.mysociety.org/mapserver/iow": "https://tilma.mysociety.org/mapserver/iow",
     max_resolution: 1.194328566789627,
     attributes: {
         central_asset_id: 'central_asset_id',
@@ -34,11 +26,7 @@ var labeled_stylemap = new OpenLayers.StyleMap({
 });
 
 fixmystreet.assets.add($.extend(true, {}, defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "streets"
-        }
-    },
+    wfs_feature: "streets",
     always_visible: true,
     non_interactive: true,
     asset_type: 'area',
@@ -181,11 +169,7 @@ for (i = 0; i < point_category_list.length; i++) {
 
     fixmystreet.assets.add($.extend(true, {}, point_asset_defaults, {
         asset_group: cat,
-        http_options: {
-            params: {
-                TYPENAME: layer
-            }
-        }
+        wfs_feature: layer
     }));
 }
 
@@ -195,68 +179,40 @@ for (i = 0; i < line_category_list.length; i++) {
 
     fixmystreet.assets.add($.extend(true, {}, line_asset_defaults, {
         asset_group: cat,
-        http_options: {
-            params: {
-                TYPENAME: layer
-            }
-        }
+        wfs_feature: layer
     }));
 }
 
 // non union layers
 fixmystreet.assets.add($.extend(true, {}, point_asset_defaults, {
     asset_group: "Roads/Highways",
-    http_options: {
-        params: {
-            TYPENAME: "Fords"
-        }
-    }
+    wfs_feature: "Fords"
 }));
 
 fixmystreet.assets.add($.extend(true, {}, point_asset_defaults, {
     asset_group: "Roads/Highways",
-    http_options: {
-        params: {
-            TYPENAME: "Furn-Grid_and_Stones"
-        }
-    }
+    wfs_feature: "Furn-Grid_and_Stones"
 }));
 
 
 fixmystreet.assets.add($.extend(true, {}, point_asset_defaults, {
     asset_group: "Drainage",
-    http_options: {
-        params: {
-            TYPENAME: "Drainage_spot"
-        }
-    }
+    wfs_feature: "Drainage_spot"
 }));
 
 fixmystreet.assets.add($.extend(true, {}, point_asset_defaults, {
     asset_group: "Car Parking",
-    http_options: {
-        params: {
-            TYPENAME: "Car_Parking"
-        }
-    }
+    wfs_feature: "Car_Parking"
 }));
 
 fixmystreet.assets.add($.extend(true, {}, line_asset_defaults, {
     asset_group: "Grass Verges & Weeds",
-    http_options: {
-        params: {
-            TYPENAME: "Verges-Natural"
-        }
-    }
+    wfs_feature: "Verges-Natural"
 }));
 
 fixmystreet.assets.add($.extend(true, {}, point_asset_defaults, {
     asset_group: "Dog Fouling",
-    http_options: {
-        params: {
-            TYPENAME: "Furn-Bins"
-        }
-    }
+    wfs_feature: "Furn-Bins"
 }));
 
 

--- a/web/cobrands/lincolnshire/assets.js
+++ b/web/cobrands/lincolnshire/assets.js
@@ -17,7 +17,6 @@ var defaults = {
     },
     geometryName: 'msGeometry',
     srsName: "EPSG:3857",
-    strategy_class: OpenLayers.Strategy.FixMyStreet,
     body: "Lincolnshire County Council"
 };
 

--- a/web/cobrands/lincolnshire/assets.js
+++ b/web/cobrands/lincolnshire/assets.js
@@ -4,154 +4,26 @@ if (!fixmystreet.maps) {
     return;
 }
 
-var host = fixmystreet.staging ? "https://tilma.staging.mysociety.org/mapserver/lincs" : "https://tilma.mysociety.org/mapserver/lincs";
-
-var defaults = {
-    wfs_url: host,
-    asset_type: 'spot',
-    max_resolution: 2.388657133579254,
-    asset_id_field: 'Confirm_CA',
-    attributes: {
-        central_asset_id: 'Confirm_CA',
-        asset_details: 'Asset_Id'
-    },
-    geometryName: 'msGeometry',
-    srsName: "EPSG:3857",
-    body: "Lincolnshire County Council"
-};
-
-fixmystreet.assets.add(defaults, {
-    wfs_feature: "SL_Bollards",
-    asset_category: "Bollards (lit)",
-    asset_item: 'bollard'
+fixmystreet.assets.lincolnshire = {};
+fixmystreet.assets.lincolnshire.barrier_stylemap = new OpenLayers.StyleMap({
+    'default': new OpenLayers.Style({
+        strokeColor: "#000000",
+        strokeOpacity: 0.9,
+        strokeWidth: 4
+    }),
+    'select': new OpenLayers.Style({
+        strokeColor: "#55BB00",
+        strokeOpacity: 1,
+        strokeWidth: 8
+    }),
+    'hover': new OpenLayers.Style({
+        strokeWidth: 6,
+        strokeOpacity: 1,
+        strokeColor: "#FFFF00",
+        cursor: 'pointer'
+    })
 });
-
-fixmystreet.assets.add(defaults, {
-    wfs_feature: "Public_Transport_Stops",
-    asset_group: [ "Bus stops and shelters" ],
-    asset_item: 'bus stop or shelter'
-});
-
-fixmystreet.assets.add(defaults, {
-    wfs_feature: "SL_Street_Light_Units",
-    asset_category: "Street light",
-    asset_item: 'street light',
-    filter_key: 'Type',
-    filter_value: [
-        "SL: Bulkhead Lighting", "SL: Refuge Beacon", "SL: Street Lighting Unit"
-    ]
-});
-
-fixmystreet.assets.add(defaults, {
-    wfs_feature: "SL_Street_Light_Units",
-    asset_category: "Subway light",
-    asset_item: 'light',
-    filter_key: 'Type',
-    filter_value: "SL: Subway Lighting Unit"
-});
-
-function get_barrier_stylemap() {
-    return new OpenLayers.StyleMap({
-        'default': new OpenLayers.Style({
-            strokeColor: "#000000",
-            strokeOpacity: 0.9,
-            strokeWidth: 4
-        }),
-        'select': new OpenLayers.Style({
-            strokeColor: "#55BB00",
-            strokeOpacity: 1,
-            strokeWidth: 8
-        }),
-        'hover': new OpenLayers.Style({
-            strokeWidth: 6,
-            strokeOpacity: 1,
-            strokeColor: "#FFFF00",
-            cursor: 'pointer'
-        })
-    });
-}
-
-fixmystreet.assets.add(defaults, {
-    wfs_feature: "Safety_Barriers",
-    asset_category: ["Roadside safety barrier", "Missing safety fence"],
-    asset_item: 'barrier or fence',
-    filter_key: 'Type',
-    filter_value: "ST: Safety Barrier",
-    stylemap: get_barrier_stylemap(),
-    max_resolution: 1.194328566789627
-});
-
-fixmystreet.assets.add(defaults, {
-    wfs_feature: "LCC_Drainage-GulliesOffletsManholes",
-    asset_category: "Blocked drain",
-    asset_item: 'drain'
-});
-
-fixmystreet.assets.add(defaults, {
-    wfs_feature: "ST_All_Structures",
-    asset_category: "Damaged dyke, ditch or culvert",
-    asset_item: 'culvert',
-    filter_key: 'Type',
-    filter_value: [
-        "ST: Culvert 1 Cell", "ST: Culvert 2+ Cells", "ST: Culvert/Pipe"
-    ]
-});
-
-fixmystreet.assets.add(defaults, {
-    wfs_feature: "SL_Lit_Signs",
-    asset_category: "Sign (lit)",
-    asset_item: 'street sign'
-});
-
-fixmystreet.assets.add(defaults, {
-    wfs_feature: "ST_All_Structures",
-    asset_category: [
-        "Bridge",
-        "Bridge or Structure"
-    ],
-    asset_item: 'bridge',
-    filter_key: 'Type',
-    filter_value: [
-        "ST: Bridge", "ST: Bridge Ped/Cycle 1 Span",
-        "ST: Bridge Ped/Cycle 2+ Spans", "ST: Bridge Vehicular 1 Span",
-        "ST: Bridge Vehicular 2-3 Spans", "ST: Bridge Vehicular 4+ Spans"
-    ]
-});
-
-fixmystreet.assets.add(defaults, {
-    wfs_feature: "Carriageway",
-    asset_category: [
-        "Advertisement (e.g. an A-board)",
-        "Damaged/missing cats eye",
-        "Damaged road edge, encroaches less than 100mm",
-        "Damaged road edge, encroaches more than 100mm",
-        "Fallen tree or branch",
-        "Loose chippings",
-        "Manhole/drain cover on road/cycleway",
-        "Pothole on road/cycleway",
-        "Road Markings",
-        "Other road surface issue"
-    ],
-    asset_item: 'road',
-    asset_item_message: '',
-    disable_pin_snapping: true,
-    stylemap: fixmystreet.assets.stylemap_invisible
-});
-
-fixmystreet.assets.add(defaults, {
-    wfs_feature: "NSG",
-    always_visible: true,
-    non_interactive: true,
-    max_resolution: 9.554628534317017,
-    usrn: {
-        attribute: 'Site_Code',
-        field: 'site_code'
-    },
-    nearest_radius: 20,
-    stylemap: fixmystreet.assets.stylemap_invisible
-});
-
-var llpg_stylemap = new OpenLayers.StyleMap({
+fixmystreet.assets.lincolnshire.llpg_stylemap = new OpenLayers.StyleMap({
     'default': new OpenLayers.Style({
         fillOpacity: 0,
         strokeColor: "#000000",
@@ -165,15 +37,6 @@ var llpg_stylemap = new OpenLayers.StyleMap({
         fontSize: '11px',
         fontWeight: 'bold'
     })
-});
-
-fixmystreet.assets.add(defaults, {
-    wfs_feature: "LLPG",
-    // LLPG is only to be shown when fully zoomed in
-    max_resolution: 0.5971642833948135,
-    stylemap: llpg_stylemap,
-    non_interactive: true,
-    always_visible: true
 });
 
 })();

--- a/web/cobrands/merton/assets.js
+++ b/web/cobrands/merton/assets.js
@@ -7,8 +7,7 @@ if (!fixmystreet.maps) {
 var defaults = {
     max_resolution: 4.777314267158508,
     srsName: "EPSG:27700",
-    body: "Merton Council",
-    strategy_class: OpenLayers.Strategy.FixMyStreet
+    body: "Merton Council"
 };
 
 var tilma_host = fixmystreet.staging ? "https://tilma.staging.mysociety.org/" : "https://tilma.mysociety.org/";

--- a/web/cobrands/northamptonshire/assets.js
+++ b/web/cobrands/northamptonshire/assets.js
@@ -98,7 +98,6 @@ var northants_defaults = {
   wfs_url: fixmystreet.staging ? "https://tilma.staging.mysociety.org/mapserver/northamptonshire" : "https://tilma.mysociety.org/mapserver/northamptonshire",
   geometryName: 'msGeometry',
   srsName: "EPSG:3857",
-  strategy_class: OpenLayers.Strategy.FixMyStreet,
   non_interactive: false,
   body: "Northamptonshire Highways",
   attributes: {

--- a/web/cobrands/oxfordshire/assets.js
+++ b/web/cobrands/oxfordshire/assets.js
@@ -43,8 +43,7 @@ var defaults = {
     max_resolution: 4.777314267158508,
     geometryName: 'msGeometry',
     srsName: "EPSG:3857",
-    body: "Oxfordshire County Council",
-    strategy_class: OpenLayers.Strategy.FixMyStreet
+    body: "Oxfordshire County Council"
 };
 
 var asset_fillColor = fixmystreet.cobrand === "oxfordshire" ? "#007258" : "#FFFF00";
@@ -513,7 +512,6 @@ var base_light_url = base_host + "/alloy/oxfordshire-lights.php?url=" + base_pro
 var oxfordshire_defaults = {
   format_class: OpenLayers.Format.GeoJSON,
   srsName: "EPSG:4326",
-  strategy_class: OpenLayers.Strategy.FixMyStreet,
   class: OpenLayers.Layer.VectorAssetMove,
   non_interactive: false,
   body: "Oxfordshire County Council",

--- a/web/cobrands/peterborough/assets.js
+++ b/web/cobrands/peterborough/assets.js
@@ -18,8 +18,7 @@ OpenLayers.Protocol.Peterborough = OpenLayers.Class(OpenLayers.Protocol.HTTP, {
 var defaults = {
     max_resolution: 4.777314267158508,
     srsName: "EPSG:3857",
-    body: "Peterborough City Council",
-    strategy_class: OpenLayers.Strategy.FixMyStreet
+    body: "Peterborough City Council"
 };
 
 var tilma_defaults = $.extend(true, {}, defaults, {

--- a/web/cobrands/peterborough/assets.js
+++ b/web/cobrands/peterborough/assets.js
@@ -22,15 +22,7 @@ var defaults = {
 };
 
 var tilma_defaults = $.extend(true, {}, defaults, {
-    http_options: {
-        url: fixmystreet.staging ? "https://tilma.staging.mysociety.org/mapserver/peterborough" : "https://tilma.mysociety.org/mapserver/peterborough",
-        params: {
-            SERVICE: "WFS",
-            VERSION: "1.1.0",
-            REQUEST: "GetFeature",
-            SRSNAME: "urn:ogc:def:crs:EPSG::3857"
-        }
-    },
+    http_wfs_url: fixmystreet.staging ? "https://tilma.staging.mysociety.org/mapserver/peterborough" : "https://tilma.mysociety.org/mapserver/peterborough",
     geometryName: 'msGeometry'
 });
 
@@ -90,21 +82,13 @@ var trees_defaults = $.extend(true, {}, tilma_defaults, {
 });
 
 fixmystreet.assets.add(trees_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "tree_groups"
-        }
-    },
+    wfs_feature: "tree_groups",
     asset_type: 'area',
     asset_item: 'tree group'
 });
 
 fixmystreet.assets.add(trees_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "tree_points"
-        }
-    },
+    wfs_feature: "tree_points",
     asset_type: 'spot',
     asset_item: 'tree'
 });
@@ -113,11 +97,7 @@ fixmystreet.assets.add(trees_defaults, {
 // separate layer with pin-snapping disabled for new tree requests.
 // The new tree request category is disabled in the other tree point layer.
 fixmystreet.assets.add(tilma_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "tree_points"
-        }
-    },
+    wfs_feature: "tree_points",
     asset_id_field: 'TREE_CODE',
     asset_type: 'spot',
     asset_category: NEW_TREE_CATEGORY_NAME,
@@ -133,11 +113,7 @@ var streetlight_stylemap = new OpenLayers.StyleMap({
 });
 
 var light_defaults = $.extend(true, {}, tilma_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "StreetLights"
-        }
-    },
+    wfs_feature: "StreetLights",
     asset_id_field: 'UNITID',
     asset_type: 'spot',
     asset_item: 'light'

--- a/web/cobrands/shropshire/assets.js
+++ b/web/cobrands/shropshire/assets.js
@@ -24,8 +24,7 @@ var defaults = {
     },
     geometryName: 'msGeometry',
     srsName: "EPSG:27700",
-    body: "Shropshire Council",
-    strategy_class: OpenLayers.Strategy.FixMyStreet
+    body: "Shropshire Council"
 };
 
 var highways_style = new OpenLayers.Style({

--- a/web/cobrands/shropshire/assets.js
+++ b/web/cobrands/shropshire/assets.js
@@ -8,15 +8,7 @@ var wfs_host = fixmystreet.staging ? 'tilma.staging.mysociety.org' : 'tilma.myso
 var tilma_url = "https://" + wfs_host + "/mapserver/shropshire";
 
 var defaults = {
-    http_options: {
-        url: tilma_url,
-        params: {
-            SERVICE: "WFS",
-            VERSION: "1.1.0",
-            REQUEST: "GetFeature",
-            SRSNAME: "urn:ogc:def:crs:EPSG::27700"
-        }
-    },
+    http_wfs_url: tilma_url,
     asset_type: 'spot',
     asset_id_field: 'CentralAssetId',
     attributes: {
@@ -35,11 +27,7 @@ var highways_style = new OpenLayers.Style({
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Street_Gazetteer"
-        }
-    },
+    wfs_feature: "Street_Gazetteer",
     stylemap: new OpenLayers.StyleMap({
          'default': highways_style
      }),
@@ -116,11 +104,7 @@ var streetlight_stylemap = new OpenLayers.StyleMap({
 
 fixmystreet.assets.add(defaults, {
     stylemap: streetlight_stylemap,
-    http_options: {
-        params: {
-            TYPENAME: "Lights_Union"
-        }
-    },
+    wfs_feature: "Lights_Union",
     asset_group: "Streetlights",
     asset_item: 'streetlight',
     asset_id_field: 'ASSET_ID',
@@ -152,11 +136,7 @@ fixmystreet.assets.add(defaults, {
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Traffic_Signal_Areas"
-        }
-    },
+    wfs_feature: "Traffic_Signal_Areas",
     asset_id_field: 'ASSET_ID',
     attributes: {
         central_asset_id: 'ASSET_ID',
@@ -166,11 +146,7 @@ fixmystreet.assets.add(defaults, {
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Illuminated_Bollards"
-        }
-    },
+    wfs_feature: "Illuminated_Bollards",
     asset_group: 'Illuminated signs',
     asset_item: 'bollard',
     asset_id_field: 'ASSET_ID',
@@ -180,31 +156,19 @@ fixmystreet.assets.add(defaults, {
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Grit_Bins"
-        }
-    },
+    wfs_feature: "Grit_Bins",
     asset_category: ["Salt bins replenish"],
     asset_item: 'salt bin'
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Cattle_Grids"
-        }
-    },
+    wfs_feature: "Cattle_Grids",
     asset_category: ["Cattle Grid"],
     asset_item: 'cattle grid'
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "Bridges"
-        }
-    },
+    wfs_feature: "Bridges",
     asset_category: ["Bridge"],
     asset_item: 'bridge'
 });

--- a/web/cobrands/tfl/assets.js
+++ b/web/cobrands/tfl/assets.js
@@ -21,8 +21,7 @@ var defaults = {
     asset_type: 'spot',
     max_resolution: 2.388657133579254,
     geometryName: 'msGeometry',
-    srsName: "EPSG:3857",
-    strategy_class: OpenLayers.Strategy.FixMyStreet
+    srsName: "EPSG:3857"
 };
 if (fixmystreet.cobrand === 'tfl') {
     // On .com we change the categories depending on where is clicked; on the

--- a/web/cobrands/tfl/assets.js
+++ b/web/cobrands/tfl/assets.js
@@ -9,15 +9,7 @@ var tilma_url = "https://" + wfs_host + "/mapserver/tfl";
 var streetmanager_url = "https://" + wfs_host + "/streetmanager.php";
 
 var defaults = {
-    http_options: {
-        url: tilma_url,
-        params: {
-            SERVICE: "WFS",
-            VERSION: "1.1.0",
-            REQUEST: "GetFeature",
-            SRSNAME: "urn:ogc:def:crs:EPSG::3857"
-        }
-    },
+    http_wfs_url: tilma_url,
     asset_type: 'spot',
     max_resolution: 2.388657133579254,
     geometryName: 'msGeometry',
@@ -49,11 +41,7 @@ var asset_defaults = $.extend(true, {}, defaults, {
 });
 
 fixmystreet.assets.add(asset_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "trafficsignals"
-        }
-    },
+    wfs_feature: "trafficsignals",
     asset_id_field: 'Site',
     attributes: {
         site: 'Site',
@@ -63,11 +51,7 @@ fixmystreet.assets.add(asset_defaults, {
 });
 
 fixmystreet.assets.add(asset_defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "busstops"
-        }
-    },
+    wfs_feature: "busstops",
     asset_id_field: 'STOP_CODE',
     attributes: {
         stop_code: 'STOP_CODE',
@@ -78,7 +62,7 @@ fixmystreet.assets.add(asset_defaults, {
 });
 
 fixmystreet.assets.add(asset_defaults, {
-    http_options: { params: { TYPENAME: "busstations" } },
+    wfs_feature: "busstations",
     asset_id_field: 'Name',
     feature_code: 'Name',
     attributes: { station_name: 'Name' },
@@ -118,6 +102,7 @@ function to_ddmmyyyy(date) {
 }
 
 fixmystreet.assets.add(asset_defaults, {
+    http_wfs_url: '',
     http_options: {
         url: streetmanager_url,
         params: {
@@ -275,11 +260,7 @@ function is_a13dbfo_category(category, bodies) {
 }
 
 var red_routes_layer = fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "RedRoutes"
-        }
-    },
+    wfs_feature: "RedRoutes",
     name: "Red Routes",
     max_resolution: 9.554628534317017,
     road: true,
@@ -319,11 +300,7 @@ if (red_routes_layer) {
 }
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "A13TLRN_DBFO"
-        }
-    },
+    wfs_feature: "A13TLRN_DBFO",
     max_resolution: 9.554628534317017,
     road: true,
     non_interactive: true,

--- a/web/cobrands/thamesmead/assets.js
+++ b/web/cobrands/thamesmead/assets.js
@@ -9,15 +9,7 @@ var tilma_url = "https://" + wfs_host + "/mapserver/thamesmead";
 var wfs_url = "https://maps.peabody.org.uk/getows.ashx?mapsource=mapsources/maplayers";
 
 var defaults = {
-    http_options: {
-        url: wfs_url,
-        params: {
-            SERVICE: "WFS",
-            VERSION: "1.1.0",
-            REQUEST: "GetFeature",
-            SRSNAME: "urn:ogc:def:crs:EPSG::27700"
-        }
-    },
+    http_wfs_url: wfs_url,
     asset_type: 'area',
     geometryName: 'msGeometry',
     srsName: "EPSG:27700",
@@ -34,56 +26,36 @@ var defaults = {
 };
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "hardsurfaces"
-        }
-    },
+    wfs_feature: "hardsurfaces",
     no_asset_msg_id: '#js-not-an-asset-hard-surfaces',
     asset_item: 'Thamesmead managed hard surface',
     asset_group: 'Hard surfaces/paths/road (Peabody)'
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "grass"
-        }
-    },
+    wfs_feature: "grass",
     no_asset_msg_id: '#js-not-an-asset-grass',
     asset_item: 'Thamesmead managed grass area',
     asset_group: 'Grass and grass areas (Peabody)'
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "water"
-        }
-    },
+    wfs_feature: "water",
     no_asset_msg_id: '#js-not-an-asset-water',
     asset_item: 'Thamesmead managed water area',
     asset_group: 'Water areas (Peabody)'
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        url: tilma_url,
-        params: {
-            TYPENAME: "treegroups"
-        }
-    },
+    http_wfs_url: tilma_url,
+    wfs_feature: "treegroups",
     no_asset_msg_id: '#js-not-an-asset-trees',
     asset_item: 'Thamesmead managed trees area',
     asset_group: 'Trees (Peabody)'
 });
 
 fixmystreet.assets.add(defaults, {
-    http_options: {
-        params: {
-            TYPENAME: "planting"
-        }
-    },
+    wfs_feature: "planting",
     no_asset_msg_id: '#js-not-an-asset-planters',
     asset_item: 'Thamesmead managed shrubs area',
     asset_group: 'Planters and flower beds (Peabody)'

--- a/web/cobrands/thamesmead/assets.js
+++ b/web/cobrands/thamesmead/assets.js
@@ -26,7 +26,6 @@ var defaults = {
     display_zoom_message: true,
     nearest_radius: 0.1,
     body: "Thamesmead",
-    strategy_class: OpenLayers.Strategy.FixMyStreet,
     asset_item_message: 'Please pick a highlighted area from the map to report an issue to Thamesmead/Peabody.',
     actions: {
         found: fixmystreet.message_controller.road_found,

--- a/web/cobrands/westminster/assets.js
+++ b/web/cobrands/westminster/assets.js
@@ -66,8 +66,7 @@ var defaults = {
     body: "Westminster City Council",
     format_class: OpenLayers.Format.GeoJSON,
     format_options: {ignoreExtraDims: true},
-    protocol_class: OpenLayers.Protocol.Westminster,
-    strategy_class: OpenLayers.Strategy.FixMyStreet
+    protocol_class: OpenLayers.Protocol.Westminster
 };
 
 fixmystreet.assets.add(defaults, {

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -1228,7 +1228,9 @@ OpenLayers.Strategy.FixMyStreet = OpenLayers.Class(OpenLayers.Strategy.BBOX, {
             mapBounds = this.getMapBounds();
         }
         this.bounds = mapBounds;
-    }
+    },
+
+    CLASS_NAME: "OpenLayers.Strategy.FixMyStreet"
 });
 
 /* This strategy additionally does not update on load, as we already have the data. */


### PR DESCRIPTION
This adds the option to read asset layer configuration from the configuration file, instead of in the JavaScript. This will make the config file quite a bit bigger (but could include it from another file, I imagine), but should make it a bit easier to add or change asset layers without having to update the code. Also a step towards making it configurable elsewhere in future. I've done Lincolnshire in this PR as a starting example, you'd need the config given below in order to have all the same layers that were present in the JS. This won't (yet) handle every layer, but should handle all standard ones.

<details>

```
COBRAND_FEATURES:
  asset_layers:
    lincolnshire:
      - wfs_url: "https://tilma.staging.mysociety.org/mapserver/lincs"
        asset_type: 'spot'
        max_resolution: 2.388657133579254
        asset_id_field: 'Confirm_CA'
        attributes:
          central_asset_id: 'Confirm_CA'
          asset_details: 'Asset_Id'
        geometryName: 'msGeometry'
        srsName: "EPSG:3857"
        body: "Lincolnshire County Council"
      - wfs_feature: "SL_Bollards"
        asset_category: "Bollards (lit)"
        asset_item: 'bollard'
      - wfs_feature: "Public_Transport_Stops"
        asset_group: [ "Bus stops and shelters" ]
        asset_item: 'bus stop or shelter'
      - wfs_feature: "SL_Street_Light_Units"
        asset_category: "Street light"
        asset_item: 'street light'
        filter_key: 'Type'
        filter_value: [ "SL: Bulkhead Lighting", "SL: Refuge Beacon", "SL: Street Lighting Unit" ]
      - wfs_feature: "SL_Street_Light_Units"
        asset_category: "Subway light"
        asset_item: 'light'
        filter_key: 'Type'
        filter_value: "SL: Subway Lighting Unit"
      - wfs_feature: "LCC_Drainage-GulliesOffletsManholes"
        asset_category: "Blocked drain"
        asset_item: 'drain'
      - wfs_feature: "ST_All_Structures"
        asset_category: "Damaged dyke, ditch or culvert"
        asset_item: 'culvert'
        filter_key: 'Type'
        filter_value: [ "ST: Culvert 1 Cell", "ST: Culvert 2+ Cells", "ST: Culvert/Pipe" ]
      - wfs_feature: "SL_Lit_Signs"
        asset_category: "Sign (lit)"
        asset_item: 'street sign'
      - wfs_feature: "ST_All_Structures"
        asset_category: [ "Bridge", "Bridge or Structure" ]
        asset_item: 'bridge'
        filter_key: 'Type'
        filter_value: [ "ST: Bridge", "ST: Bridge Ped/Cycle 1 Span", "ST: Bridge Ped/Cycle 2+ Spans", "ST: Bridge Vehicular 1 Span", "ST: Bridge Vehicular 2-3 Spans", "ST: Bridge Vehicular 4+ Spans" ]
      - wfs_feature: "Safety_Barriers"
        asset_category: ["Roadside safety barrier", "Missing safety fence"]
        asset_item: 'barrier or fence'
        filter_key: 'Type'
        filter_value: "ST: Safety Barrier"
        stylemap: fixmystreet.assets.lincolnshire.barrier_stylemap
        max_resolution: 1.194328566789627
      - wfs_feature: "Carriageway"
        asset_category: [ "Advertisement (e.g. an A-board)", "Damaged/missing cats eye", "Damaged road edge, encroaches less than 100mm", "Damaged road edge, encroaches more than 100mm", "Fallen tree or branch", "Loose chippings", "Manhole/drain cover on road/cycleway", "Pothole on road/cycleway", "Road Markings", "Other road surface issue" ]
        asset_item: 'road'
        asset_item_message: ''
        stylemap: fixmystreet.assets.stylemap_invisible
        disable_pin_snapping: true
      - wfs_feature: "NSG"
        always_visible: true
        non_interactive: true
        max_resolution: 9.554628534317017
        usrn: { attribute: 'Site_Code', field: 'site_code' }
        stylemap: fixmystreet.assets.stylemap_invisible
        nearest_radius: 20
      - wfs_feature: "LLPG"
        max_resolution: 0.5971642833948135
        non_interactive: true
        always_visible: true
        stylemap: fixmystreet.assets.lincolnshire.llpg_stylemap
```
</details>