### PR TITLE
[Bulky] Admin page for editing bulky items list

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Waste.pm
@@ -34,15 +34,32 @@ sub index : Path : Args(0) {
     }
 }
 
-sub edit : Path : Args(1) {
-    my ( $self, $c, $body_id ) = @_;
+sub body : Chained('/') : PathPart('admin/waste') : CaptureArgs(1) {
+    my ($self, $c, $body_id) = @_;
+
+    unless ( $c->user->has_body_permission_to('wasteworks_config', $body_id) ) {
+        $c->detach( '/page_error_404_not_found', [] );
+    }
+
+    # Regular users can only view their own body's config
+    if ( !$c->user->is_superuser && $body_id ne $c->user->from_body->id ) {
+        $c->res->redirect( $c->uri_for_action( '/admin/waste/edit', $c->user->from_body->id ) );
+    }
+
+    $c->stash->{body} = $c->model('DB::Body')->find($body_id)
+        or $c->detach( '/page_error_404_not_found', [] );
 
     foreach (qw(status_message)) {
         $c->stash->{$_} = $c->flash->{$_} if $c->flash->{$_};
     }
 
-    $c->forward('load_wasteworks_body', [ $body_id ]);
     $c->forward('stash_body_config_json');
+}
+
+
+sub edit : Chained('body') : PathPart('') : Args(0) {
+    my ( $self, $c ) = @_;
+
     $c->forward('/auth/get_csrf_token');
 
     if ($c->req->method eq 'POST') {
@@ -55,18 +72,89 @@ sub edit : Path : Args(1) {
             $c->stash->{errors} ||= {};
             my $e = $_;
             $e =~ s/ at \/.*$//; # trim the filename/lineno
-            $c->stash->{errors}->{body_config} = sprintf(_("Not a valid JSON string: %s"), $e);
+            $c->stash->{errors}->{body_config} =
+                sprintf(_("Not a valid JSON string: %s"), $e);
             $c->detach;
         };
         if (ref $new_cfg ne 'HASH') {
             $c->stash->{errors} ||= {};
-            $c->stash->{errors}->{body_config} = _("Config must be a JSON object literal, not array.");
+            $c->stash->{errors}->{body_config} =
+                _("Config must be a JSON object literal, not array.");
             $c->detach;
         }
         $c->stash->{body}->set_extra_metadata("wasteworks_config", $new_cfg);
         $c->stash->{body}->update;
         $c->flash->{status_message} = _("Updated!");
-        $c->res->redirect( $c->uri_for_action( '/admin/waste/edit', $c->stash->{body}->id ) );
+        $c->res->redirect(
+            $c->uri_for_action( '/admin/waste/edit', [ $c->stash->{body}->id ] )
+        );
+    }
+}
+
+sub bulky_items : Chained('body') {
+    my ( $self, $c ) = @_;
+
+    $c->forward('/auth/get_csrf_token');
+
+    my $cfg = $c->stash->{body}->get_extra_metadata("wasteworks_config", {});
+    $c->stash->{item_list} = $cfg->{item_list} || [];
+
+    my $cobrand = $c->stash->{body}->get_cobrand_handler;
+    $c->stash->{available_features} =
+        $cobrand->call_hook('bulky_available_feature_types') if $cobrand;
+
+    if ($c->req->method eq 'POST') {
+        $c->forward('/auth/check_csrf_token');
+
+        $c->stash->{has_errors} = 0;
+
+        my @indices = grep { /^bartec_id\[\d+\]/ } keys %{ $c->req->params };
+        @indices = sort map { /(\d+)/ } @indices;
+        my @items;
+        foreach my $i (@indices) {
+            if (($c->get_param("delete") // "") eq $i) {
+                next;
+            }
+            my $item = {
+                bartec_id => $c->get_param("bartec_id[$i]"),
+                category => $c->get_param("category[$i]"),
+                name => $c->get_param("name[$i]"),
+                message => $c->get_param("message[$i]"),
+                price => $c->get_param("price[$i]"),
+            };
+
+            # validate the row - if any field has a value then need to check
+            # that the three required fields are all present
+            my $any_value = 0;
+            map { $any_value ||= $_ } values %$item;
+            if ($any_value) {
+                # OK to store errors in $item itself as it won't get persisted,
+                # and $i might not be the same when form is re-rendered.
+                foreach (qw(name category bartec_id)) {
+                    if (!$item->{$_}) {
+                        $item->{errors} ||= {};
+                        $item->{errors}->{$_} = _("This field is required.");
+                        $c->stash->{has_errors} = 1;
+                    }
+                }
+                # this is within the $any_value check as we don't want to push
+                # empty items
+                push @items, $item;
+            }
+        }
+        unless ($c->stash->{has_errors}) {
+            $cfg->{item_list} = \@items;
+            $c->stash->{body}->set_extra_metadata("wasteworks_config", $cfg);
+            $c->stash->{body}->update;
+            $c->flash->{status_message} = _("Updated!");
+            $c->res->redirect(
+                $c->uri_for_action( '/admin/waste/bulky_items',
+                    [ $c->stash->{body}->id ]
+                )
+            );
+        } else {
+            $c->stash->{item_list} = \@items;
+        }
     }
 }
 
@@ -95,22 +183,5 @@ sub stash_body_config_json : Private {
         $c->stash->{body_config_json} = JSON->new->utf8(1)->pretty->canonical->encode($cfg);
     }
 }
-
-sub load_wasteworks_body : Private {
-    my ($self, $c, $body_id) = @_;
-
-    unless ( $c->user->has_body_permission_to('wasteworks_config', $body_id) ) {
-        $c->detach( '/page_error_404_not_found', [] );
-    }
-
-    # Regular users can only view their own body's config
-    if ( !$c->user->is_superuser && $body_id ne $c->user->from_body->id ) {
-        $c->res->redirect( $c->uri_for_action( '/admin/waste/edit', $c->user->from_body->id ) );
-    }
-
-    $c->stash->{body} = $c->model('DB::Body')->find($body_id)
-        or $c->detach( '/page_error_404_not_found', [] );
-}
-
 
 1;

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -1328,4 +1328,22 @@ sub available_permissions {
     return $perms;
 }
 
+sub bulky_available_feature_types {
+    my $self = shift;
+
+    return unless $self->feature('waste_features')->{bulky_enabled};
+
+    my $cfg = $self->feature('bartec');
+    my $bartec = Integrations::Bartec->new(%$cfg);
+    my @types = @{ $bartec->Features_Types_Get() };
+
+    # Limit to the feature types that are for bulky waste
+    my $waste_cfg = $self->body->get_extra_metadata("wasteworks_config", {});
+    if ( my $classes = $waste_cfg->{bulky_feature_classes} ) {
+        my %classes = map { $_ => 1 } @$classes;
+        @types = grep { $classes{$_->{FeatureClass}->{ID}} } @types;
+    }
+    return { map { $_->{ID} => $_->{Name} } @types };
+}
+
 1;

--- a/perllib/Integrations/Bartec.pm
+++ b/perllib/Integrations/Bartec.pm
@@ -353,4 +353,16 @@ sub Streets_Events_Get {
     return force_arrayref($events, 'Event');
 }
 
+sub Features_Types_Get {
+    my ($self) = @_;
+    # This expensive operation doesn't take any params so may as well cache it
+    my $key = "peterborough:bartec:Features_Types_Get";
+    my $types = Memcached::get($key);
+    unless ($types) {
+        $types = force_arrayref($self->call('Features_Types_Get', token => $self->token), 'FeatureType');
+        Memcached::set($key, $types, 60*30);
+    }
+    return $types;
+}
+
 1;

--- a/templates/web/base/admin/report_blocks.html
+++ b/templates/web/base/admin/report_blocks.html
@@ -40,6 +40,6 @@ SET state_groups = c.cobrand.state_groups_admin;
 
 [% BLOCK status_message %]
   [% IF status_message %]
-    <p><em>[% status_message %]</em></p>
+    <p class="fms-admin-info"><em>[% status_message %]</em></p>
   [% END %]
 [% END %]

--- a/templates/web/base/admin/waste/bulky_items.html
+++ b/templates/web/base/admin/waste/bulky_items.html
@@ -1,0 +1,80 @@
+[% INCLUDE 'admin/header.html' title=loc('Bulky items list') -%]
+[% PROCESS 'admin/report_blocks.html' %]
+
+[% INCLUDE status_message %]
+
+[% BLOCK item_row %]
+    <tr class="js-metadata-item[% IF item.errors %] error[% END %]">
+        <td>
+            [% IF available_features.size %]
+                <select class="form-control" name="bartec_id[[% i %]]"[% IF i < 9999 %] required[% ELSE %] data-required[% END %]>
+                    <option value="">---</option>
+                    [% FOR id IN available_features.sort %]
+                        <option value="[% id %]"[% IF id == item.bartec_id %] selected[% END %]>[% available_features.$id %]</option>
+                    [% END %]
+                </select>
+            [% ELSE %]
+            <input type="text" value="[% item.bartec_id %]" name="bartec_id[[% i %]]" />
+            [% END %]
+        </td>
+        <td>
+            [% IF item.errors.category %]<label for="[[% i %]]">[% item.errors.category %]</label>[% END %]
+            <input type="text" value="[% item.category %]" name="category[[% i %]]"[% IF i < 9999 %] required[% ELSE %] data-required[% END %]/>
+        </td>
+        <td>
+            [% IF item.errors.name %]<label for="[[% i %]]">[% item.errors.name %]</label>[% END %]
+            <input type="text" value="[% item.name %]" name="name[[% i %]]"[% IF i < 9999 %] required[% ELSE %] data-required[% END %]/>
+        </td>
+        <td>
+            [% IF item.errors.message %]<label for="[[% i %]]">[% item.errors.message %]</label>[% END %]
+            <input type="text" value="[% item.message %]" name="message[[% i %]]" />
+        </td>
+        <td>
+            [% IF item.errors.price %]<label for="[[% i %]]">[% item.errors.price %]</label>[% END %]
+            <input type="text" value="[% item.price %]" name="price[[% i %]]" />
+        </td>
+        <td><button name="delete" value="[% i %]" class="btn btn--small js-metadata-item-remove">[% loc('🗑') %]</button></td>
+    </tr>
+[% END %]
+
+<form method="post">
+    [% IF has_errors %]
+        <p class="error">[% loc('Please correct the errors below') %]</p>
+    [% END %]
+
+    <table>
+        <thead class="sticky">
+            <tr>
+                <th>Feature Type [% IF NOT available_features.size %]ID[% END %]</th>
+                <th>Category</th>
+                <th>Name</th>
+                <th>Message</th>
+                <th>Price</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody class="js-metadata-items">
+            [% FOR item IN item_list %]
+                [% INCLUDE item_row i=loop.index %]
+            [% END %]
+        </tbody>
+        <tbody class="hidden-js" id="js-template-extra-metadata-item">
+            [% INCLUDE item_row item={} i=9999 %]
+        </tbody>
+        <tfoot class="hidden-nojs">
+            <tr>
+                <td colspan="6"><button type="button" class="btn js-metadata-item-add" data-container-selector="tbody.js-metadata-items">[% loc('Add row') %]</button></td>
+            </tr>
+        </tfoot>
+    </table>
+    <p>
+        <input type="hidden" name="token" value="[% csrf_token %]" >
+        <input type="submit" class="btn btn--primary" value="Save changes" />
+    </p>
+</form>
+
+<p>
+    <a href="[% c.uri_for_action('admin/waste/edit', [ body.id ]) %]">[% loc("&larr; Back") %]</a>
+</p>
+
+[% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/admin/waste/edit.html
+++ b/templates/web/base/admin/waste/edit.html
@@ -28,4 +28,10 @@
     <a href="[% c.uri_for_action('admin/waste/index') %]">[% loc("&larr; Back") %]</a>
 </p>
 
+<h2>More config</h2>
+<ul>
+    <li><a href="[% c.uri_for_action('admin/waste/bulky_items', [ body.id ]) %]">[% loc("Bulky items list") %]</a></li>
+</ul>
+
+
 [% INCLUDE 'admin/footer.html' %]

--- a/web/cobrands/fixmystreet/admin.js
+++ b/web/cobrands/fixmystreet/admin.js
@@ -129,9 +129,21 @@ $(function(){
 
     $('.js-metadata-item-add').on('click', function(){
         var $container = $(this).prevAll('.js-metadata-items');
+
+        // The element for the add button might not be a sibling of the
+        // container, so allow the container to be specified by putting the
+        // selector in a data-container-selector attribute
+        if (!$container.length && $(this).data('containerSelector')) {
+            $container = $($(this).data('containerSelector'));
+        }
+
         var i = $container.children().length + 1;
         var html = $('#js-template-extra-metadata-item').html().replace(/9999/g, i);
         $container.append(html);
+        // Can't set required attribute on template element because then browser
+        // won't let you submit form. Instead, set data-required and then it
+        // gets converted to required when turned into a real item.
+        $container.find("[data-required]").prop('required', 1);
         fixmystreet.set_up.toggle_visibility();
         reloadSortableMetadataItems();
     });

--- a/web/cobrands/sass/_admin.scss
+++ b/web/cobrands/sass/_admin.scss
@@ -52,6 +52,10 @@ $button_bg_col: #a1a1a1;  // also search bar (tables)
             text-decoration: line-through;
           }
         }
+        thead.sticky th {
+            position: sticky;
+            top: 0;
+        }
     }
     .no-bullets {
       margin-#{$left}: 0;


### PR DESCRIPTION
Adds a new page to the admin that displays items in a table:

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/4776/193122800-c87cb52e-f51e-45d5-9766-25d2c78cbd78.png">

This is linked at the bottom of the `/admin/waste/2566` page:
<img width="401" alt="image" src="https://user-images.githubusercontent.com/4776/193122933-e4cf79cb-9cad-4f66-b9e1-4b6eef351031.png">

You can edit items, add new ones, or delete existing items, and it all gets stored in the config JSON:


https://user-images.githubusercontent.com/4776/193123593-a75ae9ed-35d7-4393-b59d-e67e40597f28.mov

I reused the existing JS that dynamically adds/removes rows, and figured out how to get the header to stick in place when scrolling a really long table :)

@nephila-nacrea let me know if the fields/data structure isn't what you expected for the part you're working on.

[skip changelog]

For https://github.com/mysociety/societyworks/issues/2914