### PR TITLE
Make js-autocomplete respect presence/absence of `required` property

### DIFF
--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -142,10 +142,12 @@ has_field location_photo => (
 
 # XXX yuck
 sub item_field {
+    my $i = shift;
     (
         type => 'Select',
         widget => 'Select',
-        label => 'Item ' . shift,
+        label => 'Item ' . $i,
+        required => $i == 1 ? 1 : 0,
         tags => { last_differs => 1, small => 1, autocomplete => 1 },
         options => [
             # XXX look these up dynamically

--- a/templates/web/base/govuk/fields.html
+++ b/templates/web/base/govuk/fields.html
@@ -271,7 +271,7 @@
         <span class="govuk-visually-hidden">Error:</span> [% error %]
     </span>
   [% END %]
-  <select class="govuk-select[% ' js-autocomplete' IF field.get_tag('autocomplete') %]" id="[% field.id %]" name="[% field.html_name %]">
+  <select class="govuk-select[% ' js-autocomplete' IF field.get_tag('autocomplete') %]" id="[% field.id %]" name="[% field.html_name %]"[% IF field.required %] required[% END %]>
     [% '<option value=""></option>' IF field.get_tag('autocomplete') %]
     [% FOR item IN field.options %]
       <option value="[% item.value %]"[% ' selected' IF field.fif == item.value %]>[% item.label %]</option>

--- a/templates/web/base/reports/index.html
+++ b/templates/web/base/reports/index.html
@@ -65,7 +65,7 @@
           [% IF body %]
             <label for="ward">[% loc('Pick your ward') %]</label>
             <div class="dashboard-search__input">
-                <select id="ward" name="ward" class="js-autocomplete">
+                <select id="ward" name="ward" class="js-autocomplete" required>
                     <option value="">[% loc('Pick your ward') %]</option>
                   [% FOR child IN children.values.sort('name') %]
                     <option>[% child.name | html ~%]</option>
@@ -75,7 +75,7 @@
           [% ELSE %]
             <label for="body">[% loc('Pick your council') %]</label>
             <div class="dashboard-search__input">
-                <select id="body" name="body" class="js-autocomplete">
+                <select id="body" name="body" class="js-autocomplete" required>
                     <option value="">[% loc('Pick your council') %]</option>
                   [% FOR b IN bodies # Not body as 'body' may be on stash %]
                     <option value="[% b.id %]">[% b.name | html ~%]

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -523,7 +523,7 @@ $.extend(fixmystreet.set_up, {
         accessibleAutocomplete.enhanceSelectElement({
             selectElement: this,
             displayMenu: 'overlay',
-            required: true,
+            required: $(this).prop('required') ? true : false,
             showAllValues: true,
             defaultValue: ''
         });


### PR DESCRIPTION
Enables situations where the autocomplete element is optional.

[skip changelog]