### PR TITLE
[Waste] Re-enable submit button when browser back button is used

### DIFF
--- a/web/js/waste.js
+++ b/web/js/waste.js
@@ -1,5 +1,9 @@
+window.addEventListener("pagehide", function() {
+    $('form.waste input[type="submit"]')
+        .prop('disabled', false)
+        .parents('.govuk-form-group').removeClass('loading');
+});
 $(function() {
-    $('form.waste input[type="submit"]').prop('disabled', false);
     $('form.waste').on('submit', function(e) {
         var $btn = $('input[type="submit"]', this);
         $btn.prop("disabled", true);


### PR DESCRIPTION
On Safari, at least, it seems that the code on L2 doesn't get called when the back button is used.

[skip changelog]