### PR TITLE
Retrieve children for all body areas

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -510,7 +510,7 @@ sub fetch_all_bodies : Private {
 sub fetch_body_areas : Private {
     my ($self, $c, $body ) = @_;
 
-    my $children = $body->first_area_children;
+    my $children = $body->area_children;
     unless ($children) {
         # Body doesn't have any areas defined.
         delete $c->stash->{areas};

--- a/perllib/FixMyStreet/App/Controller/Dashboard.pm
+++ b/perllib/FixMyStreet/App/Controller/Dashboard.pm
@@ -120,7 +120,7 @@ sub index : Path : Args(0) {
 
         $c->stash->{roles} = [ $body->roles->all ];
 
-        my $children = $c->stash->{children} = $body->first_area_children;
+        my $children = $c->stash->{children} = $body->area_children;
 
         $c->forward('/admin/fetch_contacts');
         $c->stash->{contacts} = [ $c->stash->{contacts}->all ];
@@ -409,7 +409,7 @@ sub heatmap : Local : Args(0) {
         $c->detach('/reports/ajax', [ 'dashboard/heatmap-list.html' ]);
     }
 
-    my $children = $c->stash->{body}->first_area_children;
+    my $children = $c->stash->{body}->area_children;
     $c->stash->{children} = $children;
     $c->stash->{ward_hash} = { map { $_->{id} => 1 } @{$c->stash->{wards}} } if $c->stash->{wards};
 

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -61,7 +61,7 @@ sub index : Path : Args(0) {
     }
 
     if ($c->stash->{body}) {
-        my $children = $c->stash->{body}->first_area_children;
+        my $children = $c->stash->{body}->area_children;
         unless ($children->{error}) {
             $c->stash->{children} = $children;
         }
@@ -171,7 +171,7 @@ sub ward : Path : Args(2) {
 
     # List of wards
     if ( !$c->stash->{wards} && $c->stash->{body}->id && $c->stash->{body}->body_areas->first ) {
-        my $children = $c->stash->{body}->first_area_children;
+        my $children = $c->stash->{body}->area_children;
         unless ($children->{error}) {
             foreach (values %$children) {
                 $_->{url} = $c->uri_for( $c->stash->{body_url}
@@ -484,7 +484,7 @@ sub summary : Private {
 
     $c->stash->{group_by_default} = 'category';
 
-    my $children = $c->stash->{body}->first_area_children;
+    my $children = $c->stash->{body}->area_children;
     $c->stash->{children} = $children;
 
     $c->forward('/admin/fetch_contacts');

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -814,12 +814,21 @@ cobrand's area_types_children type.
 =cut
 
 sub fetch_area_children {
-    my ($self, $area_id, $all_generations) = @_;
+    my ($self, $area_ids, $all_generations) = @_;
 
-    return FixMyStreet::MapIt::call('area/children', $area_id,
-        type => $self->area_types_children,
-        $all_generations ? (min_generation => 1) : (),
-    );
+    $area_ids = [ $area_ids ] unless ref $area_ids eq 'ARRAY';
+
+    my %all_children;
+
+    foreach my $area_id (@$area_ids) {
+        my $children = FixMyStreet::MapIt::call('area/children', $area_id,
+            type => $self->area_types_children,
+            $all_generations ? (min_generation => 1) : (),
+        );
+        %all_children = ( %all_children, %$children );
+    }
+
+    return \%all_children;
 }
 
 =item contact_name, contact_email, do_not_reply_email

--- a/perllib/FixMyStreet/DB/Result/Body.pm
+++ b/perllib/FixMyStreet/DB/Result/Body.pm
@@ -188,12 +188,12 @@ sub areas {
 sub first_area_children {
     my ( $self, $all_generations ) = @_;
 
-    my $body_area = $self->body_areas->first;
-    return unless $body_area;
+    my @body_area_ids = map { $_->area_id } $self->body_areas->all;
+    return unless @body_area_ids;
 
     my $cobrand = $self->result_source->schema->cobrand;
 
-    return $cobrand->fetch_area_children($body_area->area_id, $all_generations);
+    return $cobrand->fetch_area_children(\@body_area_ids, $all_generations);
 }
 
 =head2 get_cobrand_handler

--- a/perllib/FixMyStreet/DB/Result/Body.pm
+++ b/perllib/FixMyStreet/DB/Result/Body.pm
@@ -185,7 +185,7 @@ sub areas {
     return \%ids;
 }
 
-sub first_area_children {
+sub area_children {
     my ( $self, $all_generations ) = @_;
 
     my @body_area_ids = map { $_->area_id } $self->body_areas->all;

--- a/perllib/FixMyStreet/Reporting.pm
+++ b/perllib/FixMyStreet/Reporting.pm
@@ -274,7 +274,7 @@ sub generate_csv {
 
     my %asked_for = map { $_ => 1 } @{$self->csv_columns};
 
-    my $children = $self->body ? $self->body->first_area_children(1) : {};
+    my $children = $self->body ? $self->body->area_children(1) : {};
 
     my $objects = $self->objects_rs;
     while ( my $obj = $objects->next ) {

--- a/perllib/FixMyStreet/Script/UpdateAllReports.pm
+++ b/perllib/FixMyStreet/Script/UpdateAllReports.pm
@@ -288,7 +288,7 @@ sub calculate_top_five_bodies {
 sub calculate_top_five_wards {
     my ($data, $rs, $body) = @_;
 
-    my $children = $body->first_area_children;
+    my $children = $body->area_children;
     die $children->{error} if $children->{error};
 
     my $week_ago = $dtf->format_datetime(DateTime->now->subtract(days => 7));

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -204,6 +204,12 @@ sub dispatch_request {
         if ($area eq '2226') {
             return $self->output({22261 => {parent_area => 2226, id => 22261, name => "Lansdown and Park", type => "CED"}});
         }
+        if ($area eq '164185') {
+            return $self->output({53295 => {parent_area => 164185, id => 53295, name => "Weston By Welland", type => "CPC"}});
+        }
+        if ($area eq '164186') {
+            return $self->output({53296 => {parent_area => 164186, id => 53296, name => "Sulgrave", type => "CPC"}});
+        }
         my $response = {
             "60705" => { "parent_area" => 2245, "generation_high" => 25, "all_names" => { }, "id" => 60705, "codes" => { "ons" => "00HY226", "gss" => "E04011842", "unit_id" => "17101" }, "name" => "Trowbridge", "country" => "E", "type_name" => "Civil parish/community", "generation_low" => 12, "country_name" => "England", "type" => "CPC" },
             "62883" => { "parent_area" => 2245, "generation_high" => 25, "all_names" => { }, "id" => 62883, "codes" => { "ons" => "00HY026", "gss" => "E04011642", "unit_id" => "17205" }, "name" => "Bradford-on-Avon", "country" => "E", "type_name" => "Civil parish/community", "generation_low" => 12, "country_name" => "England", "type" => "CPC" },

--- a/t/cobrand/northamptonshire.t
+++ b/t/cobrand/northamptonshire.t
@@ -391,4 +391,25 @@ subtest 'Old report cutoff' => sub {
     is $cobrand->should_skip_sending_update($update2), 0;
 };
 
+# Associate body with North Northamptonshire area
+# (It's associated with West when it's created at the top of this file)
+FixMyStreet::DB->resultset('BodyArea')->find_or_create({
+    area_id => 164185,
+    body_id => $nh->id,
+});
+
+subtest 'Dashboard wards contains North and West wards' => sub {
+    my $staffuser = $mech->create_user_ok('counciluser@example.com', name => 'Council User',
+        from_body => $nh, password => 'password');
+    $mech->log_in_ok( $staffuser->email );
+    FixMyStreet::override_config {
+        MAPIT_URL => 'http://mapit.uk/',
+        ALLOWED_COBRANDS => 'northamptonshire',
+    }, sub {
+        $mech->get_ok('/dashboard');
+    };
+    $mech->content_contains('Weston By Welland');
+    $mech->content_contains('Sulgrave');
+};
+
 done_testing();


### PR DESCRIPTION
Updates the code that fetches children for a body to look at all associated areas.

This fixes the issue that Northamptonshire reported where they could only see North Northamptonshire wards in the dashboard dropdown.

Fixes https://github.com/mysociety/societyworks/issues/3262

[skip changelog]