### PR TITLE
[National Highways] Ensure reports don't have an update form

### DIFF
--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -427,6 +427,52 @@ sub report_new_munge_before_insert {
     }
 }
 
+# Allow cobrands to disallow updates on some things.
+# Note this only ever locks down more than the default.
+sub updates_disallowed {
+    my $self = shift;
+    my ($problem) = @_;
+    my $c = $self->{c};
+
+    # If closed due to problem/category closure, want that to take precedence
+    my $parent = $self->next::method(@_);
+    return $parent if $parent;
+
+    my $cfg = $self->feature('updates_allowed') || '';
+    if ($cfg eq 'none') {
+        return $cfg;
+    } elsif ($cfg eq 'staff') {
+        # Only staff and superusers can leave updates
+        my $staff = $c->user_exists && $c->user->from_body && $c->user->from_body->name eq $self->council_name;
+        my $superuser = $c->user_exists && $c->user->is_superuser;
+        return $cfg unless $staff || $superuser;
+    }
+
+    if ($cfg =~ /reporter/) {
+        return $cfg if !$c->user_exists || $c->user->id != $problem->user->id;
+    }
+    if ($cfg =~ /open/) {
+        return $cfg if $problem->is_fixed || $problem->is_closed;
+    }
+
+    return '';
+}
+
+# Report if cobrand denies updates by user
+sub deny_updates_by_user {
+    my ($self, $row) = @_;
+    my $cfg = $self->feature('updates_allowed') || '';
+    if ($cfg eq 'none' || $cfg eq 'staff') {
+        return 1;
+    } elsif ($cfg eq 'reporter-open' && !$row->is_open) {
+        return 1;
+    } elsif ($cfg eq 'open' && !$row->is_open) {
+        return 1;
+    } else {
+        return;
+    }
+};
+
 # To use recaptcha, add a RECAPTCHA key to your config, with subkeys secret and
 # site_key, taken from the recaptcha site. This shows it to non-UK IP addresses
 # on alert and report pages.

--- a/t/cobrand/highwaysengland.t
+++ b/t/cobrand/highwaysengland.t
@@ -51,6 +51,9 @@ FixMyStreet::override_config {
     CONTACT_EMAIL => 'fixmystreet@example.org',
     COBRAND_FEATURES => {
         contact_email => { highwaysengland => 'highwaysengland@example.org' },
+        updates_allowed => {
+            highwaysengland => 'open',
+        },
     },
 }, sub {
     ok $mech->host('highwaysengland.example.org');
@@ -126,7 +129,15 @@ FixMyStreet::override_config {
     subtest 'check not in a group' => sub {
         my $j = $mech->get_ok_json('/report/new/ajax?latitude=52.236251&longitude=-0.892052&w=1');
         is $j->{subcategories}, undef;
-    }
+    };
+
+    subtest 'Reports do not have update form' => sub {
+        $problem->state('fixed - council');
+        $problem->update;
+
+        $mech->get_ok('/report/' . $problem->id);
+        $mech->content_lacks('Provide an update');
+    };
 };
 
 subtest 'Dashboard CSV extra columns' => sub {


### PR DESCRIPTION
The HighwaysEngland cobrand module doesn't inherit from UKCouncils, so was falling back to the updates_disallowed method from Default.pm. This means that despite there being configuration designed to prevent updates they were still being permitted.

This change moves the updates_disallowed method from UKCouncils to UK.pm.

I think this should be ok, as the two places where it might matter, FixMyStreet.pm and Thamesmead.pm have their own version of the method.

Thamesmead might be a cause for concern because it calls SUPER, which will now be the new method in UK.pm, rather than Default.pm.

The other two cobrands that might be affected are EastSussex and WestBerkshire, but I can't see that it would make a difference to those.

Fixes https://github.com/mysociety/societyworks/issues/3272

[skip changelog]