### PR TITLE
Fix all warnings and offline running

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1283,7 +1283,7 @@ sub set_report_extras : Private {
             push @extra, {
                 name => $field->{code},
                 description => $field->{description},
-                value => $c->get_param($param_prefix . $field->{code}) || '',
+                value => $c->get_param($param_prefix . $field->{code}) // '',
             };
         }
     }

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -394,6 +394,8 @@ sub direct_debit_error : Path('dd_error') : Args(0) {
     my ($token, $id) = $c->cobrand->call_hook( 'garden_waste_dd_get_redirect_params' => $c );
     if ( $id && $token ) {
         $c->forward('check_payment_redirect_id', [ $id, $token ]);
+        my $p = $c->stash->{report};
+        $c->stash->{property} = $c->cobrand->call_hook(look_up_property => $p->get_extra_field_value('property_id'));
         $c->forward('populate_dd_details');
     }
 
@@ -1441,7 +1443,7 @@ sub add_report : Private {
     if ($c->user_exists) {
         if ($c->user->from_body && !$data->{email} && !$data->{phone}) {
             $c->set_param('form_as', 'anonymous_user');
-        } elsif ($c->user->from_body && $c->user->email ne $data->{email}) {
+        } elsif ($c->user->from_body && $c->user->email ne ($data->{email} || '')) {
             $c->set_param('form_as', 'another_user');
         }
         $c->set_param('username', $data->{email} || $data->{phone});

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -62,7 +62,7 @@ has_page add_items => (
 
 has_page location => (
     title => 'Location details',
-    fields => ['location', 'location_photo', 'continue'],
+    fields => ['location', 'location_photo', 'location_photo_fileid', 'continue'],
     next => 'summary',
 );
 

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -286,7 +286,7 @@ sub open311_munge_update_params {
 
     # Waste reports are sent to our Open311 endpoint, not Bromley's,
     # and we don't want to make changes to parameters in that case.
-    return if $comment->problem->cobrand_data eq 'waste';
+    return if ($comment->problem->cobrand_data || '') eq 'waste';
 
     delete $params->{update_id};
     $params->{public_anonymity_required} = $comment->anonymous ? 'TRUE' : 'FALSE',

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -1381,11 +1381,11 @@ sub emergency_message {
     my $field = 'emergency_message';
     $field .= "_$type" if $type;
 
-    my $ooh = $self->ooh_times($body);
     my $msg = $body->get_extra_metadata($field);
-    if ($ooh->active) {
-        $field .= "_ooh";
-        $msg = $body->get_extra_metadata($field) || $msg;
+    my $ooh_msg = $body->get_extra_metadata($field . '_ooh');
+    if ($ooh_msg) {
+        my $ooh = $self->ooh_times($body);
+        $msg = $ooh_msg if $ooh->active;
     }
     FixMyStreet::Template::SafeString->new($msg);
 }

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -1156,7 +1156,7 @@ sub waste_munge_problem_data {
     my $c = $self->{c};
 
     my $service_details = $self->{c}->stash->{services_problems}->{$id};
-    my $container_id = $service_details->{container};
+    my $container_id = $service_details->{container} || 0; # 497 doesn't have a container
 
     my $category = $self->body->contacts->find({ email => "Bartec-$id" })->category;
     my $category_verbose = $service_details->{label};
@@ -1180,7 +1180,7 @@ sub waste_munge_problem_data {
         $data->{detail} .= "\n\nReason: Cracked bin\n\nPlease remove cracked bin.";
     } else {
         $data->{title} = $category =~ /Lid|Wheels/ ? "Damaged $bin bin" :
-                         $category =~ /Not returned/ ? "$bin bin not returned" : $bin;
+                         $category =~ /Not returned/ ? "Bin not returned" : $bin;
         $data->{detail} = "$category_verbose\n\n" . $c->stash->{property}->{address};
     }
 

--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -263,7 +263,7 @@ sub latest_visible_problem {
         state => [ FixMyStreet::DB::Result::Problem->visible_states() ]
     }, {
         order_by => { -desc => 'id' }
-    })->single;
+    })->first;
 }
 
 =head2 check_for_errors

--- a/perllib/FixMyStreet/Roles/CobrandSLWP.pm
+++ b/perllib/FixMyStreet/Roles/CobrandSLWP.pm
@@ -614,10 +614,19 @@ sub waste_garden_sub_params {
         $c->set_param('Bin_Delivery_Detail_Container', $container);
         $c->set_param('Bin_Delivery_Detail_Quantity', abs($data->{new_bins}));
     }
+}
 
-    if ( $c->stash->{orig_sub} and ($c->stash->{orig_sub}->get_extra_field_value('payment_method')||'') eq 'direct_debit' ) {
-        $c->set_param('dd_contact_id', $c->stash->{orig_sub}->get_extra_metadata('dd_contact_id'));
-        $c->set_param('dd_mandate_id', $c->stash->{orig_sub}->get_extra_metadata('dd_mandate_id'));
+sub waste_report_extra_dd_data {
+    my ($self) = @_;
+    my $c = $self->{c};
+
+    if (my $orig = $c->stash->{orig_sub}) {
+        my $p = $c->stash->{report};
+        $p->set_extra_metadata(dd_contact_id => $orig->get_extra_metadata('dd_contact_id'))
+            if $orig->get_extra_metadata('dd_contact_id');
+        $p->set_extra_metadata(dd_mandate_id => $orig->get_extra_metadata('dd_mandate_id'))
+            if $orig->get_extra_metadata('dd_mandate_id');
+        $p->update;
     }
 }
 

--- a/perllib/FixMyStreet/Roles/CobrandSLWP.pm
+++ b/perllib/FixMyStreet/Roles/CobrandSLWP.pm
@@ -814,7 +814,7 @@ sub garden_waste_dd_check_success {
     my ($self, $c) = @_;
 
     # check if the bank details have been verified
-    my $applied = lc $c->get_param('verificationapplied') || '';
+    my $applied = lc($c->get_param('verificationapplied') || '');
     if ( $applied eq 'true' ) {
         # and if they have and verification has failed then redirect
         # to the cancelled page

--- a/t/app/controller/admin/emergencymessage.t
+++ b/t/app/controller/admin/emergencymessage.t
@@ -10,6 +10,17 @@ my $user = $mech->create_user_ok('user@example.com', name => 'Test User', from_b
 
 $mech->log_in_ok( $user->email );
 
+my $ukc = Test::MockModule->new('FixMyStreet::Cobrand::UK');
+$ukc->mock('_get_bank_holiday_json', sub {
+    {
+        "england-and-wales" => {
+            "events" => [
+                { "date" => "2019-12-25", "title" => "Christmas Day" }
+            ]
+        }
+    }
+});
+
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'oxfordshire' ],
 }, sub {
@@ -108,17 +119,6 @@ FixMyStreet::override_config {
         $mech->get_ok('/report/new?latitude=51.45556&longitude=0.15356');
         $mech->content_lacks('Testing reporting message');
     };
-
-    my $ukc = Test::MockModule->new('FixMyStreet::Cobrand::UK');
-    $ukc->mock('_get_bank_holiday_json', sub {
-        {
-            "england-and-wales" => {
-                "events" => [
-                    { "date" => "2019-12-25", "title" => "Christmas Day" }
-                ]
-            }
-        }
-    });
 
     subtest 'setting OOH messages' => sub {
         my ($csrf) = $mech->content =~ /name="token" value="([^"]*)"/;

--- a/t/app/controller/admin/templates.t
+++ b/t/app/controller/admin/templates.t
@@ -1,5 +1,9 @@
 use FixMyStreet::TestMech;
 
+use t::Mock::Tilma;
+my $tilma = t::Mock::Tilma->new;
+LWP::Protocol::PSGI->register($tilma->to_psgi_app, host => 'tilma.mysociety.org');
+
 my $mech = FixMyStreet::TestMech->new;
 
 my $user = $mech->create_user_ok('test@example.com', name => 'Test User');
@@ -401,7 +405,10 @@ subtest "category groups are shown" => sub {
 subtest "TfL cobrand only shows TfL templates" => sub {
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => [ 'tfl' ],
-        COBRAND_FEATURES => { internal_ips => { tfl => [ '127.0.0.1' ] } },
+        COBRAND_FEATURES => {
+            internal_ips => { tfl => [ '127.0.0.1' ] },
+            anonymous_account => { tfl => 'anon' },
+        },
     }, sub {
         $report->update({
             category => $tflcontact->category,

--- a/t/app/controller/index.t
+++ b/t/app/controller/index.t
@@ -1,6 +1,8 @@
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;
 
+use t::Mock::Nominatim;
+
 # check that the homepage loads
 $mech->get_ok('/');
 

--- a/t/app/controller/report_new_errors.t
+++ b/t/app/controller/report_new_errors.t
@@ -5,6 +5,8 @@ use Path::Tiny;
 FixMyStreet::App->log->disable('info');
 END { FixMyStreet::App->log->enable('info'); }
 
+use t::Mock::Nominatim;
+
 my $mech = FixMyStreet::TestMech->new;
 
 my $sample_file = path(__FILE__)->parent->child("sample.jpg");

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -114,7 +114,7 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { postcode => 'BR1 1AA' } });
         $mech->content_contains('13345'); # For comparing against type check below
         $mech->submit_form_ok({ with_fields => { address => 'missing' } });
-        $mech->content_contains('can’t find your address');
+        $mech->content_contains('find your address in our records');
     };
     subtest 'Address lookup' => sub {
         set_fixed_time('2020-05-28T17:00:00Z'); # After sample data collection
@@ -1311,7 +1311,7 @@ FixMyStreet::override_config {
         is $new_report->get_extra_field_value('Container_Instruction_Container_Type'), 44, 'correct container request bin type';
         is $new_report->get_extra_field_value('Container_Instruction_Action'), 2, 'correct container request action';
         is $new_report->get_extra_field_value('Container_Instruction_Quantity'), 1, 'correct container request count';
-        is $new_report->get_extra_field_value('payment'), '', 'no payment if removing bins';
+        is $new_report->get_extra_field_value('payment'), '0', 'no payment if removing bins';
         is $new_report->get_extra_field_value('pro_rata'), '', 'no pro rata payment if removing bins';
         $new_report->delete;
 
@@ -2100,7 +2100,7 @@ FixMyStreet::override_config {
         is $new_report->get_extra_field_value('Container_Instruction_Quantity'), 1, 'correct container request count';
         is $new_report->get_extra_metadata('contributed_by'), $staff_user->id;
         is $new_report->get_extra_metadata('contributed_as'), 'anonymous_user';
-        is $new_report->get_extra_field_value('payment'), '', 'no payment if removing bins';
+        is $new_report->get_extra_field_value('payment'), '0', 'no payment if removing bins';
         is $new_report->get_extra_field_value('pro_rata'), '', 'no pro rata payment if removing bins';
     };
 

--- a/t/app/controller/waste_kingston.t
+++ b/t/app/controller/waste_kingston.t
@@ -832,7 +832,7 @@ FixMyStreet::override_config {
         is $sent_params, undef, "no one off payment if reducing bin count";
         check_extra_data_pre_confirm($new_report, type => 'Amend', state => 'confirmed', action => 2);
         is $new_report->state, 'confirmed', 'report confirmed';
-        is $new_report->get_extra_field_value('payment'), '', 'no payment if removing bins';
+        is $new_report->get_extra_field_value('payment'), '0', 'no payment if removing bins';
         is $new_report->get_extra_field_value('pro_rata'), '', 'no pro rata payment if removing bins';
 
         $mech->clear_emails_ok;
@@ -1529,7 +1529,7 @@ FixMyStreet::override_config {
         is $new_report->get_extra_field_value('Bin_Delivery_Detail_Quantity'), 1, 'correct container request count';
         is $new_report->get_extra_metadata('contributed_by'), $staff_user->id;
         is $new_report->get_extra_metadata('contributed_as'), 'another_user';
-        is $new_report->get_extra_field_value('payment'), '', 'no payment if removing bins';
+        is $new_report->get_extra_field_value('payment'), '0', 'no payment if removing bins';
         is $new_report->get_extra_field_value('pro_rata'), '', 'no pro rata payment if removing bins';
     };
     $echo->mock('GetServiceUnitsForObject', \&garden_waste_one_bin);
@@ -1767,7 +1767,7 @@ FixMyStreet::override_config {
         $mech->content_contains('"a user"');
         $mech->content_contains(1000000002);
         $mech->content_contains('a_user@example.net');
-        $mech->content_contains('credit_card,54321,2000,,,26,1,1'); # Method/ref/fee/fee/fee/bin/current/sub
+        $mech->content_contains('credit_card,54321,2000,,0,26,1,1'); # Method/ref/fee/fee/fee/bin/current/sub
         $mech->content_contains('"a user 2"');
         $mech->content_contains('a_user_2@example.net');
         $mech->content_contains('unconfirmed');

--- a/t/app/controller/waste_kingston.t
+++ b/t/app/controller/waste_kingston.t
@@ -52,8 +52,6 @@ create_contact({ category => 'Cancel Garden Subscription', email => 'garden_canc
     { code => 'Bin_Delivery_Detail_Containers', required => 1, automated => 'hidden_field' },
     { code => 'Subscription_End_Date', required => 1, automated => 'hidden_field' },
     { code => 'payment_method', required => 1, automated => 'hidden_field' },
-    { code => 'dd_contact_id', required => 0, automated => 'hidden_field' },
-    { code => 'dd_mandate_id', required => 0, automated => 'hidden_field' },
 );
 
 package SOAP::Result;

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -12,6 +12,9 @@ END { FixMyStreet::App->log->enable('info'); }
 my $uk = Test::MockModule->new('FixMyStreet::Cobrand::UK');
 $uk->mock('_fetch_url', sub { '{}' });
 
+my $mock = Test::MockModule->new('FixMyStreet::Cobrand::Peterborough');
+$mock->mock('_fetch_features', sub { [] });
+
 my $mech = FixMyStreet::TestMech->new;
 
 my $params = {
@@ -83,7 +86,7 @@ FixMyStreet::override_config {
         $mech->get_ok('/waste');
         $mech->submit_form_ok({ with_fields => { postcode => 'PE1 3NA' } });
         $mech->submit_form_ok({ with_fields => { address => 'missing' } });
-        $mech->content_contains('can’t find your address', "Missing message found");
+        $mech->content_contains('find your address in our records', "Missing message found");
     };
     subtest 'Address lookup' => sub {
         set_fixed_time('2021-08-05T21:00:00Z');
@@ -751,7 +754,8 @@ FixMyStreet::override_config {
 
         subtest 'Summary page' => sub {
             $mech->content_contains('Submit bulky goods collection booking');
-            $mech->content_contains('Please review the information you’ve provided before you submit your bulky goods collection booking.');
+            $mech->content_contains('Please review the information');
+            $mech->content_contains('provided before you submit your bulky goods collection booking.');
             $mech->content_contains('<dd class="govuk-summary-list__value">table</dd>');
             $mech->submit_form_ok({ with_fields => { tandc => 1 } });
         };

--- a/t/app/controller/waste_sutton_garden.t
+++ b/t/app/controller/waste_sutton_garden.t
@@ -639,7 +639,7 @@ FixMyStreet::override_config {
         is $sent_params, undef, "no one off payment if reducing bin count";
         check_extra_data_pre_confirm($new_report, type => 'Amend', state => 'confirmed', action => 2);
         is $new_report->state, 'confirmed', 'report confirmed';
-        is $new_report->get_extra_field_value('payment'), '', 'no payment if removing bins';
+        is $new_report->get_extra_field_value('payment'), '0', 'no payment if removing bins';
         is $new_report->get_extra_field_value('pro_rata'), '', 'no pro rata payment if removing bins';
 
         $mech->clear_emails_ok;
@@ -1159,7 +1159,7 @@ FixMyStreet::override_config {
         is $new_report->get_extra_field_value('Bin_Delivery_Detail_Quantity'), 1, 'correct container request count';
         is $new_report->get_extra_metadata('contributed_by'), $staff_user->id;
         is $new_report->get_extra_metadata('contributed_as'), 'another_user';
-        is $new_report->get_extra_field_value('payment'), '', 'no payment if removing bins';
+        is $new_report->get_extra_field_value('payment'), '0', 'no payment if removing bins';
         is $new_report->get_extra_field_value('pro_rata'), '', 'no pro rata payment if removing bins';
     };
     $echo->mock('GetServiceUnitsForObject', \&garden_waste_one_bin);

--- a/t/app/controller/waste_sutton_r.t
+++ b/t/app/controller/waste_sutton_r.t
@@ -130,7 +130,7 @@ FixMyStreet::override_config {
     };
     subtest 'Request bins from front page' => sub {
         $mech->get_ok('/waste/12345');
-        $mech->submit_form_ok({ with_fields => { 'container-choice' => 1 } });
+        $mech->submit_form_ok({ form_number => 7 });
         $mech->content_contains('name="container-choice" value="1"');
         $mech->content_contains('Green paper and cardboard bin');
         $mech->content_contains('Green recycling box');

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -21,6 +21,10 @@ END { FixMyStreet::App->log->enable('info'); }
 my $uk = Test::MockModule->new('FixMyStreet::Cobrand::UK');
 $uk->mock('_fetch_url', sub { '{}' });
 
+use t::Mock::Tilma;
+my $tilma = t::Mock::Tilma->new;
+LWP::Protocol::PSGI->register($tilma->to_psgi_app, host => 'tilma.mysociety.org');
+
 # Create test data
 my $user = $mech->create_user_ok( 'bromley@example.com', name => 'Bromley' );
 my $body = $mech->create_body_ok( 2482, 'Bromley Council', {

--- a/t/cobrand/merton.t
+++ b/t/cobrand/merton.t
@@ -3,6 +3,9 @@ use FixMyStreet::TestMech;
 use HTML::Selector::Element qw(find);
 use FixMyStreet::Script::Reports;
 
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
 my $mech = FixMyStreet::TestMech->new;
 my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Merton');
 

--- a/t/cobrand/peterborough.t
+++ b/t/cobrand/peterborough.t
@@ -5,6 +5,25 @@ use CGI::Simple;
 use Test::LongString;
 use Open311::PostServiceRequestUpdates;
 
+my $mock = Test::MockModule->new('FixMyStreet::Cobrand::Peterborough');
+$mock->mock('_fetch_features', sub {
+    my ($self, $args, $x, $y) = @_;
+    if ( $args->{type} && $args->{type} eq 'arcgis' ) {
+        # council land
+        if ( $x == 552617 && $args->{url} =~ m{4/query} ) {
+            return [ { geometry => { type => 'Point' } } ];
+        # leased out council land
+        } elsif ( $x == 552651 && $args->{url} =~ m{3/query} ) {
+            return [ { geometry => { type => 'Point' } } ];
+        # adopted roads
+        } elsif ( $x == 552721 && $args->{url} =~ m{7/query} ) {
+            return [ { geometry => { type => 'Point' } } ];
+        }
+        return [];
+    }
+    return [];
+});
+
 my $mech = FixMyStreet::TestMech->new;
 
 my $params = {
@@ -186,25 +205,6 @@ subtest "extra bartec params are sent to open311" => sub {
         is $cgi->param('attribute[contributed_by]'), $staffuser->email, 'staff email address sent';
     };
 };
-
-my $mock = Test::MockModule->new('FixMyStreet::Cobrand::Peterborough');
-$mock->mock('_fetch_features', sub {
-    my ($self, $args, $x, $y) = @_;
-    if ( $args->{type} && $args->{type} eq 'arcgis' ) {
-        # council land
-        if ( $x == 552617 && $args->{url} =~ m{4/query} ) {
-            return [ { geometry => { type => 'Point' } } ];
-        # leased out council land
-        } elsif ( $x == 552651 && $args->{url} =~ m{3/query} ) {
-            return [ { geometry => { type => 'Point' } } ];
-        # adopted roads
-        } elsif ( $x == 552721 && $args->{url} =~ m{7/query} ) {
-            return [ { geometry => { type => 'Point' } } ];
-        }
-        return [];
-    }
-    return [];
-});
 
 for my $test (
     {

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -1189,6 +1189,7 @@ subtest 'TfL staff cannot access Bromley admin' => sub {
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'tfl' ],
     BASE_URL => 'http://www.example.org',
+    MAPIT_URL => 'http://mapit.uk/',
     COBRAND_FEATURES => {
         internal_ips => { tfl => [ '127.0.0.1' ] }, # To avoid 2-factor for test
         borough_email_addresses => { tfl => {

--- a/t/cobrand/westminster.t
+++ b/t/cobrand/westminster.t
@@ -94,6 +94,7 @@ subtest 'Reports have an update form for superusers' => sub {
         ALLOWED_COBRANDS => 'westminster',
         MAPIT_URL => 'http://mapit.uk/',
         COBRAND_FEATURES => {
+            anonymous_account => { westminster => 'anon' },
             updates_allowed => {
                 westminster => 'staff',
             },

--- a/t/open311/getservicerequestupdates.t
+++ b/t/open311/getservicerequestupdates.t
@@ -1118,7 +1118,7 @@ subtest 'check that no external_status_code and no state change does not trigger
         current_body => $bodies{2482},
     );
 
-    $update->process_body;
+    stderr_like { $update->process_body } qr/Couldn't determine update text for/, 'Error message displayed';
 
     $problem->discard_changes;
     is $problem->comments->count, 1, 'comment is still created after fetching updates';

--- a/t/sendreport/open311_send.t
+++ b/t/sendreport/open311_send.t
@@ -16,6 +16,10 @@ use FixMyStreet::Script::Reports;
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;
 
+use t::Mock::Tilma;
+my $tilma = t::Mock::Tilma->new;
+LWP::Protocol::PSGI->register($tilma->to_psgi_app, host => 'tilma.mysociety.org');
+
 my $user = $mech->create_user_ok( 'eh@example.com' );
 my $body = $mech->create_body_ok( 2342, 'East Hertfordshire Council', {}, { cobrand => 'eastherts' });
 my $contact = $mech->create_contact_ok( body_id => $body->id, category => 'Potholes', email => 'POT' );

--- a/templates/web/base/waste/garden/subscribe_summary.html
+++ b/templates/web/base/waste/garden/subscribe_summary.html
@@ -5,8 +5,6 @@ summary_title = 'Subscription';
 step1 = 'details';
 %]
 
-[% total_bins = data.current_bins + data.new_bins %]
-
 [% BLOCK answers %]
     <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key govuk-summary-list__key--sub">Green garden waste subscription</dt>


### PR DESCRIPTION
@struan First commit for you to check on the DD contact/mandate stuff discussed, and in second commit there's the fix for direct_debit_error not having the property details (already fixed for CC).
@davea In the second commit, there's one bulky goods change for you to just check - to make sure the fileid for location_photo is included in the right page, so it's not included on all pages (and thereby cause undef warnings).
Think all the rest is just to prevent warnings.
[skip changelog]