### PR TITLE
[Bulky] Added Jquery for item screen

### DIFF
--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -235,10 +235,10 @@ sub _build_items_extra_text {
     return \%hash;
 }
 
-sub format_item_string {
-    my ( $self, $str ) = @_;
-    return lc $str =~ s/\W+/_/gr;
-}
+# sub format_item_string {
+#     my ( $self, $str ) = @_;
+#     return lc $str =~ s/\W+/_/gr;
+# }
 
 sub field_list {
     my $self = shift;

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -235,11 +235,6 @@ sub _build_items_extra_text {
     return \%hash;
 }
 
-# sub format_item_string {
-#     my ( $self, $str ) = @_;
-#     return lc $str =~ s/\W+/_/gr;
-# }
-
 sub field_list {
     my $self = shift;
 

--- a/templates/web/base/govuk/fields.html
+++ b/templates/web/base/govuk/fields.html
@@ -278,7 +278,8 @@
       [% IF item.group %]
         <optgroup label="[% item.group %]"></optgroup>
         [% FOR opt IN item.options %]
-          <option value="[% opt.value %]"[% ' selected' IF field.fif == opt.value %]>[% opt.label %]</option>
+          [% extra_text = form.items_extra_text.${opt.value} %]
+          <option value="[% opt.value %]"[% IF extra_text %]data-extra_text="[% extra_text %]"[% END %][% ' selected' IF field.fif == opt.value %]>[% opt.label %]</option>
         [% END %]
       [% ELSE  %]
         <option value="[% item.value %]"[% ' selected' IF field.fif == item.value %]>[% item.label %]</option>

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -29,12 +29,18 @@
   [% PROCESS form override_fields = [ 'continue', 'saved_data', 'token', 'process', 'unique_id' ] %]
 </form>
 
-[% # XXX If JS enabled, hide unless relevant item selected %]
+[% # Only shown if JS disabled %]
 [% BLOCK extra_text %]
-  [% FOR item_desc IN form.items_extra_text.keys %]
-    [% id = 'item_' _ num _ '.' _ form.format_item_string(item_desc) _ '.extra_text' %]
-    <div id="[% id %]"><b>[% item_desc %]: [% form.items_extra_text.$item_desc %]</b></div>
-  [% END %]
+<div class="govuk-warning-text due bulky-item-message">
+  <div class="govuk-warning-text__img">
+    <span class="govuk-warning-text__icon" aria-hidden="true">i</span>
+  </div>
+  <div class="govuk-warning-text__content">
+    <span class="item-name"></span>
+    <span class="govuk-warning-text__assistive">Important information</span>
+    <p id="item-message" class="govuk-!-margin-bottom-0"></p>
+  </div>
+</div>
 [% END %]
 
 [% INCLUDE footer.html %]

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -15,13 +15,14 @@
     [% # Building names beforehand because override_fields does not seem to like them being built inside its arg list %]
     [% base_field = 'item_' _ num %]
     [% item = base_field _ '.item' %]
+    [% PROCESS form override_fields = [ item ] %]
+    [% PROCESS extra_text num = num %]
     [% photo = base_field _ '.photo' %]
     [% photo_fileid = base_field _ '.photo_fileid' %]
-    [% PROCESS form override_fields = [ item, photo, photo_fileid ] %]
+    [% PROCESS form override_fields = [ photo, photo_fileid ] %]
 
     <button type="button" class="delete-item btn-secondary govuk-!-margin-bottom-3">Delete item</button>
 
-    [% PROCESS extra_text num = num %]
     <hr>
   </div>
   [% END %]
@@ -29,7 +30,6 @@
   [% PROCESS form override_fields = [ 'continue', 'saved_data', 'token', 'process', 'unique_id' ] %]
 </form>
 
-[% # Only shown if JS enabled %]
 [% BLOCK extra_text %]
 <div class="govuk-warning-text due bulky-item-message">
   <div class="govuk-warning-text__img">

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -25,11 +25,11 @@
     <hr>
   </div>
   [% END %]
-  <button type="button" id="add-new-item" class="btn-secondary govuk-!-margin-bottom-3">+ Add item</button>
+  <button type="button" id="add-new-item" class="btn-secondary govuk-!-margin-bottom-3" aria-label="Add item">+ Add item</button>
   [% PROCESS form override_fields = [ 'continue', 'saved_data', 'token', 'process', 'unique_id' ] %]
 </form>
 
-[% # Only shown if JS disabled %]
+[% # Only shown if JS enabled %]
 [% BLOCK extra_text %]
 <div class="govuk-warning-text due bulky-item-message">
   <div class="govuk-warning-text__img">
@@ -38,7 +38,7 @@
   <div class="govuk-warning-text__content">
     <span class="item-name"></span>
     <span class="govuk-warning-text__assistive">Important information</span>
-    <p id="item-message" class="govuk-!-margin-bottom-0"></p>
+    <p class="item-message govuk-!-margin-bottom-0" aria-live="polite"></p>
   </div>
 </div>
 [% END %]

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -9,6 +9,18 @@
   [% INCLUDE 'waste/_address_display.html' %]
 [% END %]
 
+<div class="no-js-message govuk-warning-text due" style="max-width:550px">
+  <div class="govuk-warning-text__img">
+    <span class="govuk-warning-text__icon" aria-hidden="true">i</span>
+  </div>
+  <div class="govuk-warning-text__content">
+    <span class="govuk-warning-text__assistive">Important information</span>
+    <p class="govuk-!-margin-bottom-1"><strong>About your items</strong></p>
+    <p >Before continuing, please read the following file and see if any items have a note or comment that might help our crew to collect them.</p>
+    <a class="btn-primary" href="" download="">Item notes</a>
+  </div>
+</div>
+
 <form id="item-selection-form" class="waste" method="post" enctype="multipart/form-data">
   [% FOR num IN [ 1 .. form.MAX_ITEMS ] %]
   <div class="bulky-item-wrapper">

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -17,6 +17,7 @@
     <span class="govuk-warning-text__assistive">Important information</span>
     <p class="govuk-!-margin-bottom-1"><strong>About your items</strong></p>
     <p >Before continuing, please read the following file and see if any items have a note or comment that might help our crew to collect them.</p>
+    <!-- Needs file -->
     <a class="btn-primary" href="" download="">Item notes</a>
   </div>
 </div>

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -9,19 +9,23 @@
   [% INCLUDE 'waste/_address_display.html' %]
 [% END %]
 
-<form class="waste" method="post" enctype="multipart/form-data">
+<form id="item-selection-form" class="waste" method="post" enctype="multipart/form-data">
   [% FOR num IN [ 1 .. form.MAX_ITEMS ] %]
+  <div class="bulky-item-wrapper">
     [% # Building names beforehand because override_fields does not seem to like them being built inside its arg list %]
     [% base_field = 'item_' _ num %]
     [% item = base_field _ '.item' %]
-
     [% photo = base_field _ '.photo' %]
     [% photo_fileid = base_field _ '.photo_fileid' %]
     [% PROCESS form override_fields = [ item, photo, photo_fileid ] %]
 
+    <button type="button" class="delete-item btn-secondary govuk-!-margin-bottom-3">Delete item</button>
+
     [% PROCESS extra_text num = num %]
     <hr>
+  </div>
   [% END %]
+  <button type="button" id="add-new-item" class="btn-secondary govuk-!-margin-bottom-3">+ Add item</button>
   [% PROCESS form override_fields = [ 'continue', 'saved_data', 'token', 'process', 'unique_id' ] %]
 </form>
 

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -539,11 +539,11 @@ $.extend(fixmystreet.set_up, {
                     $this.val(value).trigger( "change" );
 
                     // Ables the addItem btn when the user selects an option
-                    $("#add-new-item").prop('disabled', false);
+                    disableAddItemButton();
 
                      // To display message if option has a data-extra_text
                     if (typeof valueAttribute !== 'undefined') {
-                        $this.closest('.bulky-item-wrapper').find('#item-message').text(valueAttribute);
+                        $this.closest('.bulky-item-wrapper').find('.item-message').text(valueAttribute);
                         $this.closest('.bulky-item-wrapper').find('.bulky-item-message').css('display', 'flex');
 
                     } else {
@@ -2101,7 +2101,10 @@ setTimeout(function () {
 
     // Add items
     $("#add-new-item").click(function(){
-        $('#item-selection-form > .bulky-item-wrapper:hidden:first').show();
+        var firstHidden = $('#item-selection-form > .bulky-item-wrapper:hidden:first');
+        var hiddenInput = $('#item-selection-form > .bulky-item-wrapper:hidden:first input.autocomplete__input');
+        firstHidden.show();
+        hiddenInput.focus(); // To make it friendly to screen readers
         numItemsVisible = $('.bulky-item-wrapper:visible').length;
         deleteItem();
         $("#add-new-item").prop('disabled', true);

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -535,13 +535,17 @@ $.extend(fixmystreet.set_up, {
                     // https://github.com/alphagov/accessible-autocomplete/issues/322
                     var value = $this.children("option").filter(function () {return $(this).html() == label; }).val();
                     var valueAttribute = $this.children("option").filter(function () { return $(this).html() == label; }).attr('data-extra_text');
+                    var itemMessage = $('.item-name').filter(function () { return $(this).html() == label; }).html();
                     $this.val(value).trigger( "change" );
+
+                    // Ables the addItem btn when the user selects an option
                     $("#add-new-item").prop('disabled', false);
 
                      // To display message if option has a data-extra_text
                     if (typeof valueAttribute !== 'undefined') {
                         $this.closest('.bulky-item-wrapper').find('#item-message').text(valueAttribute);
                         $this.closest('.bulky-item-wrapper').find('.bulky-item-message').css('display', 'flex');
+
                     } else {
                         $this.closest('.bulky-item-wrapper').find('.bulky-item-message').hide();
                     }
@@ -2077,6 +2081,23 @@ setTimeout(function () {
             }
         });
     }
+
+    disableAddItemButton();
+
+    // Check if current item has a message. Useful when the user refresh the page
+    $( '.bulky-item-wrapper' ).each(function() {
+        $this = $(this);
+        label = $this.find('.autocomplete__option').text();
+        value = $this.find('.js-autocomplete').children("option").filter(function () {return $(this).html() == label; }).val();
+        itemMessage = $this.find('.js-autocomplete').children("option").filter(function () {return $(this).html() == label; }).attr('data-extra_text');
+        if (typeof itemMessage !== 'undefined') {
+            $this.find('#item-message').text(itemMessage);
+            $this.find('.bulky-item-message').css('display', 'flex');
+        } else {
+            $this.find('.bulky-item-message').hide();
+        }
+    });
+
 
     // Add items
     $("#add-new-item").click(function(){

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -2125,15 +2125,9 @@ setTimeout(function () {
         $(this).closest('.bulky-item-wrapper').hide();
         $enhancedElement.val('');
         $(this).closest('.bulky-item-wrapper').find('select.js-autocomplete').val('');
-        console.log(this);
-        // $(this).closest('.bulky-item-wrapper').find('.dropzone');
-        // photodrop.removeFile(file);
-        $(this).closest('.bulky-item-wrapper').find('.dz-remove').trigger('click');
-        // console.log($(this).closest('.bulky-item-wrapper').find('.dz-remove'));
-        // console.log($(this).closest('.bulky-item-wrapper').find('.dz-remove').trigger('click'));
-        $enhancedElement.click()
-        $enhancedElement.focus()
-        $enhancedElement.blur()
+        $enhancedElement.click();
+        $enhancedElement.focus();
+        $enhancedElement.blur();
         numItemsVisible = $('.bulky-item-wrapper:visible').length;
         deleteItem();
         disableAddItemButton();

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -528,6 +528,7 @@ $.extend(fixmystreet.set_up, {
             required: $(this).prop('required') ? true : false,
             showAllValues: true,
             defaultValue: '',
+            preserveNullOptions: true,
             onConfirm: function(label) {
                 // This function runs when the user selects an item, or removes focus from the autoselect dropdown.
                 if (typeof label !== 'undefined') {
@@ -2110,10 +2111,16 @@ setTimeout(function () {
         $("#add-new-item").prop('disabled', true);
     });
 
-      //Erase bulky item
+    //Erase bulky item
+    //https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/blob/master/app/assets/javascripts/autocomplete.js#L40
       $(".delete-item").click(function(){
+        var $enhancedElement = $(this).closest('.bulky-item-wrapper').find('.autocomplete__input');
         $(this).closest('.bulky-item-wrapper').hide();
-        $(this).closest('.bulky-item-wrapper').find('.autocomplete__input').val('');
+        $enhancedElement.val('');
+        $(this).closest('.bulky-item-wrapper').find('select.js-autocomplete').val('');
+        $enhancedElement.click()
+        $enhancedElement.focus()
+        $enhancedElement.blur()
         numItemsVisible = $('.bulky-item-wrapper:visible').length;
         deleteItem();
         disableAddItemButton();

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -850,6 +850,7 @@ $.extend(fixmystreet.set_up, {
                 $upload_fileids.val(newstr);
             });
             this.on("maxfilesexceeded", function(file) {
+                console.log(this);
                 this.removeFile(file);
                 var $message = $('<div class="dz-message dz-error-message">');
                 $message.text(translation_strings.upload_max_files_exceeded);
@@ -861,6 +862,11 @@ $.extend(fixmystreet.set_up, {
                 }, 2000);
             });
             }
+        });
+
+        // Delete pictures when item is deleted on bulky waste
+        $(this).closest('.bulky-item-wrapper').find('.delete-item').click(function(){
+            photodrop.removeAllFiles(true);
         });
 
         $dropzone.on('keydown', function(e) {
@@ -2116,8 +2122,15 @@ setTimeout(function () {
       $(".delete-item").click(function(){
         var $enhancedElement = $(this).closest('.bulky-item-wrapper').find('.autocomplete__input');
         $(this).closest('.bulky-item-wrapper').hide();
+        $(this).closest('.bulky-item-wrapper').hide();
         $enhancedElement.val('');
         $(this).closest('.bulky-item-wrapper').find('select.js-autocomplete').val('');
+        console.log(this);
+        // $(this).closest('.bulky-item-wrapper').find('.dropzone');
+        // photodrop.removeFile(file);
+        $(this).closest('.bulky-item-wrapper').find('.dz-remove').trigger('click');
+        // console.log($(this).closest('.bulky-item-wrapper').find('.dz-remove'));
+        // console.log($(this).closest('.bulky-item-wrapper').find('.dz-remove').trigger('click'));
         $enhancedElement.click()
         $enhancedElement.focus()
         $enhancedElement.blur()
@@ -2126,3 +2139,4 @@ setTimeout(function () {
         disableAddItemButton();
       });
 }, 300);
+

--- a/web/cobrands/peterborough/base.scss
+++ b/web/cobrands/peterborough/base.scss
@@ -113,6 +113,8 @@ h1, h2 {
     &.is--disabled, &:disabled {
         color: $primary !important;
         border: 0.2em solid $primary;
+        opacity: 0.5;
+        pointer-events: none;
     }
 
     &.is--next {

--- a/web/cobrands/sass/_waste.scss
+++ b/web/cobrands/sass/_waste.scss
@@ -574,6 +574,17 @@ html.js #item-selection-form {
     display: block;
   }
 
+  .bulky-item-message {
+    display: none;
+    margin-top: 1em;
+    align-items: center;
+
+    .govuk-warning-text__img {
+      flex-basis: auto;
+      margin-right: 0.5em;
+    }
+  }
+
   .bulky-item-wrapper {
       display: none;
       &:first-child {

--- a/web/cobrands/sass/_waste.scss
+++ b/web/cobrands/sass/_waste.scss
@@ -562,3 +562,35 @@ body.bulky {
     }
   }
 }
+
+// Bulky item selection
+
+.delete-item, #add-new-item {
+  display: none;
+}
+
+html.js #item-selection-form {
+  #add-new-item {
+    display: block;
+  }
+
+  .bulky-item-wrapper {
+      display: none;
+      &:first-child {
+          display: block;
+          .delete-item {
+            display: none;
+          }
+      }
+      .delete-item {
+        margin-top: 1em;
+      }
+
+      &:first-child {
+        .delete-item {
+          display: none;
+        }
+      }
+  }
+}
+

--- a/web/cobrands/sass/_waste.scss
+++ b/web/cobrands/sass/_waste.scss
@@ -569,43 +569,49 @@ body.bulky {
   display: none;
 }
 
-html.js #item-selection-form {
-  #add-new-item {
-    display: block;
-  }
-
-  .bulky-item-message {
+html.js {
+  .no-js-message {
     display: none;
-    margin-top: 1em;
-    align-items: center;
-
-    .govuk-warning-text__img {
-      flex-basis: auto;
-      margin-right: 0.5em;
-    }
   }
 
-  .bulky-item-wrapper {
+  #item-selection-form {
+    #add-new-item {
+      display: block;
+    }
+
+    .bulky-item-message {
       display: none;
-      &:first-child {
-          display: block;
+      margin-top: 1em;
+      align-items: center;
+  
+      .govuk-warning-text__img {
+        flex-basis: auto;
+        margin-right: 0.5em;
+      }
+    }
+
+    .bulky-item-wrapper {
+        display: none;
+        &:first-child {
+            display: block;
+            .delete-item {
+              display: none;
+            }
+        }
+        .delete-item {
+          margin-top: 1em;
+        }
+
+        &:first-child {
           .delete-item {
             display: none;
           }
-      }
-      .delete-item {
-        margin-top: 1em;
-      }
-
-      &:first-child {
-        .delete-item {
-          display: none;
         }
-      }
 
-      .dropzone {
-        max-width: 380px;
-      }
+        .dropzone {
+          max-width: 380px;
+        }
+    }
   }
 }
 

--- a/web/cobrands/sass/_waste.scss
+++ b/web/cobrands/sass/_waste.scss
@@ -565,7 +565,7 @@ body.bulky {
 
 // Bulky item selection
 
-.delete-item, #add-new-item {
+.delete-item, #add-new-item, .bulky-item-message {
   display: none;
 }
 
@@ -601,6 +601,10 @@ html.js #item-selection-form {
         .delete-item {
           display: none;
         }
+      }
+
+      .dropzone {
+        max-width: 380px;
       }
   }
 }


### PR DESCRIPTION
This PR adds the following functionality:

- The "Delete Item" will delete item + reset the item value in case there was something selected.
- "Add item" button will become enabled when all the visible items have a selected item, but will become disabled when the max number of items has been reached or there is a visible item with nothing selected.
- Both buttons will become invisible if JS is not enabled.
- I used @nephila-nacrea[ commit](https://github.com/mysociety/fixmystreet/pull/4142/commits/62a9f9ee0a083145dc9898c73668832da31af870) for to display message. However I tweak her JS + the markup to make it more accessible and noticeable.

Preview:
https://user-images.githubusercontent.com/13790153/197184457-03e2923d-f278-48f0-90af-08550e2f0745.mov

There is one thing tat it would be nice:
At the moment the photo input field is one element that included the button to upload an image plus the file name or "No file selected", so the clickable area is a bit deceitful, because is larger than it appears. Can we break this element into two? button + message. If it's too much hassle we  can just include a max-width or width auto property, not ideal, but not terrible either.

Fixes https://github.com/mysociety/societyworks/issues/3233
Let me know if there is any feedback.
