### PR TITLE
[Bucks] Remove layer activation for two categories

### DIFF
--- a/web/cobrands/buckinghamshire/assets.js
+++ b/web/cobrands/buckinghamshire/assets.js
@@ -144,9 +144,7 @@ fixmystreet.assets.add(labeled_defaults, {
 fixmystreet.assets.add(labeled_defaults, {
     wfs_feature: "Signs_Union",
     asset_category: [
-          'Sign light not working',
-          'Sign problem',
-          'Dirty signs'
+          'Sign light not working'
         ],
     asset_item: 'sign',
 


### PR DESCRIPTION
Request from Bucks for sign layer not to be activated on Sign Problem or Dirty Sign

https://mysocietysupport.freshdesk.com/a/tickets/2486

[skip changelog]