### PR TITLE
[Bulky Goods] Post-testing fixes for collection date selection

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -659,14 +659,16 @@ sub _bulky_collection_window {
         $start_date->add( days => 1 );
     }
 
-    my $today = DateTime->today( time_zone => FixMyStreet->local_time_zone );
+    my $tomorrow
+        = DateTime->today( time_zone => FixMyStreet->local_time_zone )
+        ->add( days => 1 );
     my $date_to
-        = $today->clone->add( days => bulky_collection_window_days() );
+        = $tomorrow->clone->add( days => bulky_collection_window_days() );
 
     return {
         date_from => $start_date
         ? $start_date->strftime($fmt)
-        : $today->strftime($fmt),
+        : $tomorrow->strftime($fmt),
         date_to => $date_to->strftime($fmt),
     };
 }

--- a/templates/web/base/waste/bulky/choose_date.html
+++ b/templates/web/base/waste/bulky/choose_date.html
@@ -9,7 +9,12 @@
     [% INCLUDE 'waste/_address_display.html' %]
   [% END %]
 <form class="waste" method="post">
-  [% PROCESS form %]
+  [% # 'Show later / earlier dates' functionality has been implemented but at the time of writing, Peterborough have requested it not be made available %]
+  [% PROCESS form override_fields = [
+    'chosen_date', 'continue',
+    'process', 'token', 'saved_data', 'unique_id'
+    ]
+  %]
   [% IF form.current_page.name == 'choose_date_earlier' && !form.field('chosen_date').options.size %]
     <p>
       There are no slots available in the next 90 days. Please refer to information regarding and link to information about taking waste to the local <a href='https://www.peterborough.gov.uk/residents/rubbish-and-recycling/household-recycling-centre'>Household Waste Recycling Centre</a>.


### PR DESCRIPTION
As per feedback from Peterborough, the page for date selection now just shows the first four earliest dates, with no option to see later dates.

The time window for collection dates now starts from tomorrow's date, not today's.

[skip changelog]
