### PR TITLE
Paginate alerts on user admin page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
         - Admin 'add user' form now always creates staff users
         - Make sure staff permissions removed when anonymized.
         - Add role filter to dashboard interface.
+        - Alerts are paginated on user edit page. #4158
     - Development improvements:
         - Default make_css to `web/cobrands` rather than `web`.
         - Ability to pass custom arguments (eg: SSL config) to server when running via Docker

--- a/perllib/FixMyStreet/App/Controller/Admin/Users.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Users.pm
@@ -555,8 +555,13 @@ sub user_cobrand_extra_fields : Private {
 sub user_alert_details : Private {
     my ( $self, $c ) = @_;
 
-    my @alerts = $c->stash->{user}->alerts({}, { prefetch => 'alert_type' })->all;
+    my $page = $c->get_param('p') || 1;
+
+    my $alerts = $c->stash->{user}->alerts({}, { prefetch => 'alert_type', rows => 100 })->page( $page );
+    my @alerts = $alerts->all;
+
     $c->stash->{alerts} = \@alerts;
+    $c->stash->{alerts_pager} = $alerts->pager;
 
     my @wards;
 

--- a/templates/web/base/admin/list_updates.html
+++ b/templates/web/base/admin/list_updates.html
@@ -50,7 +50,7 @@
 </table>
 
 [% IF updates_pager %]
-[% INCLUDE 'pagination.html' admin=1 param='u' pager=updates_pager hash='updates' %]
+[% INCLUDE 'pagination.html' param='u' pager=updates_pager hash='updates' %]
 [% END %]
 
 [% END %]

--- a/templates/web/base/admin/reports/index.html
+++ b/templates/web/base/admin/reports/index.html
@@ -19,7 +19,7 @@
     [% INCLUDE 'admin/problem_row.html' %]
 </table>
 
-[% INCLUDE 'pagination.html', admin = 1, param = 'p', pager = problems_pager %]
+[% INCLUDE 'pagination.html', param = 'p', pager = problems_pager %]
 
 [% ELSIF searched %]
 

--- a/templates/web/base/admin/users/alerts.html
+++ b/templates/web/base/admin/users/alerts.html
@@ -54,7 +54,13 @@
     <td><input type="radio" name="edit_alert[[% alert.id %]]" value="delete"></td>
 </tr>
 [% END %]
+<tr>
+    <td colspan=5></td>
+    <td colspan=3 align="center">
+        <input class="btn" type="submit" value="[% loc('Update') %]">
+    </td>
+</tr>
 </table>
-<input class="btn" type="submit" value="[% loc('Update') %]">
 </form>
+[% INCLUDE 'pagination.html', param = 'p', pager = alerts_pager %]
 [% END %]

--- a/templates/web/zurich/admin/index-dm.html
+++ b/templates/web/zurich/admin/index-dm.html
@@ -13,6 +13,6 @@
 
 <h2 id="alle">[% loc('All reports') %]</h2>
 [% INCLUDE 'admin/_index_table.html' problems=other.all include_subdiv=1 hash='alle' %]
-[% INCLUDE 'pagination.html', admin = 1, param = 'p', hash = 'alle' %]
+[% INCLUDE 'pagination.html', param = 'p', hash = 'alle' %]
 
 [% INCLUDE 'admin/footer.html' %]

--- a/templates/web/zurich/admin/index-sdm.html
+++ b/templates/web/zurich/admin/index-sdm.html
@@ -9,6 +9,6 @@
 
 <h2 id="alle">[% loc('Reports published') %]</h2>
 [% INCLUDE 'admin/_index_table.html' problems=reports_published.all no_edit=1 hash='alle' %]
-[% INCLUDE 'pagination.html', admin = 1, param = 'p', hash = 'alle' %]
+[% INCLUDE 'pagination.html', param = 'p', hash = 'alle' %]
 
 [% INCLUDE 'admin/footer.html' %]

--- a/templates/web/zurich/admin/reports/index.html
+++ b/templates/web/zurich/admin/reports/index.html
@@ -7,7 +7,7 @@
 
 [% IF problems.size %]
     [% PROCESS 'admin/_index_table.html' %]
-    [% INCLUDE 'pagination.html', admin = 1, param = 'p', pager = problems_pager %]
+    [% INCLUDE 'pagination.html', param = 'p', pager = problems_pager %]
 [% END %]
 
 [% INCLUDE 'admin/list_updates.html' %]


### PR DESCRIPTION
Some shared/service user accounts have thousands of alerts and this page was timing out when attempting to render them all.

Prompted by FD-2538

<img width="978" alt="image" src="https://user-images.githubusercontent.com/4776/200854387-7ed4ace8-b710-4598-8730-4db7f7252098.png">
