### PR TITLE
Add cobrand feature fallback lookup.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -73,7 +73,7 @@ sub feature {
     my $features = FixMyStreet->config('COBRAND_FEATURES');
     return unless $features && ref $features eq 'HASH';
     return unless $features->{$feature} && ref $features->{$feature} eq 'HASH';
-    return $features->{$feature}->{$self->moniker};
+    return $features->{$feature}->{$self->moniker} || $features->{$feature}->{_fallback};
 }
 
 sub csp_config {


### PR DESCRIPTION
It is possible you might want to provide a default fallback to a cobrand feature, so this provides a way for you to do so.
[skip changelog]

This is for https://github.com/mysociety/societyworks/issues/3259 so I can provide a default to be used there for any cobrand not with a specific entry. Think it's an okay way of doing that.