### PR TITLE
[Camden] Add NSGRef to reports in JS and on server

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Camden.pm
+++ b/perllib/FixMyStreet/Cobrand/Camden.pm
@@ -64,4 +64,14 @@ sub open311_extra_data_include {
     return [];
 }
 
+sub open311_config {
+    my ($self, $row, $h, $params) = @_;
+    $params->{multi_photos} = 1;
+}
+
+sub open311_munge_update_params {
+    my ($self, $params, $comment, $body) = @_;
+    $params->{service_request_id_ext} = $comment->problem->id;
+}
+
 1;

--- a/perllib/FixMyStreet/Cobrand/Camden.pm
+++ b/perllib/FixMyStreet/Cobrand/Camden.pm
@@ -34,4 +34,34 @@ sub privacy_policy_url {
 
 sub admin_user_domain { 'camden.gov.uk' }
 
+sub lookup_site_code_config {
+    my ($self, $property) = @_;
+
+    # uncoverable subroutine
+    # uncoverable statement
+    {
+        buffer => 1000, # metres
+        url => "https://tilma.mysociety.org/mapserver/camden",
+        srsname => "urn:ogc:def:crs:EPSG::27700",
+        typename => "Streets",
+        property => $property,
+        accept_feature => sub { 1 },
+    }
+}
+
+sub open311_extra_data_include {
+    my ($self, $row, $h, $contact) = @_;
+
+    # Reports made via the app probably won't have a NSGRef because we don't
+    # display the road layer. Instead we'll look up the closest asset from the
+    # WFS service at the point we're sending the report over Open311.
+    if (!$row->get_extra_field_value('NSGRef')) {
+        if (my $ref = $self->lookup_site_code($row, 'NSG_REF')) {
+            $row->update_extra_field({ name => 'NSGRef', description => 'NSG Ref', value => $ref });
+        }
+    }
+
+    return [];
+}
+
 1;


### PR DESCRIPTION
The JS asset changed are in the config file under the `asset_layers` key.

Part of https://github.com/mysociety/societyworks/issues/3305