### PR TITLE
[Brent] Add cobrand hook to stop questionnaire changing status

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Questionnaire.pm
+++ b/perllib/FixMyStreet/App/Controller/Questionnaire.pm
@@ -160,7 +160,7 @@ sub record_state_change : Private {
     $c->stash->{new_state} = $new_state;
 
     # Record state change, if there was one
-    if ( $new_state ) {
+    if ( $new_state && !$c->cobrand->call_hook("prevent_questionnaire_updating_status")) {
         $problem->state( $new_state );
         $problem->lastupdate( \'current_timestamp' );
     } elsif ($problem->state ne $old_state) {

--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -58,4 +58,6 @@ sub open311_extra_data_include {
     return $open311_only;
 }
 
+sub prevent_questionnaire_updating_status { 1 };
+
 1;

--- a/perllib/FixMyStreet/Script/Questionnaires.pm
+++ b/perllib/FixMyStreet/Script/Questionnaires.pm
@@ -64,8 +64,8 @@ sub send_questionnaires_period {
             next;
         }
 
-        # Cobranded and non-cobranded messages can share a database. In this case, the conf file 
-        # should specify a vhost to send the reports for each cobrand, so that they don't get sent 
+        # Cobranded and non-cobranded messages can share a database. In this case, the conf file
+        # should specify a vhost to send the reports for each cobrand, so that they don't get sent
         # more than once if there are multiple vhosts running off the same database. The email_host
         # call checks if this is the host that sends mail for this cobrand.
         next unless $cobrand->email_host;

--- a/t/cobrand/brent.t
+++ b/t/cobrand/brent.t
@@ -1,0 +1,69 @@
+use FixMyStreet::TestMech;
+
+my $mech = FixMyStreet::TestMech->new;
+
+# disable info logs for this test run
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
+use_ok 'FixMyStreet::Cobrand::Brent';
+
+my $brent = $mech->create_body_ok(2488, 'Brent', {}, { cobrand => 'brent' });
+my $contact = $mech->create_contact_ok(body_id => $brent->id, category => 'Graffiti', email => 'graffiti@example.org');
+my $user1 = $mech->create_user_ok('user1@example.org', email_verified => 1, name => 'User 1');
+
+for my $test (
+    {
+        desc => 'Problem has stayed open when user reported fixed with update',
+        report_status => 'confirmed',
+        fields => { been_fixed => 'Yes', reported => 'No', another => 'No', update => 'Test' },
+    },
+    {
+        desc => 'Problem has stayed open when user reported fixed without update',
+        report_status => 'confirmed',
+        fields => { been_fixed => 'Yes', reported => 'No', another => 'No' },
+    },
+    {
+        desc => 'Problem has stayed fixed when user reported not fixed with update',
+        report_status => 'fixed - council',
+        fields => { been_fixed => 'No', reported => 'No', another => 'No', update => 'Test' },
+    },
+ ) { subtest "Response to questionnaire doesn't update problem state" => sub {
+        my $dt = DateTime->now()->subtract( weeks => 5 );
+        my $report_time = $dt->ymd . ' ' . $dt->hms;
+        my $sent = $dt->add( minutes => 5 );
+        my $sent_time = $sent->ymd . ' ' . $sent->hms;
+
+        my ($problem) = $mech->create_problems_for_body(1, $brent->id, 'Title', {
+        areas => "2488", category => 'Graffiti', cobrand => 'brent', user => $user1, confirmed => $report_time,
+        lastupdate => $report_time, whensent => $sent_time, state => $test->{report_status}});
+
+
+        FixMyStreet::override_config {
+            ALLOWED_COBRANDS => 'brent',
+        }, sub {
+
+        FixMyStreet::DB->resultset('Questionnaire')->send_questionnaires( {
+            site => 'fixmystreet'
+        } );
+
+        my $email = $mech->get_email;
+        my $url = $mech->get_link_from_email($email, 0, 1);
+        $mech->clear_emails_ok;
+        $mech->get_ok($url);
+        $mech->submit_form_ok( { with_fields => $test->{fields} }, "Questionnaire submitted");
+        $mech->get_ok('/report/' . $problem->id);
+        $problem = FixMyStreet::DB->resultset('Problem')->find_or_create( { id => $problem->id } );
+        is $problem->state, $test->{report_status}, $test->{desc};
+        my $questionnaire = FixMyStreet::DB->resultset('Questionnaire')->find( {
+            problem_id => $problem->id
+        } );
+
+        $questionnaire->delete;
+        $problem->comments->first->delete;
+        $problem->delete;
+        }
+    };
+};
+
+done_testing();


### PR DESCRIPTION
* Add cobrand hook 'prevent_questionnaire_updating_status'
* Add mechanism for stopping status of report updating when cobrand hook present
* Add tests

[skip changelog]