### PR TITLE
[Camden] Enable social auth for Microsoft Azure login

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Camden.pm
+++ b/perllib/FixMyStreet/Cobrand/Camden.pm
@@ -92,4 +92,24 @@ sub is_problem_anonymous { 1 }
 
 sub is_comment_anonymous { 1 }
 
+sub social_auth_enabled {
+    my $self = shift;
+
+    return $self->feature('oidc_login') ? 1 : 0;
+}
+
+sub user_from_oidc {
+    my ($self, $payload) = @_;
+
+    # TODO: Remove this once we know which fields the name/email are in.
+    use Data::Dumper;
+    $self->{c}->log->info("Camden OIDC payload: " . Dumper($payload));
+
+    # Extract the user's name and email address from the payload.
+    my $name = $payload->{name};
+    my $email = $payload->{email};
+
+    return ($name, $email);
+}
+
 1;


### PR DESCRIPTION
Enable social auth for the Camden cobrand.

At this stage we don't know which fields the name/email are actually in, so I've put in some placeholders and some logging to help us figure out where they are.

Credentials for this are in the config files on the servers.

Part of https://github.com/mysociety/societyworks/issues/3307

<!-- [skip changelog] -->
