### PR TITLE
Move reopening_disallowed to config

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Merton.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton.pm
@@ -70,17 +70,6 @@ sub open311_config {
     $params->{upload_files} = 1;
 }
 
-sub reopening_disallowed {
-    my ($self, $problem) = @_;
-    # allow admins to restrict staff from reopening categories using category control
-    return 1 if $self->next::method($problem);
-    # only Merton staff may reopen reports
-    my $c = $self->{c};
-    my $user = $c->user;
-    return 0 if ($c->user_exists && $user->from_body && $user->from_body->cobrand_name eq 'Merton Council');
-    return 1;
-}
-
 sub open311_extra_data_include {
     my ($self, $row, $h) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/Thamesmead.pm
+++ b/perllib/FixMyStreet/Cobrand/Thamesmead.pm
@@ -27,23 +27,6 @@ sub updates_disallowed {
     }
 }
 
-sub reopening_disallowed {
-    my $self = shift;
-    my $problem = shift;
-    my $c = $self->{c};
-
-    my $staff = $c->user_exists && $c->user->from_body && $c->user->from_body->name eq $self->council_name;
-    my $superuser = $c->user_exists && $c->user->is_superuser;
-    my $reporter = $c->user_exists && $c->user->id == $problem->user->id;
-    my $reopening_disallowed = $self->SUPER::reopening_disallowed($problem);
-
-    if (($staff || $superuser || $reporter) && !$reopening_disallowed) {
-        return;
-    } else {
-        return 1;
-    }
-}
-
 sub admin_allow_user {
     my ( $self, $user ) = @_;
     return 1 if $user->is_superuser;

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -466,14 +466,9 @@ sub reopening_disallowed {
     # Check if reopening is disallowed by the problem's category
     return 1 if $self->next::method($problem);
 
-    my $cfg = $self->feature('reopening_allowed') || '';
-    if ($cfg eq 'none') {
+    # Check if reopening is disallowed by the cobrand
+    if (my $cfg = $self->feature('reopening_disallowed')) {
         return 1;
-    } elsif ($cfg eq 'staff') {
-        # Only staff and superusers can reopen
-        my $staff = $c->user_exists && $c->user->from_body && $c->user->from_body->name eq $self->council_name;
-        my $superuser = $c->user_exists && $c->user->is_superuser;
-        return 1 unless $staff || $superuser;
     }
 
     # Default to allowing reports to be reopened

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -458,6 +458,28 @@ sub updates_disallowed {
     return '';
 }
 
+# Allow cobrands to prevent reports from being reopened
+sub reopening_disallowed {
+    my ($self, $problem) = @_;
+    my $c = $self->{c};
+
+    # Check if reopening is disallowed by the problem's category
+    return 1 if $self->next::method($problem);
+
+    my $cfg = $self->feature('reopening_allowed') || '';
+    if ($cfg eq 'none') {
+        return 1;
+    } elsif ($cfg eq 'staff') {
+        # Only staff and superusers can reopen
+        my $staff = $c->user_exists && $c->user->from_body && $c->user->from_body->name eq $self->council_name;
+        my $superuser = $c->user_exists && $c->user->is_superuser;
+        return 1 unless $staff || $superuser;
+    }
+
+    # Default to allowing reports to be reopened
+    return 0;
+}
+
 # Report if cobrand denies updates by user
 sub deny_updates_by_user {
     my ($self, $row) = @_;

--- a/t/app/controller/report_updates_reopening.t
+++ b/t/app/controller/report_updates_reopening.t
@@ -1,0 +1,66 @@
+package FixMyStreet::Cobrand::DummyUK;
+use parent 'FixMyStreet::Cobrand::UK';
+
+package main;
+
+use FixMyStreet::TestMech;
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $body = $mech->create_body_ok(2505, 'Camden Borough Council', {}, { cobrand => 'dummyuk' });
+
+my $user = $mech->create_user_ok('user@example.com');
+
+my ($report) = $mech->create_problems_for_body(1, $body->id, 'Testing', { state => 'fixed', user => $user });
+
+subtest 'reopening by original reporter is permitted by default' => sub {
+    $mech->log_out_ok();
+    $mech->log_in_ok($user->email);
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'dummyuk' ],
+    }, sub {
+        $mech->get_ok('/report/' . $report->id);
+        $mech->content_contains('This problem has not been fixed');
+    };
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'fixmystreet' ],
+    }, sub {
+        $mech->get_ok('/report/' . $report->id);
+        $mech->content_contains('This problem has not been fixed');
+    };
+};
+
+subtest 'reopening is not permitted when reopening_disallowed is set' => sub {
+    $mech->log_out_ok();
+    $mech->log_in_ok($user->email);
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'dummyuk' ],
+        COBRAND_FEATURES => {
+            reopening_disallowed => {
+                dummyuk => 1,
+            },
+        },
+    }, sub {
+        $mech->get_ok('/report/' . $report->id);
+        $mech->content_lacks("This problem has not been fixed");
+    };
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'fixmystreet' ],
+        COBRAND_FEATURES => {
+            reopening_disallowed => {
+                fixmystreet => {
+                    DummyFMS => 1,
+                }
+            },
+        },
+    }, sub {
+        $mech->get_ok('/report/' . $report->id);
+        $mech->content_lacks("This problem has not been fixed");
+    };
+};
+
+done_testing;

--- a/t/cobrand/merton.t
+++ b/t/cobrand/merton.t
@@ -122,6 +122,11 @@ subtest 'only Merton staff can reopen closed reports on Merton cobrand' => sub {
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => [ 'merton' ],
         MAPIT_URL => 'http://mapit.uk/',
+        COBRAND_FEATURES => {
+            reopening_allowed => {
+                merton => 'staff'
+            },
+        },
     }, sub {
         test_reopen_problem($normaluser, $problem1);
         test_reopen_problem($counciluser, $problem1);
@@ -132,6 +137,14 @@ subtest 'only Merton staff can reopen closed reports in Merton on fixmystreet.co
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => [ 'fixmystreet' ],
         MAPIT_URL => 'http://mapit.uk/',
+        COBRAND_FEATURES => {
+            reopening_allowed => {
+                merton => 'staff',
+                fixmystreet => {
+                    Merton => 'staff',
+                }
+            },
+        },
     }, sub {
         test_reopen_problem($normaluser, $problem1);
         test_reopen_problem($counciluser, $problem1);
@@ -142,6 +155,11 @@ subtest 'staff and problems for other bodies are not affected by this change on 
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => [ 'fixmystreet' ],
         MAPIT_URL => 'http://mapit.uk/',
+        COBRAND_FEATURES => {
+            reopening_allowed => {
+                merton => 'staff'
+            },
+        },
     }, sub {
         test_visit_problem($normaluser, $problem2);
         test_visit_problem($hackneyuser, $problem2);


### PR DESCRIPTION
This means that configuring whether reopening is disallowed can be done in config, instead of each cobrand having similar code.

Also should fix Thamesmead, which was still allowing reports to be reopened on .com.

## Note to deployer

The following config will need to be added to FixMyStreet's general.yml before this is deployed:

```yaml
  reopening_allowed:
    camden: staff
    merton: staff
    thamesmead: reporter
    fixmystreet:
      Camden: staff
      Merton: staff
      Thamesmead: reporter
```

[skip changelog]
