### PR TITLE
[Camden] Hide TfL's River Piers category

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Camden.pm
+++ b/perllib/FixMyStreet/Cobrand/Camden.pm
@@ -74,4 +74,11 @@ sub open311_munge_update_params {
     $params->{service_request_id_ext} = $comment->problem->id;
 }
 
+sub categories_restriction {
+    my ($self, $rs) = @_;
+
+    # Camden don't want TfL's River Piers category to appear on their cobrand.
+    return $rs->search( { 'me.category' => { '!=', 'River Piers' } } );
+}
+
 1;

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -92,7 +92,8 @@ my @PLACES = (
     ['?', 51.015143, -0.912160, 2227, 'Hampshire County Council', 'CTY'],
     ['?', 51.020097, -0.926065, 2227, 'Hampshire County Council', 'CTY'],
     ['?', 51.511258, -0.011937, 2506, 'Tower Hamlets Borough Council', 'LBO'],
-    ['?', 51.512139, -0.013074, 2506, 'Tower Hamlets Borough Council', 'LBO']
+    ['?', 51.512139, -0.013074, 2506, 'Tower Hamlets Borough Council', 'LBO'],
+    ['WC1H 8EQ', 51.529432, -0.124514, 2505, 'Camden Borough Council', 'LBO'],
 
 );
 

--- a/t/cobrand/camden.t
+++ b/t/cobrand/camden.t
@@ -1,0 +1,34 @@
+use Test::MockModule;
+use FixMyStreet::TestMech;
+
+my $mech = FixMyStreet::TestMech->new;
+
+# Mock tilma so TfL's report_new_is_on_tlrn method doesn't make a live API call.
+use t::Mock::Tilma;
+my $tilma = t::Mock::Tilma->new;
+LWP::Protocol::PSGI->register($tilma->to_psgi_app, host => 'tilma.mysociety.org');
+
+use constant CAMDEN_MAPIT_ID => 2505;
+
+my $camden = $mech->create_body_ok(CAMDEN_MAPIT_ID, 'Camden Council', {}, {
+    cobrand => 'camden'
+});
+
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => [ 'camden', 'tfl' ],
+    MAPIT_URL => 'http://mapit.uk/',
+}, sub {
+    subtest "hides the TfL River Piers category" => sub {
+        $mech->create_contact_ok(body_id => $camden->id, category => 'Potholes', email => 'potholes@camden.fixmystreet.com');
+
+        my $tfl = $mech->create_body_ok(CAMDEN_MAPIT_ID, 'TfL');
+        $mech->create_contact_ok(body_id => $tfl->id, category => 'River Piers', email => 'tfl@example.org');
+
+        ok $mech->host('camden.fixmystreet.com'), 'set host';
+
+        my $json = $mech->get_ok_json('/report/new/ajax?latitude=51.529432&longitude=-0.124514');
+        is_deeply $json->{by_category}, { 'Potholes' => { 'bodies' => [ 'Camden Council' ] } }, "Camden doesn't have River Piers category";
+    };
+};
+
+done_testing;


### PR DESCRIPTION
Camden don't want this displayed on their cobrand as it's not relevant to their area.

Fixes https://github.com/mysociety/societyworks/issues/3351

<!-- [skip changelog] -->
