### PR TITLE
[Peterborough] Bulky logged and reminder emails

### DIFF
--- a/bin/fixmystreet.com/waste-bulky-reminders
+++ b/bin/fixmystreet.com/waste-bulky-reminders
@@ -1,0 +1,31 @@
+#!/usr/bin/env perl
+
+use v5.14;
+use warnings;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use Getopt::Long::Descriptive;
+use FixMyStreet::Cobrand;
+
+my ($opts, $usage) = describe_options(
+    '%c %o',
+    ['nomail|n', 'do not actually send any email'],
+    ['verbose|v', 'more verbose output'],
+    ['cobrand=s', 'which cobrand to send reminders for'],
+    ['help|h', "print usage message and exit" ],
+);
+$usage->die if $opts->help;
+$usage->die unless $opts->cobrand;
+
+my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker($opts->cobrand)->new;
+$cobrand->bulky_reminders({
+    nomail => $opts->nomail,
+    verbose => $opts->verbose,
+});
+

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -1365,4 +1365,18 @@ sub bulky_available_feature_types {
     return { map { $_->{ID} => $_->{Name} } @types };
 }
 
+sub bulky_nice_collection_date {
+    my ($self, $date) = @_;
+    my $parser = DateTime::Format::Strptime->new( pattern => '%FT%T' );
+    my $dt = $parser->parse_datetime($date)->truncate( to => 'day' );
+    return $dt->strftime('%d %B');
+}
+
+sub bulky_nice_item_list {
+    my ($self, $report) = @_;
+
+    my @fields = grep { $_->{name} =~ /ITEM_/ } @{$report->get_extra_fields};
+    return [ map { $_->{value} || () } @fields ];
+}
+
 1;

--- a/templates/email/default/waste/bulky-reminder.html
+++ b/templates/email/default/waste/bulky-reminder.html
@@ -1,0 +1,76 @@
+[%
+
+USE pounds = format('%.2f');
+PROCESS '_bulky_data.html';
+
+email_columns = 2;
+
+PROCESS '_email_settings.html';
+INCLUDE '_email_top.html';
+
+%]
+
+<th style="[% td_style %][% primary_column_style %]" id="primary_column">
+  [% start_padded_box | safe %]
+
+  <p style="[% p_style %]">Dear [% report.name %],</p>
+
+  <p style="[% p_style %]">[% email_summary %]</p>
+
+  <p style="[% p_style %]">
+    [% IF days == 3 %]
+    This is a reminder that your collection is in
+    <strong>3 days</strong>.
+    [% ELSIF days == 1 %]
+    This is a reminder that your collection is
+    <strong>tomorrow</strong>.
+    [% END %]
+  </p>
+
+    [% INCLUDE '_council_reference.html' problem=report %]
+
+  <p style="[% p_style %]">
+    Collection date: [% collection_date %]
+  </p>
+
+  <p style="[% p_style %]">
+    Items to be collected:
+    [% FOR item IN item_list %]<br>[% item %][% END %]
+  </p>
+
+[% IF payment %]
+  <p style="[% p_style %]">
+    Total cost: £[% pounds(payment / 100) %]
+  </p>
+[% END %]
+
+  <p style="[% p_style %]">
+    If you wish to cancel your booking, please follow the link below.
+[% IF days == 1 %]
+You can still cancel your booking, but a refund is no longer available.
+[% ELSE %]
+You can obtain a refund if you cancel more than one day before your booking.
+[% END %]
+  </p>
+
+  <p style="margin: 20px auto; text-align: center">
+    <a style="[% button_style %]" href="[% URL %]">Cancel booking</a>
+  </p>
+
+  <p style="[% p_style %]">
+    Cancellation policy / T&amp;Cs / etc
+  </p>
+
+  <p style="[% p_style %]">
+    Kind regards,<br>Waste Services Team
+  </p>
+
+  [% end_padded_box | safe %]
+</th>
+
+[% WRAPPER '_email_sidebar.html' object = report %]
+    <h2 style="[% h2_style %]">[% report.title | html %]</h2>
+    [% report.detail | html_para_email(secondary_p_style) %]
+[% END %]
+
+[% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/waste/bulky-reminder.txt
+++ b/templates/email/default/waste/bulky-reminder.txt
@@ -1,0 +1,44 @@
+Subject: Bulky waste collection reminder - reference [% report.id %]
+
+[% PROCESS '_bulky_data.html'; ~%]
+
+Dear [% report.name %],
+
+[% email_summary %]
+
+[% IF days == 3 %]
+This is a reminder that your collection is in 3 days.
+[% ELSIF days == 1 %]
+This is a reminder that your collection is tomorrow.
+[% END %]
+
+[% INCLUDE '_council_reference.txt' problem=report %]
+
+[% report.detail %]
+
+Collection date: [% collection_date %]
+
+Items to be collected:
+
+  [% item_list.join("\n\n  ") %]
+
+[% IF payment ~%]
+Total cost: £[% pounds(payment / 100) %]
+
+[% END ~%]
+
+If you wish to cancel your booking, please visit:
+    URL XXX
+
+[% IF days == 1 %]
+You can still cancel your booking, but a refund is no longer available.
+[% ELSE %]
+You can obtain a refund if you cancel more than one day before your booking.
+[% END %]
+
+Cancellation policy / T&amp;Cs / etc
+
+[% signature %]
+
+This email was sent automatically, from an unmonitored email account - so
+please do not reply to it.

--- a/templates/email/peterborough/_bulky_data.html
+++ b/templates/email/peterborough/_bulky_data.html
@@ -1,0 +1,8 @@
+[%
+
+SET payment = report.get_extra_field_value('payment');
+SET collection_date = cobrand.bulky_nice_collection_date(report.get_extra_field_value('DATE'));
+SET item_list = cobrand.bulky_nice_item_list(report);
+SET email_summary = "Thank you for booking a Peterborough bulky waste collection.";
+
+~%]

--- a/templates/email/peterborough/other-reported-bulky.html
+++ b/templates/email/peterborough/other-reported-bulky.html
@@ -1,0 +1,58 @@
+[%
+
+USE pounds = format('%.2f');
+PROCESS '_bulky_data.html';
+
+email_columns = 2;
+
+PROCESS '_email_settings.html';
+INCLUDE '_email_top.html';
+
+%]
+
+<th style="[% td_style %][% primary_column_style %]" id="primary_column">
+  [% start_padded_box | safe %]
+
+  <p style="[% p_style %]">Dear [% report.name %],</p>
+
+  <p style="[% p_style %]">[% email_summary %]</p>
+
+    [% INCLUDE '_council_reference.html' problem=report %]
+
+  <p style="[% p_style %]">
+    Collection date: [% collection_date %]
+  </p>
+
+  <p style="[% p_style %]">
+    Items to be collected:
+    [% FOR item IN item_list %]<br>[% item %][% END %]
+  </p>
+
+[% IF payment %]
+  <p style="[% p_style %]">
+    Total cost: £[% pounds(payment / 100) %]
+  </p>
+[% END %]
+
+  <p style="[% p_style %]">
+    If you wish to cancel your booking, please visit this link: URL XXX
+    You can obtain a refund if you cancel more than one day before your booking.
+  </p>
+
+  <p style="[% p_style %]">
+    Cancellation policy / T&amp;Cs / etc
+  </p>
+
+  <p style="[% p_style %]">
+    Kind regards,<br>Waste Services Team
+  </p>
+
+  [% end_padded_box | safe %]
+</th>
+
+[% WRAPPER '_email_sidebar.html' object = report %]
+    <h2 style="[% h2_style %]">[% report.title | html %]</h2>
+    [% report.detail | html_para_email(secondary_p_style) %]
+[% END %]
+
+[% INCLUDE '_email_bottom.html' %]

--- a/templates/email/peterborough/other-reported-bulky.txt
+++ b/templates/email/peterborough/other-reported-bulky.txt
@@ -1,0 +1,37 @@
+Subject: Bulky waste collection service - reference [% report.id %]
+
+[%
+USE pounds = format('%.2f');
+PROCESS '_bulky_data.html';
+~%]
+
+Dear [% report.name %],
+
+[% email_summary %]
+
+[% INCLUDE '_council_reference.txt' problem=report %]
+
+[% report.detail %]
+
+Collection date: [% collection_date %]
+
+Items to be collected:
+
+  [% item_list.join("\n\n  ") %]
+
+[% IF payment ~%]
+Total cost: £[% pounds(payment / 100) %]
+
+[% END ~%]
+
+If you wish to cancel your booking, please visit:
+    URL XXX
+
+You can obtain a refund if you cancel more than one day before your booking.
+
+Cancellation policy / T&amp;Cs / etc
+
+[% signature %]
+
+This email was sent automatically, from an unmonitored email account - so
+please do not reply to it.

--- a/templates/email/peterborough/other-reported.html
+++ b/templates/email/peterborough/other-reported.html
@@ -1,0 +1,29 @@
+[% IF report.category == 'Bulky collection' ~%]
+[% PROCESS 'other-reported-bulky.html' ~%]
+[% ELSE ~%]
+[%
+
+email_summary = "Thanks for logging your report";
+email_columns = 2;
+
+PROCESS '_email_settings.html';
+INCLUDE '_email_top.html';
+
+%]
+
+<th style="[% td_style %][% primary_column_style %]" id="primary_column">
+  [% start_padded_box | safe %]
+  <h1 style="[% h1_style %]">Your report has been&nbsp;logged</h1>
+  <p style="[% p_style %]">Your report to [% report.body %] has been logged on [% site_name %].</p>
+
+[% INCLUDE '_council_reference.html' problem=report %]
+
+  [% end_padded_box | safe %]
+</th>
+[% WRAPPER '_email_sidebar.html' object = report %]
+    <h2 style="[% h2_style %]">[% report.title | html %]</h2>
+    [% report.detail | html_para_email(secondary_p_style) %]
+[% END %]
+
+[% INCLUDE '_email_bottom.html' %]
+[% END %]

--- a/templates/email/peterborough/other-reported.txt
+++ b/templates/email/peterborough/other-reported.txt
@@ -1,0 +1,24 @@
+[% IF report.category == 'Bulky collection' ~%]
+[% PROCESS 'other-reported-bulky.txt' ~%]
+[% ELSE ~%]
+Subject: Your report has been logged, reference [% report.id %]
+
+Dear [% report.name %],
+
+Your report to [% report.body %] has been logged on [% site_name %].
+
+[% INCLUDE '_council_reference.txt' problem=report %]
+
+Your report has the title:
+
+[% report.title %]
+
+And details:
+
+[% report.detail %]
+
+[% signature %]
+
+This email was sent automatically, from an unmonitored email account - so
+please do not reply to it.
+[% END %]


### PR DESCRIPTION
For https://github.com/mysociety/societyworks/issues/2901 (apart from querying if something has been cancelled, awaiting details on that) 
For https://github.com/mysociety/societyworks/issues/2913 (bar text changes and cancellation link - which I think should be the "view bookings" page, most straightforwardly)
[skip changelog]