### PR TITLE
[Camden] Fixed checkbox on heatmap page

### DIFF
--- a/web/cobrands/camden/base.scss
+++ b/web/cobrands/camden/base.scss
@@ -183,7 +183,14 @@ input[type="checkbox"] {
   &:not(.govuk-checkboxes__input) {
     @include input-small;
   }
+
+  &.bulk-assign {
+    position: relative;
+    transform: scale(1);
+  }
 }
+
+
 
 input[type="radio"] {
   @include input-small;


### PR DESCRIPTION
Hey @chrismytton I have added a fix some of the from FMS base don't get apply to checkboxes with `.bulk-assign class`

<img width="1140" alt="Screenshot 2022-11-25 at 12 00 54" src="https://user-images.githubusercontent.com/13790153/203981898-3d422148-3244-41dc-9eb0-64d0a3724b78.png">

Fixes: https://github.com/mysociety/societyworks/issues/3354

Note for self: To visit this page the body needs to be added to the url.
https://camden.localhost:3000/dashboard/heatmap?body=8

Let me know if there any that need a fix =)