### PR TITLE
[Bulky] Added fix that improves layout on bin days page

### DIFF
--- a/web/cobrands/sass/_waste.scss
+++ b/web/cobrands/sass/_waste.scss
@@ -401,6 +401,7 @@ input[type="submit"].waste-service-link {
 // Bulky Waste
 body.bulky {
   $border: 1px solid #e9e9e9;
+  $bulky-mobile-breakpoint: 720px;
 
   #form-location_photo-row {
     .dropzone.dz-clickable {
@@ -455,6 +456,13 @@ body.bulky {
     align-self: auto;
   }
 
+  .govuk-grid-column-two-thirds {
+    @media only screen and (max-width: ($bulky-mobile-breakpoint - 1px)) {
+      // So the service-navbar on the right doesn't overlap with the content on the left.
+      width:100%;
+    }
+  }
+
   .services-navbar {
     // This variables will help when we want to reuse this
     //component on another cobrand and the default colors
@@ -471,7 +479,7 @@ body.bulky {
     top: 100px;
     right: 0;
   
-    @media only screen and (min-width: 720px) {
+    @media only screen and (min-width: $bulky-mobile-breakpoint) {
       display:block;
     }
 
@@ -536,7 +544,7 @@ body.bulky {
     }
   
     &.is--mobile-only {
-      @media only screen and (min-width: 720px) {
+      @media only screen and (min-width: $bulky-mobile-breakpoint) {
         display:none;
       }
     }


### PR DESCRIPTION
Small fixes that overrides the media breakpoint for `.govuk-grid-column-two-thirds` class only when the body has the `.bulky` class.

Fixes: https://mysociety.slack.com/archives/C02QNSSP2QK/p1669384971151229

### At 719px
<img width="712" alt="Screenshot 2022-11-25 at 15 11 52" src="https://user-images.githubusercontent.com/13790153/204013611-38ce5f9b-a1a0-4aea-9e6e-207f20d3bd0e.png">

### At 720px
<img width="712" alt="Screenshot 2022-11-25 at 15 12 02" src="https://user-images.githubusercontent.com/13790153/204013606-a5cca55d-f2ce-4240-ae00-cf3068f964a7.png">

Let me know if there is any feedback.
