### PR TITLE
[Camden] Hide user's name on cobrand

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Camden.pm
+++ b/perllib/FixMyStreet/Cobrand/Camden.pm
@@ -81,4 +81,9 @@ sub categories_restriction {
     return $rs->search( { 'me.category' => { '!=', 'River Piers' } } );
 }
 
+# Problems and comments are always treated as anonymous so the user's name isn't displayed.
+sub is_problem_anonymous { 1 }
+
+sub is_comment_anonymous { 1 }
+
 1;

--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -283,7 +283,7 @@ sub meta_line {
 
     my $contributed_as = $self->get_extra_metadata('contributed_as') || '';
     my $staff = $self->user->from_body || $self->get_extra_metadata('is_body_user') || $self->get_extra_metadata('is_superuser');
-    my $anon = $self->anonymous || !$self->name;
+    my $anon = $self->anonymous || !$self->name || $cobrand->call_hook('is_comment_anonymous');
 
     if ($anon && (!$staff || $contributed_as eq 'anonymous_user' || $contributed_as eq 'another_user')) {
         $meta = $cobrand->call_hook(update_anonymous_message => $self);

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -708,7 +708,10 @@ sub meta_line {
     my $category = $problem->category_display;
     $category = $cobrand->call_hook(change_category_text => $category) || $category;
 
-    if ( $problem->anonymous ) {
+    # Call a hook on the cobrand to check if the problem should be treated as anonymous
+    my $anonymous = $cobrand->call_hook('is_problem_anonymous');
+
+    if ( $problem->anonymous || $anonymous ) {
         if ( $problem->service and $category && $category ne _('Other') ) {
             $meta =
             sprintf( _('Reported via %s in the %s category anonymously at %s'),

--- a/templates/web/camden/report/_show_name_label.html
+++ b/templates/web/camden/report/_show_name_label.html
@@ -1,0 +1,1 @@
+[%# Camden don't want users to be able to display their name on the cobrand. %]


### PR DESCRIPTION
Camden don't want users to have the option to be able to display their name publicly on the cobrand.

## Todo

- [x] Handle hiding the name for updates

Fixes https://github.com/mysociety/societyworks/issues/3300

<!-- [skip changelog] -->
