### PR TITLE
[TfL] Add extra data to all report on dashboard

### DIFF
--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -234,10 +234,18 @@ sub dashboard_export_problems_add_columns {
     );
     $csv->splice_csv_column('fixed', action_scheduled => 'Action scheduled');
 
+    my @contacts = $csv->body->contacts->search(undef, { order_by => [ 'category' ] } )->all;
+
     if ($csv->category) {
-        my @contacts = $csv->body->contacts->search(undef, { order_by => [ 'category' ] } )->all;
         my ($contact) = grep { $_->category eq $csv->category } @contacts;
         if ($contact) {
+            foreach (@{$contact->get_metadata_for_storage}) {
+                next if $_->{code} eq 'safety_critical';
+                $csv->add_csv_columns( "extra.$_->{code}" => $_->{description} );
+            }
+        }
+    } else {
+        foreach my $contact (@contacts) {
             foreach (@{$contact->get_metadata_for_storage}) {
                 next if $_->{code} eq 'safety_critical';
                 $csv->add_csv_columns( "extra.$_->{code}" => $_->{description} );

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -89,7 +89,7 @@ $contact1->set_extra_fields(
         description => 'Stop number',
         datatype => 'string',
         automated => 'hidden_field',
-    }
+    },
 );
 $contact1->update;
 my $contact2 = $mech->create_contact_ok(
@@ -483,11 +483,14 @@ subtest 'Dashboard CSV extra columns' => sub {
     $mech->content_contains($dt . ',,,confirmed,51.4021');
     $mech->content_contains(',,,yes,busstops@example.com,,' . $dt . ',"Council User"');
 
-    $report->set_extra_fields({ name => 'Question', value => '12345' });
+    $report->set_extra_fields({ name => 'stop_code', value => '98756' }, { name => 'Question', value => '12345' });
     $report->update;
 
     $mech->get_ok('/dashboard?export=1');
     $mech->content_contains(',12345,,no,busstops@example.com,,', "Bike number added to csv");
+    $mech->content_contains('"Council User",,98756', "Stop code added to csv for all categories report");
+    $mech->get_ok('/dashboard?export=1&category=Bus+stops');
+    $mech->content_contains('"Council User",,98756', "Stop code added to csv for bus stop category report");
 };
 
 subtest 'Inspect form state choices' => sub {


### PR DESCRIPTION
TfL would like to be able to see the extra data for a category on the 'All report' on the dashboard as well as on the specifically selected category.

https://mysocietysupport.freshdesk.com/a/tickets/2556

[skip changelog]