### PR TITLE
[Bulky Goods] Handle coming back from payment page

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -1130,6 +1130,25 @@ sub waste_munge_bulky_data {
     # XXX what about photos?
 }
 
+sub waste_reconstruct_bulky_data {
+    my ($self, $p) = @_;
+
+    # XXX Photos not present in report as yet
+    my $saved_data = {
+        "chosen_date" => $p->get_extra_field_value('DATE'),
+        "location" => $p->get_extra_field_value('CREW NOTES'),
+        #"location_photo_fileid" => '???',
+    };
+    my @fields = grep { $_->{name} =~ /ITEM_/ } @{$p->get_extra_fields};
+    foreach (@fields) {
+        my ($id) = $_->{name} =~ /ITEM_(\d+)/;
+        $saved_data->{"item_" . ($id+0)} = $_->{value};
+        #$saved_data->{"item_photo_" . ($id+0)} = '???';
+    }
+
+    return $saved_data;
+}
+
 sub bulky_total_cost {
     my ($self, $data) = @_;
     my $c = $self->{c};

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -144,7 +144,7 @@
     </div>
   </div>
 
-  <form class="waste" method="post">
+  <form class="waste" method="post" action="[% c.uri_for_action('waste/bulky', [ property.id ]) %]">
     [% PROCESS form %]
   </form>
 


### PR DESCRIPTION
Fixes https://github.com/mysociety/societyworks/issues/3370 [skip changelog] The other approach would have been to save `saved_data` in the session or somewhere just before redirecting to payment page, and then picking it up if they come back, but assuming most uses aren't going to be going back, that seemed like extra data storage that wasn't needed. I think it's okay reconstructing from the created report, the data should all be there - ~~it needs moving into Peterborough.pm to be the reverse of the waste_munge_bulky_data there, ideally, but wanted to get it up for review first.~~