### PR TITLE
[Bromley] Adjust codes for adding feature_id

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -336,7 +336,7 @@ sub open311_contact_meta_override {
         required => 'false',
         variable => 'true',
         automated => 'hidden_field',
-    } if $service->{service_code} eq 'SLRS';
+    } if $service->{service_code} =~ /^SL_/;
 
     my @override = qw(
         requested_datetime


### PR DESCRIPTION
Change to make all light codes add feature_id to the category

https://mysocietysupport.freshdesk.com/a/tickets/2569

[skip changelog]
