### PR TITLE
[Camden] Add service_code to update params

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Camden.pm
+++ b/perllib/FixMyStreet/Cobrand/Camden.pm
@@ -73,6 +73,9 @@ sub open311_config {
 sub open311_munge_update_params {
     my ($self, $params, $comment, $body) = @_;
     $params->{service_request_id_ext} = $comment->problem->id;
+
+    my $contact = $comment->problem->contact;
+    $params->{service_code} = $contact->email;
 }
 
 sub categories_restriction {


### PR DESCRIPTION
This is needed for the Symology code in open311-adapter.

[skip changelog]