### PR TITLE
[Bulky Goods] Add per-item maximums.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Waste.pm
@@ -148,6 +148,7 @@ sub bulky_items : Chained('body') {
                 name => $c->get_param("name[$i]"),
                 message => $c->get_param("message[$i]"),
                 price => $c->get_param("price[$i]"),
+                max => $c->get_param("max[$i]"),
             };
 
             # validate the row - if any field has a value then need to check

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -732,12 +732,14 @@ FixMyStreet::override_config {
                     message   => '',
                     name      => 'DVD/BR Video players',
                     price     => '2002',
+                    max => 1,
                 },
                 {   bartec_id => '1001',
                     category  => 'Audio / Visual Elec. equipment',
                     message   => '',
                     name      => 'HiFi Stereos',
                     price     => '3003',
+                    max => 2,
                 },
 
                 {   bartec_id => '1002',
@@ -1158,6 +1160,18 @@ FixMyStreet::override_config {
         $report->delete; # So can have another one below
     };
 
+    subtest 'Bulky collection, per item maximum' => sub {
+        $mech->get_ok('/waste/PE1%203NA:100090215480');
+        $mech->follow_link_ok( { text_regex => qr/Book bulky goods collection/i, }, "follow 'Book bulky...' link" );
+        $mech->submit_form_ok;
+        $mech->submit_form_ok({ with_fields => { resident => 'Yes' } });
+        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
+        $mech->submit_form_ok({ with_fields => { chosen_date => '2022-08-26T00:00:00' } });
+        $mech->content_contains('HiFi Stereos: 2');
+        $mech->submit_form_ok({ with_fields => { 'item_1' => 'HiFi Stereos', 'item_2' => 'HiFi Stereos', item_3 => 'HiFi Stereos' } });
+        $mech->content_contains('Too many of item: HiFi Stereos');
+    };
+
     subtest 'Bulky collection, per item payment' => sub {
         $mech->log_in_ok($user->email);
         my $cfg = $body->get_extra_metadata('wasteworks_config');
@@ -1416,6 +1430,7 @@ FixMyStreet::override_config {
                     category => "Furniture",
                     message => "test",
                     name => "Sofa",
+                    max => "",
                     price => "0"
                 }]
             };
@@ -1437,6 +1452,7 @@ FixMyStreet::override_config {
                         category => "Furniture",
                         message => "test",
                         name => "Sofa",
+                        max => "",
                         price => "0"
                     },
                     {
@@ -1444,6 +1460,7 @@ FixMyStreet::override_config {
                         category => "Furniture",
                         message => "",
                         name => "Armchair",
+                        max => "",
                         price => "10"
                     },
                 ]
@@ -1465,6 +1482,7 @@ FixMyStreet::override_config {
                         category => "Furniture",
                         message => "",
                         name => "Armchair",
+                        max => "",
                         price => "10"
                     },
                 ]
@@ -1509,6 +1527,7 @@ FixMyStreet::override_config {
                 'category[9999]' => 'Furniture',
                 'name[9999]' => 'Bookcase',
                 'price[9999]' => '0',
+                'max[9999]' => '',
                 'message[9999]' => '',
             }});
             $mech->content_contains("Updated!");
@@ -1520,6 +1539,7 @@ FixMyStreet::override_config {
                     category => "Furniture",
                     message => "",
                     name => "Bookcase",
+                    max => "",
                     price => "0"
                 }]
             };

--- a/templates/web/base/admin/waste/bulky_items.html
+++ b/templates/web/base/admin/waste/bulky_items.html
@@ -33,6 +33,10 @@
             [% IF item.errors.price %]<label for="[[% i %]]">[% item.errors.price %]</label>[% END %]
             <input type="text" value="[% item.price %]" name="price[[% i %]]" />
         </td>
+        <td>
+            [% IF item.errors.max %]<label for="[[% i %]]">[% item.errors.max %]</label>[% END %]
+            <input type="text" value="[% item.max %]" name="max[[% i %]]" />
+        </td>
         <td><button name="delete" value="[% i %]" class="btn btn--small js-metadata-item-remove">[% loc('🗑') %]</button></td>
     </tr>
 [% END %]
@@ -49,7 +53,8 @@
                 <th>Category</th>
                 <th>Name</th>
                 <th>Message</th>
-                <th>Price</th>
+                <th>Price (pence)</th>
+                <th title="Max per collection">Max</th>
                 <th></th>
             </tr>
         </thead>

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -29,6 +29,23 @@
   </div>
 </div>
 
+<div class="govuk-warning-text due" style="max-width:550px">
+  <div class="govuk-warning-text__img">
+    <span class="govuk-warning-text__icon" aria-hidden="true">i</span>
+  </div>
+  <div class="govuk-warning-text__content">
+    <span class="govuk-warning-text__assistive">Important information</span>
+    <p class="govuk-!-margin-bottom-1"><strong>Maximum numbers</strong></p>
+    <p>The following types of item have a maximum number that can be collected in one collection:</p>
+    <ul>
+      [% FOR item IN form.items_extra; IF item.value.max %]
+        <li>[% item.key %]: [% item.value.max %]</li>
+      [% END; END %]
+    </ul>
+
+  </div>
+</div>
+
 <form id="item-selection-form" class="waste" method="post" enctype="multipart/form-data">
   [% FOR num IN [ 1 .. c.cobrand.bulky_items_maximum ] %]
   <div class="bulky-item-wrapper">


### PR DESCRIPTION
For https://github.com/mysociety/societyworks/issues/3374 [skip changelog]
This adds the admin interface, some text to the items page describing any maximums if present, and prevents submission if items selected are over these maximums. It does not do any client side updating to e.g. disallow an item from being selected once the maximum number have been selected because that seemed like it would be a non-trivial amount of work for not really that much gain, given if someone does do it they get the error immediately and quickly and can resolve it, it'd only be a small improvement and I'm not entirely sure how to have it work with the autocompletes etc.