### PR TITLE
Camden fron end v5

### DIFF
--- a/templates/web/camden/main_nav_items.html
+++ b/templates/web/camden/main_nav_items.html
@@ -2,6 +2,8 @@
 
 [%~ IF c.user_exists ~%]
     [%~ INCLUDE navitem uri='/my' label=loc('Your account') ~%]
+[%~ ELSE ~%]
+    [%~ INCLUDE navitem uri='/auth' label=loc('Sign in') ~%]
 [%~ END ~%]
 
 [%~ IF c.user_exists AND c.user.has_body_permission_to('planned_reports') ~%]

--- a/web/cobrands/camden/_mixins.scss
+++ b/web/cobrands/camden/_mixins.scss
@@ -115,10 +115,12 @@
 
 @mixin one-line-input-height {
     height: $input-height-small-screen;
+    line-height: $input-height-small-screen;
 
     @if variable-exists(large-view-point) {
         @media only screen and (min-width: $large-view-point) {
             height: $input-height-large-screen;
+            line-height: $input-height-large-screen;
         }
     }
 }

--- a/web/cobrands/camden/_mixins.scss
+++ b/web/cobrands/camden/_mixins.scss
@@ -45,8 +45,8 @@
     border-radius: $input-border-radius;
     box-shadow: none;
     font-family: $body-font;
-    padding-left: $input-padding-x;
-    padding-right: $input-padding-x;
+    // padding-left: $input-padding-x;
+    // padding-right: $input-padding-x;
     @include cobrand-body;
     color: $primary-b;
 
@@ -63,7 +63,7 @@
     min-width: $checkbox-width-small-version;
     position: absolute;
 
-    &+ label {
+    & + label.inline, & + legend.inline, & + .label.inline {
         padding-left: $checkbox-width-small-version * 1.5;
     }
 
@@ -115,12 +115,12 @@
 
 @mixin one-line-input-height {
     height: $input-height-small-screen;
-    line-height: $input-height-small-screen;
+    line-height: $input-height-small-screen * 0.9;
 
     @if variable-exists(large-view-point) {
         @media only screen and (min-width: $large-view-point) {
             height: $input-height-large-screen;
-            line-height: $input-height-large-screen;
+            line-height: $input-height-large-screen * 0.9;
         }
     }
 }

--- a/web/cobrands/camden/base.scss
+++ b/web/cobrands/camden/base.scss
@@ -141,8 +141,11 @@ a {
 }
 
 .report-list-filters {
-  color: $white;
   @include cobrand-body;
+  line-height: $input-height-small-screen;
+  @media only screen and (min-width: 641px) { 
+    line-height: $input-height-large-screen;
+  }
 }
 
 // * FORMS AND INPUTS
@@ -158,7 +161,32 @@ select,
   @include input-reset;
 }
 
-.multi-select-button, .form-control#sort, select {
+.mobile-filters-active .report-list-filters-wrapper, 
+.mobile-filters-active #bulk-assign-form {
+  .multi-select-button,
+  .form-control#sort,
+  input[type='text'],
+  input[type='radio'],
+  input[type='checkbox'],
+  .govuk-radios__input,
+  select,
+  .report-list-filters .form-control {
+    border-color: $white;
+  }
+
+  #show_old_reports_wrapper input[type="checkbox"]:checked:after {
+    @include svg-background-image("/cobrands/fixmystreet/images/check-white");
+  }
+}
+
+#sort {
+  max-width: 14em;
+}
+
+.multi-select-button,
+.report-list-filters .multi-select-button,
+.form-control#sort,
+select {
   @include one-line-input-height;
 }
 
@@ -497,6 +525,33 @@ a#geolocate_link {
   &:focus, &:focus-visible {
     background-color: transparentize($color: $link-hover-color, $amount: 0.7);
     border-color: $yellow;
+  }
+}
+
+#key-tools {
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  padding: 15px;
+
+  li {
+    display: block;
+    width: 90%;
+
+    &:nth-child(2) {
+      margin-top: 15px;
+    }
+  }
+
+  a {
+    text-decoration: none;
+    color: $primary_b !important;
+    text-align: left;
+    font-size: 14px !important;
+    @media only screen and (min-width: 641px) { 
+        font-size: 16px !important;
+        text-align: center;
+    }
   }
 }
 

--- a/web/cobrands/camden/base.scss
+++ b/web/cobrands/camden/base.scss
@@ -140,25 +140,132 @@ a {
   color: $gray-2;
 }
 
-.report-list-filters {
-  @include cobrand-body;
-  line-height: $input-height-small-screen;
-  @media only screen and (min-width: 641px) { 
-    line-height: $input-height-large-screen;
-  }
-}
-
 // * FORMS AND INPUTS
-.multi-select-button,
-.form-control#sort,
-input[type='text'],
-input[type='radio'],
-input[type='checkbox'],
-.govuk-radios__input,
-select,
-.report-list-filters .form-control,
-#bulk-assign-form .form-control, textarea {
-  @include input-reset;
+body:not(.admin) {
+  .multi-select-button,
+  .form-control#sort,
+  input[type='text'],
+  input[type='radio'],
+  input[type='checkbox'],
+  .govuk-radios__input,
+  select,
+  .report-list-filters .form-control,
+  #bulk-assign-form .form-control, textarea {
+    @include input-reset;
+  }
+
+  select {
+    // This makes that the arrow is the same as .multi-select-container
+    position: relative;
+    background: transparent;
+    background-image: url("data:image/svg+xml;utf8,<svg fill='black' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>");
+    background-repeat: no-repeat;
+    background-position-x: right;
+    background-size: contain;
+    padding-left: 8px !important; // overrides .report-list-filters .form-control
+  }
+
+  input[type="checkbox"] {
+    &:not(.govuk-checkboxes__input) {
+      @include input-small;
+    }
+  
+    &.bulk-assign {
+      position: relative;
+      transform: scale(1);
+    }
+  }
+  
+  input[type="radio"] {
+    @include input-small;
+    min-height: $radio-height-small-version;
+    min-width: $radio-height-small-version;
+    border-radius: 50%;
+    &:not(.govuk-radios__input) {
+      @include input-small;
+    }
+  }
+
+  .form-check {
+    padding-left: 0;
+  
+    &>input {
+      top: auto;
+    }
+  }
+
+  #sort {
+    max-width: 14em;
+  }
+
+  .report-list-filters {
+    @include cobrand-body;
+    line-height: $input-height-small-screen;
+    @media only screen and (min-width: 641px) { 
+      line-height: $input-height-large-screen;
+    }
+  }
+
+  .multi-select-button,
+  .report-list-filters .multi-select-button,
+  .form-control#sort,
+  select {
+    @include one-line-input-height;
+  }
+
+  .multi-select-button:after {
+    border-color: $primary_b transparent transparent transparent;
+    transform: translateY(-50%);
+    margin: 0;
+  }
+  
+  .multi-select-menuitem {
+      font-size:$font-size-small-view;
+      padding: $checkbox-height-small-version/3 $checkbox-height-small-version $checkbox-height-small-version/3 $checkbox-width-small-version * 2;
+      line-height: $font-size-small-view * 2;
+      margin: 0;
+      white-space: nowrap !important;
+  
+    input {
+      margin-top: 0.25em;
+      margin-left: -($checkbox-width-small-version) * 1.5;
+      @include input-small;
+    }
+  }
+  
+  #show_old_reports_wrapper {
+    label {
+      line-height: $checkbox-height-small-version;
+    }
+  
+    input {
+      margin-left: 0.5em;
+      @include input-small;
+      left: auto;
+    }
+  }
+  
+  .label-containing-checkbox {
+    line-height: $checkbox-height-small-version * 1.2;
+    padding-left:$checkbox-height-small-version * 1.5;
+  
+    input {
+      margin-right: 0.5em;
+      @include input-small;
+    }
+  }
+  
+  .govuk-radios__input:focus {
+    & +.govuk-radios__label:before {
+      border-width: 4px;
+      box-shadow: 0 0 0 4px $link-focus-background-colour;
+    }
+    &:hover {
+        &+.govuk-radios__label:before {
+            box-shadow: $input-box-shadow-focus-hover;
+        }
+    }
+  }
 }
 
 .mobile-filters-active .report-list-filters-wrapper, 
@@ -178,120 +285,6 @@ select,
     @include svg-background-image("/cobrands/fixmystreet/images/check-white");
   }
 }
-
-#sort {
-  max-width: 14em;
-}
-
-.multi-select-button,
-.report-list-filters .multi-select-button,
-.form-control#sort,
-select {
-  @include one-line-input-height;
-}
-
-.multi-select-button:after {
-  border-color: $primary_b transparent transparent transparent;
-  transform: translateY(-50%);
-  margin: 0;
-}
-
-select {
-  // This makes that the arrow is the same as .multi-select-container
-  position: relative;
-  background: transparent;
-  background-image: url("data:image/svg+xml;utf8,<svg fill='black' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>");
-  background-repeat: no-repeat;
-  background-position-x: right;
-  background-size: contain;
-  padding-right: 30px;
-}
-
-input[type="checkbox"] {
-  &:not(.govuk-checkboxes__input) {
-    @include input-small;
-  }
-
-  &.bulk-assign {
-    position: relative;
-    transform: scale(1);
-  }
-}
-
-
-
-input[type="radio"] {
-  @include input-small;
-  min-height: $radio-height-small-version;
-  min-width: $radio-height-small-version;
-  border-radius: 50%;
-  &:not(.govuk-radios__input) {
-    @include input-small;
-  }
-}
-
-.form-check {
-  padding-left: 0;
-
-  &>input {
-    top: auto;
-  }
-
-  .admin & {
-    &>input {
-      left: 0;
-    }
-  }
-}
-
-.multi-select-menuitem {
-    font-size:$font-size-small-view;
-    padding: $checkbox-height-small-version/3 $checkbox-height-small-version $checkbox-height-small-version/3 $checkbox-width-small-version * 2;
-    line-height: $font-size-small-view * 2;
-    margin: 0;
-    white-space: nowrap !important;
-
-  input {
-    margin-top: 0.25em;
-    margin-left: -($checkbox-width-small-version) * 1.5;
-    @include input-small;
-  }
-}
-
-#show_old_reports_wrapper {
-  label {
-    line-height: $checkbox-height-small-version;
-  }
-
-  input {
-    margin-left: 0.5em;
-    @include input-small;
-    left: auto;
-  }
-}
-
-.label-containing-checkbox {
-  line-height: 140%;
-  padding-left:$checkbox-height-small-version * 1.5;
-
-  input {
-    margin-right: 0.5em;
-    @include input-small;
-  }
-}
-
-.govuk-radios__input:focus {
-  & +.govuk-radios__label:before {
-    border-width: 4px;
-    box-shadow: 0 0 0 4px $link-focus-background-colour;
-  }
-  &:hover {
-      &+.govuk-radios__label:before {
-          box-shadow: $input-box-shadow-focus-hover;
-      }
-  }
-}
-
 
 input.form-error, textarea.form-error {
   border-color: $error-color;
@@ -641,7 +634,7 @@ border-right-width: 3px;
       text-decoration-thickness: 1px;
     }
     &:visited {
-      color: lighten($purple, 55%);
+      color: $white;
     }
 
     &:focus {

--- a/web/cobrands/camden/base.scss
+++ b/web/cobrands/camden/base.scss
@@ -66,7 +66,7 @@ h4, .h4 {
   }
 }
 
-.body-large-bold {
+.body-large {
   font-weight: 400 !important;
   font-size: 18px;
   @media only screen and (min-width: 641px) { 
@@ -417,13 +417,8 @@ dl dt {
 
   h2 {
     font-style: normal;
-    font-size: 24px;
     color: $primary_b;
-    @if variable-exists(large-view-point) {
-      @media only screen and (min-width: $large-view-point) {
-        font-size:32px;
-      }
-    }
+    @extend .body-large;
   }
 
   #postcodeForm {

--- a/web/cobrands/camden/base.scss
+++ b/web/cobrands/camden/base.scss
@@ -323,7 +323,7 @@ div.form-error, p.form-error {
     }
 
     &:visited {
-      color: lighten($purple, 35%);
+      color: $white;
     }
 
     &:focus {

--- a/web/cobrands/camden/base.scss
+++ b/web/cobrands/camden/base.scss
@@ -278,7 +278,7 @@ div.form-error, p.form-error {
 }
 
 .form-hint, .item-list--reports__item small, .item-list--reports__item .small-print {
-  color: $gray-2;
+  color: $primary_b;
   margin-top: 0.2em;
 }
 
@@ -471,8 +471,9 @@ dl dt {
       margin: 2px 0;
       max-height: $max-height;
       height: $max-height;
-      border: $border-width solid $secondary_button_border_color !important;
       background: $secondary_button_background_color_hover !important;
+      border: $border-width solid $primary_b !important;
+      border-right-width: 0 !important;
       &:focus {
         outline:  2px solid $link-focus-background-colour;
       }

--- a/web/cobrands/camden/layout.scss
+++ b/web/cobrands/camden/layout.scss
@@ -139,6 +139,20 @@ body.mappage {
   @include cobrand-body;
 }
 
+#key-tools {
+  display: table;
+  padding: 0;
+
+  li {
+    display: table-cell;
+    width: auto;
+
+    &:nth-child(2) {
+      margin-top: 0px;
+    }
+  }
+}
+
 // Footer
 .camden-footer {
   padding-top: 20px;

--- a/web/cobrands/camden/layout.scss
+++ b/web/cobrands/camden/layout.scss
@@ -46,10 +46,6 @@ body.frontpage, body.twothirdswidthpage, body.fullwidthpage, body.authpage {
       div {
         margin: 0;
       }
-
-      .form-hint {
-        color: $gray-2;
-      }
     }
 
     h2 {

--- a/web/cobrands/fixmystreet/images/check-white.svg
+++ b/web/cobrands/fixmystreet/images/check-white.svg
@@ -1,0 +1,1 @@
+<svg fill="none" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="m10 15.586-3.293-3.293-1.414 1.414 4.707 4.707 9.707-9.707-1.414-1.414z" fill="#fff"/></svg>


### PR DESCRIPTION
Hi @chrismytton =)
I have implemented the latest feedback from Camden. Let me know if you need me to change anything.

<img width="387" alt="Screenshot 2022-12-06 at 09 23 47" src="https://user-images.githubusercontent.com/13790153/205872158-a243a176-8ac5-43e4-930a-34b26bb0036f.png">
<img width="387" alt="Screenshot 2022-12-06 at 09 23 54" src="https://user-images.githubusercontent.com/13790153/205872176-e648291c-0bc3-401c-a69d-b685e1bf2ee7.png">
<img width="1164" alt="Screenshot 2022-12-06 at 09 24 16" src="https://user-images.githubusercontent.com/13790153/205872180-c1a151b8-b130-4f66-b783-3fac034ade55.png">

Before submitting this pull request. @bekkileaver after our chat here
https://github.com/mysociety/societyworks/issues/3355
I think they client hasn't seen the admin page(@jacquelinebylau  could you confirm this?), so I could revert the special input styles for the admin pages so they look like our default FMS. After your research it seems unnecessary to override our current styles. However in the likely scenario the client ask to keep the consistency between the citizen user and the admin side, can we share your research with them to persuade them not to move forward with it?

Fixes part of:
https://3.basecamp.com/4020879/buckets/27695641/todos/5470577758#__recording_5592648455
Except the alert page feedback, according to this guideline: https://github.com/mysociety/societyworks/issues/3107
