### PR TITLE
[Peterborough] Clear cached bulky slots at start of wizard

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1078,6 +1078,10 @@ sub bulky : Chained('bulky_setup') : Args(0) {
     $c->stash->{field_list} = $field_list;
 
     $c->forward('form');
+
+    if ( $c->stash->{form}->current_page->name eq 'intro' ) {
+        $c->cobrand->call_hook(clear_cached_lookups_bulky_slots => $c->stash->{property}{uprn});
+    }
 }
 
 # Called by F::A::Controller::Report::display if the report in question is

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -453,6 +453,12 @@ sub clear_cached_lookups_property {
         delete $self->{c}->session->{"peterborough:bartec:$_:$uprn"};
     }
 
+    $self->clear_cached_lookups_bulky_slots($uprn);
+}
+
+sub clear_cached_lookups_bulky_slots {
+    my ($self, $uprn) = @_;
+
     for (qw/earlier later/) {
         delete $self->{c}
             ->session->{"peterborough:bartec:available_bulky_slots:$_:$uprn"};


### PR DESCRIPTION
Did think about adding an expiry to the cached slots but that seemed like overkill; similarly I thought clearing the slots every time you visit the "available slots" page might be a bit irritating. This seemed like an OK way to (hopefully) catch the majority of cases.

For https://github.com/mysociety/societyworks/issues/3372.

[skip changelog]