### PR TITLE
[FMS] Stop cobrand removing stopper of another on mobile

### DIFF
--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -1439,7 +1439,8 @@ fixmystreet.message_controller = (function() {
         });
         if ($('html').hasClass('mobile')) {
             var msg = $(id).html();
-            $div = $('<div class="js-mobile-not-an-asset"></div>').html(msg);
+            var mobile_class = id.replace('#', '');
+            $div = $('<div class="js-mobile-not-an-asset mob_' + mobile_class + '"></div>').html(msg);
             $div.appendTo('#map_box');
         } else {
             $("#js-roads-responsibility").removeClass("hidden");
@@ -1456,7 +1457,9 @@ fixmystreet.message_controller = (function() {
         } else {
             $(id).addClass("hidden");
         }
-        $('.js-mobile-not-an-asset').remove();
+        var mobile_id = id.replace('#', '');
+        var mobile_class = '.mob_' + mobile_id;
+        $(mobile_class).remove();
         if (!$("#js-roads-responsibility .js-responsibility-message:not(.hidden)").length) {
             $("#js-roads-responsibility").addClass("hidden");
         }
@@ -1464,7 +1467,7 @@ fixmystreet.message_controller = (function() {
 
     // Show the reporting form, unless the road responsibility message is visible.
     function enable_report_form() {
-        if ( $('#js-roads-responsibility').is(':visible') ) {
+        if ( $('#js-roads-responsibility').is(':visible') || $('.js-mobile-not-an-asset').length ) {
             return;
         }
         $('.js-reporting-page--next').prop('disabled', false);


### PR DESCRIPTION
Adds a class to the mobile alert message that an asset has not been found based on the id of the alert message. That way a cobrand will only remove its own messages when triggered through 'not_found'.

Adds a check when enabling the report form too if there are any mobile asset not found messages.

https://github.com/mysociety/societyworks/issues/3269

[skip changelog]