### PR TITLE
Add CAPTCHA to contact form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@
     - Open311 improvements:
         - Increase default timeout.
         - Check for an identical latest update when adding a new one.
+    - UK:
+        - Add CAPTCHA to contact form for non-UK IP addresses
 
 * v4.0 (3rd December 2021)
     - Front end improvements:

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -491,7 +491,7 @@ sub requires_recaptcha {
 
     return 0 if $c->user_exists;
     return 0 if !FixMyStreet->config('RECAPTCHA');
-    return 0 unless $c->action =~ /^(alert|report|around)/;
+    return 0 unless $c->action =~ /^(alert|report|around|contact)/;
     return 0 if $c->user_country eq 'GB';
     return 1;
 }

--- a/t/app/controller/contact.t
+++ b/t/app/controller/contact.t
@@ -627,4 +627,86 @@ subtest 'check redirected to correct form for general enquiries cobrand' => sub 
 
 $problem_main->delete;
 
+subtest 'recaptcha' => sub {
+    my $mod_lwp = Test::MockModule->new('LWP::UserAgent');
+    $mod_lwp->mock(
+        'post',
+        sub {
+            HTTP::Response->new( 200, 'OK', [], '{ "success": true }' );
+        },
+    );
+    my $mod_app = Test::MockModule->new('FixMyStreet::App');
+
+    subtest 'for FMS' => sub {
+        FixMyStreet::override_config {
+            ALLOWED_COBRANDS => 'fixmystreet',
+            RECAPTCHA => { secret => 'secret', site_key => 'site_key' },
+        } => sub {
+            ok $mech->host('www.fixmystreet.com');
+            $mech->get_ok('/contact');
+            $mech->content_lacks('g-recaptcha');  # GB is default test country
+
+            $mod_app->mock( 'user_country', sub {'FR'} );
+
+            $mech->get_ok('/contact');
+            $mech->content_contains('g-recaptcha');
+            $mech->submit_form_ok(
+                { with_fields => { %common, dest => 'help' } } );
+            $mech->content_contains('Thank you for your enquiry');
+        };
+    };
+
+    subtest 'for BathNES (has its own contact/index.html file)' => sub {
+        FixMyStreet::override_config {
+            ALLOWED_COBRANDS => 'bathnes',
+            RECAPTCHA => { secret => 'secret', site_key => 'site_key' },
+        } => sub {
+            my $bathnes = $mech->create_body_ok(
+                2551, 'Bath and North East Somerset Council',
+                {}, { cobrand => 'bathnes' },
+            );
+            ok $mech->host('https://fix.bathnes.gov.uk/');
+
+            $mod_app->mock( 'user_country', sub {'GB'} );
+
+            $mech->get_ok('/contact');
+            $mech->content_contains('Bath & North East Somerset Council');
+            $mech->content_lacks('g-recaptcha');
+
+            $mod_app->mock( 'user_country', sub {'FR'} );
+
+            $mech->get_ok('/contact');
+            $mech->content_contains('g-recaptcha');
+            $mech->submit_form_ok( { with_fields => \%common } );
+            $mech->content_contains('Thank you for your enquiry');
+        };
+    };
+
+    subtest 'for another cobrand (Lincolnshire)' => sub {
+        FixMyStreet::override_config {
+            ALLOWED_COBRANDS => 'lincolnshire',
+            RECAPTCHA => { secret => 'secret', site_key => 'site_key' },
+        } => sub {
+            my $lincs = $mech->create_body_ok(
+                2232, 'Lincolnshire County Council',
+                {}, { cobrand => 'lincolnshire' },
+            );
+            ok $mech->host('fixmystreet.lincolnshire.gov.uk');
+
+            $mod_app->mock( 'user_country', sub {'GB'} );
+
+            $mech->get_ok('/contact');
+            $mech->content_contains('Lincolnshire County Council');
+            $mech->content_lacks('g-recaptcha');
+
+            $mod_app->mock( 'user_country', sub {'FR'} );
+
+            $mech->get_ok('/contact');
+            $mech->content_contains('g-recaptcha');
+            $mech->submit_form_ok( { with_fields => \%common } );
+            $mech->content_contains('Thank you for your enquiry');
+        };
+    };
+};
+
 done_testing();

--- a/templates/web/base/contact/form.html
+++ b/templates/web/base/contact/form.html
@@ -95,6 +95,7 @@
       <p>[% loc('If you are contacting us about a specific report or update please include a link to the report in the message.') %]</p>
       [% END %]
 
+      [% PROCESS 'auth/form_extra.html' %]
 
       <input class="final-submit green-btn" type="submit" value="[% loc('Send') %]">
 

--- a/templates/web/bathnes/contact/index.html
+++ b/templates/web/bathnes/contact/index.html
@@ -136,6 +136,7 @@
         <p>[% loc('If you are contacting us about a specific report or update please include a link to the report in the message.') %]</p>
         [% END %]
 
+        [% PROCESS 'auth/form_extra.html' %]
 
         <input class="final-submit green-btn" type="submit" value="[% loc('Send') %]">
 


### PR DESCRIPTION
Closes https://github.com/mysociety/fixmystreet/issues/2303.

Adds a CAPTCHA to the contact form on FMS and cobrand sites; this only shows up for non-UK IP addresses.
