### PR TITLE
[Brent] Change report prompt and send title as attribute to open311

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -70,6 +70,8 @@ sub open311_extra_data_include {
         }
     }
 
+    push @$open311_only, { name => 'title', value => $row->title };
+
     return $open311_only;
 }
 

--- a/t/cobrand/brent.t
+++ b/t/cobrand/brent.t
@@ -77,7 +77,7 @@ for my $test (
     };
 };
 
-subtest "UnitID on gully sent across in detail" => sub {
+subtest "Open311 attribute changes" => sub {
     my ($problem) = $mech->create_problems_for_body(1, $brent->id, 'Gully', {
         areas => "2488", category => 'Gully grid missing', cobrand => 'brent',
     });
@@ -97,8 +97,9 @@ subtest "UnitID on gully sent across in detail" => sub {
         FixMyStreet::Script::Reports::send();
         my $req = Open311->test_req_used;
         my $c = CGI::Simple->new($req->content);
-        is $c->param('attribute[UnitID]'), undef;
-        like $c->param('description'), qr/ukey: 234/;
+        is $c->param('attribute[UnitID]'), undef, 'UnitID removed from attributes';
+        like $c->param('description'), qr/ukey: 234/, 'UnitID on gully sent across in detail';
+        is $c->param('attribute[title]'), $problem->title, 'Report title passed as attribute for Open311';
     };
 };
 

--- a/templates/web/brent/report/new/_form_labels.html
+++ b/templates/web/brent/report/new/_form_labels.html
@@ -1,0 +1,4 @@
+[%
+SET form_title = 'Location of the problem';
+SET form_title_placeholder = 'Exact location, including any landmarks';
+%]


### PR DESCRIPTION
Report prompt should ask for a location based summary of the issue and then send the title as an attribute so symology endpoint can transfer the attribute into the report location field

https://github.com/mysociety/societyworks/issues/3407229

[skip changelog]
