### PR TITLE
Allow cookie-less API calls from iOS app

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Auth.pm
+++ b/perllib/FixMyStreet/App/Controller/Auth.pm
@@ -611,6 +611,12 @@ sub ajax_check_auth : Path('ajax/check_auth') {
     my $code = 401;
     my $data = { not_authorized => 1 };
 
+    # iOS app can't send cookies so instead sends email/password
+    # to check login status
+    if ( ( my $username = $c->get_param('username') ) && !$c->user ) {
+        $c->forward('sign_in', [ $username ]);
+    }
+
     if ( $c->user ) {
         $data = { name => $c->user->name };
         $code = 200;

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1014,8 +1014,15 @@ sub process_user : Private {
         my $user = $c->user->obj;
         $report->user( $user );
         $report->name( $user->name );
-        $c->stash->{check_name} = 1;
-        $c->stash->{login_success} = 1;
+
+        # iOS app can't send cookies, so instead sends
+        # user's email/password when making a new report.
+        # The POST request has submit_sign_in set to 2 if
+        # the name has been checked.
+        unless ( $c->get_param('submit_sign_in') eq '2' ) {
+            $c->stash->{check_name} = 1;
+            $c->stash->{login_success} = 1;
+        }
         $c->log->info($user->id . ' logged in during problem creation');
         return 1;
     }

--- a/t/app/controller/auth.t
+++ b/t/app/controller/auth.t
@@ -15,6 +15,7 @@ sub password_expiry { 86400 }
 package main;
 
 use Test::MockModule;
+use JSON::MaybeXS;
 
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;
@@ -515,6 +516,17 @@ FixMyStreet::override_config {
         $mech->clear_emails_ok;
         $mech->get_ok($link);
         $mech->logged_in_ok;
+    };
+};
+
+subtest "Check that AJAX check_auth works for username/password" => sub {
+    $mech->log_out_ok;
+    my $u = $mech->create_user_ok('appuser@example.org', password => '1234567890abcdefgh', name => 'App User');
+    $mech->post_ok("/auth/ajax/check_auth",
+        { username => $u->email, password_sign_in => '1234567890abcdefgh' },
+        );
+    is_deeply decode_json( $mech->response->content ), {
+        name => 'App User',
     };
 };
 


### PR DESCRIPTION
Works around iOS bug where users login info is forgotten each time they launch the app.

[skip changelog]

For https://github.com/mysociety/fixmystreet-mobile/issues/300