### PR TITLE
[Brent] Look for Azure name in correct parameters

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -95,4 +95,13 @@ sub social_auth_enabled {
     return $self->feature('oidc_login') ? 1 : 0;
 }
 
+sub user_from_oidc {
+    my ($self, $payload) = @_;
+
+    my $name = join(" ", $payload->{givenName}, $payload->{surname});
+    my $email = $payload->{email};
+
+    return ($name, $email);
+}
+
 1;

--- a/perllib/FixMyStreet/Cobrand/Hackney.pm
+++ b/perllib/FixMyStreet/Cobrand/Hackney.pm
@@ -167,6 +167,15 @@ sub social_auth_enabled {
     return $self->feature('oidc_login') ? 1 : 0;
 }
 
+sub user_from_oidc {
+    my ($self, $payload) = @_;
+
+    my $name = $payload->{name};
+    my $email = $payload->{email};
+
+    return ($name, $email);
+}
+
 sub open311_skip_existing_contact {
     my ($self, $contact) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/Westminster.pm
+++ b/perllib/FixMyStreet/Cobrand/Westminster.pm
@@ -46,6 +46,20 @@ sub social_auth_enabled {
     return $self->feature('oidc_login') ? 1 : 0;
 }
 
+sub user_from_oidc {
+    my ($self, $payload) = @_;
+
+    my $name = join(" ", $payload->{given_name}, $payload->{family_name});
+    # WCC Azure provides a single email address as an array for some reason
+    my $email = $payload->{email};
+    my $emails = $payload->{emails};
+    if ($emails && @$emails) {
+        $email = $emails->[0];
+    }
+
+    return ($name, $email);
+}
+
 sub allow_anonymous_reports { 'button' }
 
 sub admin_user_domain { 'westminster.gov.uk' }

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -92,7 +92,8 @@ my @PLACES = (
     ['?', 51.015143, -0.912160, 2227, 'Hampshire County Council', 'CTY'],
     ['?', 51.020097, -0.926065, 2227, 'Hampshire County Council', 'CTY'],
     ['?', 51.511258, -0.011937, 2506, 'Tower Hamlets Borough Council', 'LBO'],
-    ['?', 51.512139, -0.013074, 2506, 'Tower Hamlets Borough Council', 'LBO']
+    ['?', 51.512139, -0.013074, 2506, 'Tower Hamlets Borough Council', 'LBO'],
+    ['HA9 0FJ', 51.55904, -0.28168, 2488, 'Brent Council', 'LBO'],
 
 );
 

--- a/t/Mock/OpenIDConnect.pm
+++ b/t/Mock/OpenIDConnect.pm
@@ -19,6 +19,12 @@ has returns_email => (
     default => 1,
 );
 
+has cobrand => (
+    is => 'rw',
+    isa => Str,
+    default => '',
+);
+
 sub dispatch_request {
     my $self = shift;
 
@@ -54,13 +60,19 @@ sub dispatch_request {
             aud => "example_client_id",
             iat => $now,
             auth_time => $now,
-            given_name => "Andy",
-            family_name => "Dwyer",
             tfp => "B2C_1_default",
             extension_CrmContactId => "1c304134-ef12-c128-9212-123908123901",
             nonce => 'MyAwesomeRandomValue',
         };
-        $payload->{emails} = ['pkg-tappcontrollerauth_socialt-oidc@example.org'] if $self->returns_email;
+        if ($self->cobrand eq 'westminster') {
+            $payload->{given_name} = "Andy";
+            $payload->{family_name} = "Dwyer";
+            $payload->{emails} = ['pkg-tappcontrollerauth_socialt-oidc@example.org'] if $self->returns_email;
+        } elsif ($self->cobrand eq 'brent') {
+            $payload->{givenName} = "Andy";
+            $payload->{surname} = "Dwyer";
+            $payload->{email} = 'pkg-tappcontrollerauth_socialt-oidc@example.org' if $self->returns_email;
+        }
         my $signature = "dummy";
         my $id_token = join(".", (
             encode_base64($self->json->encode($header), ''),
@@ -102,7 +114,7 @@ sub dispatch_request {
             nonce => 'MyAwesomeRandomValue',
             hd => 'example.org',
         };
-        $payload->{email} = 'pkg-tappcontrollerauth_socialt-oidc_google@example.org' if $self->returns_email;
+        $payload->{email} = 'pkg-tappcontrollerauth_socialt-oidc_google@example.org' if $self->returns_email && $self->cobrand eq 'hackney';
         $payload->{email_verified} = JSON->true if $self->returns_email;
         my $signature = "dummy";
         my $id_token = join(".", (


### PR DESCRIPTION
Azure oidc payload is client specific for details like name and email.

Change to make parameter fetching cobrand specific
and adapts Westminster and Hackney to use this.

https://github.com/mysociety/societyworks/issues/3411

[skip changelog]