### PR TITLE
Peterborough bulky goods: post-staging fixes

### DIFF
--- a/perllib/FixMyStreet/App/Controller/My.pm
+++ b/perllib/FixMyStreet/App/Controller/My.pm
@@ -140,9 +140,12 @@ sub get_problems : Private {
         "$table.state" => [ keys %$states ],
     };
 
+    # We do not want to show bulky goods cancellation reports
+    $params->{"$table.category"}{'!='} = 'Bulky cancel';
+
     my $categories = [ $c->get_param_list('filter_category', 1) ];
     if ( @$categories ) {
-        $params->{"$table.category"} = $categories;
+        $params->{"$table.category"}{'='} = $categories;
         $c->stash->{filter_category} = { map { $_ => 1 } @$categories };
     }
 
@@ -191,6 +194,7 @@ sub setup_page_data : Private {
     my $table = $c->action eq 'my/planned' ? 'report' : 'me';
     my @categories = $c->stash->{problems_rs}->search({
         "$table.state" => [ FixMyStreet::DB::Result::Problem->visible_states() ],
+        "$table.category" => { '!=', 'Bulky cancel' },
     }, {
         join => 'contact',
         columns => [ "$table.category", 'contact.extra', 'contact.category' ],

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1125,7 +1125,8 @@ sub bulky_cancel : Chained('property') : Args(0) {
 
     $c->detach('property_redirect')
         if !$c->stash->{waste_features}{bulky_enabled}
-        || !$c->cobrand->call_hook('bulky_can_cancel');
+        || !$c->cobrand->call_hook( 'bulky_can_cancel_collection',
+                $c->stash->{property}{pending_bulky_collection} );
 
     $c->stash->{first_page} = 'intro';
     $c->stash->{form_class} = 'FixMyStreet::App::Form::Waste::Bulky::Cancel';

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -495,6 +495,8 @@ sub look_up_property {
     my $self = shift;
     my $id = shift;
 
+    return unless $id;
+
     my ($pc, $uprn) = split ":", $id;
 
     my $premises = $self->_premises_for_postcode($pc);

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -1640,6 +1640,15 @@ sub bulky_nice_collection_date {
     return $dt->strftime('%d %B');
 }
 
+sub bulky_nice_cancellation_cutoff_date {
+    my ( $self, $collection_date ) = @_;
+    my $parser = DateTime::Format::Strptime->new( pattern => '%FT%T' );
+    my $dt
+        = $parser->parse_datetime($collection_date)->truncate( to => 'day' );
+    $dt->subtract( minutes => 5 );
+    return $dt->strftime('%H:%M on %d %B %Y');
+}
+
 sub bulky_nice_item_list {
     my ($self, $report) = @_;
 

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -1260,6 +1260,7 @@ FixMyStreet::override_config {
             my $email = $mech->get_email->as_string;
             like $email, qr/1 Pope Way/;
             like $email, qr/Collection date: 26 August/;
+            like $email, qr{rborough.example.org/waste/PE1%203NA%3A100090215480/bulky_cancel};
             $mech->clear_emails_ok;
         };
 
@@ -1271,6 +1272,8 @@ FixMyStreet::override_config {
                 my $email = $mech->get_email->as_string;
                 like $email, qr/26 August/;
                 like $email, qr/Wardrobe/;
+                like $email, qr{peterborough.example.org/waste/PE1%203NA%3A100090};
+                like $email, qr{215480/bulky_cancel};
                 if ($days == 3) {
                     like $email, qr/This is a reminder that your collection is in 3 days./;
                 } else {

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -937,6 +937,7 @@ FixMyStreet::override_config {
         };
 
         sub test_summary {
+            my $date_day = shift;
             $mech->content_contains('Request a bulky waste collection');
             $mech->content_lacks('Your bulky waste collection');
             $mech->content_contains('Booking Summary');
@@ -954,6 +955,9 @@ FixMyStreet::override_config {
             $mech->content_contains('<img class="img-preview is--medium" alt="Preview image successfully attached" src="/photo/temp.74e3362283b6ef0c48686fb0e161da4043bbcc97.jpeg">');
             $mech->content_lacks('No image of the location has been attached.');
             $mech->content_contains('£23.50');
+            $mech->content_contains("<dd>$date_day August</dd>");
+            my $day_before = $date_day - 1;
+            $mech->content_contains("23:55 on $day_before August 2022");
             $mech->content_lacks('Cancel this booking');
             $mech->content_lacks('Show upcoming bin days');
         }
@@ -982,7 +986,7 @@ FixMyStreet::override_config {
             return ($token, $new_report, $report_id);
         }
 
-        subtest 'Summary page' => \&test_summary;
+        subtest 'Summary page' => sub { test_summary(19) }; # 19th August
 
         subtest 'Slot has become fully booked' => sub {
             # Slot has become fully booked in the meantime - should
@@ -1025,7 +1029,7 @@ FixMyStreet::override_config {
             $mech->get_ok("/waste/pay_cancel/$report_id/$token?property_id=PE1%203NA:100090215480");
         };
 
-        subtest 'Summary page' => \&test_summary;
+        subtest 'Summary page' => sub { test_summary(26) }; # 26th August
         subtest 'Summary submission again' => \&test_summary_submission;
         subtest 'Payment page again' => sub {
             my ($token, $new_report, $report_id) = test_payment_page($sent_params);

--- a/templates/email/default/waste/bulky-reminder.html
+++ b/templates/email/default/waste/bulky-reminder.html
@@ -54,7 +54,7 @@ You can obtain a refund if you cancel more than one day before your booking.
   </p>
 
   <p style="margin: 20px auto; text-align: center">
-    <a style="[% button_style %]" href="[% URL %]">Cancel booking</a>
+    <a style="[% button_style %]" href="[% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') | uri %]/bulky_cancel">Cancel booking</a>
   </p>
 
   <p style="[% p_style %]">

--- a/templates/email/peterborough/other-reported-bulky.html
+++ b/templates/email/peterborough/other-reported-bulky.html
@@ -35,7 +35,7 @@ INCLUDE '_email_top.html';
 [% END %]
 
   <p style="[% p_style %]">
-    If you wish to cancel your booking, please visit this link: URL XXX
+    If you wish to cancel your booking, please visit <a href="[% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') | uri %]/bulky_cancel">this link</a>.
     You can obtain a refund if you cancel more than one day before your booking.
   </p>
 

--- a/templates/web/base/govuk/fields.html
+++ b/templates/web/base/govuk/fields.html
@@ -278,9 +278,15 @@
         <span class="govuk-visually-hidden">Error:</span> [% error %]
     </span>
   [% END %]
+
+  [% options_list = field.options %]
+  [% IF !options_list.0 %]
+    [% # Single item; not an array, so force into one %]
+    [% options_list = [options_list] %]
+  [% END %]
   <select class="govuk-select[% ' js-autocomplete' IF field.get_tag('autocomplete') %]" id="[% field.id %]" name="[% field.html_name %]"[% IF field.required %] required[% END %]>
     [% '<option value=""></option>' IF field.get_tag('autocomplete') %]
-    [% FOR item IN field.options %]
+    [% FOR item IN options_list %]
       [% # Select options may be optgrouped %]
       [% IF item.group %]
         <optgroup label="[% item.group %]"></optgroup>

--- a/templates/web/base/waste/bulky/cannot_book.html
+++ b/templates/web/base/waste/bulky/cannot_book.html
@@ -1,5 +1,6 @@
 <p>
-You cannot book a bulky collection online, please contact 01733 747474 to request a quote.
+We are afraid you cannot book a bulky collection online.
+[% # XXX Do we need to offer the user an alternative? %]
 </p>
 
 <p><a class="govuk-button" href="/waste/[% property.id %]">Show upcoming bin days</a></p>

--- a/templates/web/base/waste/bulky/confirmation.html
+++ b/templates/web/base/waste/bulky/confirmation.html
@@ -28,7 +28,7 @@
         <p class="govuk-!-margin-bottom-2">We have sent you an email confirming this booking.</p>
         <p>Can’t find our email? <strong>Check your spam folder.</strong></p>
       [% END %]
-        <a href="/waste" class="btn btn-primary">Go back home</a>
+        <a href="[% c.uri_for_action('waste/bin_days', [ report.get_extra_field_value('property_id') ]) %]" class="btn btn-primary">Go back home</a>
     </div>
 </div>
 

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -34,6 +34,25 @@
   [% END %]
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      [% IF problem %]
+        [% cancellation_report = cobrand.bulky_cancellation_report(problem) %]
+        [% IF cancellation_report %]
+          <div class="govuk-warning-text due" style="padding:1em">
+            <div class="govuk-warning-text__img">
+              <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            </div>
+            <div class="govuk-warning-text__content" style="display:flex; align-items:center;">
+                <span class="govuk-warning-text__assistive">Notification of cancellation</span>
+                <p class="govuk-!-margin-bottom-0">
+                  This collection has been cancelled.
+                  [% IF cobrand.bulky_can_view_cancellation(problem) %]
+                    <a href="/report/[% cancellation_report.id %]">View cancellation report.</a>
+                  [% END %]
+                </p>
+            </div>
+          </div>
+        [% END %]
+      [% END %]
       <h3>Property details</h3>
       [% INCLUDE 'waste/_address_display_bulky_summary.html' %]
 
@@ -44,18 +63,21 @@
           <dd>[% cobrand.bulky_nice_collection_date(data.chosen_date) %]</dd>
       </dl>
 
-      <div class="govuk-warning-text due">
-        <div class="govuk-warning-text__img">
-          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      [% IF !problem
+        || cobrand.bulky_can_cancel_collection( problem, 1 ) %]
+        <div class="govuk-warning-text due">
+          <div class="govuk-warning-text__img">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          </div>
+          <div class="govuk-warning-text__content">
+              <span class="govuk-warning-text__assistive">Warning</span>
+              <p class="govuk-!-margin-bottom-3">You can cancel this booking till
+                [% cobrand.bulky_nice_cancellation_cutoff_date(data.chosen_date) %].</p>
+              <p class="govuk-!-margin-bottom-0">You can get a refund by cancelling 24 hours
+                before the day of collection.</p>
+          </div>
         </div>
-        <div class="govuk-warning-text__content">
-            <span class="govuk-warning-text__assistive">Warning</span>
-            <p class="govuk-!-margin-bottom-3">You can cancel this booking till
-              [% cobrand.bulky_nice_cancellation_cutoff_date(data.chosen_date) %].</p>
-            <p class="govuk-!-margin-bottom-0">You can get a refund by cancelling 24 hours
-               before the day of collection.</p>
-        </div>
-      </div>
+      [% END %]
 
       <hr>
       <h3>Items to be collected</h3>
@@ -153,9 +175,11 @@
   </div>
 
   [% IF problem %]
-    <p>
-      <a class="govuk-button govuk-button--secondary" href="# [% #XXX cancellations %]">Cancel this booking</a>
-    </p>
+    [% IF cobrand.bulky_can_cancel_collection(problem) %]
+      <p>
+        <a class="govuk-button govuk-button--secondary" href="[% c.uri_for_action( 'waste/bulky_cancel', [ property.id ] ) %]">Cancel this booking</a>
+      </p>
+    [% END %]
     <p>
       <a class="govuk-button" href="/waste/[% property.id %]">Show upcoming bin days</a>
     </p>

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -51,8 +51,8 @@
         <div class="govuk-warning-text__content">
             <span class="govuk-warning-text__assistive">Warning</span>
             <p class="govuk-!-margin-bottom-3">You can cancel this booking till
-              23:55hrs on the 2nd of August 2022. [% #XXX calculate cut off when we do cancellations  %]</p>
-            <p class="govuk-!-margin-bottom-0">You can get a refund by cancelling 24hrs
+              [% cobrand.bulky_nice_cancellation_cutoff_date(data.chosen_date) %].</p>
+            <p class="govuk-!-margin-bottom-0">You can get a refund by cancelling 24 hours
                before the day of collection.</p>
         </div>
       </div>

--- a/templates/web/base/waste/garden/csc_code.html
+++ b/templates/web/base/waste/garden/csc_code.html
@@ -3,7 +3,7 @@
 <h1 class="govuk-heading-xl">Enter paye.net code</h1>
 
 <form name="post" method="post" action="[% c.uri_for('csc_payment') %]">
-<input type="text" name="payenet_code" id="payenet_code"  value="[% payenet_code %]" />
+<input type="text" name="payenet_code" id="payenet_code"  value="[% payenet_code %]"[% IF report.category == 'Bulky collection' %] required[% END %]/>
 <input type="hidden" name="report_id" id="report_id"  value="[% report.id %]" />
 <input type="hidden" name="token" id="token"  value="[% csrf_token %]" />
 

--- a/templates/web/peterborough/waste/bin_days_bulky.html
+++ b/templates/web/peterborough/waste/bin_days_bulky.html
@@ -1,4 +1,5 @@
 [% USE date(format = c.cobrand.bin_day_format) %]
+[% USE pounds = format('%.2f'); ~%]
 [% PROCESS 'waste/header.html' %]
 
 
@@ -127,7 +128,8 @@
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Cost</dt>
             <dd class="govuk-summary-list__value">
-              [% IF free_collection_available # XXX %]
+              [% cost = cobrand.bulky_minimum_cost %]
+              [% IF cobrand.bulky_free_collection_available %]
                 <!-- #03 Should only display when: There is a free collection option and
                   the property hasn't had a collection on this tax year. -->
                 <!-- I know we are not implementing this at the moment, so feel free
@@ -136,10 +138,10 @@
                 <p class="govuk-!-margin-bottom-2"><strong>One free</strong> collection per tax year.</p>
                 <!-- END #03 -->
                 <!-- #02 Always visible EXCEPT when address is commercial-->
-                <p class="govuk-!-margin-bottom-0"><strong>From £23.50</strong> Afterwards.</p>
+                <p class="govuk-!-margin-bottom-0"><strong>From £[% pounds(cost / 100) %]</strong> Afterwards.</p>
                 <!-- END #02 -->
               [% ELSE %]
-                  <p class="govuk-!-margin-bottom-0"><strong>£23.50</strong></p>
+                  <p class="govuk-!-margin-bottom-0"><strong>From £[% pounds(cost / 100) %]</strong></p>
               [% END %]
             </dd>
           </div>

--- a/templates/web/peterborough/waste/bin_days_bulky.html
+++ b/templates/web/peterborough/waste/bin_days_bulky.html
@@ -175,7 +175,7 @@
           [% IF c.cobrand.bulky_can_view_collection(property.pending_bulky_collection) %]
             <!-- #05 Should only display when: There IS a booking AND is a signed user -->
             <a class="btn btn-primary govuk-!-margin-bottom-2" href="/report/[% property.pending_bulky_collection.id %]">Check collection details</a>
-            [% IF c.cobrand.bulky_can_cancel %]
+            [% IF c.cobrand.bulky_can_cancel_collection(property.pending_bulky_collection) %]
               <a class="btn btn-primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky_cancel', [ property.id ]) %]">Cancel booking</a>
             [% END %]
             <!-- END #05 -->


### PR DESCRIPTION
Fixes issues that have been raised by the client themselves or spotted by devs.

These include:

- [ ] Fixing an issue that meant a select element with a single item was showing as empty
- [ ] Preventing a legacy report with no property ID from fetching all postcodes (thus causing a timeout)
- [ ] Collection summary page improvements:
  - [ ] Cancel button actually links to cancellation journey
  - [ ] Show message when collection cancelled
  - [ ] Hide cancellation messaging & button when collection cancelled
  - [ ] DIsplay correct cancellation cutoff date
- [ ] Only allowing admin to view cancellation reports (and adding a link to such on the collection summary page)
- [ ] Displaying the correct pricing on the bin days page

[skip changelog]