### PR TITLE
[Camden] Add Housing Estate custom JS and templates

### DIFF
--- a/templates/web/camden/report/new/roads_message.html
+++ b/templates/web/camden/report/new/roads_message.html
@@ -1,0 +1,4 @@
+    <div id="js-camden-housing-estate-restriction" class="js-responsibility-message hidden">
+        <strong>Not maintained by Camden Council</strong>
+        <p>The location you have selected is not maintained by Camden Council.</p>
+    </div>

--- a/templates/web/fixmystreet.com/report/new/roads_message.html
+++ b/templates/web/fixmystreet.com/report/new/roads_message.html
@@ -31,6 +31,10 @@
     <div id="js-not-council-car-park" class="hidden js-responsibility-message">
         <p>There is no council car park in the area selected.</p>
     </div>
+    <div id="js-camden-housing-estate-restriction" class="js-responsibility-message hidden">
+        <strong>Not maintained by Camden Council</strong>
+        <p>The location you have selected is not maintained by Camden Council.</p>
+    </div>
 </div>
 <div id="js-environment-message" class="hidden">
     <p>

--- a/web/cobrands/fixmystreet-uk-councils/assets.js
+++ b/web/cobrands/fixmystreet-uk-councils/assets.js
@@ -39,6 +39,33 @@ fixmystreet.assets.bromley.prow_stylemap = new OpenLayers.StyleMap({
     })
 });
 
+fixmystreet.assets.camden = {};
+fixmystreet.assets.camden.housing_estate_actions = {
+    // When a housing estate is found we want to prevent reporting,
+    // which is why we run the road_not_found function, to display
+    // the message.
+    found: function(layer) {
+        var currentCategory = fixmystreet.reporting.selectedCategory().category;
+        if (!fixmystreet.reporting_data || currentCategory === '') {
+            // Skip checks until category has been selected.
+            fixmystreet.message_controller.road_found(layer);
+            return;
+        }
+        var category = fixmystreet.reporting_data.by_category[currentCategory];
+
+        // If this category is non-TfL then disable reporting.
+        if (category.bodies.indexOf('TfL') === -1) {
+            // Need to pass a criterion function to force the not found message to be shown.
+            fixmystreet.message_controller.road_not_found(layer, function() { return true; });
+        } else {
+            fixmystreet.message_controller.road_found(layer);
+        }
+    },
+    not_found: function(layer) {
+        fixmystreet.message_controller.road_found(layer);
+    }
+};
+
 fixmystreet.assets.centralbedfordshire = {};
 fixmystreet.assets.centralbedfordshire.streetlight_stylemap = new OpenLayers.StyleMap({
     'default': fixmystreet.assets.style_default,


### PR DESCRIPTION
This prevents reports from being made on housing estate land and shows a not maintained message.

The asset config changes in `/data/servers` are in commit `7b54f1179fe6d9c43b17c3ad0f429f04090b9abf` on the `camden-housing-estates-asset-layer` branch.

<img width="817" alt="image" src="https://user-images.githubusercontent.com/22996/207689803-988466de-ef47-4d33-a0da-30a946d69197.png">


Fixes https://github.com/mysociety/societyworks/issues/3416

<!-- [skip changelog] -->
