### PR TITLE
[Brent] Add a working bin page with report missed collection

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -6,6 +6,7 @@ use warnings;
 use Moo;
 with 'FixMyStreet::Roles::Open311Multi';
 with 'FixMyStreet::Roles::CobrandOpenUSRN';
+with 'FixMyStreet::Roles::CobrandEcho';
 
 sub council_area_id { return 2488; }
 sub council_area { return 'Brent'; }
@@ -113,6 +114,277 @@ sub categories_restriction {
 
     # Brent don't want TfL's River Piers category to appear on their cobrand.
     return $rs->search( { 'me.category' => { '!=', 'River Piers' } } );
+}
+
+sub waste_on_the_day_criteria {
+    my ($self, $completed, $state, $now, $row) = @_;
+
+    if ($state eq 'Outstanding' && $now->hour < 17) {
+        $row->{next} = $row->{last};
+        $row->{next}{state} = 'In progress';
+        delete $row->{last};
+    }
+    if (!$completed && $now->hour < 17) {
+        $row->{report_allowed} = 0;
+    }
+}
+
+sub bin_services_for_address {
+    my $self = shift;
+    my $property = shift;
+
+# THESE ARE BROMLEY CONTAINER TYPES AS WAITING FOR CORRECT ONES
+    $self->{c}->stash->{containers} = {
+        1 => 'Green Box (Plastic)',
+        3 => 'Wheeled Bin (Plastic)',
+        12 => 'Black Box (Paper)',
+        14 => 'Wheeled Bin (Paper)',
+        9 => 'Kitchen Caddy',
+        10 => 'Outside Food Waste Container',
+        44 => 'Garden Waste Container',
+        46 => 'Wheeled Bin (Food)',
+    };
+
+    $self->{c}->stash->{container_actions} = $self->waste_container_actions;
+
+    my %service_to_containers = (
+        262 => [ 1 ],
+        265 => [ 3 ],
+        316 => [ 12 ]
+    );
+    my %request_allowed = map { $_ => 1 } keys %service_to_containers;
+    my %quantity_max = (
+        262 => 1,
+        265 => 1,
+        316 => 1
+    );
+
+    $self->{c}->stash->{quantity_max} = \%quantity_max;
+
+    $self->{c}->stash->{garden_subs} = $self->waste_subscription_types;
+
+    my $result = $self->{api_serviceunits};
+    return [] unless @$result;
+
+    my $events = $self->_parse_events($self->{api_events});
+    $self->{c}->stash->{open_service_requests} = $events->{enquiry};
+
+# THIS IS BROMLEY GGW SUBSCRIPTION NUMBER
+    # If there is an open Garden subscription (2106) event, assume
+    # that means a bin is being delivered and so a pending subscription
+    if ($events->{enquiry}{2106}) {
+        $self->{c}->stash->{pending_subscription} = { title => 'Garden Subscription - New' };
+        $self->{c}->stash->{open_garden_event} = 1;
+    }
+
+    my @to_fetch;
+    my %schedules;
+    my @task_refs;
+    my %expired;
+    foreach (@$result) {
+        my $servicetask = $self->_get_current_service_task($_) or next;
+        my $schedules = _parse_schedules($servicetask);
+        $expired{$_->{Id}} = $schedules if $self->waste_sub_overdue( $schedules->{end_date}, weeks => 4 );
+
+        next unless $schedules->{next} or $schedules->{last};
+        $schedules{$_->{Id}} = $schedules;
+        push @to_fetch, GetEventsForObject => [ ServiceUnit => $_->{Id} ];
+        push @task_refs, $schedules->{last}{ref} if $schedules->{last};
+    }
+    push @to_fetch, GetTasks => \@task_refs if @task_refs;
+
+    my $cfg = $self->feature('echo');
+    my $echo = Integrations::Echo->new(%$cfg);
+    my $calls = $echo->call_api($self->{c}, 'brent', 'bin_services_for_address:' . $property->{id}, @to_fetch);
+
+    my @out;
+    my %task_ref_to_row;
+    foreach (@$result) {
+        my $service_id = $_->{ServiceId};
+        my $service_name = $self->service_name_override($_);
+        next unless $schedules{$_->{Id}} || ( $service_name eq 'Garden Waste' && $expired{$_->{Id}} );
+
+        my $schedules = $schedules{$_->{Id}} || $expired{$_->{Id}};
+        my $servicetask = $self->_get_current_service_task($_);
+
+        my $containers = $service_to_containers{$service_id};
+        my $open_requests = { map { $_ => $events->{request}->{$_} } grep { $events->{request}->{$_} } @$containers };
+
+        my $request_max = $quantity_max{$service_id};
+
+        my $garden = 0;
+        my $garden_bins;
+        my $garden_cost = 0;
+        my $garden_due = $self->waste_sub_due($schedules->{end_date});
+        my $garden_overdue = $expired{$_->{Id}};
+        if ($service_name eq 'Garden Waste') {
+            $garden = 1;
+            my $data = Integrations::Echo::force_arrayref($servicetask->{Data}, 'ExtensibleDatum');
+            foreach (@$data) {
+                my $moredata = Integrations::Echo::force_arrayref($_->{ChildData}, 'ExtensibleDatum');
+                foreach (@$moredata) {
+                    if ( $_->{DatatypeName} eq 'Quantity' ) {
+                        $garden_bins = $_->{Value};
+                        $garden_cost = $self->garden_waste_cost_pa($garden_bins) / 100;
+                    }
+                }
+            }
+            $request_max = $garden_bins;
+
+            if ($self->{c}->stash->{waste_features}->{garden_disabled}) {
+                $garden = 0;
+            }
+        }
+
+        my $row = {
+            id => $_->{Id},
+            service_id => $service_id,
+            service_name => $service_name,
+            garden_waste => $garden,
+            garden_bins => $garden_bins,
+            garden_cost => $garden_cost,
+            garden_due => $garden_due,
+            garden_overdue => $garden_overdue,
+            request_allowed => $request_allowed{$service_id} && $request_max && $schedules->{next},
+            requests_open => $open_requests,
+            request_containers => $containers,
+            request_max => $request_max,
+            service_task_id => $servicetask->{Id},
+            service_task_name => $servicetask->{TaskTypeName},
+            service_task_type_id => $servicetask->{TaskTypeId},
+            schedule => $schedules->{description},
+            last => $schedules->{last},
+            next => $schedules->{next},
+            end_date => $schedules->{end_date},
+        };
+        if ($row->{last}) {
+            my $ref = join(',', @{$row->{last}{ref}});
+            $task_ref_to_row{$ref} = $row;
+
+            $row->{report_allowed} = $self->within_working_days($row->{last}{date}, 2);
+
+            my $events_unit = $self->_parse_events($calls->{"GetEventsForObject ServiceUnit $_->{Id}"});
+            my $missed_events = [
+                @{$events->{missed}->{$service_id} || []},
+                @{$events_unit->{missed}->{$service_id} || []},
+            ];
+            my $recent_events = $self->_events_since_date($row->{last}{date}, $missed_events);
+            $row->{report_open} = $recent_events->{open} || $recent_events->{closed};
+        }
+        push @out, $row;
+    }
+
+    $self->waste_task_resolutions($calls->{GetTasks}, \%task_ref_to_row);
+
+    return \@out;
+}
+
+sub waste_container_actions {
+    return {
+        deliver => 1,
+        remove => 2
+    };
+}
+
+sub waste_subscription_types {
+    return {
+        New => 1,
+        Renew => 2,
+        Amend => 3,
+    };
+}
+
+sub _parse_events {
+    my $self = shift;
+    my $events_data = shift;
+    my $events;
+# THESE ARE BROMLEY CODES SO WILL NEED UPDATING
+    foreach (@$events_data) {
+        my $event_type = $_->{EventTypeId};
+        my $type = 'enquiry';
+        $type = 'request' if $event_type == 2104;
+        $type = 'missed' if 2095 <= $event_type && $event_type <= 2103;
+
+        # Only care about open requests/enquiries
+        my $closed = _closed_event($_);
+        next if $type ne 'missed' && $closed;
+
+        if ($type eq 'request') {
+            my $data = Integrations::Echo::force_arrayref($_->{Data}, 'ExtensibleDatum');
+            my $container;
+            DATA: foreach (@$data) {
+                my $moredata = Integrations::Echo::force_arrayref($_->{ChildData}, 'ExtensibleDatum');
+                foreach (@$moredata) {
+                    if ($_->{DatatypeName} eq 'Container Type') {
+                        $container = $_->{Value};
+                        last DATA;
+                    }
+                }
+            }
+            my $report = $self->problems->search({ external_id => $_->{Guid} })->first;
+            $events->{request}->{$container} = $report ? { report => $report } : 1;
+        } elsif ($type eq 'missed') {
+            my $report = $self->problems->search({ external_id => $_->{Guid} })->first;
+            my $service_id = $_->{ServiceId};
+            my $data = {
+                closed => $closed,
+                date => construct_bin_date($_->{EventDate}),
+            };
+            $data->{report} = $report if $report;
+            push @{$events->{missed}->{$service_id}}, $data;
+        } else { # General enquiry of some sort
+            $events->{enquiry}->{$event_type} = 1;
+        }
+    }
+    return $events;
+}
+
+sub image_for_unit {
+    my ($self, $unit) = @_;
+    my $service_id = $unit->{service_id};
+
+    my $base = '/i/waste-containers';
+    my $images = {
+        262 => "$base/bin-black",
+        265 => "$base/bin-grey-blue-lid-recycling",
+        316 => "$base/bin-brown-recycling",
+    };
+    return $images->{$service_id};
+}
+
+sub bin_day_format { '%A, %-d~~~ %B' }
+
+sub service_name_override {
+    my ($self, $service) = @_;
+
+    my %service_name_override = (
+
+    );
+
+    return $service_name_override{$service->{ServiceId}} || $service->{ServiceName};
+}
+
+sub clear_cached_lookups_property {
+    my ($self, $id) = @_;
+
+    my $key = "brent:echo:look_up_property:$id";
+    delete $self->{c}->session->{$key};
+    $key = "brent:echo:bin_services_for_address:$id";
+    delete $self->{c}->session->{$key};
+}
+
+sub garden_due_days { 48 }
+
+sub within_working_days {
+    my ($self, $dt, $days, $future) = @_;
+    my $wd = FixMyStreet::WorkingDays->new(public_holidays => FixMyStreet::Cobrand::UK::public_holidays());
+    $dt = $wd->add_days($dt, $days)->ymd;
+    my $today = DateTime->now->set_time_zone(FixMyStreet->local_time_zone)->ymd;
+    if ( $future ) {
+        return $today ge $dt;
+    } else {
+        return $today le $dt;
+    }
 }
 
 1;

--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -303,7 +303,7 @@ sub _parse_events {
         my $event_type = $_->{EventTypeId};
         my $type = 'enquiry';
         $type = 'request' if $event_type == 2104;
-        $type = 'missed' if 2095 <= $event_type && $event_type <= 2103;
+        $type = 'missed' if $event_type == 918; # THIS IS BRENT ID
 
         # Only care about open requests/enquiries
         my $closed = _closed_event($_);
@@ -385,6 +385,18 @@ sub within_working_days {
     } else {
         return $today le $dt;
     }
+}
+
+sub waste_munge_report_data {
+    my ($self, $id, $data) = @_;
+
+    my $c = $self->{c};
+
+    my $address = $c->stash->{property}->{address};
+    my $service = $c->stash->{services}{$id}{service_name};
+    $data->{title} = "Report missed $service";
+    $data->{detail} = "$data->{title}\n\n$address";
+    $c->set_param('service_id', $id);
 }
 
 1;

--- a/templates/web/brent/header_extra.html
+++ b/templates/web/brent/header_extra.html
@@ -1,3 +1,4 @@
+<link rel="stylesheet" href="/vendor/govuk-frontend/forms.css">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;700&family=Poppins:wght@700&display=swap" rel="stylesheet">

--- a/templates/web/brent/waste/services.html
+++ b/templates/web/brent/waste/services.html
@@ -1,0 +1,74 @@
+[% IF unit.report_open %]
+  <span class="waste-service-descriptor">
+    A [% unit.service_name FILTER lower %] collection has been reported as missed.
+    Please check your email for an update on your request.
+  </span>
+[% ELSIF unit.report_allowed %]
+  [% any_report_allowed = 1 %]
+  <form method="post" action="[% c.uri_for_action('waste/report', [ property.id ]) %]">
+    <input type="hidden" name="token" value="[% csrf_token %]">
+    <input type="hidden" name="service-[% unit.service_id %]" value="1">
+    <input type="submit" value="Report a [% unit.service_name FILTER lower %] collection as missed" class="waste-service-descriptor waste-service-link">
+  </form>
+[% ELSIF unit.report_locked_out %]
+  <span class="waste-service-descriptor">A missed collection cannot be reported, please see the last collection status above.</span>
+[% ELSE %]
+  <span class="waste-service-descriptor" style="margin-top: 1.5em;">Please note that missed collections can only be reported after 6pm on your scheduled collection day and for 2 working days after your scheduled collection.</span>
+[% END %]
+
+[% IF unit.requests_open.size %]
+  <span class="waste-service-descriptor">
+    A [% unit.service_name FILTER lower %] container request has been made
+  </span>
+[% ELSIF unit.request_allowed %]
+  [% any_request_allowed = 1 %]
+  <form method="post" action="[% c.uri_for_action('waste/request', [ property.id ]) %]">
+    <input type="hidden" name="token" value="[% csrf_token %]">
+    <input type="hidden" name="container-choice" value="[% unit.request_containers.0 %]">
+    <input type="submit" value="Request a [% unit.service_name == 'Garden Waste' ? 'replacement ' : '' %][% unit.service_name FILTER lower %] container" class="waste-service-descriptor waste-service-link">
+  </form>
+[% ELSIF unit.garden_waste && NOT unit.garden_due %]
+  <form method="post" action="[% c.uri_for_action('waste/garden_modify', [ property.id ]) %]">
+    <input type="hidden" name="token" value="[% csrf_token %]">
+    <input type="submit" value="Change the number of [% unit.service_name FILTER lower %] containers" class="waste-service-descriptor waste-service-link">
+  </form>
+[% END %]
+
+[% IF unit.garden_waste %]
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Subscription</dt>
+        <dd class="govuk-summary-list__value">
+          £[% tprintf('%.2f', unit.garden_cost) %] per year ([% unit.garden_bins %] [% nget('bin', 'bins', unit.garden_bins) %])
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Renewal</dt>
+        <dd class="govuk-summary-list__value
+        [%~ ' renewal-status' IF unit.garden_due ~%]
+        ">[% date.format(unit.end_date _ ' 00:00:00', '%d %B %Y') %][% ' Cancellation in progress' IF pending_cancellation %][% ', soon due for renewal.' IF unit.garden_due %]</dd>
+      </div>
+    </dl>
+
+  [% IF ( unit.garden_due ) %]
+  <form method="post" action="[% c.uri_for_action('waste/garden_renew', [ property.id ]) %]">
+    <input type="hidden" name="token" value="[% csrf_token %]">
+    <input type="submit" value="Renew your [% unit.service_name FILTER lower %] subscription" class="waste-service-descriptor waste-service-link">
+  </form>
+  [% END %]
+  [% IF NOT pending_cancellation %]
+      [% IF NOT unit.garden_due %]
+          <form method="post" action="[% c.uri_for_action('waste/garden_modify', [ property.id ]) %]">
+            <input type="hidden" name="token" value="[% csrf_token %]">
+            <input type="submit" value="Modify your [% unit.service_name FILTER lower %] subscription" class="waste-service-descriptor waste-service-link">
+          </form>
+      [% END %]
+      [% IF c.cobrand.call_hook('waste_garden_allow_cancellation') == 'staff' AND is_staff %]
+          <form method="post" action="[% c.uri_for_action('waste/garden_cancel', [ property.id ]) %]">
+            <input type="hidden" name="token" value="[% csrf_token %]">
+            <input type="submit" value="Cancel your [% unit.service_name FILTER lower %] subscription" class="waste-service-descriptor waste-service-link">
+          </form>
+      [% END %]
+  [% END %]
+[% END %]

--- a/web/cobrands/brent/base.scss
+++ b/web/cobrands/brent/base.scss
@@ -4,7 +4,7 @@
 @import "../sass/mixins";
 
 @import "../sass/base";
-
+@import "../sass/waste";
 @import "./_mixins";
 
 // Optimize legibility

--- a/web/cobrands/brent/base.scss
+++ b/web/cobrands/brent/base.scss
@@ -617,6 +617,13 @@ h1.govuk-heading-xl {
   background-blend-mode: normal!important;
 }
 
+.waste__collections .govuk-summary-list,
+.waste__summary .govuk-summary-list,
+.waste__collections .govuk-summary-list__row,
+.waste__summary .govuk-summary-list__row{
+background-color: transparent;
+}
+
 form.waste {
     background-color: $section-background-color;
     color: $primary_b;

--- a/web/cobrands/brent/base.scss
+++ b/web/cobrands/brent/base.scss
@@ -40,7 +40,7 @@ a {
   background-color: $link-focus-color;
 }
 
-.btn, .btn--primary, .btn-primary, .green-btn, #report-cta, .govuk-button {
+.btn, .btn--primary, .btn-primary, .green-btn, #report-cta {
   @include brent-btn-primary;
 }
 
@@ -595,11 +595,20 @@ body.twothirdswidthpage {
 }
 
 // Waste
-.content {
-  .waste & {
+.waste {
+  .content {
     padding-top: 0;
     margin-top: 2rem;
     background-color: $section-background-color;
+  }
+
+  .govuk-button {
+    background-color: $link-color;
+    box-shadow: 0 4px 0 $btn-primary-background-hover;
+
+    &:hover {
+      background-color: $btn-primary-background-hover;
+    }
   }
 }
 

--- a/web/cobrands/brent/base.scss
+++ b/web/cobrands/brent/base.scss
@@ -605,14 +605,13 @@ body.twothirdswidthpage {
 
 h1.govuk-heading-xl {
   text-align: left;
-  color: $white;
   margin: 0 -1rem;
   padding: 1.5rem 1rem;
   // background-color: $front_main_colour;
   background: $front_main_colour inline-image("../brent/images/logo-pattern-bolder_gray-transparent.svg") $right center no-repeat;
   z-index: 1;
   background-repeat: no-repeat;
-  background-size: cover;
+  background-size: 50%;
   background-position: left top;
   background-blend-mode: soft-light;
   background-blend-mode: normal!important;


### PR DESCRIPTION
Adds the framework for a working bin page with reporting a missed collection.

Will need services, events and correct bin images adding.

'Request a new container' and 'Subscribe to' are not implemented.

https://github.com/mysociety/societyworks/issues/3403

[skip changelog]