### PR TITLE
[FMS] Move single sign on detail params to cobrand

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Auth/Social.pm
+++ b/perllib/FixMyStreet/App/Controller/Auth/Social.pm
@@ -380,7 +380,7 @@ sub oauth_success : Private {
         } elsif ( $type eq 'oidc' ) {
             $user->add_oidc_id($uid);
         }
-        $user->name($name);
+        $user->name($name) if $name;
         if ($extra) {
             $user->extra({
                 %{ $user->get_extra() },
@@ -399,7 +399,7 @@ sub oauth_success : Private {
         }
         if ($user) {
             # Matching ID in our database
-            $user->name($name);
+            $user->name($name) if $name;
             if ($extra) {
                 $user->extra({
                     %{ $user->get_extra() },
@@ -410,7 +410,7 @@ sub oauth_success : Private {
         } else {
             # No matching ID, store ID for use later
             $c->session->{oauth}{$type . '_id'} = $uid;
-            $c->session->{oauth}{name} = $name;
+            $c->session->{oauth}{name} = $name if $name;
             $c->session->{oauth}{extra} = $extra;
             $c->stash->{oauth_need_email} = 1;
         }

--- a/perllib/FixMyStreet/Cobrand/Hackney.pm
+++ b/perllib/FixMyStreet/Cobrand/Hackney.pm
@@ -175,6 +175,15 @@ sub anonymous_account {
     };
 }
 
+sub user_from_oidc {
+    my ($self, $payload) = @_;
+
+    my $name = $payload->{name};
+    my $email = $payload->{email};
+
+    return ($name, $email);
+}
+
 sub open311_skip_existing_contact {
     my ($self, $contact) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/Westminster.pm
+++ b/perllib/FixMyStreet/Cobrand/Westminster.pm
@@ -58,6 +58,20 @@ sub anonymous_account {
     };
 }
 
+sub user_from_oidc {
+    my ($self, $payload) = @_;
+
+    my $name = join(" ", $payload->{given_name}, $payload->{family_name});
+    # WCC Azure provides a single email address as an array for some reason
+    my $email = $payload->{email};
+    my $emails = $payload->{emails};
+    if ($emails && @$emails) {
+        $email = $emails->[0];
+    }
+
+    return ($name, $email);
+}
+
 sub oidc_user_extra {
     my ($self, $id_token) = @_;
 

--- a/t/Mock/OpenIDConnect.pm
+++ b/t/Mock/OpenIDConnect.pm
@@ -19,6 +19,12 @@ has returns_email => (
     default => 1,
 );
 
+has cobrand => (
+    is => 'rw',
+    isa => Str,
+    default => '',
+);
+
 sub dispatch_request {
     my $self = shift;
 
@@ -54,13 +60,15 @@ sub dispatch_request {
             aud => "example_client_id",
             iat => $now,
             auth_time => $now,
-            given_name => "Andy",
-            family_name => "Dwyer",
             tfp => "B2C_1_default",
             extension_CrmContactId => "1c304134-ef12-c128-9212-123908123901",
             nonce => 'MyAwesomeRandomValue',
         };
-        $payload->{emails} = ['pkg-tappcontrollerauth_socialt-oidc@example.org'] if $self->returns_email;
+        if ($self->cobrand eq 'westminster') {
+            $payload->{given_name} = "Andy";
+            $payload->{family_name} = "Dwyer";
+            $payload->{emails} = ['pkg-tappcontrollerauth_socialt-oidc@example.org'] if $self->returns_email;
+        }
         my $signature = "dummy";
         my $id_token = join(".", (
             encode_base64($self->json->encode($header), ''),
@@ -102,7 +110,7 @@ sub dispatch_request {
             nonce => 'MyAwesomeRandomValue',
             hd => 'example.org',
         };
-        $payload->{email} = 'pkg-tappcontrollerauth_socialt-oidc_google@example.org' if $self->returns_email;
+        $payload->{email} = 'pkg-tappcontrollerauth_socialt-oidc_google@example.org' if $self->returns_email && $self->cobrand eq 'hackney';
         $payload->{email_verified} = JSON->true if $self->returns_email;
         my $signature = "dummy";
         my $id_token = join(".", (

--- a/t/app/controller/auth_social.t
+++ b/t/app/controller/auth_social.t
@@ -168,6 +168,11 @@ for my $state ( 'refused', 'no email', 'existing UID', 'okay' ) {
 
             # Set up a mock to catch (most, see below) requests to the OAuth API
             my $mock_api = $test->{mock}->new;
+
+            if ($test->{uid} =~ /:/) {
+                my ($cobrand) = $test->{uid} =~ /^(.*?):/;
+                $mock_api->cobrand($cobrand);
+            }
             $mock_api->returns_email(0) if $state eq 'no email' || $state eq 'existing UID';
             for my $host (@{ $test->{mock_hosts} }) {
                 LWP::Protocol::PSGI->register($mock_api->to_psgi_app, host => $host);


### PR DESCRIPTION
Different single sign on instances send different parameter names containing user name and email details.

This moves the field identification to the Cobrand.

Refactored out of https://github.com/mysociety/fixmystreet/pull/4224 as core functionality as will affect Camden implementation.

[skip changelog]