### PR TITLE
[Brent] WW front end

### DIFF
--- a/web/cobrands/brent/base.scss
+++ b/web/cobrands/brent/base.scss
@@ -617,6 +617,13 @@ h1.govuk-heading-xl {
   background-blend-mode: normal!important;
 }
 
+.waste__collections .govuk-summary-list,
+.waste__summary .govuk-summary-list,
+.waste__collections .govuk-summary-list__row,
+.waste__summary .govuk-summary-list__row{
+background-color: transparent;
+}
+
 form.waste {
     background-color: $section-background-color;
     color: $primary_b;

--- a/web/cobrands/brent/base.scss
+++ b/web/cobrands/brent/base.scss
@@ -40,7 +40,7 @@ a {
   background-color: $link-focus-color;
 }
 
-.btn, .btn--primary, .btn-primary, .green-btn, #report-cta, .govuk-button {
+.btn, .btn--primary, .btn-primary, .green-btn, #report-cta {
   @include brent-btn-primary;
 }
 
@@ -595,11 +595,20 @@ body.twothirdswidthpage {
 }
 
 // Waste
-.content {
-  .waste & {
+.waste {
+  .content {
     padding-top: 0;
     margin-top: 2rem;
     background-color: $section-background-color;
+  }
+
+  .govuk-button {
+    background-color: $link-color;
+    box-shadow: 0 4px 0 $btn-primary-background-hover;
+
+    &:hover {
+      background-color: $btn-primary-background-hover;
+    }
   }
 }
 

--- a/web/cobrands/brent/base.scss
+++ b/web/cobrands/brent/base.scss
@@ -605,14 +605,13 @@ body.twothirdswidthpage {
 
 h1.govuk-heading-xl {
   text-align: left;
-  color: $white;
   margin: 0 -1rem;
   padding: 1.5rem 1rem;
   // background-color: $front_main_colour;
   background: $front_main_colour inline-image("../brent/images/logo-pattern-bolder_gray-transparent.svg") $right center no-repeat;
   z-index: 1;
   background-repeat: no-repeat;
-  background-size: cover;
+  background-size: 50%;
   background-position: left top;
   background-blend-mode: soft-light;
   background-blend-mode: normal!important;


### PR DESCRIPTION
Hey @dracos 
The original PR was replaced by a later [PR](https://github.com/mysociety/fixmystreet/pull/4191) on [client's request here](https://3.basecamp.com/4020879/buckets/28996137/todos/5548702394#__recording_5577093487):
So the first screenshot on this [issue]( https://github.com/mysociety/societyworks/issues/3419) is not longer the version we are using.

### Regarding this PR

- Fixes the white colour on h1 headings for WW
<img width="1272" alt="Screenshot 2022-12-19 at 12 56 05" src="https://user-images.githubusercontent.com/13790153/208441605-09f8e14e-e139-4f1e-bd42-e2a50aaadc20.png">

- Transparent bg colour for summary-list element
<img width="1272" alt="Screenshot 2022-12-19 at 13 54 51" src="https://user-images.githubusercontent.com/13790153/208441428-77c0fe8d-b6f9-4c41-bd8d-393a95f936db.png">

- Styling of .govuk-button element
Let me know if you want to apply this one, it basically follows the style of the primary button. But if you prefer to use the default styling govuk-button I'll drop this commit.

Fixes: https://github.com/mysociety/societyworks/issues/3419

Let me know if there is any feedback.

