### PR TITLE
Log response when id_token is missing

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Auth/Social.pm
+++ b/perllib/FixMyStreet/App/Controller/Auth/Social.pm
@@ -298,7 +298,10 @@ sub oidc_callback: Path('/auth/OIDC') : Args(0) {
         $c->detach('/page_error_500_internal_error', [ $message ]);
     }
 
-    $c->detach('oauth_failure') unless $id_token;
+    if (!$id_token) {
+        $c->log->info("Social::oidc_callback no id_token: " . $oidc->{last_response}->{_content});
+        $c->detach('oauth_failure');
+    }
 
     # sanity check the token audience is us...
     unless ($id_token->payload->{aud} eq $c->cobrand->feature('oidc_login')->{client_id}) {


### PR DESCRIPTION
I recently had a situation where the id_token was missing so I was getting the "Sorry, we could not log you in" error but there were no details in the logs about _why_ it failed.

This change adds an extra bit of logging to show the response that comes back from the OIDC provider in the event that the id_token is determined to be invalid for whatever reason.

<!-- [skip changelog] -->