### PR TITLE
Add reporter/staff update_disallowed options

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
@@ -44,9 +44,9 @@ sub updates_disallowed {
     my ($problem) = @_;
 
     # Only open reports
-    return 1 if $problem->is_fixed || $problem->is_closed;
+    return 'open' if $problem->is_fixed || $problem->is_closed;
     # Not on reports made by the body user
-    return 1 if $problem->user_id == $self->body->comment_user_id;
+    return 'notopen311' if $problem->user_id == $self->body->comment_user_id;
 
     return $self->next::method(@_);
 }

--- a/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
@@ -39,18 +39,6 @@ sub report_sent_confirmation_email { 'id' }
 
 sub admin_user_domain { 'northamptonshire.gov.uk' }
 
-sub updates_disallowed {
-    my $self = shift;
-    my ($problem) = @_;
-
-    # Only open reports
-    return 'open' if $problem->is_fixed || $problem->is_closed;
-    # Not on reports made by the body user
-    return 'notopen311' if $problem->user_id == $self->body->comment_user_id;
-
-    return $self->next::method(@_);
-}
-
 sub is_defect {
     my ($self, $p) = @_;
     return $p->user_id == $self->body->comment_user_id;

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -117,16 +117,6 @@ sub state_groups_inspect {
     ]
 }
 
-sub updates_disallowed {
-    my $self = shift;
-    my ($problem) = @_;
-
-    # Not on reports made by the body user
-    return 1 if $self->body->comment_user_id && $problem->user_id == $self->body->comment_user_id;
-
-    return $self->next::method(@_);
-}
-
 sub open311_config {
     my ($self, $row, $h, $params) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/Thamesmead.pm
+++ b/perllib/FixMyStreet/Cobrand/Thamesmead.pm
@@ -10,23 +10,6 @@ sub council_url { return 'thamesmead'; }
 
 sub admin_user_domain { ( 'thamesmeadnow.org.uk', 'peabody.org.uk' ) }
 
-sub updates_disallowed {
-    my $self = shift;
-    my $problem = shift;
-    my $c = $self->{c};
-
-    my $staff = $c->user_exists && $c->user->from_body && $c->user->from_body->name eq $self->council_name;
-    my $superuser = $c->user_exists && $c->user->is_superuser;
-    my $reporter = $c->user_exists && $c->user->id == $problem->user->id;
-    my $closed_to_updates = $self->SUPER::updates_disallowed($problem);
-
-    if (($staff || $superuser || $reporter) && !$closed_to_updates) {
-        return;
-    } else {
-        return 1;
-    }
-}
-
 sub reopening_disallowed {
     my $self = shift;
     my $problem = shift;

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -460,6 +460,7 @@ sub _updates_disallowed_check {
     my $staff = $body_user || $superuser;
     my $reporter = $c->user_exists && $c->user->id == $problem->user->id;
     my $open = !($problem->is_fixed || $problem->is_closed);
+    my $body_comment_user = $self->body && $self->body->comment_user_id && $problem->user_id == $self->body->comment_user_id;
 
     if ($cfg eq 'none') {
         return $cfg;
@@ -476,6 +477,10 @@ sub _updates_disallowed_check {
         return $cfg unless $reporter || $staff;
     } elsif ($cfg eq 'reporter/staff-open') {
         return $cfg unless ($reporter || $staff) && $open;
+    } elsif ($cfg eq 'notopen311') {
+        return $cfg unless !$body_comment_user;
+    } elsif ($cfg eq 'notopen311-open') {
+        return $cfg unless !$body_comment_user && $open;
     }
     return '';
 }

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -472,6 +472,10 @@ sub _updates_disallowed_check {
         return $cfg unless $reporter;
     } elsif ($cfg eq 'reporter-open') {
         return $cfg unless $reporter && $open;
+    } elsif ($cfg eq 'reporter/staff') {
+        return $cfg unless $reporter || $staff;
+    } elsif ($cfg eq 'reporter/staff-open') {
+        return $cfg unless ($reporter || $staff) && $open;
     }
     return '';
 }

--- a/t/cobrand/northamptonshire.t
+++ b/t/cobrand/northamptonshire.t
@@ -1,5 +1,6 @@
 use Test::MockModule;
 
+use Catalyst::Test 'FixMyStreet::App';
 use FixMyStreet::TestMech;
 use FixMyStreet::Script::Reports;
 use Open311::PostServiceRequestUpdates;
@@ -113,14 +114,15 @@ subtest 'check updates sent for non defects' => sub {
     is $comment->send_fail_count, 1, "comment sending attempted";
 };
 
-my $cobrand = FixMyStreet::Cobrand::Northamptonshire->new;
+my ($res, $c) = ctx_request('/');
+my $cobrand = FixMyStreet::Cobrand::Northamptonshire->new({ c => $c });
 
 subtest 'check updates disallowed correctly' => sub {
     is $cobrand->updates_disallowed($report), '';
     $report->update({ state => 'closed' });
-    is $cobrand->updates_disallowed($report), 1;
+    is $cobrand->updates_disallowed($report), 'open';
     $report->update({ state => 'confirmed', user => $counciluser });
-    is $cobrand->updates_disallowed($report), 1;
+    is $cobrand->updates_disallowed($report), 'notopen311';
 };
 
 subtest 'check further investigation state' => sub {

--- a/t/cobrand/thamesmead.t
+++ b/t/cobrand/thamesmead.t
@@ -108,6 +108,11 @@ $osm->mock('cache', sub {
 
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'thamesmead' ],
+    COBRAND_FEATURES => {
+        updates_allowed => {
+            thamesmead => 'reporter/staff',
+        }
+    }
 }, sub {
     subtest 'Check updating a normal report' => sub {
         $mech->log_in_ok($user1->email);

--- a/templates/web/fixmystreet-uk-councils/about/faq-en-gb.html
+++ b/templates/web/fixmystreet-uk-councils/about/faq-en-gb.html
@@ -222,13 +222,13 @@ cleaning</strong> or <strong>clearing</strong>.
         Yes, you can leave updates on open reports, by visiting a report page and
         filling in the update form.
     </p>
-[% ELSIF c.cobrand.feature('updates_allowed') == 'reporter-open' %]
+[% ELSIF c.cobrand.feature('updates_allowed') == 'reporter-open' OR c.cobrand.feature('updates_allowed') == 'reporter/staff-open' %]
     <dt>Can I make updates to my report?</dt>
     <p>
         Yes, you can leave updates on open reports you have made, by visiting a
         report page and filling in the update form.
     </p>
-[% ELSIF c.cobrand.feature('updates_allowed') == 'reporter' %]
+[% ELSIF c.cobrand.feature('updates_allowed') == 'reporter' OR c.cobrand.feature('updates_allowed') == 'reporter/staff' %]
     <dt>Can I make updates to my report?</dt>
     <p>
         Yes, you can leave updates on reports you have made, by visiting a report

--- a/templates/web/fixmystreet-uk-councils/admin/bodies/_updates_disallowed_hint.html
+++ b/templates/web/fixmystreet-uk-councils/admin/bodies/_updates_disallowed_hint.html
@@ -5,6 +5,8 @@
   [%~ IF cfg == 'staff' %] staff will be able to leave updates.
   [%~ ELSIF cfg == 'reporter' %] the problem reporter will be able to leave updates.
   [%~ ELSIF cfg == 'reporter-open' %] the problem reporter will be able to leave updates on open reports.
+  [%~ ELSIF cfg == 'reporter/staff' %] the problem reporter or staff will be able to leave updates.
+  [%~ ELSIF cfg == 'reporter/staff-open' %] the problem reporter or staff will be able to leave updates.
   [%~ ELSIF cfg == 'open' %] open reports can have updates left on them.
   [%~ END %]
 </span>


### PR DESCRIPTION
Adds new options to updates_disallowed for reporter/staff to both leave updates (sure this has come up before, but never implemented as far as I can see). Fixes FD-2619 [skip changelog]