### PR TITLE
[FMS] Single sign on name should not be multiple spaces

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Auth/Social.pm
+++ b/perllib/FixMyStreet/App/Controller/Auth/Social.pm
@@ -322,6 +322,7 @@ sub oidc_callback: Path('/auth/OIDC') : Args(0) {
 
     # Cobrands can use different fields for name and email
     my ($name, $email) = $c->cobrand->call_hook(user_from_oidc => $id_token->payload);
+    $name = '' if $name && $name !~ /\w/;
 
     # There's a chance that a user may have multiple OIDC logins, so build a namespaced uid to prevent collisions
     my $uid = join(":", $c->cobrand->moniker, $c->cobrand->feature('oidc_login')->{client_id}, $id_token->payload->{sub});


### PR DESCRIPTION
    The name field returned from user_from_oidc should be
    tested to make sure it doesn't contain just spaces.

    It is tested for truth later in the process so should
    be an empty string if it is blank.

    This prevents guarding against that in every implementation
    of user_from_oidc.

[skip changelog]