### PR TITLE
[Oxfordshire] Use renamed state also on .com.

### DIFF
--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -358,12 +358,7 @@ sub problem_state_display {
     return '' unless $state;
 
     my $cobrand = $self->result_source->schema->cobrand;
-    my $cobrand_name = $cobrand->moniker;
-    my $names = join(',,', @{$self->problem->body_names});
-    if ($names =~ /(Bromley|Isle of Wight|TfL)/) {
-        ($cobrand_name = lc $1) =~ s/ //g;
-    }
-
+    my $cobrand_name = $self->problem->cobrand_name_for_state($cobrand);
     return FixMyStreet::DB->resultset("State")->display($state, 1, $cobrand_name);
 }
 

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -1059,7 +1059,7 @@ sub as_hashref {
     my ($self, $cols) = @_;
     my $cobrand = $self->result_source->schema->cobrand;
 
-    my $state_t = FixMyStreet::DB->resultset("State")->display($self->state);
+    my $state_t = FixMyStreet::DB->resultset("State")->display($self->state, 0, $cobrand->moniker);
 
     my $out = {
         id        => $self->id,
@@ -1132,6 +1132,15 @@ has get_cobrand_logged => (
     },
 );
 
+sub cobrand_name_for_state {
+    my ($self, $cobrand) = @_;
+    my $cobrand_name = $cobrand->moniker;
+    my $names = join(',,', @{$self->body_names});
+    if ($names =~ /(Bromley|Isle of Wight|Oxfordshire|TfL)/) {
+        ($cobrand_name = lc $1) =~ s/ //g;
+    }
+    return $cobrand_name;
+}
 
 sub pin_data {
     my ($self, $page, %opts) = @_;

--- a/perllib/FixMyStreet/Script/Alerts.pm
+++ b/perllib/FixMyStreet/Script/Alerts.pm
@@ -113,12 +113,20 @@ sub send_alert_type {
             $last_problem_state = 'confirmed';
         }
 
+        # Here because report is needed by e.g. _extra_new_update_data,
+        # and the state display function
+        if (!$data{alert_user_id} && $ref eq 'new_updates') {
+            # Get a report object for its photo and static map
+            $data{report} = $schema->resultset('Problem')->find({ id => $row->{id} });
+        }
+
         # this is currently only for new_updates
         if ($row->{is_new_update}) {
             # this might throw up the odd false positive but only in cases where the
             # state has changed and there was already update text
             if ($row->{item_problem_state} && $last_problem_state ne $row->{item_problem_state}) {
-                my $state = FixMyStreet::DB->resultset("State")->display($row->{item_problem_state}, 1, $cobrand->moniker);
+                my $cobrand_name = $data{report}->cobrand_name_for_state($cobrand);
+                my $state = FixMyStreet::DB->resultset("State")->display($row->{item_problem_state}, 1, $cobrand_name);
 
                 my $update = _('State changed to:') . ' ' . $state;
                 $row->{item_text} = $row->{item_text} ? $row->{item_text} . "\n\n" . $update :
@@ -140,13 +148,6 @@ sub send_alert_type {
             $data{state_message} = _("This report is currently marked as closed.")
         } else {
             $data{state_message} = _("This report is currently marked as open.");
-        }
-
-        if (!$data{alert_user_id}) {
-            if ($ref eq 'new_updates') {
-                # Get a report object for its photo and static map
-                $data{report} = $schema->resultset('Problem')->find({ id => $row->{id} });
-            }
         }
 
         # this is currently only for new_updates


### PR DESCRIPTION
This also fixes an issue where alert emails were not renaming the state on the cobrand.

Please check the following:

- [ ] Whether this PR should include changes to any documentation, or the FAQ;
- [ ] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [ ] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [ ] Will cobrand-specific changes require additional work to ensure consistent behaviour on www.fixmystreet.com? 
- [ ] Are the changes tested for accessibility?
- [ ] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
