### PR TITLE
[Bulky] Added front-end fixes for Bulky waste

### DIFF
--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -122,7 +122,7 @@
                   [% IF item.photo %]
                     <img class="img-preview is--small" alt="Preview image successfully attached" src="/photo/temp.[% item.photo %]">
                   [% ELSE %]
-                    <span class="govuk-text__assistive">No image attached for this item</span>
+                    <span>No image attached for this item</span>
                   [% END %]
               </td>
           </tr>

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -33,7 +33,7 @@
     </div>
   [% END %]
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-5">
       [% IF problem %]
         [% cancellation_report = cobrand.bulky_cancellation_report(problem) %]
         [% IF cancellation_report %]

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -6,6 +6,16 @@
 [% PROCESS errors %]
 [% SET data = form.saved_data ~%]
 
+[% BLOCK change_answers_button %]
+  [% UNLESS problem %]
+    <form method="post">
+      <input type="hidden" name="saved_data" value="[% form.fif.saved_data %]">
+      <input type="hidden" name="goto" value="[% goto %]">
+      <input type="submit" class="fake-link" value="Change answers">
+    </form>
+  [% END %]
+[% END %]
+
 
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-9">
   [% IF problem %]
@@ -53,11 +63,16 @@
           </div>
         [% END %]
       [% END %]
-      <h3>Property details</h3>
+      <div class="summary-section-header">
+        <h3 class="summary-section--heading">Property details</h3>
+      </div>
       [% INCLUDE 'waste/_address_display_bulky_summary.html' %]
 
       <hr>
-      <h3>Collection date</h3>
+      <div class="summary-section-header">
+        <h3 class="summary-section--heading">Collection date</h3>
+        [% PROCESS change_answers_button goto='choose_date_earlier' %]
+      </div>
       <dl>
           <dt>Date</dt>
           <dd>[% cobrand.bulky_nice_collection_date(data.chosen_date) %]</dd>
@@ -82,7 +97,10 @@
       [% END %]
 
       <hr>
-      <h3>Items to be collected</h3>
+      <div class="summary-section-header">
+        <h3 class="summary-section--heading">Items to be collected</h3>
+        [% PROCESS change_answers_button goto='add_items' %]
+      </div>
       [% items = [] %]
       [% FOR num IN [ 1 .. cobrand.bulky_items_maximum ];
         item_key = 'item_' _ num;
@@ -145,8 +163,10 @@
         </tbody>
       </table>
 
-
-      <h3>Location details</h3>
+      <div class="summary-section-header">
+        <h3 class="summary-section--heading">Location details</h3>
+        [% PROCESS change_answers_button goto='location' %]
+      </div>
       <p>
         [% IF data.location %]
           [% data.location %]
@@ -162,7 +182,10 @@
     </div>
 
     <div class="govuk-grid-column-one-third">
-      <h3>Your details</h3>
+      <div class="summary-section-header">
+        <h3 class="summary-section--heading">Your details</h3>
+        [% PROCESS change_answers_button goto='about_you' %]
+      </div>
       <dl>
         <dt>Name</dt>
         <dd>[% data.name %]</dd>

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -105,7 +105,6 @@
       <table class="item-summary-table govuk-!-margin-bottom-9">
         <thead>
           <tr>
-              <th></th>
               <th>Item</th>
               <th>
                 <span class="govuk-text__assistive">Item images preview</span>
@@ -116,7 +115,6 @@
           [% FOR item IN items %]
           [% extra_text = form.items_extra.${item.item}.message %]
           <tr [% IF extra_text %]class="is--no-border-bottom"[% END %]>
-              <td class="item-number-cell">[% loop.index + 1 %]</td>
               <td>
                 <p class="govuk-!-margin-bottom-0">[% item.item %]</p>
               </td>

--- a/web/cobrands/peterborough/base.scss
+++ b/web/cobrands/peterborough/base.scss
@@ -83,16 +83,6 @@ h1, h2 {
         color: $primary_text;
         background: $primary;
     }
-
-    &.is--next {
-        @include svg-background-image('/cobrands/peterborough/images/chevron-next-white');
-        @include next-back-button(right);
-    }
-
-    &.is--back {
-        @include svg-background-image('/cobrands/peterborough/images/chevron-back-white');
-        @include next-back-button(left);
-    }
 }
 
 .btn-secondary, input.btn-secondary {
@@ -115,26 +105,6 @@ h1, h2 {
         border: 0.2em solid $primary;
         opacity: 0.5;
         pointer-events: none;
-    }
-
-    &.is--next {
-        @include svg-background-image('/cobrands/peterborough/images/chevron-next-green');
-        @include next-back-button(right);
-
-        &:hover,
-        &:active {
-            @include svg-background-image('/cobrands/peterborough/images/chevron-next-white');
-        }
-    }
-
-    &.is--back {
-        @include svg-background-image('/cobrands/peterborough/images/chevron-back-green');
-        @include next-back-button(left);
-
-        &:hover,
-        &:active {
-            @include svg-background-image('/cobrands/peterborough/images/chevron-back-white');
-        }
     }
 }
 

--- a/web/cobrands/sass/_waste.scss
+++ b/web/cobrands/sass/_waste.scss
@@ -605,6 +605,21 @@ body.bulky {
       color: darken($primary_text, 80%);
     }
   }
+
+  // Summary page
+  .summary-section-header {
+    margin-top: 1.2em;
+    margin-bottom: 0.8em;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    flex-wrap: wrap;
+
+    .summary-section--heading {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
 }
 
 // Bulky item selection


### PR DESCRIPTION
Fixes part of https://github.com/mysociety/societyworks/issues/3425

### Changes included in this PR

- [x] [Pboro] I have erased the styling for the next and back button, because we are not longer using them.
- [x] [Summary page]Tweak the number of items column. At the moment it could be confusing for user to see a number 2 right next to the second item. Some people could actually see it as the number of items been requested.
- [x] [Summary page] Added some extra space between the summary and T&C
- [x] [Summary page] "No image attached for this item" message now is visible for every user.
- [x] [Summary page] [Backend needed] Added a link to each section so users don't have to press back plenty of times if they need to go back to the firsts steps. @davea let me know if adding the links it's possible otherwise I can drop this commit.

<img width="1071" alt="Screenshot 2023-01-16 at 09 23 59" src="https://user-images.githubusercontent.com/13790153/212644746-204b1313-4094-431b-bf4c-ae2508c8839b.png">


### Pending
In the "Location details" page I think we should wrap the instructions using the `govuk-warning-text` with the icon so it doesn't get lost, specially for visually impaired users. It seems like and important message that needs some special attention. I tried changing it, but I realise it's part the `bulky.pm` file.
<img width="1891" alt="Screenshot 2023-01-12 at 11 20 40" src="https://user-images.githubusercontent.com/13790153/212625922-44147f87-2d37-4ba6-9b24-a7f05f412f2e.png">

Let me know if there is any feedback


