### PR TITLE
[Brent] Add roads messages for parks and highways

### DIFF
--- a/templates/web/brent/report/new/roads_message.html
+++ b/templates/web/brent/report/new/roads_message.html
@@ -1,4 +1,13 @@
+    <div id="js-brent-road-services" class="hidden js-responsibility-message">
+        <p><strong>Public Highway issue</strong></p>
+        <p>To report this issue, please select a point on a public road</p>
+    </div>
     <div id="js-brent-tenant-services" class="hidden js-responsibility-message">
         <p><strong>Please use our estate services page</strong></p>
         <p>For issues relating to housing estates, please use our <a href="https://www.brent.gov.uk/housing/tenant-services/estate-services#estatecleaning">Estate services page</a> directly</p>
     </div>
+    <div id="js-brent-park-services" class="hidden js-responsibility-message">
+        <p><strong>Park issue</strong></p>
+        <p>To report this issue, please select a point within a park</p>
+    </div>
+

--- a/templates/web/fixmystreet.com/report/new/roads_message.html
+++ b/templates/web/fixmystreet.com/report/new/roads_message.html
@@ -31,12 +31,21 @@
     <div id="js-not-council-car-park" class="hidden js-responsibility-message">
         <p>There is no council car park in the area selected.</p>
     </div>
+    <div id="js-brent-road-services" class="hidden js-responsibility-message">
+        <p><strong>Public Highway issue</strong></p>
+        <p>To report this issue, please select a point on a public road</p>
+    </div>
     <div id="js-brent-tenant-services" class="hidden js-responsibility-message">
         <p><strong>Please use Brent Council's estate services page</strong></p>
         <p>For issues relating to housing estates in Brent, please use the Brent Council <a href="https://www.brent.gov.uk/housing/tenant-services/estate-services#estatecleaning">Estate services page</a> directly</p>
+    </div>
+    <div id="js-brent-park-services" class="hidden js-responsibility-message">
+        <p><strong>Park issue</strong></p>
+        <p>To report this issue, please select a point within a park</p>
     </div>
 </div>
 <div id="js-environment-message" class="hidden">
     <p>
     [% INCLUDE 'report/new/flytipping_text.html' %]
     </p>
+

--- a/web/cobrands/fixmystreet-uk-councils/assets.js
+++ b/web/cobrands/fixmystreet-uk-councils/assets.js
@@ -39,7 +39,7 @@ fixmystreet.assets.brent.construct_asset_name = function(id) {
 
 
 fixmystreet.assets.brent.found = function(layer) {
-    fixmystreet.message_controller.road_not_found(layer);
+    fixmystreet.message_controller.road_not_found(layer, function() {return true;});
 };
 
 fixmystreet.assets.brent.not_found = function(layer) {


### PR DESCRIPTION
Add messages for Brent and FixMyStreet.com for
categories that must be made in a park or on a highway.

Add in a function for the criterion argument for `road_not_found` to fix issue with housing stopper not being triggered when multiple bodies covering area.

[skip changelog]
