### PR TITLE
Add admin page to view COBRAND_FEATURES config.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -10,7 +10,7 @@ use FixMyStreet::SMS;
 
 =head1 NAME
 
-FixMyStreet::App::Controller::Admin- Catalyst Controller
+FixMyStreet::App::Controller::Admin - Controller for main admin pages
 
 =head1 DESCRIPTION
 
@@ -93,6 +93,12 @@ sub index : Path : Args(0) {
     return 1;
 }
 
+=head2 config_page
+
+This admin page displays the overall configuration for the site.
+
+=cut
+
 sub config_page : Path( 'config' ) : Args(0) {
     my ($self, $c) = @_;
     my $dir = FixMyStreet->path_to();
@@ -101,6 +107,46 @@ sub config_page : Path( 'config' ) : Args(0) {
     $c->stash(
         git_version => $git_version,
     );
+}
+
+=head2 config_page_cobrand
+
+This displays the COBRAND_FEATURES configuration for the site, grouped by
+feature, and provides links to the configuration for each cobrand.
+
+=cut
+
+sub config_page_cobrand : Path( 'config/cobrand_features' ) : Args(0) {
+    my ($self, $c) = @_;
+    $c->detach('/page_error_403_access_denied', []) unless $c->user->is_superuser;
+}
+
+=head2 config_page_cobrand_one
+
+This displays the COBRAND_FEATURES configuration for a particular cobrand given
+in the URL.
+
+=cut
+
+sub config_page_cobrand_one : Path( 'config/cobrand_features' ) : Args(1) {
+    my ($self, $c, $cobrand) = @_;
+
+    $c->detach('/page_error_403_access_denied', []) unless $c->user->is_superuser;
+
+    $c->stash->{cob} = $cobrand;
+    my $features = FixMyStreet->config('COBRAND_FEATURES');
+    return unless $features && ref $features eq 'HASH';
+
+    my $config = $c->stash->{config} = {};
+    my $fallback = $c->stash->{fallback} = {};
+    foreach my $feature (sort keys %$features) {
+        next unless $features->{$feature} && ref $features->{$feature} eq 'HASH';
+        if (defined $features->{$feature}{$cobrand}) {
+            $config->{$feature} = $features->{$feature}{$cobrand};
+        } elsif (defined $features->{$feature}{_fallback}) {
+            $fallback->{$feature} = $features->{$feature}{_fallback};
+        }
+    }
 }
 
 sub timeline : Path( 'timeline' ) : Args(0) {

--- a/perllib/FixMyStreet/Map.pm
+++ b/perllib/FixMyStreet/Map.pm
@@ -28,7 +28,9 @@ are permitted by the config.
 =cut
 
 sub allowed_maps {
-    my @allowed = split /,/, ( FixMyStreet->config('MAP_TYPE') or "");
+    my $cfg = FixMyStreet->config('MAP_TYPE') || [];
+    $cfg = [ split /,/, $cfg ] unless ref $cfg eq 'ARRAY';
+    my @allowed = @$cfg;
     push @allowed, 'OSM'; # OSM is always allowed
     @allowed = map { __PACKAGE__.'::'.$_ } @allowed;
     my %avail = map { $_ => 1 } __PACKAGE__->maps;

--- a/t/app/controller/admin/templates.t
+++ b/t/app/controller/admin/templates.t
@@ -360,9 +360,6 @@ subtest "category groups are shown" => sub {
             category_groups => {
                 oxfordshire => 1,
             },
-            multiple_category_groups => {
-                oxfordshire => 1,
-            },
         },
     }, sub {
 

--- a/t/app/controller/report_import.t
+++ b/t/app/controller/report_import.t
@@ -331,7 +331,7 @@ subtest "Submit a correct entry (with location) to cobrand" => sub {
     MAPIT_URL => 'http://mapit.zurich/',
     MAPIT_TYPES => [ 'O08' ],
     MAPIT_ID_WHITELIST => [],
-    MAP_TYPE => 'Zurich,OSM',
+    MAP_TYPE => ['Zurich', 'OSM'],
   }, sub {
     ok $mech->host("zurich.example.org"), 'change host to zurich';
 

--- a/templates/web/base/admin/config_page.html
+++ b/templates/web/base/admin/config_page.html
@@ -28,6 +28,10 @@
 running version <strong>[% git_version || 'unknown' %]</strong>.
 </p>
 
+[% IF c.config.COBRAND_FEATURES %]
+<p><a href="[% c.uri_for_action('admin/config_page_cobrand') %]">View <code>COBRAND_FEATURES</code> configuration</a></p>
+[% END %]
+
 <table>
 <tr><th>Variable</th>
     <th>general.yml value</th>

--- a/templates/web/base/admin/config_page_cobrand.html
+++ b/templates/web/base/admin/config_page_cobrand.html
@@ -1,0 +1,81 @@
+[% INCLUDE 'admin/header.html' title=loc('Configuration') -%]
+
+<p>This site’s <code>COBRAND_FEATURES</code> configuration.
+</p>
+
+<h2>By feature</h2>
+
+<table>
+    <tr>
+        <th scope="col">Cobrand</th><th scope="col">Value</th>
+    </tr>
+[% FOR feature IN c.config.COBRAND_FEATURES %]
+    <tr>
+        <th align="left" colspan="2">[% feature.key %]
+    [% SWITCH feature.key %]
+    [% CASE 'address_api' %] - (Hackney only, unused) API details for address lookup
+    [% CASE 'always_use_reply_to' %] - to deal with DMARC
+    [% CASE 'anonymous_account' %] - account to use for anonymous reporting (needs code as well)
+    [% CASE 'area_code_mapping' %] - (Central Bedfordshire only) special lookup for data to send via Open311
+    [% CASE 'bartec' %] - login details, plus any blocked UPRNs
+    [% CASE 'base_url' %] - the main URL of the site
+    [% CASE 'borough_email_addresses' %] - report email sending based upon a sub-area (e.g. Bucks districts, TfL boroughs)
+    [% CASE 'bottomline' %] - login details (why not in payment_gateway?)
+    [% CASE 'category_groups' %] - enables category groups
+    [% CASE 'claims' %] - enabling of the claims section
+    [% CASE 'contact_email' %] - for sending of abuse emails
+    [% CASE 'contact_name' %] - for use in emails
+    [% CASE 'contact_us_url' %] - separate contact us form
+    [% CASE 'content_security_policy' %] - security hardening where possible
+    [% CASE 'do_not_reply_email' %] - special do not reply email if possible, needs them setting up SPF/DMARC or delegation
+    [% CASE 'echo' %] - login details for sending and receiving, plus address types and NLPG
+    [% CASE 'example_places' %] - front page examples to use
+    [% CASE 'extra_state_mapping' %] - allows special mapping of extra states (used for Northamptonshire, could be consolidated with State display special cases?)
+    [% CASE 'govuk_notify' %] - configuration details for Notify
+    [% CASE 'heatmap' %] - heatmap enabled
+    [% CASE 'heatmap_dashboard_body' %] - anyone with council gov.uk email can access the heatmap
+    [% CASE 'internal_ips' %] - (TfL only) IPs that can skip 2FA
+    [% CASE 'noise' %] - enabling of the noise section
+    [% CASE 'oidc_login' %] - third party OIDC login details
+    [% CASE 'open311_email' %] - special additional emails to Open311 (e.g. Bexley out of hours or Bucks flytipping)
+    [% CASE 'open311_token' %] - token to enable updates to be pushed to us via Open311
+    [% CASE 'os_maps_licence' %] - licence ID to show on map
+    [% CASE 'os_maps_premium' %] - boolean as to whether is premium or not
+    [% CASE 'os_maps_url' %] - URL to use for OS Maps API
+    [% CASE 'payment_gateway' %] - cost and configuration details for payments
+    [% CASE 'public_asset_ids' %] - Asset IDs to display on a report page
+    [% CASE 'safety_critical_categories:' %] - (TfL only) categories that are safety critical
+    [% CASE 'send_questionnaire' %] - whether to send or not on .com (cobrand setting in code)
+    [% CASE 'sms_authentication' %] - SMS confirmation/updates enabled
+    [% CASE 'staff_url' %] - special different URL for staff in category
+    [% CASE 'suggest_duplicates' %] - duplicates are suggested to the user
+    [% CASE 'throttle_username' %] - authentication throttling
+    [% CASE 'update_states_disallowed' %] - normal user not allowed to mark fixed (or reopen if reporter)
+    [% CASE 'updates_allowed' %] - who is allowed to leave updates
+    [% CASE 'verp_email_domain' %] - custom domain to handle VERP bounces
+    [% CASE 'waste' %] - enabling of the waste section
+    [% CASE 'waste_features' %] - waste configuration
+    [% END %]
+        </th>
+    </tr>
+
+      [% FOR cobrand IN feature.value %]
+    <tr>
+        <td>[% cobrand.key %]</td>
+        <td>[% INCLUDE 'admin/config_page_value.html' key=feature.key value=cobrand.value %]</td>
+    </tr>
+      [% END %]
+
+[% END %]
+</table>
+
+<h2>By cobrand</h2>
+
+<ul>
+[% FOR cobrand IN c.config.ALLOWED_COBRANDS %]
+[% NEXT IF cobrand.values.size %]
+<li><a href="cobrand_features/[% cobrand %]">[% cobrand %]</a></li>
+[% END %]
+</ul>
+
+[% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/admin/config_page_cobrand_one.html
+++ b/templates/web/base/admin/config_page_cobrand_one.html
@@ -1,0 +1,30 @@
+[% INCLUDE 'admin/header.html' title=loc('Configuration') -%]
+
+<p>This site’s <strong>[% cob %]</strong> <code>COBRAND_FEATURES</code> configuration.
+</p>
+
+<table>
+  <tr>
+      <th>Feature</th><th>Value</th>
+  </tr>
+
+  [% FOR feature IN config %]
+    <tr>
+        <td>[% feature.key %]</td>
+        <td>[% INCLUDE 'admin/config_page_value.html', key=feature.key value=feature.value %]</td>
+    </tr>
+  [% END %]
+
+  <tr>
+      <th colspan="2" align="left">Fallback values</th>
+  </tr>
+
+  [% FOR feature IN fallback %]
+    <tr>
+        <td>[% feature.key %]</td>
+    <td>[% INCLUDE 'admin/config_page_value.html', key=feature.key value=feature.value %]</td>
+  [% END %]
+
+</table>
+
+[% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/admin/config_page_value.html
+++ b/templates/web/base/admin/config_page_value.html
@@ -1,0 +1,122 @@
+[% SWITCH key %]
+
+[% CASE [ # Booleans
+    'always_use_reply_to',
+    'category_groups',
+    'claims',
+    'heatmap',
+    'heatmap_dashboard_body',
+    'noise',
+    'os_maps_premium',
+    'sms_authentication',
+    'suggest_duplicates',
+    'update_states_disallowed',
+    'waste',
+    ] %]
+    [% IF value %]Yes[% ELSE %]No[% END %]
+
+[% CASE [ # Strings
+    'anonymous_account',
+    'base_url',
+    'contact_email',
+    'contact_name',
+    'contact_us_url',
+    'content_security_policy',
+    'do_not_reply_email',
+    'open311_token',
+    'os_maps_licence',
+    'os_maps_url',
+    'updates_allowed',
+    'verp_email_domain',
+    ] %]
+    [% value %]
+
+[% CASE [ # List
+    'example_places',
+    'internal_ips',
+    'public_asset_ids',
+    ] %]
+    [% value.join(', ') %]
+
+[%# Simple display %]
+[% CASE 'address_api' %]
+    URL: [% value.url %]
+[% CASE 'area_code_mapping' %]
+    <i>Mapping</i>
+[% CASE 'asset_layers' %]
+    [% value.size - 1 %] layers
+[% CASE 'bartec' %]
+    Blocked UPRNs: [% value.blocked_uprns.join(', ') %]
+[% CASE 'bottomline' %]
+    Endpoint: [% value.endpoint %]
+[% CASE 'echo' %]
+    Username: [% value.username %]
+[% CASE 'govuk_notify' %]
+    Template ID: [% value.template_id %]
+[% CASE 'oidc_login' %]
+    Display name: [% value.display_name %]
+[% CASE 'throttle_username' %]
+    [% value.attempts %] per [% value.time %]s
+
+[% CASE 'borough_email_addresses' %]
+    <ul>
+    [% FOR e IN value %]
+        <li><i>[% e.key %]</i> <dl>
+            [% FOR ee IN e.value %] <dt>[% ee.areas.join(', ') %]</dt> <dd>[% ee.email %]</dd> [% END %]
+            </dl> </li>
+    [% END %]
+    </ul>
+[% CASE 'extra_state_mapping' %]
+    <ul>
+    [% FOR e IN value %]
+        <li><i>[% e.key %]</i> <dl>
+            [% FOR ee IN e.value %] <dt>[% ee.key %]</dt> <dd>[% ee.value %]</dd> [% END %]
+            </dl> </li>
+    [% END %]
+    </ul>
+[% CASE 'open311_email' %]
+    &nbsp;
+    <dl>
+      [% FOR ee IN value %]
+        <dt>[% ee.key %]</dt>
+        <dd>[% ee.value %]</dd>
+      [% END %]
+    </dl>
+[% CASE 'safety_critical_categories' %]
+    <ul>
+    [% FOR e IN value %]
+        <li>[% e.key %][% IF e.value != 1 %]:
+                [% FOR ee IN e.value %]
+                    [% ee.key %] = [% ee.value.join(', ') %]
+                [% END %]
+            [% END %]
+    [% END %]
+    </ul>
+[% CASE 'send_questionnaire' %]
+    <ul>
+    [% FOR e IN value %]
+        <li>[% e.key %]: [% e.value %]</li>
+    [% END %]
+    </ul>
+[% CASE 'staff_url' %]
+    <ul>
+    [% FOR e IN value %]
+        <li>[% e.key %]: [% e.value.join(', ') %]
+    [% END %]
+    </ul>
+
+[% CASE 'payment_gateway' %]
+    [% SET any = 0 %][% FOR k IN value %]
+    [% IF k.key.match('^ggw_|^pro_rata') %][% any = 1 %][% k.key %]: [% k.value %]<br>[% END %]
+    [% END %]
+    [% IF NOT any %]-[% END %]
+[% CASE 'waste_features' %]
+    [% SET any = 0 %][% FOR k IN value %]
+    [% any = 1 %][% k.key %]: [% k.value %]<br>
+    [% END %]
+    [% IF NOT any %]-[% END %]
+
+[% CASE %]
+    [% value %]
+
+[% END %]


### PR DESCRIPTION
This adds a superuser-only page to the site listing the `COBRAND_FEATURES` configuration indexed by feature, plus a page per cobrand showing that cobrand's entries in that configuration.

Please check the following:

- [x] Has the code POD documentation been added or updated?
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
