### PR TITLE
Cascade delete alert_sent and user_planned_reports.

### DIFF
--- a/bin/update-schema
+++ b/bin/update-schema
@@ -215,6 +215,7 @@ else {
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
     return 'EMPTY' if ! table_exists('problem');
+    return '0081' if constraint_delete_cascade('alert_sent_alert_id_fkey');
     return '0080' if column_exists('roles', 'extra');
     return '0079' if column_exists('response_templates', 'email_text');
     return '0078' if column_exists('problem','send_fail_body_ids');
@@ -333,6 +334,14 @@ sub constraint_contains {
     my ($consrc) = $db->dbh->selectrow_array('select pg_get_expr(conbin, conrelid) from pg_constraint where conname = ?', {}, $constraint);
     return unless $consrc;
     return $consrc =~ /$check/;
+}
+
+# Returns true if a constraint has on delete cascade set
+sub constraint_delete_cascade {
+    my ( $constraint, $check ) = @_;
+    my ($deltype) = $db->dbh->selectrow_array('select confdeltype from pg_constraint where conname = ?', {}, $constraint);
+    return unless $deltype;
+    return $deltype eq 'c';
 }
 
 # Returns true if a function exists

--- a/db/downgrade_0081---0080.sql
+++ b/db/downgrade_0081---0080.sql
@@ -1,0 +1,33 @@
+BEGIN;
+
+ALTER TABLE alert_sent
+    DROP CONSTRAINT alert_sent_alert_id_fkey,
+    ADD CONSTRAINT alert_sent_alert_id_fkey
+        FOREIGN KEY (alert_id)
+        REFERENCES alert(id)
+        NOT VALID;
+
+ALTER TABLE alert_sent
+    VALIDATE CONSTRAINT alert_sent_alert_id_fkey;
+
+ALTER TABLE user_planned_reports
+    DROP CONSTRAINT user_planned_reports_report_id_fkey,
+    ADD CONSTRAINT user_planned_reports_report_id_fkey
+        FOREIGN KEY (report_id)
+        REFERENCES problem(id)
+        NOT VALID;
+
+ALTER TABLE user_planned_reports
+    VALIDATE CONSTRAINT user_planned_reports_report_id_fkey;
+
+ALTER TABLE user_planned_reports
+    DROP CONSTRAINT user_planned_reports_user_id_fkey,
+    ADD CONSTRAINT user_planned_reports_user_id_fkey
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        NOT VALID;
+
+ALTER TABLE user_planned_reports
+    VALIDATE CONSTRAINT user_planned_reports_user_id_fkey;
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -432,7 +432,7 @@ create index alert_whensubscribed_confirmed_cobrand_idx on alert(whensubscribed,
 -- Possible indexes - unique (alert_type,user_id,parameter)
 
 create table alert_sent (
-    alert_id integer not null references alert(id),
+    alert_id integer not null references alert(id) ON DELETE CASCADE,
     parameter text, -- e.g. Update ID for new updates
     whenqueued timestamp not null default current_timestamp
 );
@@ -523,8 +523,8 @@ create table user_body_permissions (
 
 create table user_planned_reports (
     id serial not null primary key,
-    user_id int references users(id) not null,
-    report_id int references problem(id) not null,
+    user_id int references users(id) ON DELETE CASCADE not null,
+    report_id int references problem(id) ON DELETE CASCADE not null,
     added timestamp not null default current_timestamp,
     removed timestamp
 );

--- a/db/schema_0081-alert-sent-cascade.sql
+++ b/db/schema_0081-alert-sent-cascade.sql
@@ -1,0 +1,36 @@
+BEGIN;
+
+ALTER TABLE alert_sent
+    DROP CONSTRAINT alert_sent_alert_id_fkey,
+    ADD CONSTRAINT alert_sent_alert_id_fkey
+        FOREIGN KEY (alert_id)
+        REFERENCES alert(id)
+        ON DELETE CASCADE
+        NOT VALID;
+
+ALTER TABLE alert_sent
+    VALIDATE CONSTRAINT alert_sent_alert_id_fkey;
+
+ALTER TABLE user_planned_reports
+    DROP CONSTRAINT user_planned_reports_report_id_fkey,
+    ADD CONSTRAINT user_planned_reports_report_id_fkey
+        FOREIGN KEY (report_id)
+        REFERENCES problem(id)
+        ON DELETE CASCADE
+        NOT VALID;
+
+ALTER TABLE user_planned_reports
+    VALIDATE CONSTRAINT user_planned_reports_report_id_fkey;
+
+ALTER TABLE user_planned_reports
+    DROP CONSTRAINT user_planned_reports_user_id_fkey,
+    ADD CONSTRAINT user_planned_reports_user_id_fkey
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE
+        NOT VALID;
+
+ALTER TABLE user_planned_reports
+    VALIDATE CONSTRAINT user_planned_reports_user_id_fkey;
+
+COMMIT;

--- a/perllib/FixMyStreet/DB/Result/AlertSent.pm
+++ b/perllib/FixMyStreet/DB/Result/AlertSent.pm
@@ -22,21 +22,20 @@ __PACKAGE__->add_columns(
   "whenqueued",
   {
     data_type     => "timestamp",
-    default_value => \"current_timestamp",
+    default_value => \"CURRENT_TIMESTAMP",
     is_nullable   => 0,
-    original      => { default_value => \"now()" },
   },
 );
 __PACKAGE__->belongs_to(
   "alert",
   "FixMyStreet::DB::Result::Alert",
   { id => "alert_id" },
-  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+  { is_deferrable => 0, on_delete => "CASCADE,", on_update => "NO ACTION" },
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2019-04-25 12:06:39
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:xriosaSCkOo/REOG1OxdQA
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2023-01-17 09:56:14
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:1KKtNyeJJNc24sAVhmi0jQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/perllib/FixMyStreet/DB/Result/UserPlannedReport.pm
+++ b/perllib/FixMyStreet/DB/Result/UserPlannedReport.pm
@@ -29,9 +29,8 @@ __PACKAGE__->add_columns(
   "added",
   {
     data_type     => "timestamp",
-    default_value => \"current_timestamp",
+    default_value => \"CURRENT_TIMESTAMP",
     is_nullable   => 0,
-    original      => { default_value => \"now()" },
   },
   "removed",
   { data_type => "timestamp", is_nullable => 1 },
@@ -41,18 +40,18 @@ __PACKAGE__->belongs_to(
   "report",
   "FixMyStreet::DB::Result::Problem",
   { id => "report_id" },
-  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+  { is_deferrable => 0, on_delete => "CASCADE,", on_update => "NO ACTION" },
 );
 __PACKAGE__->belongs_to(
   "user",
   "FixMyStreet::DB::Result::User",
   { id => "user_id" },
-  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+  { is_deferrable => 0, on_delete => "CASCADE,", on_update => "NO ACTION" },
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2019-04-25 12:06:39
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:A9ICDFNVzkmd/erdtYdeVA
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2023-01-17 09:56:14
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:0FwfUVG7zPi57oYSfXG/lg
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/perllib/FixMyStreet/TestMech.pm
+++ b/perllib/FixMyStreet/TestMech.pm
@@ -181,13 +181,9 @@ sub delete_user {
     for my $p ( $user->problems ) {
         $p->comments->delete;
         $p->questionnaires->delete;
-        $p->user_planned_reports->delete;
         $p->delete;
     }
-    for my $a ( $user->alerts ) {
-        $a->alerts_sent->delete;
-        $a->delete;
-    }
+    $user->alerts->delete;
     $_->delete for $user->comments;
     $_->delete for $user->admin_logs;
     $_->delete for $user->user_body_permissions;


### PR DESCRIPTION
If an alert is deleted, automatically drop its alert_sent rows; if a report or a user are deleted, drop any relevant user_planned_reports rows. [skip changelog]
