### PR TITLE
[Camden] Ignore street light assets with symlink = 0

### DIFF
--- a/web/cobrands/fixmystreet-uk-councils/assets.js
+++ b/web/cobrands/fixmystreet-uk-councils/assets.js
@@ -481,6 +481,13 @@ fixmystreet.assets.camden.housing_estate_actions = {
     }
 };
 
+// Filter to check for symlink != 0
+fixmystreet.assets.camden.filter_column = new OpenLayers.Filter.Comparison({
+    type: OpenLayers.Filter.Comparison.NOT_EQUAL_TO,
+    property: "symlink",
+    value: "0"
+});
+
 /* Central Bedfordshire */
 
 fixmystreet.assets.centralbedfordshire = {};

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -709,7 +709,9 @@ function construct_layer_options(options, protocol) {
         layer_options.projection = new OpenLayers.Projection(fixmystreet.wmts_config.map_projection);
     }
 
-    if (options.filter_key) {
+    if (options.filter) {
+        layer_options.filter = options.filter;
+    } else if (options.filter_key) {
         // Add this filter to the layer, so it can potentially be
         // used in the request if non-HTTP WFS
         if (OpenLayers.Util.isArray(options.filter_value)) {
@@ -735,11 +737,12 @@ function construct_layer_options(options, protocol) {
                 value: options.filter_value
             });
         }
-        // If using HTTP WFS, add a strategy filter to the layer,
-        // to filter the incoming results after being received.
-        if (options.http_options) {
-            layer_options.strategies.push(new OpenLayers.Strategy.Filter({filter: layer_options.filter}));
-        }
+    }
+
+    // If using HTTP WFS, add a strategy filter to the layer,
+    // to filter the incoming results after being received.
+    if (layer_options.filter && options.http_options) {
+        layer_options.strategies.push(new OpenLayers.Strategy.Filter({filter: layer_options.filter}));
     }
 
     return layer_options;


### PR DESCRIPTION
This adds a new `filter:` option for the asset_layers which allows you to pass an instance of `OpenLayers.Filter.Comparison` or similar, for times when `filter_key`/`filter_value` don't do what you need.

I've used this new option to filter out streetlights (aka columns) that have a `symlink` property of `0`.

See also commit `b4cd0ce6d4f16113b5f4182b4f319877ae426bc4` in the `/data/servers` repo, which has the change to the asset YAML.

Fixes https://github.com/mysociety/societyworks/issues/3418

<!-- [skip changelog] -->