### PR TITLE
[Bulky Goods] Munge photo data so it can be picked up by Bartec

### DIFF
--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -1142,6 +1142,8 @@ FixMyStreet::override_config {
             is $report->get_extra_field_value('ITEM_04'), '';
             is $report->get_extra_field_value('ITEM_05'), '';
             is $report->get_extra_field_value('property_id'), 'PE1 3NA:100090215480';
+            is $report->photo,
+                '74e3362283b6ef0c48686fb0e161da4043bbcc97.jpeg,74e3362283b6ef0c48686fb0e161da4043bbcc97.jpeg';
         };
 
         # Collection date: 2022-08-26T00:00:00


### PR DESCRIPTION
For https://github.com/mysociety/societyworks/issues/3410.

Adds code that gathers together the various photos that may be uploaded during a bulky collection,  so that `process_photo_upload_or_cache` in App/Controller/Photo.pm can handle them (put them in an 'upload_fileid' stash field). This is because `save_user_and_report` in App/Controller/Report/New.pm expects 'upload_fileid' in the stash, in order to set 'photo' on the report (the 'photo' field is what is ultimately used to send data through Open311 to Bartec).

[skip changelog]
