### PR TITLE
Use digest rather than mtime for static versioning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
         - Enable alternative response from templates to be emailed to issue reporter. #4001
         - Option to read asset layers from configuration.
         - Add GitHub Action to generate POD documentation.
+        - Use digest rather than last modified time for static versioning. #4280
     - Security
         - Permit control over database connection `sslmode` via $FMS_DB_SSLMODE
     - Open311 improvements:


### PR DESCRIPTION
If the site is present on multiple application servers, the last modified times will be different on each server. This means that multiple copies can be fetched/cached by a browser, and that the service worker can repeatedly fetch the files to go in the cache as it thinks they have changed when they have not.
