### PR TITLE
[Bucks] Text changes for Bucks

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -899,4 +899,9 @@ sub about_hook {
     }
 }
 
+sub enter_postcode_text {
+    my ($self) = @_;
+    return 'Enter a Buckinghamshire postcode, street name and area, or report reference number';
+}
+
 1;

--- a/templates/web/buckinghamshire/report/new/roads_message.html
+++ b/templates/web/buckinghamshire/report/new/roads_message.html
@@ -7,9 +7,7 @@
     </div>
     <div id="js-not-council-road-other" class="hidden js-responsibility-message js-roads-bucks">
         <strong>Not maintained by Buckinghamshire Council</strong>
-        <p>The selected road is not maintained by Buckinghamshire Council,
-        but by a neighbouring council. Please move your pin slightly, to the
-        other side of the border.
+        <p>That location is not covered by Buckinghamshire council. Please visit <a href="https://www.fixmystreet.com/report/new?latitude=[% latitude |html %]&amp;longitude=[% longitude | html %]"> the main FixMyStreet site</a>.
         </p>
     </div>
     <div id="js-not-council-road-he" class="hidden js-responsibility-message js-roads-bucks">


### PR DESCRIPTION
Requests to update the postcode text to say that you can enter a report number.

Not to prompt the citizens to nudge the report pin over the border when on a borderline road and to direct to FMS instead.


https://mysocietysupport.freshdesk.com/a/tickets/2683
https://mysocietysupport.freshdesk.com/a/tickets/2692

[skip changelog]