### PR TITLE
Peterborough Bulky Goods: text & link updates

### DIFF
--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -134,7 +134,7 @@ has_field resident => (
     type => 'Select',
     widget => 'RadioGroup',
     required => 1,
-    label => 'Are you the resident of this property or booking on behalf of the property resident?',
+    label => 'Do you live at the property or are you booking on behalf of the householder?',
     options => [
         { label => 'Yes', value => 'Yes' },
         { label => 'No', value => 'No' },
@@ -265,7 +265,7 @@ has_field tandc => (
     required => 1,
     label => 'Terms and conditions',
     option_label => FixMyStreet::Template::SafeString->new(
-        'I agree to the <a href="/about/bulky_terms" target="_blank">terms and conditions</a>',
+        'I agree to the <a href="https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections" target="_blank">terms and conditions</a>',
     ),
 );
 
@@ -273,9 +273,6 @@ has_field location => (
     type => 'Text',
     widget => 'Textarea',
     label => "Please tell us about anything else you feel is relevant",
-    tags => {
-        hint => "(e.g. 'The large items are in the front garden which can be accessed via the gate.')",
-    },
 );
 
 has_field location_photo_fileid => (
@@ -290,7 +287,7 @@ has_field location_photo => (
         max_photos => 1,
     },
     label => <<HERE,
-Items should be left as close to your usual bin collection point as possible. Items must not cause an obstruction on the footpath. We can collect items from your front garden assuming we can gain access and there are no vehicles or gates blocking or limiting access.
+Please check the <a href="https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections" target="_blank">Terms & Conditions</a> for information about when and where to leave your items for collection.
 
 Help us by attaching a photo of where the items will be left for collection.
 HERE

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -941,7 +941,7 @@ FixMyStreet::override_config {
         };
 
         subtest 'Residency check page' => sub {
-            $mech->content_contains('Are you the resident of this property or booking on behalf of the property resident?');
+            $mech->content_contains('Do you live at the property or are you booking on behalf of the householder?');
             $mech->submit_form_ok({ with_fields => { resident => 'No' } });
             $mech->content_contains('cannot book');
             $mech->back;

--- a/templates/email/peterborough/_bulky_data.html
+++ b/templates/email/peterborough/_bulky_data.html
@@ -3,7 +3,7 @@
 SET payment = report.get_extra_field_value('payment');
 SET collection_date = cobrand.bulky_nice_collection_date(report.get_extra_field_value('DATE'));
 SET item_list = cobrand.bulky_nice_item_list(report);
-SET email_summary = "Thank you for booking a Peterborough bulky waste collection.";
+SET email_summary = "Thank you for booking a bulky waste collection with Peterborough City Council.";
 SET staff_cancellation = cobrand.feature('waste_features').bulky_enabled == 'staff';
 
 ~%]

--- a/templates/email/peterborough/other-reported-bulky.html
+++ b/templates/email/peterborough/other-reported-bulky.html
@@ -40,12 +40,10 @@ INCLUDE '_email_top.html';
     [% ELSE %]
     If you wish to cancel your booking, please visit <a href="[% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') | uri %]/bulky_cancel">this link</a>.
     [% END %]
-
-    You can obtain a refund if you cancel more than one day before your booking.
   </p>
 
   <p style="[% p_style %]">
-    <a href="https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections">Terms and Conditions</a>
+    Please read the <a href="https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections" target="_blank">Terms & Conditions</a> for information about this service. This includes when and where to put your items out for collection, cancelling the service and obtaining a refund.
   </p>
 
   <p style="[% p_style %]">

--- a/templates/email/peterborough/other-reported-bulky.txt
+++ b/templates/email/peterborough/other-reported-bulky.txt
@@ -36,11 +36,7 @@ If you wish to cancel your booking, please visit:
 
 [% END ~%]
 
-You can obtain a refund if you cancel more than one day before your booking.
-
-Terms and Conditions:
-
-    https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections
+Please read the Terms & Conditions ( https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections ) for information about this service. This includes when and where to put your items out for collection, cancelling the service and obtaining a refund.
 
 [% signature %]
 

--- a/templates/web/base/govuk/fields.html
+++ b/templates/web/base/govuk/fields.html
@@ -304,7 +304,7 @@
 
 [% BLOCK photo %]
     <label class="govuk-label js-photo-label" for="[% field.id %]">
-        [% field.label | html_para %]
+        [% mark_safe( field.label ) | html_para %]
     </label>
   [% IF field.get_tag('hint') %]
     <span id="[% field.id %]-hint" class="govuk-hint">

--- a/templates/web/base/waste/bulky/booking_cancellation.html
+++ b/templates/web/base/waste/bulky/booking_cancellation.html
@@ -13,7 +13,7 @@
         <dt><strong>Booking reference number</strong></dt>
         <dd class="govuk-!-margin-bottom-4">[% property.pending_bulky_collection.id %]</dd>
         [% IF entitled_to_refund %]
-            <p class="govuk-!-margin-bottom-2">Your refund is on its way. It usually takes between x-x working days.</p>
+            <p class="govuk-!-margin-bottom-2">Your refund is on its way.</p>
         [% END %]
         <a href="[% c.uri_for_action('waste/bin_days', [ property.id ]) %]" class="btn btn-primary">Go back home</a>
     </div>

--- a/templates/web/base/waste/bulky/cancel_intro.html
+++ b/templates/web/base/waste/bulky/cancel_intro.html
@@ -1,9 +1,8 @@
 [% USE pounds = format('%.2f') %]
 [% IF entitled_to_refund %]
 <h3>Refund</h3>
-<p class="govuk-!-margin-bottom-2">If you cancel this booking you will receive a refund of £[% pounds(property.pending_bulky_collection.get_extra_field_value('payment') / 100) %] within XXX days.</p>
+<p class="govuk-!-margin-bottom-2">If you cancel this booking you will receive a refund of £[% pounds(property.pending_bulky_collection.get_extra_field_value('payment') / 100) %].</p>
 [% ELSIF property.pending_bulky_collection.get_extra_field_value('CHARGEABLE') == 'CHARGED' %]
 <h3>No Refund Will Be Issued</h3>
 <p class="govuk-!-margin-bottom-2">If you cancel this booking you will not receive a refund as it is within 24 hours of the collection.</p>
 [% END %]
-

--- a/templates/web/base/waste/bulky/intro.html
+++ b/templates/web/base/waste/bulky/intro.html
@@ -2,6 +2,7 @@
 <ol>
     <li>Requesting a bulky waste collection usually takes approximately <strong>X minutes</strong></li>
     <li>You can request up to <strong>[% c.cobrand.bulky_items_maximum %] items per collection</strong></li>
+    <li>Please ensure you read the <strong><a href="https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections" target="_blank">Terms & Conditions</a></strong> before booking your bulky waste collection</li>
     <li>In order to help us with your collection, we will ask you to optionally add pictures of the items to be collected and the location</li>
     <li>Before confirming your booking, check all the info provided is correct</li>
     <li>You can cancel your booking anytime up until 23:55 the day before the collection is scheduled</li>


### PR DESCRIPTION
For https://github.com/mysociety/societyworks/issues/3410.

Fixes https://3.basecamp.com/4020879/buckets/26662378/todos/5745542885, https://3.basecamp.com/4020879/buckets/26662378/todos/5449035154 and https://3.basecamp.com/4020879/buckets/26662378/todos/5851755632.

- [x] Booking form:
    - [x]  ‘Before you start your booking’ page: extra list item with link to T&Cs
    - [x]  ‘Are you the resident…’ ⇒ ‘Do you live…’
    - [x]  Location details page:
        - [x]  Remove ‘The large items are in…’
        - [x]  ‘Items should be left…’ ⇒ ‘Please check the Terms & Conditions <link>…’
- [x] Cancellation form:
    - [x] Remove references to number of days for refunds on form
    - [x] Same on confirmation page 
- [x]  Email:
    - [x]  ⇒ ‘Thank you for booking a bulky waste collection with Peterborough City Council.’
    - [x]  ‘You can obtain a refund if you cancel more than one day before your booking.’ ⇒ ‘Please read the Terms & Conditions <link>…’

[skip changelog]
