### PR TITLE
Offline reporting functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
         - Add initial update template on report sending, not creation.
         - Add option to set an emergency message on reporting pages.
         - Add label to questionnaire textarea. #3944
+        - Offline report drafting. #4290
     - Bugfixes:
         - Add ID attributes to change password form inputs.
         - Fix link deactivation for privacy policy link on privacy policy page. #3704

--- a/perllib/FixMyStreet/App/Controller/Offline.pm
+++ b/perllib/FixMyStreet/App/Controller/Offline.pm
@@ -33,6 +33,10 @@ sub service_worker : Path("/service-worker.js") {
 
 sub fallback : Local {
     my ($self, $c) = @_;
+
+    # Fetch git version
+    $c->forward('/admin/config_page');
+
 }
 
 sub manifest_waste: Path('/.well-known/manifest-waste.webmanifest') {

--- a/templates/web/base/around/postcode_form.html
+++ b/templates/web/base/around/postcode_form.html
@@ -9,6 +9,10 @@
         %]
 
         <form action="[% c.uri_for('/around') %]" method="get" name="postcodeForm" id="postcodeForm" class="js-geolocate">
+            <p class="hidden js-continue-draft">
+                <a href="#" class="btn continue-draft-btn">Continue draft report...</a><br />
+                - or -
+            </p>
             <label for="pc">[% question %]:</label>
             [% INCLUDE 'around/_postcode_form_examples.html' %]
             <div>

--- a/templates/web/base/around/postcode_form.html
+++ b/templates/web/base/around/postcode_form.html
@@ -8,11 +8,11 @@
             question = c.cobrand.enter_postcode_text || loc('Enter a nearby street name and area');
         %]
 
+        <div class="hidden js-continue-draft">
+            <p>You have a draft report made while offline:<br>
+            <a href="#" class="btn continue-draft-btn">Continue draft report</a>
+        </div>
         <form action="[% c.uri_for('/around') %]" method="get" name="postcodeForm" id="postcodeForm" class="js-geolocate">
-            <p class="hidden js-continue-draft">
-                <a href="#" class="btn continue-draft-btn">Continue draft report...</a><br />
-                - or -
-            </p>
             <label for="pc">[% question %]:</label>
             [% INCLUDE 'around/_postcode_form_examples.html' %]
             <div>

--- a/templates/web/base/common_scripts.html
+++ b/templates/web/base/common_scripts.html
@@ -11,6 +11,10 @@ scripts.push(
 
 IF bodyclass.match('frontpage');
     scripts.push(
+        # Hmmm, how to keep front page JS tiny?
+        version('/vendor/idb-keyval-iife.min.js'),
+        version('/cobrands/fixmystreet/offline_report.js'),
+
         version('/js/front.js'),
         version('/js/geolocation.js'),
         version('/js/loading-attribute-polyfill.js'),
@@ -32,6 +36,8 @@ ELSE;
         version('/vendor/jquery-3.6.0.min.js'),
         version('/vendor/jquery.multi-select.min.js'),
         version('/vendor/jquery.validate.min.js'),
+        version('/vendor/idb-keyval-iife.min.js'),
+        version('/cobrands/fixmystreet/offline_report.js'),
         version('/cobrands/fixmystreet/fixmystreet.js'),
     );
 END;

--- a/templates/web/base/common_scripts.html
+++ b/templates/web/base/common_scripts.html
@@ -11,10 +11,8 @@ scripts.push(
 
 IF bodyclass.match('frontpage');
     scripts.push(
-        # Hmmm, how to keep front page JS tiny?
         version('/vendor/idb-keyval-iife.min.js'),
-        version('/cobrands/fixmystreet/offline_report.js'),
-
+        version('/js/offline_draft.js'),
         version('/js/front.js'),
         version('/js/geolocation.js'),
         version('/js/loading-attribute-polyfill.js'),
@@ -38,6 +36,7 @@ ELSE;
         version('/vendor/jquery.multi-select.min.js'),
         version('/vendor/jquery.validate.min.js'),
         version('/vendor/idb-keyval-iife.min.js'),
+        version('/js/offline_draft.js'),
         version('/cobrands/fixmystreet/offline_report.js'),
         version('/cobrands/fixmystreet/fixmystreet.js'),
     );

--- a/templates/web/base/common_scripts.html
+++ b/templates/web/base/common_scripts.html
@@ -20,6 +20,12 @@ ELSIF bodyclass.match('alertpage');
         version('/js/geolocation.js'),
     );
 ELSIF bodyclass.match('offlinepage');
+    scripts.push(
+        version('/js/geolocation.js'),
+        version('/vendor/jquery-3.6.0.min.js'),
+        version('/vendor/idb-keyval-iife.min.js'),
+        version('/cobrands/fixmystreet/offline_report.js'),
+    );
 ELSE;
     scripts.push(
         version('/js/validation_rules.js'),

--- a/templates/web/base/common_scripts.html
+++ b/templates/web/base/common_scripts.html
@@ -28,6 +28,7 @@ ELSIF bodyclass.match('offlinepage');
         version('/js/geolocation.js'),
         version('/vendor/jquery-3.6.0.min.js'),
         version('/vendor/idb-keyval-iife.min.js'),
+        version('/vendor/dropzone.min.js'),
         version('/cobrands/fixmystreet/offline_report.js'),
     );
 ELSE;

--- a/templates/web/base/main_nav_items.html
+++ b/templates/web/base/main_nav_items.html
@@ -30,3 +30,5 @@
 [%~ IF c.user_exists AND c.cobrand.admin_allow_user(c.user) ~%]
   [%~ INCLUDE navitem uri='/admin' label=loc('Admin') ~%]
 [%~ END ~%]
+
+[%~ INCLUDE navitem uri='/report/new' liattrs='class="hidden js-continue-draft"' always_url=1 label=loc('Continue draft report...') ~%]

--- a/templates/web/base/offline/fallback.html
+++ b/templates/web/base/offline/fallback.html
@@ -3,19 +3,22 @@
 
 <h1>[% loc('Offline') %]</h1>
 
-<p>[% loc('Sorry, we don’t have a good enough connection to fetch that page.') %]</p>
+<p>
+    [% loc('You are currently offline. You can still make a draft report below, to finish and submit when you have signal again.') %]
+</p>
 
 <ul class="item-list item-list--reports" id="offline_list"></ul>
-
-<div id="offline_clear"></div>
+<div id="offline_clear" align="right"></div>
 
 <div>
-    <h2>Offline Draft Report</h2>
+    <h2>[% loc('New offline draft report') %]</h2>
+    <p>[% loc('Anything you enter here is automatically saved for finishing and submitting when you’re back online.') %]</p>
     <form id="offline_report">
         <input name=latitude type=hidden />
         <input name=longitude type=hidden />
-        <p>
-        <button id=geolocate class="btn">[% INCLUDE 'around/geolocate_link_icon.html' %]<span>Use my location</span></button>
+        <p align="center">
+        <button id=offline_geolocate class="btn">[% INCLUDE 'around/geolocate_link_icon.html' %]<span>[% loc('Use my location') %]</span></button>
+        <br><small id=offline_geolocate_location></small>
         </p>
 
         <div style="max-width: 27em" id="form_photos" class="dropzone"></div>
@@ -24,14 +27,15 @@
         <label for="form_title">[% form_title %]</label>
         <input class="form-control" type="text"  name="title" autocomplete="off" id="form_title">
 
-
         [% DEFAULT form_detail_label = loc('Explain what’s wrong') %]
         <label for="form_detail">[% form_detail_label %]</label>
         <textarea class="form-control" rows="7" cols="26" name=detail id="form_detail"></textarea>
     </form>
-    <p id="draft_save_message" class="hidden"><small>Draft report saved at <span></span></small></p>
-    <hr>
-    <p><button class="btn-danger js-delete-drafts" data-confirm="sure?">Delete draft</button></p>
+    <p id="draft_save_message" class="hidden"><small>[% tprintf(loc('Draft report saved on %s'), '<span></span>') %]</small></p>
+    <p class="submit-and-cancel">
+        <button class="btn btn-primary js-save-draft">[% loc('Save draft') %]</button>
+        <a href="" class="js-delete-drafts" data-confirm="[% loc('Are you sure?') %]">[% loc('Delete draft') %]</a>
+    </p>
 </div>
 
 [% INCLUDE 'footer.html' %]

--- a/templates/web/base/offline/fallback.html
+++ b/templates/web/base/offline/fallback.html
@@ -16,6 +16,8 @@
         <input name=longitude />
         <button id=geolocate>Use my location</button>
 
+        <div id="form_photos" class="dropzone"></div>
+
         [% DEFAULT form_title = loc('Summarise the problem') %]
         <label for="form_title">[% form_title %]</label>
         <input class="form-control" type="text"  name="title" autocomplete="off" id="form_title">

--- a/templates/web/base/offline/fallback.html
+++ b/templates/web/base/offline/fallback.html
@@ -15,8 +15,7 @@
         <input name=latitude />
         <input name=longitude />
         <button id=geolocate>Use my location</button>
-        
-        
+
         [% DEFAULT form_title = loc('Summarise the problem') %]
         <label for="form_title">[% form_title %]</label>
         <input class="form-control" type="text"  name="title" autocomplete="off" id="form_title">

--- a/templates/web/base/offline/fallback.html
+++ b/templates/web/base/offline/fallback.html
@@ -12,11 +12,13 @@
 <div>
     <h2>Offline Draft Report</h2>
     <form id="offline_report">
-        <input name=latitude />
-        <input name=longitude />
-        <button id=geolocate>Use my location</button>
+        <input name=latitude type=hidden />
+        <input name=longitude type=hidden />
+        <p>
+        <button id=geolocate class="btn">[% INCLUDE 'around/geolocate_link_icon.html' %]<span>Use my location</span></button>
+        </p>
 
-        <div id="form_photos" class="dropzone"></div>
+        <div style="max-width: 27em" id="form_photos" class="dropzone"></div>
 
         [% DEFAULT form_title = loc('Summarise the problem') %]
         <label for="form_title">[% form_title %]</label>
@@ -28,6 +30,8 @@
         <textarea class="form-control" rows="7" cols="26" name=detail id="form_detail"></textarea>
     </form>
     <p id="draft_save_message" class="hidden"><small>Draft report saved at <span></span></small></p>
+    <hr>
+    <p><button class="btn-danger js-delete-drafts" data-confirm="sure?">Delete draft</button></p>
 </div>
 
 [% INCLUDE 'footer.html' %]

--- a/templates/web/base/offline/fallback.html
+++ b/templates/web/base/offline/fallback.html
@@ -9,4 +9,24 @@
 
 <div id="offline_clear"></div>
 
+<div>
+    <h2>Offline Draft Report</h2>
+    <form id="offline_report">
+        <input name=latitude />
+        <input name=longitude />
+        <button id=geolocate>Use my location</button>
+        
+        
+        [% DEFAULT form_title = loc('Summarise the problem') %]
+        <label for="form_title">[% form_title %]</label>
+        <input class="form-control" type="text"  name="title" autocomplete="off" id="form_title">
+
+
+        [% DEFAULT form_detail_label = loc('Explain what’s wrong') %]
+        <label for="form_detail">[% form_detail_label %]</label>
+        <textarea class="form-control" rows="7" cols="26" name=detail id="form_detail"></textarea>
+    </form>
+    <p id="draft_save_message" class="hidden"><small>Draft report saved at <span></span></small></p>
+</div>
+
 [% INCLUDE 'footer.html' %]

--- a/templates/web/base/offline/service_worker.html
+++ b/templates/web/base/offline/service_worker.html
@@ -86,6 +86,13 @@ addEventListener('fetch',  fetchEvent => {
     }());
   }
 
+  if (request.method === "POST" && RegExp('/photo/upload/offline').test(url)) {
+    // Pretend that the upload worked, to keep Dropzone happy.
+    // XXX could maybe actually cache photo here and upload automatically when
+    // online? But how to calculate same ID as server and give that to Dropzone...
+    fetchEvent.respondWith(new Response("OK"));
+  }
+
   if (request.method !== "GET") {
       return;
   }

--- a/templates/web/fixmystreet.com/footer_extra.html
+++ b/templates/web/fixmystreet.com/footer_extra.html
@@ -1,3 +1,4 @@
+[% USE date %]
 <div class="mysoc-footer" role="contentinfo">
     <div class="container">
         <div class="row">
@@ -7,6 +8,9 @@
                 <div class="mysoc-footer__site-description">
                     <p>Mapping and reporting street problems to the councils responsible for fixing them &ndash; anywhere in the UK.</p>
                 </div>
+                [% IF bodyclass.match('offlinepage') %]
+                    <pre>[% date.format(date.now) %] [% git_version %]</pre>
+                [% END %]
 
                 <div class="fms-app-badges">
                     <a class="js-lazyload fms-app-badge fms-app-badge--ios" href="https://itunes.apple.com/gb/app/fixmystreet/id297456545">

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1076,6 +1076,12 @@ $.extend(fixmystreet.set_up, {
     });
   },
 
+  offline_draft: function() {
+    if (fixmystreet.offlineReporting) {
+        fixmystreet.offlineReporting.reportNewSetup();
+    }
+  },
+
   page_controller: function() {
     // Delegation because e.g. National Highways button gets added
     $('#problem_form, #form_update_form').on('click', '.js-reporting-page .js-reporting-page--next', function(e) {

--- a/web/cobrands/fixmystreet/offline.js
+++ b/web/cobrands/fixmystreet/offline.js
@@ -399,7 +399,7 @@ if ($('#offline_list').length) {
                 }
             });
         });
-        $('#offline_clear').css('margin-top', '5em').html('<button id="js-clear-storage">'+translation_strings.offline.clear_data+'</button>');
+        $('#offline_clear').css('margin-top', '2em').html('<button id="js-clear-storage">'+translation_strings.offline.clear_data+'</button>');
         $('#js-clear-storage').on('click', function() {
             if (window.confirm(translation_strings.offline.are_you_sure)) {
                 fixmystreet.offlineData.getCachedReports().then(function(reports) {

--- a/web/cobrands/fixmystreet/offline_report.js
+++ b/web/cobrands/fixmystreet/offline_report.js
@@ -253,21 +253,6 @@ fixmystreet.offlineReporting = (function() {
                 });
             }
          },
-
-         frontPageSetup: function() {
-            if (!window.idbKeyval) {
-                return;
-            }
-            idbKeyval.get('draftOfflineReports').then(function(drafts) {
-                if (drafts && drafts.length) {
-                    var d = drafts[0];
-                    document.querySelector(".js-continue-draft").className = "";
-                    var lk = document.querySelector('a.continue-draft-btn');
-                    lk.href = "/report/new?restoreDraft=1&latitude=" + d.latitude + "&longitude=" + d.longitude;
-                }
-            });
-
-         },
     };
 })();
 

--- a/web/cobrands/fixmystreet/offline_report.js
+++ b/web/cobrands/fixmystreet/offline_report.js
@@ -118,7 +118,12 @@ fixmystreet.offlineReporting = (function() {
      }
 
     function restoreDraftPhotos(photos) {
-        var dropzone = $("#form_photos").get(0).dropzone;
+        var $dropzone = $('#form_photos');
+        if (!$dropzone.length) {
+            return;
+        }
+
+        var dropzone =$dropzone.get(0).dropzone;
         dropzone.removeAllFiles();
         Object.values(photos).map(function (file) {
             var reader = new FileReader();
@@ -131,7 +136,12 @@ fixmystreet.offlineReporting = (function() {
     }
 
     function uploadDraftPhotos(photos) {
-        var dropzone = $('.dropzone').get(0).dropzone;
+        var $dropzone = $('.dropzone');
+        if (!$dropzone.length) {
+            return;
+        }
+
+        var dropzone =$dropzone.get(0).dropzone;
         dropzone.on("complete", function(file) {
             // Photo was sent to server so store its server_id so we don't have
             // to upload it again
@@ -198,6 +208,10 @@ fixmystreet.offlineReporting = (function() {
             restoreDraft();
         },
 
+        deleteCurrentDraft: function() {
+            deleteDrafts();
+        },
+
         geolocate: function(pos) {
             $("input[name=latitude]").val(pos.coords.latitude.toFixed(6));
             $("input[name=longitude]").val(pos.coords.longitude.toFixed(6));
@@ -248,4 +262,9 @@ if (fixmystreet.geolocate && link) {
 if (document.getElementById('offline_report')) {
     fixmystreet.offlineReporting.offlineFormSetup();
 }
+
+if (document.querySelector('.confirmation-header')) {
+    fixmystreet.offlineReporting.deleteCurrentDraft();
+}
+
 })();

--- a/web/cobrands/fixmystreet/offline_report.js
+++ b/web/cobrands/fixmystreet/offline_report.js
@@ -1,0 +1,55 @@
+fixmystreet.offlineReporting = (function() {
+    $("form#offline_report").find("input, textarea").change(function() {
+        fixmystreet.offlineReporting.saveDraft();
+    });
+
+    function updateDraftSavedTimestamp(ts) {
+        $("#draft_save_message").removeClass("hidden").find("span").text(ts);
+    }
+
+    return {
+         geolocate: function(pos) {
+            $("input[name=latitude]").val(pos.coords.latitude.toFixed(6));
+            $("input[name=longitude]").val(pos.coords.longitude.toFixed(6));
+            $("#geolocate").hide();
+            fixmystreet.offlineReporting.saveDraft();
+         },
+
+         saveDraft: function() {
+            console.log("saveDraft");
+            var ts = (new Date()).toISOString();
+            idbKeyval.set('draftOfflineReports', [{
+                latitude: $("input[name=latitude]").val(),
+                longitude: $("input[name=longitude]").val(),
+                title: $("input[name=title]").val(),
+                detail: $("textarea[name=detail]").val(),
+                saved: ts
+            }]).then(function() {
+                updateDraftSavedTimestamp(ts);
+            });
+         },
+
+         restoreDraft: function() {
+            idbKeyval.get('draftOfflineReports').then(function(drafts) {
+                if (drafts && drafts.length) {
+                    var d = drafts[0];
+                    $("input[name=latitude]").val(d.latitude);
+                    $("input[name=longitude]").val(d.longitude);
+                    $("input[name=title]").val(d.title);
+                    $("textarea[name=detail]").val(d.detail);
+                    updateDraftSavedTimestamp(d.saved);
+                }
+            });
+         },
+    };
+})();
+
+(function(){
+
+var link = document.getElementById('geolocate');
+if (fixmystreet.geolocate && link) {
+    fixmystreet.geolocate(link, fixmystreet.offlineReporting.geolocate);
+}
+
+fixmystreet.offlineReporting.restoreDraft();
+})();

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2992,6 +2992,16 @@ a#geolocate_link {
   visibility: hidden;
 }
 
+.submit-and-cancel {
+    display: flex;
+    align-items: center;
+}
+.submit-and-cancel a {
+    border-left: solid 1px #999;
+    padding-left: 1em;
+    margin-left: 1em;
+}
+
 @media screen {
   .print-only {
     display: none !important;

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -753,6 +753,16 @@ label[for="main-nav-btn"] {
   html.js-nav-open & {
     background-image: inline-image("../fixmystreet/images/#{$close-menu-image}.svg");
   }
+
+  // Sometimes we want to display a little red dot on the mobile nav
+  &.indicator:after {
+    content: "";
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    border-radius: 100%;
+    border: solid 5px red;
+  }
 }
 
 #nav-link,
@@ -2992,14 +3002,36 @@ a#geolocate_link {
   visibility: hidden;
 }
 
+// Offline reporting UI
+#front-main {
+  .js-continue-draft {
+    display:flex;
+    justify-content:center;
+  }
+  .js-continue-draft p {
+    background-color: #ff3333;
+    padding: 0.5em 1em;
+  }
+}
+
+#main-nav {
+  .js-continue-draft a {
+    background-color: #ffc2b3;
+
+    &:hover {
+      background-color: #ff3333;
+    }
+  }
+}
+
 .submit-and-cancel {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 .submit-and-cancel a {
-    border-left: solid 1px #999;
-    padding-left: 1em;
-    margin-left: 1em;
+  border-left: solid 1px #999;
+  padding-left: 1em;
+  margin-left: 1em;
 }
 
 @media screen {

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -907,6 +907,21 @@ textarea.form-error {
     background-position: $left 2em;
 }
 
+// Offline reporting UI
+#front-main {
+  .js-continue-draft p {
+      background-color: white;
+      border: solid 2px #ff3333;
+  }
+}
+
+#main-nav {
+  .js-continue-draft {
+    display: none;
+  }
+}
+
+
 /* Admin interface */
 
 .fms-admin-floated {

--- a/web/js/front.js
+++ b/web/js/front.js
@@ -94,4 +94,9 @@ document.getElementById('pc').focus();
             document.getElementById('pc').focus();
         });
     }
+
+    if (fixmystreet && fixmystreet.offlineReporting) {
+        fixmystreet.offlineReporting.frontPageSetup();
+    }
+
 })();

--- a/web/js/front.js
+++ b/web/js/front.js
@@ -95,8 +95,4 @@ document.getElementById('pc').focus();
         });
     }
 
-    if (fixmystreet && fixmystreet.offlineReporting) {
-        fixmystreet.offlineReporting.frontPageSetup();
-    }
-
 })();

--- a/web/js/offline_draft.js
+++ b/web/js/offline_draft.js
@@ -1,0 +1,27 @@
+(function(){
+    function showContinueDraftUI(d) {
+        // Don't show on continuing draft or offline pages
+        if (location.search.indexOf("restoreDraft=") > 0 || document.getElementById('offline_report')) {
+            return;
+        }
+
+        document.querySelectorAll(".js-continue-draft").forEach(function(p) {
+            p.classList.remove("hidden");
+            p.querySelectorAll("a").forEach(function(a) {
+                a.href = "/report/new?restoreDraft=1&latitude=" + d.latitude + "&longitude=" + d.longitude;
+            });
+        });
+
+        document.querySelector("#nav-link").classList.add("indicator");
+    }
+
+    if (window.idbKeyval) {
+        idbKeyval.get('draftOfflineReports').then(function(drafts) {
+            if (drafts && drafts.length) {
+                var d = drafts[0];
+                showContinueDraftUI(d);
+            }
+        });
+    }
+
+})();


### PR DESCRIPTION
 - Adds report form to offline fallback page
 - Automatically saves data from that form as a draft report in IndexedDB
 - Button on front page to continue draft report on normal /report/new flow when back online
 - Edits made to report when continuing draft are saved
 - Uses Dropzone for photo handling, stores images in IndexedDB

Bugs yet to be fixed:
 - [x] Correctly submitting photos to server when continuing draft
 - [x] Clearing draft when back online and report successfully submitted
 - [ ] Front page 'continue draft' button missing from some cobrands
 - [ ] Needs front end tests

Outstanding features required for parity with existing app:
 - [ ] Multiple drafts

Future improvements:
 - Automatically start draft when going through /report/new flow in usual online manner
 - ???

For https://github.com/mysociety/fixmystreet/issues/2221

# Screenshots

**NB** This would all probably benefit from some design love :)

The offline page now has a form for storing a draft report:

<img width="50%" src="https://user-images.githubusercontent.com/4776/219393617-03121561-8024-4599-b07d-497ba5a6c68a.png" />


Users can store their current location, attach photos with the usual Dropzone UI, and enter a title & description of the problem:

<img width="50%" src="https://user-images.githubusercontent.com/4776/219393802-88c93a8f-83da-40c7-9e11-e21113732b77.png" />

Their changes are automatically persisted with every keypress. There's a timestamp of when the report was saved. There's also a timestamp in the footer that shows when the offline page was cached, for debugging purposes:

<img width="50%" src="https://user-images.githubusercontent.com/4776/219393919-e6c1baa3-8f60-4709-b019-7be95e611024.png" />


When the user goes back online, the front page has a big button to continue & submit their draft report:

<img width="50%" src="https://user-images.githubusercontent.com/4776/219394407-2228c22d-66ba-42f0-b079-bc6685d10bac.png" />

This takes the user through the usual reporting flow, but their draft report's location/photos/text are all automatically populated in the report form:

<img width="50%" src="https://user-images.githubusercontent.com/4776/219394827-25167fea-3ab9-47cb-b1ae-2fffe4d6328f.png" />

<img width="50%" src="https://user-images.githubusercontent.com/4776/219395954-a700fc49-e339-4da5-8470-24b7365b22a8.png" />

<img width="50%" src="https://user-images.githubusercontent.com/4776/219395975-80a88403-7b3e-41cf-a5b0-39e56c1bafda.png" />



