### PR TITLE
[Camden] Ignore live TfL River Piers categories

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Camden.pm
+++ b/perllib/FixMyStreet/Cobrand/Camden.pm
@@ -81,11 +81,16 @@ sub open311_munge_update_params {
     $params->{service_code} = $contact->email;
 }
 
+=head2 categories_restriction
+
+Camden don't want TfL's River Piers categories on their cobrand.
+
+=cut
+
 sub categories_restriction {
     my ($self, $rs) = @_;
 
-    # Camden don't want TfL's River Piers category to appear on their cobrand.
-    return $rs->search( { 'me.category' => { '!=', 'River Piers' } } );
+    return $rs->search( { 'me.category' => { -not_like => 'River Piers%' } } );
 }
 
 # Problems and comments are always treated as anonymous so the user's name isn't displayed.

--- a/t/cobrand/camden.t
+++ b/t/cobrand/camden.t
@@ -25,6 +25,8 @@ FixMyStreet::override_config {
 
         my $tfl = $mech->create_body_ok(CAMDEN_MAPIT_ID, 'TfL');
         $mech->create_contact_ok(body_id => $tfl->id, category => 'River Piers', email => 'tfl@example.org');
+        $mech->create_contact_ok(body_id => $tfl->id, category => 'River Piers - Cleaning', email => 'tfl@example.org');
+        $mech->create_contact_ok(body_id => $tfl->id, category => 'River Piers Damage doors and glass', email => 'tfl@example.org');
 
         ok $mech->host('camden.fixmystreet.com'), 'set host';
 


### PR DESCRIPTION
On the staging site there's just one "River Piers" category, but on the live site there are quite a few. Luckily they all start with "River Piers", so switching to using `NOT LIKE` is enough to ignore the live categories.

Fixes https://github.com/mysociety/societyworks/issues/3500

<!-- [skip changelog] -->
