### PR TITLE
[Shropshire] Add 'Private' column to exported report

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Shropshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Shropshire.pm
@@ -144,4 +144,20 @@ sub open311_config {
     $params->{upload_files} = 1;
 }
 
+sub dashboard_export_problems_add_columns {
+    my ($self, $csv) = @_;
+
+    $csv->add_csv_columns(
+        private_report => 'Private'
+    );
+
+    $csv->csv_extra_data(sub {
+        my $report = shift;
+
+        return {
+            private_report => $report->non_public ? 'Yes' : 'No'
+        };
+    });
+}
+
 1;


### PR DESCRIPTION
Shropshire requested ability to be able to filter reports on whether the report is hidden or not.

[skip changelog]

https://mysocietysupport.freshdesk.com/a/tickets/2696


