### PR TITLE
[Brent] Don't show river piers fix for live

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -47,7 +47,7 @@ sub categories_restriction {
     my ($self, $rs) = @_;
 
     # Brent don't want TfL's River Piers category to appear on their cobrand.
-    return $rs->search( { 'me.category' => { '!=', 'River Piers' } } );
+    return $rs->search( { 'me.category' => { '-not_like' => 'River Piers%' } } );
 }
 
 sub social_auth_enabled {

--- a/t/cobrand/brent.t
+++ b/t/cobrand/brent.t
@@ -152,10 +152,14 @@ FixMyStreet::override_config {
 
         my $tfl = $mech->create_body_ok(2488, 'TfL');
         $mech->create_contact_ok(body_id => $tfl->id, category => 'River Piers', email => 'tfl@example.org');
+        $mech->create_contact_ok(body_id => $tfl->id, category => 'River Piers - Cleaning', email => 'tfl@example.org');
+        $mech->create_contact_ok(body_id => $tfl->id, category => 'River Piers Damage doors and glass', email => 'tfl@example.org');
 
         ok $mech->host('brent.fixmystreet.com'), 'set host';
         my $json = $mech->get_ok_json('/report/new/ajax?latitude=51.55904&longitude=-0.28168');
         is $json->{by_category}->{"River Piers"}, undef, "Brent doesn't have River Piers category";
+        is $json->{by_category}->{"River Piers - Cleaning"}, undef, "Brent doesn't have River Piers with hyphen and extra text category";
+        is $json->{by_category}->{"River Piers Damage doors and glass"}, undef, "Brent doesn't have River Piers with extra text category";
     };
 };
 


### PR DESCRIPTION
Live FMS has multiple types of River Pier category.

Change search to filter them all.

Notified by Camden change https://github.com/mysociety/fixmystreet/pull/4292

[skip changelog]
