### PR TITLE
[Northumberland] Increse z-index staging warning site banner

### DIFF
--- a/web/cobrands/northumberland/base.scss
+++ b/web/cobrands/northumberland/base.scss
@@ -65,6 +65,10 @@ a#geolocate_link {
 }
 
 /* NAVBAR */
+.dev-site-notice {
+    z-index: 5;
+}
+
 #site-header {
     -moz-box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
     -webkit-box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2); 


### PR DESCRIPTION
This PR prevents the staging sit banner to get hidden by the navbar:

### Before
<img width="1911" alt="Screenshot 2023-02-16 at 11 40 22" src="https://user-images.githubusercontent.com/13790153/219355447-99d9a3a2-1c0c-454c-b107-e6a7b844b416.png">

### After

<img width="1911" alt="Screenshot 2023-02-16 at 11 40 29" src="https://user-images.githubusercontent.com/13790153/219355438-dd886f80-3a45-4b58-9c7f-747b69a9d97b.png">