### PR TITLE
[Bulky Goods] Soft launch for staff-only

### DIFF
--- a/bin/fixmystreet.com/waste-bulky-reminders
+++ b/bin/fixmystreet.com/waste-bulky-reminders
@@ -11,7 +11,11 @@ BEGIN {
 }
 
 use Getopt::Long::Descriptive;
+use CronFns;
 use FixMyStreet::Cobrand;
+
+my $site = CronFns::site(FixMyStreet->config('BASE_URL'));
+CronFns::language($site);
 
 my ($opts, $usage) = describe_options(
     '%c %o',

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -591,7 +591,7 @@ sub bin_days : Chained('property') : PathPart('') : Args(0) {
     my $cfg = $c->cobrand->feature('waste_features');
 
     # Bulky goods has a new design for the bin days page
-    if ($cfg->{bulky_enabled}) {
+    if ($c->cobrand->call_hook('bulky_enabled')) {
         $c->stash->{template} = 'waste/bin_days_bulky.html';
     }
 
@@ -974,7 +974,7 @@ sub check_if_staff_can_pay : Private {
 sub bulky_setup : Chained('property') : PathPart('') : CaptureArgs(0) {
     my ($self, $c) = @_;
 
-    if (  !$c->stash->{waste_features}{bulky_enabled}
+    if (  !$c->cobrand->call_hook('bulky_enabled')
         || $c->stash->{property}{pending_bulky_collection} )
     {
         $c->detach('property_redirect');
@@ -1123,7 +1123,7 @@ sub bulky_cancel : Chained('property') : Args(0) {
     my ( $self, $c ) = @_;
 
     $c->detach('property_redirect')
-        if !$c->stash->{waste_features}{bulky_enabled}
+        if !$c->cobrand->call_hook('bulky_enabled')
         || !$c->cobrand->call_hook( 'bulky_can_cancel_collection',
                 $c->stash->{property}{pending_bulky_collection} );
 

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -1671,10 +1671,26 @@ sub available_permissions {
     return $perms;
 }
 
+sub bulky_enabled {
+    my $self = shift;
+    my $c = $self->{c};
+
+    my $cfg = $self->feature('waste_features') || {};
+
+    if ($cfg->{bulky_enabled} && $cfg->{bulky_enabled} eq 'staff') {
+        return $c->user_exists && (
+            $c->user->is_superuser
+            || ( $c->user->from_body && $c->user->from_body->name eq $self->council_name)
+        );
+    } else {
+        return $cfg->{bulky_enabled};
+    }
+}
+
 sub bulky_available_feature_types {
     my $self = shift;
 
-    return unless $self->feature('waste_features')->{bulky_enabled};
+    return unless $self->bulky_enabled;
 
     my $cfg = $self->feature('bartec');
     my $bartec = Integrations::Bartec->new(%$cfg);

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -1716,6 +1716,52 @@ FixMyStreet::override_config {
 };
 
 FixMyStreet::override_config {
+    MAPIT_URL => 'http://mapit.uk/',
+    ALLOWED_COBRANDS => 'peterborough',
+    COBRAND_FEATURES => {
+        bartec => { peterborough => {
+            sample_data => 1,
+        } },
+        waste => { peterborough => 1 },
+        waste_features => { peterborough => {
+            bulky_enabled => 'staff',
+        } },
+    },
+}, sub {
+    my ($b, $jobs_fsd_get) = shared_bartec_mocks();
+
+    my $bin_days_url = 'http://localhost/waste/PE1%203NA:100090215480';
+
+    subtest 'Logged-out users can’t see bulky goods when set to staff-only' => sub {
+        $mech->log_out_ok;
+
+        $mech->get_ok($bin_days_url);
+        $mech->content_lacks('Bulky Waste');
+    };
+
+    subtest 'Logged-in users can’t see bulky goods when set to staff-only' => sub {
+        $mech->log_in_ok($user->email);
+
+        $mech->get_ok($bin_days_url);
+        $mech->content_lacks('Bulky Waste');
+    };
+
+    subtest 'Logged-in staff can see bulky goods when set to staff-only' => sub {
+        $mech->log_in_ok($staff->email);
+
+        $mech->get_ok($bin_days_url);
+        $mech->content_contains('Bulky Waste');
+    };
+
+    subtest 'Logged-in superusers can see bulky goods when set to staff-only' => sub {
+        $mech->log_in_ok($super->email);
+
+        $mech->get_ok($bin_days_url);
+        $mech->content_contains('Bulky Waste');
+    };
+};
+
+FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'peterborough', 'bromley' ],
     COBRAND_FEATURES => {
         bartec => { peterborough => {

--- a/templates/email/default/waste/bulky-reminder.html
+++ b/templates/email/default/waste/bulky-reminder.html
@@ -44,8 +44,13 @@ INCLUDE '_email_top.html';
   </p>
 [% END %]
 
-  <p style="[% p_style %]">
-    If you wish to cancel your booking, please follow the link below.
+<p style="[% p_style %]">
+  [%~ IF staff_cancellation %]
+    If you wish to cancel your booking, please call 01733 74 74 74.
+  [% ELSE %]
+  If you wish to cancel your booking, please visit <a href="[% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') | uri %]/bulky_cancel">this link</a>.
+  [% END %]
+
 [% IF days == 1 %]
 You can still cancel your booking, but a refund is no longer available.
 [% ELSE %]
@@ -53,12 +58,8 @@ You can obtain a refund if you cancel more than one day before your booking.
 [% END %]
   </p>
 
-  <p style="margin: 20px auto; text-align: center">
-    <a style="[% button_style %]" href="[% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') | uri %]/bulky_cancel">Cancel booking</a>
-  </p>
-
   <p style="[% p_style %]">
-    Cancellation policy / T&amp;Cs / etc
+    <a href="https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections">Terms and Conditions</a>
   </p>
 
   <p style="[% p_style %]">

--- a/templates/email/default/waste/bulky-reminder.txt
+++ b/templates/email/default/waste/bulky-reminder.txt
@@ -27,8 +27,17 @@ Total cost: £[% pounds(payment / 100) %]
 
 [% END ~%]
 
+[%~ IF staff_cancellation %]
+
+If you wish to cancel your booking, please call 01733 74 74 74.
+
+[% ELSE %]
+
 If you wish to cancel your booking, please visit:
-    URL XXX
+
+    [% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') | uri %]/bulky_cancel
+
+[% END ~%]
 
 [% IF days == 1 %]
 You can still cancel your booking, but a refund is no longer available.
@@ -36,7 +45,9 @@ You can still cancel your booking, but a refund is no longer available.
 You can obtain a refund if you cancel more than one day before your booking.
 [% END %]
 
-Cancellation policy / T&amp;Cs / etc
+Terms and Conditions:
+
+    https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections
 
 [% signature %]
 

--- a/templates/email/peterborough/_bulky_data.html
+++ b/templates/email/peterborough/_bulky_data.html
@@ -4,5 +4,6 @@ SET payment = report.get_extra_field_value('payment');
 SET collection_date = cobrand.bulky_nice_collection_date(report.get_extra_field_value('DATE'));
 SET item_list = cobrand.bulky_nice_item_list(report);
 SET email_summary = "Thank you for booking a Peterborough bulky waste collection.";
+SET staff_cancellation = cobrand.feature('waste_features').bulky_enabled == 'staff';
 
 ~%]

--- a/templates/email/peterborough/other-reported-bulky.html
+++ b/templates/email/peterborough/other-reported-bulky.html
@@ -35,12 +35,17 @@ INCLUDE '_email_top.html';
 [% END %]
 
   <p style="[% p_style %]">
+    [%~ IF staff_cancellation %]
+      If you wish to cancel your booking, please call 01733 74 74 74.
+    [% ELSE %]
     If you wish to cancel your booking, please visit <a href="[% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') | uri %]/bulky_cancel">this link</a>.
+    [% END %]
+
     You can obtain a refund if you cancel more than one day before your booking.
   </p>
 
   <p style="[% p_style %]">
-    Cancellation policy / T&amp;Cs / etc
+    <a href="https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections">Terms and Conditions</a>
   </p>
 
   <p style="[% p_style %]">

--- a/templates/email/peterborough/other-reported-bulky.txt
+++ b/templates/email/peterborough/other-reported-bulky.txt
@@ -24,12 +24,23 @@ Total cost: £[% pounds(payment / 100) %]
 
 [% END ~%]
 
+[%~ IF staff_cancellation %]
+
+If you wish to cancel your booking, please call 01733 74 74 74.
+
+[% ELSE %]
+
 If you wish to cancel your booking, please visit:
-    URL XXX
+
+    [% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') | uri %]/bulky_cancel
+
+[% END ~%]
 
 You can obtain a refund if you cancel more than one day before your booking.
 
-Cancellation policy / T&amp;Cs / etc
+Terms and Conditions:
+
+    https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections
 
 [% signature %]
 

--- a/templates/web/base/waste/bin_days_sidebar.html
+++ b/templates/web/base/waste/bin_days_sidebar.html
@@ -1,4 +1,4 @@
-       [% IF service_data.size AND NOT waste_features.bulky_enabled %]
+       [% IF service_data.size AND NOT c.cobrand.call_hook('bulky_enabled') %]
        <div class="aside-download">
          <h3>Download your collection schedule</h3>
          <ul>

--- a/templates/web/peterborough/waste/_more_services_sidebar.html
+++ b/templates/web/peterborough/waste/_more_services_sidebar.html
@@ -34,7 +34,7 @@
           </form>
     </li>
   [% END %]
-  [% IF waste_features.bulky_enabled %]
+  [% IF c.cobrand.call_hook('bulky_enabled') %]
    [% IF NOT property.commercial_property %]
     <li>
         <a href="[% c.uri_for_action('waste/bulky', [ property.id ]) %]">Book bulky goods collection</a>

--- a/templates/web/peterborough/waste/header.html
+++ b/templates/web/peterborough/waste/header.html
@@ -1,5 +1,5 @@
 [%
-IF waste_features.bulky_enabled;
+IF c.cobrand.call_hook('bulky_enabled');
   SET bodyclass = 'waste govuk bulky';
 ELSE;
   SET bodyclass = 'waste govuk';

--- a/templates/web/peterborough/waste/services.html
+++ b/templates/web/peterborough/waste/services.html
@@ -38,7 +38,7 @@
     <form method="post" action="[% c.uri_for_action('waste/report', [ property.id ]) %]">
       <input type="hidden" name="token" value="[% csrf_token %]">
       <input type="hidden" name="service-[% unit.service_id %]" value="1">
-      [% IF waste_features.bulky_enabled %]
+      [% IF c.cobrand.call_hook('bulky_enabled') %]
         <input class="btn btn-primary govuk-!-margin-bottom-2" type="submit" aria-label="Report a [% unit.service_name FILTER lower %] collection as missed" value="Report a missed collection" class="waste-service-descriptor waste-service-link">
       [% ELSE %]
         <input type="submit" value="Report a [% unit.service_name FILTER lower %] collection as missed" class="waste-service-descriptor waste-service-link">
@@ -56,7 +56,7 @@
 [% UNLESS waste_features.problem_disabled OR (open_service_requests.422 AND unit.service_id == 6533) %]
   <form method="post" action="[% c.uri_for_action('waste/problem', [ property.id ]) %]">
     <input type="hidden" name="token" value="[% csrf_token %]">
-    [% IF waste_features.bulky_enabled %]
+    [% IF c.cobrand.call_hook('bulky_enabled') %]
       <input class="btn btn-primary govuk-!-margin-bottom-2" type="submit" aria-label="Report a problem with a [% unit.service_name FILTER lower %]" value="Report a problem" class="waste-service-descriptor waste-service-link">
     [% ELSE %]
       <input type="submit" value="Report a problem with a [% unit.service_name FILTER lower %]" class="waste-service-descriptor waste-service-link">
@@ -75,7 +75,7 @@
       <input type="hidden" name="token" value="[% csrf_token %]">
       <input type="hidden" name="container-[% unit.request_containers.0 %]" value="1">
       <input type="hidden" name="skip_bags" value="1">
-      [% IF waste_features.bulky_enabled %]
+      [% IF c.cobrand.call_hook('bulky_enabled') %]
         <input class="btn btn-primary govuk-!-margin-bottom-2" type="submit" aria-label="Request a new [% unit.service_name FILTER lower %]" value="Request a new bin" class="waste-service-descriptor waste-service-link">
       [% ELSE %]
         <input type="submit" value="Request a new [% unit.service_name FILTER lower %]" class="waste-service-descriptor waste-service-link">


### PR DESCRIPTION
 - Adds a `staff` value to `bulky_enabled` setting that prevents non-staff users accessing bulky goods feature
 - Replaces cancellation link with phone number in confirmation & reminder emails

[skip changelog]