### PR TITLE
[Bulky Goods] Sort item list on booking form alphabetically

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -984,39 +984,16 @@ sub bulky_setup : Chained('property') : PathPart('') : CaptureArgs(0) {
 sub bulky_item_options_method {
     my $field = shift;
 
-    # JS autocomplete ignores optgroups, but we want them in case
-    # a user has JS disabled.
-    # In order to display under optgroups, we have to build
-    # data structures like the following:
-    # {   group   => 'First Group',
-    #     options => [
-    #         { value => 1, label => 'One' },
-    #         { value => 2, label => 'Two' },
-    #         { value => 3, label => 'Three' },
-    #     ],
-    # },
-    my @option_groups;
+    my @options;
 
-    for my $cat ( sort keys %{ $field->form->items_by_category } )
-    {
-        my @options;
-
-        for my $name (
-            @{ $field->form->items_by_category->{$cat} } )
-        {
-            push @options => {
-                label => $name,
-                value => $name,
-            };
-        }
-
-        push @option_groups => {
-            group   => $cat,
-            options => \@options,
+    for my $item ( @{ $field->form->items_master_list } ) {
+        push @options => {
+            label => $item->{name},
+            value => $item->{name},
         };
     }
 
-    return \@option_groups;
+    return \@options;
 };
 
 sub bulky : Chained('bulky_setup') : Args(0) {

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -216,24 +216,8 @@ has items_master_list => (
 );
 
 sub _build_items_master_list {
-    $_[0]->c->cobrand->call_hook('bulky_items_master_list');
-}
-
-has items_by_category => (
-    is      => 'ro',
-    isa     => 'HashRef',
-    lazy    => 1,
-    builder => '_build_items_by_category',
-);
-
-sub _build_items_by_category {
-    my $self = shift;
-
-    my %hash;
-    for my $item ( @{ $self->items_master_list } ) {
-        push @{ $hash{ $item->{category} } }, $item->{name};
-    }
-    return \%hash;
+    [ sort { lc $a->{name} cmp lc $b->{name} }
+            @{ $_[0]->c->cobrand->call_hook('bulky_items_master_list') } ];
 }
 
 # Hash of item names mapped to extra text

--- a/t/forms/waste/bulky.t
+++ b/t/forms/waste/bulky.t
@@ -37,7 +37,7 @@ my $body = $mech->create_body_ok(
                 {   bartec_id => '1001',
                     category  => 'Audio / Visual Elec. equipment',
                     message   => '',
-                    name      => 'HiFi Stereos',
+                    name      => 'e-Scooters',
                     price     => '',
                 },
 
@@ -77,12 +77,16 @@ my $form = FixMyStreet::App::Form::Waste::Bulky->new(
     page_name => 'intro',
 );
 
-is_deeply $form->items_by_category => {
-    'Audio / Visual Elec. equipment' =>
-        [ 'Amplifiers', 'DVD/BR Video players', 'HiFi Stereos' ],
-    'Baby / Toddler' => [ 'Childs bed / cot', 'High chairs' ],
-    'Bedroom'        => [ 'Chest of drawers', 'Wardrobes' ]
-};
+my @master_list = map { $_->{name} } @{ $form->items_master_list };
+is_deeply \@master_list => [
+    'Amplifiers',
+    'Chest of drawers',
+    'Childs bed / cot',
+    'DVD/BR Video players',
+    'e-Scooters',
+    'High chairs',
+    'Wardrobes',
+];
 is_deeply $form->items_extra => { 'Wardrobes' => { message => "Please dismantlé", json => '{"message":"Please dismantlé"}' } };
 
 done_testing;

--- a/templates/web/base/govuk/fields.html
+++ b/templates/web/base/govuk/fields.html
@@ -296,7 +296,9 @@
           <option value="[% opt.value %]"[% IF extra %] data-extra="[% extra.json %]"[% END %][% ' selected' IF field.fif == val_safe %]>[% opt.label %]</option>
         [% END %]
       [% ELSE  %]
-        <option value="[% item.value %]"[% ' selected' IF field.fif == item.value %]>[% item.label %]</option>
+        [% SET val_safe = mark_safe(item.value) %]
+        [% extra = form.items_extra.${val_safe} %]
+        <option value="[% item.value %]"[% IF extra %] data-extra="[% extra.json %]"[% END %][% ' selected' IF field.fif == item.value %]>[% item.label %]</option>
       [% END %]
 	[% END %]
   </select>


### PR DESCRIPTION
For https://3.basecamp.com/4020879/buckets/26662378/todos/5821380701.

Removed the optgroup logic because this prevents the list of items being alphabetical under JS (JS users do not see option grouping; option grouping was there for the benefit of non-JS users, but the non-JS experience is already less than ideal so option grouping arguably doesn't add much).

[skip changelog]
