### PR TITLE
Add cobrand hook for validating category name and implement suffix test for National Highways.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
         - Alerts are paginated on user edit page. #4158
         - Restrict flagging users and reports to superusers.
         - Display photos in report moderation updates, rather than just the image hashes.
+        - Add 'admin_contact_validate_category' cobrand hook to validate category names when editing or creating contacts.
     - Development improvements:
         - Default make_css to `web/cobrands` rather than `web`.
         - Ability to pass custom arguments (eg: SSL config) to server when running via Docker

--- a/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
+++ b/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
@@ -431,4 +431,9 @@ sub _cleaning_categories { [
     #Street Cleaning Enquiry,
 ] }
 
+sub admin_contact_validate_category {
+    my ( $self, $category ) = @_;
+    return "(NH)" eq substr($category, -4) ? "" : "Category must end with (NH).";
+}
+
 1;


### PR DESCRIPTION
Partially fixes https://github.com/mysociety/societyworks/issues/3469.