### PR TITLE
[Peterborough] Make bin not returned to collection point staff only

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -1563,6 +1563,11 @@ sub waste_munge_problem_data {
 sub waste_munge_problem_form_fields {
     my ($self, $field_list) = @_;
 
+    my $not_staff = !($self->{c}->user_exists && $self->{c}->user->from_body && $self->{c}->user->from_body->name eq "Peterborough City Council");
+    my $label_497 = $not_staff 
+    ? 'The bin wasn’t returned to the collection point (Please phone 01733 747474 to report this issue)'
+    : 'The bin wasn’t returned to the collection point';
+
     my %services_problems = (
         538 => {
             container => 6533,
@@ -1606,7 +1611,8 @@ sub waste_munge_problem_form_fields {
         },
         497 => {
             container_name => "General",
-            label => "The bin wasn’t returned to the collection point",
+            label => $label_497,
+            disabled => $not_staff,
         },
     );
     $self->{c}->stash->{services_problems} = \%services_problems;
@@ -1654,8 +1660,9 @@ sub waste_munge_problem_form_fields {
         type => 'Checkbox',
         label => $self->{c}->stash->{services_problems}->{497}->{container_name},
         option_label => $self->{c}->stash->{services_problems}->{497}->{label},
-        disabled => $open_requests->{497},
+        disabled => $open_requests->{497} || $self->{c}->stash->{services_problems}->{497}->{disabled},
     };
+
     push @$field_list, "extra_detail" => {
         type => 'Text',
         widget => 'Textarea',

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -482,7 +482,20 @@ FixMyStreet::override_config {
         $mech->content_contains('You have already submitted this form.');
     };
     subtest 'Report bin not returned' => sub {
+        $mech->log_in_ok($user->email);
         $mech->get_ok('/waste/PE1 3NA:100090215480/problem');
+        my $tree = HTML::TreeBuilder->new_from_content($mech->content());
+        my $checkbox_497 = $tree->look_down(
+            'id' => 'service-497-0'
+        );
+        is ($checkbox_497->attr('disabled'), 'disabled', '"Bin not returned to collection point" disabled for user');
+        $mech->log_in_ok($staff->email);
+        $mech->get_ok('/waste/PE1 3NA:100090215480/problem');
+        $tree = HTML::TreeBuilder->new_from_content($mech->content());
+        $checkbox_497 = $tree->look_down(
+            'id' => 'service-497-0'
+        );
+        is ($checkbox_497->attr('disabled'), undef, '"Bin not returned to collection point" enabled for staff');
         $mech->submit_form_ok({ with_fields => { 'service-497' => 1 } });
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => 'email@example.org' }});
         $mech->submit_form_ok({ with_fields => { process => 'summary' } });


### PR DESCRIPTION
Request from client support to make this category only usable by staff and to advise users to phone

https://mysocietysupport.freshdesk.com/a/tickets/2706

[skip changelog]