### PR TITLE
[Bulky Goods] Only show two dates per page

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -47,8 +47,8 @@ sub service_name_override {
 }
 
 # XXX Use config to set max daily slots etc.
-sub bulky_collection_window_days     {90}
-sub max_bulky_collection_dates       {4}
+sub bulky_collection_window_days     {56}
+sub max_bulky_collection_dates       {2}
 sub bulky_workpack_name {
     qr/Waste-(BULKY WASTE|WHITES)-(?<date_suffix>\d{6})/;
 }

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -961,12 +961,10 @@ FixMyStreet::override_config {
             $mech->content_contains('Available dates');
             $mech->content_contains('05 August');
             $mech->content_contains('12 August');
-            $mech->content_contains('19 August');
-            $mech->content_contains('26 August');
-            $mech->content_lacks('02 September'); # Max of 4 dates fetched
+            $mech->content_lacks('19 August'); # Max of 2 dates fetched
             $mech->submit_form_ok(
                 {   with_fields =>
-                        { chosen_date => '2022-08-19T00:00:00' }
+                        { chosen_date => '2022-08-12T00:00:00' }
                 }
             );
         };
@@ -1057,7 +1055,7 @@ FixMyStreet::override_config {
             return ($token, $new_report, $report_id);
         }
 
-        subtest 'Summary page' => sub { test_summary(19) }; # 19th August
+        subtest 'Summary page' => sub { test_summary(12) }; # 12th August
 
         subtest 'Slot has become fully booked' => sub {
             # Slot has become fully booked in the meantime - should
@@ -1067,8 +1065,8 @@ FixMyStreet::override_config {
             $b->mock(
                 'WorkPacks_Get',
                 sub {
-                    [   {   'ID'   => '190822',
-                            'Name' => 'Waste-BULKY WASTE-190822',
+                    [   {   'ID'   => '120822',
+                            'Name' => 'Waste-BULKY WASTE-120822',
                         },
                     ];
                 },
@@ -1083,7 +1081,7 @@ FixMyStreet::override_config {
             $mech->content_contains(
                 'Unfortunately, the slot you originally chose has become fully booked. Please select another date.',
             );
-            $mech->content_lacks( '2022-08-19T00:00:00', 'Original date no longer an option' );
+            $mech->content_lacks( '2022-08-12T00:00:00', 'Original date no longer an option' );
         };
 
         subtest 'New date selected, submit pages again' => sub {

--- a/t/cobrand/peterborough/bulky-goods/unit.t
+++ b/t/cobrand/peterborough/bulky-goods/unit.t
@@ -13,14 +13,14 @@ subtest '_bulky_collection_window' => sub {
     is_deeply(
         FixMyStreet::Cobrand::Peterborough::_bulky_collection_window(),
         {   date_from => '2022-01-01',
-            date_to   => '2022-04-01',
+            date_to   => '2022-02-26',
         },
     );
     set_fixed_time('2021-12-31T23:00:00Z');
     is_deeply(
         FixMyStreet::Cobrand::Peterborough::_bulky_collection_window(),
         {   date_from => '2022-01-02',
-            date_to   => '2022-04-01',
+            date_to   => '2022-02-26',
         },
     );
 };
@@ -59,12 +59,6 @@ subtest 'find_available_bulky_slots' => sub {
             },
             {   date        => '2022-09-02T00:00:00',
                 workpack_id => 75496,
-            },
-            {   date        => '2022-09-09T00:00:00',
-                workpack_id => 75497,
-            },
-            {   date        => '2022-09-16T00:00:00',
-                workpack_id => 75498,
             },
         ],
     );

--- a/templates/web/base/waste/bulky/choose_date.html
+++ b/templates/web/base/waste/bulky/choose_date.html
@@ -18,12 +18,7 @@
 [% END %]
 
 <form class="waste" method="post">
-  [% # 'Show later / earlier dates' functionality has been implemented but at the time of writing, Peterborough have requested it not be made available %]
-  [% PROCESS form override_fields = [
-    'chosen_date', 'continue',
-    'process', 'token', 'saved_data', 'unique_id'
-    ]
-  %]
+  [% PROCESS form %]
   [% IF form.current_page.name == 'choose_date_earlier' && !form.field('chosen_date').options.size %]
     <p>
       There are no slots available in the next 90 days. Please refer to information regarding and link to information about taking waste to the local <a href='https://www.peterborough.gov.uk/residents/rubbish-and-recycling/household-recycling-centre'>Household Waste Recycling Centre</a>.


### PR DESCRIPTION
Should hopefully speed up display of the available dates page a bit...?

Shows first two available dates on "Choose date for collection" page, and reinstates "Show later dates"/"Show earlier dates" buttons.

[skip changelog]