### PR TITLE
[Brent] Added styling for .govuk-button--secondary button

### DIFF
--- a/web/cobrands/brent/base.scss
+++ b/web/cobrands/brent/base.scss
@@ -610,6 +610,10 @@ body.twothirdswidthpage {
       background-color: $btn-primary-background-hover;
     }
   }
+
+  .govuk-button--secondary {
+    @include brent-btn-secondary;
+  }
 }
 
 h1.govuk-heading-xl {


### PR DESCRIPTION
This PR fixes:
https://github.com/mysociety/societyworks/issues/3516

I couldn't check if "Subscribe to Garden waste collection service" was solved, not if I need to add something to the cobrand in order to be able to access that content. But I think it used the same `.govuk-button--secondary` class than the "Submit a container request". 

<img width="1187" alt="Screenshot 2023-03-01 at 09 33 33" src="https://user-images.githubusercontent.com/13790153/222102697-90dabf3e-377f-4a04-a2cf-61b8acf380da.png">

Let me know if there is anything I need to amend =)
