### PR TITLE
[TFL] Added fix that prevents scroll bar to appear on navbar

### DIFF
--- a/web/cobrands/tfl/layout.scss
+++ b/web/cobrands/tfl/layout.scss
@@ -21,6 +21,7 @@ h1 {
 #main-nav {
   float: none;
   margin-top: $mappage-header-height;
+  overflow: hidden;
 
   .ie9 & > * {
     #{$right}: auto;


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/3132

They issue of the odd scroll bar appearing on the navbar was a problem only in Chrome, when I tried to replicate the problem on Safari and Firefox I couldn't see it. 

I added a fix that prevents the scroll bar to be displayed.


<img width="1156" alt="Screenshot 2023-03-02 at 08 26 15" src="https://user-images.githubusercontent.com/13790153/222372853-b29bd7fc-563c-4acf-ac4b-eec3b2a494e2.png">
