### PR TITLE
[SLWP] Add support for dynamic costs based on date

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1196,7 +1196,10 @@ sub garden_setup : Chained('property') : PathPart('') : CaptureArgs(0) {
 
     $c->detach('property_redirect') if $c->stash->{waste_features}->{garden_disabled};
 
-    $c->stash->{per_bin_cost} = $c->cobrand->feature('payment_gateway')->{ggw_cost};
+    $c->stash->{per_bin_cost} = $c->cobrand->garden_waste_cost_pa;
+    if ($c->stash->{garden_sacks}) {
+        $c->stash->{per_sack_cost} = $c->cobrand->garden_waste_sacks_cost_pa;
+    }
     $c->stash->{per_new_bin_cost} = $c->cobrand->feature('payment_gateway')->{ggw_new_bin_cost};
     $c->stash->{per_new_bin_first_cost} = $c->cobrand->feature('payment_gateway')->{ggw_new_bin_first_cost} || $c->stash->{per_new_bin_cost};
 }

--- a/perllib/FixMyStreet/Roles/CobrandSLWP.pm
+++ b/perllib/FixMyStreet/Roles/CobrandSLWP.pm
@@ -788,8 +788,7 @@ sub waste_munge_report_data {
 # Same as full cost
 sub waste_get_pro_rata_cost {
     my ($self, $bins, $end) = @_;
-    my $cost = $bins * $self->feature('payment_gateway')->{ggw_cost};
-    return $cost;
+    return $self->garden_waste_cost_pa($bins);
 }
 
 sub waste_display_payment_method {
@@ -801,22 +800,6 @@ sub waste_display_payment_method {
     };
 
     return $display->{$method};
-}
-
-sub garden_waste_sacks_cost_pa {
-    my ($self) = @_;
-    my $cost = $self->feature('payment_gateway')->{ggw_sacks_cost};
-    return $cost;
-}
-
-sub garden_waste_cost_pa {
-    my ($self, $bin_count) = @_;
-
-    $bin_count ||= 1;
-
-    my $per_bin_cost = $self->feature('payment_gateway')->{ggw_cost};
-    my $cost = $per_bin_cost * $bin_count;
-    return $cost;
 }
 
 sub garden_waste_new_bin_admin_fee {

--- a/t/app/controller/waste_kingston.t
+++ b/t/app/controller/waste_kingston.t
@@ -243,10 +243,28 @@ FixMyStreet::override_config {
         waste => { kingston => 1 },
         payment_gateway => { kingston => {
             cc_url => 'http://example.com',
-            ggw_cost => 2000,
+            ggw_cost => [
+                {
+                    start_date => '2020-01-01',
+                    cost => 2000,
+                },
+                {
+                    start_date => '2023-01-06 00:00',
+                    cost => 2500,
+                }
+            ],
             ggw_new_bin_first_cost => 1500,
             ggw_new_bin_cost => 750,
-            ggw_sacks_cost => 4100,
+            ggw_sacks_cost => [
+                {
+                    start_date => '2020-01-01',
+                    cost => 4100,
+                },
+                {
+                    start_date => '2023-01-06 00:00',
+                    cost => 4300,
+                },
+            ],
             hmac => '1234',
             hmac_id => '1234',
             scpID => '1234',
@@ -1777,6 +1795,50 @@ FixMyStreet::override_config {
         $mech->content_contains('a_user_2@example.net');
         $mech->content_contains('unconfirmed');
         $mech->content_contains('4000,,1500,26,1,2'); # Fee/fee/fee/bin/current/sub
+    };
+
+    subtest 'check new sub price changes at fixed time' => sub {
+        set_fixed_time('2023-01-05T23:59:59Z');
+        $mech->log_out_ok;
+
+        $mech->get_ok('/waste/12345/garden');
+        $mech->content_contains('A 12 month subscription is £20.00 per bin');
+        $mech->submit_form_ok({ form_number => 1 });
+        $mech->submit_form_ok({ with_fields => { existing => 'no' } });
+        $mech->content_contains('<span class="cost-pa">£20.00 per bin per year</span>');
+
+        set_fixed_time('2023-01-06T00:00:00Z'); # New pricing should be in effect
+
+        $mech->get_ok('/waste/12345/garden');
+        $mech->content_contains('A 12 month subscription is £25.00 per bin');
+        $mech->submit_form_ok({ form_number => 1 });
+        $mech->submit_form_ok({ with_fields => { existing => 'no' } });
+        $mech->content_contains('<span class="cost-pa">£25.00 per bin per year</span>');
+
+        restore_time;
+    };
+
+    $echo->mock('GetServiceUnitsForObject', \&garden_waste_only_refuse_sacks);
+
+    subtest 'sacks, subscription price changes at fixed time' => sub {
+        set_fixed_time('2023-01-05T23:59:59Z');
+        $mech->log_out_ok;
+
+        $mech->get_ok('/waste/12345/garden');
+        $mech->content_contains('A roll of 10 garden waste sacks costs £41.00');
+        $mech->submit_form_ok({ form_number => 1 });
+        $mech->submit_form_ok({ with_fields => { container_choice => 'sack' } });
+        $mech->content_like(qr#Total per year: £<span[^>]*>41.00#, "initial cost correct");
+
+        set_fixed_time('2023-01-06T00:00:00Z'); # New pricing should be in effect
+
+        $mech->get_ok('/waste/12345/garden');
+        $mech->content_contains('A roll of 10 garden waste sacks costs £43.00');
+        $mech->submit_form_ok({ form_number => 1 });
+        $mech->submit_form_ok({ with_fields => { container_choice => 'sack' } });
+        $mech->content_like(qr#Total per year: £<span[^>]*>43.00#, "new cost correct");
+
+        restore_time;
     };
 };
 

--- a/templates/web/kingston/waste/garden/subscribe_intro.html
+++ b/templates/web/kingston/waste/garden/subscribe_intro.html
@@ -13,16 +13,16 @@ You can subscribe to our garden waste collection service if you are a frequent g
 <h2>Costs</h2>
 
 <p>
-A 12 month subscription is £82 per bin.
+A 12 month subscription is £[% tprintf('%.2f', per_bin_cost / 100 ) %] per bin.
 </p>
 
 <p>
-If you need us to deliver bins to you, there is a fee of £15 per bin for admin and delivery. If you order more than one bin at once, the admin and delivery fee will be £7.50 for each additional bin.
+If you need us to deliver bins to you, there is a fee of £[% tprintf('%.2f', per_new_bin_first_cost / 100 ) %] per bin for admin and delivery. If you order more than one bin at once, the admin and delivery fee will be £[% tprintf('%.2f', per_new_bin_cost / 100 ) %] for each additional bin.
 </p>
 
 [% IF garden_sacks %]
 <p>
-A roll of 10 garden waste sacks costs £41.
+A roll of 10 garden waste sacks costs £[% tprintf('%.2f', per_sack_cost / 100 ) %].
 </p>
 [% END %]
 

--- a/templates/web/sutton/waste/garden/subscribe_intro.html
+++ b/templates/web/sutton/waste/garden/subscribe_intro.html
@@ -13,12 +13,12 @@ You can subscribe to our garden waste collection service if you are a frequent g
 <h2>Costs</h2>
 
 <p>
-A 12 month subscription is £70.52 per bin.
+A 12 month subscription is £[% tprintf('%.2f', per_bin_cost / 100 ) %] per bin.
 </p>
 
 [% IF garden_sacks %]
 <p>
-A roll of 20 garden waste sacks also costs £70.52.
+A roll of 20 garden waste sacks also costs £[% tprintf('%.2f', per_sack_cost / 100 ) %].
 </p>
 [% END %]
 


### PR DESCRIPTION
This means you can add new costs that will come into effect in the future in the config and it will automatically start using them at the appropriate time.

Fixes https://github.com/mysociety/societyworks/issues/3451

## General notes

- ~~At the moment this is just for the SLWP cobrands, I haven't made this change affect e.g. Bromley.~~ See below, have updated this so it works with all cobrands.
- All of the costs need a `start_date`, so need to make up a start date in the past for the current cost. See example configuration below.
- If the cost in the config is a numerical value rather than an array of values then this will be used as the cost (so will work without updating the config, if needed)

## Note to deployer

Will need to update the server config when deploying this to reflect the new prices.

```yaml
COBRAND_FEATURES:
...
  payment_gateway:
  ...
    kingston:
      ggw_sacks_cost:
        - start_date: 2022-01-01 00:00
          cost: 4100
        - start_date: 2023-03-06 00:00
          cost: 4300
      ggw_cost:
        - start_date: 2022-01-01 00:00
          cost: 8200
        - start_date: 2023-03-06 00:00
          cost: 8600
       ...
    sutton:
      ggw_sacks_cost:
        - start_date: 2022-01-01 00:00
          cost: 7052
        - start_date: 2023-04-01 00:00
          cost: 8052
      ggw_cost:
        - start_date: 2022-01-01 00:00
          cost: 7052
        - start_date: 2023-04-01 00:00
          cost: 8052
      ...
```

<!-- [skip changelog] -->
