### PR TITLE
[Brent] Add auto template triggering to Echo for Brent

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -132,6 +132,21 @@ sub open311_post_send {
 
 sub prevent_questionnaire_updating_status { 1 };
 
+sub admin_templates_external_status_code_hook {
+    my ($self) = @_;
+    my $c = $self->{c};
+
+    my $res_code = $c->get_param('resolution_code') || '';
+    my $task_type = $c->get_param('task_type') || '';
+    my $task_state = $c->get_param('task_state') || '';
+
+    my $code = "$res_code,$task_type,$task_state";
+    $code = '' if $code eq ',,';
+    $code =~ s/,,$// if $code;
+
+    return $code;
+}
+
 sub waste_event_state_map {
     return {
         New => { New => 'confirmed' },

--- a/perllib/FixMyStreet/Roles/CobrandEcho.pm
+++ b/perllib/FixMyStreet/Roles/CobrandEcho.pm
@@ -346,13 +346,19 @@ sub construct_waste_open311_update {
     my $resolution_id = $event->{ResolutionCodeId} || '';
     my $status = $event_type->{states}{$state_id}{state};
     my $description = $event_type->{resolution}{$resolution_id} || $event_type->{states}{$state_id}{name};
+    my $external_status_code;
+    if ($self->moniker eq "brent") {
+        $external_status_code = $resolution_id ? "$resolution_id" : "",
+    } else {
+        $external_status_code = $resolution_id ? "$resolution_id,," : "",
+    }
     return {
         description => $description,
         status => $status,
         update_id => 'waste',
-        external_status_code => $resolution_id ? "$resolution_id,," : "",
+        external_status_code => $external_status_code,
         prefer_template => 1,
-    };
+    }
 }
 
 sub waste_get_event_type {

--- a/t/cobrand/brent.t
+++ b/t/cobrand/brent.t
@@ -56,6 +56,7 @@ $osm->mock('cache', sub {
 
 use_ok 'FixMyStreet::Cobrand::Brent';
 
+my $super_user = $mech->create_user_ok('superuser@example.com', is_superuser => 1, name => "Super User");
 my $comment_user = $mech->create_user_ok('comment@example.org', email_verified => 1, name => 'Brent');
 my $brent = $mech->create_body_ok(2488, 'Brent', {
     api_key => 'abc',
@@ -122,6 +123,51 @@ for my $test (
         $problem->comments->first->delete;
         $problem->delete;
         }
+    };
+};
+
+for my $test (
+    {
+        desc => 'No commas when only resolution coded',
+        resolution_code => 60,
+        task_type => '',
+        task_state => '',
+        result => 60,
+    },
+    {
+        desc => 'Commas in full waste details',
+        resolution_code => 60,
+        task_type => 20,
+        task_state => 40,
+        result => '60,20,40',
+    },
+    {
+        desc => 'Commas if only task_state ',
+        resolution_code => '',
+        task_type => '',
+        task_state => 40,
+        result => ',,40',
+    },
+) {
+    subtest 'Brent templates provide external_status_code for non-waste reports' => sub {
+        FixMyStreet::override_config {
+            ALLOWED_COBRANDS => 'brent',
+    }, sub {
+        $mech->log_in_ok($super_user->email);
+        $mech->get_ok('/admin/templates/' . $brent->id . '/new');
+        $mech->submit_form_ok({ with_fields => {
+            title => 'We are investigating your report',
+            text => 'We are now looking into your report and will update you soon.',
+            resolution_code => $test->{resolution_code},
+            task_type => $test->{task_type},
+            task_state => $test->{task_state},
+        } });
+        my $template = $brent->response_templates->first;
+        is($template->external_status_code, $test->{result}, $test->{desc});
+        $template->delete;
+        $template->update;
+        $mech->log_out_ok;
+        };
     };
 };
 

--- a/templates/web/brent/admin/templates/_external.html
+++ b/templates/web/brent/admin/templates/_external.html
@@ -1,0 +1,24 @@
+[% parts = rt.external_status_code.split(',') ~%]
+
+[% IF errors.external_status_code %]
+    <div class="form-error">[% errors.external_status_code %]</div>
+[% END %]
+<p>
+  <label for="resolution_code">External status code / Resolution Code ID</label>
+  <input type="text" id="resolution_code" name="resolution_code" class="form-control" size="30" value="[% parts.0 %]">
+</p>
+
+<p>
+  <label for="task_type">Task type ID</label>
+  <input type="text" id="task_type" name="task_type" class="form-control" size="30" value="[% parts.1 %]">
+</p>
+
+<p>
+  <label for="task_state">Task state</label>
+  <select class="form-control" name="task_state" id="task_state">
+      <option value="">---</option>
+    [% FOR opt IN ['Completed', 'Not Completed'] %]
+      <option value="[% opt %]"[% ' selected' IF parts.2 == opt %]>[% opt %]</option>
+    [% END %]
+  </select>
+</p>


### PR DESCRIPTION
Auto responses for non-waste categories for Echo
need to be stripped down to just the resolution code and not to have commas in.

https://github.com/mysociety/societyworks/issues/3531
(linking to https://3.basecamp.com/4020879/buckets/28996137/todos/5870961914#__subscriptions)

[skip changelog]
