### PR TITLE
[Bulky Goods] Redirect logged-out user to /auth if following cancel link

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1098,10 +1098,14 @@ sub bulky_view : Private {
 sub bulky_cancel : Chained('property') : Args(0) {
     my ( $self, $c ) = @_;
 
+    $c->detach( '/auth/redirect' ) unless $c->user_exists;
+
     $c->detach('property_redirect')
         if !$c->cobrand->call_hook('bulky_enabled')
-        || !$c->cobrand->call_hook( 'bulky_can_cancel_collection',
-                $c->stash->{property}{pending_bulky_collection} );
+            || !$c->cobrand->call_hook( 'bulky_can_view_collection',
+            $c->stash->{property}{pending_bulky_collection} )
+            || !$c->cobrand->call_hook( 'bulky_collection_can_be_cancelled',
+            $c->stash->{property}{pending_bulky_collection} );
 
     $c->stash->{first_page} = 'intro';
     $c->stash->{form_class} = 'FixMyStreet::App::Form::Waste::Bulky::Cancel';

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -787,7 +787,9 @@ sub bulky_per_item_costs {
     return $cfg->{per_item_costs};
 }
 
-sub bulky_can_cancel_collection {
+# Returns whether a collection can be cancelled, irrespective of logged-in
+# user or lack thereof
+sub bulky_collection_can_be_cancelled {
     # There is an $ignore_external_id option because we display some
     # cancellation messaging without needing a report in Bartec
     my ( $self, $collection, $ignore_external_id ) = @_;
@@ -796,7 +798,6 @@ sub bulky_can_cancel_collection {
            $collection
         && $collection->is_open
         && ( $collection->external_id || $ignore_external_id )
-        && $self->bulky_can_view_collection($collection)
         && $self->within_bulky_cancel_window($collection);
 }
 

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -1352,54 +1352,94 @@ FixMyStreet::override_config {
 
         subtest 'Cancellation' => sub {
             set_fixed_time($good_date);
+            my $base_path = '/waste/PE1%203NA:100090215480';
 
-            # Presence of external_id in report implies we have sent request
-            # to Bartec
-            $report->external_id(undef);
-            $report->update;
-            $mech->content_lacks( 'Cancel booking',
-                'Cancel option unavailable before request sent to Bartec' );
+            subtest 'Before request sent to Bartec' => sub {
+                # Presence of external_id in report implies we have sent request
+                # to Bartec
+                $report->external_id(undef);
+                $report->update;
+                $mech->get_ok($base_path);
+                $mech->content_lacks(
+                    'Cancel booking',
+                    'Cancel option unavailable',
+                );
+                $mech->get_ok("$base_path/bulky_cancel");
+                is $mech->uri->path, $base_path,
+                    'Cancel link redirects to bin days';
+            };
 
-            $report->external_id('Bartec-SR00100001');
-            $report->update;
-            $mech->get_ok('/waste/PE1%203NA:100090215480');
-            $mech->content_contains( 'Cancel booking',
-                'Cancel option available after request sent to Bartec' );
+            subtest 'After request sent to Bartec' => sub {
+                $report->external_id('Bartec-SR00100001');
+                $report->update;
+                $mech->get_ok($base_path);
+                $mech->content_contains(
+                    'Cancel booking',
+                    'Cancel option available',
+                );
+                $mech->get_ok("$base_path/bulky_cancel");
+                is $mech->uri->path, "$base_path/bulky_cancel",
+                    'Cancel link does not redirect';
+            };
 
-            $mech->log_in_ok( $user2->email );
-            $mech->get_ok('/waste/PE1%203NA:100090215480');
-            $mech->content_lacks(
-                'Cancel booking',
-                'Cancel option unavailable if booking does not belong to user',
-            );
+            subtest 'User logged out' => sub {
+                $mech->log_out_ok;
+                $mech->get_ok($base_path);
+                $mech->content_lacks(
+                    'Cancel booking',
+                    'Cancel option unavailable',
+                );
+                $mech->get_ok("$base_path/bulky_cancel");
+                like $mech->uri->path, qr/auth/,
+                    'Cancel link redirects to /auth';
+            };
 
-            $mech->log_in_ok( $staff->email );
-            $mech->get_ok('/waste/PE1%203NA:100090215480');
-            $mech->content_contains( 'Cancel booking',
-                'Cancel option available to staff' );
+            subtest 'Other user logged in' => sub {
+                $mech->log_in_ok( $user2->email );
+                $mech->get_ok($base_path);
+                $mech->content_lacks(
+                    'Cancel booking',
+                    'Cancel option unavailable if booking does not belong to user',
+                );
+                $mech->get_ok("$base_path/bulky_cancel");
+                is $mech->uri->path, $base_path,
+                    'Cancel link redirects to bin days';
+            };
+
+            subtest 'Staff user logged in' => sub {
+                $mech->log_in_ok( $staff->email );
+                $mech->get_ok($base_path);
+                $mech->content_contains(
+                    'Cancel booking',
+                    'Cancel option available',
+                );
+                $mech->get_ok("$base_path/bulky_cancel");
+                is $mech->uri->path, "$base_path/bulky_cancel",
+                    'Cancel link does not redirect';
+            };
 
             $mech->log_in_ok( $user->email );
 
             set_fixed_time($bad_date);
-            $mech->get_ok('/waste/PE1%203NA:100090215480');
+            $mech->get_ok($base_path);
             $mech->content_lacks( 'Cancel booking',
                 'Cancel option unavailable if outside cancellation window' );
 
             set_fixed_time($no_refund_date);
-            $mech->get_ok('/waste/PE1%203NA:100090215480/bulky_cancel');
+            $mech->get_ok("$base_path/bulky_cancel");
             $mech->content_lacks("If you cancel this booking you will receive a refund");
             $mech->content_contains("No Refund Will Be Issued");
 
             $report->update_extra_field({ name => 'CHARGEABLE', value => 'FREE'});
             $report->update;
-            $mech->get_ok('/waste/PE1%203NA:100090215480/bulky_cancel');
+            $mech->get_ok("$base_path/bulky_cancel");
             $mech->content_lacks("If you cancel this booking you will receive a refund");
             $mech->content_lacks("No Refund Will Be Issued");
             $report->update_extra_field({ name => 'CHARGEABLE', value => 'CHARGED'});
             $report->update;
 
             set_fixed_time($good_date);
-            $mech->get_ok('/waste/PE1%203NA:100090215480/bulky_cancel');
+            $mech->get_ok("$base_path/bulky_cancel");
             $mech->content_contains("If you cancel this booking you will receive a refund");
             $mech->submit_form_ok( { with_fields => { confirm => 1 } } );
             $mech->content_contains(
@@ -1407,7 +1447,7 @@ FixMyStreet::override_config {
                 'Cancellation confirmation page shown',
             );
             $mech->follow_link_ok( { text => 'Go back home' } );
-            is $mech->uri->path, '/waste/PE1%203NA:100090215480',
+            is $mech->uri->path, $base_path,
                 'Returned to bin days';
             $mech->content_lacks( 'Cancel booking',
                 'Cancel option unavailable if already cancelled' );

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -79,7 +79,7 @@
       </dl>
 
       [% IF !problem
-        || cobrand.bulky_can_cancel_collection( problem, 1 ) %]
+        || cobrand.bulky_collection_can_be_cancelled( problem, 1 ) %]
         <div class="govuk-warning-text due">
           <div class="govuk-warning-text__img">
             <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
@@ -198,7 +198,7 @@
   </div>
 
   [% IF problem %]
-    [% IF cobrand.bulky_can_cancel_collection(problem) %]
+    [% IF cobrand.bulky_collection_can_be_cancelled(problem) %]
       <p>
         <a class="govuk-button govuk-button--secondary" href="[% c.uri_for_action( 'waste/bulky_cancel', [ property.id ] ) %]">Cancel this booking</a>
       </p>

--- a/templates/web/peterborough/waste/bin_days_bulky.html
+++ b/templates/web/peterborough/waste/bin_days_bulky.html
@@ -195,7 +195,7 @@ hx-trigger="every [% page_refresh %]s"
           [% IF c.cobrand.bulky_can_view_collection(property.pending_bulky_collection) %]
             <!-- #05 Should only display when: There IS a booking AND is a signed user -->
             <a class="btn btn-primary govuk-!-margin-bottom-2" href="/report/[% property.pending_bulky_collection.id %]">Check collection details</a>
-            [% IF c.cobrand.bulky_can_cancel_collection(property.pending_bulky_collection) %]
+            [% IF c.cobrand.bulky_collection_can_be_cancelled(property.pending_bulky_collection) %]
               <a class="btn btn-primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky_cancel', [ property.id ]) %]">Cancel booking</a>
             [% END %]
             <!-- END #05 -->


### PR DESCRIPTION
If a logged-out user tried to follow the `/bulky_cancel` link from an email, for example, they would just be redirected to the bin days page with no obvious signal that they need to log in to cancel. Now they are redirected to `/auth`; if, after logging in, they are still not authorised to cancel a collection, then we take them back to bin days.

Fixes https://3.basecamp.com/4020879/buckets/26662378/todos/5843431647.

Part of https://github.com/mysociety/societyworks/issues/3543.

[skip changelog]