### PR TITLE
[Bulky Goods] Use Workpacks_Metrics_Get API call instead of Jobs_Get

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -975,7 +975,7 @@ sub bin_services_for_address {
         # Need to set the custom template here because Waste::bin_days
         # doesn't actually get run because of the detach
         # XXX This can be removed when the bulky template is removed
-        if ( $self->feature('waste_features')->{bulky_enabled} ) {
+        if ( $self->bulky_enabled ) {
             $self->{c}->stash->{template} = 'waste/bin_days_bulky.html';
         }
         $self->{c}->stash->{data_loading} = 1;

--- a/perllib/FixMyStreet/Roles/ParallelAPI.pm
+++ b/perllib/FixMyStreet/Roles/ParallelAPI.pm
@@ -62,6 +62,7 @@ sub call_api {
             # uncoverable statement
             system(@cmd);
             $data = retrieve($tmp);
+            unlink $tmp; # don't want to inadvertently cache forever
         }
     }
     if ($data) {

--- a/perllib/Integrations/Bartec.pm
+++ b/perllib/Integrations/Bartec.pm
@@ -264,6 +264,18 @@ sub Jobs_Get_for_workpack {
     return force_arrayref( $res, 'Jobs' );
 }
 
+sub Workpacks_Metrics_Get {
+    my ( $self, $workpack_ids ) = @_;
+
+    my $res = $self->call(
+        'Workpacks_Metrics_Get',
+        token      => $self->token,
+        Workpacks => [ map { { int => $_ } } @$workpack_ids ],
+    );
+
+    return force_arrayref( $res, 'WorkPack' );
+}
+
 sub Jobs_FeatureScheduleDates_Get {
     my ($self, $uprn, $start, $end) = @_;
 


### PR DESCRIPTION
The latter is much slower and returns more data than we actually need

[skip changelog]