### PR TITLE
[Brent] Remove extra padding above blank update

### DIFF
--- a/web/cobrands/brent/base.scss
+++ b/web/cobrands/brent/base.scss
@@ -87,6 +87,11 @@ a {
     padding-top: 0.75em;
     padding-bottom: 0.75em;
   }
+
+  .internal-link-fixed-header {
+    padding-top: 0em;
+    padding-bottom: 0em;
+  }
 }
 
 .item-list__item__shortlist-add { 


### PR DESCRIPTION
Removes excess padding on an empty update in Brent

From:
![Screenshot from 2023-03-08 15-21-46](https://user-images.githubusercontent.com/87022664/223755449-313d41ee-7b30-46aa-bb54-3566f1ab64fc.png)

To:
![image](https://user-images.githubusercontent.com/87022664/223756177-5acd65ce-ef20-4ae9-86b3-2c9a61b36912.png)

[skip changelog]


