### PR TITLE
[SLWP] Use fetched DD rather than storing info.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -465,6 +465,7 @@ sub direct_debit_modify : Private {
                 comments => '',
                 date => $c->cobrand->waste_get_next_dd_day('ad-hoc'),
                 orig_sub => $c->stash->{orig_sub},
+                mandate => $c->stash->{direct_debit_mandate},
         } );
     }
 
@@ -472,6 +473,7 @@ sub direct_debit_modify : Private {
         payer_reference => $ref,
         amount => sprintf('%.2f', $total / 100),
         orig_sub => $c->stash->{orig_sub},
+        mandate => $c->stash->{direct_debit_mandate},
     } );
 }
 
@@ -490,6 +492,7 @@ sub direct_debit_cancel_sub : Private {
     my $update_ref = $i->cancel_plan( {
         payer_reference => $ref,
         report => $p,
+        mandate => $c->stash->{direct_debit_mandate},
     } );
 }
 
@@ -1263,7 +1266,7 @@ sub garden_modify : Chained('garden_setup') : Args(0) {
 
         $c->forward('get_original_sub', ['user']);
 
-        if (!$c->stash->{orig_sub}) {
+        if (!$c->stash->{orig_sub} || $c->stash->{direct_debit_status} eq 'none') {
             $c->stash->{template} = 'waste/garden/wrong_user.html';
             $c->detach;
         }
@@ -1311,7 +1314,7 @@ sub garden_cancel : Chained('garden_setup') : Args(0) {
 
     $c->forward('get_original_sub', ['user']);
 
-    if (!$c->stash->{orig_sub}) {
+    if (!$c->stash->{orig_sub} || $c->stash->{direct_debit_status} eq 'none') {
         $c->stash->{template} = 'waste/garden/wrong_user.html';
         $c->detach;
     }
@@ -1435,6 +1438,7 @@ sub get_original_sub : Private {
     }
 
     my $r = $c->stash->{orig_sub} = $p->first;
+    $c->stash->{direct_debit_status} = '';
     $c->cobrand->call_hook(waste_check_existing_dd => $r)
         if $r && ($r->get_extra_field_value('payment_method') || '') eq 'direct_debit';
 }

--- a/perllib/FixMyStreet/Roles/Bottomline.pm
+++ b/perllib/FixMyStreet/Roles/Bottomline.pm
@@ -57,13 +57,7 @@ sub add_new_sub_metadata {
     my ($self, $new_sub, $payment) = @_;
 
     $new_sub->set_extra_metadata('dd_profile_id', $payment->data->{profileId});
-    $new_sub->set_extra_metadata('dd_mandate_id', $payment->data->{mandateId});
     $new_sub->set_extra_metadata('dd_instruction_id', $payment->data->{instructionId});
-
-    my $contact = $self->get_dd_integration->get_contact_from_email($new_sub->user->email);
-    if ($contact) {
-        $new_sub->set_extra_metadata('dd_contact_id', $contact->{id});
-    }
 }
 
 sub get_dd_integration {
@@ -111,6 +105,7 @@ sub waste_check_existing_dd {
     my $i = $self->get_dd_integration;
     my $mandate = $i->get_mandate_from_reference($payer_reference) || {};
     my $dd_status = $mandate->{status} || '';
+    $c->stash->{direct_debit_mandate} = $mandate;
 
     if ($dd_status eq 'DRAFT') {
         $c->stash->{direct_debit_status} = 'pending';

--- a/perllib/FixMyStreet/Roles/CobrandSLWP.pm
+++ b/perllib/FixMyStreet/Roles/CobrandSLWP.pm
@@ -694,20 +694,6 @@ sub waste_garden_sub_params {
     }
 }
 
-sub waste_report_extra_dd_data {
-    my ($self) = @_;
-    my $c = $self->{c};
-
-    if (my $orig = $c->stash->{orig_sub}) {
-        my $p = $c->stash->{report};
-        $p->set_extra_metadata(dd_contact_id => $orig->get_extra_metadata('dd_contact_id'))
-            if $orig->get_extra_metadata('dd_contact_id');
-        $p->set_extra_metadata(dd_mandate_id => $orig->get_extra_metadata('dd_mandate_id'))
-            if $orig->get_extra_metadata('dd_mandate_id');
-        $p->update;
-    }
-}
-
 =head2 waste_munge_report_form_fields
 
 We use a custom report form to add some text to the "About you" page.

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -1383,6 +1383,8 @@ FixMyStreet::override_config {
     $p->set_extra_metadata('payerReference', $dd_ref);
     $p->update;
 
+    $dd->mock('get_payer', sub { 'Active' });
+
     subtest 'check modify sub direct debit payment' => sub {
         my $echo = Test::MockModule->new('Integrations::Echo');
         $echo->mock('GetServiceUnitsForObject', \&garden_waste_one_bin);
@@ -1418,9 +1420,11 @@ FixMyStreet::override_config {
             reference => $new_report->id,
             comments => '',
             date => $ad_hoc_payment_date,
+            mandate => undef,
         }, "correct direct debit ad hoc payment params sent";
         is_deeply $dd_sent_params->{amend_plan}, {
             payer_reference => $dd_ref,
+            mandate => undef,
             amount => '40.00',
         }, "correct direct debit amendment params sent";
         $new_report->delete;
@@ -1454,13 +1458,13 @@ FixMyStreet::override_config {
         is $dd_sent_params->{one_off_payment}, undef, "no one off payment if reducing bin count";
         is_deeply $dd_sent_params->{amend_plan}, {
             payer_reference => $dd_ref,
+            mandate => undef,
             amount => '20.00',
         }, "correct direct debit amendment params sent";
     };
 
     subtest 'renew direct debit sub' => sub {
         set_fixed_time('2021-03-09T17:00:00Z'); # After sample data collection
-        $dd->mock('get_payer', sub { 'Active' });
 
         $mech->get_ok('/waste/12345');
         $mech->content_lacks('Renew subscription today');
@@ -1486,14 +1490,6 @@ FixMyStreet::override_config {
 
         $p->state('confirmed');
         $p->update;
-        $dd->mock('get_payer', sub { });
-    };
-
-    subtest 'renew direct debit after expiry' => sub {
-        set_fixed_time('2021-04-09T17:00:00Z'); # After expiry
-        $mech->get_ok('/waste/12345');
-        $mech->content_contains('Renew subscription today');
-        set_fixed_time('2021-03-09T17:00:00Z');
     };
 
     subtest 'cancel direct debit sub' => sub {
@@ -1512,11 +1508,21 @@ FixMyStreet::override_config {
         is $new_report->state, 'unconfirmed', 'report confirmed';
 
         is_deeply $dd_sent_params->{cancel_plan}, {
+            mandate => undef,
             payer_reference => $dd_ref,
         }, "correct direct debit cancellation params sent";
 
         $mech->get_ok('/waste/12345');
         $mech->content_contains('Cancellation in progress');
+    };
+
+    $dd->mock('get_payer', sub { });
+
+    subtest 'renew direct debit after expiry' => sub {
+        set_fixed_time('2021-04-09T17:00:00Z'); # After expiry
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('Renew subscription today');
+        set_fixed_time('2021-03-09T17:00:00Z');
     };
 
     $p->update_extra_field({ name => 'payment_method', value => 'credit_card' });
@@ -1995,10 +2001,13 @@ FixMyStreet::override_config {
         $mech->content_contains('This property has a direct debit subscription which will renew');
 
         $mech->get_ok('/waste/12345/garden_modify');
+        $mech->content_contains('could not locate an existing Direct Debit');
+        $dd->mock('get_payer', sub { 'Active' });
+        $mech->get_ok('/waste/12345/garden_modify');
         $mech->content_contains('can only be updated by the original user');
-
         $mech->get_ok('/waste/12345/garden_cancel');
         $mech->content_contains('can only be updated by the original user');
+        $dd->mock('get_payer', sub { });
     };
 
     $report->update_extra_field({ name => 'payment_method', value => 'credit_card' });

--- a/t/app/controller/waste_sutton_garden.t
+++ b/t/app/controller/waste_sutton_garden.t
@@ -48,8 +48,6 @@ create_contact({ category => 'Cancel Garden Subscription', email => 'garden_canc
     { code => 'Bin_Delivery_Detail_Containers', required => 1, automated => 'hidden_field' },
     { code => 'Subscription_End_Date', required => 1, automated => 'hidden_field' },
     { code => 'payment_method', required => 1, automated => 'hidden_field' },
-    { code => 'dd_contact_id', required => 0, automated => 'hidden_field' },
-    { code => 'dd_mandate_id', required => 0, automated => 'hidden_field' },
 );
 
 package SOAP::Result;

--- a/t/cobrand/kingston.t
+++ b/t/cobrand/kingston.t
@@ -779,7 +779,6 @@ FixMyStreet::override_config {
         is $new_sub->get_extra_metadata('payerReference'), get_reference("RBK-NEW_SUB-654321", $id_replacements), "payer reference set";
         is $new_sub->get_extra_field_value('PaymentCode'), get_reference("RBK-NEW_SUB-654321", $id_replacements), 'correct echo payment code field';
         is $new_sub->get_extra_field_value('LastPayMethod'), 3, 'correct echo payment method field';
-        is $new_sub->get_extra_metadata('dd_mandate_id'), 1, 'correct mandate id set';
 
         $renewal_from_cc_sub->discard_changes;
         is $renewal_from_cc_sub->state, 'confirmed', "Renewal report confirmed";

--- a/templates/web/base/waste/garden/wrong_user.html
+++ b/templates/web/base/waste/garden/wrong_user.html
@@ -11,10 +11,14 @@
   </dl>
   [% END %]
 
-[% IF c.action == 'waste/garden_cancel' %]
-<p>Only the account that created the garden waste subscription can cancel it.</p>
-[% ELSIF c.action == 'waste/garden_modify' %]
-<p>Only the account that created the garden waste subscription can modify it.</p>
+[% IF direct_debit_status == 'none' %]
+    <p>We could not locate an existing Direct Debit associated with this account.</p>
+[% ELSE %]
+    [% IF c.action == 'waste/garden_cancel' %]
+        <p>Only the account that created the garden waste subscription can cancel it.</p>
+    [% ELSIF c.action == 'waste/garden_modify' %]
+        <p>Only the account that created the garden waste subscription can modify it.</p>
+    [% END %]
 [% END %]
 
 <p><a class="govuk-button" href="/waste/[% property.id %]">Show upcoming bin days</a></p>


### PR DESCRIPTION
The contact ID seems to be available in the mandate, and given this it seemed safer to only proceed if we know we have got a mandate to amend/cancel. [skip changelog]