### PR TITLE
Block /report/new URLs from search engines

### DIFF
--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Disallow: /photo/
+Disallow: /report/new
 Crawl-delay: 3


### PR DESCRIPTION
Users were starting new reports at whatever latlon had appeared in their search results rather than choosing on the map or going via postcode form, meaning lots of reports at identical and incorrect locations.

For .com we should probably combine this with a Varnish rule that redirects users to `/` if they arrive at `/report/new` from Google/Bing/etc.

For FD-2794

[skip changelog]