### PR TITLE
[Camden] Add Name and email fields to data export

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Camden.pm
+++ b/perllib/FixMyStreet/Cobrand/Camden.pm
@@ -1,3 +1,14 @@
+=head1 NAME
+
+FixMyStreet::Cobrand::Camden - code specific to the Camden cobrand
+
+=head1 SYNOPSIS
+
+Camden is a London borough using FMS with a Symology integration
+
+=cut
+
+
 package FixMyStreet::Cobrand::Camden;
 use parent 'FixMyStreet::Cobrand::Whitelabel';
 
@@ -112,6 +123,30 @@ sub user_from_oidc {
     my $email = $payload->{preferred_username};
 
     return ($name, $email);
+}
+
+=head2 dashboard_export_problems_add_columns
+
+Has user name and email fields added to their csv export
+
+=cut
+
+sub dashboard_export_problems_add_columns {
+    my ($self, $csv) = @_;
+
+    $csv->add_csv_columns(
+        user_name => 'User Name',
+        user_email => 'User Email',
+    );
+
+    $csv->csv_extra_data(sub {
+        my $report = shift;
+
+        return {
+            user_name => $report->user->name || '',
+            user_email => $report->user->email || '',
+        };
+    });
 }
 
 1;

--- a/t/cobrand/camden.t
+++ b/t/cobrand/camden.t
@@ -15,7 +15,7 @@ my $camden = $mech->create_body_ok(CAMDEN_MAPIT_ID, 'Camden Council', {}, {
 });
 
 $mech->create_contact_ok(body_id => $camden->id, category => 'Potholes', email => 'potholes@camden.fixmystreet.com');
-
+my $staffuser = $mech->create_user_ok( 'staff@example.com', name => 'Staffer', from_body => $camden );
 
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'camden', 'tfl' ],
@@ -103,6 +103,13 @@ FixMyStreet::override_config {
         $mech->get_ok('/report/' . $report->id);
         $mech->content_contains('This is a test comment');
         $mech->content_lacks('Test User');
+    };
+
+    subtest 'Dashboard CSV extra columns' => sub {
+        $mech->log_in_ok($staffuser->email);
+        $mech->get_ok('/dashboard?export=1');
+        $mech->content_contains('"Reported As","User Name","User Email"');
+        $mech->content_like(qr/default,,"Test User",pkg-tcobrandcamdent-test\@example.com/);
     };
 };
 


### PR DESCRIPTION
Request to add user name and email to csv export

https://mysocietysupport.freshdesk.com/a/tickets/2812

[skip changelog]
