### PR TITLE
[Bucks] Dont give staff name/email when contributing for anon user

### DIFF
--- a/templates/email/buckinghamshire/submit.html
+++ b/templates/email/buckinghamshire/submit.html
@@ -19,6 +19,9 @@ of a local problem that they believe might require your attention.</p>
   <p style="margin: 20px auto; text-align: center">
     <a style="[% button_style %]" href="[% url %]">Show full report</a>
   </p>
+  [% IF report.get_extra_metadata('contributed_as') == 'anonymous_user' %]
+  <h2 style="[% h2_style %] margin: 30px 0 10px 0">Reported anonymously</h2>
+  [% ELSE %]
   <h2 style="[% h2_style %] margin: 30px 0 10px 0">Reported by:</h2>
   <table [% table_reset | safe %]>
     <tr>
@@ -42,6 +45,7 @@ of a local problem that they believe might require your attention.</p>
       </tr>
     [%~ END %]
   </table>
+  [% END %]
   <p style="[% p_style %] margin-top: 0.5em;">
     Replies to this email will go to FixMyStreet and updated according to the
     SC code used in the Subject line.

--- a/templates/email/buckinghamshire/submit.txt
+++ b/templates/email/buckinghamshire/submit.txt
@@ -14,11 +14,16 @@ please visit the following link:
 [% has_photo %]----------
 
 Name: [% report.name %]
+[% report.get_extra_metadata('contributed_as') %]
+[% IF report.get_extra_metadata('contributed_as' == 'anonymous_user') %]
+Reported anonymously
+[% ELSE %]
 
 Email: [% report.user.email OR "None provided" %]
 
 Phone: [% report.user.phone OR "None provided" %]
 
+[% END %]
 Category: [% report.category %]
 
 Subject: [% report.title %]


### PR DESCRIPTION
Request by Bucks not to show staff details when user is anonymous

https://mysocietysupport.freshdesk.com/a/tickets/2725

[skip changelog]