### PR TITLE
Revert "[Peterborough] Request to suspend food bags"

### DIFF
--- a/templates/web/peterborough/waste/_more_services_sidebar.html
+++ b/templates/web/peterborough/waste/_more_services_sidebar.html
@@ -18,7 +18,7 @@
             <input type="hidden" name="container-428" value="1">
             <input type="hidden" name="quantity-428" value="1">
             <input type="hidden" name="process" value="request">
-            <input type="submit" disabled value="Food bags currently out of stock" class="waste-service-descriptor">
+            <input type="submit" value="Request more food bags" class="waste-service-descriptor waste-service-link">
           </form>
     </li>
   [% END %]

--- a/templates/web/peterborough/waste/confirmation.html
+++ b/templates/web/peterborough/waste/confirmation.html
@@ -55,7 +55,7 @@ END ~%]
 
 [% IF first_page == 'request' %]
     [% IF report.category == 'Food bag request' %]
-      <p>Food bags will be supplied by the crew on your next collection day.</p>
+      <p>Bin liners will be delivered in due course.</p>
     [% ELSE %]
       <p>
         Bins arrive typically within two weeks, but this may vary due to demand.


### PR DESCRIPTION
This reverts commit d4d5cd612893f9958e6170b52f0b27c7f1761a10 (https://github.com/mysociety/fixmystreet/pull/4277).

 As per FD ticket https://mysocietysupport.freshdesk.com/a/tickets/2839,
 which asks for food bags to be re-enabled.
Confirmation messaging has also been changed.

[skip changelog]
