### PR TITLE
[Bathnes] New style for homepage

### DIFF
--- a/templates/web/bathnes/around/intro.html
+++ b/templates/web/bathnes/around/intro.html
@@ -1,2 +1,6 @@
-<h1>Report a problem<br />
-Roads, pavements, and parks</h1>
+<h1>Report a problem</h1>
+<ul>
+  <li>Continue here to report a problem on a street, park or green space</li>
+  <li><a href="https://beta.bathnes.gov.uk/report-emergency">Report an emergency</a></li>
+  <li><a href="mailto:parking@bathnes.gov.uk?subject=I would like to report a parking issue">Report a parking issue</a></li>
+</ul>

--- a/templates/web/bathnes/header_site.html
+++ b/templates/web/bathnes/header_site.html
@@ -31,8 +31,6 @@
     <nav role="navigation" id="navigation-primary" class="navigation-primary">
         [% INCLUDE 'main_nav.html' omit_wrapper=1 ul_class='navigation-primary-list' liattrs='class="navigation-primary-list__item"' %]
     </nav>
-
-    <div class="header-marque"></div>
 </header>
 
 <div class="nav-wrapper">

--- a/web/cobrands/bathnes/_colours.scss
+++ b/web/cobrands/bathnes/_colours.scss
@@ -47,3 +47,9 @@ $header-top-border: false;
 
 $search-help-background: #fff3f3;
 $search-help-header-font-size-desktop: 1.25em;
+
+
+/* FONTS */
+$heading-font: arial, sans-serif;
+$body-font: arial, sans-serif;
+$meta-font: arial, sans-serif;

--- a/web/cobrands/bathnes/base.scss
+++ b/web/cobrands/bathnes/base.scss
@@ -66,6 +66,7 @@ a, .fake-link {
 // Front page
 
 #front-main {
+    text-align: left;
     h1 {
         font-size: 1.7em;
     }
@@ -90,6 +91,11 @@ a, .fake-link {
 
 #front-main #postcodeForm {
     margin-top: 1em;
+    background-color: #fff;
+
+    div {
+        margin-left: 0;
+    }
 
     label {
         color: $primary_b;

--- a/web/cobrands/bathnes/layout.scss
+++ b/web/cobrands/bathnes/layout.scss
@@ -42,7 +42,7 @@
 
 #front-main {
     padding: 2em 1em;
-    background-color: $front_main_background;
+    background-color: #fff;
     color: $primary_b;
 
     h1 {
@@ -55,18 +55,30 @@
     }
     #postcodeForm {
         margin-top: 0;
-        padding: 0;
+        padding-top: 0;
+        div {
+            margin-left: 0;
+        }
     }
 
     a {
         color: $primary_b;
+
+        &:hover {
+            color: $primary_b;
+            text-decoration: none;
+        }
     }
 
     .front-main-other-issues-wrapper {
-        padding: 1em;
-        background: $bathens-cyan;
-        max-width: 500px;
-        margin: 1em auto;
+        margin-top: 3em;
+        margin-left: 0;
+        margin-right: 0;
+        border: 5px solid #6F777B;
+        padding: 20px;
+        margin-bottom: 50px;
+        background: #ffffff;
+        max-width: 100%;
 
         a {
             &:hover {


### PR DESCRIPTION
Bathnes council asked for a new style for their homepage and also to use "Arial" instead of the current one.
Fixes: https://github.com/mysociety/societyworks/issues/3581

Preview:
<img width="1270" alt="Screenshot 2023-04-10 at 06 10 56" src="https://user-images.githubusercontent.com/13790153/230851262-3394a02a-8ab4-496e-b5f4-83454fc64814.png">


 [skip changelog ] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

Let me know if there is any feedback
