### PR TITLE
Set ‘width=device-width’ in viewport meta tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
         - Add option to set an emergency message on reporting pages.
         - Add label to questionnaire textarea. #3944
         - Offline report drafting. #4290
+        - Set width=device-width in viewport meta tag. #4384
     - Bugfixes:
         - Add ID attributes to change password form inputs.
         - Fix link deactivation for privacy policy link on privacy policy page. #3704

--- a/templates/web/base/header.html
+++ b/templates/web/base/header.html
@@ -7,7 +7,7 @@
 <!--[if IE 9]>   <html class="no-js ie9"[% html_att | safe %]><![endif]-->
 <!--[if gt IE 9]><!--><html class="no-js"[% html_att | safe %]><!--<![endif]-->
     <head>
-        <meta name="viewport" content="initial-scale=1.0">
+        <meta name="viewport" content="initial-scale=1.0, width=device-width">
 
         <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
         [% IF page_refresh %]

--- a/templates/web/oxfordshire/header.html
+++ b/templates/web/oxfordshire/header.html
@@ -7,7 +7,7 @@
 <!--[if IE 9]>   <html class="no-js ie9"[% html_att | safe %]><![endif]-->
 <!--[if gt IE 9]><!--><html class="no-js"[% html_att | safe %]><!--<![endif]-->
     <head>
-        <meta name="viewport" content="initial-scale=1.0">
+        <meta name="viewport" content="initial-scale=1.0, width=device-width">
 
         <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
         <meta name="HandHeldFriendly" content="true">

--- a/templates/web/zurich/header.html
+++ b/templates/web/zurich/header.html
@@ -9,7 +9,7 @@
 <!--[if IE 9]>   <html class="no-js ie9"[% html_att | safe %]><![endif]-->
 <!--[if gt IE 9]><!--><html class="no-js"[% html_att | safe %]><!--<![endif]-->
     <head>
-        <meta name="viewport" content="initial-scale=1.0">
+        <meta name="viewport" content="initial-scale=1.0, width=device-width">
 
         <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
         <meta name="HandHeldFriendly" content="true">


### PR DESCRIPTION
This improves the responsiveness of UI elements on mobile by telling the browser not to wait 350ms before acting upon the event.

More details on the WebKit blog:
    https://webkit.org/blog/5610/more-responsive-tapping-on-ios/
and the Chrome blog:
    https://developer.chrome.com/blog/300ms-tap-delay-gone-away/

