### PR TITLE
[Brent] Fixed background logo in waste front page

### DIFF
--- a/web/cobrands/brent/base.scss
+++ b/web/cobrands/brent/base.scss
@@ -620,14 +620,15 @@ h1.govuk-heading-xl {
   text-align: left;
   margin: 0 -1rem;
   padding: 1.5rem 1rem;
-  // background-color: $front_main_colour;
-  background: $front_main_colour inline-image("../brent/images/logo-pattern-bolder_gray-transparent.svg") $right center no-repeat;
   z-index: 1;
+}
+
+.waste.waste--uprn {
+  background: $front_main_colour inline-image("../brent/images/logo-pattern-bolder_gray.svg") $left;
+  background-size: 100%;
+  border: 1px solid #ebebed;
+  background-position: 0;
   background-repeat: no-repeat;
-  background-size: 50%;
-  background-position: left top;
-  background-blend-mode: soft-light;
-  background-blend-mode: normal!important;
 }
 
 .waste__collections .govuk-summary-list,


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/3635

<img width="1913" alt="Screenshot 2023-04-20 at 09 53 09" src="https://user-images.githubusercontent.com/13790153/233313841-84b45c84-f0c8-473b-85e5-5a805e077883.png">

<img width="373" alt="Screenshot 2023-04-20 at 09 52 57" src="https://user-images.githubusercontent.com/13790153/233313863-c34a6d18-9342-4bab-8b35-39c09ea6aa36.png">

[skip changelog]

Let me know if there is any feedback
