### PR TITLE
Tweak app-like display CSS.

### DIFF
--- a/templates/web/base/header.html
+++ b/templates/web/base/header.html
@@ -7,7 +7,7 @@
 <!--[if IE 9]>   <html class="no-js ie9"[% html_att | safe %]><![endif]-->
 <!--[if gt IE 9]><!--><html class="no-js"[% html_att | safe %]><!--<![endif]-->
     <head>
-        <meta name="viewport" content="initial-scale=1.0, width=device-width">
+        <meta name="viewport" content="initial-scale=1.0, width=device-width, viewport-fit=cover">
 
         <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
         [% IF page_refresh %]

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2166,6 +2166,11 @@ html.js #map .noscript {
     }
 }
 
+// Hide the "Start new report here" button when map filters are open
+#mapForm.mobile-filters-active .map-mobile-report-button {
+  display: none;
+}
+
 .map-crosshairs {
     display: none;
     position: absolute;

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1812,6 +1812,10 @@ input.final-submit {
   overflow: hidden;
   position: relative;
 
+  // Don't want people 'selecting' the map tiles etc and it looking a bit odd
+  user-select: none;
+  -webkit-user-select: none;
+
   #map {
     width: 100%;
     height: 100%;
@@ -2134,6 +2138,7 @@ html.js #map .noscript {
   bottom: 0;
   margin: 0;
   margin-bottom: 6em;
+  margin-bottom: calc(env(safe-area-inset-bottom) + 6em);
 
   @include border-radius(0.5em);
 
@@ -2240,6 +2245,7 @@ html.js #map .noscript {
 
 .olControlAttribution {
   bottom: 3.25em !important;
+  bottom: calc(env(safe-area-inset-bottom) + 3.25em) !important;
   #{$right}: 0.25em !important;
   #{$left}: 0.25em !important;
   color: #222222;
@@ -2339,7 +2345,15 @@ div.assigned-to {
     height: auto; // override `.mobile #map_box` height:10em
     margin: 0;
     z-index: 1; // stack above positioned elements later on the page (eg: .report-list-filters)
+
+    .sub-map-links {
+      padding-bottom: env(safe-area-inset-bottom);
+    }
   }
+}
+
+#mapForm.mobile-filters-active .sub-map-links {
+  padding-bottom: 0;
 }
 
 .only-map,

--- a/web/cobrands/sass/_report_list.scss
+++ b/web/cobrands/sass/_report_list.scss
@@ -12,6 +12,7 @@
     background: #000;
     color: #fff;
     border: none;
+    padding-bottom: env(safe-area-inset-bottom);
   }
 }
 


### PR DESCRIPTION
Prevent over-scrolling of the page, user selection on the map, and leave enough gap at the bottom on the full screen map.

I have tested the first two on my phone, but the last one I'm not sure how to emulate properly (as it's only in the native app wrapper that it's fullscreen enough for it to matter, IYSWIM).

[skip changelog]