### PR TITLE
Add way to use digest in static filename.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ FixMyBarangay.po
 /web/photo
 # And theme upload
 /web/theme
+# And copied static files with content hash in the name
+/web/static
 
 # Installation
 /local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
         - Option to read asset layers from configuration.
         - Add GitHub Action to generate POD documentation.
         - Use digest rather than last modified time for static versioning. #4280
+        - Add way to use digest in static filename rather than query parameter.
     - Security
         - Permit control over database connection `sslmode` via $FMS_DB_SSLMODE
     - Open311 improvements:

--- a/web/cobrands/bathnes/pattern-lib/_header.scss
+++ b/web/cobrands/bathnes/pattern-lib/_header.scss
@@ -69,7 +69,7 @@
             right: 45px;
             //right: 0;
             text-indent: -9999px;
-            background-image: url(images/icon-search-2x.png);
+            background-image: url(/cobrands/bathnes/images/icon-search-2x.png);
             background-repeat: no-repeat;
             background-position: 55% 50%;
             background-size: 52.5% 40%;

--- a/web/cobrands/bristol/_fonts.scss
+++ b/web/cobrands/bristol/_fonts.scss
@@ -1,14 +1,14 @@
 @font-face {
     font-family: 'Thesans-Plain';
-    src: url("fonts/the-sans/thesans-lp5plain-webfont-webfont.eot");
-    src: url("fonts/the-sans/thesans-lp5plain-webfont-webfont.eot?#iefix") format("embedded-opentype"), url("fonts/the-sans/thesans-lp5plain-webfont-webfont.woff") format("woff"), url("fonts/the-sans/thesans-lp5plain-webfont-webfont.ttf") format("truetype"), url("fonts/the-sans/thesans-lp5plain-webfont-webfont.svg#Thesans-Plain") format("svg");
+    src: url("/cobrands/bristol/fonts/the-sans/thesans-lp5plain-webfont-webfont.eot");
+    src: url("/cobrands/bristol/fonts/the-sans/thesans-lp5plain-webfont-webfont.eot?#iefix") format("embedded-opentype"), url("/cobrands/bristol/fonts/the-sans/thesans-lp5plain-webfont-webfont.woff") format("woff"), url("/cobrands/bristol/fonts/the-sans/thesans-lp5plain-webfont-webfont.ttf") format("truetype"), url("/cobrands/bristol/fonts/the-sans/thesans-lp5plain-webfont-webfont.svg#Thesans-Plain") format("svg");
     font-weight: normal;
     font-style: normal;
 }
 @font-face {
     font-family: 'Thesans-Semi-Bold';
-    src: url("fonts/the-sans/TheSans-B6SemiBold.eot");
-    src: url("fonts/the-sans/TheSans-B6SemiBold.eot?#iefix") format("embedded-opentype"), url("fonts/the-sans/TheSans-B6SemiBold.woff") format("woff"), url("fonts/the-sans/TheSans-B6SemiBold.ttf") format("truetype"), url("fonts/the-sans/TheSans-B6SemiBold.svg#Thesans-Semi-Bold") format("svg");
+    src: url("/cobrands/bristol/fonts/the-sans/TheSans-B6SemiBold.eot");
+    src: url("/cobrands/bristol/fonts/the-sans/TheSans-B6SemiBold.eot?#iefix") format("embedded-opentype"), url("/cobrands/bristol/fonts/the-sans/TheSans-B6SemiBold.woff") format("woff"), url("/cobrands/bristol/fonts/the-sans/TheSans-B6SemiBold.ttf") format("truetype"), url("/cobrands/bristol/fonts/the-sans/TheSans-B6SemiBold.svg#Thesans-Semi-Bold") format("svg");
     font-weight: normal;
     font-style: normal;
 }
@@ -17,12 +17,12 @@
     // Family Name
     font-family: 'Thesans-Semi-Light';
     // IE9 Compatibility Mode
-    src: url('fonts/the-sans/TheSansLP-SemiLight.eot');
+    src: url('/cobrands/bristol/fonts/the-sans/TheSansLP-SemiLight.eot');
     // Various Browsers
-    src: url('fonts/the-sans/TheSansLP-SemiLight.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-         url('fonts/the-sans/TheSansLP-SemiLight.woff') format('woff'), /* Modern Browsers */
-         url('fonts/the-sans/TheSansLP-SemiLight.ttf')  format('truetype'), /* Safari, Android, iOS */
-         url('fonts/the-sans/TheSansLP-SemiLight.svg#Thesans-Semi-Light') format('svg'); /* Legacy iOS */
+    src: url('/cobrands/bristol/fonts/the-sans/TheSansLP-SemiLight.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+         url('/cobrands/bristol/fonts/the-sans/TheSansLP-SemiLight.woff') format('woff'), /* Modern Browsers */
+         url('/cobrands/bristol/fonts/the-sans/TheSansLP-SemiLight.ttf')  format('truetype'), /* Safari, Android, iOS */
+         url('/cobrands/bristol/fonts/the-sans/TheSansLP-SemiLight.svg#Thesans-Semi-Light') format('svg'); /* Legacy iOS */
     font-weight: normal;
     font-style: normal;
 }
@@ -31,12 +31,12 @@
     // Family Name
     font-family: 'Thesans-Bold';
     // IE9 Compatibility Mode
-    src: url('fonts/the-sans/TheSans_LP_700_Bold.eot');
+    src: url('/cobrands/bristol/fonts/the-sans/TheSans_LP_700_Bold.eot');
     // Various Browsers
-    src: url('fonts/the-sans/TheSans_LP_700_Bold.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-         url('fonts/the-sans/TheSans_LP_700_Bold.woff') format('woff'), /* Modern Browsers */
-         url('fonts/the-sans/TheSans_LP_700_Bold.ttf')  format('truetype'), /* Safari, Android, iOS */
-         url('fonts/the-sans/TheSans_LP_700_Bold.svg#Thesans-Bold') format('svg'); /* Legacy iOS */
+    src: url('/cobrands/bristol/fonts/the-sans/TheSans_LP_700_Bold.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+         url('/cobrands/bristol/fonts/the-sans/TheSans_LP_700_Bold.woff') format('woff'), /* Modern Browsers */
+         url('/cobrands/bristol/fonts/the-sans/TheSans_LP_700_Bold.ttf')  format('truetype'), /* Safari, Android, iOS */
+         url('/cobrands/bristol/fonts/the-sans/TheSans_LP_700_Bold.svg#Thesans-Bold') format('svg'); /* Legacy iOS */
     font-weight: normal;
     font-style: normal;
 }
@@ -45,12 +45,12 @@
     // Family Name
     font-family: 'Thesans-Semi-Light-Select';
     // IE9 Compatibility Mode
-    src: url('fonts/the-sans/TheSansLP-SemiLight.eot');
+    src: url('/cobrands/bristol/fonts/the-sans/TheSansLP-SemiLight.eot');
     // Various Browsers
-    src: url('fonts/the-sans/TheSansLP-SemiLight.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-         url('fonts/the-sans/TheSansLP-SemiLight.woff') format('woff'), /* Modern Browsers */
-         url('fonts/the-sans/TheSansLP-SemiLight.ttf')  format('truetype'), /* Safari, Android, iOS */
-         url('fonts/the-sans/TheSansLP-SemiLight.svg#Thesans-Semi-Light-Select') format('svg'); /* Legacy iOS */
+    src: url('/cobrands/bristol/fonts/the-sans/TheSansLP-SemiLight.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+         url('/cobrands/bristol/fonts/the-sans/TheSansLP-SemiLight.woff') format('woff'), /* Modern Browsers */
+         url('/cobrands/bristol/fonts/the-sans/TheSansLP-SemiLight.ttf')  format('truetype'), /* Safari, Android, iOS */
+         url('/cobrands/bristol/fonts/the-sans/TheSansLP-SemiLight.svg#Thesans-Semi-Light-Select') format('svg'); /* Legacy iOS */
     font-weight: normal;
     font-style: normal;
 }
@@ -59,12 +59,12 @@
     // Family Name
     font-family: 'bcc';
     // IE9 Compatibility Mode
-    src: url('fonts/icomoon/bcc.eot');
+    src: url('/cobrands/bristol/fonts/icomoon/bcc.eot');
     // Various Browsers
-    src: url('fonts/icomoon/bcc.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-         url('fonts/icomoon/bcc.woff') format('woff'), /* Modern Browsers */
-         url('fonts/icomoon/bcc.ttf')  format('truetype'), /* Safari, Android, iOS */
-         url('fonts/icomoon/bcc.svg#TheSans_LP_400_SemiLight') format('svg'); /* Legacy iOS */
+    src: url('/cobrands/bristol/fonts/icomoon/bcc.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+         url('/cobrands/bristol/fonts/icomoon/bcc.woff') format('woff'), /* Modern Browsers */
+         url('/cobrands/bristol/fonts/icomoon/bcc.ttf')  format('truetype'), /* Safari, Android, iOS */
+         url('/cobrands/bristol/fonts/icomoon/bcc.svg#TheSans_LP_400_SemiLight') format('svg'); /* Legacy iOS */
     font-weight: normal;
     font-style: normal;
 }

--- a/web/cobrands/bromley/base.scss
+++ b/web/cobrands/bromley/base.scss
@@ -16,7 +16,7 @@
   $logo-height: 60px;
   width: 95px;
   height: 0;
-  @include svg-background-image("images/site-logo");
+  @include svg-background-image("/cobrands/bromley/images/site-logo");
   background-size: 95px $logo-height;
   background-position: center;
   background-repeat: no-repeat;
@@ -259,7 +259,7 @@ input.field, input.text,
 
 // Bromley's footer
 .site-footer {
-  @include svg-background-image("images/footer-blue-bg");
+  @include svg-background-image("/cobrands/bromley/images/footer-blue-bg");
   background-repeat: no-repeat;
   background-position: bottom right;
   background-color: #f5f3ed;

--- a/web/cobrands/bromley/layout.scss
+++ b/web/cobrands/bromley/layout.scss
@@ -19,7 +19,7 @@ body.fullwidthpage, body.twothirdswidthpage, body.authpage, body.waste {
     width: 157px;
     height: 0;
 
-    @include svg-background-image("images/site-logo");
+    @include svg-background-image("/cobrands/bromley/images/site-logo");
     background-size: 157px $logo-height-desktop;
     background-position: center;
     background-repeat: no-repeat;
@@ -147,7 +147,7 @@ body.fullwidthpage, body.twothirdswidthpage, body.authpage, body.waste {
 
   .bromley-bubble {
     position: absolute;
-    @include svg-background-image("images/curve-top");
+    @include svg-background-image("/cobrands/bromley/images/curve-top");
     background-position: bottom 0 right 0;
     background-size: contain;
     background-repeat: no-repeat;

--- a/web/cobrands/buckinghamshire/base.scss
+++ b/web/cobrands/buckinghamshire/base.scss
@@ -40,7 +40,7 @@ h4 {
 // Put the logo in place, and reveal the text alongside it
 #site-logo {
   @extend %normal-font;
-  @include svg-background-image("img/bucks-logo");
+  @include svg-background-image("/cobrands/buckinghamshire/img/bucks-logo");
   background-position: 0 50%;
   background-repeat: no-repeat;
   background-size: 178px 45px;

--- a/web/cobrands/centralbedfordshire/base.scss
+++ b/web/cobrands/centralbedfordshire/base.scss
@@ -24,8 +24,8 @@
     width: 72px;
     height: 0;
     margin: 0.25em auto 0 auto;
-    background: $central-beds-green url(images/central-beds-logo.png) 50% 50% no-repeat;
-    background-image: url(images/central-beds-logo.svg), none;
+    background: $central-beds-green url(/cobrands/centralbedfordshire/images/central-beds-logo.png) 50% 50% no-repeat;
+    background-image: url(/cobrands/centralbedfordshire/images/central-beds-logo.svg), none;
     background-size: cover;
     border-radius: 50%;
 }

--- a/web/cobrands/fiksgatami/base.scss
+++ b/web/cobrands/fiksgatami/base.scss
@@ -5,7 +5,7 @@
 @import "../sass/base";
 
 #site-logo {
-    background: transparent url('images/site-logo.png') 0 50% no-repeat;
+    background: transparent url('/cobrands/fiksgatami/images/site-logo.png') 0 50% no-repeat;
 }
 
 .nav-menu--mysoc {

--- a/web/cobrands/fiksgatami/layout.scss
+++ b/web/cobrands/fiksgatami/layout.scss
@@ -41,6 +41,6 @@ body.frontpage {
     margin: 2em 0;
     width: 300px;
     height: 60px;
-    background: transparent url('images/homepage-logo.png') 0 50% no-repeat;
+    background: transparent url('/cobrands/fiksgatami/images/homepage-logo.png') 0 50% no-repeat;
   }
 }

--- a/web/cobrands/fixamingata/_colours.scss
+++ b/web/cobrands/fixamingata/_colours.scss
@@ -8,7 +8,7 @@ $primary_text: #222;
 $primary_link_color: $primary_text;
 $primary_link_hover_color: rgba($primary_text, 0.8);
 
-$base_bg: #eee url(images/tile.jpg) 0 0 repeat;
+$base_bg: #eee url(/cobrands/fixamingata/images/tile.jpg) 0 0 repeat;
 $base_fg: $primary_text;
 
 $nav_background_colour: unset;

--- a/web/cobrands/fixamingata/base.scss
+++ b/web/cobrands/fixamingata/base.scss
@@ -82,7 +82,7 @@ $mysoc-footer-donate-button-text-color: rgb(34, 34, 34);
 
 $mysoc-footer-legal-text-color: rgb(68, 68, 68);
 
-$mysoc-footer-image-path: 'images/mysoc-footer/';
+$mysoc-footer-image-path: '/cobrands/fixamingata/images/mysoc-footer/';
 $mysoc-footer-breakpoint-sm: 48em;
 
 $grid-max-width: 60em;

--- a/web/cobrands/fixamingata/layout.scss
+++ b/web/cobrands/fixamingata/layout.scss
@@ -1,54 +1,54 @@
 @font-face {
   font-family: 'MuseoSans';
-  src: url('../fixmystreet.com/fonts/MuseoSans_300-webfont.eot');
-  src: url('../fixmystreet.com/fonts/MuseoSans_300-webfont.eot?#iefix') format('embedded-opentype'),
-       url('../fixmystreet.com/fonts/MuseoSans_300-webfont.woff') format('woff'),
-       url('../fixmystreet.com/fonts/MuseoSans_300-webfont.ttf') format('truetype'),
-       url('../fixmystreet.com/fonts/MuseoSans_300-webfont.svg#MuseoSans300') format('svg');
+  src: url('/cobrands/fixmystreet.com/fonts/MuseoSans_300-webfont.eot');
+  src: url('/cobrands/fixmystreet.com/fonts/MuseoSans_300-webfont.eot?#iefix') format('embedded-opentype'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_300-webfont.woff') format('woff'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_300-webfont.ttf') format('truetype'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_300-webfont.svg#MuseoSans300') format('svg');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'MuseoSans';
-  src: url('../fixmystreet.com/fonts/MuseoSans_300_Italic-webfont.eot');
-  src: url('../fixmystreet.com/fonts/MuseoSans_300_Italic-webfont.eot?#iefix') format('embedded-opentype'),
-       url('../fixmystreet.com/fonts/MuseoSans_300_Italic-webfont.woff') format('woff'),
-       url('../fixmystreet.com/fonts/MuseoSans_300_Italic-webfont.ttf') format('truetype'),
-       url('../fixmystreet.com/fonts/MuseoSans_300_Italic-webfont.svg#MuseoSans300Italic') format('svg');
+  src: url('/cobrands/fixmystreet.com/fonts/MuseoSans_300_Italic-webfont.eot');
+  src: url('/cobrands/fixmystreet.com/fonts/MuseoSans_300_Italic-webfont.eot?#iefix') format('embedded-opentype'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_300_Italic-webfont.woff') format('woff'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_300_Italic-webfont.ttf') format('truetype'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_300_Italic-webfont.svg#MuseoSans300Italic') format('svg');
   font-weight: normal;
   font-style: italic;
 }
 
 @font-face {
   font-family: 'MuseoSans';
-  src: url('../fixmystreet.com/fonts/MuseoSans_500-webfont.eot');
-  src: url('../fixmystreet.com/fonts/MuseoSans_500-webfont.eot?#iefix') format('embedded-opentype'),
-       url('../fixmystreet.com/fonts/MuseoSans_500-webfont.woff') format('woff'),
-       url('../fixmystreet.com/fonts/MuseoSans_500-webfont.ttf') format('truetype'),
-       url('../fixmystreet.com/fonts/MuseoSans_500-webfont.svg#MuseoSans500') format('svg');
+  src: url('/cobrands/fixmystreet.com/fonts/MuseoSans_500-webfont.eot');
+  src: url('/cobrands/fixmystreet.com/fonts/MuseoSans_500-webfont.eot?#iefix') format('embedded-opentype'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_500-webfont.woff') format('woff'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_500-webfont.ttf') format('truetype'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_500-webfont.svg#MuseoSans500') format('svg');
   font-weight: bold;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'MuseoSans';
-  src: url('../fixmystreet.com/fonts/MuseoSans_500_Italic-webfont.eot');
-  src: url('../fixmystreet.com/fonts/MuseoSans_500_Italic-webfont.eot?#iefix') format('embedded-opentype'),
-       url('../fixmystreet.com/fonts/MuseoSans_500_Italic-webfont.woff') format('woff'),
-       url('../fixmystreet.com/fonts/MuseoSans_500_Italic-webfont.ttf') format('truetype'),
-       url('../fixmystreet.com/fonts/MuseoSans_500_Italic-webfont.svg#MuseoSans500Italic') format('svg');
+  src: url('/cobrands/fixmystreet.com/fonts/MuseoSans_500_Italic-webfont.eot');
+  src: url('/cobrands/fixmystreet.com/fonts/MuseoSans_500_Italic-webfont.eot?#iefix') format('embedded-opentype'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_500_Italic-webfont.woff') format('woff'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_500_Italic-webfont.ttf') format('truetype'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_500_Italic-webfont.svg#MuseoSans500Italic') format('svg');
   font-weight: bold;
   font-style: italic;
 }
 
 @font-face {
   font-family: 'Museo300-display';
-  src: url('../fixmystreet.com/fonts/Museo300-Regular-webfont.eot');
-  src: url('../fixmystreet.com/fonts/Museo300-Regular-webfont.eot?#iefix') format('embedded-opentype'),
-       url('../fixmystreet.com/fonts/Museo300-Regular-webfont.woff') format('woff'),
-       url('../fixmystreet.com/fonts/Museo300-Regular-webfont.ttf') format('truetype'),
-       url('../fixmystreet.com/fonts/Museo300-Regular-webfont.svg#Museo300') format('svg');
+  src: url('/cobrands/fixmystreet.com/fonts/Museo300-Regular-webfont.eot');
+  src: url('/cobrands/fixmystreet.com/fonts/Museo300-Regular-webfont.eot?#iefix') format('embedded-opentype'),
+       url('/cobrands/fixmystreet.com/fonts/Museo300-Regular-webfont.woff') format('woff'),
+       url('/cobrands/fixmystreet.com/fonts/Museo300-Regular-webfont.ttf') format('truetype'),
+       url('/cobrands/fixmystreet.com/fonts/Museo300-Regular-webfont.svg#Museo300') format('svg');
   font-weight: normal;
   font-style: normal;
 }

--- a/web/cobrands/fixmystreet.com/_colours.scss
+++ b/web/cobrands/fixmystreet.com/_colours.scss
@@ -7,7 +7,7 @@ $primary_link_color: $primary_text;
 $primary_link_hover_color: rgba($primary_text, 0.8);
 
 // Tiled main body background
-$base_bg: #272727 url(images/tile.jpg) 0 0 repeat;
+$base_bg: #272727 url(/cobrands/fixmystreet.com/images/tile.jpg) 0 0 repeat;
 $base_fg: #fff;
 
 $nav_background_colour: #222;

--- a/web/cobrands/fixmystreet.com/base.scss
+++ b/web/cobrands/fixmystreet.com/base.scss
@@ -278,7 +278,7 @@ $mysoc-footer-donate-button-text-color: #000;
 
 $mysoc-footer-legal-text-color: #9a9a9a;
 
-$mysoc-footer-image-path: 'images/mysoc-footer/';
+$mysoc-footer-image-path: '/cobrands/fixmystreet.com/images/mysoc-footer/';
 $mysoc-footer-breakpoint-sm: 48em;
 
 $grid-max-width: 60em;

--- a/web/cobrands/fixmystreet.com/layout.scss
+++ b/web/cobrands/fixmystreet.com/layout.scss
@@ -1,54 +1,54 @@
 @font-face {
   font-family: 'MuseoSans';
-  src: url('fonts/MuseoSans_300-webfont.eot');
-  src: url('fonts/MuseoSans_300-webfont.eot?#iefix') format('embedded-opentype'),
-       url('fonts/MuseoSans_300-webfont.woff') format('woff'),
-       url('fonts/MuseoSans_300-webfont.ttf') format('truetype'),
-       url('fonts/MuseoSans_300-webfont.svg#MuseoSans300') format('svg');
+  src: url('/cobrands/fixmystreet.com/fonts/MuseoSans_300-webfont.eot');
+  src: url('/cobrands/fixmystreet.com/fonts/MuseoSans_300-webfont.eot?#iefix') format('embedded-opentype'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_300-webfont.woff') format('woff'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_300-webfont.ttf') format('truetype'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_300-webfont.svg#MuseoSans300') format('svg');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'MuseoSans';
-  src: url('fonts/MuseoSans_300_Italic-webfont.eot');
-  src: url('fonts/MuseoSans_300_Italic-webfont.eot?#iefix') format('embedded-opentype'),
-       url('fonts/MuseoSans_300_Italic-webfont.woff') format('woff'),
-       url('fonts/MuseoSans_300_Italic-webfont.ttf') format('truetype'),
-       url('fonts/MuseoSans_300_Italic-webfont.svg#MuseoSans300Italic') format('svg');
+  src: url('/cobrands/fixmystreet.com/fonts/MuseoSans_300_Italic-webfont.eot');
+  src: url('/cobrands/fixmystreet.com/fonts/MuseoSans_300_Italic-webfont.eot?#iefix') format('embedded-opentype'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_300_Italic-webfont.woff') format('woff'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_300_Italic-webfont.ttf') format('truetype'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_300_Italic-webfont.svg#MuseoSans300Italic') format('svg');
   font-weight: normal;
   font-style: italic;
 }
 
 @font-face {
   font-family: 'MuseoSans';
-  src: url('fonts/MuseoSans_500-webfont.eot');
-  src: url('fonts/MuseoSans_500-webfont.eot?#iefix') format('embedded-opentype'),
-       url('fonts/MuseoSans_500-webfont.woff') format('woff'),
-       url('fonts/MuseoSans_500-webfont.ttf') format('truetype'),
-       url('fonts/MuseoSans_500-webfont.svg#MuseoSans500') format('svg');
+  src: url('/cobrands/fixmystreet.com/fonts/MuseoSans_500-webfont.eot');
+  src: url('/cobrands/fixmystreet.com/fonts/MuseoSans_500-webfont.eot?#iefix') format('embedded-opentype'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_500-webfont.woff') format('woff'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_500-webfont.ttf') format('truetype'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_500-webfont.svg#MuseoSans500') format('svg');
   font-weight: bold;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'MuseoSans';
-  src: url('fonts/MuseoSans_500_Italic-webfont.eot');
-  src: url('fonts/MuseoSans_500_Italic-webfont.eot?#iefix') format('embedded-opentype'),
-       url('fonts/MuseoSans_500_Italic-webfont.woff') format('woff'),
-       url('fonts/MuseoSans_500_Italic-webfont.ttf') format('truetype'),
-       url('fonts/MuseoSans_500_Italic-webfont.svg#MuseoSans500Italic') format('svg');
+  src: url('/cobrands/fixmystreet.com/fonts/MuseoSans_500_Italic-webfont.eot');
+  src: url('/cobrands/fixmystreet.com/fonts/MuseoSans_500_Italic-webfont.eot?#iefix') format('embedded-opentype'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_500_Italic-webfont.woff') format('woff'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_500_Italic-webfont.ttf') format('truetype'),
+       url('/cobrands/fixmystreet.com/fonts/MuseoSans_500_Italic-webfont.svg#MuseoSans500Italic') format('svg');
   font-weight: bold;
   font-style: italic;
 }
 
 @font-face {
   font-family: 'Museo300-display';
-  src: url('fonts/Museo300-Regular-webfont.eot');
-  src: url('fonts/Museo300-Regular-webfont.eot?#iefix') format('embedded-opentype'),
-       url('fonts/Museo300-Regular-webfont.woff') format('woff'),
-       url('fonts/Museo300-Regular-webfont.ttf') format('truetype'),
-       url('fonts/Museo300-Regular-webfont.svg#Museo300') format('svg');
+  src: url('/cobrands/fixmystreet.com/fonts/Museo300-Regular-webfont.eot');
+  src: url('/cobrands/fixmystreet.com/fonts/Museo300-Regular-webfont.eot?#iefix') format('embedded-opentype'),
+       url('/cobrands/fixmystreet.com/fonts/Museo300-Regular-webfont.woff') format('woff'),
+       url('/cobrands/fixmystreet.com/fonts/Museo300-Regular-webfont.ttf') format('truetype'),
+       url('/cobrands/fixmystreet.com/fonts/Museo300-Regular-webfont.svg#Museo300') format('svg');
   font-weight: normal;
   font-style: normal;
 }
@@ -71,7 +71,7 @@ h3, h4,
 
 body {
     @media ($high-dpi-screen) {
-        background-image: url(images/tile@2x.jpg);
+        background-image: url(/cobrands/fixmystreet.com/images/tile@2x.jpg);
         background-size: 500px;
     }
 }
@@ -81,10 +81,10 @@ body.mappage {
 
 // Tiled background stripe, not plain colour
 #front-main {
-    background: $primary url(images/tile-y.jpg);
+    background: $primary url(/cobrands/fixmystreet.com/images/tile-y.jpg);
 
     @media ($high-dpi-screen) {
-        background-image: url(images/tile-y@2x.jpg);
+        background-image: url(/cobrands/fixmystreet.com/images/tile-y@2x.jpg);
         background-size: 500px;
     }
 }
@@ -100,12 +100,12 @@ body.mappage {
 
 #site-header {
     background: none;
-    border-image-source: url(images/tile-y.jpg);
+    border-image-source: url(/cobrands/fixmystreet.com/images/tile-y.jpg);
     border-image-slice: 4 0 0 0;
     border-image-repeat: repeat;
 
     @media ($high-dpi-screen) {
-        border-image-source: url(images/tile-y@2x.jpg);
+        border-image-source: url(/cobrands/fixmystreet.com/images/tile-y@2x.jpg);
         border-image-slice: 8 0 0 0;
     }
 }
@@ -309,12 +309,12 @@ body.unresponsive-council {
     margin: 1.5em 0;
     max-width: 20em;
     padding-#{$right}: 6em;
-    background-image: url(images/unresponsive-council-cta-arrow.png);
+    background-image: url(/cobrands/fixmystreet.com/images/unresponsive-council-cta-arrow.png);
     background-position: $right center;
     background-repeat: no-repeat;
 
     @media ($high-dpi-screen) {
-        background-image: url(images/unresponsive-council-cta-arrow@2.png);
+        background-image: url(/cobrands/fixmystreet.com/images/unresponsive-council-cta-arrow@2.png);
         background-size: 60px;
     }
 }
@@ -337,7 +337,7 @@ footer {
   padding: 1em 0;
 
   @media ($high-dpi-screen) {
-    background-image: url(images/tile@2x.jpg);
+    background-image: url(/cobrands/fixmystreet.com/images/tile@2x.jpg);
     background-size: 500px;
   }
 }
@@ -377,10 +377,10 @@ footer {
 
 .fms-pro-promo__pro {
     width: 40%;
-    background: $primary url(images/tile-y.jpg) 0 0 repeat;
+    background: $primary url(/cobrands/fixmystreet.com/images/tile-y.jpg) 0 0 repeat;
 
     @media ($high-dpi-screen) {
-        background-image: url(images/tile-y@2x.jpg);
+        background-image: url(/cobrands/fixmystreet.com/images/tile-y@2x.jpg);
         background-size: 500px;
     }
 }

--- a/web/cobrands/fixmystreet.com/posters.scss
+++ b/web/cobrands/fixmystreet.com/posters.scss
@@ -43,7 +43,7 @@ body.goodies {
       display: inline-block;
       width: 16px;
       height: 16px;
-      background: transparent url(images/arrow-down-16px-16px.png) 0 0 no-repeat;
+      background: transparent url(/cobrands/fixmystreet.com/images/arrow-down-16px-16px.png) 0 0 no-repeat;
       margin-#{$right}: 0.5em;
       vertical-align: -0.1em;
     }

--- a/web/cobrands/hackney/base.scss
+++ b/web/cobrands/hackney/base.scss
@@ -16,7 +16,7 @@
 }
 
 #site-logo {
-    background: transparent url('images/hackney-logo-white.png') 0 50% no-repeat;
+    background: transparent url('/cobrands/hackney/images/hackney-logo-white.png') 0 50% no-repeat;
     background-size: 200px 36px;
     width: 200px;
     &:focus {
@@ -64,12 +64,12 @@
                 padding-left: 50px;
                 overflow: hidden;
                 @include flex(0 0 auto);
-                background: $black url('hackney-search-icon.png') no-repeat 50% 50%;
+                background: $black url('/cobrands/hackney/hackney-search-icon.png') no-repeat 50% 50%;
                 background-size: 25px 25px;
                 color: $black;
                 &:hover,
                 &:focus {
-                    background: $dark-green url('hackney-search-icon.png') no-repeat 50% 50%;
+                    background: $dark-green url('/cobrands/hackney/hackney-search-icon.png') no-repeat 50% 50%;
                     background-size: 25px 25px;
                     color: $dark_green;
                 }
@@ -92,7 +92,7 @@
 }
 
 .hackney-footer__logo {
-  background: transparent url('images/hackney-logo-white.png') 0 50% no-repeat;
+  background: transparent url('/cobrands/hackney/images/hackney-logo-white.png') 0 50% no-repeat;
   background-size: 200px 36px;
   width: 200px;
   height: 54px;

--- a/web/cobrands/hackney/layout.scss
+++ b/web/cobrands/hackney/layout.scss
@@ -48,7 +48,7 @@ body.frontpage {
     margin: 0.5em 0 0.5em;
     width: 200px;
     height: 54px;
-    background: transparent url('images/hackney-logo-white.png') 0 50% no-repeat;
+    background: transparent url('/cobrands/hackney/images/hackney-logo-white.png') 0 50% no-repeat;
     background-size: 200px 36px;
   }
 }

--- a/web/cobrands/highwaysengland/base.scss
+++ b/web/cobrands/highwaysengland/base.scss
@@ -167,7 +167,7 @@ p.form-error {
 }
 
 .hero-bg {
-    background-image: url(images/maintenance-hero.jpg);
+    background-image: url(/cobrands/highwaysengland/images/maintenance-hero.jpg);
     background-repeat: repeat;
     background-size: cover;
     background-position: center;

--- a/web/cobrands/merton/base.scss
+++ b/web/cobrands/merton/base.scss
@@ -134,7 +134,7 @@ a.skiplink:focus {
     padding-top: 70px;
     width: 116px;
     height: 0;
-    background: $merton-lavender-l2 url(images/merton-logo.png) center center no-repeat;
+    background: $merton-lavender-l2 url(/cobrands/merton/images/merton-logo.png) center center no-repeat;
     background-size: contain;
 }
 

--- a/web/cobrands/oxfordshire/base.scss
+++ b/web/cobrands/oxfordshire/base.scss
@@ -43,7 +43,7 @@ a:not([class]):focus {
 }
 
 #site-logo {
-    @include svg-background-image("images/site-logo-mobile");
+    @include svg-background-image("/cobrands/oxfordshire/images/site-logo-mobile");
     background-color: $nav_background_colour;
     background-size: 175px 38px;
     background-repeat: no-repeat;

--- a/web/cobrands/oxfordshire/layout.scss
+++ b/web/cobrands/oxfordshire/layout.scss
@@ -170,7 +170,7 @@ body.twothirdswidthpage {
                 li { // from occ website
                   padding-left: 19px;
                   font: 0.813em "Trebuchet MS";
-                  background: url("images/dot6x6.jpg") no-repeat 0 5px;
+                  background: url("/cobrands/oxfordshire/images/dot6x6.jpg") no-repeat 0 5px;
                 }
             }
         }
@@ -283,7 +283,7 @@ h2.static-with-rule {
 
     p {
         color: $color-oxfordshire-bright-green;
-        background-image: url(images/click-map-chevron-small.gif);
+        background-image: url(/cobrands/oxfordshire/images/click-map-chevron-small.gif);
     }
 }
 

--- a/web/cobrands/sass/_admin.scss
+++ b/web/cobrands/sass/_admin.scss
@@ -84,7 +84,7 @@ $button_bg_col: #a1a1a1;  // also search bar (tables)
 .admin-offsite-link {
     display: inline;
     padding-#{$right}: 12px;
-    background-image: url(../../i/external-link.png);
+    background-image: url(/i/external-link.png);
     background-position: $right top;
     background-repeat: no-repeat;
 }

--- a/web/cobrands/shropshire/_cookies.scss
+++ b/web/cobrands/shropshire/_cookies.scss
@@ -64,7 +64,7 @@ div.cookie-jar:before {
     /*left: -64px;*/
     width: 48px;
     height: 48px;
-    background-image: url(cookie-icon.png);
+    background-image: url(/cobrands/shropshire/cookie-icon.png);
 }
 div.cookie-jar p {
     width: 88%;
@@ -87,7 +87,7 @@ div.cookie-dismiss {
 @media (min-width:50.063em){
 
 .cookie-warning{
-    background-image: url(cookie-icon.png);
+    background-image: url(/cobrands/shropshire/cookie-icon.png);
     background-repeat:no-repeat;
     background-position: 2.5em center;
 }

--- a/web/cobrands/shropshire/base.scss
+++ b/web/cobrands/shropshire/base.scss
@@ -41,7 +41,7 @@ a:focus,
     width:  $logo-width;
     // height: 61px; // see below
     background-size:  $logo-width  $logo-height;
-    @include svg-background-image("images/sc-logo-v3");
+    @include svg-background-image("/cobrands/shropshire/images/sc-logo-v3");
 
     // text-indent doesn’t play nicely with focus outline,
     // so use padding overflow trick instead

--- a/web/cobrands/shropshire/layout.scss
+++ b/web/cobrands/shropshire/layout.scss
@@ -74,7 +74,7 @@ body {
     width: 240px;
     // height: 61px; // see below
     background-size: 240px 74px;
-    @include svg-background-image("images/sc-logo-swoosh-v1_257x80");
+    @include svg-background-image("/cobrands/shropshire/images/sc-logo-swoosh-v1_257x80");
 
     // text-indent doesn’t play nicely with focus outline,
     // so use padding overflow trick instead
@@ -89,7 +89,7 @@ body {
         width:  $logo-width;
         // height: 61px; // see below
         background-size:  $logo-width  $logo-height;
-        @include svg-background-image("images/sc-logo-v3");
+        @include svg-background-image("/cobrands/shropshire/images/sc-logo-v3");
     
         // text-indent doesn’t play nicely with focus outline,
         // so use padding overflow trick instead

--- a/web/cobrands/sutton/base.scss
+++ b/web/cobrands/sutton/base.scss
@@ -1,6 +1,6 @@
 @font-face {
     font-family: "proxima-nova";
-    src: url("fonts/proximanova-semibold-webfont.woff2") format("woff2"), url("fonts/proximanova-semibold-webfont.woff") format("woff");
+    src: url("/cobrands/sutton/fonts/proximanova-semibold-webfont.woff2") format("woff2"), url("/cobrands/sutton/fonts/proximanova-semibold-webfont.woff") format("woff");
     font-display: auto;
     font-style: normal;
     font-weight:700
@@ -8,7 +8,7 @@
 
 @font-face {
     font-family: "proxima-nova";
-    src: url("fonts/proximanova-bold-webfont.woff2") format("woff2"), url("fonts/proximanova-bold-webfont.woff") format("woff");
+    src: url("/cobrands/sutton/fonts/proximanova-bold-webfont.woff2") format("woff2"), url("/cobrands/sutton/fonts/proximanova-bold-webfont.woff") format("woff");
     font-display: auto;
     font-style: normal;
     font-weight:900
@@ -16,7 +16,7 @@
 
 @font-face {
     font-family: "proxima-nova";
-    src: url("fonts/proximanova-regular-webfont.woff2") format("woff2"), url("fonts/proximanova-regular-webfont.woff") format("woff");
+    src: url("/cobrands/sutton/fonts/proximanova-regular-webfont.woff2") format("woff2"), url("/cobrands/sutton/fonts/proximanova-regular-webfont.woff") format("woff");
     font-display: auto;
     font-style: normal;
     font-weight:400
@@ -24,7 +24,7 @@
 
 @font-face {
     font-family: "proxima-nova";
-    src: url("fonts/proximanova-light-webfont.woff2") format("woff2"), url("fonts/proximanova-light-webfont.woff") format("woff");
+    src: url("/cobrands/sutton/fonts/proximanova-light-webfont.woff2") format("woff2"), url("/cobrands/sutton/fonts/proximanova-light-webfont.woff") format("woff");
     font-display: auto;
     font-style: normal;
     font-weight:300
@@ -122,7 +122,7 @@ a,
     height: $mappage-header-height;
     // Using line-height to vertically align the logo
     line-height: $mappage-header-height;
-    background-image: url('images/sutton-logo.png');
+    background-image: url('/cobrands/sutton/images/sutton-logo.png');
     background-size: contain;
 
     .mappage & {

--- a/web/cobrands/tfl/base.scss
+++ b/web/cobrands/tfl/base.scss
@@ -1,21 +1,21 @@
 @font-face {
     font-family: 'Johnston100-Light';
-    src: url("fonts/Johnston100-Light.woff2") format("woff2"),url("fonts/Johnston100-Light.woff") format("woff")
+    src: url("/cobrands/tfl/fonts/Johnston100-Light.woff2") format("woff2"),url("/cobrands/tfl/fonts/Johnston100-Light.woff") format("woff")
 }
 
 @font-face {
     font-family: 'Johnston100-Medium';
-    src: url("fonts/Johnston100-Medium.woff2") format("woff2"),url("fonts/Johnston100-Medium.woff") format("woff")
+    src: url("/cobrands/tfl/fonts/Johnston100-Medium.woff2") format("woff2"),url("/cobrands/tfl/fonts/Johnston100-Medium.woff") format("woff")
 }
 
 @font-face {
     font-family: 'Johnston100-Regular';
-    src: url("fonts/Johnston100-Regular.woff2") format("woff2"),url("fonts/Johnston100-Regular.woff") format("woff")
+    src: url("/cobrands/tfl/fonts/Johnston100-Regular.woff2") format("woff2"),url("/cobrands/tfl/fonts/Johnston100-Regular.woff") format("woff")
 }
 
 @font-face {
     font-family: 'Johnston100-Bold';
-    src: url("fonts/Johnston100-Bold.woff2") format("woff2"),url("fonts/Johnston100-Bold.woff") format("woff")
+    src: url("/cobrands/tfl/fonts/Johnston100-Bold.woff2") format("woff2"),url("/cobrands/tfl/fonts/Johnston100-Bold.woff") format("woff")
 }
 
 @import "../sass/h5bp";

--- a/web/cobrands/thamesmead/_cookies.scss
+++ b/web/cobrands/thamesmead/_cookies.scss
@@ -63,7 +63,7 @@ div.cookie-jar:before {
     /*left: -64px;*/
     width: 48px;
     height: 48px;
-    background-image: url(cookie-icon.png);
+    background-image: url(/cobrands/thamesmead/cookie-icon.png);
 }
 div.cookie-jar p {
     width: 88%;
@@ -86,7 +86,7 @@ div.cookie-dismiss {
 @media (min-width:50.063em){
 
 .cookie-warning{
-    background-image: url(cookie-icon.png);
+    background-image: url(/cobrands/thamesmead/cookie-icon.png);
     background-repeat:no-repeat;
     background-position: 2.5em center;
 }

--- a/web/cobrands/thamesmead/_fonts.scss
+++ b/web/cobrands/thamesmead/_fonts.scss
@@ -2,12 +2,12 @@
     // Family Name
     font-family: 'AvantGardeGothicITCW02Dm';
     // IE9 Compatibility Mode
-    src: url('fonts/344B63_4_0.eot');
+    src: url('/cobrands/thamesmead/fonts/344B63_4_0.eot');
     // Various Browsers
-    src: url('fonts/344B63_4_0.eot?#iefix') format('embedded-opentype'),
-         url('fonts/344B63_4_0.woff2') format('woff2'),
-         url('fonts/344B63_4_0.woff') format('woff'),
-         url('fonts/344B63_4_0.ttf') format('truetype');
+    src: url('/cobrands/thamesmead/fonts/344B63_4_0.eot?#iefix') format('embedded-opentype'),
+         url('/cobrands/thamesmead/fonts/344B63_4_0.woff2') format('woff2'),
+         url('/cobrands/thamesmead/fonts/344B63_4_0.woff') format('woff'),
+         url('/cobrands/thamesmead/fonts/344B63_4_0.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
 }

--- a/web/cobrands/thamesmead/base.scss
+++ b/web/cobrands/thamesmead/base.scss
@@ -54,7 +54,7 @@ html.js-nav-open #nav-link {
     width: 144px;
     // height: 61px; // see below
     background-size: cover;
-    @include svg-background-image('images/peabody_logo');
+    @include svg-background-image('/cobrands/thamesmead/images/peabody_logo');
 
     // text-indent doesn’t play nicely with focus outline,
     // so use padding overflow trick instead

--- a/web/cobrands/zurich/_zurich.scss
+++ b/web/cobrands/zurich/_zurich.scss
@@ -5,7 +5,7 @@
     font-size: 67.5%;
     line-height: 1.5em;
     clear: both;
-    background-image: url(bg_mainnav_portal.png);
+    background-image: url(/cobrands/zurich/bg_mainnav_portal.png);
     background-repeat: repeat-x;
     border: 1px solid #d8d8d8;
     max-width: 953px;

--- a/web/cobrands/zurich/base.scss
+++ b/web/cobrands/zurich/base.scss
@@ -59,7 +59,7 @@
     display: none;
 }
 #site-logo {
-    background: url(logo.svg) no-repeat;
+    background: url(/cobrands/zurich/logo.svg) no-repeat;
     max-width: 100%;
     height: 40px;
     background-size: contain;
@@ -175,7 +175,7 @@ h2.static-with-rule {
         li.search-box {
             border:none;
             padding: 0.2em 0.5em 0.2em 30px;
-            background-image: url('search-icon.png');
+            background-image: url('/cobrands/zurich/search-icon.png');
             background-position: 2px center;
             background-repeat: no-repeat;
             input {

--- a/web/cobrands/zurich/layout.scss
+++ b/web/cobrands/zurich/layout.scss
@@ -102,9 +102,9 @@ body.frontpage {
     .table-cell {
         background-position: 50% 112px;
         background-repeat: no-repeat;
-        background-image: url(mapbg-1024.jpg);
+        background-image: url(/cobrands/zurich/mapbg-1024.jpg);
         @media all and (min-width: 1025px) {
-            background-image: url(mapbg-1600.jpg);
+            background-image: url(/cobrands/zurich/mapbg-1600.jpg);
         }
         .content {
             margin: 2em auto; // Spacing around front content on top of static map

--- a/web/vendor/OpenLayers/theme/default/style.css
+++ b/web/vendor/OpenLayers/theme/default/style.css
@@ -107,14 +107,14 @@ div.olControlMousePosition {
 
 .olControlOverviewMapExtentRectangle {
     overflow: hidden;
-    background-image: url("img/blank.gif");
+    background-image: url("/vendor/OpenLayers/theme/default/img/blank.gif");
     cursor: move;
     border: 2px dotted red;
 }
 .olControlOverviewMapRectReplacement {
     overflow: hidden;
     cursor: move;
-    background-image: url("img/overview_replacement.gif");
+    background-image: url("/vendor/OpenLayers/theme/default/img/overview_replacement.gif");
     background-repeat: no-repeat;
     background-position: center;
 }
@@ -142,7 +142,7 @@ div.olControlMousePosition {
 }
 
 .olControlNavigationHistory {
-   background-image: url("img/navigation_history.png");
+   background-image: url("/vendor/OpenLayers/theme/default/img/navigation_history.png");
    background-repeat: no-repeat;
    width:  24px;
    height: 24px;
@@ -162,12 +162,12 @@ div.olControlMousePosition {
 }
 
 div.olControlSaveFeaturesItemActive {
-    background-image: url(img/save_features_on.png);
+    background-image: url(/vendor/OpenLayers/theme/default/img/save_features_on.png);
     background-repeat: no-repeat;
     background-position: 0 1px;
 }
 div.olControlSaveFeaturesItemInactive {
-    background-image: url(img/save_features_off.png);
+    background-image: url(/vendor/OpenLayers/theme/default/img/save_features_off.png);
     background-repeat: no-repeat;
     background-position: 0 1px;
 }
@@ -195,7 +195,7 @@ div.olControlSaveFeaturesItemInactive {
 }
 
 .olControlPanPanel div {
-    background-image: url(img/pan-panel.png);
+    background-image: url(/vendor/OpenLayers/theme/default/img/pan-panel.png);
     height: 18px;
     width: 18px;
     cursor: pointer;
@@ -230,7 +230,7 @@ div.olControlSaveFeaturesItemInactive {
 }
 
 .olControlZoomPanel div {
-    background-image: url(img/zoom-panel.png);
+    background-image: url(/vendor/OpenLayers/theme/default/img/zoom-panel.png);
     position: absolute;
     height: 18px;
     width: 18px;
@@ -264,7 +264,7 @@ div.olControlSaveFeaturesItemInactive {
 }
 
 .olPopupCloseBox {
-  background: url("img/close.gif") no-repeat;
+  background: url("/vendor/OpenLayers/theme/default/img/close.gif") no-repeat;
   cursor: pointer;
 }
 
@@ -381,7 +381,7 @@ span.olGoogleAttribution.hybrid a, span.olGoogleAttribution.satellite a {
 }
 .olControlNavToolbar div,
 .olControlEditingToolbar div {
-    background-image: url("img/editing_tool_bar.png");
+    background-image: url("/vendor/OpenLayers/theme/default/img/editing_tool_bar.png");
     background-repeat: no-repeat;
     margin: 0 0 5px 5px;
     width: 24px;

--- a/web/vendor/fancybox/jquery.fancybox-1.3.4.css
+++ b/web/vendor/fancybox/jquery.fancybox-1.3.4.css
@@ -35,7 +35,7 @@
 	left: 0;
 	width: 40px;
 	height: 480px;
-	background-image: url('fancybox.png');
+	background-image: url('/vendor/fancybox/fancybox.png');
 }
 
 #fancybox-overlay {
@@ -99,7 +99,7 @@
 	right: -15px;
 	width: 30px;
 	height: 30px;
-	background: transparent url('fancybox.png') -40px 0px;
+	background: transparent url('/vendor/fancybox/fancybox.png') -40px 0px;
 	cursor: pointer;
 	z-index: 1103;
 	display: none;
@@ -137,7 +137,7 @@
 	width: 35%;
 	cursor: pointer;
 	outline: none;
-	background: transparent url('blank.gif');
+	background: transparent url('/vendor/fancybox/blank.gif');
 	z-index: 1102;
 	display: none;
 }
@@ -163,12 +163,12 @@
 }
 
 #fancybox-left-ico {
-	background-image: url('fancybox.png');
+	background-image: url('/vendor/fancybox/fancybox.png');
 	background-position: -40px -30px;
 }
 
 #fancybox-right-ico {
-	background-image: url('fancybox.png');
+	background-image: url('/vendor/fancybox/fancybox.png');
 	background-position: -40px -60px;
 }
 
@@ -199,13 +199,13 @@
 	top: -20px;
 	left: 0;
 	width: 100%;
-	background-image: url('fancybox-x.png');
+	background-image: url('/vendor/fancybox/fancybox-x.png');
 }
 
 #fancybox-bg-ne {
 	top: -20px;
 	right: -20px;
-	background-image: url('fancybox.png');
+	background-image: url('/vendor/fancybox/fancybox.png');
 	background-position: -40px -162px;
 }
 
@@ -213,14 +213,14 @@
 	top: 0;
 	right: -20px;
 	height: 100%;
-	background-image: url('fancybox-y.png');
+	background-image: url('/vendor/fancybox/fancybox-y.png');
 	background-position: -20px 0px;
 }
 
 #fancybox-bg-se {
 	bottom: -20px;
 	right: -20px;
-	background-image: url('fancybox.png');
+	background-image: url('/vendor/fancybox/fancybox.png');
 	background-position: -40px -182px; 
 }
 
@@ -228,14 +228,14 @@
 	bottom: -20px;
 	left: 0;
 	width: 100%;
-	background-image: url('fancybox-x.png');
+	background-image: url('/vendor/fancybox/fancybox-x.png');
 	background-position: 0px -20px;
 }
 
 #fancybox-bg-sw {
 	bottom: -20px;
 	left: -20px;
-	background-image: url('fancybox.png');
+	background-image: url('/vendor/fancybox/fancybox.png');
 	background-position: -40px -142px;
 }
 
@@ -243,13 +243,13 @@
 	top: 0;
 	left: -20px;
 	height: 100%;
-	background-image: url('fancybox-y.png');
+	background-image: url('/vendor/fancybox/fancybox-y.png');
 }
 
 #fancybox-bg-nw {
 	top: -20px;
 	left: -20px;
-	background-image: url('fancybox.png');
+	background-image: url('/vendor/fancybox/fancybox.png');
 	background-position: -40px -122px;
 }
 
@@ -282,7 +282,7 @@
 
 #fancybox-title-over {
 	padding: 10px;
-	background-image: url('fancy_title_over.png');
+	background-image: url('/vendor/fancybox/fancy_title_over.png');
 	display: block;
 }
 
@@ -306,7 +306,7 @@
 
 #fancybox-title-float-left {
 	padding: 0 0 0 15px;
-	background: url('fancybox.png') -40px -90px no-repeat;
+	background: url('/vendor/fancybox/fancybox.png') -40px -90px no-repeat;
 }
 
 #fancybox-title-float-main {
@@ -314,10 +314,10 @@
 	line-height: 29px;
 	font-weight: bold;
 	padding: 0 0 3px 0;
-	background: url('fancybox-x.png') 0px -40px;
+	background: url('/vendor/fancybox/fancybox-x.png') 0px -40px;
 }
 
 #fancybox-title-float-right {
 	padding: 0 0 0 15px;
-	background: url('fancybox.png') -55px -90px no-repeat;
+	background: url('/vendor/fancybox/fancybox.png') -55px -90px no-repeat;
 }


### PR DESCRIPTION
A query parameter works fine, and is easier to manage, until you get to the situation where you have your website on three application servers, which get deployed in sequence. After the first server is deployed, the HTML for a page could be served from the first server (with a new hash) but the file is then requested from the third server (with old content) and your load balancer then happily caches the old content with the new hash URL.

In a backwards-compatible manner, we set up a static folder (probably a symlink to a shared folder generated at the start of a deploy) that can contain files with the hash in their filename. If present, they will be used instead of the main file with a hash in the query string.

All the other changes bar the change to the server code are to make all CSS paths relative to the root, so that they work from either location.