### PR TITLE
[Zürich] Stop showing optional label on photo field when not optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
         - Add label to questionnaire textarea. #3944
         - Offline report drafting. #4290
         - Set width=device-width in viewport meta tag. #4384
+        - Fix photo field label not visually appearing as a label.
     - Bugfixes:
         - Add ID attributes to change password form inputs.
         - Fix link deactivation for privacy policy link on privacy policy page. #3704

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -331,6 +331,9 @@ sub by_category_ajax_data : Private {
         $body->{category_extra_json} = $c->forward('generate_category_extra_json');
         $body->{extra_hidden} = 1 if $c->stash->{category_extras_hidden}->{$category};
     }
+    if ( $c->cobrand->moniker eq 'zurich' ) {
+        $body->{category_photo_required} = $c->stash->{category_photo_required}->{$category};
+    }
 
     # councils_text.html must be rendered if it differs from the default output,
     # which currently means for unresponsive and non_public categories.
@@ -773,6 +776,8 @@ sub setup_categories_and_bodies : Private {
       (); # whether all of a category's fields are simple notices and not inputs
     my %non_public_categories =
       ();    # categories for which the reports are not public
+    my %category_photo_required =
+      (); # whether a category requires a photo to be uploaded.
     $c->stash->{unresponsive} = {};
 
     my @refused_bodies = grep { ($_->send_method || "") eq 'Refused' } values %bodies;
@@ -814,6 +819,8 @@ sub setup_categories_and_bodies : Private {
                 $category_extras_notices{$contact->category} = $all_notices;
             }
         }
+
+        $category_photo_required{$contact->category} = $contact->get_extra_metadata('photo_required') ? 1 : 0;
 
         $non_public_categories{ $contact->category } = 1 if $contact->non_public;
 
@@ -858,6 +865,7 @@ sub setup_categories_and_bodies : Private {
     $c->stash->{category_extras_hidden}  = \%category_extras_hidden;
     $c->stash->{category_extras_notices}  = \%category_extras_notices;
     $c->stash->{non_public_categories}  = \%non_public_categories;
+    $c->stash->{category_photo_required}  = \%category_photo_required;
     $c->stash->{extra_name_info} = $all_areas->{+COUNCIL_ID_BROMLEY} ? 1 : 0;
 
     # escape these so we can then split on , cleanly in the template.

--- a/templates/web/base/report/form/photo_upload.html
+++ b/templates/web/base/report/form/photo_upload.html
@@ -3,7 +3,7 @@
     <label id="photo-upload-label" for="form_photo">
         <span data-singular="[% loc('Photo') %]" data-plural="[% loc('Photos') %]">[% loc('Photo') %]</span>
         [% IF c.cobrand.moniker == 'zurich' %][% loc('(Defect &amp; location of defect)') %][% END %]
-        [% loc('(optional)') %]
+        <span class="js-hide-if-category-photo-required">[% loc('(optional)') %]</span>
     </label>
 
       [% IF field_errors.photo %]

--- a/templates/web/zurich/report/new/fill_in_details_form.html
+++ b/templates/web/zurich/report/new/fill_in_details_form.html
@@ -13,6 +13,8 @@
                 <p class='form-error'>[% field_errors.bodies %]</p>
             [% END %]
 
+            [% PROCESS "report/new/category_wrapper.html" %]
+
             [% PROCESS 'report/form/photo_upload.html' %]
             [% PROCESS 'report/new/after_photo.html' %]
 
@@ -21,8 +23,6 @@
                 <p class='form-error'>[% field_errors.detail %]</p>
             [% END %]
             <textarea class="form-control" rows="7" cols="26" name="detail" id="form_detail" required>[% report.detail | html %]</textarea>
-
-            [% PROCESS "report/new/category_wrapper.html" %]
 
                 <label for="form_username_register">[% loc('Your email') %]</label>
                 [% IF field_errors.username_register %]

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -910,7 +910,7 @@ $.extend(fixmystreet.set_up, {
     // proper aria-label to improve accessibility.
     function replace_label(id, sibling_class, sibling_child, str) {
         $(id).siblings(sibling_class).children(sibling_child).attr('aria-label', str);
-        $(id).addClass('hidden-js').after(function(){ return $('<span>' + this.innerHTML + '</span>'); });
+        $(id).addClass('hidden-js').after(function(){ return $('<span class="label">' + this.innerHTML + '</span>'); });
     }
     replace_label('#photo-upload-label','.dropzone.dz-clickable', '.dz-default.dz-message', translation_strings.upload_aria_label);
   },

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -609,6 +609,11 @@ $.extend(fixmystreet.set_up, {
             $(".js-hide-if-public-category").hide();
             $('#form_non_public').prop('checked', false).prop('disabled', false);
         }
+        if (data.category_photo_required) {
+            $(".js-hide-if-category-photo-required").addClass('hidden-js');
+        } else {
+            $(".js-hide-if-category-photo-required").removeClass('hidden-js');
+        }
         if (data.allow_anonymous) {
             $('.js-show-if-anonymous').removeClass('hidden-js');
             $('.js-reporting-page--include-if-anonymous').removeClass('js-reporting-page--skip');


### PR DESCRIPTION
fixes https://github.com/mysociety/societyworks/issues/3072

Additionally:
* Move category selection before photo upload for Zurich so the label is changed before the reporter is prompted.
* Make the photo field label visually appear as a label. Currently this appears as normal text which looks especially weird for Zürich after the above change. This applies to all cobrands.

I have skipped setting up a cypress test as it was taking me too long.

# Demo

Setup: category 'Graffiti' requires a photo, the others don't.

## Before changes

<img width="311" alt="Zurich Before" src="https://user-images.githubusercontent.com/9289297/235450659-6b9f9662-ab1d-41ab-ad8f-18418c6a42a1.png">

## After

https://user-images.githubusercontent.com/9289297/235450684-cf0452c6-bb82-47aa-a3f0-1ea3bd0ca46b.mov

