### PR TITLE
[Northumberland] Add contact-by-phone information to FAQ

### DIFF
--- a/templates/web/northumberland/about/faq-en-gb.html
+++ b/templates/web/northumberland/about/faq-en-gb.html
@@ -1,0 +1,271 @@
+[% INCLUDE 'header.html', title = loc('Frequently Asked Questions'), bodyclass = 'twothirdswidthpage' %]
+
+[% INCLUDE 'about/_sidebar.html' %]
+
+<h1>Frequently Asked Questions</h1>
+
+<dl>
+
+<dt>What sort of issues can I report?</dt>
+<dd>
+<p>This site is for reporting things which are <strong>broken, dirty,
+damaged</strong> or <strong>dumped</strong>, and need <strong>fixing,
+cleaning</strong> or <strong>clearing</strong>.
+</dd>
+
+<dt>Which issues shouldn't I report?</dt>
+
+<dd>
+<p>Please don’t use this site to inform us of:</p>
+
+<ul>
+    <li>Urgent and emergency problems</li>
+    <li>Complaints about people, including anti-social behaviour</li>
+    <li>Issues with council services, such as bins and recycling</li>
+    <li>Proposals for change, eg to road layouts</li>
+    <li>Complaints about [% c.cobrand.council_name %]</li>
+</ul>
+
+<p>
+    For these types of issue, please
+    [%~ IF c.cobrand.feature('contact_us_url') %]
+     <a href="[% c.cobrand.feature('contact_us_url') %]">contact us</a>
+    [%~ ELSE %]
+    contact us
+    [%~ END %]
+    through the appropriate channel.
+</p>
+
+<p><b>Contact us by phone</b></p>
+
+<p>You can call us on 0345 600 6400:</p>
+
+<ul>
+    <li>Monday to Thursday 08:30 - 17:00</li>
+    <li>Friday 08:30 - 16:30</li>
+</ul>
+
+<p><b>PLEASE NOTE</b>: Calls outside of the hours above are for <b>emergency cases only</b> and will be answered by Northumberland Fire & Rescue Service.</p>
+
+<b>Customers with speech or hearing difficulties</b>
+
+<p>If you have speech or hearing difficulties you can use Relay UK to contact us by dialling 018001 01670 623515. <a href="https://www.relayuk.bt.com/">Find more information about Relay UK</a>.</p>
+
+<p>
+    If you use this site to report issues it wasn’t designed for, there may be
+    a delay in your report getting to the right department.
+</p>
+
+<p>
+    Also: remember that all reports are published online, so it’s not a good
+    idea to use it for any issue that requires the inclusion of people’s
+    personal information, like names, addresses, photos of people, or car
+    number plates.
+</p>
+</dd>
+
+<dt>Where do my reports go?</dt>
+
+<dd>
+<p>
+    This site is an official street fault reporting system for
+    [% c.cobrand.council_name %].
+</p>
+
+<p>
+    Your report will go directly to the department responsible for getting it
+    fixed, or, if it’s not our responsibility, will be routed to the relevant
+    body. Reports are also published online for others to see.
+</p>
+
+<p>
+    The system is provided by SocietyWorks, and operates in tandem with their
+    nationwide site <a href="https://www.fixmystreet.com/">FixMyStreet.com</a>
+    — so reports made on FixMyStreet.com will also be shown here, and vice
+    versa.
+</p>
+</dd>
+
+<dt>How do I use this site?</dt>
+
+<dd>
+<p>
+    Begin by entering the location of your issue <a href="/">on the front
+    page</a>. You can use the name of a street, area, a place or a postcode —
+    or you can click “use my location” which will automatically detect where
+    you are.
+</p>
+<p>
+    You’ll be taken to a map centred on that location, where you can view
+    reports already made in that area. If someone has already reported your
+    issue, there’s no need to report it again: click ‘get updates’ at the
+    bottom of the report to be kept informed on progress.
+</p>
+<p>
+    If you don’t see the issue you’ve come to report, start a new one by
+    clicking on the map to show precisely where the issue is.
+</p>
+<p>
+    You’ll then be asked to fill in a few details.
+</p>
+</dd>
+
+<dt>Do I have to be a [% c.cobrand.council_name %] resident to use this site?</dt>
+
+<dd>
+<p>
+    No — anyone can use this site.
+</p>
+</dd>
+
+<dt>Do I need to make an account to use this site?</dt>
+
+<dd>
+<p>
+    No; if you wish to see previous reports you have made, you can sign in by
+    clicking ‘Sign in’ and then either have a link sent to your email, sign in
+    with a previously set password, or set a password using the ‘create an
+    account’ link.
+</p>
+<p>
+    If you already have an account on fixmystreet.com, you can use the same
+    details on this site.
+</p>
+</dd>
+
+<dt>How are the issues resolved?
+
+<dd>
+<p>
+    When you make a report on this site, we ask you where the issue is, what
+    category it fits within, and perhaps some other information, like questions
+    specific to the category, or which particular street light is broken.
+</p>
+
+<p>
+    These pieces of information will help direct your report to the right
+    place to get it fixed. If the issue is our responsibility, it will drop
+    into our internal system which will route it to the correct department. If
+    it’s more suited to another authority, we will try and send it there
+    instead.
+</p>
+</dd>
+
+<dt>What happens next?
+
+<dd>
+<p>
+    When there’s a change in your report’s status, and where you have provided
+    your email address, you’ll receive an update. This might tell you, for
+    example, that:
+</p>
+
+<ul>
+    <li>our inspectors have gone out to assess the issue</li>
+    <li>our contractors have scheduled the issue for repair</li>
+    <li>the issue has been resolved</li>
+    <li>The issue has been deemed unsuitable for fixing (as happens in some cases)</li>
+</ul>
+
+<p>
+    These updates are also published on the site so that everyone can see what
+    progress has been made.
+</p>
+</dd>
+
+<dt>Can I use this site on my smartphone or tablet?</dt>
+
+<dd>
+<p>
+    Yes - use your device’s browser to visit this site or fixmystreet.com. The
+    site works well on all sizes of screen, resizing automatically.
+</p>
+</dd>
+
+<dt>Why do you publish reports online?</dt>
+
+<dd>
+<p>
+    There’s no need to make a report if we’re already aware of the issue, so by
+    showing which issues have already been reported, we save your time and
+    ours.
+</p>
+<p>
+    Having everything visible online also allows everyone to keep up with an
+    issue’s status, even if they aren’t the one who reported it.
+</p>
+</dd>
+
+<dt>What else can I do on this site?</dt>
+
+<dd>
+<p>
+    You can subscribe to a specific area, so you’ll get an email whenever
+    someone makes a report in your chosen neighbourhood.
+</p>
+<p>
+    Search for a location, and then click ‘get updates’ at the bottom of the
+    list of reports.
+</p>
+<p>
+    If you run a website and you’d like to publish reports automatically from a
+    specific area, you can also access an RSS feed from the ‘get updates’
+    interface.
+</p>
+</dd>
+
+<dt>Can I edit or delete a report?</dt>
+
+<dd>
+<p>
+    You can remove your name from a report if you have included it by accident,
+    or changed your mind about it being published. Visit the report page when
+    signed in and click on the link marked ‘hide your name?’.
+</p>
+<p>
+    You’ll then have the option to remove your name from one report or every
+    report you’ve made.
+</p>
+<p>
+    If you’d like to edit some other part of your report, please get in touch.
+</p>
+</dd>
+
+[% IF c.cobrand.feature('updates_allowed') == 'open' %]
+    <dt>Can I make updates to my report?</dt>
+    <p>
+        Yes, you can leave updates on open reports, by visiting a report page and
+        filling in the update form.
+    </p>
+[% ELSIF c.cobrand.feature('updates_allowed') == 'reporter-open' OR c.cobrand.feature('updates_allowed') == 'reporter/staff-open' %]
+    <dt>Can I make updates to my report?</dt>
+    <p>
+        Yes, you can leave updates on open reports you have made, by visiting a
+        report page and filling in the update form.
+    </p>
+[% ELSIF c.cobrand.feature('updates_allowed') == 'reporter' OR c.cobrand.feature('updates_allowed') == 'reporter/staff' %]
+    <dt>Can I make updates to my report?</dt>
+    <p>
+        Yes, you can leave updates on reports you have made, by visiting a report
+        page and filling in the update form.
+    </p>
+[% END %]
+
+<dt>Do you remove content from this site?</dt>
+
+<dd>
+<p>
+    [% c.cobrand.council_name %] is not responsible for the content and
+    accuracy of material submitted by its users. We reserve the right to edit
+    or remove any problems or updates which we consider to be inappropriate
+    upon being informed by a user of the site.
+</p>
+<p>
+    If you have seen content that is offensive or inappropriate, please click
+    the ‘report abuse’ link at the foot of the report and let us know.
+</p>
+</dd>
+
+</dl>
+
+[% INCLUDE 'footer.html' pagefooter = 'yes' %]


### PR DESCRIPTION
Add a section to the FAQ page about contacting the council by phone.

Fixes https://github.com/mysociety/societyworks/issues/3629

To see the actual changes you can run:

```
git diff --no-index templates/web/fixmystreet-uk-councils/about/faq-en-gb.html templates/web/northumberland/about/faq-en-gb.html
```

<!-- [skip changelog] -->