### PR TITLE
FMS Admin Dashboard form

### DIFF
--- a/web/cobrands/sass/_dashboard.scss
+++ b/web/cobrands/sass/_dashboard.scss
@@ -227,6 +227,7 @@
     // Force field elements onto a single line.
     @media (min-width: 48em) {
         @include flex-container();
+        flex-wrap: wrap;
     }
 
     // No border-top when visually preceded by .dashboard-header
@@ -245,12 +246,13 @@
 
         @media (min-width: 48em) {
             float: $left;
-            max-width: 25%;
         }
     }
 
     .no-label {
         margin-top: 1.25em + 1.5em + 0.5em; // label line-height + margin-top + margin-bottom
+        text-align: right;
+        flex-grow: 1;
     }
 
     select {
@@ -282,6 +284,10 @@
         border-color: #ccc;
         color: #999;
         box-shadow: none;
+    }
+
+    .form-control {
+        height: 2.2em;
     }
 
     .btn {


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/3663

This PR includes two commits:

The first one should* fix the non-wrapping behaviour that the dashboard currently has. I think due to the number of fields in the form it makes sense that they wrap up instead of just cutting each other.

<img width="1360" alt="Screenshot 2023-05-11 at 07 28 00" src="https://github.com/mysociety/fixmystreet/assets/13790153/07b595ee-15cd-4f49-be05-9b26ca791aba">

_*I couldn't find the original screen that was shown in the issue listed above, so I used one screen that seemed similar(/dashboard?group_by=month), but I might need to enable something in order to see the original screen and properly test it. In this case I only added extra fields in the browser to test what happens with extra fields, like the ones shown in the original issue._

The second one is just for aesthetics purpose and happy to drop it if it only adds more complexity to the code. I noticed the the fields had different height, making the form look a bit odd, especially when is only one line. 

<img width="1360" alt="Screenshot 2023-05-11 at 07 27 35" src="https://github.com/mysociety/fixmystreet/assets/13790153/1d4f5ce7-ed1f-4f26-b52b-5fd6753cbd62">


[skip changelog]


