### PR TITLE
[Northumberland] Add litter categories to NH _cleaning_categories

### DIFF
--- a/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
+++ b/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
@@ -399,6 +399,13 @@ sub _cleaning_categories { [
     'Street cleaning',
     'Street cleansing',
     'Sweeping & Cleansing Hazard',
+
+    # Northumberland's litter categories
+    'Damaged Litter Bin (Litter)',
+    'Full Litter Bin (Litter)',
+    'Littering (Litter)',
+    'Other (Litter)',
+
     #Bench/cycle rack/litter bin/planter,
     #Bus Station Cleaning - Floor,
     #Bus Station Cleaning - General,


### PR DESCRIPTION
This is required so that these categories don't appear when National Highways is responsible for the litter on a section of road.

[skip changelog]
