### PR TITLE
Fix status in open311 service request update when report closed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
         - Fix JS error going back from page to report page to map page #4175
         - Fix existing groups being removed when a contact is edited with the category_groups flag unset. #4307
         - Stop map panning breaking after press on pin #4132
+        - With extended statuses, send 'closed' rather than 'open' status in Open311 service request when report is closed.
     - Accessibility improvements:
         - The "skip map" link on /around now has new wording. #3794
         - Improve visual contrast of pagination links. #3794

--- a/perllib/Open311.pm
+++ b/perllib/Open311.pm
@@ -423,6 +423,8 @@ sub _populate_service_request_update_params {
             $status = 'NO_FURTHER_ACTION';
         } elsif ( $state eq 'internal referral' ) {
             $status = 'INTERNAL_REFERRAL';
+        } elsif ( $state eq 'closed' ) {
+            $status = 'CLOSED';
         } elsif ($comment->mark_open && $self->mark_reopen) {
             $status = 'REOPEN';
         }


### PR DESCRIPTION
Send 'closed' rather than 'open' when a report is closed and extended statuses are being used.
