### PR TITLE
Glos. confirm integration: Homepage placeholder text

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Gloucestershire.pm
+++ b/perllib/FixMyStreet/Cobrand/Gloucestershire.pm
@@ -57,6 +57,28 @@ sub send_questionnaires { 0 }
 
 =cut
 
+sub disambiguate_location {
+    my $self = shift;
+    my $string = shift;
+
+    my $town = 'Gloucestershire';
+
+    # As it's the requested example location, try to avoid a disambiguation page
+    $town .= ', GL20 5XA'
+        if $string =~ /^\s*gloucester\s+r(oa)?d,\s*tewkesbury\s*$/i;
+
+    return {
+        %{ $self->SUPER::disambiguate_location() },
+        town   => $town,
+        centre => '51.825508771929094,-2.1263689427866654',
+        span   => '0.53502964014244,1.07233523662321',
+        bounds => [
+            51.57753580138198, -2.687537158717889,
+            52.11256544152442, -1.6152019220946803,
+        ],
+    };
+}
+
 # TODO Sending currently fails
 sub lookup_site_code_config {
     {

--- a/t/cobrand/gloucestershire.t
+++ b/t/cobrand/gloucestershire.t
@@ -7,6 +7,16 @@ FixMyStreet::override_config { ALLOWED_COBRANDS => ['gloucestershire'] },
     ok $mech->host('gloucestershire'), 'change host to gloucestershire';
     $mech->get_ok('/');
     $mech->content_like(qr/Enter a Gloucestershire postcode/);
+
+    my $cobrand = FixMyStreet::Cobrand::Gloucestershire->new;
+    for my $string (
+        'Gloucester Road, Tewkesbury',
+        '  gloucester  rd,tewkesbury  ',
+    ) {
+        is $cobrand->disambiguate_location($string)->{town},
+            'Gloucestershire, GL20 5XA',
+            'variation of example search location is disambiguated';
+    }
 };
 
 done_testing();


### PR DESCRIPTION
Fixes https://github.com/mysociety/societyworks/issues/3650.

There is also a change in commit 553a30878, `glos-confirm-integration`, in mysociety-servers.

[skip changelog]