### PR TITLE
Use email field type when SMS authentication not in use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Unreleased
     - Front end improvements:
         - Include requirements for redeeming the link in the email change confirmation mail. #4422
+        - Use email field type for username if SMS authentication not enabled. #4455
     - Bugfixes:
         - Stop map panning breaking after long press. #4423
         - Fix RSS feed subscription from alert page button.

--- a/templates/web/base/auth/create.html
+++ b/templates/web/base/auth/create.html
@@ -45,15 +45,17 @@ INCLUDE 'header.html', bodyclass='authpage' %]
 
     [% IF c.cobrand.sms_authentication %]
         [% SET username_label = loc('Your email or mobile') %]
+        [% SET username_type = 'text' %]
     [% ELSE %]
         [% SET username_label = loc('Your email') %]
+        [% SET username_type = 'email' %]
     [% END %]
 
     <label class="n" for="username">[% username_label %]</label>
   [% IF loc_username_error %]
     <div class="form-error">[% loc_username_error %]</div>
   [% END %]
-    <input type="text" class="form-control required" id="username" name="username" value="[% username | html %]" autofocus autocomplete="username">
+    <input type="[% username_type %]" class="form-control required" id="username" name="username" value="[% username | html %]" autofocus autocomplete="username">
 
   [% END %]
 

--- a/templates/web/base/auth/general.html
+++ b/templates/web/base/auth/general.html
@@ -51,15 +51,17 @@
 
 [% IF c.cobrand.sms_authentication %]
     [% SET username_label = loc('Your email or mobile') %]
+    [% SET username_type = 'text' %]
 [% ELSE %]
     [% SET username_label = loc('Your email') %]
+    [% SET username_type = 'email' %]
 [% END %]
 
         <label class="n" for="username">[% username_label %]</label>
       [% IF loc_username_error %]
         <div class="form-error">[% loc_username_error %]</div>
       [% END %]
-        <input type="text" class="form-control required" id="username" name="username" value="[% username | html %]" autocomplete="username"
+        <input type="[% username_type %]" class="form-control required" id="username" name="username" value="[% username | html %]" autocomplete="username"
         [%~ IF c.cobrand.moniker != 'borsetshire' %] autofocus[% END %]>
 
         <div id="form_sign_in">

--- a/templates/web/camden/auth/general.html
+++ b/templates/web/camden/auth/general.html
@@ -23,15 +23,17 @@
 
 [% IF c.cobrand.sms_authentication %]
     [% SET username_label = loc('Your email or mobile') %]
+    [% SET username_type = 'text' %]
 [% ELSE %]
     [% SET username_label = loc('Your email') %]
+    [% SET username_type = 'email' %]
 [% END %]
 
     <label class="n" for="username">[% username_label %]</label>
   [% IF loc_username_error %]
     <div class="form-error">[% loc_username_error %]</div>
   [% END %]
-    <input type="text" class="form-control required" id="username" name="username" value="[% username | html %]" autocomplete="username" autofocus>
+    <input type="[% username_type %]" class="form-control required" id="username" name="username" value="[% username | html %]" autocomplete="username" autofocus>
 
     <div id="form_sign_in">
       [% IF oauth_need_email %]

--- a/templates/web/hackney/auth/general.html
+++ b/templates/web/hackney/auth/general.html
@@ -24,15 +24,17 @@
 
 [% IF c.cobrand.sms_authentication %]
     [% SET username_label = loc('Your email or mobile') %]
+    [% SET username_type = 'text' %]
 [% ELSE %]
     [% SET username_label = loc('Your email') %]
+    [% SET username_type = 'email' %]
 [% END %]
 
     <label class="n" for="username">[% username_label %]</label>
   [% IF loc_username_error %]
     <div class="form-error">[% loc_username_error %]</div>
   [% END %]
-    <input type="text" class="form-control required" id="username" name="username" value="[% username | html %]" autocomplete="username"
+    <input type="[% username_type %]" class="form-control required" id="username" name="username" value="[% username | html %]" autocomplete="username"
     [%~ IF c.cobrand.moniker != 'borsetshire' %] autofocus[% END %]>
 
     <div id="form_sign_in">

--- a/templates/web/kingston/auth/general.html
+++ b/templates/web/kingston/auth/general.html
@@ -10,15 +10,17 @@
 
   [% IF c.cobrand.sms_authentication %]
     [% SET username_label = loc('Your email or mobile') %]
+    [% SET username_type = 'text' %]
   [% ELSE %]
     [% SET username_label = loc('Your email') %]
+    [% SET username_type = 'email' %]
   [% END %]
 
     <label class="n" for="username">[% username_label %]</label>
   [% IF loc_username_error %]
     <div class="form-error">[% loc_username_error %]</div>
   [% END %]
-    <input type="text" class="form-control required" id="username" name="username" value="[% username | html %]" autocomplete="username" autofocus>
+    <input type="[% username_type %]" class="form-control required" id="username" name="username" value="[% username | html %]" autocomplete="username" autofocus>
 
   [% IF c.req.params.staff %]
      <label for="password_sign_in">[% loc('Your password') %]</label>

--- a/templates/web/sutton/auth/general.html
+++ b/templates/web/sutton/auth/general.html
@@ -10,15 +10,17 @@
 
   [% IF c.cobrand.sms_authentication %]
     [% SET username_label = loc('Your email or mobile') %]
+    [% SET username_type = 'text' %]
   [% ELSE %]
     [% SET username_label = loc('Your email') %]
+    [% SET username_type = 'email' %]
   [% END %]
 
     <label class="n" for="username">[% username_label %]</label>
   [% IF loc_username_error %]
     <div class="form-error">[% loc_username_error %]</div>
   [% END %]
-    <input type="text" class="form-control required" id="username" name="username" value="[% username | html %]" autocomplete="username" autofocus>
+    <input type="[% username_type %]" class="form-control required" id="username" name="username" value="[% username | html %]" autocomplete="username" autofocus>
 
   [% IF c.req.params.staff %]
      <label for="password_sign_in">[% loc('Your password') %]</label>

--- a/templates/web/westminster/auth/general.html
+++ b/templates/web/westminster/auth/general.html
@@ -31,15 +31,17 @@
 
 [% IF c.cobrand.sms_authentication %]
     [% SET username_label = loc('Your email or mobile') %]
+    [% SET username_type = 'text' %]
 [% ELSE %]
     [% SET username_label = loc('Your email') %]
+    [% SET username_type = 'email' %]
 [% END %]
 
     <label class="n" for="username">[% username_label %]</label>
   [% IF loc_username_error %]
     <div class="form-error">[% loc_username_error %]</div>
   [% END %]
-    <input type="text" class="form-control required" id="username" name="username" value="[% username | html %]" autocomplete="username"
+    <input type="[% username_type %]" class="form-control required" id="username" name="username" value="[% username | html %]" autocomplete="username"
     autofocus>
 
     <div id="form_sign_in">


### PR DESCRIPTION
This makes logging in easier on mobiles as the email-specific soft keyboard is presented.
