### PR TITLE
Allow cobrands to customise nearby lookup distances for duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
         - Fix RSS feed subscription from alert page button.
     - Development improvements:
         - Extra data columns now stored as JSON, not RABX. #3216
+        - Cobrands can provide custom distances for duplicate lookup. #4456
     - Changes:
         - Switch to OpenStreetMap for reverse geocoding. #4444
 

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -679,10 +679,14 @@ sub _nearby_json :Private {
     $c->stash->{page} = 'report';
 
     # distance in metres
-    my $dist = $c->get_param('distance') || '';
+    my $dist;
+    if (my $mode = $c->get_param('mode')) {
+        $dist = $c->cobrand->nearby_distances->{$mode};
+    }
+    $dist ||= $c->get_param('distance') || '';
     $dist = 1000 unless $dist =~ /^\d+$/;
     $dist = 1000 if $dist > 1000;
-    $params->{distance} = $dist / 1000 unless $params->{distance};
+    $params->{distance} = $dist / 1000 unless $params->{distance}; # DB measures in km
 
     my $pin_size = $c->get_param('pin_size') || '';
     $pin_size = 'small' unless $pin_size =~ /^(mini|small|normal|big)$/;

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -1464,4 +1464,29 @@ sub post_report_report_problem_link {
     return;
 }
 
+
+=item nearby_distances
+
+Specifies the distance in metres to search for nearby reports for
+inspector de-duplication and report duplicate suggestions features.
+
+Defaults to 1000m for inspectors, 250m for duplicate suggestions.
+
+Should return a hashref of the form
+
+{
+    inspector => 1000,
+    suggestions => 250,
+}
+
+where each key corresponds to value for the C<mode> query param passed to
+/report/<id>/nearby.json or /around/nearby
+
+=cut
+
+sub nearby_distances { {
+    inspector => 1000,
+    suggestions => 250,
+} }
+
 1;

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -643,4 +643,9 @@ sub csv_staff_user_lookup {
     };
 }
 
+sub nearby_distances {
+    my $self = shift;
+    return $self->feature('nearby_distances') || $self->next::method();
+}
+
 1;

--- a/templates/web/base/admin/config_page_cobrand.html
+++ b/templates/web/base/admin/config_page_cobrand.html
@@ -35,6 +35,7 @@
     [% CASE 'heatmap' %] - heatmap enabled
     [% CASE 'heatmap_dashboard_body' %] - anyone with council gov.uk email can access the heatmap
     [% CASE 'internal_ips' %] - (TfL only) IPs that can skip 2FA
+    [% CASE 'nearby_distances' %] - distances to use when searching for duplicate reports
     [% CASE 'noise' %] - enabling of the noise section
     [% CASE 'oidc_login' %] - third party OIDC login details
     [% CASE 'open311_email' %] - special additional emails to Open311 (e.g. Bexley out of hours or Bucks flytipping)

--- a/templates/web/base/admin/config_page_value.html
+++ b/templates/web/base/admin/config_page_value.html
@@ -54,6 +54,8 @@
     Username: [% value.username %]
 [% CASE 'govuk_notify' %]
     Template ID: [% value.template_id %]
+[% CASE 'nearby_distances' %]
+    Inspectors: [% value.inspector %]m, Suggestions: [% value.suggestions %]m
 [% CASE 'oidc_login' %]
     Display name: [% value.display_name %]
 [% CASE 'throttle_username' %]

--- a/web/js/duplicates.js
+++ b/web/js/duplicates.js
@@ -27,11 +27,11 @@
 
         if ( report_id ) {
             nearby_url = '/report/' + report_id + '/nearby.json';
-            url_params.distance = 1000; // Inspectors might want to see reports fairly far away (1000 metres)
+            url_params.mode = 'inspector'; // Inspectors might want to see reports fairly far away (default 1000 metres)
             url_params.pin_size = 'small'; // How it's always been
         } else {
             nearby_url = '/around/nearby';
-            url_params.distance = 250; // Only want to bother public with very nearby reports (250 metres)
+            url_params.mode = 'suggestions'; // Only want to bother public with very nearby reports (default 250 metres)
             url_params.pin_size = 'normal';
         }
 


### PR DESCRIPTION
For UK councils this is picked up from cobrand feature config.

For FD-2997.
