### PR TITLE
[Glos] Contact and privacy information

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Gloucestershire.pm
+++ b/perllib/FixMyStreet/Cobrand/Gloucestershire.pm
@@ -45,6 +45,14 @@ sub council_url { 'gloucestershire' }
 
 sub admin_user_domain { 'gloucestershire.gov.uk' }
 
+=item * Gloucestershire use their own privacy policy
+
+=cut
+
+sub privacy_policy_url {
+    'https://www.gloucestershire.gov.uk/council-and-democracy/data-protection/privacy-notices/gloucestershire-county-council-general-privacy-statement/gloucestershire-county-council-general-privacy-statement/'
+}
+
 =item * We do not send questionnaires.
 
 =cut

--- a/templates/web/gloucestershire/about/faq-en-gb.html
+++ b/templates/web/gloucestershire/about/faq-en-gb.html
@@ -4,7 +4,7 @@
     <aside>
         <ul class="plain-list">
             <li><strong>Frequently Asked Questions</strong></li>
-            <li><a href="/privacy">Privacy and cookies</a></li>
+            <li><a href=[% cobrand.privacy_policy_url %]>Privacy and cookies</a></li>
             <li><a href="https://www.gloucestershire.gov.uk/contact-gloucestershire-county-council/">Contact Gloucestershire County Council</a></li>
         </ul>
     </aside>

--- a/templates/web/gloucestershire/contact/_footer.html
+++ b/templates/web/gloucestershire/contact/_footer.html
@@ -1,0 +1,1 @@
+[%# Disables display of email address on contact form. %]

--- a/templates/web/gloucestershire/contact/submit.html
+++ b/templates/web/gloucestershire/contact/submit.html
@@ -1,0 +1,21 @@
+[% INCLUDE 'header.html', bodyclass = 'fullwidthpage', title = loc('Contact Us') %]
+
+[% IF success %]
+
+  <div class="confirmation-header">
+    <h1>[% loc('Thank you for your enquiry') %]</h1>
+    <p>[% loc('We’ll get back to you as soon as we can.') %]</p>
+  </div>
+
+[% ELSE %]
+
+  <div class="confirmation-header confirmation-header--failure">
+    <h1>[% loc('Failed to send message') %]</h1>
+    <p>[% loc('Try contacting us ') %] <a href="https://www.gloucestershire.gov.uk/contact-gloucestershire-county-council/">directly</a></p>
+  </div>
+
+[% END %]
+
+[% INCLUDE next_steps.html utm_content='contact form submitted' %]
+
+[% INCLUDE 'footer.html' %]


### PR DESCRIPTION
Closes https://github.com/mysociety/societyworks/issues/3653.

- We hide the fixmystreet.support@gloucestershire.gov.uk email from
    public view (this includes the error message shown when contact form
    submission fails)
    
- We direct users to GCC's external privacy page

There is also a commit (4e02a79d9) in mysociety-servers -> `glos-confirm-integration` branch to add `contact_email` to the staging config.

[skip changelog]

