### PR TITLE
Add bin/repl script

### DIFF
--- a/bin/repl
+++ b/bin/repl
@@ -1,0 +1,71 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../setenv.pl";
+}
+
+use Term::ReadLine;
+use Data::Dumper;
+
+$Data::Dumper::Terse = 1;
+$Data::Dumper::Indent = 0;
+
+# Define convenience functions for accessing models like Problem, Comment, User, etc.
+# These are defined in the REPL package so that they don't pollute the main namespace.
+#
+# This allows you to do things like:
+#
+#   >> Problem->search({ category => 'Pothole' })
+#   >> Comment->search({ state => 'confirmed' })
+#   >> User->search({ email => 'user@example.com' })
+{
+    no strict 'refs';
+    no warnings 'redefine';
+
+    use FixMyStreet::DB;
+    use Module::Pluggable search_path => ['FixMyStreet::DB::Result'], require => 1, sub_name => 'resultsets';
+
+    for my $resultset_name (resultsets()) {
+        $resultset_name =~ s/^FixMyStreet::DB::Result:://;
+
+        *{"REPL::$resultset_name"} = sub {
+            FixMyStreet::DB->resultset($resultset_name);
+        };
+    }
+}
+
+my $term = Term::ReadLine->new('FixMyStreet REPL');
+my $prompt = "FMS> ";
+
+while (defined(my $input = $term->readline($prompt))) {
+    my $output;
+    my $code = "package REPL; no strict; no warnings; sub { $input }";
+
+    local $@;
+    my $eval_result = eval $code;
+
+    if ($@) {
+        $output = "Error: $@";
+    } else {
+        local $@;
+        my $result = eval { $eval_result->() };
+
+        if ($@) {
+            $output = "Error: $@";
+        } elsif ($input =~ /;\s*$/) {
+            # Input ends with a semi-colon, suppress the output.
+            $output = '';
+        } elsif (defined $result) {
+            $output = Dumper($result);
+        } else {
+            $output = 'undef';
+        }
+    }
+
+    print "$output\n";
+}

--- a/cpanfile
+++ b/cpanfile
@@ -173,6 +173,8 @@ requires 'Plack::Middleware::Debug';
 requires 'Plack::Middleware::Debug::DBIC::QueryLog';
 requires 'Plack::Middleware::Debug::LWP';
 requires 'Plack::Middleware::Debug::Template';
+requires 'Term::ReadLine';
+requires 'Term::ReadLine::Gnu';
 recommends 'Linux::Inotify2' if $^O eq 'linux';
 recommends 'Mac::FSEvents' if $^O eq 'darwin';
 

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -7517,6 +7517,16 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       Term::ProgressBar::Quiet 0
+  Term-ReadLine-Gnu-1.45
+    pathname: H/HA/HAYASHI/Term-ReadLine-Gnu-1.45.tar.gz
+    provides:
+      Term::ReadLine::Gnu 1.45
+      Term::ReadLine::Gnu::AU 1.45
+      Term::ReadLine::Gnu::Var 1.45
+      Term::ReadLine::Gnu::XS 1.45
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.008001
   TermReadKey-2.37
     pathname: J/JS/JSTOWE/TermReadKey-2.37.tar.gz
     provides:

--- a/script/console
+++ b/script/console
@@ -3,4 +3,4 @@
 set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
 
-eval `"$DIR"/setenv.pl`
+exec "$DIR"/bin/repl "$@"


### PR DESCRIPTION
This is a very simple REPL for making quick database queries via the perl interface, without having to go via bin/cron-wrapper.

It defines top-level convenience methods for all `FixMyStreet::DB::Result` subclasses, so you can do `Problem->search` instead of `FixMyStreet::DB->resultset('Problem')->search`.

Adding a semi-colon to the end of a line suppresses the output, which is useful when you get back a big database result object that you don't want dumped to the terminal.

## Example

    $ bin/repl
    FMS> $p = Problem->find(id => 42);

    FMS> $p->get_extra_metadata
    {}
    FMS> $p->set_extra_metadata(foo => 'bar')
    {'foo' => 'bar'}
    FMS> $p->update;

    FMS> Comment->search({ state => 'confirmed' });

    FMS> User->search({ email => 'user@example.com' });

<!-- [skip changelog] -->