### PR TITLE
[Brent] Allow missed reports before 10pm

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -386,7 +386,7 @@ sub waste_event_state_map {
 
 If it's before 10pm on the day of collection, treat an Outstanding/Allocated
 task as if it's the next collection and in progress, and do not allow missed
-collection reporting.
+collection reporting unless it's already been completed.
 
 =cut
 
@@ -399,9 +399,9 @@ sub waste_on_the_day_criteria {
         $row->{next}{state} = 'In progress';
         delete $row->{last};
     }
-    #if (!$completed) {
-    $row->{report_allowed} = 0;
-    #}
+    if (!$completed) {
+        $row->{report_allowed} = 0;
+    }
 }
 
 sub bin_services_for_address {


### PR DESCRIPTION
Essentially reverts https://github.com/mysociety/fixmystreet/commit/4e1db0039cb4cbb5cfae87ea3468b9cf26092c70.

For FD-3057.

<!-- [skip changelog] -->