### PR TITLE
[Brent] Street cleaning on red routes

### DIFF
--- a/.cypress/cypress/fixtures/brent-tfl.xml
+++ b/.cypress/cypress/fixtures/brent-tfl.xml
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver https://tilma.staging.mysociety.org:80/mapserver/tfl?SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=RedRoutes&amp;OUTPUTFORMAT=text/xml;%20subtype=gml/3.1.1  http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+      <gml:boundedBy>
+      	<gml:Envelope srsName="EPSG:3857">
+      		<gml:lowerCorner>-31406.345299 6716977.791440</gml:lowerCorner>
+      		<gml:upperCorner>-25880.223137 6722918.383799</gml:upperCorner>
+      	</gml:Envelope>
+      </gml:boundedBy>
+<!-- WARNING: FeatureId item 'fid' not found in typename 'RedRoutes'. -->
+    <gml:featureMember>
+      <ms:RedRoutes>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-31406.345299 6716977.791440</gml:lowerCorner>
+        		<gml:upperCorner>-25880.223137 6722918.383799</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Polygon srsName="EPSG:3857">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:posList srsDimension="2">
+                  -29100 6719400
+                  -29100 6719500
+                  -29000 6719500
+                  -29000 6719400
+                  -29100 6719400
+                </gml:posList>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+        </ms:msGeometry>
+        <ms:HA_ID>28</ms:HA_ID>
+      </ms:RedRoutes>
+    </gml:featureMember>
+</wfs:FeatureCollection>

--- a/.cypress/cypress/integration/brent.js
+++ b/.cypress/cypress/integration/brent.js
@@ -66,3 +66,44 @@ describe('Brent asset layers', function() {
         cy.get('span').contains('Photo').should('be.visible');
     });
 });
+
+describe('Brent road behaviour', function() {
+
+    beforeEach(function() {
+        cy.server();
+        cy.route('/report/new/ajax*').as('report-ajax');
+        cy.route('**/mapserver/brent*Highways*', 'fixture:brent-highways.xml').as('highways');
+        cy.route('**/mapserver/tfl*RedRoutes*', 'fixture:brent-tfl.xml').as('tfl');
+        cy.viewport(480, 800);
+    });
+
+    function make_flytip() {
+        cy.get('#mob_ok').click();
+        cy.wait('@report-ajax');
+        cy.pickCategory('Fly-tipping');
+        cy.wait('@highways');
+        cy.wait('@tfl');
+        cy.nextPageReporting();
+    }
+
+    it('prevents reporting not on a road', function() {
+        cy.visit('http://brent.localhost:3001/report/new?longitude=-0.28168&latitude=51.55904');
+        make_flytip();
+        cy.contains('please select a point on a public road').should('be.visible');
+        cy.get('span').contains('Photo').should('not.be.visible');
+    });
+
+    it('allows reporting on a Brent road', function() {
+        cy.visit('http://brent.localhost:3001/report/new?longitude=-0.276120&latitude=51.563683');
+        make_flytip();
+        cy.contains('please select a point on a public road').should('not.be.visible');
+        cy.get('span').contains('Photo').should('be.visible');
+    });
+
+    it('allows reporting on a TfL road', function() {
+        cy.visit('http://brent.localhost:3001/report/new?longitude=-0.260869&latitude=51.551717');
+        make_flytip();
+        cy.contains('please select a point on a public road').should('not.be.visible');
+        cy.get('span').contains('Photo').should('be.visible');
+    });
+});

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -148,7 +148,7 @@ if ($opt->test_fixtures) {
         { area_id => 2551, categories => [ 'Abandoned vehicles', 'Dog fouling', 'Blocked drain' ], name => 'Bath and North East Somerset Council', cobrand => 'bathnes' },
         { area_id => 2238, categories => [ 'Flytipping', 'Roads', 'Parks' ], name => 'Shropshire Council', cobrand => 'shropshire' },
         { area_id => 2500, categories => [ 'Abandoned vehicles', 'Flytipping', 'Flyposting' ], name => 'Merton Council', cobrand => 'merton' },
-        { area_id => 2488, categories => [ 'Grass verges / shrub beds - littering' , 'Pavement damage'], name => 'Brent Council', cobrand => 'brent' },
+        { area_id => 2488, categories => [ 'Grass verges / shrub beds - littering' , 'Pavement damage', 'Fly-tipping'], name => 'Brent Council', cobrand => 'brent' },
     ) {
         $bodies->{$_->{area_id}} = FixMyStreet::DB::Factory::Body->find_or_create($_);
         if ($_->{cobrand}) {

--- a/data/test-asset-layers.yml
+++ b/data/test-asset-layers.yml
@@ -69,7 +69,7 @@ brent:
     stylemap: 'fixmystreet.assets.stylemap_invisible'
     nearest_radius: '0.1'
     non_interactive: 1
-    asset_category: [ 'Pavement damage', 'Grass verges / shrub beds - littering' ]
+    asset_category: [ 'Fly-tipping', 'Pavement damage', 'Grass verges / shrub beds - littering' ]
     no_asset_msg_id: '#js-brent-road-services'
     road: 1
     actions:

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -572,7 +572,7 @@ sub _cleaning_categories { [
     'Faulty Christmas Lights',
 ] }
 
-sub _cleaning_groups { [ 'Street cleaning', 'Street Cleansing', 'Fly-tipping' ] }
+sub _cleaning_groups { [ 'Street cleaning', 'Street Cleansing', 'Fly-tipping', 'Street cleaning issues' ] }
 
 sub _tfl_council_categories { [
     'General Litter / Rubbish Collection',

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -95,10 +95,11 @@ my @PLACES = (
     ['?', 51.511258, -0.011937, 2506, 'Tower Hamlets Borough Council', 'LBO'],
     ['?', 51.512139, -0.013074, 2506, 'Tower Hamlets Borough Council', 'LBO'],
     ['WC1H 8EQ', 51.529432, -0.124514, 2505, 'Camden Borough Council', 'LBO'],
-    ['HA9 0FJ', 51.55904, -0.28168, 2488, 'Brent Council', 'LBO'],
-    ['?', 51.564493, -0.277156, 2488, 'Brent Council', 'LBO'],
-    ['?', 51.563623, -0.274082, 2488, 'Brent Council', 'LBO'],
-    ['?', 51.563683, -0.276120, 2488, 'Brent Council', 'LBO'],
+    ['HA9 0FJ', 51.55904, -0.28168, 2488, 'Brent Council', 'LBO'], # Somewhere in Brent
+    ['?', 51.564493, -0.277156, 2488, 'Brent Council', 'LBO'], # Housing estate in Brent
+    ['?', 51.563623, -0.274082, 2488, 'Brent Council', 'LBO'], # Park in Brent
+    ['?', 51.563683, -0.276120, 2488, 'Brent Council', 'LBO'], # Road in Brent
+    ['?', 51.551717, -0.260869, 2488, 'Brent Council', 'LBO'], # TfL road in Brent
     [ 'SE1 2QH', 51.50351, -0.08051, 2491, 'Southwark Council', 'LBO' ],
     [ '?', 51.50352, -0.08052, 2491, 'Southwark Council', 'LBO' ],
     [ 'BA11 6BA', 51.26345, -2.28191, 2428, 'Mendip District Council', 'DIS' ],

--- a/web/cobrands/fixmystreet-uk-councils/assets.js
+++ b/web/cobrands/fixmystreet-uk-councils/assets.js
@@ -238,8 +238,9 @@ fixmystreet.assets.brent.found_filter = function(layer) {
 };
 
 fixmystreet.assets.brent.not_found_filter = function(layer) {
-    if (fixmystreet.reporting.selectedCategory().category === 'Grass verges / shrub beds - littering'||
-    fixmystreet.reporting.selectedCategory().category === 'Grass verge / shrub beds - maintenance issue') {
+    var selected = fixmystreet.reporting.selectedCategory();
+    if (selected.category === 'Grass verges / shrub beds - littering' ||
+    selected.category === 'Grass verge / shrub beds - maintenance issue') {
         layer.fixmystreet.no_asset_msg_id = '#js-brent-parks-and-highways';
         if (layer.fixmystreet.http_options.params.TYPENAME === 'Parks_and_Open_Spaces') {
             brent_parkRoadIsFound.park = false;
@@ -257,11 +258,24 @@ fixmystreet.assets.brent.not_found_filter = function(layer) {
         // if we have changed category while it was in place
         layer.fixmystreet.no_asset_msg_id = '#js-brent-parks-and-highways';
         fixmystreet.message_controller.road_found(layer);
-
         layer.fixmystreet.no_asset_msg_id = fixmystreet.assets.brent.no_asset_message_defaults[layer.fixmystreet.http_options.params.TYPENAME];
-        fixmystreet.message_controller.road_not_found(layer);
+
+        if (brent_on_red_route()) {
+            fixmystreet.message_controller.road_found(layer);
+        } else {
+            fixmystreet.message_controller.road_not_found(layer);
+        }
     }
 };
+
+function brent_on_red_route() {
+    var red_routes = fixmystreet.map.getLayersByName("Red Routes");
+    if (!red_routes.length) {
+        return false;
+    }
+    red_routes = red_routes[0];
+    return !!red_routes.selected_feature;
+}
 
 /* Bristol */
 


### PR DESCRIPTION
[skip changelog] Fixes FD-3072.
Adds the relevant Brent group to the cleaning list, and allows through reports if they're made on a red route.