### PR TITLE
[Buckinghamshire] Allow templates in same category, different code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - Bugfixes:
         - Stop map panning breaking after long press. #4423
         - Fix RSS feed subscription from alert page button.
+        - Fix link to edit category with apostrophe in category name.
     - Admin improvements:
         - Rename emergency message to site message.
     - Development improvements:

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -1,3 +1,17 @@
+=head1 NAME
+
+FixMyStreet::Cobrand::Buckinghamshire - code specific to the Buckinghamshire cobrand
+
+=head1 SYNOPSIS
+
+We integrate with Buckinghamshire's Alloy back end for highways reporting and
+Alloy+Evo for red claims, also send emails for some categories, and send
+reports to Buckinghamshire parishes based on category/speed limit.
+
+=head1 DESCRIPTION
+
+=cut
+
 package FixMyStreet::Cobrand::Buckinghamshire;
 use parent 'FixMyStreet::Cobrand::Whitelabel';
 
@@ -87,6 +101,15 @@ sub admin_pages {
     $pages->{triage} = [ undef, undef ];
     return $pages;
 }
+
+=item admin_templates_state_and_external_status_code
+
+We can set response templates with both state and external status code,
+for updating reports by email.
+
+=cut
+
+sub admin_templates_state_and_external_status_code { 1 }
 
 sub available_permissions {
     my $self = shift;

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -794,6 +794,16 @@ sub available_permissions {
     };
 }
 
+=item admin_templates_state_and_external_status_code
+
+Whether the cobrand allows response templates with both state and external
+status code. Normally this is not allowed, but if a cobrand is updating report
+state by email (and so the state is being used for the new state, not the
+existing one), then we would want to allow it.
+
+=cut
+
+sub admin_templates_state_and_external_status_code { 0 }
 
 =item area_types
 

--- a/perllib/FixMyStreet/DB/Result/Contact.pm
+++ b/perllib/FixMyStreet/DB/Result/Contact.pm
@@ -111,6 +111,17 @@ sub category_display {
     $self->get_extra_metadata('display_name') || $self->translate_column('category');
 }
 
+=item category_safe
+
+This returns a safe category name, that can be passed to URI generation or similar.
+
+=cut
+
+sub category_safe {
+    my $self = shift;
+    return FixMyStreet::Template::SafeString->new($self->category);
+}
+
 # Returns an arrayref of groups this Contact is in; if it is
 # not in any group, returns an arrayref of the empty string.
 sub groups {

--- a/t/app/controller/admin/bodies.t
+++ b/t/app/controller/admin/bodies.t
@@ -11,6 +11,7 @@ sub anonymous_account { { email => 'anoncategory@example.org', name => 'Anonymou
 
 package main;
 
+use utf8;
 use FixMyStreet::TestMech;
 
 my $mech = FixMyStreet::TestMech->new;
@@ -69,6 +70,14 @@ subtest 'check contact creation' => sub {
         note     => 'test/note',
         non_public => 'on',
     } } );
+
+    $mech->submit_form_ok( { with_fields => {
+        category => 'test \' ’ category',
+        email    => 'test@example.com',
+        note     => 'note',
+    } } );
+    $mech->content_contains("/test%20'%20%E2%80%99%20category");
+
     $mech->get_ok('/admin/body/' . $body->id . '/test/category');
     $mech->content_contains('test/category');
 };

--- a/templates/web/base/admin/bodies/body.html
+++ b/templates/web/base/admin/bodies/body.html
@@ -81,7 +81,7 @@
 
     [% BLOCK category_row %]
       <tr [% IF cat.state == 'deleted' %]class="is-deleted"[% END %]>
-        <td class="contact-category"><a href="[% c.uri_for_action( '/admin/bodies/edit', [ body_id ], cat.category ) %]">[% cat.category_display | html %]</a>
+        <td class="contact-category"><a href="[% c.uri_for_action( '/admin/bodies/edit', [ body_id ], cat.category_safe ) %]">[% cat.category_display %]</a>
             <br>[% cat.email.replace('([;,])', '$1 ') %]</td>
         <td>
             [% cat.state %]


### PR DESCRIPTION
As Bucks can set both state and external status code (for email updates), need to check differently. Use a cobrand variable. [skip changelog] Fixes FD-3138.

Plus a fix for apostrophe in category name noticed in FD-3141.