### PR TITLE
Add libreadline-dev to conf/packages

### DIFF
--- a/conf/packages
+++ b/conf/packages
@@ -20,3 +20,4 @@ libexpat1-dev
 libssl-dev
 zlib1g-dev
 libxml2-dev
+libreadline-dev


### PR DESCRIPTION
This package is needed for the Term::ReadLine dependency, which is used by the `bin/repl` script.

Follows on from #4479 

<!-- [skip changelog] -->
