### PR TITLE
[Peterborough] Small bulky text changes

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -987,6 +987,7 @@ sub bulky_setup : Chained('property') : PathPart('') : CaptureArgs(0) {
     my ($self, $c) = @_;
 
     if (  !$c->cobrand->call_hook('bulky_enabled')
+        || !$c->cobrand->call_hook(bulky_allowed_property => $c->stash->{property})
         || $c->stash->{property}{pending_bulky_collection} )
     {
         $c->detach('property_redirect');

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1048,7 +1048,7 @@ sub bulky : Chained('bulky_setup') : Args(0) {
             ],
             template => 'waste/bulky/items.html',
             title => 'Add items for collection',
-            next => 'location',
+            next => $c->stash->{is_staff} ? 'location' : 'summary',
             update_field_list => sub {
                 my $form = shift;
                 my $fields = {};

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -237,7 +237,7 @@ has_field tandc => (
     required => 1,
     label => 'Terms and conditions',
     option_label => FixMyStreet::Template::SafeString->new(
-        'I agree to the <a href="https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections" target="_blank">terms and conditions</a>',
+        'I have read the <a href="https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections" target="_blank">bulky waste collection</a> page on the council’s website',
     ),
 );
 

--- a/perllib/FixMyStreet/App/View/Web.pm
+++ b/perllib/FixMyStreet/App/View/Web.pm
@@ -5,6 +5,7 @@ use strict;
 use warnings;
 
 use Digest::MD5;
+use Lingua::EN::Inflect qw(NUMWORDS);
 use File::Basename qw(fileparse);
 use FixMyStreet;
 use FixMyStreet::Template;
@@ -27,6 +28,7 @@ __PACKAGE__->config(
     FILTERS => {
         add_links => \&add_links,
         escape_js => \&escape_js,
+        numwords => \&numwords,
         staff_html_markup => [ \&staff_html_markup_factory, 1 ],
     },
     COMPILE_EXT => '.ttc',
@@ -196,6 +198,8 @@ sub prettify_state {
 
     return FixMyStreet::DB->resultset("State")->display($text, $single_fixed);
 }
+
+sub numwords { NUMWORDS($_[0]) }
 
 1;
 

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -749,6 +749,10 @@ sub bin_services_for_address {
 
         my %requests_open = map { $_ => 1 } @request_service_ids_open;
 
+        if ($container_id == 6533) {
+            $property->{show_bulky_waste} = 1;
+        }
+
         my $last_obj = { date => $last, ordinal => ordinal($last->day) } if $last;
         my $next_obj = { date => $next, ordinal => ordinal($next->day) } if $next;
         my $row = {
@@ -1819,6 +1823,11 @@ sub bulky_total_cost {
         $data->{"extra_payment_method"} = "credit_card";
     }
     return $c->stash->{payment};
+}
+
+sub bulky_allowed_property {
+    my ($self, $property) = @_;
+    return 1 if $property->{show_bulky_waste} && !$property->{commercial_property};
 }
 
 sub bulky_enabled {

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -1876,9 +1876,9 @@ sub bulky_nice_collection_date {
 
 sub bulky_nice_cancellation_cutoff_time {
     my $time = bulky_cancellation_cutoff_time();
-    return
-          sprintf( "%02d", $time->{hours} ) . ':'
-        . sprintf( "%02d", $time->{minutes} // 0 );
+    $time = DateTime->now->set(hour => $time->{hours}, minute => $time->{minutes})->strftime('%I:%M%P');
+    $time =~ s/^0|:00//g;
+    return $time;
 }
 
 sub bulky_nice_cancellation_cutoff_date {
@@ -1889,9 +1889,9 @@ sub bulky_nice_cancellation_cutoff_date {
 
 sub bulky_nice_collection_time {
     my $time = bulky_collection_time();
-    return
-          sprintf( "%02d", $time->{hours} ) . ':'
-        . sprintf( "%02d", $time->{minutes} // 0 );
+    $time = DateTime->now->set(hour => $time->{hours}, minute => $time->{minutes})->strftime('%I:%M%P');
+    $time =~ s/^0|:00//g;
+    return $time;
 }
 
 sub bulky_nice_item_list {

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -998,9 +998,9 @@ FixMyStreet::override_config {
             $mech->content_contains('Book bulky goods collection');
             $mech->content_contains('Before you start your booking');
             # XXX make this dynamic according to config in DB
-            $mech->content_contains('You can request up to <strong>5 items per collection');
+            $mech->content_contains('You can request up to <strong>five items per collection');
             # XXX and this one too
-            $mech->content_contains('You can cancel your booking anytime up until 15:00 the day before the collection is scheduled');
+            $mech->content_contains('You can amend the items in your booking up until 3pm the day before the collection is scheduled');
             $mech->submit_form_ok;
         };
 

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -1059,16 +1059,6 @@ FixMyStreet::override_config {
             );
         };
 
-        subtest 'Location details page' => sub {
-            $mech->content_contains('Location details');
-            $mech->content_contains('Please provide the exact location where the items will be left');
-            $mech->content_contains('Help us by attaching a photo of where the items will be left for collection');
-            $mech->submit_form_ok({ with_fields => {
-                location => 'behind the hedge in the front garden',
-                location_photo => [ $sample_file, undef, Content_Type => 'image/jpeg' ],
-            } });
-        };
-
         sub test_summary {
             my $date_day = shift;
             $mech->content_contains('Request a bulky waste collection');
@@ -1084,8 +1074,6 @@ FixMyStreet::override_config {
             $mech->content_like(qr/<p class="govuk-!-margin-bottom-0">Please dismantle/s);
             $mech->content_contains('3 items requested for collection');
             $mech->content_contains('2 remaining slots available');
-            $mech->content_contains('behind the hedge in the front garden');
-            $mech->content_contains('<img class="img-preview is--medium" alt="Preview image successfully attached" src="/photo/temp.74e3362283b6ef0c48686fb0e161da4043bbcc97.jpeg">');
             $mech->content_lacks('No image of the location has been attached.');
             $mech->content_contains('£23.50');
             $mech->content_contains("<dd>$date_day August</dd>");
@@ -1151,7 +1139,6 @@ FixMyStreet::override_config {
         subtest 'New date selected, submit pages again' => sub {
             $mech->submit_form_ok({ with_fields => { chosen_date => '2022-08-26T00:00:00' } });
             $mech->submit_form_ok({ with_fields => { 'item_1' => 'Amplifiers', 'item_2' => 'High chairs', 'item_3' => 'Wardrobes' } });
-            $mech->submit_form_ok({ with_fields => { location => 'behind the hedge in the front garden' } });
         };
 
         subtest 'Summary submission' => \&test_summary_submission;
@@ -1192,7 +1179,7 @@ FixMyStreet::override_config {
             is $report->title, 'Bulky goods collection';
             is $report->get_extra_field_value('uprn'), 100090215480;
             is $report->get_extra_field_value('DATE'), '2022-08-26T00:00:00';
-            is $report->get_extra_field_value('CREW NOTES'), 'behind the hedge in the front garden';
+            is $report->get_extra_field_value('CREW NOTES'), '';
             is $report->get_extra_field_value('CHARGEABLE'), 'CHARGED';
             is $report->get_extra_field_value('ITEM_01'), 'Amplifiers';
             is $report->get_extra_field_value('ITEM_02'), 'High chairs';
@@ -1201,7 +1188,7 @@ FixMyStreet::override_config {
             is $report->get_extra_field_value('ITEM_05'), '';
             is $report->get_extra_field_value('property_id'), 'PE1 3NA:100090215480';
             is $report->photo,
-                '74e3362283b6ef0c48686fb0e161da4043bbcc97.jpeg,74e3362283b6ef0c48686fb0e161da4043bbcc97.jpeg';
+                '74e3362283b6ef0c48686fb0e161da4043bbcc97.jpeg';
         };
 
         # Collection date: 2022-08-26T00:00:00
@@ -1227,7 +1214,6 @@ FixMyStreet::override_config {
             $mech->content_like(qr/<p class="govuk-!-margin-bottom-0">Please dismantle/s);
             $mech->content_contains('3 items requested for collection');
             $mech->content_contains('2 remaining slots available');
-            $mech->content_contains('behind the hedge in the front garden');
             $mech->content_contains('£23.50');
             $mech->content_contains('26 August');
             $mech->content_lacks('Request a bulky waste collection');
@@ -1679,7 +1665,6 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
         $mech->submit_form_ok({ with_fields => { chosen_date => '2022-08-26T00:00:00' } });
         $mech->submit_form_ok({ with_fields => { 'item_1' => 'Amplifiers', 'item_2' => 'High chairs' } });
-        $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
         $mech->submit_form_ok({ with_fields => { tandc => 1 } });
         my ( $token, $report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
@@ -1759,7 +1744,6 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { chosen_date => '2022-08-26T00:00:00' } });
         $mech->content_contains('£0.00');
         $mech->submit_form_ok({ with_fields => { 'item_1' => 'Amplifiers', 'item_2' => 'High chairs' } });
-        $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
         $mech->submit_form_ok({ with_fields => { tandc => 1 } });
 
         $mech->content_contains('Your booking is not complete yet');
@@ -1774,7 +1758,6 @@ FixMyStreet::override_config {
         is $report->get_extra_field_value('payment_method'), '';
         is $report->get_extra_field_value('uprn'), 100090215480;
         is $report->get_extra_field_value('DATE'), '2022-08-26T00:00:00';
-        is $report->get_extra_field_value('CREW NOTES'), 'in the middle of the drive';
         is $report->get_extra_field_value('CHARGEABLE'), 'FREE';
 
         subtest 'cancel free collection' => sub {
@@ -1823,7 +1806,6 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { chosen_date => '2022-08-26T00:00:00' } });
         $mech->content_contains('£23.50');
         $mech->submit_form_ok({ with_fields => { 'item_1' => 'Amplifiers', 'item_2' => 'High chairs' } });
-        $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
         $mech->submit_form_ok({ with_fields => { tandc => 1 } });
         my ( $token, $report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 

--- a/templates/email/default/waste/bulky-reminder.html
+++ b/templates/email/default/waste/bulky-reminder.html
@@ -54,7 +54,8 @@ INCLUDE '_email_top.html';
 </p>
 
   <p style="[% p_style %]">
-    <a href="https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections">Terms and Conditions</a>
+    Please read the <a href="https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections">bulky waste collection</a>
+    page on the council’s website for information about this service.
   </p>
 
   <p style="[% p_style %]">

--- a/templates/email/default/waste/bulky-reminder.txt
+++ b/templates/email/default/waste/bulky-reminder.txt
@@ -44,7 +44,7 @@ You can obtain a refund if you cancel by [% cobrand.bulky_nice_collection_time %
 
 [% END ~%]
 
-Terms and Conditions:
+Please read the bulky waste collection page on the council’s website for information about this service:
 
     https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections
 

--- a/templates/web/base/waste/bulky/intro.html
+++ b/templates/web/base/waste/bulky/intro.html
@@ -1,11 +1,11 @@
 <h3>Before you start your booking</h3>
 <ol>
     <li>Requesting a bulky waste collection usually takes approximately <strong>10 minutes</strong></li>
-    <li>You can request up to <strong>[% c.cobrand.bulky_items_maximum %] items per collection</strong></li>
-    <li>Please ensure you read the <strong><a href="https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections" target="_blank">Terms & Conditions</a></strong> before booking your bulky waste collection</li>
+    <li>You can request up to <strong>[% c.cobrand.bulky_items_maximum | numwords %] items per collection</strong></li>
+    <li>Please ensure you have read the <strong><a href="https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections" target="_blank">bulky waste collection</a></strong> page on the council’s website</li>
     <li>In order to help us with your collection, we will ask you to optionally add pictures of the items to be collected and the location</li>
     <li>Before confirming your booking, check all the info provided is correct</li>
-    <li>You can cancel your booking anytime up until [% c.cobrand.bulky_nice_cancellation_cutoff_time %] the day before the collection is scheduled</li>
+    <li>You can amend the items in your booking up until [% c.cobrand.bulky_nice_cancellation_cutoff_time %] the day before the collection is scheduled by calling 01733 747474 (9am to 5pm Monday to Friday excluding bank holidays)</li>
     [% UNLESS cobrand.call_hook('bulky_enabled_staff_only') %]
     <li><strong>Cancellations made by [% c.cobrand.bulky_nice_collection_time %]</strong> the day before collection is scheduled are entitled to a refund</li>
     [% END %]

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -15,9 +15,9 @@
     <span class="govuk-warning-text__icon" aria-hidden="true">i</span>
   </div>
   <div class="govuk-warning-text__content">
-    <span class="govuk-warning-text__assistive">Important information</span>
+    <span class="govuk-warning-text__assistive">Information</span>
     <p class="govuk-!-margin-bottom-1"><strong>Note</strong></p>
-    <p>If an item is not available for selection on this page, it may not be eligible for bulky collection; please check <strong><a href="https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections" target="_blank">here</a></strong> for further information.</p>
+    <p>If an item is not available for selection on this page, it is not eligible for collection.</p>
   </div>
 </div>
 

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -162,6 +162,7 @@
         </tbody>
       </table>
 
+    [% IF is_staff %]
       <div class="summary-section-header">
         <h3 class="summary-section--heading">Location details</h3>
         [% PROCESS change_answers_button goto='location' %]
@@ -178,6 +179,8 @@
       [% ELSE %]
         <p class="due" style="padding:1em">No image of the location has been attached.</p>
       [% END %]
+    [% END %]
+
     </div>
 
     <div class="govuk-grid-column-one-third">

--- a/templates/web/peterborough/waste/_announcement.html
+++ b/templates/web/peterborough/waste/_announcement.html
@@ -1,3 +1,4 @@
+[% IF property.show_bulky_waste %]
 <div class="govuk-grid-row govuk-!-margin-bottom-9 cta-announcement-wrapper is--mobile-only">
     <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-2">
         <div class="cta-announcement">
@@ -6,3 +7,4 @@
         </div>
     </div>
 </div>
+[% END %]

--- a/templates/web/peterborough/waste/_more_services_sidebar.html
+++ b/templates/web/peterborough/waste/_more_services_sidebar.html
@@ -39,7 +39,7 @@
     </li>
   [% END %]
   [% IF c.cobrand.call_hook('bulky_enabled') %]
-   [% IF NOT property.commercial_property %]
+   [% IF c.cobrand.bulky_allowed_property(property) %]
     <li>
         <a href="[% c.uri_for_action('waste/bulky', [ property.id ]) %]">Book bulky goods collection</a>
     </li>

--- a/templates/web/peterborough/waste/_service_navigation_bar.html
+++ b/templates/web/peterborough/waste/_service_navigation_bar.html
@@ -5,7 +5,9 @@
         <a href="#[% unit.service_name %]">[% unit.service_name %]</a>
     [% END %]
     [% END %]
+    [% IF property.show_bulky_waste %]
     <a href="#bulky-waste">Bulky Waste<span class="highlight-label">New</span></a>
+    [% END %]
     <hr>
     <a href="#more-services">More services</a>
     <a href="#help">Help</a>

--- a/templates/web/peterborough/waste/bin_days_bulky.html
+++ b/templates/web/peterborough/waste/bin_days_bulky.html
@@ -127,6 +127,8 @@ hx-trigger="every [% page_refresh %]s"
   </div>
 [% END %]
 [% END %]
+
+[% IF property.commercial_property || property.show_bulky_waste %]
   <div class="govuk-grid-row waste-service-wrapper">
     <div class="govuk-grid-column-one-quarter text-centered">
       <h3 id="bulky-waste" class="govuk-heading-m waste-service-name">Bulky Waste</h3>
@@ -217,8 +219,9 @@ hx-trigger="every [% page_refresh %]s"
       [% END %]
         <hr>
     </div>
-
   </div>
+[% END %]
+
 [% IF NOT service_data.size %]
     [% TRY %][% PROCESS waste/_bin_days_no_collections.html %][% CATCH file %]
     <p>This property has no collections.</p>


### PR DESCRIPTION
And make location page staff only. And only allow bulky on properties with black bin service.

[skip changelog] Fixes FD-3148 and FD-3150