### PR TITLE
[Buckinghamshire] Turn off claims emails

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -181,11 +181,11 @@ sub open311_pre_send {
     my ($self, $row, $open311) = @_;
     if ($row->category eq 'Claim') {
         if ($row->get_extra_metadata('fault_fixed') eq 'Yes') {
-            # We want to send to Confirm, but with slightly altered information
+            # We want to send via Open311, but with slightly altered information
             $row->update_extra_field({ name => 'title', value => $row->get_extra_metadata('direction') }); # XXX See doc note
             $row->update_extra_field({ name => 'description', value => $row->get_extra_metadata('describe_cause') });
         } else {
-            # We do not want to send to Confirm, only email
+            # We do not want to send via Open311, only email
             return 'SKIP';
         }
     }
@@ -518,7 +518,7 @@ sub is_two_tier { 1 }
 sub should_skip_sending_update {
     my ($self, $update ) = @_;
 
-    # Bucks don't want to receive updates into Confirm that were made by anyone
+    # Bucks don't want to receive updates that were made by anyone
     # except the original problem reporter.
     return $update->user_id != $update->problem->user_id;
 }

--- a/t/app/controller/claims.t
+++ b/t/app/controller/claims.t
@@ -159,7 +159,10 @@ Mileage of the tyre(s) at the time of the incident: 20
 EOF
         is $report->detail, $expected_detail;
         is $report->latitude, 51.81386;
+        is $report->comments->count, 0, 'No updates added to report';
         FixMyStreet::Script::Reports::send();
+        $report->discard_changes;
+        is $report->comments->count, 1, 'updates added to report post send';
         my @email = $mech->get_email;
         is $email[0]->header('To'), 'TfB <claims@example.net>, TfB <claims2@example.net>';
         is $email[0]->header('Subject'), "New claim - vehicle - Test McTest - $fault_id - Rain Road, Aylesbury";

--- a/t/app/controller/claims.t
+++ b/t/app/controller/claims.t
@@ -66,7 +66,6 @@ FixMyStreet::override_config {
     STAGING_FLAGS => { send_reports => 1 },
     COBRAND_FEATURES => {
         claims => { buckinghamshire => 1 },
-        open311_email => { buckinghamshire => { claim => 'claims@example.net,claims2@example.net' } },
     },
     PHONE_COUNTRY => 'GB',
     MAPIT_URL => 'http://mapit.uk/',
@@ -164,10 +163,8 @@ EOF
         $report->discard_changes;
         is $report->comments->count, 1, 'updates added to report post send';
         my @email = $mech->get_email;
-        is $email[0]->header('To'), 'TfB <claims@example.net>, TfB <claims2@example.net>';
-        is $email[0]->header('Subject'), "New claim - vehicle - Test McTest - $fault_id - Rain Road, Aylesbury";
-        like $email[1]->header('To'), qr/madeareport\@/;
-        is $email[1]->header('Subject'), "Your claim has been submitted, ref $report_id";
+        like $email[0]->header('To'), qr/madeareport\@/;
+        is $email[0]->header('Subject'), "Your claim has been submitted, ref $report_id";
         my $req = Open311->test_req_used;
         is $req, undef, 'Nothing sent by Open311';
         is $report->user->alerts->count, 1, 'User has an alert for this report';
@@ -221,11 +218,8 @@ EOF
         $report->discard_changes;
         is $report->comments->count, 1, 'updates added to report post send';
         my @email = $mech->get_email;
-        is $email[0]->header('To'), 'TfB <claims@example.net>, TfB <claims2@example.net>';
-        my $bucks_text = $mech->get_html_body_from_email($email[0]);
-        like $bucks_text, qr/Confirm reference: 248/, 'confirm reference included in bucks email';
-        my $text = $mech->get_text_body_from_email($email[1]);
-        is $email[1]->header('Subject'), "Your claim has been submitted, ref $report_id";
+        my $text = $mech->get_text_body_from_email($email[0]);
+        is $email[0]->header('Subject'), "Your claim has been submitted, ref $report_id";
         like $text, qr/reference number is $report_id/;
         like $text, qr/is a lengthy process/;
         my $req = Open311->test_req_used;


### PR DESCRIPTION
Bucks no longer need claims going to email now we're sending claims to EvoClaim (#4357).

This change separates the claim auto-response template code from the claims email sending code and then removes the claim email sending code entirely.

Also updated a couple of comments while I was in the file.

Fixes https://github.com/mysociety/societyworks/issues/3768

<!-- [skip changelog] -->
