### PR TITLE
[Waste] Move request timeframe to configuration.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -453,11 +453,6 @@ Functions specific to the waste product & Bartec integration.
 
 =cut
 
-has wasteworks_config => (
-    is => 'lazy',
-    default => sub { $_[0]->body->get_extra_metadata( 'wasteworks_config', {} ) },
-);
-
 sub _premises_for_postcode {
     my $self = shift;
     my $pc = shift;

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -1,9 +1,7 @@
 package FixMyStreet::Cobrand::UKCouncils;
 use parent 'FixMyStreet::Cobrand::UK';
 
-use strict;
-use warnings;
-
+use Moo;
 use Carp;
 use List::Util qw(min max);
 use URI::Escape;
@@ -421,6 +419,17 @@ sub munge_report_new_contacts {
         $nh->national_highways_cleaning_groups($contacts);
     }
 }
+
+=item wasteworks_config
+
+Returns any database-stored WasteWorks configuration.
+
+=cut
+
+has wasteworks_config => (
+    is => 'lazy',
+    default => sub { $_[0]->body->get_extra_metadata( 'wasteworks_config', {} ) },
+);
 
 sub open311_extra_data {
     my $self = shift;

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -9,7 +9,10 @@ END { FixMyStreet::App->log->enable('info'); }
 
 my $mech = FixMyStreet::TestMech->new;
 
-my $body = $mech->create_body_ok(2482, 'Bromley Council', {}, { cobrand => 'bromley' });
+my $body = $mech->create_body_ok(2482, 'Bromley Council', {}, {
+    cobrand => 'bromley',
+    wasteworks_config => { request_timeframe => "two weeks" }
+});
 my $user = $mech->create_user_ok('test@example.net', name => 'Normal User');
 $user->update({ phone => "07123 456789" });
 my $nameless_user = $mech->create_user_ok('nameless@example.net', name => '');
@@ -248,6 +251,7 @@ FixMyStreet::override_config {
         $mech->content_contains($user->email);
         $mech->submit_form_ok({ with_fields => { process => 'summary' } });
         $mech->content_contains('Your container request has been sent');
+        $mech->content_contains('Containers typically arrive within two weeks,');
         $mech->content_contains('Show upcoming bin days');
         $mech->content_contains('/waste/12345"');
         my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;

--- a/templates/email/kingston/other-reported.html
+++ b/templates/email/kingston/other-reported.html
@@ -21,8 +21,8 @@ INCLUDE '_email_top.html';
   <p style="[% p_style %]">We will arrange another collection as soon as possible
   in the next 2 working days (not including Saturday and Sunday).</p>
 [% ELSIF report.category == 'Request new container' %]
-  <p style="[% p_style %]">We aim to deliver this container to you within 20
-  working days. If you have requested a replacement bin please leave your
+  <p style="[% p_style %]">We aim to deliver this container to you within [% cobrand.wasteworks_config.request_timeframe %].
+  If you have requested a replacement bin please leave your
   broken one available for collection at the front of your property.</p>
 [% END %]
 

--- a/templates/email/kingston/other-reported.txt
+++ b/templates/email/kingston/other-reported.txt
@@ -11,7 +11,7 @@ Dear [% report.name %],
 We will arrange another collection as soon as possible in the next 2
 working days (not including Saturday and Sunday).
 [% ELSIF report.category == 'Request new container' %]
-We aim to deliver this container to you within 20 working days. If
+We aim to deliver this container to you within [% cobrand.wasteworks_config.request_timeframe %]. If
 you have requested a replacement bin please leave your broken one
 available for collection at the front of your property.
 [% END %]

--- a/templates/email/sutton/other-reported.html
+++ b/templates/email/sutton/other-reported.html
@@ -19,8 +19,9 @@ INCLUDE '_email_top.html';
 [% INCLUDE '_council_reference.html' problem=report %]
 
 [% IF report.category == 'Request new container' %]
-<p style="[% p_style %]">Due to the current high demand, please allow up to 40
-working days for this order to be processed. We thank you for your patience and
+<p style="[% p_style %]">Due to the current high demand, please allow up to
+[% cobrand.wasteworks_config.request_timeframe %]
+for this order to be processed. We thank you for your patience and
 understanding in advance.</p>
 [% END %]
 

--- a/templates/email/sutton/other-reported.txt
+++ b/templates/email/sutton/other-reported.txt
@@ -10,7 +10,8 @@ Your report to [% report.body %] has been logged on [% site_name %].
 [% INCLUDE '_council_reference.txt' problem=report %]
 
 [% IF report.category == 'Request new container' %]
-Due to the current high demand, please allow up to 40 working days for this
+Due to the current high demand, please allow up to
+[% cobrand.wasteworks_config.request_timeframe %] for this
 order to be processed. We thank you for your patience and understanding in
 advance.
 [% END %]

--- a/templates/web/base/waste/confirmation.html
+++ b/templates/web/base/waste/confirmation.html
@@ -20,12 +20,8 @@ END ~%]
         </p>
         <p>
           [% IF report.category == 'Request new container' %]
-            [% IF c.cobrand.moniker == 'kingston' %]
-              Containers typically arrive within 20 working days, but this may vary due to demand.
-            [% ELSIF c.cobrand.moniker == 'sutton' %]
-              Containers typically arrive within 40 working days, but this may vary due to demand.
-            [% ELSIF c.cobrand.moniker == 'bromley' %]
-              Containers typically arrive within two weeks, but this may vary due to demand.
+            [% IF c.cobrand.moniker == 'kingston' || c.cobrand.moniker == 'sutton' || c.cobrand.moniker == 'bromley' %]
+              Containers typically arrive within [% c.cobrand.wasteworks_config.request_timeframe %], but this may vary due to demand.
             [% END %]
           [% END %]
           [% INCLUDE 'waste/_report_ids.html' %]

--- a/templates/web/kingston/waste/_confirmation_after.html
+++ b/templates/web/kingston/waste/_confirmation_after.html
@@ -2,7 +2,8 @@
 
 <h2>Order confirmation</h2>
 
-<p>Your container request has been approved and should be with you within the next 20 working days. Please contact us after this time with your reference number if you haven’t received it.
+<p>Your container request has been approved and should be with you within the next [% c.cobrand.wasteworks_config.request_timeframe %].
+Please contact us after this time with your reference number if you haven’t received it.
 
 <p>If you’ve requested any containers to be removed please leave these available at the front of your property.
 


### PR DESCRIPTION
[skip changelog] Fixes FD-3154.
This turns on wasteworks_config for bromley/sutton/Kingston and then you'd create a `request_timeframe` key which would contain "20 working days" for Kingston, "30 working days" for Sutton, and "two weeks" for Bromley.