### PR TITLE
[FMS] Adds duplicate_suggestion functionality to FMS

### DIFF
--- a/.cypress/cypress/integration/duplicates.js
+++ b/.cypress/cypress/integration/duplicates.js
@@ -26,7 +26,7 @@ describe('Duplicate tests', function() {
       cy.wait('@report-ajax');
       cy.pickCategory('Licensing');
       cy.nextPageReporting();
-      cy.get('[id=subcategory_Licensing]').select('Skips');
+      cy.get('input[value=Skips]').click();
       cy.wait('@nearby-ajax');
       cy.nextPageReporting();
       cy.contains('Already been reported?');

--- a/.cypress/cypress/integration/duplicates.js
+++ b/.cypress/cypress/integration/duplicates.js
@@ -34,7 +34,25 @@ describe('Duplicate tests', function() {
       cy.visit('http://borsetshire.localhost:3001/_test/teardown/regression-duplicate-hide');
     });
 
-    it.only('does not show duplicate suggestions when signing in during reporting', function() {
+    it('has a separate duplicate suggestions step when on cobrands on FMS', function() {
+      cy.server();
+      cy.route('/report/new/ajax*').as('report-ajax');
+      cy.route('/around/nearby*').as('nearby-ajax');
+      cy.visit('http://fixmystreet.localhost:3001/_test/setup/regression-duplicate-hide'); // Server-side setup
+      cy.visit('http://fixmystreet.localhost:3001/report/1');
+      cy.contains('Report another problem here').click();
+      cy.wait('@report-ajax');
+      cy.pickCategory('Licensing');
+      cy.nextPageReporting();
+      cy.get('input[value=Skips]').click();
+      cy.wait('@nearby-ajax');
+      cy.nextPageReporting();
+      cy.contains('Already been reported?');
+      cy.get('.extra-category-questions').should('not.be.visible');
+      cy.visit('http://fixmystreet.localhost:3001/_test/teardown/regression-duplicate-hide');
+    });
+
+    it('does not show duplicate suggestions when signing in during reporting', function() {
       cy.server();
       cy.route('/report/new/ajax*').as('report-ajax');
       cy.route('/around/nearby*').as('nearby-ajax');

--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -370,6 +370,7 @@ sub nearby : Path {
         longitude => $c->get_param('longitude'),
         categories => [ $c->get_param('filter_category') || () ],
         states => $states,
+        bodies => $c->get_param('bodies'),
     };
     $c->cobrand->call_hook('around_nearby_filter', $params);
     $c->forward('/report/_nearby_json', [ $params ]);

--- a/t/app/controller/report_new_open311.t
+++ b/t/app/controller/report_new_open311.t
@@ -21,7 +21,7 @@ my $contact1 = $mech->create_contact_ok(
     category => 'Street lighting',
     email => '100',
     extra => [ { description => 'Lamppost number', code => 'number', required => 'True' },
-               { description => 'Lamppost type', code => 'type', required => 'False', values =>
+               { description => 'Lamppost type', code => 'lamptype', required => 'False', values =>
                    { value => [ { name => ['Gas'], key => ['old'] }, { name => [ 'Yellow' ], key => [ 'modern' ] } ] }
                }
              ],
@@ -125,7 +125,7 @@ foreach my $test (
         },
         changes => {
             number => '',
-            type   => '',
+            lamptype   => '',
         },
         errors  => [
             'This information is required',
@@ -141,7 +141,7 @@ foreach my $test (
             username_register => 'testopen311@example.com',
             category => 'Street lighting',
             number => 27,
-            type => 'old',
+            lamptype => 'old',
         },
         extra => [
             {
@@ -150,7 +150,7 @@ foreach my $test (
                 description => 'Lamppost number',
             },
             {
-                name => 'type',
+                name => 'lamptype',
                 value => 'old',
                 description => 'Lamppost type',
             }
@@ -251,7 +251,7 @@ foreach my $test (
 
         if ( $test->{fields}->{category} eq 'Street lighting' ) {
             my $result = scraper {
-                process 'select#form_type option', 'option[]' => '@value';
+                process 'select#form_lamptype option', 'option[]' => '@value';
             }
             ->scrape( $mech->response );
 

--- a/web/js/duplicates.js
+++ b/web/js/duplicates.js
@@ -33,6 +33,7 @@
             nearby_url = '/around/nearby';
             url_params.mode = 'suggestions'; // Only want to bother public with very nearby reports (default 250 metres)
             url_params.pin_size = 'normal';
+            url_params.bodies = JSON.stringify(fixmystreet.bodies);
         }
 
         if ($('html').hasClass('mobile')) {


### PR DESCRIPTION
Showing reports that might be duplicates of the report the user is making is a cobrand feature, and only works on branded sites.
    
This makes it work on cobrand areas on FixMyStreet where the duplication_suggestion is turned on for the cobrand on the selected category.
    
https://github.com/mysociety/societyworks/issues/3646

[skip changelog]