### PR TITLE
Fix £NaN display on bulky items page when per-item pricing active

### DIFF
--- a/web/js/waste.js
+++ b/web/js/waste.js
@@ -104,7 +104,9 @@ $(function() {
         $('.govuk-select[name^="item_"]').each(function(i, e) {
             var extra = $(this).find('option').filter(':selected').data('extra');
             var price = extra ? parseFloat(extra.price) : 0;
-            total += price;
+            if (!isNaN(price)) {
+                total += price;
+            }
         });
         $('#js-bulky-total').text((total / 100).toFixed(2));
     });


### PR DESCRIPTION
If only some items have a price set it's possible for the total price of the booking to be displayed as `£NaN`.

[skip changelog]