### PR TITLE
[Bulky] Allow multiple bookings

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
@@ -100,8 +100,8 @@ sub item_list : Private {
 sub index : PathPart('') : Chained('setup') : Args(0) {
     my ($self, $c) = @_;
 
-    # TODO Remove when allowing more than one booking
-    if ($c->stash->{pending_bulky_collections}) {
+    my $cfg = $c->cobrand->feature('waste_features');
+    if ($c->stash->{pending_bulky_collections} && !$cfg->{bulky_multiple_bookings}) {
         $c->detach('/waste/property_redirect');
     }
 

--- a/templates/web/base/waste/bulky/_bin_days_list.html
+++ b/templates/web/base/waste/bulky/_bin_days_list.html
@@ -79,13 +79,11 @@
     <a class="btn btn-primary govuk-!-margin-bottom-2" href="/auth?r=waste/[% property.id %]">View existing bookings</a>
     <!-- END #07 -->
   [% END %]
-  [% UNLESS pending_bulky_collections %]
-    <!-- #06 Should NOT be displayed when: there is a signed user with a booking request -->
+  [% IF waste_features.bulky_multiple_bookings OR NOT pending_bulky_collections %]
     <form method="post" action="[% c.uri_for_action('waste/bulky/index', [ property.id ]) %]">
       <input type="hidden" name="token" value="[% csrf_token %]">
       <input class="btn btn-primary govuk-!-margin-bottom-2" type="submit" aria-label="Book a collection" value="Book a collection">
     </form>
-    <!-- END #06 -->
   [% END %]
 </div>
 

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -114,9 +114,9 @@
         <dd>£[% pounds(payment / 100) %]</dd>
       </dl>
       <div class="govuk-!-margin-bottom-4">
-        <p class="govuk-!-margin-bottom-0">[% items.size %] item[% 's' IF items.size > 1 %] requested for collection.</p>
+        <p class="govuk-!-margin-bottom-0">[% tprintf(nget('%d item requested for collection.', '%d items requested for collection.', items.size), items.size) %]</p>
         [% remaining = cobrand.bulky_items_maximum - items.size %]
-        <small >([% remaining %] remaining slot[% 's' IF remaining > 1 %] available)</small>
+        <small>([% tprintf(nget('%d remaining slot available', '%d remaining slots available', remaining), remaining) %])</small>
       </div>
 
       <table class="item-summary-table govuk-!-margin-bottom-9">


### PR DESCRIPTION
Fixes https://github.com/mysociety/societyworks/issues/3780 [skip changelog]
First adds ID to cancel URLs (so that you'll be able to choose which to cancel), then lists all bookings on bin day page (even though there's only one at this point), and then allow multiple bookings.