### PR TITLE
Increase front page thumbnail right padding on mobile

### DIFF
--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1268,6 +1268,10 @@ input.final-submit {
   }
 }
 
+body.frontpage .item-list--reports__item a {
+  padding: 0 1em 0 1em;
+}
+
 .item-list__item__metadata {
   display: none;
 


### PR DESCRIPTION
Having the report thumbnails butted up against the right hand edge of the page looked a little odd, so this commit mirrors the padding from the left hand side for symmetry.

Raised in FD-3161

[skip changelog]