### PR TITLE
[Lincs] Adds grass cutting layer and actions

### DIFF
--- a/.cypress/cypress/fixtures/lincs_grass_LCDC_contactLCC.xml
+++ b/.cypress/cypress/fixtures/lincs_grass_LCDC_contactLCC.xml
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver https://tilma.staging.mysociety.org:80/mapserver/lincs?SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=feature:LCC_Verges&amp;OUTPUTFORMAT=text/xml;%20subtype=gml/3.1.1  http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+      <gml:boundedBy>
+      	<gml:Envelope srsName="EPSG:3857">
+      		<gml:lowerCorner>-57390.375388 6918829.024662</gml:lowerCorner>
+      		<gml:upperCorner>-54164.074490 6920304.282900</gml:upperCorner>
+      	</gml:Envelope>
+      </gml:boundedBy>
+    <gml:featureMember>
+      <ms:LCC_Verges gml:id="LCC_Verges.">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-56899.959868 6919536.186899</gml:lowerCorner>
+        		<gml:upperCorner>-56862.445020 6919558.224214</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Polygon srsName="EPSG:3857">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:posList srsDimension="2">-56899.874561 6919554.442915 -56895.600401 6919554.205905 -56890.465020 6919558.224214 -56862.826303 6919556.117338 -56862.445020 6919553.057184 -56862.505189 6919550.138165 -56863.630450 6919546.647258 -56865.992920 6919543.016995 -56868.668768 6919540.152163 -56870.993163 6919538.368961 -56873.620944 6919537.037507 -56877.160452 6919536.186899 -56884.036889 6919536.329332 -56889.834508 6919536.911376 -56894.241559 6919538.685515 -56896.944662 6919540.886324 -56898.568946 6919543.526752 -56899.720033 6919546.767831 -56899.959868 6919550.303514 -56899.874561 6919554.442915 </gml:posList>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+        </ms:msGeometry>
+        <ms:Cut_By>LCDC</ms:Cut_By>
+        <ms:Authority>LCDC</ms:Authority>
+        <ms:Asset_Id></ms:Asset_Id>
+        <ms:Cut_1>Contact LCC to Add to Cut</ms:Cut_1>
+        <ms:Cut_2>Contact LCC to Add to Cut</ms:Cut_2>
+        <ms:Cut_3>Contact LCC to Add to Cut</ms:Cut_3>
+        <ms:CutType>CountyUrban</ms:CutType>
+      </ms:LCC_Verges>
+    </gml:featureMember>
+</wfs:FeatureCollection>

--- a/.cypress/cypress/fixtures/lincs_grass_LCDC_contactLCDC.xml
+++ b/.cypress/cypress/fixtures/lincs_grass_LCDC_contactLCDC.xml
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver https://tilma.staging.mysociety.org:80/mapserver/lincs?SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=feature:LCC_Verges&amp;OUTPUTFORMAT=text/xml;%20subtype=gml/3.1.1  http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+      <gml:boundedBy>
+      	<gml:Envelope srsName="EPSG:3857">
+      		<gml:lowerCorner>-57390.375388 6918829.024662</gml:lowerCorner>
+      		<gml:upperCorner>-54164.074490 6920304.282900</gml:upperCorner>
+      	</gml:Envelope>
+      </gml:boundedBy>
+    <gml:featureMember>
+      <ms:LCC_Verges gml:id="LCC_Verges.">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-56899.959868 6919536.186899</gml:lowerCorner>
+        		<gml:upperCorner>-56862.445020 6919558.224214</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Polygon srsName="EPSG:3857">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:posList srsDimension="2">-56899.874561 6919554.442915 -56895.600401 6919554.205905 -56890.465020 6919558.224214 -56862.826303 6919556.117338 -56862.445020 6919553.057184 -56862.505189 6919550.138165 -56863.630450 6919546.647258 -56865.992920 6919543.016995 -56868.668768 6919540.152163 -56870.993163 6919538.368961 -56873.620944 6919537.037507 -56877.160452 6919536.186899 -56884.036889 6919536.329332 -56889.834508 6919536.911376 -56894.241559 6919538.685515 -56896.944662 6919540.886324 -56898.568946 6919543.526752 -56899.720033 6919546.767831 -56899.959868 6919550.303514 -56899.874561 6919554.442915 </gml:posList>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+        </ms:msGeometry>
+        <ms:Cut_By>DIS</ms:Cut_By>
+        <ms:Authority>LCDC</ms:Authority>
+        <ms:Asset_Id></ms:Asset_Id>
+        <ms:Cut_1>Contact LCDC to Add to Cut</ms:Cut_1>
+        <ms:Cut_2>Contact LCDC to Add to Cut</ms:Cut_2>
+        <ms:Cut_3>Contact LCDC to Add to Cut</ms:Cut_3>
+        <ms:CutType>CountyUrban</ms:CutType>
+      </ms:LCC_Verges>
+    </gml:featureMember>
+</wfs:FeatureCollection>

--- a/.cypress/cypress/fixtures/lincs_grass_contact_cp.xml
+++ b/.cypress/cypress/fixtures/lincs_grass_contact_cp.xml
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver https://tilma.staging.mysociety.org:80/mapserver/lincs?SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=feature:LCC_Verges&amp;OUTPUTFORMAT=text/xml;%20subtype=gml/3.1.1  http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+      <gml:boundedBy>
+      	<gml:Envelope srsName="EPSG:3857">
+      		<gml:lowerCorner>-57390.375388 6918829.024662</gml:lowerCorner>
+      		<gml:upperCorner>-54164.074490 6920304.282900</gml:upperCorner>
+      	</gml:Envelope>
+      </gml:boundedBy>
+    <gml:featureMember>
+      <ms:LCC_Verges gml:id="LCC_Verges.">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-56899.959868 6919536.186899</gml:lowerCorner>
+        		<gml:upperCorner>-56862.445020 6919558.224214</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Polygon srsName="EPSG:3857">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:posList srsDimension="2">-56899.874561 6919554.442915 -56895.600401 6919554.205905 -56890.465020 6919558.224214 -56862.826303 6919556.117338 -56862.445020 6919553.057184 -56862.505189 6919550.138165 -56863.630450 6919546.647258 -56865.992920 6919543.016995 -56868.668768 6919540.152163 -56870.993163 6919538.368961 -56873.620944 6919537.037507 -56877.160452 6919536.186899 -56884.036889 6919536.329332 -56889.834508 6919536.911376 -56894.241559 6919538.685515 -56896.944662 6919540.886324 -56898.568946 6919543.526752 -56899.720033 6919546.767831 -56899.959868 6919550.303514 -56899.874561 6919554.442915 </gml:posList>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+        </ms:msGeometry>
+        <ms:Cut_By>CPM</ms:Cut_By>
+        <ms:Authority>CP Media</ms:Authority>
+        <ms:Asset_Id></ms:Asset_Id>
+        <ms:Cut_1>CP Media Sponsorship</ms:Cut_1>
+        <ms:Cut_2>CP Media Sponsorship</ms:Cut_2>
+        <ms:Cut_3>CP Media Sponsorship</ms:Cut_3>
+        <ms:CutType>CountyUrban</ms:CutType>
+      </ms:LCC_Verges>
+    </gml:featureMember>
+</wfs:FeatureCollection>

--- a/.cypress/cypress/fixtures/lincs_grass_contact_parish.xml
+++ b/.cypress/cypress/fixtures/lincs_grass_contact_parish.xml
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver https://tilma.staging.mysociety.org:80/mapserver/lincs?SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=feature:LCC_Verges&amp;OUTPUTFORMAT=text/xml;%20subtype=gml/3.1.1  http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+      <gml:boundedBy>
+      	<gml:Envelope srsName="EPSG:3857">
+      		<gml:lowerCorner>-57390.375388 6918829.024662</gml:lowerCorner>
+      		<gml:upperCorner>-54164.074490 6920304.282900</gml:upperCorner>
+      	</gml:Envelope>
+      </gml:boundedBy>
+    <gml:featureMember>
+      <ms:LCC_Verges gml:id="LCC_Verges.">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-56899.959868 6919536.186899</gml:lowerCorner>
+        		<gml:upperCorner>-56862.445020 6919558.224214</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Polygon srsName="EPSG:3857">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:posList srsDimension="2">-56899.874561 6919554.442915 -56895.600401 6919554.205905 -56890.465020 6919558.224214 -56862.826303 6919556.117338 -56862.445020 6919553.057184 -56862.505189 6919550.138165 -56863.630450 6919546.647258 -56865.992920 6919543.016995 -56868.668768 6919540.152163 -56870.993163 6919538.368961 -56873.620944 6919537.037507 -56877.160452 6919536.186899 -56884.036889 6919536.329332 -56889.834508 6919536.911376 -56894.241559 6919538.685515 -56896.944662 6919540.886324 -56898.568946 6919543.526752 -56899.720033 6919546.767831 -56899.959868 6919550.303514 -56899.874561 6919554.442915 </gml:posList>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+        </ms:msGeometry>
+        <ms:Cut_By>PAR</ms:Cut_By>
+        <ms:Authority>North Somercotes</ms:Authority>
+        <ms:Asset_Id></ms:Asset_Id>
+        <ms:Cut_1>Contact Parish Council</ms:Cut_1>
+        <ms:Cut_2>Contact Parish Council</ms:Cut_2>
+        <ms:Cut_3>Contact Parish Council</ms:Cut_3>
+        <ms:CutType>CountyUrban</ms:CutType>
+      </ms:LCC_Verges>
+    </gml:featureMember>
+</wfs:FeatureCollection>

--- a/.cypress/cypress/fixtures/lincs_grass_f0_withDates.xml
+++ b/.cypress/cypress/fixtures/lincs_grass_f0_withDates.xml
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver https://tilma.staging.mysociety.org:80/mapserver/lincs?SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=feature:LCC_Verges&amp;OUTPUTFORMAT=text/xml;%20subtype=gml/3.1.1  http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+      <gml:boundedBy>
+      	<gml:Envelope srsName="EPSG:3857">
+      		<gml:lowerCorner>-57390.375388 6918829.024662</gml:lowerCorner>
+      		<gml:upperCorner>-54164.074490 6920304.282900</gml:upperCorner>
+      	</gml:Envelope>
+      </gml:boundedBy>
+    <gml:featureMember>
+      <ms:LCC_Verges gml:id="LCC_Verges.">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-56899.959868 6919536.186899</gml:lowerCorner>
+        		<gml:upperCorner>-56862.445020 6919558.224214</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Polygon srsName="EPSG:3857">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:posList srsDimension="2">-56899.874561 6919554.442915 -56895.600401 6919554.205905 -56890.465020 6919558.224214 -56862.826303 6919556.117338 -56862.445020 6919553.057184 -56862.505189 6919550.138165 -56863.630450 6919546.647258 -56865.992920 6919543.016995 -56868.668768 6919540.152163 -56870.993163 6919538.368961 -56873.620944 6919537.037507 -56877.160452 6919536.186899 -56884.036889 6919536.329332 -56889.834508 6919536.911376 -56894.241559 6919538.685515 -56896.944662 6919540.886324 -56898.568946 6919543.526752 -56899.720033 6919546.767831 -56899.959868 6919550.303514 -56899.874561 6919554.442915 </gml:posList>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+        </ms:msGeometry>
+        <ms:Cut_By>F0</ms:Cut_By>
+        <ms:Authority>LCC</ms:Authority>
+        <ms:Asset_Id></ms:Asset_Id>
+        <ms:Cut_1>1 June</ms:Cut_1>
+        <ms:Cut_2>6 September</ms:Cut_2>
+        <ms:Cut_3>N/A</ms:Cut_3>
+        <ms:CutType>CountyUrban</ms:CutType>
+      </ms:LCC_Verges>
+    </gml:featureMember>
+</wfs:FeatureCollection>

--- a/.cypress/cypress/fixtures/lincs_grass_f1_withDates.xml
+++ b/.cypress/cypress/fixtures/lincs_grass_f1_withDates.xml
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver https://tilma.staging.mysociety.org:80/mapserver/lincs?SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=feature:LCC_Verges&amp;OUTPUTFORMAT=text/xml;%20subtype=gml/3.1.1  http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+      <gml:boundedBy>
+      	<gml:Envelope srsName="EPSG:3857">
+      		<gml:lowerCorner>-57390.375388 6918829.024662</gml:lowerCorner>
+      		<gml:upperCorner>-54164.074490 6920304.282900</gml:upperCorner>
+      	</gml:Envelope>
+      </gml:boundedBy>
+    <gml:featureMember>
+      <ms:LCC_Verges gml:id="LCC_Verges.">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-56899.959868 6919536.186899</gml:lowerCorner>
+        		<gml:upperCorner>-56862.445020 6919558.224214</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Polygon srsName="EPSG:3857">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:posList srsDimension="2">-56899.874561 6919554.442915 -56895.600401 6919554.205905 -56890.465020 6919558.224214 -56862.826303 6919556.117338 -56862.445020 6919553.057184 -56862.505189 6919550.138165 -56863.630450 6919546.647258 -56865.992920 6919543.016995 -56868.668768 6919540.152163 -56870.993163 6919538.368961 -56873.620944 6919537.037507 -56877.160452 6919536.186899 -56884.036889 6919536.329332 -56889.834508 6919536.911376 -56894.241559 6919538.685515 -56896.944662 6919540.886324 -56898.568946 6919543.526752 -56899.720033 6919546.767831 -56899.959868 6919550.303514 -56899.874561 6919554.442915 </gml:posList>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+        </ms:msGeometry>
+        <ms:Cut_By>F1</ms:Cut_By>
+        <ms:Authority>LCC</ms:Authority>
+        <ms:Asset_Id></ms:Asset_Id>
+        <ms:Cut_1>24 April - 28 May</ms:Cut_1>
+        <ms:Cut_2>12 June - 16 July</ms:Cut_2>
+        <ms:Cut_3>4 September - 8 October</ms:Cut_3>
+        <ms:CutType>CountyUrban</ms:CutType>
+      </ms:LCC_Verges>
+    </gml:featureMember>
+</wfs:FeatureCollection>

--- a/.cypress/cypress/fixtures/lincs_grass_lcc_noDate.xml
+++ b/.cypress/cypress/fixtures/lincs_grass_lcc_noDate.xml
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver https://tilma.staging.mysociety.org:80/mapserver/lincs?SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=feature:LCC_Verges&amp;OUTPUTFORMAT=text/xml;%20subtype=gml/3.1.1  http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+      <gml:boundedBy>
+      	<gml:Envelope srsName="EPSG:3857">
+      		<gml:lowerCorner>-57390.375388 6918829.024662</gml:lowerCorner>
+      		<gml:upperCorner>-54164.074490 6920304.282900</gml:upperCorner>
+      	</gml:Envelope>
+      </gml:boundedBy>
+    <gml:featureMember>
+      <ms:LCC_Verges gml:id="LCC_Verges.">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-56899.959868 6919536.186899</gml:lowerCorner>
+        		<gml:upperCorner>-56862.445020 6919558.224214</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Polygon srsName="EPSG:3857">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:posList srsDimension="2">-56899.874561 6919554.442915 -56895.600401 6919554.205905 -56890.465020 6919558.224214 -56862.826303 6919556.117338 -56862.445020 6919553.057184 -56862.505189 6919550.138165 -56863.630450 6919546.647258 -56865.992920 6919543.016995 -56868.668768 6919540.152163 -56870.993163 6919538.368961 -56873.620944 6919537.037507 -56877.160452 6919536.186899 -56884.036889 6919536.329332 -56889.834508 6919536.911376 -56894.241559 6919538.685515 -56896.944662 6919540.886324 -56898.568946 6919543.526752 -56899.720033 6919546.767831 -56899.959868 6919550.303514 -56899.874561 6919554.442915 </gml:posList>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+        </ms:msGeometry>
+        <ms:Cut_By>LCC</ms:Cut_By>
+        <ms:Authority>LCC</ms:Authority>
+        <ms:Asset_Id></ms:Asset_Id>
+        <ms:Cut_1>Contact LCC to Add to Cut</ms:Cut_1>
+        <ms:Cut_2>Contact LCC to Add to Cut</ms:Cut_2>
+        <ms:Cut_3>Contact LCC to Add to Cut</ms:Cut_3>
+        <ms:CutType>CountyUrban</ms:CutType>
+      </ms:LCC_Verges>
+    </gml:featureMember>
+</wfs:FeatureCollection>

--- a/.cypress/cypress/fixtures/lincs_grass_lcc_withDates.xml
+++ b/.cypress/cypress/fixtures/lincs_grass_lcc_withDates.xml
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver https://tilma.staging.mysociety.org:80/mapserver/lincs?SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=feature:LCC_Verges&amp;OUTPUTFORMAT=text/xml;%20subtype=gml/3.1.1  http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+      <gml:boundedBy>
+      	<gml:Envelope srsName="EPSG:3857">
+      		<gml:lowerCorner>-57390.375388 6918829.024662</gml:lowerCorner>
+      		<gml:upperCorner>-54164.074490 6920304.282900</gml:upperCorner>
+      	</gml:Envelope>
+      </gml:boundedBy>
+    <gml:featureMember>
+      <ms:LCC_Verges gml:id="LCC_Verges.">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="EPSG:3857">
+        		<gml:lowerCorner>-56899.959868 6919536.186899</gml:lowerCorner>
+        		<gml:upperCorner>-56862.445020 6919558.224214</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Polygon srsName="EPSG:3857">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:posList srsDimension="2">-56899.874561 6919554.442915 -56895.600401 6919554.205905 -56890.465020 6919558.224214 -56862.826303 6919556.117338 -56862.445020 6919553.057184 -56862.505189 6919550.138165 -56863.630450 6919546.647258 -56865.992920 6919543.016995 -56868.668768 6919540.152163 -56870.993163 6919538.368961 -56873.620944 6919537.037507 -56877.160452 6919536.186899 -56884.036889 6919536.329332 -56889.834508 6919536.911376 -56894.241559 6919538.685515 -56896.944662 6919540.886324 -56898.568946 6919543.526752 -56899.720033 6919546.767831 -56899.959868 6919550.303514 -56899.874561 6919554.442915 </gml:posList>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+        </ms:msGeometry>
+        <ms:Cut_By>LCC</ms:Cut_By>
+        <ms:Authority>LCC</ms:Authority>
+        <ms:Asset_Id></ms:Asset_Id>
+        <ms:Cut_1>24 April - 28 May</ms:Cut_1>
+        <ms:Cut_2>12 June - 16 July</ms:Cut_2>
+        <ms:Cut_3>4 September - 8 October</ms:Cut_3>
+        <ms:CutType>CountyUrban</ms:CutType>
+      </ms:LCC_Verges>
+    </gml:featureMember>
+</wfs:FeatureCollection>

--- a/.cypress/cypress/integration/lincolnshire.js
+++ b/.cypress/cypress/integration/lincolnshire.js
@@ -47,3 +47,114 @@ describe('Lincolnshire cobrand', function(){
         });
     });
 });
+
+describe('Grass cutting layer', function(){
+
+    beforeEach(function() {
+        cy.server();
+        cy.route('/report/new/ajax*').as('report-ajax');
+    });
+
+    it('proceeds with report to LCC if LCC and no date given', function(){
+        cy.route('POST', '**/mapserver/lincs', 'fixture:lincs_grass_lcc_noDate.xml').as('grass');
+        cy.visit('http://lincolnshire.localhost:3001/report/new?longitude=-0.510956&latitude=52.655591');
+        cy.wait('@report-ajax');
+        cy.pickCategory('Grass cutting');
+        cy.wait('@grass');
+        cy.nextPageReporting();
+        cy.contains('Drag photos here').should('be.visible');
+        cy.nextPageReporting();
+        cy.contains('These will be sent to Lincolnshire County Council').should('be.visible');
+    });
+
+    it('presents a message with grass cutting date if LCC responsibility and cut date given, and reports to LCC if continued', function(){
+        cy.route('POST', '**/mapserver/lincs', 'fixture:lincs_grass_lcc_withDates.xml').as('grass');
+        cy.clock(Date.UTC(2020, 6, 10), ['Date']);
+        cy.visit('http://lincolnshire.localhost:3001/report/new?longitude=-0.510956&latitude=52.655591');
+        cy.wait('@report-ajax');
+        cy.pickCategory('Grass cutting');
+        cy.wait('@grass');
+        cy.nextPageReporting();
+        cy.contains('12 June - 16 July').should('be.visible');
+        cy.contains('Thank you for making an enquiry').should('not.be.visible');
+        cy.get('.js-reporting-page--next').contains('No');
+        cy.get('#lincs-yes-verge-query').contains('Yes').click();
+        cy.get('.js-reporting-page--next').should('be.disabled');
+        cy.contains('In rural areas we cut roads to the first').should('not.be.visible');
+        cy.contains('Thank you for making an enquiry').should('be.visible');
+        cy.go('back');
+        cy.get('.js-reporting-page--next').contains('Continue');
+        cy.nextPageReporting();
+        cy.nextPageReporting();
+        cy.contains('Drag photos here').should('be.visible');
+        cy.get('.js-reporting-page--next').contains('Continue');
+        cy.nextPageReporting();
+        cy.contains('These will be sent to Lincolnshire County Council').should('be.visible');
+    });
+
+    it('presents a message with grass cutting date if F1 responsibility and cut date given with extra message', function(){
+        cy.route('POST', '**/mapserver/lincs', 'fixture:lincs_grass_f1_withDates.xml').as('grass');
+        cy.clock(Date.UTC(2020, 6, 10), ['Date']);
+        cy.visit('http://lincolnshire.localhost:3001/report/new?longitude=-0.510956&latitude=52.655591');
+        cy.wait('@report-ajax');
+        cy.pickCategory('Grass cutting');
+        cy.wait('@grass');
+        cy.nextPageReporting();
+        cy.contains('12 June - 16 July').should('be.visible');
+        cy.contains('In rural areas we cut roads to the first').should('be.visible');
+        cy.contains('Thank you for making an enquiry').should('not.be.visible');
+        cy.get('#lincs-yes-verge-query').contains('Yes').click();
+        cy.contains('Thank you for making an enquiry').should('be.visible');
+    });
+
+    it('presents a message with grass cutting date if F0 responsibility and cut date given with extra message', function(){
+        cy.route('POST', '**/mapserver/lincs', 'fixture:lincs_grass_f0_withDates.xml').as('grass');
+        cy.clock(Date.UTC(2020, 6, 10), ['Date']);
+        cy.visit('http://lincolnshire.localhost:3001/report/new?longitude=-0.510956&latitude=52.655591');
+        cy.wait('@report-ajax');
+        cy.pickCategory('Grass cutting');
+        cy.wait('@grass');
+        cy.nextPageReporting();
+        cy.contains('on 6 September').should('be.visible');
+        cy.contains('In rural areas we cut roads to the first').should('be.visible');
+        cy.contains('Thank you for making an enquiry').should('not.be.visible');
+        cy.get('#lincs-yes-verge-query').contains('Yes').click();
+        cy.contains('Thank you for making an enquiry').should('be.visible');
+    });
+
+    it('reports to LCC if LCDC responsibility and data says contact LCC', function(){
+        cy.route('POST', '**/mapserver/lincs', 'fixture:lincs_grass_LCDC_contactLCC.xml').as('grass');
+        cy.visit('http://lincolnshire.localhost:3001/report/new?longitude=-0.510956&latitude=52.655591');
+        cy.wait('@report-ajax');
+        cy.pickCategory('Grass cutting');
+        cy.wait('@grass');
+        cy.nextPageReporting();
+        cy.contains('Drag photos here').should('be.visible');
+        cy.nextPageReporting();
+        cy.contains('These will be sent to Lincolnshire County Council').should('be.visible');
+    });
+
+    it('reports to LCDC if their responsibility and data doesn\t say report to LCC ', function(){
+        cy.route('POST', '**/mapserver/lincs', 'fixture:lincs_grass_LCDC_contactLCDC.xml').as('grass');
+        cy.visit('http://lincolnshire.localhost:3001/report/new?longitude=-0.510956&latitude=52.655591');
+        cy.wait('@report-ajax');
+        cy.pickCategory('Grass cutting');
+        cy.wait('@grass');
+        cy.nextPageReporting();
+        cy.contains('Drag photos here').should('be.visible');
+        cy.nextPageReporting();
+        cy.contains('These will be sent to Lincoln City Council').should('be.visible');
+    });
+
+    it('presents a parish message if Parish responsibility and stops', function(){
+        cy.route('POST', '**/mapserver/lincs', 'fixture:lincs_grass_contact_parish.xml').as('grass');
+        cy.visit('http://lincolnshire.localhost:3001/report/new?longitude=-0.510956&latitude=52.655591');
+        cy.wait('@report-ajax');
+        cy.pickCategory('Grass cutting');
+        cy.wait('@grass');
+        cy.get('#map_sidebar').scrollTo('bottom');
+        cy.contains('responsibility of North Somercotes Parish/Town Council').should('be.visible');
+        cy.get('.js-reporting-page--next:visible').should('be.disabled');
+    });
+
+});

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -163,7 +163,8 @@ if ($opt->test_fixtures) {
                 { category => 'Private', send_method => 'Triage', non_public => 1 },
                 { category => 'Extra', send_method => 'Triage' },
             ], name => 'Isle of Wight Council', cobrand => 'isleofwight' },
-        { area_id => 2232, categories => ['Damaged/missing cats eye'], name => 'Lincolnshire County Council', cobrand => 'lincolnshire' },
+        { area_id => 2232, categories => ['Damaged/missing cats eye', 'Grass cutting'], name => 'Lincolnshire County Council', cobrand => 'lincolnshire' },
+        { area_id => 2385, categories => ['Grass cutting'], name => 'Lincoln City Council' },
         { area_id => 2226, categories => [
                 { group => 'A pothole in pavement', category => 'A pothole in pavement' },
                 { group => 'A pothole in road', category => 'A pothole in road' },

--- a/data/test-asset-layers.yml
+++ b/data/test-asset-layers.yml
@@ -260,6 +260,14 @@ lincolnshire:
     asset_item_message: ''
     disable_pin_snapping: true
     stylemap: 'fixmystreet.assets.stylemap_invisible'
+  - wfs_feature: "LCC_Verges"
+    asset_category: "Grass cutting"
+    asset_type: area
+    road: true
+    non_interactive: true
+    actions:
+      found: fixmystreet.assets.lincolnshire.grass_found
+      not_found: fixmystreet.assets.lincolnshire.grass_not_found
 merton:
 - - name: 'default'
     max_resolution: 4.777314267158508

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -42,6 +42,7 @@ my @PLACES = (
     [ 'OX16 9UP', 52.038712, -1.346397, 2237, 'Oxfordshire County Council', 'CTY', 2419, 'Cherwell District Council', 'DIS', 151767, "Banbury, Calthorpe & Easington", "DIW" ],
     [ 'RG9 6TL', 51.561705, -0.868388, 163793, 'Buckinghamshire Council', 'UTA'],
     [ 'PE9 2GX', 52.656144, -0.502566, 2232, 'Lincolnshire County Council', 'CTY'],
+    [ 'PE9 3GX', 52.655591, -0.510956, 2232, 'Lincolnshire County Council', 'CTY'],
     [ 'LE15 0GJ', 52.670447, -0.727877, 2600, 'Rutland County Council', 'UTA'],
     [ 'BR1 3UH', 51.4021, 0.01578, 2482, 'Bromley Council', 'LBO' ],
     [ 'BR1 3UH', 51.402096, 0.015784, 2482, 'Bromley Council', 'LBO' ],

--- a/templates/web/fixmystreet.com/report/new/roads_message.html
+++ b/templates/web/fixmystreet.com/report/new/roads_message.html
@@ -79,6 +79,11 @@
             To enable you to find out who owns/maintains this area please contact HM Land Registry at https://www.gov.uk/search-property-information-land-registry.
         </p>
     </div>
+    <div id="js-lincs-parish-grass" class="hidden js-responsibility-message">
+      <p>The grass in this area is the responsibility of {{PARISH_COUNCIL}} Parish/Town Council.</p>
+      <p>Please contact them directly to report the issue.</p>
+      <p>To find your Town or Parish Council’s contact details visit <a href='https://parish.uk/find-parish-council'>https://parish.uk/find-parish-council</a></p>
+    </div>
 </div>
 <div id="js-environment-message" class="hidden">
     [% fly_text = INCLUDE 'report/new/flytipping_text.html' %][% fly_text | html_para %]

--- a/templates/web/lincolnshire/report/new/roads_message.html
+++ b/templates/web/lincolnshire/report/new/roads_message.html
@@ -1,0 +1,6 @@
+    <div id="js-lincs-parish-grass" class="hidden js-responsibility-message">
+      <p>The grass in this area is the responsibility of {{PARISH_COUNCIL}} Parish/Town Council.</p>
+      <p>Please contact them directly to report the issue.</p>
+      <p>To find your Town or Parish Council’s contact details visit <a href='https://parish.uk/find-parish-council'>https://parish.uk/find-parish-council</a></p>
+    </div>
+


### PR DESCRIPTION
Adds layer which provides information about repsponsibility of grass areas in Lincolnshire which is triggered on selecting 'Grass cutting'

New action - if grass is Lincolnshire County Council responsibility (including those that are 'cut by' F1, F0, STR, Flail) and has cutting dates, show the dates to the user and invite them to carry on with the report or abandon it depending if that answers their query

Keep action - if grass is Lincolnshire County Council and no cutting dates, report continues to make report to Lincolnshire County Council

New action - if grass is District Council South Keveston or Lincoln City council and responsibility is with Lincolnshire County Council, send report to Lincolnshire County Council. Otherwise send to the District Council

New action - if grass is a Parish Council and refers to contact the Parish Council adds a stopper message to say contact the Parish Council

New action - if grass is CP Media adds a stopper message to say contact CP Media

https://github.com/mysociety/societyworks/issues/3739

[skip changelog]