### PR TITLE
Move form override defaults into cobrand code from templates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
     - Front end improvements:
         - Include requirements for redeeming the link in the email change confirmation mail. #4422
         - Use email field type for username if SMS authentication not enabled. #4455
-        - Text overrides for new report fields can be configured to apply when it is known the report will go to a particular cobrand. #4466
+        - Text overrides for new report fields can be configured to apply when it is known the report will go to a particular cobrand. #4466, #4516
     - Bugfixes:
         - Stop map panning breaking after long press. #4423
         - Fix RSS feed subscription from alert page button.

--- a/templates/web/base/admin/bodies/contact-form.html
+++ b/templates/web/base/admin/bodies/contact-form.html
@@ -76,12 +76,12 @@
     [% TRY %][% PROCESS 'report/new/_form_labels.html' %][% CATCH file %][% END %]
     <label for="title-hint">[% loc('Summary hint text') %]</label>
     <p class="form-hint" id="title-hint-hint">
-        Default is “[% form_title_placeholder OR loc('e.g. ‘10 inch pothole on Example St, near post box’') %]”
+        Default is “[% form_title_placeholder %]”
     </p>
     <input type="text" class="form-control" id="title-hint" aria-describedby="title-hint-hint" name="title_hint" size="30" value="[% contact.get_extra_metadata('title_hint') %]">
     <label for="detail-hint">[% loc('Details hint text') %]</label>
     <p class="form-hint" id="detail-hint-hint">
-        Default is “[% form_detail_placeholder.defined ? form_detail_placeholder : loc('e.g. ‘This pothole has been here for two months and…’') %]”
+        Default is “[% form_detail_placeholder %]”
     </p>
     <input type="text" class="form-control" id="detail-hint" aria-describedby="detail-hint-hint" name="detail_hint" size="30" value="[% contact.get_extra_metadata('detail_hint') %]">
 

--- a/templates/web/base/report/new/_form_labels.html
+++ b/templates/web/base/report/new/_form_labels.html
@@ -1,5 +1,8 @@
 [%
-SET form_title = c.cobrand.new_report_title_field_label;
-SET form_title_placeholder = c.cobrand.new_report_title_field_hint;
-SET form_detail_placeholder = c.cobrand.new_report_detail_field_hint;
+SET form_title = c.cobrand.new_report_title_field_label.defined ?
+    c.cobrand.new_report_title_field_label : loc("Summarise the problem");
+SET form_title_placeholder = c.cobrand.new_report_title_field_hint.defined ?
+    c.cobrand.new_report_title_field_hint : loc("e.g. ‘10 inch pothole on Example St, near post box’");
+SET form_detail_placeholder = c.cobrand.new_report_detail_field_hint.defined ?
+    c.cobrand.new_report_detail_field_hint : loc('e.g. ‘This pothole has been here for two months and…’');
 -%]

--- a/templates/web/base/report/new/form_report.html
+++ b/templates/web/base/report/new/form_report.html
@@ -74,11 +74,6 @@
     [% DEFAULT form_detail_label = loc('Explain what’s wrong') %]
     <label for="form_detail">[% form_detail_label %]</label>
 
-    [%# You can prevent a hint being printed by setting form_detail_placeholder to a Falsey value %]
-  [% IF NOT form_detail_placeholder.defined %]
-    [% SET form_detail_placeholder = loc('e.g. ‘This pothole has been here for two months and…’') %]
-  [% END %]
-
   [% IF contact_detail_hint %]
     <p class="form-hint" id="detail-hint">[% contact_detail_hint %]</p>
   [% ELSIF form_detail_placeholder %]
@@ -89,7 +84,7 @@
     <p class='form-error'>[% field_errors.detail %]</p>
   [% END %]
 
-    <textarea class="form-control" rows="7" cols="26" name="detail" id="form_detail" [% IF form_detail_placeholder %]aria-describedby="detail-hint"[% END %][% field_required %]>[% report.detail | html %]</textarea>
+    <textarea class="form-control" rows="7" cols="26" name="detail" id="form_detail" [% IF form_detail_placeholder OR contact_detail_hint %]aria-describedby="detail-hint"[% END %][% field_required %]>[% report.detail | html %]</textarea>
 
     [% TRY %][% PROCESS 'report/new/inline-tips.html' %][% CATCH file %][% END %]
 

--- a/templates/web/base/report/new/form_title.html
+++ b/templates/web/base/report/new/form_title.html
@@ -1,5 +1,3 @@
-[% DEFAULT form_title = loc('Summarise the problem') %]
-[% DEFAULT form_title_placeholder = loc('e.g. ‘10 inch pothole on Example St, near post box’') %]
 <label id="title-label" for="form_title">[% form_title %]</label>
 <p class="form-hint" id="title-hint">[% contact_title_hint OR form_title_placeholder %]</p>
 [% IF field_errors.title %]


### PR DESCRIPTION
Also fixes a bug introduced in #4471 where the detail hint default text would stop displaying for cobrands without a bespoke value set.