### PR TITLE
Add send state to problems (fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
         - Extra data columns now stored as JSON, not RABX. #3216
         - Cobrands can provide custom distances for duplicate lookup. #4456
         - Auto-spot a default favicon.ico.
+        - Add `send_state` column to reports. #4048
     - Changes:
         - Switch to OpenStreetMap for reverse geocoding. #4444
 

--- a/bin/update-schema
+++ b/bin/update-schema
@@ -223,6 +223,7 @@ else {
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
     return 'EMPTY' if ! table_exists('problem');
+    return '0085' if column_exists('problem', 'send_state');
     return '0084' if column_type_equals('problem', 'extra', 'jsonb');
     return '0083' if column_not_null('token', 'data_json');
     return '0082' if column_exists('problem', 'extra_json');

--- a/db/downgrade_0085---0084.sql
+++ b/db/downgrade_0085---0084.sql
@@ -1,0 +1,1 @@
+ALTER TABLE problem DROP COLUMN send_state;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -227,6 +227,13 @@ create table problem (
     geocode jsonb,
     response_priority_id int REFERENCES response_priorities(id),
 
+    send_state text not null default 'unprocessed' check (
+        send_state = 'unprocessed'
+        or send_state = 'processed'
+        or send_state = 'skipped'
+        or send_state = 'sent'
+        or send_state = 'acknowledged'
+    ),
     -- logging sending failures (used by webservices)
     send_fail_count integer not null default 0,
     send_fail_reason text,
@@ -253,6 +260,7 @@ create index problem_state_latitude_longitude_idx on problem(state, latitude, lo
 create index problem_user_id_idx on problem ( user_id );
 create index problem_external_id_idx on problem(external_id);
 create index problem_external_body_idx on problem(lower(external_body));
+create index problem_state_send_state_idx on problem(state, send_state);
 create index problem_radians_latitude_longitude_idx on problem(radians(latitude), radians(longitude));
 create index problem_bodies_str_array_idx on problem USING gin(regexp_split_to_array(bodies_str, ','));
 create index problem_fulltext_idx on problem USING GIN(

--- a/db/schema_0085-add-problem-send-state.sql
+++ b/db/schema_0085-add-problem-send-state.sql
@@ -1,0 +1,16 @@
+alter table problem add send_state text not null default 'processed' check (
+    send_state = 'unprocessed'
+    or send_state = 'processed'
+    or send_state = 'skipped'
+    or send_state = 'sent'
+    or send_state = 'acknowledged'
+);
+
+UPDATE problem SET send_state = 'unprocessed'
+    WHERE (whensent IS NULL OR send_fail_body_ids != '{}')
+        AND bodies_str IS NOT NULL
+        AND state IN (SELECT label FROM state WHERE type='open' UNION SELECT 'confirmed');
+
+alter table problem alter column send_state set default 'unprocessed';
+
+create index concurrently problem_state_send_state_idx on problem(state, send_state);

--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -71,11 +71,8 @@ sub index : Path : Args(0) {
     }
 
     my @unsent = $c->cobrand->problems->search( {
+        send_state => ['unprocessed', 'acknowledged'],
         'me.state' => [ FixMyStreet::DB::Result::Problem::open_states() ],
-        -or => {
-            whensent => undef,
-            send_fail_body_ids => { '!=', '{}' },
-        },
         bodies_str => { '!=', undef },
         # Ignore very recent ones that probably just haven't been sent yet
         confirmed => { '<', \"current_timestamp - '5 minutes'::interval" },

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -659,7 +659,7 @@ sub admin_report_edit {
         #   Note that 2 types of email may be sent
         #    1) _admin_send_email()  sends an email to the *user*, if their email is confirmed
         #
-        #    2) setting $problem->whensent(undef) may make it eligible for generating an email
+        #    2) calling $problem->resend may make it eligible for generating an email
         #   to the body (internal or external).  See DBRS::Problem->send_reports for Zurich-
         #   specific categories which are eligible for this.
 
@@ -687,7 +687,7 @@ sub admin_report_edit {
             $problem->category( $new_cat );
             $problem->external_body( undef );
             $problem->bodies_str( $cat->body_id );
-            $problem->whensent( undef );
+            $problem->resend;
             $problem->set_extra_metadata(changed_category => 1);
             $internal_note_text = "Weitergeleitet von $old_cat an $new_cat";
             $self->update_admin_log($c, $problem, "Changed category from $old_cat to $new_cat");
@@ -713,7 +713,7 @@ sub admin_report_edit {
             $self->set_problem_state($c, $problem, 'in progress');
             $problem->external_body( undef );
             $problem->bodies_str( $subdiv );
-            $problem->whensent( undef );
+            $problem->resend;
             $redirect = 1;
         } else {
             if ($state) {
@@ -753,7 +753,7 @@ sub admin_report_edit {
                     $problem->external_body( $external );
                 }
                 if ($problem->external_body && $c->get_param('publish_response')) {
-                    $problem->whensent( undef );
+                    $problem->resend;
                     $self->set_problem_state($c, $problem, $state);
                     my $template = ($state eq 'wish') ? 'problem-wish.txt' : 'problem-external.txt';
                     _admin_send_email( $c, $template, $problem );
@@ -938,7 +938,7 @@ sub admin_report_edit {
                 } else {
                     $problem->set_extra_metadata( subdiv_overdue => $self->overdue( $problem ) );
                     $problem->bodies_str( $body->parent->id );
-                    $problem->whensent( undef );
+                    $problem->resend;
                     $self->set_problem_state($c, $problem, 'feedback pending');
                 }
                 $problem->update;

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -1085,6 +1085,7 @@ sub resend {
     $self->whensent(undef);
     $self->send_method_used(undef);
     $self->send_fail_body_ids([]);
+    $self->send_state('unprocessed');
 }
 
 sub as_hashref {

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -93,6 +93,8 @@ __PACKAGE__->add_columns(
   { data_type => "jsonb", is_nullable => 1 },
   "response_priority_id",
   { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
+  "send_state",
+  { data_type => "text", default_value => "unprocessed", is_nullable => 0 },
   "send_fail_count",
   { data_type => "integer", default_value => 0, is_nullable => 0 },
   "send_fail_reason",
@@ -175,8 +177,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2023-05-10 17:09:58
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:j4rW2OqSWiUON0skMn7qfw
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2023-06-30 10:16:43
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ixrwVkFgOn2KJLGaBrKRww
 
 # Add fake relationship to stored procedure table
 __PACKAGE__->has_one(

--- a/perllib/FixMyStreet/Script/Reports.pm
+++ b/perllib/FixMyStreet/Script/Reports.pm
@@ -1,7 +1,6 @@
 package FixMyStreet::Script::Reports;
 
 use Moo;
-use CronFns;
 use FixMyStreet;
 use FixMyStreet::DB;
 use FixMyStreet::Queue::Item::Report;
@@ -47,9 +46,6 @@ sub send {
 
 sub construct_query {
     my ($debug) = @_;
-    my $site = CronFns::site(FixMyStreet->config('BASE_URL'));
-    my $states = [ FixMyStreet::DB::Result::Problem::open_states() ];
-    $states = [ 'submitted', 'confirmed', 'in progress', 'feedback pending', 'external', 'wish' ] if $site eq 'zurich';
 
     # Devolved Noop categories (unlikely to be any, but still)
     my @noop_params;
@@ -66,21 +62,12 @@ sub construct_query {
     # Noop bodies
     my @noop_bodies = FixMyStreet::DB->resultset('Body')->search({ send_method => 'Noop' })->all;
     @noop_bodies = map { $_->id } @noop_bodies;
-    push @noop_params, \[ "NOT regexp_split_to_array(bodies_str, ',') && ?", [ {} => \@noop_bodies ] ];
-
-    my @and = (
-        @noop_params,
-        {   -or => {
-                whensent       => undef,
-                send_fail_body_ids => { '!=', '{}' },
-            }
-        },
-    );
+    push @noop_params, \[ "NOT regexp_split_to_array(bodies_str, ',') && ?", [ {} => \@noop_bodies ] ] if @noop_bodies;
 
     my $params = {
-        state => $states,
-        bodies_str => { '!=', undef },
-        -and => \@and,
+        state => { -not_in => [ FixMyStreet::DB::Result::Problem::hidden_states ] },
+        send_state => 'unprocessed',
+        @noop_params ? (-and => \@noop_params) : (),
     };
     if (!$debug) {
         $params->{'-or'} = [
@@ -100,7 +87,7 @@ sub end_line {
     if ($unsent_count) {
         $self->log("processed all unsent reports (total: $unsent_count)");
     } else {
-        $self->log("no unsent reports were found (must have whensent=null and suitable bodies_str & state) -- nothing to send");
+        $self->log("no unsent reports were found (must have send_state=unprocessed) -- nothing to send");
     }
 }
 
@@ -123,11 +110,8 @@ sub end_summary_failures {
 
     my $sending_errors = '';
     my $unsent = FixMyStreet::DB->resultset('Problem')->search( {
+        send_state => 'unprocessed',
         state => [ FixMyStreet::DB::Result::Problem::open_states() ],
-        -or => {
-            whensent           => undef,
-            send_fail_body_ids => { '!=', '{}' },
-        },
         bodies_str => { '!=', undef },
         send_fail_count => { '>', 0 }
     },

--- a/t/app/controller/report_new_unresponsive.t
+++ b/t/app/controller/report_new_unresponsive.t
@@ -56,7 +56,7 @@ FixMyStreet::override_config {
 
         my $report = $user->problems->first;
         ok $report, "Found the report";
-        is $report->bodies_str, undef, "Report not going anywhere";
+        is $report->send_state, 'skipped', "Report not going anywhere";
 
         like $mech->get_text_body_from_email, qr/despite not being sent/i, "correct email sent";
 
@@ -118,5 +118,5 @@ sub make_report {
 
     my $report = $user->problems->first;
     ok $report, "Found the report";
-    is $report->bodies_str, undef, "Report not going anywhere";
+    is $report->send_state, 'skipped', "Report not going anywhere";
 }

--- a/t/app/controller/report_new_update.t
+++ b/t/app/controller/report_new_update.t
@@ -54,7 +54,8 @@ subtest "test report creation with initial auto-update" => sub {
 
 subtest "test resending does not leave another initial auto-update" => sub {
     $report->discard_changes;
-    $report->update({ whensent => undef });
+    $report->resend;
+    $report->update;
     FixMyStreet::Script::Reports::send(0, 0, 1);
     my $comments = FixMyStreet::DB->resultset('Comment');
     is $comments->count, 1;

--- a/t/app/controller/waste_brent_garden.t
+++ b/t/app/controller/waste_brent_garden.t
@@ -178,6 +178,7 @@ FixMyStreet::override_config {
         user_id => $user->id,
         category => 'Garden Subscription',
         whensent => \'current_timestamp',
+        send_state => 'sent',
     });
     $p->title('Garden Subscription - New');
     $p->update_extra_field({ name => 'property_id', value => 12345});

--- a/t/app/controller/waste_kingston.t
+++ b/t/app/controller/waste_kingston.t
@@ -281,6 +281,7 @@ FixMyStreet::override_config {
         user_id => $user->id,
         category => 'Garden Subscription',
         whensent => \'current_timestamp',
+        send_state => 'sent',
     });
     $p->title('Garden Subscription - New');
     $p->update_extra_field({ name => 'property_id', value => '12345'});

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -520,9 +520,9 @@ FixMyStreet::override_config {
     subtest 'Report broken wheels' => sub {
         FixMyStreet::DB->resultset('Problem')->search(
             {
-                whensent => undef
+                send_state => 'unprocessed'
             }
-        )->update( { whensent => \'current_timestamp' } );
+        )->update( { send_state => 'sent' } );
 
 
         $mech->get_ok('/waste/PE1 3NA:100090215480/problem');
@@ -538,7 +538,7 @@ FixMyStreet::override_config {
         FixMyStreet::Script::Reports::send();
 
         my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
-        ok $report->whensent, 'Report marked as sent';
+        is $report->send_state, 'sent', 'Report marked as sent';
         is $report->title, 'Damaged 240L Black bin';
         is $report->detail, "The bin’s wheels are damaged\n\n1 Pope Way, Peterborough, PE1 3NA\n\nExtra detail: Some extra detail.";
 

--- a/t/app/controller/waste_sutton_garden.t
+++ b/t/app/controller/waste_sutton_garden.t
@@ -321,6 +321,7 @@ FixMyStreet::override_config {
         user_id => $user->id,
         category => 'Garden Subscription',
         whensent => \'current_timestamp',
+        send_state => 'sent',
     });
     $p->title('Garden Subscription - New');
     $p->update_extra_field({ name => 'property_id', value => '12345' });

--- a/t/app/model/problem.t
+++ b/t/app/model/problem.t
@@ -494,9 +494,9 @@ foreach my $test ( {
 
         $problem_rs->search(
             {
-                whensent => undef
+                send_state => 'unprocessed'
             }
-        )->update( { whensent => \'current_timestamp' } );
+        )->update( { send_state => 'sent' } );
 
         $problem->discard_changes;
         $problem->update( {
@@ -505,6 +505,7 @@ foreach my $test ( {
             state => 'confirmed',
             confirmed => \'current_timestamp',
             whensent => $test->{ unset_whendef } ? undef : \'current_timestamp',
+            send_state => $test->{unset_whendef} ? 'unprocessed' : 'sent',
             category => $test->{ category } || 'potholes',
             name => $test->{ name },
             cobrand => $test->{ cobrand } || 'fixmystreet',
@@ -574,9 +575,9 @@ subtest 'check can set multiple emails as a single contact' => sub {
 
     $problem_rs->search(
         {
-            whensent => undef
+            send_state => 'unprocessed'
         }
-    )->update( { whensent => \'current_timestamp' } );
+    )->update( { send_state => 'sent' } );
 
     $problem->discard_changes;
     $problem->update( {
@@ -584,6 +585,7 @@ subtest 'check can set multiple emails as a single contact' => sub {
         state => 'confirmed',
         confirmed => \'current_timestamp',
         whensent => undef,
+        send_state => 'unprocessed',
         category => 'trees',
         name => 'Test User',
         cobrand => 'fixmystreet',
@@ -611,9 +613,9 @@ subtest 'check can turn on report sent email alerts' => sub {
 
     $problem_rs->search(
         {
-            whensent => undef
+            send_state => 'unprocessed'
         }
-    )->update( { whensent => \'current_timestamp' } );
+    )->update( { send_state => 'sent' } );
 
     $problem->discard_changes;
     $problem->update( {
@@ -621,6 +623,7 @@ subtest 'check can turn on report sent email alerts' => sub {
         state => 'confirmed',
         confirmed => \'current_timestamp',
         whensent => undef,
+        send_state => 'unprocessed',
         category => 'potholes',
         name => 'Test User',
         cobrand => 'fixmystreet',
@@ -659,9 +662,9 @@ subtest 'check iOS app store test reports not sent' => sub {
 
     $problem_rs->search(
         {
-            whensent => undef
+            send_state => 'unprocessed'
         }
-    )->update( { whensent => \'current_timestamp' } );
+    )->update( { send_state => 'sent' } );
 
     $problem->discard_changes;
     $problem->update( {
@@ -670,6 +673,7 @@ subtest 'check iOS app store test reports not sent' => sub {
         state => 'confirmed',
         confirmed => \'current_timestamp',
         whensent => undef,
+        send_state => 'unprocessed',
         category => 'potholes',
         send_fail_count => 0,
     } );
@@ -688,9 +692,9 @@ subtest 'check reports from abuser not sent' => sub {
 
     $problem_rs->search(
         {
-            whensent => undef
+            send_state => 'unprocessed'
         }
-    )->update( { whensent => \'current_timestamp' } );
+    )->update( { send_state => 'sent' } );
 
     $problem->discard_changes;
     $problem->update( {
@@ -699,6 +703,7 @@ subtest 'check reports from abuser not sent' => sub {
         state => 'confirmed',
         confirmed => \'current_timestamp',
         whensent => undef,
+        send_state => 'unprocessed',
         category => 'potholes',
         send_fail_count => 0,
     } );
@@ -714,6 +719,7 @@ subtest 'check reports from abuser not sent' => sub {
         state => 'confirmed',
         confirmed => \'current_timestamp',
         whensent => undef,
+        send_state => 'unprocessed',
     } );
 
     my $abuse = FixMyStreet::DB->resultset('Abuse')->create( { email => $problem->user->email } );

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -472,7 +472,7 @@ subtest 'Can triage parish reports' => sub {
     $mech->content_contains('Grass cutting (grass@example.org)');
     $mech->content_contains('Grass cutting (grassparish@example.org)');
     $mech->submit_form_ok({ with_fields => { category => $grass_bucks->id } });
-    $report->update({ whensent => \'current_timestamp' });
+    $report->update({ whensent => \'current_timestamp', send_state => 'sent' });
 };
 
 subtest '.com reports get the logged email too' => sub {

--- a/t/cobrand/hackney.t
+++ b/t/cobrand/hackney.t
@@ -332,7 +332,8 @@ FixMyStreet::override_config {
             is $email->header('To'), '"Hackney Council" <parks@example>';
             $mech->clear_emails_ok;
             $p->discard_changes;
-            $p->update({ whensent => undef });
+            $p->resend;
+            $p->update;
         };
 
         subtest 'in an estate' => sub {
@@ -351,7 +352,8 @@ FixMyStreet::override_config {
             is $email->header('To'), '"Hackney Council" <estates@example>';
             $mech->clear_emails_ok;
             $p->discard_changes;
-            $p->update({ whensent => undef });
+            $p->resend;
+            $p->update;
         };
 
         subtest 'elsewhere' => sub {
@@ -375,6 +377,7 @@ FixMyStreet::override_config {
             cobrand => 'hackney',
             category => 'Roads',
             whensent => \'current_timestamp',
+            send_state => 'sent',
         });
         my $whensent = $problem->whensent;
         $mech->log_in_ok( $hackney_user->email );
@@ -388,10 +391,10 @@ FixMyStreet::override_config {
             $mech->submit_form_ok({ with_fields => { category => $_->{category} } }, "Switch to $_->{category}");
             $problem->discard_changes;
             if ($_->{resent}) {
-                is $problem->whensent, undef, "Marked for resending";
-                $problem->update({ whensent => $whensent, send_method_used => 'Open311' }); # reset as sent
+                is $problem->send_state, 'unprocessed', "Marked for resending";
+                $problem->update({ whensent => $whensent, send_method_used => 'Open311', send_state => 'sent' }); # reset as sent
             } else {
-                isnt $problem->whensent, undef, "Not marked for resending";
+                is $problem->send_state, 'sent', "Not marked for resending";
             }
         }
     };

--- a/t/cobrand/highwaysengland.t
+++ b/t/cobrand/highwaysengland.t
@@ -123,7 +123,7 @@ FixMyStreet::override_config {
     subtest "Reports from FMS cobrand use correct branding in email" => sub {
         my $report = FixMyStreet::DB->resultset("Problem")->first;
         ok $report, "Found the report";
-        $report->whensent(undef);
+        $report->send_state('unprocessed');
         $report->cobrand("fixmystreet");
         $report->update;
 

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -44,6 +44,7 @@ sub reset_report_state {
     $report->unset_extra_metadata('closed_overdue');
     $report->unset_extra_metadata('closure_status');
     $report->whensent(undef);
+    $report->send_state('unprocessed');
     $report->state('submitted');
     $report->created($created) if $created;
     $report->category('Other');

--- a/t/script/send-daemon.t
+++ b/t/script/send-daemon.t
@@ -14,7 +14,7 @@ use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;
 my $body = $mech->create_body_ok(2514, 'Birmingham');
 $mech->create_contact_ok(email => 'g@example.org', category => 'Graffiti', body => $body);
-my ($p) = $mech->create_problems_for_body(1, $body->id, 'Title', { category => 'Graffiti' });
+my ($p) = $mech->create_problems_for_body(1, $body->id, 'Title', { category => 'Graffiti', state => 'unconfirmed' });
 
 package TestObj;
 use base 'Class::Accessor::Fast';
@@ -24,7 +24,16 @@ package main;
 my $opts = TestObj->new({ debug => 0, verbose => 0, nomail => 0 });
 FixMyStreet::Script::SendDaemon::setverboselevel(-1); # Nothing
 
-{
+subtest 'Unconfirmed reports ignored' => sub {
+    FixMyStreet::Script::SendDaemon::look_for_report($opts);
+    $p->discard_changes;
+    is $p->send_state, 'unprocessed';
+    is $p->send_fail_count, 0;
+};
+
+$p->update({ state => 'confirmed' });
+
+subtest 'Error in sending caught okay' => sub {
     my $mock = Test::MockModule->new('FixMyStreet::Cobrand::Default');
     $mock->mock('find_closest', sub {
         die q[Can't use string ("<h1>Server Error (500)</h1>")]
@@ -36,11 +45,16 @@ FixMyStreet::Script::SendDaemon::setverboselevel(-1); # Nothing
     # check that problem has send fail count > 0 etc.
     $p->discard_changes;
     is $p->send_fail_count, 1;
-}
+    is $p->send_state, 'unprocessed';
+};
 
-$p->update({ send_fail_count => 0 });
-FixMyStreet::Script::SendDaemon::look_for_report($opts);
-$p->discard_changes;
-isnt $p->whensent, undef;
+subtest 'Normal sending works' => sub {
+    $p->update({ send_fail_count => 0 });
+    is $p->whensent, undef;
+    FixMyStreet::Script::SendDaemon::look_for_report($opts);
+    $p->discard_changes;
+    isnt $p->whensent, undef;
+    is $p->send_state, 'sent';
+};
 
 done_testing;

--- a/t/sendreport/open311_send.t
+++ b/t/sendreport/open311_send.t
@@ -104,9 +104,8 @@ subtest 'test report with multiple photos only sends one', sub {
     ], 'One photo in media_url';
 };
 
-$photo_report->whensent(undef);
+$photo_report->resend;
 $photo_report->cobrand('tester');
-$photo_report->send_method_used('');
 $photo_report->update();
 
 subtest 'test sending multiple photos', sub {

--- a/t/sendreport/two-tier/open311-both.t
+++ b/t/sendreport/two-tier/open311-both.t
@@ -78,6 +78,7 @@ subtest '1st attempt - both fail' => sub {
 
     is $report->whensent,         undef, 'whensent not recorded';
     is $report->send_method_used, undef, 'send_method_used not recorded';
+    is $report->send_state, 'unprocessed';
 
     ok $report->send_fail_timestamp, 'send_fail_timestamp recorded';
     is $report->send_fail_count, 1, 'send_fail_count recorded';
@@ -109,6 +110,7 @@ subtest '2nd attempt - both fail again' => sub {
 
     is $report->whensent,         undef, 'whensent not recorded';
     is $report->send_method_used, undef, 'send_method_used not recorded';
+    is $report->send_state, 'unprocessed';
 
     is $report->send_fail_count, 2, 'send_fail_count updated';
     is $report->send_fail_reason, 'Open311 fail|Open311 fail',
@@ -145,6 +147,7 @@ subtest '3rd attempt - one succeeds, other fails' => sub {
 
     ok $report->whensent, 'whensent recorded';
     is $report->send_method_used, 'Open311', 'send_method_used recorded';
+    is $report->send_state, 'unprocessed';
 
     is $report->send_fail_count, 3, 'send_fail_count incremented';
     is $report->send_fail_reason, 'Open311 fail',
@@ -179,6 +182,7 @@ subtest '4th attempt - both set to fail again' => sub {
     is $hits, 1, 'Sender hit once';
 
     is $report->send_method_used, 'Open311', 'send_method_used unchanged';
+    is $report->send_state, 'unprocessed';
 
     is $report->send_fail_count, 4, 'send_fail_count incremented';
     is $report->send_fail_reason, 'Open311 fail',
@@ -210,6 +214,7 @@ subtest '5th attempt - both set to succeed' => sub {
 
     is $report->send_method_used, 'Open311,Open311',
         'send_method_used has 2 x Open311';
+    is $report->send_state, 'sent';
 
     is $report->send_fail_count, 4, 'send_fail_count unchanged';
     is $report->send_fail_reason, 'Open311 fail',
@@ -256,6 +261,7 @@ subtest 'Test resend' => sub {
 
     is $report->send_method_used, 'Open311,Open311',
         'send_method_used has 2 x Open311';
+    is $report->send_state, 'sent';
 
     is $report->send_fail_count, 4, 'send_fail_count unchanged';
     is $report->send_fail_reason, 'Open311 fail',
@@ -304,6 +310,7 @@ subtest 'Test staging send' => sub {
 
     test_send(0);
     $report_for_staging->discard_changes;
+    is $report->send_state, 'sent';
 
     is $hits_email,   1,     'Email sender hit once';
     is $hits_open311, undef, 'Open311 sender not hit';

--- a/templates/web/base/admin/problem_row.html
+++ b/templates/web/base/admin/problem_row.html
@@ -1,5 +1,5 @@
 [%- FOR problem IN problems %]
-    <tr[% ' class="adminhidden"' IF problem.state == 'hidden' %]>
+    <tr[% ' class="adminhidden"' IF problem.state == 'hidden' OR problem.send_state == 'acknowledged' %]>
         <td class="record-id">[%- IF problem.is_visible -%]
         [%- uri = c.uri_for_email( '/report', problem.id ) %]
         <a href="[% uri %]" class="admin-offsite-link">[% problem.id %]</a>
@@ -34,15 +34,15 @@
                 </span>
             [%- END -%]
         </td>
-        <td>[% prettify_state(problem.state, 1) %]<br><small>
-            [% loc('Created') %]:&nbsp;[% PROCESS format_time time=problem.created %]
-            <br>[% loc('When sent') %]:&nbsp;[% PROCESS format_time time=problem.whensent %]
+        <td>[% prettify_state(problem.state, 1) %]<small>
+            [% IF problem.whensent %]<br>[% loc('When sent') %]:&nbsp;[% PROCESS format_time time=problem.whensent %][% END %]
             [%- send_fail_bodies = problem.send_fail_bodies -%]
             [%- IF send_fail_bodies.size %]<br>[% loc('Failed bodies:') %]&nbsp;[% send_fail_bodies.join(', ') %][% END -%]
+            <br>[% loc('Created') %]:&nbsp;[% PROCESS format_time time=problem.created %]
             [%- IF problem.is_visible %]<br>[% loc('Confirmed:' ) %]&nbsp;[% PROCESS format_time time=problem.confirmed %][% END -%]
             [%- IF problem.is_fixed %]<br>[% prettify_state('fixed') %]: [% PROCESS format_time time=problem.lastupdate %][% END -%]
             [%- IF problem.is_closed %]<br>[% prettify_state('closed') %]: [% PROCESS format_time time=problem.lastupdate %][% END -%]
-            [%- IF problem.is_open %]<br>[% loc('Last&nbsp;update:') %] [% PROCESS format_time time=problem.lastupdate %][% END -%]
+            [%- IF problem.is_open AND problem.lastupdate != problem.whensent %]<br>[% loc('Last&nbsp;update:') %] [% PROCESS format_time time=problem.lastupdate %][% END -%]
         </small></td>
         <td>
             [% IF c.user.has_permission_to('report_edit', problem.bodies_str_ids) %]


### PR DESCRIPTION
The first two commits were reviewed in #4505. The two fixups in here deal with issues found before putting live:
* There was an issue with the marking of rows as processed not being saved; and if that had been working, then it would have marked unconfirmed reports as processed
* The DB migration marked all rows as processed, when we need to update any currently unsent rows as unprocessed.