### PR TITLE
[Bulky] Allow retrying of failed CSC payments.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
@@ -217,7 +217,13 @@ sub process_bulky_data : Private {
 
     if ($c->stash->{payment}) {
         $c->set_param('payment', $c->stash->{payment});
-        $c->forward('/waste/add_report', [ $data, 1 ]) or return;
+        if ($data->{continue_id}) {
+            $c->stash->{report} = $c->cobrand->problems->find($data->{continue_id});
+            amend_extra_data($c, $c->stash->{report}, $data);
+            $c->stash->{report}->update;
+        } else {
+            $c->forward('/waste/add_report', [ $data, 1 ]) or return;
+        }
         if ( FixMyStreet->staging_flag('skip_waste_payment') ) {
             $c->stash->{message} = 'Payment skipped on staging';
             $c->stash->{reference} = $c->stash->{report}->id;
@@ -253,6 +259,23 @@ sub process_bulky_amend : Private {
 
     $p->detail($p->detail . " | Previously submitted as " . $p->external_id);
 
+    amend_extra_data($c, $p, $data);
+
+    $c->forward('add_cancellation_report');
+
+    $p->resend;
+    $p->external_id(undef);
+    $p->update;
+
+    # Need to reset stashed report to the amended one, not the new cancellation one
+    $c->stash->{report} = $p;
+
+    return 1;
+}
+
+sub amend_extra_data {
+    my ($c, $p, $data) = @_;
+
     $c->cobrand->waste_munge_bulky_amend($p, $data);
 
     if ($data->{location_photo}) {
@@ -276,17 +299,6 @@ sub process_bulky_amend : Private {
         push @bulky_photo_data, $data->{$_} if $data->{$_};
     }
     $p->photo( join(',', @bulky_photo_data) );
-
-    $c->forward('add_cancellation_report');
-
-    $p->resend;
-    $p->external_id(undef);
-    $p->update;
-
-    # Need to reset stashed report to the amended one, not the new cancellation one
-    $c->stash->{report} = $p;
-
-    return 1;
 }
 
 sub add_cancellation_report : Private {

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -552,9 +552,16 @@ sub look_up_property {
 
     my %premises = map { $_->{uprn} => $_ } @$premises;
 
+    my $c = $self->{c};
     my @pending = $self->find_pending_bulky_collections($uprn)->all;
-    $self->{c}->stash->{pending_bulky_collections}
+    $c->stash->{pending_bulky_collections}
         = @pending ? \@pending : undef;
+
+    my $cfg = $self->feature('waste_features');
+    if ($cfg->{bulky_retry_bookings} && $c->stash->{is_staff}) {
+        my @unconfirmed = $self->find_unconfirmed_bulky_collections($uprn)->all;
+        $c->stash->{unconfirmed_bulky_collections} = @unconfirmed ? \@unconfirmed : undef;
+    }
 
     return $premises{$uprn};
 }

--- a/perllib/FixMyStreet/Roles/CobrandBulkyWaste.pm
+++ b/perllib/FixMyStreet/Roles/CobrandBulkyWaste.pm
@@ -159,13 +159,25 @@ sub bulky_total_cost {
     return $c->stash->{payment};
 }
 
+sub find_unconfirmed_bulky_collections {
+    my ( $self, $uprn ) = @_;
+
+    return $self->problems->search({
+        category => 'Bulky collection',
+        extra => { '@>' => encode_json({ "_fields" => [ { name => 'uprn', value => $uprn } ] }) },
+        state => 'unconfirmed',
+    }, {
+        order_by => { -desc => 'id' }
+    });
+}
+
 sub find_pending_bulky_collections {
     my ( $self, $uprn ) = @_;
 
     return $self->problems->search({
         category => 'Bulky collection',
         extra => { '@>' => encode_json({ "_fields" => [ { name => 'uprn', value => $uprn } ] }) },
-        state => { '=', [ FixMyStreet::DB::Result::Problem->open_states ] },
+        state => [ FixMyStreet::DB::Result::Problem->open_states ],
     }, {
         order_by => { -desc => 'id' }
     });

--- a/templates/email/default/waste/csc_payment_failed.html
+++ b/templates/email/default/waste/csc_payment_failed.html
@@ -12,9 +12,11 @@ INCLUDE '_email_top.html';
   [% start_padded_box | safe %]
   <h1 style="[% h1_style %]">There was a problem with your payment</h1>
   [% IF report.category == 'Bulky collection' %]
-    <p style="[% p_style %]">There was a problem taking payment for your [% report.title %]. No details have been saved for the booking.</p>
-
-    <p style="[% p_style %]">Please contact 01733 747474 to start again; if you feel you will have difficulty with the auto payment system please advise the call handler at the start of the call.</p>
+    <p style="[% p_style %]">There was a problem taking payment for your [% report.title %].</p>
+    <p style="[% p_style %]">Please contact 01733 747474; if you feel you will have difficulty with the auto payment system please advise the call handler at the start of the call.</p>
+   [% IF waste_features.bulky_retry_bookings %]
+    <p style="[% p_style %]">Provide the reference number <strong>[% report.id %]</strong> so you do not have to provide details of your collection again.</p>
+   [% END %]
   [% ELSE %]
     <p style="[% p_style %]">There was a problem taking payment for your [% report.title %]</p>
 

--- a/templates/email/default/waste/csc_payment_failed.txt
+++ b/templates/email/default/waste/csc_payment_failed.txt
@@ -3,9 +3,13 @@ Subject: There was a problem with your payment: [% report.title %]
 Hello [% report.name %],
 
 [% IF report.category == 'Bulky collection' ~%]
-There was a problem taking payment for your [% report.title %]. No details have been saved for the booking.
+There was a problem taking payment for your [% report.title %].
 
-Please contact 01733 747474 to start again; if you feel you will have difficulty with the auto payment system please advise the call handler at the start of the call.
+Please contact 01733 747474; if you feel you will have difficulty with the auto payment system please advise the call handler at the start of the call.
+
+[% IF waste_features.bulky_retry_bookings %]
+Provide the reference number [% report.id %] so you do not have to provide details of your collection again.
+[% END %]
 [% ELSE ~%]
 There was a problem collecting payment for your [% report.title %]. Please
 contact the Customer Service Centre to try again.

--- a/templates/web/base/waste/bulky/_bin_days_list.html
+++ b/templates/web/base/waste/bulky/_bin_days_list.html
@@ -26,29 +26,23 @@
   </div>
 
   [% FOR booking IN pending_bulky_collections %]
-
-    [% IF c.cobrand.bulky_can_view_collection(booking) %]
-        <!-- #01 Should only display when: There IS a booking AND is a signed user -->
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Next collection</dt>
-          <dd class="govuk-summary-list__value">[% c.cobrand.bulky_nice_collection_date(booking) %]</dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Reference number</dt>
-          <dd class="govuk-summary-list__value">[% booking.id %]</dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Items to be collected</dt>
-          <dd class="govuk-summary-list__value">
-            <p class="govuk-!-margin-bottom-0">[% c.cobrand.bulky_nice_item_list(booking).size %]</p>
-          </dd>
-        </div>
-        <!-- END #01 -->
-    [% END %]
+    [% NEXT UNLESS c.cobrand.bulky_can_view_collection(booking) %]
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Next collection</dt>
+      <dd class="govuk-summary-list__value">[% c.cobrand.bulky_nice_collection_date(booking) %]</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Reference number</dt>
+      <dd class="govuk-summary-list__value">[% booking.id %]</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Items to be collected</dt>
+      <dd class="govuk-summary-list__value">
+        <p class="govuk-!-margin-bottom-0">[% c.cobrand.bulky_nice_item_list(booking).size %]</p>
+      </dd>
+    </div>
 
     <div class="waste-services-launch-panel">
-      [% IF c.cobrand.bulky_can_view_collection(booking) %]
-        <!-- #05 Should only display when: There IS a booking AND is a signed user -->
         <a class="btn btn-primary govuk-!-margin-bottom-2" href="/report/[% booking.id %]">Check collection details</a>
         [% IF c.cobrand.bulky_can_amend_collection(booking) %]
           <a class="btn btn-primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky/amend', [ property.id, booking.id ]) %]">Amend booking</a>
@@ -56,8 +50,6 @@
         [% IF c.cobrand.bulky_collection_can_be_cancelled(booking) %]
           <a class="btn btn-primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky/cancel', [ property.id, booking.id ]) %]">Cancel booking</a>
         [% END %]
-        <!-- END #05 -->
-      [% END %]
     </div>
   [% END %]
 
@@ -70,6 +62,34 @@
     <!-- END #04 -->
   [% END %]
 </dl>
+
+  [% IF unconfirmed_bulky_collections %]
+    <hr>
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+
+        <h2>Unconfirmed&nbsp;bookings</h2>
+      [% FOR booking IN unconfirmed_bulky_collections %]
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Collection date</dt>
+          <dd class="govuk-summary-list__value">[% c.cobrand.bulky_nice_collection_date(booking) %]</dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Reference number</dt>
+          <dd class="govuk-summary-list__value">[% booking.id %]</dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Items to be collected</dt>
+          <dd class="govuk-summary-list__value">
+            <p class="govuk-!-margin-bottom-0">[% c.cobrand.bulky_nice_item_list(booking).size %]</p>
+          </dd>
+        </div>
+
+        <div class="waste-services-launch-panel">
+            <a class="btn btn-primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/index', { continue_id => booking.id }) %]">Retry booking</a>
+        </div>
+      [% END %]
+    </dl>
+  [% END %]
 
 <hr>
 

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -8,7 +8,7 @@
 
 [% BLOCK change_answers_button %]
   [% UNLESS problem %]
-    <form method="post">
+    <form method="post" action="[% c.uri_for_action('waste/bulky/index', [ property.id ]) %]">
       <input type="hidden" name="saved_data" value="[% form.fif.saved_data %]">
       <input type="hidden" name="goto" value="[% goto %]">
       <input type="submit" class="fake-link" value="Change answers">
@@ -187,7 +187,7 @@
     <div class="govuk-grid-column-one-third">
       <div class="summary-section-header">
         <h3 class="summary-section--heading">Your details</h3>
-        [% PROCESS change_answers_button goto='about_you' %]
+        [% IF NOT data.continue_id %][% PROCESS change_answers_button goto='about_you' %][% END %]
       </div>
       <dl>
         <dt>Name</dt>

--- a/templates/web/base/waste/garden/csc_payment_failed.html
+++ b/templates/web/base/waste/garden/csc_payment_failed.html
@@ -3,19 +3,26 @@
 <h1 class="govuk-heading-xl">Payment Failed</h1>
 
 <div class="govuk-panel govuk-panel--confirmation">
-    <h1 class="govuk-panel__title">
-        [% title %]
-    </h1>
     <div class="govuk-panel__body">
-        <p>[% message %]
+        <p>
           [% IF sent_email %]
             A payment failed notification has been sent to the user at [% report.user.email %].
           [% END %]
         </p>
 
+      [% IF report.category == 'Bulky collection' %]
         <p>
-        No subscription will be created.
+            No booking has been created.
+          [% IF waste_features.bulky_retry_bookings %]
+            The following code – <strong>[% report.id %]</strong> – can be used to retry the payment.
+          [% END %]
         </p>
+      [% ELSE %]
+        <p>
+            No subscription will be created.
+        </p>
+      [% END %]
+
     </div>
 </div>
 

--- a/templates/web/peterborough/waste/index.html
+++ b/templates/web/peterborough/waste/index.html
@@ -17,4 +17,11 @@
     [% PROCESS form %]
 </form>
 
+ [% IF is_staff AND waste_features.bulky_retry_bookings %]
+    <form method="post" style="display:flex;gap:0.25em;align-items:center">
+        Unpaid booking reference: <input type="text" name="continue_id" value="[% continue_id %]" style="max-width:10em;">
+        <input type="submit" value="Retry bulky payment" class="btn btn-primary">
+    </form>
+ [% END %]
+
 [% INCLUDE footer.html %]


### PR DESCRIPTION
[skip changelog] Fixes https://github.com/mysociety/societyworks/issues/3781
The form is shown to staff at /waste, as requested by Peterborough.