### PR TITLE
[Glos] Add stylemap and not-found messages for assets

### DIFF
--- a/templates/web/gloucestershire/report/new/roads_message.html
+++ b/templates/web/gloucestershire/report/new/roads_message.html
@@ -1,0 +1,12 @@
+    <div id="js-not-a-road" class="hidden js-responsibility-message">
+        <p><strong>Public Highway issue</strong></p>
+        <p>To report this issue, please select a point on a public road</p>
+    </div>
+    <div id="js-not-a-prow" class="hidden js-responsibility-message">
+        <p><strong>Public Right of Way issue</strong></p>
+        <p>To report this issue, please select a point on a public right of way</p>
+    </div>
+    <div id="js-not-a-private-road" class="hidden js-responsibility-message">
+        <p><strong>Private Road issue</strong></p>
+        <p>To report this issue, please select a point on a private road</p>
+    </div>

--- a/web/cobrands/fixmystreet-uk-councils/assets.js
+++ b/web/cobrands/fixmystreet-uk-councils/assets.js
@@ -745,6 +745,19 @@ fixmystreet.assets.eastsussex.construct_selected_asset_message = function(asset)
     }
 };
 
+/* Gloucestershire */
+
+fixmystreet.assets.gloucestershire = {};
+
+fixmystreet.assets.gloucestershire.street_stylemap = new OpenLayers.StyleMap({
+    'default': new OpenLayers.Style({
+        fill: false,
+        strokeColor: "navy",
+        strokeOpacity: 0.5,
+        strokeWidth: 5
+    })
+});
+
 /* Hounslow */
 
 fixmystreet.assets.hounslow = {};


### PR DESCRIPTION
In conjunction with assets .yml file in `mysociety-servers` -> `glos-confirm-integration-assets` -> 72fa38c9d.

Closes https://github.com/mysociety/societyworks/issues/3696.

[skip changelog]

