### PR TITLE
[Buckinghamshire] Evo: Handle locations with no nearby roads

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -663,6 +663,11 @@ sub claim_location {
     my ($self, $row) = @_;
 
     my $road = $self->_lookup_site_name($row);
+
+    if (!$road) {
+        return "Unknown location";
+    }
+
     my $site_name = $road->{properties}->{site_name};
     $site_name =~ s/([\w']+)/\u\L$1/g;
     my $area_name = $road->{properties}->{area_name};


### PR DESCRIPTION
When looking up the nearest road we're only checking a 200m radius, which means that sometimes there are claim reports that don't get a road because they're further than 200m from a road (e.g. claims for accidents on a footpath). Handle this by returning "Unknown location" if no roads are returned.

Fixes https://github.com/mysociety/societyworks/issues/3803

<!-- [skip changelog] -->
