### PR TITLE
[Brent] Use OSPlaces API as reverse geocoder

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -206,6 +206,28 @@ sub user_from_oidc {
 
 =cut
 
+=head2 dashboard_export_problems_add_columns
+
+Brent have an additional column for street name.
+
+=cut
+
+sub dashboard_export_problems_add_columns {
+    my ($self, $csv) = @_;
+
+    $csv->add_csv_columns(
+        street_name => 'Street Name',
+    );
+
+    $csv->csv_extra_data(sub {
+        my $report = shift;
+        return {
+            street_name =>
+                $report->nearest_address_parts->{street}
+        }
+    });
+}
+
 =head2 open311_config
 
 Sends all photo urls in the Open311 data

--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -304,14 +304,22 @@ Same as Symology above, but different attribute name.
         }
     }
 
-    # The title field gets pushed to location fields in Echo/Symology, so include closest address
+=item * The title field gets pushed to location fields in Echo/Symology, so include closest address
+
+We use {closest_address}->summary as this is geocoder-agnostic.
+
+=cut
+
     my $title = $row->title;
-    if ($h->{closest_address}) {
-        if (my $addr = $h->{closest_address}{name} || $h->{closest_address}{display_name} || '') {
-            $addr =~ s/, England, United Kingdom$//;
-            $title .= "; Nearest calculated address = $addr";
-        }
+    if ( $h->{closest_address} ) {
+        my $addr = $h->{closest_address}->summary;
+
+        $addr =~ s/, England//;
+        $addr =~ s/, United Kingdom$//;
+
+        $title .= '; Nearest calculated address = ' . $addr;
     }
+
     push @$open311_only, { name => 'title', value => $title };
     push @$open311_only, { name => 'description', value => $row->detail };
 


### PR DESCRIPTION
As discussed in https://mysocietysupport.freshdesk.com/a/tickets/3047.

Brent are switching to the OSPlaces API as a reverse geocoder, and along with this change, want a street name column in their reports CSVs.

Also handles OSPlaces data for open311_extra_data_include() method.

[skip changelog]
