### PR TITLE
[Waste] Async Echo API calls for bin days page

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -540,7 +540,7 @@ sub bin_services_for_address {
 
     my $cfg = $self->feature('echo');
     my $echo = Integrations::Echo->new(%$cfg);
-    my $calls = $echo->call_api($self->{c}, 'brent', 'bin_services_for_address:' . $property->{id}, 0, @to_fetch);
+    my $calls = $echo->call_api($self->{c}, 'brent', 'bin_services_for_address:' . $property->{id}, 1, @to_fetch);
 
     my @out;
     my %task_ref_to_row;

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -611,7 +611,7 @@ sub bin_services_for_address {
 
     my $cfg = $self->feature('echo');
     my $echo = Integrations::Echo->new(%$cfg);
-    my $calls = $echo->call_api($self->{c}, 'bromley', 'bin_services_for_address:' . $property->{id}, 0, @to_fetch);
+    my $calls = $echo->call_api($self->{c}, 'bromley', 'bin_services_for_address:' . $property->{id}, 1, @to_fetch);
 
     my @out;
     my %task_ref_to_row;

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -656,17 +656,6 @@ sub bin_services_for_address {
     my $async = $self->{c}->action eq 'waste/bin_days' && $self->{c}->req->method eq 'GET';
 
     my $results = $bartec->call_api($self->{c}, 'peterborough', 'bin_services_for_address:' . $uprn, $async, @calls);
-    if (!$results) {
-        # Need to set the custom template here because Waste::bin_days
-        # doesn't actually get run because of the detach
-        # XXX This can be removed when the bulky template is removed
-        if ( $self->bulky_enabled ) {
-            $self->{c}->stash->{template} = 'waste/bin_days_bulky.html';
-        }
-        $self->{c}->stash->{data_loading} = 1;
-        $self->{c}->stash->{page_refresh} = 2;
-        $self->{c}->detach;
-    }
 
     my $jobs = $results->{"Jobs_Get $uprn"};
     my $schedules = $results->{"Features_Schedules_Get $uprn"};

--- a/perllib/FixMyStreet/Roles/CobrandEcho.pm
+++ b/perllib/FixMyStreet/Roles/CobrandEcho.pm
@@ -36,7 +36,7 @@ sub look_up_property {
     my $echo = Integrations::Echo->new(%$cfg);
     my $calls = $echo->call_api($self->{c}, $self->moniker,
         "look_up_property:$id",
-        0,
+        1,
         GetPointAddress => [ $id ],
         GetServiceUnitsForObject => [ $id ],
         GetEventsForObject => [ 'PointAddress', $id ],

--- a/perllib/FixMyStreet/Roles/CobrandSLWP.pm
+++ b/perllib/FixMyStreet/Roles/CobrandSLWP.pm
@@ -442,7 +442,7 @@ sub bin_services_for_address {
 
     my $cfg = $self->feature('echo');
     my $echo = Integrations::Echo->new(%$cfg);
-    my $calls = $echo->call_api($self->{c}, $self->council_url, 'bin_services_for_address:' . $property->{id}, 0, @to_fetch);
+    my $calls = $echo->call_api($self->{c}, $self->council_url, 'bin_services_for_address:' . $property->{id}, 1, @to_fetch);
 
     my @out;
     my %task_ref_to_row;

--- a/templates/web/base/header.html
+++ b/templates/web/base/header.html
@@ -12,7 +12,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
         [% IF page_refresh %]
             <noscript>
-                <meta http-equiv="refresh" content="[% page_refresh %]">
+                <meta http-equiv="refresh" content="[% page_refresh %];url=?page_loading=1">
             </noscript>
         [% END %]
         <meta name="HandHeldFriendly" content="true">

--- a/templates/web/base/waste/bin_days.html
+++ b/templates/web/base/waste/bin_days.html
@@ -5,22 +5,31 @@
 <h1 class="govuk-heading-xl">Your bin days</h1>
 [% END %]
 
-[% INCLUDE 'waste/_address_display.html' %]
-<div class="waste__collections" [% IF data_loading AND page_refresh %]
-  hx-get="[% c.req.uri.path %]"
-  hx-swap="outerHTML"
-  hx-select=".waste__collections"
-  hx-trigger="every [% page_refresh %]s"
-[% END %]>
-  <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Your collections</h2>
-  [% IF data_loading %]
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full text-centered">
-        <img id="loading-indicator" aria-hidden="true" src="/i/loading.svg" alt="Loading...">
-        <h2>Loading your bin days...</h2>
-      </div>
+[% IF data_loading %]
+    <div class="waste__loading_wrapper"
+      hx-get="[% c.req.uri.path %]"
+      hx-swap="outerHTML"
+      hx-select=".waste__loading_wrapper"
+      hx-trigger="every [% page_refresh %]s">
+
+        <div class="waste__collections">
+            <div class="govuk-grid-row">
+              <div class="govuk-grid-column-full text-centered">
+                <img id="loading-indicator" aria-hidden="true" src="/i/loading.svg" alt="Loading...">
+                <h2>Loading your bin days...</h2>
+              </div>
+            </div>
+        </div>
     </div>
-  [% ELSE %]
+    [% INCLUDE footer.html %]
+    [% RETURN %]
+[% END %]
+
+<div class="waste__loading_wrapper">
+
+[% INCLUDE 'waste/_address_display.html' %]
+<div class="waste__collections">
+  <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Your collections</h2>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -133,7 +142,8 @@
       </div>
     </div>
   </div>
-[% END %]
 </div>
-[% INCLUDE footer.html %]
 
+</div>
+
+[% INCLUDE footer.html %]

--- a/templates/web/fixmystreet-uk-councils/footer_extra_js_base.html
+++ b/templates/web/fixmystreet-uk-councils/footer_extra_js_base.html
@@ -43,4 +43,9 @@ IF bodyclass.match('mappage') AND bodyclass.match('formflow');
         version('/vendor/OpenLayers.Projection.OrdnanceSurvey.js'),
     );
 END;
+IF page_refresh;
+    scripts.push(
+        version('/vendor/htmx.min.js'),
+    );
+END;
 ~%]

--- a/templates/web/peterborough/footer_extra_js.html
+++ b/templates/web/peterborough/footer_extra_js.html
@@ -1,6 +1,1 @@
 [% PROCESS 'footer_extra_js_base.html' highways=1 validation=1 roadworks=1 %]
-[% IF page_refresh;
-    scripts.push(
-        version('/vendor/htmx.min.js'),
-    );
-END %]

--- a/templates/web/peterborough/waste/bin_days_bulky.html
+++ b/templates/web/peterborough/waste/bin_days_bulky.html
@@ -2,21 +2,36 @@
 [% USE pounds = format('%.2f'); ~%]
 [% PROCESS 'waste/header.html' %]
 
-
-[% UNLESS data_loading %]
-  [% TRY %][% PROCESS waste/_service_navigation_bar.html %][% CATCH file %][% END %]
-[% END %]
 <h1 class="govuk-heading-xl">Your bin days</h1>
 
 [% INCLUDE 'waste/_address_display.html' %]
+
+[% IF data_loading %]
+    <div class="waste__loading_wrapper"
+      hx-get="[% c.req.uri.path %]"
+      hx-swap="outerHTML"
+      hx-select=".waste__loading_wrapper"
+      hx-trigger="every [% page_refresh %]s">
+
+        <div class="waste__collections">
+            <div class="govuk-grid-row">
+              <div class="govuk-grid-column-full text-centered">
+                <img id="loading-indicator" aria-hidden="true" src="/i/loading.svg" alt="Loading...">
+                <h2>Loading your bin days...</h2>
+              </div>
+            </div>
+        </div>
+    </div>
+    [% INCLUDE footer.html %]
+    [% RETURN %]
+[% END %]
+
+<div class="waste__loading_wrapper">
+
+[% TRY %][% PROCESS waste/_service_navigation_bar.html %][% CATCH file %][% END %]
 [% TRY %][% PROCESS waste/_announcement.html %][% CATCH file %][% END %]
-<div class="waste__collections" [% IF data_loading AND page_refresh %]
-hx-get="[% c.req.uri.path %]"
-hx-swap="outerHTML"
-hx-select="div.content"
-hx-target="div.content"
-hx-trigger="every [% page_refresh %]s"
-[% END %]>
+
+<div class="waste__collections">
   <div class="govuk-!-margin-bottom-8">
     <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Your collections</h2>
     [% IF service_data.size %]
@@ -25,15 +40,6 @@ hx-trigger="every [% page_refresh %]s"
       [% END %]
     [% END %]
   </div>
-
-  [% IF data_loading %]
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full text-centered">
-        <img id="loading-indicator" aria-hidden="true" src="/i/loading.svg" alt="Loading...">
-        <h2>Loading your bin days...</h2>
-      </div>
-    </div>
-  [% ELSE %]
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -235,6 +241,7 @@ hx-trigger="every [% page_refresh %]s"
   <div id="more-services">
     [% INCLUDE waste/bin_days_sidebar.html %]
   </div>
-[% END %]
+</div>
+
 </div>
 [% INCLUDE footer.html %]


### PR DESCRIPTION
Extends the use of the HTMX partial page refresh to Echo WasteWorks API calls. Turned out to be fairly straightforward in the end, the only real change was to ensure the results of the property lookup aren’t cleared if the request is made by HTMX/page refresh while waiting for second batch of API calls to return.

(That makes me wonder if I’ve missed something somewhere though… But everything seems to work as expected.)

[skip changelog]