### PR TITLE
[Brent] Amend template so '9' represents sacks rather than 9 bins

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -531,6 +531,7 @@ sub bin_services_for_address {
 
         my $garden = 0;
         my $garden_bins;
+        my $garden_sacks;
         my $garden_cost = 0;
         my $garden_due = $self->waste_sub_due($schedules->{end_date});
         my $garden_overdue = $expired{$_->{Id}};
@@ -540,7 +541,14 @@ sub bin_services_for_address {
             foreach (@$data) {
                 if ( $_->{DatatypeName} eq 'BRT - Paid Collection Container Quantity' ) {
                     $garden_bins = $_->{Value};
-                    $garden_cost = $self->garden_waste_cost_pa($garden_bins) / 100;
+                    # $_->{Value} is a code for the number of bins and corresponds 1:1 (bin), 2:2 (bins) etc,
+                    # until it gets to 9 when it corresponds to sacks
+                    if ($garden_bins == '9') {
+                        $garden_sacks = 1;
+                        $garden_cost = $self->garden_waste_sacks_cost_pa($garden_bins) / 100;
+                    } else {
+                        $garden_cost = $self->garden_waste_cost_pa($garden_bins) / 100;
+                    }
                 }
             }
             $request_max = $garden_bins;
@@ -556,6 +564,7 @@ sub bin_services_for_address {
             service_name => $service_name,
             garden_waste => $garden,
             garden_bins => $garden_bins,
+            garden_sacks => $garden_sacks,
             garden_cost => $garden_cost,
             garden_due => $garden_due,
             garden_overdue => $garden_overdue,

--- a/templates/web/brent/waste/services.html
+++ b/templates/web/brent/waste/services.html
@@ -46,9 +46,15 @@
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Subscription</dt>
+        [% IF unit.garden_sacks %]
+        <dd class="govuk-summary-list__value">
+          £[% tprintf('%.2f', unit.garden_cost) %] per year (Sack subscription)
+        </dd>
+        [% ELSE %]
         <dd class="govuk-summary-list__value">
           £[% tprintf('%.2f', unit.garden_cost) %] per year ([% unit.garden_bins %] [% nget('bin', 'bins', unit.garden_bins) %])
         </dd>
+        [% END %]
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Renewal</dt>


### PR DESCRIPTION
The BRT - Paid Collection Container Quantity has code 1 matching 1 bin and continues with 2:2, 3:3 etc so the number code corresponds to the number of bins.

We have relied on the code for the number of bins.

However, when we reach 9, that corresponds to sacks rather than a number so if we have 9 bins - it is, in fact, a sack subscription and the template adapts accordingly.

https://mysocietysupport.freshdesk.com/a/tickets/3211

[skip changelog]