### PR TITLE
Fixed padding for 'item-list--reports__item a'

### DIFF
--- a/web/cobrands/bromley/layout.scss
+++ b/web/cobrands/bromley/layout.scss
@@ -195,14 +195,6 @@ body.alertindex form.full-width {
     font-size: 1em;
 }
 
-// We have slightly different content in our lists of issues to what
-// reports_list.scss expects, so we need to tweak the padding back to normal.
-// This stops the spacing being too large.
-.item-list__item--with-pin a {
-  padding: 0;
-  padding-left: 3em;
-}
-
 // Bromley's footer
 .site-footer {
   padding: 120px 0 0;

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1248,7 +1248,7 @@ input.final-submit {
 
   a {
     @include clearfix;
-    padding: flip(0 0 0 1em, 0 1em 0 0);
+    padding: 0 1em;
 
     @media print {
       padding: 0;
@@ -1267,10 +1267,6 @@ input.final-submit {
     display: block;
     padding: 0.25em 0;
   }
-}
-
-body.frontpage .item-list--reports__item a {
-  padding: 0 1em 0 1em;
 }
 
 .item-list__item__metadata {


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/3810

The rule padding: flip(0 0 0 1em, 0 1em 0 0) has been replaced so there is always some horizontal padding.
This commit also fixes the left padding for cobrands using a pin icon in the "Recently reported problems" section in the front page.

### Preview

### Cobrand with Pin
<img width="1212" alt="Screenshot 2023-08-01 at 08 31 17" src="https://github.com/mysociety/fixmystreet/assets/13790153/9ab73653-2059-4938-97e4-a446a0098c25">

<img width="405" alt="Screenshot 2023-08-01 at 08 31 51" src="https://github.com/mysociety/fixmystreet/assets/13790153/9722fbe0-8a7a-484f-927a-73612c36f568">


### Cobrand with no Pin
<img width="1096" alt="Screenshot 2023-08-01 at 08 32 26" src="https://github.com/mysociety/fixmystreet/assets/13790153/8a331978-9630-4872-8dda-12352cc51254">
<img width="404" alt="Screenshot 2023-08-01 at 08 32 52" src="https://github.com/mysociety/fixmystreet/assets/13790153/090ea165-ceaa-4641-bdd7-f3179e798e09">

[Skip changelog]

