### PR TITLE
Return random unprocessed row to daemon.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
         - Cobrands can provide custom distances for duplicate lookup. #4456
         - Auto-spot a default favicon.ico.
         - Add `send_state` column to reports. #4048
+        - Return random unprocessed row to daemon.
     - Changes:
         - Switch to OpenStreetMap for reverse geocoding. #4444
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
         - Stop map panning breaking after long press. #4423
         - Fix RSS feed subscription from alert page button.
         - Fix link to edit category with apostrophe in category name.
+        - Fallback extra field in submit email should be `name`, not `code`.
     - Admin improvements:
         - Rename emergency message to site message.
     - Development improvements:

--- a/perllib/FixMyStreet/Script/SendDaemon.pm
+++ b/perllib/FixMyStreet/Script/SendDaemon.pm
@@ -18,6 +18,7 @@ sub look_for_report {
     my $unsent = FixMyStreet::DB->resultset('Problem')->search($params, {
         for => \'UPDATE SKIP LOCKED',
         rows => 1,
+        order_by => \'RANDOM()'
     } )->single or return;
 
     print_log('debug', "Trying to send report " . $unsent->id);
@@ -45,8 +46,11 @@ sub look_for_update {
     my $params = $updates->construct_query($opts->debug);
     my $comment = FixMyStreet::DB->resultset('Comment')
         ->to_body([ keys %$bodies ])
-        ->search($params, { for => \'UPDATE SKIP LOCKED', rows => 1 })
-        ->single or return;
+        ->search($params, {
+            for => \'UPDATE SKIP LOCKED',
+            rows => 1,
+            order_by => \'RANDOM()'
+        })->single or return;
 
     print_log('debug', "Trying to send update " . $comment->id);
 

--- a/templates/email/buckinghamshire/submit.html
+++ b/templates/email/buckinghamshire/submit.html
@@ -63,7 +63,7 @@ of a local problem that they believe might require your attention.</p>
   [% IF report.get_extra_fields %]
     <p style="[% secondary_p_style %]">
       [%~ FOR field IN report.get_extra_fields %][% IF field.value %]
-      [% field.description OR field.code %]: [% field.value %]
+      [% field.description OR field.name %]: [% field.value %]
       [% IF NOT loop.last %]<br>[% END %]
       [%~ END %][% END %]
     </p>

--- a/templates/email/buckinghamshire/submit.txt
+++ b/templates/email/buckinghamshire/submit.txt
@@ -35,7 +35,7 @@ Confirm reference: [% report.external_id %]
 Details: [% report.detail %]
 
 [% FOR field IN report.get_extra_fields %][% IF field.value ~%]
-[% field.description OR field.code %]: [% field.value %]
+[% field.description OR field.name %]: [% field.value %]
 
 [% END %][% END ~%]
 

--- a/templates/email/default/cy/submit.html
+++ b/templates/email/default/cy/submit.html
@@ -52,7 +52,7 @@ am broblem leol y maent yn credu y gallai fod angen eich sylw.</p>
   [% IF report.get_extra_fields %]
     <p style="[% secondary_p_style %]">
       [%~ FOR field IN report.get_extra_fields %][% IF field.value %]
-      [% field.description OR field.code %]: [% field.value %]
+      [% field.description OR field.name %]: [% field.value %]
       [% IF NOT loop.last %]<br>[% END %]
       [%~ END %][% END %]
     </p>

--- a/templates/email/default/cy/submit.txt
+++ b/templates/email/default/cy/submit.txt
@@ -26,7 +26,7 @@ Pwnc: [% report.title %]
 Manylion: [% report.detail %]
 
 [% FOR field IN report.get_extra_fields %][% IF field.value ~%]
-[% field.description OR field.code %]: [% field.value %]
+[% field.description OR field.name %]: [% field.value %]
 
 [% END %][% END ~%]
 

--- a/templates/email/default/submit.html
+++ b/templates/email/default/submit.html
@@ -52,7 +52,7 @@ of a local problem that they believe might require your attention.</p>
   [% IF report.get_extra_fields %]
     <p style="[% secondary_p_style %]">
       [%~ FOR field IN report.get_extra_fields %][% IF field.value %]
-      [% field.description OR field.code %]: [% field.value %]
+      [% field.description OR field.name %]: [% field.value %]
       [% IF NOT loop.last %]<br>[% END %]
       [%~ END %][% END %]
     </p>

--- a/templates/email/default/submit.txt
+++ b/templates/email/default/submit.txt
@@ -26,7 +26,7 @@ Subject: [% report.title %]
 Details: [% report.detail %]
 
 [% FOR field IN report.get_extra_fields %][% IF field.value ~%]
-[% field.description OR field.code %]: [% field.value %]
+[% field.description OR field.name %]: [% field.value %]
 
 [% END %][% END ~%]
 

--- a/templates/email/fixmystreet.com/cy/submit.html
+++ b/templates/email/fixmystreet.com/cy/submit.html
@@ -53,7 +53,7 @@ am broblem leol credant y gallai fod angen eich sylw.
   [% IF report.get_extra_fields %]
     <p style="[% secondary_p_style %]">
       [%~ FOR field IN report.get_extra_fields %][% IF field.value %]
-        [% field.description OR field.code %]: [% field.value %]
+        [% field.description OR field.name %]: [% field.value %]
         [% IF NOT loop.last %]<br>[% END %]
       [%~ END %][% END %]
     </p>

--- a/templates/email/fixmystreet.com/cy/submit.txt
+++ b/templates/email/fixmystreet.com/cy/submit.txt
@@ -26,7 +26,7 @@ Pwnc: [% report.title %]
 Manylion: [% report.detail %]
 
 [% FOR field IN report.get_extra_fields %][% IF field.value ~%]
-[% field.description OR field.code %]: [% field.value %]
+[% field.description OR field.name %]: [% field.value %]
 
 [% END %][% END ~%]
 

--- a/templates/email/fixmystreet.com/submit.html
+++ b/templates/email/fixmystreet.com/submit.html
@@ -52,7 +52,7 @@ of a local problem that they believe might require your attention.</p>
   [% IF report.get_extra_fields %]
     <p style="[% secondary_p_style %]">
       [%~ FOR field IN report.get_extra_fields %][% IF field.value %]
-        [% field.description OR field.code %]: [% field.value %]
+        [% field.description OR field.name %]: [% field.value %]
         [% IF NOT loop.last %]<br>[% END %]
       [%~ END %][% END %]
     </p>

--- a/templates/email/fixmystreet.com/submit.txt
+++ b/templates/email/fixmystreet.com/submit.txt
@@ -26,7 +26,7 @@ Subject: [% report.title %]
 Details: [% report.detail %]
 
 [% FOR field IN report.get_extra_fields %][% IF field.value ~%]
-[% field.description OR field.code %]: [% field.value %]
+[% field.description OR field.name %]: [% field.value %]
 
 [% END %][% END ~%]
 

--- a/templates/web/base/admin/triage/_inspect.html
+++ b/templates/web/base/admin/triage/_inspect.html
@@ -70,7 +70,7 @@
           [% FOR field IN extra_fields %]
           [% NEXT IF field.name == 'urgent' %]
           <p>
-              <label for="[% field.name %]">[% field.description %]</label>
+              <label for="[% field.name %]">[% field.description OR field.name %]</label>
               <input class="form-control" name="[% field.name %]" type="text" value="[% field.value %]" disabled>
           </p>
           [% END %]


### PR DESCRIPTION
If there are a number of reports failing to send, leaving it to database order could cause the same reports to be returned over and over, never looking at other waiting reports.

And fix fallback code thing.