### PR TITLE
Mark non-Open311 updates as processed by daemon.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
     - Performance improvements:
         - Reduce database queries on shortlist page.
         - Provide ResultSet fallback translation in lookup.
+        - Mark non-Open311 updates as processed by daemon. #4552
     - Changes:
         - Switch to OpenStreetMap for reverse geocoding. #4444
 


### PR DESCRIPTION
Currently the update daemon query looks for 1) unprocessed, 2) confirmed, updates on reports that 3) have been sent to 4) bodies-with-Open311+send_comments-on. This query is quite slow, due to e.g. the number of updates (1+2) it's considering each time that are never going to be processed because they're not on relevant bodies.

This PR changes the query to fetch all unprocessed confirmed updates, regardless of sent state or body. If the body isn't an Open311+send_comments one, it now marks as processed and moves on. If it's not been sent and it's a non-open state, it marks as processed (only open state reports are sent) and moves on. If it's not been sent, it skips processing this one (is an update on a report still awaiting being sent to a backend which needs to happen first). Otherwise it tries to send the update as usual.

This means every update will be marked as 'processed' first time they're dealt with, leaving 'unprocessed' only for those that really do need looking at.