### PR TITLE
Increased contrast for problem state label

### DIFF
--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1481,7 +1481,7 @@ input.final-submit {
   font-weight: bold;
   padding: 0.2em 0.5em;
   vertical-align: -0.1em;
-  background: #888;
+  background: #666;
   color: #fff;
   border-radius: 0.3em;
   margin-#{$right}: 0.1em;


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/3831
Fixes part of:  https://github.com/mysociety/societyworks/issues/3812

For the background colour I reused the `#666` hex colour that we use across FMS. Now the contrast colour is 5.74.

<img width="461" alt="Screenshot 2023-08-03 at 08 18 15" src="https://github.com/mysociety/fixmystreet/assets/13790153/c94ebeb7-ed1c-4337-b2a0-da29e237ba30">
