### PR TITLE
Increased contrast ratio for 'No reports to show on map'

### DIFF
--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1489,7 +1489,7 @@ input.final-submit {
 
 .item-list__item--empty {
   background: none;
-  color: #777;
+  color: #666;
 
   p {
     margin: 0;


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/3832
Fixes part of: https://github.com/mysociety/societyworks/issues/3812

I'm reusing the` #666` hex colour that we use on FMS.

<img width="461" alt="Screenshot 2023-08-03 at 08 46 04" src="https://github.com/mysociety/fixmystreet/assets/13790153/404576bc-8bff-40f3-b6fd-7313c09f8d1c">

