### PR TITLE
[Glos] Accessibility Issues

### DIFF
--- a/web/cobrands/gloucestershire/_variables.scss
+++ b/web/cobrands/gloucestershire/_variables.scss
@@ -105,7 +105,7 @@ $search-help-header-font-size-desktop: 1.25em;
 $dropzone-button-text: $primary_text;
 
 // $pagination_background: #f6f6f6;
-$itemlist_item_background:  darken($base_bg, 5%);
+$itemlist_item_background:  $base_bg;
 $itemlist_item_background_hover: $gloucestershire_primary_light;
 $col_big_numbers: $primary_b;
 

--- a/web/cobrands/gloucestershire/base.scss
+++ b/web/cobrands/gloucestershire/base.scss
@@ -41,12 +41,15 @@ a {
     }
 }
 
-.btn,
+
+// This will prevent the update notifications buttons to have the same styling when checked and not checked. By default .btn doesn't have the primary button styling, it has a gray background colour, therefore in cobrands where the .btn has a primary button styling we get the .segmented-control looking the same no matter if they are selected or not.
+.btn:not(label),
 a#geolocate_link {
     @include button-variant($bg-top: $button-primary-bg-top, $bg-bottom: $button-primary-bg-bottom, $border: $button-primary-border, $text: $button-primary-text, $hover-bg-bottom: $button-primary-hover-bg-bottom, $hover-bg-top: $button-primary-hover-bg-top, $hover-border: $button-primary-hover-border, $hover-text: $button-primary-hover-text);
     border-width: $button-border-width;
     @include focus-state;
 }
+
 
 #report-cta {
     padding: 0.75em;

--- a/web/cobrands/gloucestershire/base.scss
+++ b/web/cobrands/gloucestershire/base.scss
@@ -133,7 +133,6 @@ a#geolocate_link {
 
 /* OTHERS */
 .item-list__item {
-    border-bottom: 1px solid $gloucestershire_grey;
     a {
         text-decoration: none;
 


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/3811
Fixes part of: https://github.com/mysociety/societyworks/issues/3812 

This PR fixes:

Button styling on "Your account" page
<img width="461" alt="Screenshot 2023-08-03 at 08 59 11" src="https://github.com/mysociety/fixmystreet/assets/13790153/17f54040-2968-40c5-9a49-f44765c2ccdc">

Date contrast ratio
<img width="1127" alt="Screenshot 2023-08-03 at 08 59 57" src="https://github.com/mysociety/fixmystreet/assets/13790153/9deeae1d-24e7-4692-8d6c-cc320a724c5a">


@nephila-nacrea and @jacquelinebylau 
Two of the problems listed[ here](https://github.com/mysociety/societyworks/issues/3812 ), weren't just Glos problems. So I fixed it across all cobrands on these PRs:

- [Here are some nearby reports marginal - ration required = 4.5 - actual = 4.48](https://github.com/mysociety/fixmystreet/pull/4554)
- [ 'Closed' marker well below - actual = 3.54](https://github.com/mysociety/fixmystreet/pull/4553)