### PR TITLE
Fms input accessibility

### DIFF
--- a/templates/web/base/header/css.html
+++ b/templates/web/base/header/css.html
@@ -7,5 +7,6 @@
     <link rel="stylesheet" href="[% layout_css %]">
 <![endif]-->
 <link rel="stylesheet" href="[% version('/vendor/OpenLayers/theme/default/style.css') %]">
+<link rel="stylesheet" href="[% version('/vendor/govuk-frontend/forms.css') %]">
 
 [% extra_css | safe %]

--- a/templates/web/base/reports/_list-filters.html
+++ b/templates/web/base/reports/_list-filters.html
@@ -33,10 +33,14 @@
     <form method="get" action="">
 [% END %]
 
-        <p class="report-list-filters">
-          [% tprintf(loc('<label for="statuses">Show</label> %s reports <label for="filter_categories">about</label> %s', "The first %s is a dropdown of all/fixed/etc, the second is a dropdown of categories"), mark_safe(select_status), mark_safe(select_category)) %]
+        <div class="report-list-filters">
+          [% tprintf(loc('<label for="statuses">Show</label> %s reports', "Dropdown of all/fixed/etc"), mark_safe(select_status)) %]
+        </div>
+
+        <div class="report-list-filters">
+          [% tprintf(loc('<label for="filter_categories">about</label> %s', "Dropdown of categories"), mark_safe(select_category)) %]
           <input type="submit" name="filter_update" value="[% loc('Go') %]">
-        </p>
+        </div>
 
         [% PROCESS 'reports/_list-filters-sort.html' %]
 

--- a/templates/web/fixmystreet.com/header/css.html
+++ b/templates/web/fixmystreet.com/header/css.html
@@ -1,6 +1,8 @@
 [% SET base_css = version('/cobrands/' _ c.cobrand.asset_moniker _ '/base.css') %]
 [% SET layout_css = version('/cobrands/' _ c.cobrand.asset_moniker _ '/layout.css') %]
 [% SET ol_css = version('/vendor/OpenLayers/theme/default/style.css') %]
+[% SET govuk_css = version('/vendor/govuk-frontend/forms.css') %]
+
 
 [% TRY %][% critical = INSERT "header/critical.auto.min.css" %][% CATCH file %][% END %]
 
@@ -17,6 +19,7 @@
 <noscript><link rel="stylesheet" href="[% base_css %]"></noscript>
 <link rel="prefetch" href="[% ol_css %]" as="style">
 <link id="preload_base_css" rel="preload" href="[% base_css %]" as="style">
+<link rel="stylesheet" href="[% govuk_css %]" as="style">
 <script nonce="[% csp_nonce %]">
 /* If browser *does* support preload, use stylesheets when loaded */
 document.getElementById('preload_base_css').onload = function(){this.onload=null;this.rel='stylesheet'};
@@ -28,6 +31,7 @@ document.getElementById('preload_base_css').onload = function(){this.onload=null
 [% ELSE %]
 <link rel="stylesheet" href="[% ol_css %]">
 <link rel="stylesheet" href="[% base_css %]">
+<link rel="stylesheet" href="[% govuk_css %]">
 [% END %]
 <link rel="stylesheet" href="[% layout_css %]" media="screen and (min-width:48em)">
 <!--[if (lt IE 9) & (!IEMobile)]>

--- a/templates/web/fixmystreet.com/header/css.html
+++ b/templates/web/fixmystreet.com/header/css.html
@@ -1,8 +1,6 @@
 [% SET base_css = version('/cobrands/' _ c.cobrand.asset_moniker _ '/base.css') %]
 [% SET layout_css = version('/cobrands/' _ c.cobrand.asset_moniker _ '/layout.css') %]
 [% SET ol_css = version('/vendor/OpenLayers/theme/default/style.css') %]
-[% SET govuk_css = version('/vendor/govuk-frontend/forms.css') %]
-
 
 [% TRY %][% critical = INSERT "header/critical.auto.min.css" %][% CATCH file %][% END %]
 
@@ -19,7 +17,6 @@
 <noscript><link rel="stylesheet" href="[% base_css %]"></noscript>
 <link rel="prefetch" href="[% ol_css %]" as="style">
 <link id="preload_base_css" rel="preload" href="[% base_css %]" as="style">
-<link rel="stylesheet" href="[% govuk_css %]" as="style">
 <script nonce="[% csp_nonce %]">
 /* If browser *does* support preload, use stylesheets when loaded */
 document.getElementById('preload_base_css').onload = function(){this.onload=null;this.rel='stylesheet'};
@@ -31,7 +28,6 @@ document.getElementById('preload_base_css').onload = function(){this.onload=null
 [% ELSE %]
 <link rel="stylesheet" href="[% ol_css %]">
 <link rel="stylesheet" href="[% base_css %]">
-<link rel="stylesheet" href="[% govuk_css %]">
 [% END %]
 <link rel="stylesheet" href="[% layout_css %]" media="screen and (min-width:48em)">
 <!--[if (lt IE 9) & (!IEMobile)]>

--- a/web/cobrands/fixmystreet/images/chevron-black-down.svg
+++ b/web/cobrands/fixmystreet/images/chevron-black-down.svg
@@ -1,0 +1,10 @@
+<svg width="24" height="20" viewBox="0 0 24 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_555_2190)">
+<path d="M12.866 19.5C12.4811 20.1667 11.5189 20.1667 11.134 19.5L0.74167 1.5C0.356769 0.833333 0.837895 0 1.6077 0H22.3923C23.1621 0 23.6432 0.833333 23.2583 1.5L12.866 19.5Z" fill="black"/>
+</g>
+<defs>
+<clipPath id="clip0_555_2190">
+<rect width="24" height="20" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/web/cobrands/fixmystreet/images/chevron-black-up.svg
+++ b/web/cobrands/fixmystreet/images/chevron-black-up.svg
@@ -1,0 +1,10 @@
+<svg width="24" height="20" viewBox="0 0 24 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_555_2192)">
+<path d="M11.134 0.499999C11.5189 -0.166667 12.4811 -0.166667 12.866 0.5L23.2583 18.5C23.6432 19.1667 23.1621 20 22.3923 20L1.60769 20C0.837894 20 0.35677 19.1667 0.74167 18.5L11.134 0.499999Z" fill="black"/>
+</g>
+<defs>
+<clipPath id="clip0_555_2192">
+<rect width="24" height="20" fill="white" transform="matrix(-1 0 0 -1 24 20)"/>
+</clipPath>
+</defs>
+</svg>

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -58,6 +58,7 @@ $geolocation-link-border: $geolocation-link !default;
 $geolocation-link-background-color: transparent !default;
 
 @import "_mixins";
+@import "_govuk";
 @import "_report_list";
 
 body {

--- a/web/cobrands/sass/_govuk.scss
+++ b/web/cobrands/sass/_govuk.scss
@@ -1,0 +1,11 @@
+.govuk-select {
+      // This will make the arrow for the multi-select component and GOVUK look the same.
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      appearance: none;
+      background-image: inline-image("../fixmystreet/images/chevron-black-down.svg");
+      background-repeat: no-repeat;
+      background-size: 11px;
+      background-position: right 0.5em center;
+      background-color: #fff;
+}

--- a/web/cobrands/sass/_multiselect.scss
+++ b/web/cobrands/sass/_multiselect.scss
@@ -11,7 +11,7 @@
     float: #{$left}; // shrink to width of child elements
     min-width: 100%; // always at least as wide as its .multi-select-button sibling
     background: #fff;
-    margin: 1em 0;
+    margin: 1.5em 0;
     border: 1px solid #aaa;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
     display: none;
@@ -35,12 +35,25 @@
     }
 }
 
-.multi-select-menuitem--titled:before {
-    display: block;
-    font-weight: bold;
-    content: attr(data-group-title);
-    margin: 0 0 0.25em -20px;
-    cursor: default;
+.multi-select-menuitem--titled {
+
+    &:before {
+        display: block;
+        font-weight: bold;
+        content: attr(data-group-title);
+        margin: 0 0 0.25em -20px;
+        cursor: default;
+    }
+
+    &.govuk-checkboxes__item {
+        margin-top: 1.85em;
+        &:before {
+            position: absolute;
+            left: 1em;
+            top: -1.5em;
+        }
+    }
+    
 }
 
 .multi-select-menuitem--titledsr:before {
@@ -108,44 +121,26 @@
 
 .multi-select-button {
     display: inline-block;
-    font-size: 0.875em;
-    padding: flip(0.2em 1.5em 0.2em 0.6em, 0.2em 0.6em 0.2em 1.5em);
-    max-width: 20em;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    vertical-align: -0.5em;
-    background-color: #fff;
-    border: 1px solid $form-control-border-color;
-    border-radius: 4px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    // fit-content: It will allow to display most as many selected option as possible. If it's not supported then it will use a max-width of 33%
+    width: 33%;
+    width: fit-content;
     cursor: default;
     position: relative;
 
-    &:after {
-        content: "";
-        display: block;
-        width: 0;
-        height: 0;
-        border-style: solid;
-        border-width: 0.4em 0.4em 0 0.4em;
-        border-color: #999 transparent transparent transparent;
-
-        position: absolute;
-        #{$right}: 0.5em;
-        top: 50%;
-        margin: -0.2em 0 0 0;
-    }
+    @extend .govuk-select;
 }
 
 .multi-select-container--open {
     .multi-select-menu {
         display: block;
+        padding: 0 1em;
     }
 
-    .multi-select-button:after {
-        border-width: 0 0.4em 0.4em 0.4em;
-        border-color: transparent transparent #999 transparent;
+    .multi-select-button {
+        background-image: inline-image("../fixmystreet/images/chevron-black-up.svg");
     }
 }
 

--- a/web/cobrands/sass/_report_list.scss
+++ b/web/cobrands/sass/_report_list.scss
@@ -1,5 +1,4 @@
 .report-list-filters-wrapper, #bulk-assign-form {
-  color: #666;
   border-top: 1px solid #e5e5e5;
   border-bottom: 1px solid #e5e5e5;
 
@@ -54,7 +53,6 @@
   }
 
   .multi-select-container {
-    margin: 0 0.2em;
     color: #000;
   }
 
@@ -64,9 +62,9 @@
   }
 
   .multi-select-button {
-    max-width: 10em;
-    padding: flip(0 1.5em 0 0.6em, 0 0.6em 0 1.5em);
-    line-height: 1.8em;
+    box-sizing: border-box;
+    max-width: 100%;
+    padding: flip(0.4em 1.5em 0.4em 0.6em, 0.4em 0.6em 0.4em 1.5em);
     vertical-align: top;
   }
 
@@ -91,10 +89,51 @@
     content: none;
   }
 
+  &.sort-select {
+    width: fit-content;
+  }
+
 }
 
 input.bulk-assign {
     float: right;
     margin: 2em;
     transform: scale(2);
+}
+
+.multi-select-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1em;
+}
+
+@media (min-width: 48em) {
+  .report-list-filters {
+    display: flex;
+    flex-direction: row;
+    gap: 1em;
+
+    .multi-select-group {
+      flex-basis: 50%;
+    }
+
+    .multi-select-button {
+      width: 100%;
+    }
+
+    &.sort-container {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+      float: left;
+    }
+  }
+
+  #show_old_reports_wrapper {
+    padding-top: 24px;
+    padding-left: 0;
+    .govuk-label.govuk-checkboxes__label {
+      font-size: 0.85em;
+    }
+  }
 }


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/3821

- Should include these changes in the changelog?
- Should we take the opportunity to create variables for the GOVUK styling: `border-color`, `color`, `focus-yellow` for the GOVUK input elements. Thinking of cases like Camden.
- The layout has changed quite a bit, the filters use more vertical space, but considering that the filter section doesn't have a sticky property and you can still see the reports when the page loads, I didn't think it would be a deal breaker. But let me know what you think.

### What do you think is the best approach with this file:
`web/vendor/jquery.multi-select.min.js` Right now is not a minified version anymore. Also the file has changed quite a lot, so it might be worth it just to move the content to `FixMyStreet.js` or just rename the file to something like `multi-select.js`. The other alternative, but I wasn't to keen for that one, was to apply the gOVUK styling to the multi-select classes, which potentially add a lot of extra code.

### Desktop

https://github.com/mysociety/fixmystreet/assets/13790153/91e6ae43-3c5c-4abd-bcd2-a58d3fef2e89

<img width="1904" alt="Screenshot 2023-08-14 at 08 22 38" src="https://github.com/mysociety/fixmystreet/assets/13790153/28350586-1862-4e72-8896-491a17b83133">

### Mobile

https://github.com/mysociety/fixmystreet/assets/13790153/41e92433-f5ad-42c9-92d9-655d11b23813

<img width="378" alt="Screenshot 2023-08-14 at 08 23 07" src="https://github.com/mysociety/fixmystreet/assets/13790153/779c30db-7c0c-4d99-8223-104abdfd4fe5">


