### PR TITLE
[Thamesmead] Add PWA instructions

### DIFF
--- a/templates/web/thamesmead/about/web-app.html
+++ b/templates/web/thamesmead/about/web-app.html
@@ -1,0 +1,1 @@
+../../fixmystreet-uk-councils/about/web-app.html


### PR DESCRIPTION
Similar to https://github.com/mysociety/fixmystreet/pull/4485 the Peabody/Thamesmead cobrand was missing PWA instructions because it doesn't inherit from the UKCouncil cobrand. Fixed by symlinking the appropriate file.

<img width="966" alt="image" src="https://github.com/mysociety/fixmystreet/assets/22996/543bf526-b2ce-427c-b99f-418e708a0a4e">


<!-- [skip changelog] -->