### PR TITLE
Improved width for map area in around page

### DIFF
--- a/web/cobrands/highwaysengland/_colours.scss
+++ b/web/cobrands/highwaysengland/_colours.scss
@@ -58,9 +58,15 @@ $front-main-background: $color-he-grey-2;
 
 // NH want the inspector form to be wider
 $mappage-actions-sidebar-width: 24em;
-$mappage-actions-width: 36em;
+
 $mappage-sidebar-width--medium: 24em;
+$mappage-sidebar-width--large:  24em;
+$mappage-sidebar-width--xlarge: 24em;
+
+$mappage-actions-width: 36em;
 $mappage-actions-width--medium: 36em;
+$mappage-actions-width--large:  36em;
+$mappage-actions-width--xlarge: 36em;
 
 $mobile-sticky-sidebar-button-menu-image: "menu-white";
 

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -2,13 +2,17 @@
 
 $layout_front_stats_color: $primary !default;
 $mappage-header-height: 4em !default; // eg: might want this to equal outer height of #site-header on normal pages
-$mappage-sidebar-width: 29em !default;
-$mappage-sidebar-padding: 1em;
+$screen-size--medium: 63em !default;
+$screen-size--large:  79em !default;
+$mappage-sidebar-width: 26em !default;
 $mappage-notes-width: 15em;
-$mappage-actions-width: 25em !default;
+$mappage-actions-width: 18em !default;
+$mappage-sidebar-width--large:  28em !default;
+$mappage-actions-width--large:  20em !default;
+$mappage-sidebar-width--xlarge: 29em !default;
+$mappage-actions-width--xlarge: 25em !default;
+$mappage-sidebar-padding: 1em;
 $mappage-actions-sidebar-width: $mappage-sidebar-width !default;
-$mappage-sidebar-width--medium: 24em !default;
-$mappage-actions-width--medium: 20em !default;
 $header-top-border-width: 0.25em !default;
 $header-top-border: $header-top-border-width solid $primary !default;
 
@@ -252,6 +256,14 @@ body.mappage.admin {
   height: auto; // stretch from bottom of header to bottom of window
   margin: 0;
 
+  @media only screen and (max-width: $screen-size--large) and (min-width: $screen-size--medium)  {
+    #{$left}: $mappage-sidebar-width--large;
+  }
+
+  @media (min-width: $screen-size--large) {
+    #{$left}: $mappage-sidebar-width--xlarge;
+  }
+
   .with-notes & {
     #{$left}: $mappage-sidebar-width + $mappage-notes-width;
   }
@@ -259,8 +271,12 @@ body.mappage.admin {
   .with-actions & {
     #{$left}: $mappage-actions-sidebar-width + $mappage-actions-width;
 
-    @media (max-width: 79em) {
-      #{$left}: $mappage-sidebar-width--medium  + $mappage-actions-width--medium;
+    @media only screen and (max-width: $screen-size--large) and (min-width: $screen-size--medium)  {
+      #{$left}: $mappage-sidebar-width--large + $mappage-actions-width--large;
+    }
+  
+    @media (min-width: $screen-size--large) {
+      #{$left}: $mappage-sidebar-width--xlarge + $mappage-actions-width--xlarge;
     }
   }
 }
@@ -284,6 +300,14 @@ body.mappage.admin {
     background-image: linear-gradient(flip(90deg, 270deg), transparent 29em, #E9F2FF 29em);
   }
 
+  @media only screen and (max-width: $screen-size--large) and (min-width: $screen-size--medium)  {
+    width: ($mappage-sidebar-width--large - ($mappage-sidebar-padding * 2));
+  }
+
+  @media (min-width: $screen-size--large) {
+    width: ($mappage-sidebar-width--xlarge - ($mappage-sidebar-padding * 2));
+  }
+
   .with-actions & {
     width: $mappage-actions-sidebar-width + $mappage-actions-width;
     max-width: 100%; // Secondary column will squish on screens 768-960px
@@ -293,8 +317,12 @@ body.mappage.admin {
       display: none; // 4em bottom spacing will be handled by children of .two_column_sidebar
     }
 
-    @media (max-width: 79em) {
-      width: $mappage-sidebar-width--medium + $mappage-actions-width--medium;
+    @media only screen and (max-width: $screen-size--large) and (min-width: $screen-size--medium)  {
+      width: $mappage-sidebar-width--large + $mappage-actions-width--large;
+    }
+
+    @media (min-width: $screen-size--large) {
+      width: $mappage-sidebar-width--xlarge + $mappage-actions-width--xlarge;
     }
   }
 }
@@ -331,12 +359,24 @@ body.mappage.admin {
     width: $mappage-sidebar-width;
     flex: 0 0 auto;
 
-    @media (max-width: 79em) {
-      width: $mappage-sidebar-width--medium;
+    @media only screen and (max-width: $screen-size--large) and (min-width: $screen-size--medium)  {
+      width: $mappage-sidebar-width--large;
+    }
+
+    @media (min-width: $screen-size--large) {
+      width: $mappage-sidebar-width--xlarge;
     }
 
     .with-actions & {
       width: $mappage-actions-sidebar-width;
+
+      @media only screen and (max-width: $screen-size--large) and (min-width: $screen-size--medium)  {
+        width: $mappage-sidebar-width--large;
+      }
+  
+      @media (min-width: $screen-size--large) {
+        width: $mappage-sidebar-width--xlarge;
+      }
     }
   }
 
@@ -344,12 +384,24 @@ body.mappage.admin {
   .shadow-wrap {
     width: $mappage-sidebar-width;
 
-    @media (max-width: 79em) {
-      width: $mappage-sidebar-width--medium;
+    @media only screen and (max-width: $screen-size--large) and (min-width: $screen-size--medium)  {
+      width: $mappage-sidebar-width--large;
+    }
+
+    @media (min-width: $screen-size--large) {
+      width: $mappage-sidebar-width--xlarge;
     }
 
     .with-actions & {
       width: $mappage-actions-sidebar-width;
+
+      @media only screen and (max-width: $screen-size--large) and (min-width: $screen-size--medium)  {
+        width: $mappage-sidebar-width--large;
+      }
+  
+      @media (min-width: $screen-size--large) {
+        width: $mappage-sidebar-width--xlarge;
+      }
     }
   }
 

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -4,15 +4,30 @@ $layout_front_stats_color: $primary !default;
 $mappage-header-height: 4em !default; // eg: might want this to equal outer height of #site-header on normal pages
 $screen-size--medium: 63em !default;
 $screen-size--large:  79em !default;
-$mappage-sidebar-width: 26em !default;
+$screen-size--xlarge:  90em !default;
+
 $mappage-notes-width: 15em;
-$mappage-actions-width: 18em !default;
+$mappage-notes-width--medium: 17em;
+$mappage-notes-width--large: 19em;
+$mappage-notes-width--xlarge: 20em;
+
+$mappage-sidebar-width: 20em !default;
+$mappage-sidebar-width--medium:  27em !default;
 $mappage-sidebar-width--large:  28em !default;
-$mappage-actions-width--large:  20em !default;
-$mappage-sidebar-width--xlarge: 29em !default;
-$mappage-actions-width--xlarge: 25em !default;
-$mappage-sidebar-padding: 1em;
+$mappage-sidebar-width--xlarge: 30em !default;
+
+$mappage-actions-width: 16em !default;
+$mappage-actions-width--medium:  18em !default;
+$mappage-actions-width--large:  22em !default;
+$mappage-actions-width--xlarge: 26em !default;
+
 $mappage-actions-sidebar-width: $mappage-sidebar-width !default;
+$mappage-actions-sidebar-width--medium: $mappage-sidebar-width--medium !default;
+$mappage-actions-sidebar-width--large: $mappage-sidebar-width--large !default;
+$mappage-actions-sidebar-width--xlarge: $mappage-sidebar-width--xlarge !default;
+
+$mappage-sidebar-padding: 1em;
+
 $header-top-border-width: 0.25em !default;
 $header-top-border: $header-top-border-width solid $primary !default;
 
@@ -256,26 +271,46 @@ body.mappage.admin {
   height: auto; // stretch from bottom of header to bottom of window
   margin: 0;
 
-  @media only screen and (max-width: $screen-size--large) and (min-width: $screen-size--medium)  {
-    #{$left}: $mappage-sidebar-width--large;
+  @media (min-width: $screen-size--medium) {
+    #{$left}: $mappage-sidebar-width--medium;
   }
 
   @media (min-width: $screen-size--large) {
+    #{$left}: $mappage-sidebar-width--large;
+  }
+
+  @media (min-width: $screen-size--xlarge) {
     #{$left}: $mappage-sidebar-width--xlarge;
   }
 
   .with-notes & {
     #{$left}: $mappage-sidebar-width + $mappage-notes-width;
+
+    @media (min-width: $screen-size--medium) {
+      #{$left}: $mappage-sidebar-width--medium + $mappage-notes-width--medium;
+    }
+
+    @media (min-width: $screen-size--large) {
+      #{$left}: $mappage-sidebar-width--large + $mappage-notes-width--large;
+    }
+
+    @media (min-width: $screen-size--xlarge) {
+      #{$left}: $mappage-sidebar-width--xlarge + $mappage-notes-width--xlarge;
+    }
   }
 
   .with-actions & {
     #{$left}: $mappage-actions-sidebar-width + $mappage-actions-width;
 
-    @media only screen and (max-width: $screen-size--large) and (min-width: $screen-size--medium)  {
+    @media (min-width: $screen-size--medium) {
+      #{$left}: $mappage-sidebar-width--medium + $mappage-actions-width--medium;
+    }
+
+    @media (min-width: $screen-size--large) {
       #{$left}: $mappage-sidebar-width--large + $mappage-actions-width--large;
     }
-  
-    @media (min-width: $screen-size--large) {
+
+    @media (min-width: $screen-size--xlarge) {
       #{$left}: $mappage-sidebar-width--xlarge + $mappage-actions-width--xlarge;
     }
   }
@@ -296,15 +331,32 @@ body.mappage.admin {
   .with-notes & {
     width: (($mappage-sidebar-width + $mappage-notes-width) - ($mappage-sidebar-padding * 2));
     // TODO: Should have a bitmap image fallback for old browsers!!
-    background-image: -webkit-linear-gradient(flip(90deg, 270deg), transparent 29em, #E9F2FF 29em);
-    background-image: linear-gradient(flip(90deg, 270deg), transparent 29em, #E9F2FF 29em);
+    background-image: -webkit-linear-gradient(flip(90deg, 270deg), transparent 52%, #E9F2FF 52%);
+    background-image: linear-gradient(flip(90deg, 270deg), transparent 52%, #E9F2FF 52%);
+    background-repeat: no-repeat;
+
+    @media (min-width: $screen-size--medium) {
+      width: (($mappage-sidebar-width--medium + $mappage-notes-width--medium) - ($mappage-sidebar-padding * 2));
+    }
+
+    @media (min-width: $screen-size--large) {
+      width: (($mappage-sidebar-width--large + $mappage-notes-width--large) - ($mappage-sidebar-padding * 2));
+    }
+
+    @media (min-width: $screen-size--xlarge) {
+      width: (($mappage-sidebar-width--xlarge + $mappage-notes-width--xlarge) - ($mappage-sidebar-padding * 2));
+    }
   }
 
-  @media only screen and (max-width: $screen-size--large) and (min-width: $screen-size--medium)  {
-    width: ($mappage-sidebar-width--large - ($mappage-sidebar-padding * 2));
+  @media (min-width: $screen-size--medium) {
+    width: ($mappage-sidebar-width--medium - ($mappage-sidebar-padding * 2));
   }
 
   @media (min-width: $screen-size--large) {
+    width: ($mappage-sidebar-width--large - ($mappage-sidebar-padding * 2));
+  }
+
+  @media (min-width: $screen-size--xlarge) {
     width: ($mappage-sidebar-width--xlarge - ($mappage-sidebar-padding * 2));
   }
 
@@ -317,11 +369,15 @@ body.mappage.admin {
       display: none; // 4em bottom spacing will be handled by children of .two_column_sidebar
     }
 
-    @media only screen and (max-width: $screen-size--large) and (min-width: $screen-size--medium)  {
-      width: $mappage-sidebar-width--large + $mappage-actions-width--large;
+    @media (min-width: $screen-size--medium) {
+      width: $mappage-sidebar-width--medium + $mappage-actions-width--medium;
     }
 
     @media (min-width: $screen-size--large) {
+      width: $mappage-sidebar-width--large + $mappage-actions-width--large;
+    }
+
+    @media (min-width: $screen-size--xlarge) {
       width: $mappage-sidebar-width--xlarge + $mappage-actions-width--xlarge;
     }
   }
@@ -359,22 +415,30 @@ body.mappage.admin {
     width: $mappage-sidebar-width;
     flex: 0 0 auto;
 
-    @media only screen and (max-width: $screen-size--large) and (min-width: $screen-size--medium)  {
-      width: $mappage-sidebar-width--large;
+    @media (min-width: $screen-size--medium) {
+      width: $mappage-sidebar-width--medium;
     }
 
     @media (min-width: $screen-size--large) {
+      width: $mappage-sidebar-width--large;
+    }
+
+    @media (min-width: $screen-size--xlarge) {
       width: $mappage-sidebar-width--xlarge;
     }
 
     .with-actions & {
       width: $mappage-actions-sidebar-width;
 
-      @media only screen and (max-width: $screen-size--large) and (min-width: $screen-size--medium)  {
+      @media (min-width: $screen-size--medium) {
+        width: $mappage-sidebar-width--medium;
+      }
+
+      @media (min-width: $screen-size--large) {
         width: $mappage-sidebar-width--large;
       }
-  
-      @media (min-width: $screen-size--large) {
+
+      @media (min-width: $screen-size--xlarge) {
         width: $mappage-sidebar-width--xlarge;
       }
     }
@@ -384,23 +448,31 @@ body.mappage.admin {
   .shadow-wrap {
     width: $mappage-sidebar-width;
 
-    @media only screen and (max-width: $screen-size--large) and (min-width: $screen-size--medium)  {
-      width: $mappage-sidebar-width--large;
+    @media (min-width: $screen-size--medium) {
+      width: $mappage-sidebar-width--medium;
     }
 
     @media (min-width: $screen-size--large) {
+      width: $mappage-sidebar-width--large;
+    }
+
+    @media (min-width: $screen-size--xlarge) {
       width: $mappage-sidebar-width--xlarge;
     }
 
     .with-actions & {
       width: $mappage-actions-sidebar-width;
 
-      @media only screen and (max-width: $screen-size--large) and (min-width: $screen-size--medium)  {
-        width: $mappage-sidebar-width--large;
+      @media (min-width: $screen-size--medium) {
+        width: $mappage-actions-sidebar-width--medium;
       }
-  
+
       @media (min-width: $screen-size--large) {
-        width: $mappage-sidebar-width--xlarge;
+        width: $mappage-actions-sidebar-width--large;
+      }
+
+      @media (min-width: $screen-size--xlarge) {
+        width: $mappage-actions-sidebar-width--xlarge;
       }
     }
   }
@@ -717,12 +789,16 @@ body.authpage {
   overflow: hidden;
   padding-top: 2em;
 
-  .js & {
-    // If JS is not available then shadow wrap position will be static and won't cover any other content on the page.
-    position: fixed;
-    z-index: 10; //this is just to ensure anything inside .content that has position set goes sites it
-    bottom: 0;
-    #{$left}: 0;
+  @media (min-width: $screen-size--medium) {
+    width: $mappage-sidebar-width--medium;
+  }
+
+  @media (min-width: $screen-size--large) {
+    width: $mappage-sidebar-width--large;
+  }
+
+  @media (min-width: $screen-size--xlarge) {
+    width: $mappage-sidebar-width--xlarge;
   }
 
   &.static {
@@ -834,7 +910,7 @@ textarea.form-error {
 // to make space for the #report-a-problem-sidebar.
 #side-form, #side {
   .with-notes & {
-    width: 27em;
+    width: 50%;
   }
 }
 

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -9,17 +9,17 @@ $screen-size--xlarge:  90em !default;
 $mappage-notes-width: 15em;
 $mappage-notes-width--medium: 17em;
 $mappage-notes-width--large: 19em;
-$mappage-notes-width--xlarge: 20em;
+$mappage-notes-width--xlarge: 25em;
 
 $mappage-sidebar-width: 20em !default;
 $mappage-sidebar-width--medium:  27em !default;
 $mappage-sidebar-width--large:  28em !default;
 $mappage-sidebar-width--xlarge: 30em !default;
 
-$mappage-actions-width: 16em !default;
+$mappage-actions-width: 15em !default;
 $mappage-actions-width--medium:  18em !default;
 $mappage-actions-width--large:  22em !default;
-$mappage-actions-width--xlarge: 26em !default;
+$mappage-actions-width--xlarge: 25em !default;
 
 $mappage-actions-sidebar-width: $mappage-sidebar-width !default;
 $mappage-actions-sidebar-width--medium: $mappage-sidebar-width--medium !default;

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -9,7 +9,7 @@ $screen-size--xlarge:  90em !default;
 $mappage-notes-width: 15em;
 $mappage-notes-width--medium: 17em;
 $mappage-notes-width--large: 19em;
-$mappage-notes-width--xlarge: 25em;
+$mappage-notes-width--xlarge: 21em;
 
 $mappage-sidebar-width: 20em !default;
 $mappage-sidebar-width--medium:  27em !default;
@@ -19,7 +19,7 @@ $mappage-sidebar-width--xlarge: 30em !default;
 $mappage-actions-width: 15em !default;
 $mappage-actions-width--medium:  18em !default;
 $mappage-actions-width--large:  22em !default;
-$mappage-actions-width--xlarge: 25em !default;
+$mappage-actions-width--xlarge: 23em !default;
 
 $mappage-actions-sidebar-width: $mappage-sidebar-width !default;
 $mappage-actions-sidebar-width--medium: $mappage-sidebar-width--medium !default;
@@ -303,15 +303,15 @@ body.mappage.admin {
     #{$left}: $mappage-actions-sidebar-width + $mappage-actions-width;
 
     @media (min-width: $screen-size--medium) {
-      #{$left}: $mappage-sidebar-width--medium + $mappage-actions-width--medium;
+      #{$left}: $mappage-actions-sidebar-width--medium + $mappage-actions-width--medium;
     }
 
     @media (min-width: $screen-size--large) {
-      #{$left}: $mappage-sidebar-width--large + $mappage-actions-width--large;
+      #{$left}: $mappage-actions-sidebar-width--large + $mappage-actions-width--large;
     }
 
     @media (min-width: $screen-size--xlarge) {
-      #{$left}: $mappage-sidebar-width--xlarge + $mappage-actions-width--xlarge;
+      #{$left}: $mappage-actions-sidebar-width--xlarge + $mappage-actions-width--xlarge;
     }
   }
 }
@@ -370,15 +370,15 @@ body.mappage.admin {
     }
 
     @media (min-width: $screen-size--medium) {
-      width: $mappage-sidebar-width--medium + $mappage-actions-width--medium;
+      width: $mappage-actions-sidebar-width--medium + $mappage-actions-width--medium;
     }
 
     @media (min-width: $screen-size--large) {
-      width: $mappage-sidebar-width--large + $mappage-actions-width--large;
+      width: $mappage-actions-sidebar-width--large + $mappage-actions-width--large;
     }
 
     @media (min-width: $screen-size--xlarge) {
-      width: $mappage-sidebar-width--xlarge + $mappage-actions-width--xlarge;
+      width: $mappage-actions-sidebar-width--xlarge + $mappage-actions-width--xlarge;
     }
   }
 }
@@ -431,15 +431,15 @@ body.mappage.admin {
       width: $mappage-actions-sidebar-width;
 
       @media (min-width: $screen-size--medium) {
-        width: $mappage-sidebar-width--medium;
+        width: $mappage-actions-sidebar-width--medium;
       }
 
       @media (min-width: $screen-size--large) {
-        width: $mappage-sidebar-width--large;
+        width: $mappage-actions-sidebar-width--large;
       }
 
       @media (min-width: $screen-size--xlarge) {
-        width: $mappage-sidebar-width--xlarge;
+        width:$mappage-actions-sidebar-width--xlarge;
       }
     }
   }

--- a/web/cobrands/sass/_report_list.scss
+++ b/web/cobrands/sass/_report_list.scss
@@ -163,6 +163,5 @@ input.bulk-assign {
     flex-direction: column;
     gap: 0;
     padding: 0;
-    flex-basis: 50%;
   }
 }

--- a/web/cobrands/sass/_report_list.scss
+++ b/web/cobrands/sass/_report_list.scss
@@ -152,15 +152,10 @@ input.bulk-assign {
   padding: 1rem;
 
   .filter-group {
-    display: flex;
-    flex-direction: row;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
     gap: 1rem;
     margin-bottom: 1rem;
-
-    @media (max-height: 30em) {
-      // To avoid horizontal scrolling when zooming >300%
-      flex-direction: column;
-    }
   }
 
   .report-list-filters {
@@ -169,15 +164,5 @@ input.bulk-assign {
     gap: 0;
     padding: 0;
     flex-basis: 50%;
-  }
-
-  .multi-select-button, .govuk-select {
-    width: 150px;
-  }
-
-  @media (min-width: 48em) {
-    .multi-select-button, .govuk-select {
-      width: 200px;
-    }
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/3784

Decreased the width for the .map_side element. This should make the map to have more space on medium screens portrait mode, like tablets.

### Preview `.mappage.with-actions`
### 48em to 63em
<img width="765" alt="Screenshot 2023-08-15 at 14 47 32" src="https://github.com/mysociety/fixmystreet/assets/13790153/621ce479-e71f-42ac-90fe-d58828dfcd20">

### 63em to 79em
<img width="1028" alt="Screenshot 2023-08-15 at 14 48 08" src="https://github.com/mysociety/fixmystreet/assets/13790153/8be60d9b-b010-4388-8a3f-dccc0a5c8665">

### >79em
<img width="1877" alt="Screenshot 2023-08-15 at 14 48 27" src="https://github.com/mysociety/fixmystreet/assets/13790153/78ed4289-dcb1-4311-83d4-9a7866f25e63">


###   Preview `.mappage`
### 48em to 63em
<img width="762" alt="Screenshot 2023-08-15 at 14 49 04" src="https://github.com/mysociety/fixmystreet/assets/13790153/c16aded9-e4e4-47e5-b3dd-9691bfb22977">

### 63em to 79em
<img width="1000" alt="Screenshot 2023-08-15 at 14 49 51" src="https://github.com/mysociety/fixmystreet/assets/13790153/5d390c41-e8d2-4c80-8b93-e3e19c8cd45e">

### >79em
<img width="1268" alt="Screenshot 2023-08-15 at 14 50 26" src="https://github.com/mysociety/fixmystreet/assets/13790153/5e847cb2-9b40-42ed-8875-1e571b0dd27f">


----
`48-63em: 22em (46% … 35%)`
In the issue there is a proposed width for the `.map_sidebar` element of 22em. However at that size we the filter in the around area looks like this:

<img width="768" alt="Screenshot 2023-08-15 at 14 51 49" src="https://github.com/mysociety/fixmystreet/assets/13790153/574968de-3fab-4dff-9c70-5ce00de2655d">

Considering that is not a massive difference we could comeback to this PR after seeing the outcome of [this other PR](https://github.com/mysociety/fixmystreet/pull/4560), where the layout of the filter might change and therefore we could decrease the `.map_sidebar` width further.

Let me know what you think.

