### PR TITLE
Added variables for btn-primary, green-btn and btn--primary

### DIFF
--- a/web/cobrands/bathnes/_colours.scss
+++ b/web/cobrands/bathnes/_colours.scss
@@ -55,3 +55,14 @@ $search-help-header-font-size-desktop: 1.25em;
 $heading-font: arial, sans-serif;
 $body-font: arial, sans-serif;
 $meta-font: arial, sans-serif;
+
+
+// Base on this styling https://beta.bathnes.gov.uk/
+$button-primary-bg-top: #00703c;
+$button-primary-border: #00703c;
+$button-primary-text: #fff;
+
+$button-primary-hover-bg-top: #005a30;
+$button-primary-hover-bg-bottom: #005a30;
+$button-primary-hover-border: #005a30;
+$button-primary-hover-text: #fff;

--- a/web/cobrands/bristol/_colours.scss
+++ b/web/cobrands/bristol/_colours.scss
@@ -50,3 +50,9 @@ $front-main-h2-color: $primary_b;
 $front-main-color-desktop: $primary_b;
 
 $mobile-sticky-sidebar-button-menu-image: "menu-white";
+
+$button-primary-bg-top: $primary;
+$button-primary-border: $primary;
+$button-primary-text: #fff;
+
+$button-primary-hover-border: $primary;

--- a/web/cobrands/centralbedfordshire/_colours.scss
+++ b/web/cobrands/centralbedfordshire/_colours.scss
@@ -41,3 +41,14 @@ $dropzone-button-background: $central-beds-purple;
 $dropzone-button-border: $central-beds-purple;
 
 $front-main-background: $central-beds-cream;
+
+// Style taken from: https://www.centralbedfordshire.gov.uk/info/55/transport_roads_and_parking/588/report_or_track_roads_and_highways_problems_-_potholes_street_lights
+
+$button-primary-bg-top: $central-beds-purple;
+$button-primary-border: $central-beds-purple;
+$button-primary-text: #fff;
+
+$button-primary-hover-bg-top: $central-beds-fuschia;
+$button-primary-hover-bg-bottom: $central-beds-fuschia;
+$button-primary-hover-border: $central-beds-fuschia;
+$button-primary-hover-text: #fff;

--- a/web/cobrands/isleofwight/_colours.scss
+++ b/web/cobrands/isleofwight/_colours.scss
@@ -47,3 +47,8 @@ $front-main-background-desktop: $blue;
 $front-main-color: $primary_text;
 $front-main-background: $blue;
 $postcodeform-background: $blue;
+
+// This is not the colour the use on their website for their buttons, but at it matches the navbar and more important is accessible.
+$button-primary-bg-top: $blue;
+$button-primary-border: $blue;
+$button-primary-text: #fff;

--- a/web/cobrands/lincolnshire/_colours.scss
+++ b/web/cobrands/lincolnshire/_colours.scss
@@ -57,3 +57,5 @@ $search-help-margin-desktop: -2em -2em 0 -2em;
 
 $form-hint-color: transparentize(#000, 0.3);
 $form-hint-color-desktop: transparentize(#000, 0.3);
+
+$button-primary-text: $lincs-text;

--- a/web/cobrands/rutland/_colours.scss
+++ b/web/cobrands/rutland/_colours.scss
@@ -34,3 +34,10 @@ $col_click_map: $RCCGreen_dark;
 //$image-sprite: '/cobrands/rutland/RCCLogo.gif';
 
 $front-main-background-desktop: $primary;
+
+$button-primary-bg-top: $primary;
+$button-primary-border: $primary;
+$button-primary-text: $primary_b;
+
+$button-primary-hover-text: $primary_b;
+$button-primary-hover-border: $primary;

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -15,6 +15,21 @@ $link-hover-text-decoration: underline !default;
 $primary_link_decoration: underline !default;
 $primary_link_hover_decoration: $primary_link_decoration !default;
 
+$button-primary-bg-top: #222 !default;
+$button-primary-bg-bottom: $button-primary-bg-top !default;
+$button-primary-border: darken($button-primary-bg-top, 50%) !default;
+$button-primary-text: #fff !default;
+
+$button-primary-hover-bg-top: mix($button-primary-bg-top, #fff, 80%) !default;
+$button-primary-hover-bg-bottom: mix($button-primary-bg-bottom, #fff, 80%) !default;
+$button-primary-hover-border: darken($button-primary-border, 100%) !default;
+$button-primary-hover-text: #fff !default;
+
+$button-primary-focus-bg-top: #ffe100 !default;
+$button-primary-focus-bg-bottom: #ffe100 !default;
+$button-primary-focus-border: $button-primary-border !default;
+$button-primary-focus-text: #222 !default;
+
 $pagination_background: #f6f6f6 !default;
 $itemlist_item_background: #f6f6f6 !default;
 $itemlist_item_background_hover: #e6e6e6 !default;
@@ -1051,7 +1066,7 @@ footer {
 .btn-primary,
 .green-btn,
 .btn--primary {
-  @include button-variant(#9fde23, #7fb900, #5b9700, #fff, #9fde23, #7fb900, #5b9700, #fff);
+  @include button-variant($button-primary-bg-top, $button-primary-bg-bottom, $button-primary-border, $button-primary-text, $button-primary-hover-bg-top, $button-primary-hover-bg-bottom, $button-primary-hover-border, $button-primary-hover-text,$button-primary-focus-bg-bottom,$button-primary-focus-bg-top, $button-primary-focus-border, $button-primary-focus-text);
 }
 
 .btn-danger,


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/3827
This should fix the accessibility issue with the white text against green background for the `.green-btn` class . A list of variables has been included, so the button can be customised according to a cobrand's branding guide.

NOTE: I went for a neutral default colour for the background, because some cobrands will use these colours as well, and the FMS yellow would look odd with their branding colour. Which brings the question, with this PR, the primary button has variables now, therefore we could update all cobrands so they use their own colours, instead of the default ones.  Let me know what you think so I can create the relevant ticket.

<img width="666" alt="Screenshot 2023-08-24 at 07 21 37" src="https://github.com/mysociety/fixmystreet/assets/13790153/d2fb8cc8-8a66-457b-94c6-5b184193e4f1">

[skip changelog]