### PR TITLE
GOVUK Styling for inputs in contact page

### DIFF
--- a/templates/web/base/contact/form.html
+++ b/templates/web/base/contact/form.html
@@ -61,35 +61,43 @@
 
   [% INCLUDE 'contact/who.html' %]
 
-  <label for="form_name">[% loc('Your name') %]</label>
-  [% IF field_errors.name %]
-     <div class="form-error">[% field_errors.name %]</div>
-  [% END %]
-  <input type="text" class="form-control required" name="name" id="form_name" value="[% form_name | html %]" size="30">
-
-  <label for="form_email">[% loc('Your email') %]</label>
-  [% IF field_errors.em %]
-     <div class="form-error">[% field_errors.em %]</div>
-  [% END %]
-  <input type="text" class="form-control required email" name="em" id="form_email" value="[% em | html %]" size="30">
-
-  <div class="form-group">
-    <label for="form_phone">[% loc('Your phone number') %]</label>
-    <span class="required-text required-text--optional">[% loc('optional') %]</span>
-    <input type="text" class="form-control extra.phone" name="extra.phone" id="form_phone" value="" size="30">
+  <div class="govuk-form-group">
+    <label class="govuk-label" for="form_name">[% loc('Your name') %]</label>
+    [% IF field_errors.name %]
+        <div class="form-error">[% field_errors.name %]</div>
+    [% END %]
+    <input type="text" class="govuk-input required" name="name" id="form_name" value="[% form_name | html %]" size="30">
   </div>
 
-  <label for="form_subject">[% loc('Subject') %]</label>
-  [% IF field_errors.subject %]
-     <div class="form-error">[% field_errors.subject %]</div>
-  [% END %]
-  <input type="text" class="form-control required" name="subject" id="form_subject" value="[% subject | html %]" size="30">
+  <div class="govuk-form-group">
+    <label class="govuk-label" for="form_email">[% loc('Your email') %]</label>
+    [% IF field_errors.em %]
+       <div class="form-error">[% field_errors.em %]</div>
+    [% END %]
+    <input type="text" class="govuk-input required email" name="em" id="form_email" value="[% em | html %]" size="30">
+  </div>
 
-  <label for="form_message">[% loc('Message') %]</label>
-  [% IF field_errors.message %]
-     <div class="form-error">[% field_errors.message %]</div>
-  [% END %]
-  <textarea class="form-control required" name="message" id="form_message" rows="7" cols="50">[% message | html %]</textarea>
+  <div class="govuk-form-group">
+    <label class="govuk-label" for="form_phone">[% loc('Your phone number') %]</label>
+    <span class="required-text required-text--optional">[% loc('optional') %]</span>
+    <input type="text" class="govuk-input extra.phone" name="extra.phone" id="form_phone" value="" size="30">
+  </div>
+
+  <div class="govuk-form-group">
+    <label class="govuk-label" for="form_subject">[% loc('Subject') %]</label>
+    [% IF field_errors.subject %]
+       <div class="form-error">[% field_errors.subject %]</div>
+    [% END %]
+    <input type="text" class="govuk-input required" name="subject" id="form_subject" value="[% subject | html %]" size="30">
+  </div>
+
+  <div class="govuk-form-group">
+    <label class="govuk-label" for="form_message">[% loc('Message') %]</label>
+    [% IF field_errors.message %]
+       <div class="form-error">[% field_errors.message %]</div>
+    [% END %]
+    <textarea class="govuk-textarea required" name="message" id="form_message" rows="7" cols="50">[% message | html %]</textarea>
+  </div>
 
   [% IF NOT problem AND NOT update %]
   <p>[% loc('If you are contacting us about a specific report or update please include a link to the report in the message.') %]</p>

--- a/templates/web/fixmystreet.com/contact/who.html
+++ b/templates/web/fixmystreet.com/contact/who.html
@@ -5,49 +5,59 @@
 [% END %]
 
 [% IF problem %]
-<div class="checkbox-group">
-    <input name="dest" id="dest_rules" type="radio" value="rules" class="required"[% IF dest AND dest == 'rules' %] checked[% END %]>
-    <label class="inline" for="dest_rules">[%
-        IF update;
-            loc('This update breaks the <a href="/about/house-rules">Conditions of Use</a>');
-        ELSE;
-            loc('This report breaks the <a href="/about/house-rules">Conditions of Use</a>');
-        END;
-    %]</label>
+<div class="govuk-form-group">
+    <div class="govuk-radios govuk-radios--small">
+        <div class="govuk-radios__item">
+            <input name="dest" id="dest_rules" type="radio" value="rules" class="govuk-radios__input required"[% IF dest AND dest == 'rules' %] checked[% END %]>
+            <label class="govuk-label govuk-radios__label" for="dest_rules">[%
+                IF update;
+                    loc('This update breaks the <a href="/about/house-rules">Conditions of Use</a>');
+                ELSE;
+                    loc('This report breaks the <a href="/about/house-rules">Conditions of Use</a>');
+                END;
+            %]</label>
+        </div>
+        <div class="govuk-radios__item">
+            <input name="dest" id="dest_update" type="radio" value="update" class="govuk-radios__input required"[% IF dest AND dest == 'update' %] checked[% END %]>
+            <label class="govuk-label govuk-radios__label" for="dest_update">[% loc('This report has not been fixed') %]</label>
+        </div>
+        <div class="govuk-radios__item">
+            <input name="dest" id="dest_council" type="radio" value="council" class="govuk-radios__input required"[% IF dest AND dest == 'council' %] checked[% END %]>
+            <label class="govuk-label govuk-radios__label" for="dest_council">[% loc('I want to make a new report about a street problem') %]</label>
+        </div>
+    </div>
 </div>
-<div class="checkbox-group">
-    <input name="dest" id="dest_update" type="radio" value="update" class="required"[% IF dest AND dest == 'update' %] checked[% END %]>
-    <label class="inline" for="dest_update">[% loc('This report has not been fixed') %]</label>
-</div>
-<div class="checkbox-group">
-    <input name="dest" id="dest_council" type="radio" value="council" class="required"[% IF dest AND dest == 'council' %] checked[% END %]>
-    <label class="inline" for="dest_council">[% loc('I want to make a new report about a street problem') %]</label>
-</div>
+
 [% ELSE %]
-<div class="checkbox-group">
-    <input name="dest" id="dest_help" type="radio" value="help" class="required"[% IF dest AND dest == 'help' %] checked[% END %]>
-    <label class="inline" for="dest_help">[% loc('I need help using the site') %]</label>
+<div class="govuk-form-group">
+    <div class="govuk-radios govuk-radios--small">
+        <div class="govuk-radios__item">
+            <input name="dest" id="dest_help" type="radio" value="help" class="govuk-radios__input required"[% IF dest AND dest == 'help' %] checked[% END %]>
+            <label class="govuk-label govuk-radios__label" for="dest_help">[% loc('I need help using the site') %]</label>
+        </div>
+        <div class="govuk-radios__item">
+            <input name="dest" id="dest_feedback" type="radio" value="feedback" class="govuk-radios__input required"[% IF dest AND dest == 'feedback' %] checked[% END %]>
+            <label class="govuk-label govuk-radios__label" for="dest_feedback">[% loc('I have feedback about the site') %]</label>
+        </div>
+        <div class="govuk-radios__item">
+            <input name="dest" id="dest_from_council" type="radio" value="from_council" class="govuk-radios__input required"[% IF dest AND dest == 'from_council' %] checked[% END %]>
+            <label class="govuk-label govuk-radios__label" for="dest_from_council">[% loc('I am from a council and I have a question for the FixMyStreet team') %]</label>
+        </div>
+        <div class="govuk-radios__item">
+            <input name="dest" id="dest_from_council" type="radio" value="from_council" class="govuk-radios__input required"[% IF dest AND dest == 'from_council' %] checked[% END %]>
+            <label class="govuk-label govuk-radios__label" for="dest_from_council">[% loc('I am from a council and I have a question for the FixMyStreet team') %]</label>
+        </div>
+        <div class="govuk-radios__item">
+            <input name="dest" id="dest_council" type="radio" value="council" class="govuk-radios__input required"[% IF dest AND dest == 'council' %] checked[% END %]>
+            <label class="govuk-label govuk-radios__label" for="dest_council">[% loc('I want to report a street problem') %]</label>
+        </div>
+        <div class="govuk-radios__item">
+            <input class="govuk-radios__input" name="dest" id="dest_update" type="radio" value="update"[% IF dest AND dest == 'update' %] checked[% END %]>
+            <label class="govuk-label govuk-radios__label" for="dest_update">[% loc('My street problem hasn’t been fixed') %]</label>
+        </div>
+    </div>
 </div>
 
-<div class="checkbox-group">
-    <input name="dest" id="dest_feedback" type="radio" value="feedback" class="required"[% IF dest AND dest == 'feedback' %] checked[% END %]>
-    <label class="inline" for="dest_feedback">[% loc('I have feedback about the site') %]</label>
-</div>
-
-<div class="checkbox-group">
-    <input name="dest" id="dest_from_council" type="radio" value="from_council" class="required"[% IF dest AND dest == 'from_council' %] checked[% END %]>
-    <label class="inline" for="dest_from_council">[% loc('I am from a council and I have a question for the FixMyStreet team') %]</label>
-</div>
-
-<div class="checkbox-group">
-    <input name="dest" id="dest_council" type="radio" value="council" class="required"[% IF dest AND dest == 'council' %] checked[% END %]>
-    <label class="inline" for="dest_council">[% loc('I want to report a street problem') %]</label>
-</div>
-
-<div class="checkbox-group">
-    <input name="dest" id="dest_update" type="radio" value="update"[% IF dest AND dest == 'update' %] checked[% END %]>
-    <label class="inline" for="dest_update">[% loc('My street problem hasn’t been fixed') %]</label>
-</div>
 [% END %]
 
 <div id="dest-error"[% IF NOT field_errors.not_for_us %] class="hidden"[% END %]>


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/3826
Part of this milestone: https://github.com/mysociety/societyworks/milestone/99

This PR should improve accessibility and make the input looks more noticeable.
I have also include the `input[type="text"] and  input[type="textarea"]` in this PR.

[Skip Change log]

<img width="1035" alt="Screenshot 2023-08-24 at 10 42 08" src="https://github.com/mysociety/fixmystreet/assets/13790153/7df3afa2-db3e-4f6f-8f33-fa503dcdfbec">
<img width="681" alt="Screenshot 2023-08-24 at 10 57 30" src="https://github.com/mysociety/fixmystreet/assets/13790153/5e84721a-2d2e-478f-8faa-bd610509231f">

