### PR TITLE
Added fix to .form-error width

### DIFF
--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -768,7 +768,8 @@ textarea{
 /* form errors */
 div.form-error,
 p.form-error {
-  display:block;
+  display: block;
+  width: fit-content;
 }
 
 input.form-error,


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/3873

Another alternative to accomplish the same result was to use `width: fit-content`, but it's not supported by IE11. Not that it matter according to [GOVUK](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices). Let me know if you prefer me to use that property instead.

### Before
<img width="648" alt="Screenshot 2023-08-24 at 11 08 14" src="https://github.com/mysociety/fixmystreet/assets/13790153/2d5b996c-df56-415c-bcbf-4284222338b3">

### After
<img width="648" alt="Screenshot 2023-08-24 at 11 07 50" src="https://github.com/mysociety/fixmystreet/assets/13790153/3f54db57-6796-40cc-8a02-0a005fbbc3bc">

[Skip changelog]


