### PR TITLE
[Kingston][Sutton][WW] Bulky waste terms and conditions

### DIFF
--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -79,6 +79,14 @@ has_page summary => (
     title => 'Submit collection booking',
     template => 'waste/bulky/summary.html',
     next => sub { $_[0]->{no_slots} ? 'choose_date_earlier' : 'done' },
+    update_field_list => sub {
+        my $form = shift;
+        my $c = $form->c;
+        my $label = FixMyStreet::Template::SafeString->new('I have read the <a href="' . $c->cobrand->call_hook('bulky_tandc_link') . '" target="_blank">bulky waste collection</a> page on the council’s website');
+        return {
+            tandc => { option_label => $label }
+        };
+    },
     # Return to 'Choose date' page if slot has been taken in the meantime.
     # Otherwise, proceed to payment.
     pre_finished => sub {
@@ -236,9 +244,7 @@ has_field tandc => (
     type => 'Checkbox',
     required => 1,
     label => 'Terms and conditions',
-    option_label => FixMyStreet::Template::SafeString->new(
-        'I have read the <a href="https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections" target="_blank">bulky waste collection</a> page on the council’s website',
-    ),
+    option_label => '' # Generated in update_field_list of page summary
 );
 
 has_field location => (
@@ -258,11 +264,12 @@ has_field location_photo => (
     tags => {
         max_photos => 1,
     },
-    label => <<HERE,
-Please check the <a href="https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections" target="_blank">Terms & Conditions</a> for information about when and where to leave your items for collection.
+    build_label_method => sub {
+        my $self = shift;
 
-Help us by attaching a photo of where the items will be left for collection.
-HERE
+        return 'Please check the <a href="' . $self->parent->{c}->cobrand->call_hook('bulky_tandc_link') . '" target="_blank">Terms & Conditions</a> for information about when and where to leave your items for collection.' . "\n\n\n"
+        . 'Help us by attaching a photo of where the items will be left for collection.'
+    }
 );
 
 sub validate {

--- a/perllib/FixMyStreet/Roles/CobrandBulkyWaste.pm
+++ b/perllib/FixMyStreet/Roles/CobrandBulkyWaste.pm
@@ -45,7 +45,11 @@ sub bulky_enabled_staff_only {
 sub bulky_items_master_list { $_[0]->wasteworks_config->{item_list} || [] }
 sub bulky_items_maximum { $_[0]->wasteworks_config->{items_per_collection_max} || 5 }
 sub bulky_per_item_costs { $_[0]->wasteworks_config->{per_item_costs} }
-
+sub bulky_tandc_link {
+    my $self = shift;
+    my $cfg = $self->feature('waste_features') || {};
+    return FixMyStreet::Template::SafeString->new($cfg->{bulky_tandc_link});
+}
 =head2 Requirements
 
 Users of this role must supply the following:

--- a/t/app/controller/waste_peterborough_bulky.t
+++ b/t/app/controller/waste_peterborough_bulky.t
@@ -104,6 +104,7 @@ FixMyStreet::override_config {
         waste => { peterborough => 1 },
         waste_features => { peterborough => {
             bulky_enabled => 1,
+            bulky_tandc_link => 'peterborough-bulky-waste-tandc.com'
         } },
         payment_gateway => { peterborough => {
             cc_url => 'https://example.org/scp/',
@@ -343,6 +344,7 @@ FixMyStreet::override_config {
         subtest 'Intro page' => sub {
             $mech->content_contains('Book bulky goods collection');
             $mech->content_contains('Before you start your booking');
+            $mech->content_contains('a href="peterborough-bulky-waste-tandc.com"');
             $mech->content_contains('You can request up to <strong>five items per collection');
             $mech->content_contains('You can amend the items in your booking up until 3pm the day before the collection is scheduled');
             $mech->content_contains('the day before collection is scheduled are entitled to a refund');
@@ -426,6 +428,7 @@ FixMyStreet::override_config {
             $mech->content_contains("15:00 on $day_before August 2022");
             $mech->content_lacks('Cancel this booking');
             $mech->content_lacks('Show upcoming bin days');
+            $mech->content_contains('a href="peterborough-bulky-waste-tandc.com"');
         }
         sub test_summary_submission {
             # external redirects make Test::WWW::Mechanize unhappy so clone
@@ -1031,6 +1034,7 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
         $mech->submit_form_ok({ with_fields => { chosen_date => '2022-08-26T00:00:00' } });
         $mech->submit_form_ok({ with_fields => { 'item_1' => 'Amplifiers', 'item_2' => 'High chairs' } });
+        $mech->content_contains('a href="peterborough-bulky-waste-tandc.com"');
         $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
         $mech->submit_form_ok({ with_fields => { tandc => 1 } });
         $mech->content_contains("Confirm Booking");

--- a/t/app/controller/waste_peterborough_bulky.t
+++ b/t/app/controller/waste_peterborough_bulky.t
@@ -345,6 +345,7 @@ FixMyStreet::override_config {
             $mech->content_contains('Before you start your booking');
             $mech->content_contains('You can request up to <strong>five items per collection');
             $mech->content_contains('You can amend the items in your booking up until 3pm the day before the collection is scheduled');
+            $mech->content_contains('the day before collection is scheduled are entitled to a refund');
             $mech->submit_form_ok;
         };
 

--- a/templates/web/base/waste/bulky/intro.html
+++ b/templates/web/base/waste/bulky/intro.html
@@ -5,8 +5,14 @@
     <li>Please ensure you have read the <strong><a href="https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections" target="_blank">bulky waste collection</a></strong> page on the council’s website</li>
     <li>In order to help us with your collection, we will ask you to optionally add pictures of the items to be collected and the location</li>
     <li>Before confirming your booking, check all the info provided is correct</li>
+    [% IF cobrand.moniker == 'peterborough' -%]
     <li>You can amend the items in your booking up until [% c.cobrand.bulky_nice_cancellation_cutoff_time %] the day before the collection is scheduled by calling 01733 747474 (9am to 5pm Monday to Friday excluding bank holidays)</li>
+    [% END %]
     [% UNLESS cobrand.call_hook('bulky_enabled_staff_only') %]
+        [% IF cobrand.moniker == 'peterborough' %]
     <li><strong>Cancellations made by [% c.cobrand.bulky_nice_collection_time %]</strong> the day before collection is scheduled are entitled to a refund</li>
+        [% ELSIF cobrand.moniker == 'sutton' || cobrand.moniker == 'kingston' %]
+    <li><strong>Cancellations made by [% c.cobrand.bulky_nice_collection_time %]</strong> two days before collection is scheduled are entitled to a refund</li>
+        [% END %]
     [% END %]
 </ol>

--- a/templates/web/base/waste/bulky/intro.html
+++ b/templates/web/base/waste/bulky/intro.html
@@ -2,7 +2,7 @@
 <ol>
     <li>Requesting a bulky waste collection usually takes approximately <strong>10 minutes</strong></li>
     <li>You can request up to <strong>[% c.cobrand.bulky_items_maximum | numwords %] items per collection</strong></li>
-    <li>Please ensure you have read the <strong><a href="https://www.peterborough.gov.uk/residents/rubbish-and-recycling/other-waste-collections" target="_blank">bulky waste collection</a></strong> page on the council’s website</li>
+    <li>Please ensure you have read the <strong><a href="[% c.cobrand.call_hook('bulky_tandc_link') %]" target="_blank">bulky waste collection</a></strong> page on the council’s website</li>
     <li>In order to help us with your collection, we will ask you to optionally add pictures of the items to be collected and the location</li>
     <li>Before confirming your booking, check all the info provided is correct</li>
     [% IF cobrand.moniker == 'peterborough' -%]


### PR DESCRIPTION
Creates a wasteworks feature option - bulky_tandc_link - to add the correct link for a council's T&C's where necessary

Also adds cobrand clauses to intro as time limits, permissions and contact details differe between cobrands on amending or cancelling bulky waste appointments

https://github.com/mysociety/societyworks/issues/3840

[skip changelog]