### PR TITLE
Front page cache herding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - Include requirements for redeeming the link in the email change confirmation mail. #4422
         - Use email field type for username if SMS authentication not enabled. #4455
         - Text overrides for new report fields can be configured to apply when it is known the report will go to a particular cobrand. #4466, #4516
+        - Improve handling cache expiry for front page statistics.
     - Bugfixes:
         - Stop map panning breaking after long press. #4423
         - Fix RSS feed subscription from alert page button.

--- a/perllib/FixMyStreet/DB/ResultSet/Problem.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Problem.pm
@@ -76,7 +76,10 @@ sub to_body {
 # Front page statistics
 
 sub _cache_timeout {
-    FixMyStreet->config('CACHE_TIMEOUT') // 3600;
+    my $timeout = FixMyStreet->config('CACHE_TIMEOUT') // 3600;
+    # Spread it out a bit
+    $timeout = $timeout * (0.75 + rand()/2);
+    return $timeout;
 }
 
 sub recent_completed {

--- a/perllib/Memcached.pm
+++ b/perllib/Memcached.pm
@@ -44,4 +44,14 @@ sub increment {
     return $count;
 }
 
+sub get_or_calculate {
+    my ($key, $expiry, $callback) = @_;
+    my $result = instance->get($key);
+    if (!defined($result)) {
+        $result = $callback->();
+        instance->set($key, $result, $expiry);
+    }
+    return $result;
+}
+
 1;


### PR DESCRIPTION
This PR changes the front page number calculations to do two things:
* Change the cache time from a fixed number (default 1hr) to a spread (45-75 minutes)
* Adds a 'lock' so that only one call to the backend calculation should be made - so 3 memcached calls rather than 1, but much better than having to do the calc.

@sagepe asked you as of interest in terms of stopping the hourly issue, and doesn't really involve any FMS code, only generic Perl, but can ask someone else/as well if preferred