### PR TITLE
[SLWP] bulky slot expiry

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1522,7 +1522,10 @@ sub add_report : Private {
 
     $c->user->update({ name => $original_name }) if $original_name;
 
-    $c->cobrand->call_hook( clear_cached_lookups_property => $c->stash->{property}{id} );
+    $c->cobrand->call_hook(
+        clear_cached_lookups_property => $c->stash->{property}{id},
+        'skip_echo', # We do not want to remove/cancel anything in Echo just before payment
+    );
 
     return 1;
 }

--- a/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
@@ -108,7 +108,8 @@ sub index : PathPart('') : Chained('setup') : Args(0) {
     $c->forward('form');
 
     if ( $c->stash->{form}->current_page->name eq 'intro' ) {
-        $c->cobrand->call_hook(clear_cached_lookups_bulky_slots => $c->stash->{property}{uprn});
+        $c->cobrand->call_hook(
+            clear_cached_lookups_bulky_slots => $c->stash->{property}{id} );
     }
 }
 

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -103,15 +103,17 @@ has_page summary => (
         my $form = shift;
         my $c = $form->c;
 
-        my $slot_still_available
-            = $c->cobrand->call_hook(
-            check_bulky_slot_available => $form->saved_data->{chosen_date} );
+        # Some cobrands may set a new chosen_date on the form
+        my $slot_still_available = $c->cobrand->call_hook(
+            check_bulky_slot_available => $form->saved_data->{chosen_date},
+            form                       => $form,
+        );
 
         return 1 if $slot_still_available;
 
         # Clear date cache so user gets updated selection
         $c->cobrand->call_hook(
-            clear_cached_lookups_bulky_slots => $c->stash->{property}{uprn} );
+            clear_cached_lookups_bulky_slots => $c->stash->{property}{id} );
 
         $c->stash->{flash_message} = 'choose_another_date';
         $form->saved_data->{no_slots} = 1;
@@ -120,7 +122,6 @@ has_page summary => (
     finished => sub {
         return $_[0]->wizard_finished('process_bulky_data');
     },
-
 );
 
 has_page done => (

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -110,10 +110,9 @@ has_page summary => (
         return 1 if $slot_still_available;
 
         # Clear date cache so user gets updated selection
-        my $uprn = $c->stash->{property}{uprn};
-        for (qw/earlier later/) {
-            delete $c->session->{"peterborough:bartec:available_bulky_slots:$_:$uprn"};
-        }
+        $c->cobrand->call_hook(
+            clear_cached_lookups_bulky_slots => $c->stash->{property}{uprn} );
+
         $c->stash->{flash_message} = 'choose_another_date';
         $form->saved_data->{no_slots} = 1;
         return 0;

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -505,6 +505,9 @@ sub clear_cached_lookups_property {
 sub clear_cached_lookups_bulky_slots {
     my ($self, $uprn) = @_;
 
+    # might be prefixed with postcode
+    $uprn =~ s/^.+\://g;
+
     for (qw/earlier later/) {
         delete $self->{c}
             ->session->{"peterborough:bartec:available_bulky_slots:$_:$uprn"};

--- a/perllib/FixMyStreet/Cobrand/Peterborough/Bulky.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough/Bulky.pm
@@ -144,7 +144,7 @@ sub find_available_bulky_slots {
             date        => $workpack->{WorkPackDate},
             }
             if $self->check_bulky_slot_available( $workpack->{WorkPackDate},
-            $bartec );
+            bartec => $bartec );
 
         $last_workpack_date = $workpack->{WorkPackDate};
 
@@ -175,7 +175,9 @@ sub _bulky_date_to_dt {
 
 # Checks if there is a slot available for a given date
 sub check_bulky_slot_available {
-    my ( $self, $date, $bartec ) = @_;
+    my ( $self, $date, %args ) = @_;
+
+    my $bartec = $args{bartec};
 
     unless ($bartec) {
         $bartec = $self->feature('bartec');

--- a/perllib/FixMyStreet/Roles/CobrandSLWP.pm
+++ b/perllib/FixMyStreet/Roles/CobrandSLWP.pm
@@ -207,11 +207,20 @@ sub clear_cached_lookups_property {
     foreach my $key (
         $self->council_url . ":echo:look_up_property:$id",
         $self->council_url . ":echo:bin_services_for_address:$id",
-        $self->council_url . ":echo:available_bulky_slots:earlier:$id",
-        $self->council_url . ":echo:available_bulky_slots:later:$id",
         $self->council_url . ":echo:bulky_event_guid:$id",
     ) {
         delete $self->{c}->session->{$key};
+    }
+
+    $self->clear_cached_lookups_bulky_slots($id);
+}
+
+sub clear_cached_lookups_bulky_slots {
+    my ( $self, $id ) = @_;
+
+    for (qw/earlier later/) {
+        delete $self->{c}->session->{ $self->council_url
+                . ":echo:available_bulky_slots:$_:$id" };
     }
 }
 

--- a/perllib/Integrations/Echo.pm
+++ b/perllib/Integrations/Echo.pm
@@ -472,6 +472,9 @@ sub ReserveAvailableSlotsForEvent {
             To => dt_to_hash($to),
         ),
     );
+
+    return [] unless ref $res eq 'HASH';
+
     return force_arrayref($res->{ReservedTaskInfo}{ReservedSlots}, 'ReservedSlot');
 }
 

--- a/t/app/controller/waste_kands_bulky.t
+++ b/t/app/controller/waste_kands_bulky.t
@@ -304,6 +304,36 @@ FixMyStreet::override_config {
         }
 
         subtest 'Summary page' => \&test_summary;
+
+        subtest 'Chosen date expired' => sub {
+            set_fixed_time('2023-06-25T10:10:01');
+
+            $mech->submit_form_ok( { with_fields => { tandc => 1 } } );
+            $mech->content_contains(
+                'Unfortunately, the slot you originally chose has become fully booked. Please select another date.',
+                'Redirects to slot selection page',
+            );
+
+            $mech->submit_form_ok(
+                {   with_fields => {
+                        chosen_date =>
+                            '2023-07-08T00:00:00;reserve1==;2023-06-25T10:20:00'
+                    }
+                },
+                'submit new slot selection',
+            );
+
+            subtest 'submit items & location again' => sub {
+                $mech->submit_form_ok;
+                $mech->submit_form_ok;
+            };
+
+            subtest 'date info has changed on summary page' => sub {
+                $mech->content_contains("<dd>08 July</dd>");
+                $mech->content_contains("06:30 on 08 July 2023");
+            };
+        };
+
         subtest 'Summary submission' => \&test_summary_submission;
         subtest 'Payment page' => sub {
             my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
@@ -339,7 +369,7 @@ FixMyStreet::override_config {
             is $report->category, 'Bulky collection';
             is $report->title, 'Bulky goods collection';
             is $report->get_extra_field_value('uprn'), 1000000002;
-            is $report->get_extra_field_value('Collection_Date'), '2023-07-01T00:00:00';
+            is $report->get_extra_field_value('Collection_Date'), '2023-07-08T00:00:00';
             is $report->get_extra_field_value('Bulky_Collection_Bulky_Items'), '3::85::83';
             is $report->get_extra_field_value('property_id'), '12345';
             is $report->get_extra_field_value('Payment_Details_Payment_Amount'), 4000;

--- a/t/app/controller/waste_kingston.t
+++ b/t/app/controller/waste_kingston.t
@@ -223,6 +223,7 @@ FixMyStreet::override_config {
     });
     $echo->mock('GetServiceUnitsForObject', \&garden_waste_one_bin);
     $echo->mock('GetTasks', sub { [] });
+    mock_CancelReservedSlotsForEvent($echo);
 
     subtest 'Look up of address not in correct borough' => sub {
         $mech->get_ok('/waste');
@@ -306,6 +307,7 @@ FixMyStreet::override_config {
         };
     });
     $echo->mock('GetServiceUnitsForObject', \&garden_waste_one_bin);
+    mock_CancelReservedSlotsForEvent($echo);
 
     my $sent_params;
     my $call_params;
@@ -1043,6 +1045,8 @@ FixMyStreet::override_config {
     subtest 'renew credit card sub with direct debit' => sub {
         my $echo = Test::MockModule->new('Integrations::Echo');
         $echo->mock('GetServiceUnitsForObject', \&garden_waste_one_bin);
+        mock_CancelReservedSlotsForEvent($echo);
+
         set_fixed_time('2021-03-09T17:00:00Z'); # After sample data collection
         $mech->get_ok('/waste/12345/garden_renew');
         $mech->submit_form_ok({ with_fields => {
@@ -1862,6 +1866,7 @@ FixMyStreet::override_config {
         };
     });
     $echo->mock('GetServiceUnitsForObject', \&garden_waste_one_bin);
+    mock_CancelReservedSlotsForEvent($echo);
 
     subtest 'check no sub when disabled' => sub {
         set_fixed_time('2021-03-09T17:00:00Z');
@@ -1899,6 +1904,7 @@ FixMyStreet::override_config {
         };
     });
     $echo->mock('GetServiceUnitsForObject', \&garden_waste_one_bin);
+    mock_CancelReservedSlotsForEvent($echo);
 
     subtest 'check no renew when disabled' => sub {
         set_fixed_time('2021-03-05T17:00:00Z');
@@ -1974,6 +1980,13 @@ sub check_extra_data_post_confirm {
     is $report->get_extra_field_value('LastPayMethod'), 2, 'correct echo payment method field';
     is $report->get_extra_field_value('PaymentCode'), '54321', 'correct echo payment reference field';
     is $report->get_extra_metadata('payment_reference'), '54321', 'correct payment reference on report';
+}
+
+sub mock_CancelReservedSlotsForEvent {
+    shift->mock( 'CancelReservedSlotsForEvent', sub {
+        my (undef, $guid) = @_;
+        ok $guid, 'non-nil GUID passed to CancelReservedSlotsForEvent';
+    } );
 }
 
 done_testing;

--- a/t/app/controller/waste_kingston_r.t
+++ b/t/app/controller/waste_kingston_r.t
@@ -443,6 +443,11 @@ sub shared_echo_mocks {
     $e->mock('GetServiceUnitsForObject', sub { $bin_data });
     $e->mock('GetEventsForObject', sub { [] });
     $e->mock('GetTasks', sub { [] });
+    $e->mock( 'CancelReservedSlotsForEvent', sub {
+        my (undef, $guid) = @_;
+        ok $guid, 'non-nil GUID passed to CancelReservedSlotsForEvent';
+    } );
+
     return $e;
 }
 

--- a/t/app/controller/waste_sutton_garden.t
+++ b/t/app/controller/waste_sutton_garden.t
@@ -264,6 +264,7 @@ FixMyStreet::override_config {
         };
     });
     $echo->mock('GetServiceUnitsForObject', \&garden_waste_one_bin);
+    mock_CancelReservedSlotsForEvent($echo);
 
     subtest 'Look up of address not in correct borough' => sub {
         $mech->get_ok('/waste');
@@ -349,6 +350,7 @@ FixMyStreet::override_config {
         };
     });
     $echo->mock('GetServiceUnitsForObject', \&garden_waste_one_bin);
+    mock_CancelReservedSlotsForEvent($echo);
 
     subtest 'Garden type lookup' => sub {
         set_fixed_time('2021-03-09T17:00:00Z');
@@ -1441,6 +1443,13 @@ sub check_extra_data_post_confirm {
     is $report->get_extra_field_value('LastPayMethod'), $pay_method, 'correct echo payment method field';
     is $report->get_extra_field_value('PaymentCode'), '54321', 'correct echo payment reference field';
     is $report->get_extra_metadata('payment_reference'), '54321', 'correct payment reference on report';
+}
+
+sub mock_CancelReservedSlotsForEvent {
+    shift->mock( 'CancelReservedSlotsForEvent', sub {
+        my (undef, $guid) = @_;
+        ok $guid, 'non-nil GUID passed to CancelReservedSlotsForEvent';
+    } );
 }
 
 done_testing;

--- a/t/app/controller/waste_sutton_r.t
+++ b/t/app/controller/waste_sutton_r.t
@@ -321,6 +321,10 @@ sub shared_echo_mocks {
     $e->mock('GetServiceUnitsForObject', sub { $bin_data });
     $e->mock('GetEventsForObject', sub { [] });
     $e->mock('GetTasks', sub { [] });
+    $e->mock( 'CancelReservedSlotsForEvent', sub {
+        my (undef, $guid) = @_;
+        ok $guid, 'non-nil GUID passed to CancelReservedSlotsForEvent';
+    } );
     return $e;
 }
 


### PR DESCRIPTION
Contributes to https://github.com/mysociety/fixmystreet/pull/4547.

- Checks if a reserved collection slot has expired when user submits summary page
- If it has, we
  - cancel the reserved slot
  - attempt to automatically reserve a new slot with the same date before continuing to payment
  - if this fails, we return the user to the slot selection page

[skip changelog]
