### PR TITLE
[SLWP] Hide 'show_later_dates' option for bulky slot selection

### DIFF
--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -310,6 +310,11 @@ after 'process' => sub {
     # XXX Do we want to let the user know there are no available dates
     # much earlier in the journey?
 
+    # Hide 'show_later_dates' for certain cobrands
+    if ( $self->c->cobrand->call_hook('bulky_hide_later_dates') ) {
+        $self->field('show_later_dates')->inactive(1);
+    }
+
     # Hide certain fields if no date options
     if ( $self->current_page->name eq 'choose_date_earlier'
         && !@{ $self->field('chosen_date')->options } )

--- a/perllib/FixMyStreet/Roles/CobrandSLWP.pm
+++ b/perllib/FixMyStreet/Roles/CobrandSLWP.pm
@@ -1194,5 +1194,6 @@ sub _bulky_date_to_dt {
     return $dt ? $dt->truncate( to => 'day' ) : undef;
 }
 
+sub bulky_hide_later_dates { 1 };
 
 1;


### PR DESCRIPTION
Functionality for 'show_later_dates' for K&S is a) currently broken and b) is not needed, so we simply deactivate that field.

[skip changelog]