### PR TITLE
[Brent] Correct fields for Echo

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1418,20 +1418,26 @@ sub waste_munge_bulky_data {
     $data->{extra_Collection_Date} = $date;
     $data->{extra_Exact_Location} = $data->{location};
 
-    my @items_list = @{ $self->bulky_items_master_list };
-    my %items = map { $_->{name} => $_->{bartec_id} } @items_list;
-
-    my @ids;
-    my @photos;
-
+    my (%types, @photos);
     my $max = $self->bulky_items_maximum;
     for (1..$max) {
         if (my $item = $data->{"item_$_"}) {
-            push @ids, $items{$item};
+            $types{$item}++;
+            if ($item eq 'Tied bag of domestic batteries (min 10 - max 100)') {
+                $data->{extra_Batteries} = 1;
+            } elsif ($item eq 'Podback Bag') {
+                $data->{extra_Coffee_Pods} = 1;
+            } elsif ($item eq 'Paint, up to 5 litres capacity (1 x 5 litre tin, 5 x 1 litre tins etc.)') {
+                $data->{extra_Paint} = 1;
+            } elsif ($item eq 'Textiles, up to 60 litres (one black sack / 3 carrier bags)') {
+                $data->{extra_Textiles} = 1;
+            } elsif ($item =~ /Small WEEE/) {
+                $data->{extra_Small_WEEE} = 1;
+            }
             push @photos, $data->{"item_photos_$_"} || '';
         };
     }
-    $data->{extra_Bulky_Collection_Bulky_Items} = join("::", @ids);
+    $data->{extra_Notes} = join("\n", map { "$types{$_} x $_" } sort keys %types);
     $data->{extra_Image} = join("::", @photos);
 }
 

--- a/t/app/controller/waste_brent_small_items.t
+++ b/t/app/controller/waste_brent_small_items.t
@@ -187,8 +187,14 @@ FixMyStreet::override_config {
             is $report->detail, "Address: 1 Example Street, Brent, HA0 5HF";
             is $report->get_extra_field_value('uprn'), 1000000002;
             is $report->get_extra_field_value('Collection_Date'), '2023-07-01T00:00:00';
-            # TODO
-            # Check right booleans set as extra field values
+
+            is $report->get_extra_field_value('Notes'), "1 x Podback Bag\n1 x Small WEEE: Toaster\n1 x Tied bag of domestic batteries (min 10 - max 100)";
+            is $report->get_extra_field_value('Textiles'), '';
+            is $report->get_extra_field_value('Paint'), '';
+            is $report->get_extra_field_value('Batteries'), 1;
+            is $report->get_extra_field_value('Small_WEEE'), 1;
+            is $report->get_extra_field_value('Coffee_Pods'), 1;
+
             is $report->get_extra_field_value('property_id'), '12345';
             like $report->get_extra_field_value('GUID'), qr/^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/;
             is $report->get_extra_field_value('reservation'), 'reserve1==';


### PR DESCRIPTION
For https://github.com/mysociety/societyworks/issues/3883
I wondered if it'd be better to have the checkbox flags at the open311-adapter end, but that also seemed fragile in that it would have to e.g. parse the Notes field being passed through (given no individual data is). This is probably okay?
[skip changelog]