### PR TITLE
[Brent][WW] Small items eligibility

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -727,6 +727,7 @@ sub bin_services_for_address {
         $expired{$_->{Id}} = $schedules if $self->waste_sub_overdue( $schedules->{end_date}, weeks => 4 );
 
         next unless $schedules->{next} or $schedules->{last};
+        $property->{show_bulky_waste} ||= $self->bulky_allowed_property($_->{ServiceId});
         $schedules{$_->{Id}} = $schedules;
         push @to_fetch, GetEventsForObject => [ ServiceUnit => $_->{Id} ];
         push @task_refs, $schedules->{last}{ref} if $schedules->{last};
@@ -754,8 +755,6 @@ sub bin_services_for_address {
     my $cfg = $self->feature('echo');
     my $echo = Integrations::Echo->new(%$cfg);
     my $calls = $echo->call_api($self->{c}, 'brent', 'bin_services_for_address:' . $property->{id}, 1, @to_fetch);
-
-    $property->{show_bulky_waste} = $self->bulky_allowed_property($property);
 
     my @out;
     my %task_ref_to_row;
@@ -1345,9 +1344,18 @@ sub bulky_can_refund { 0 }
 sub bulky_free_collection_available { 0 }
 sub bulky_hide_later_dates { 1 }
 
+=head2 bulky_allowed_property
+
+Brent allows bulky waste collection for any property
+with a domestic refuse collection so check against
+any domestic refuse service id
+
+=cut
+
 sub bulky_allowed_property {
-    my ( $self, $property ) = @_;
-    return $self->bulky_enabled;
+    my ($self, $id) = @_;
+
+    return $self->bulky_enabled && $id == 262;
 }
 
 sub collection_date {

--- a/t/cobrand/brent.t
+++ b/t/cobrand/brent.t
@@ -735,6 +735,7 @@ FixMyStreet::override_config {
     MAPIT_URL => 'http://mapit.uk/',
     COBRAND_FEATURES => {
         echo => { brent => { sample_data => 1 } },
+        waste_features => { brent => { bulky_enabled => 1 } },
         waste => { brent => 1 },
         anonymous_account => { brent => 'anonymous' },
         waste_calendar_links => { brent => {
@@ -863,6 +864,11 @@ FixMyStreet::override_config {
         set_fixed_time('2020-05-19T12:00:00Z'); # After sample food waste collection
         $mech->get_ok('/waste/12345');
         restore_time();
+    };
+
+    subtest 'bulky waste allowed for property with domestic collection' => sub {
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('Book bulky goods collection');
     };
 
     subtest 'shows time band' => sub {

--- a/t/cobrand/brent.t
+++ b/t/cobrand/brent.t
@@ -754,16 +754,12 @@ FixMyStreet::override_config {
     return [
         {
             Id => 1001,
-            ServiceId => 262,
+            ServiceId => 265,
             ServiceName => 'Domestic Dry Recycling Collection',
             ServiceTasks => { ServiceTask => {
                 Id => 401,
                 ServiceTaskSchedules => { ServiceTaskSchedule => {
                     ScheduleDescription => 'every other Wednesday',
-                    Allocation => {
-                        RoundName => 'Friday ',
-                        RoundGroupName => 'Delta 04 Week 2',
-                    },
                     StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                     EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                     NextInstance => {
@@ -779,12 +775,16 @@ FixMyStreet::override_config {
             } },
         }, {
             Id => 1002,
-            ServiceId => 265,
+            ServiceId => 262,
             ServiceName => 'Domestic Refuse Collection',
             ServiceTasks => { ServiceTask => {
                 Id => 402,
                 ServiceTaskSchedules => { ServiceTaskSchedule => {
                     ScheduleDescription => 'every other Wednesday',
+                    Allocation => {
+                        RoundName => 'Friday ',
+                        RoundGroupName => 'Delta 04 Week 2',
+                    },
                     StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                     EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                     NextInstance => {

--- a/templates/web/brent/waste/_more_services_sidebar.html
+++ b/templates/web/brent/waste/_more_services_sidebar.html
@@ -15,5 +15,10 @@
        <li><a href="[% c.uri_for_action('waste/enquiry', [ property.id ]) %]?category=Assisted+collection+add&amp;service_id=262">Set up for assisted collection</a></li>
      -->
      [% END %]
+     [% IF property.show_bulky_waste %]
+      <li>
+          <a href="[% c.uri_for_action('waste/bulky/index', [ property.id ]) %]">Book bulky goods collection</a>
+      </li>
+    [% END %]
    </ul>
 [% END %]


### PR DESCRIPTION
Allows any Brent resident with a domestic refuse collection to make a small items collection request.

In process fixes small error in Brent test mock data that is confusing but wasn't causing an issue.

[skip changelog]