### PR TITLE
[Brent] Send the report group over Open311

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -377,6 +377,8 @@ Same as Symology above, but different attribute name.
         push @$open311_only, { name => 'title', value => $row->title };
         push @$open311_only, { name => 'report_url', value => $h->{url} };
         push @$open311_only, { name => 'detail', value => $row->detail };
+        push @$open311_only, { name => 'group', value => $row->get_extra_metadata('group') };
+
 
 =item * Adds location name from WFS service for ATAK reports if missing
 


### PR DESCRIPTION
So that it can be included in the issue text in open311-adapter.

See also https://github.com/mysociety/open311-adapter/pull/304, which handles the open311-adapter side of things.

Part of https://github.com/mysociety/societyworks/issues/3836

<!-- [skip changelog] -->