### PR TITLE
[Bulky waste] Framework for multiple bookings, different way of cancelling

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
@@ -99,7 +99,8 @@ sub item_list : Private {
 sub index : PathPart('') : Chained('setup') : Args(0) {
     my ($self, $c) = @_;
 
-    if ($c->stash->{property}{pending_bulky_collection}) {
+    # TODO Remove when allowing more than one booking
+    if ($c->stash->{pending_bulky_collections}) {
         $c->detach('/waste/property_redirect');
     }
 

--- a/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
@@ -21,9 +21,7 @@ has index_template => (
 sub setup : Chained('/waste/property') : PathPart('bulky') : CaptureArgs(0) {
     my ($self, $c) = @_;
 
-    if (  !$c->stash->{property}{show_bulky_waste}
-        || $c->stash->{property}{pending_bulky_collection} )
-    {
+    if ( !$c->stash->{property}{show_bulky_waste} ) {
         $c->detach('/waste/property_redirect');
     }
 }
@@ -43,11 +41,8 @@ sub bulky_item_options_method {
     return \@options;
 };
 
-sub index : PathPart('') : Chained('setup') : Args(0) {
+sub item_list : Private {
     my ($self, $c) = @_;
-
-    $c->stash->{first_page} = 'intro';
-    $c->stash->{form_class} = 'FixMyStreet::App::Form::Waste::Bulky';
 
     my $max_items = $c->cobrand->bulky_items_maximum;
     my $field_list = [];
@@ -99,7 +94,18 @@ sub index : PathPart('') : Chained('setup') : Args(0) {
         },
     ];
     $c->stash->{field_list} = $field_list;
+}
 
+sub index : PathPart('') : Chained('setup') : Args(0) {
+    my ($self, $c) = @_;
+
+    if ($c->stash->{property}{pending_bulky_collection}) {
+        $c->detach('/waste/property_redirect');
+    }
+
+    $c->stash->{first_page} = 'intro';
+    $c->stash->{form_class} = 'FixMyStreet::App::Form::Waste::Bulky';
+    $c->forward('item_list');
     $c->forward('form');
 
     if ( $c->stash->{form}->current_page->name eq 'intro' ) {
@@ -128,27 +134,23 @@ sub view : Private {
     $saved_data->{phone} = $p->user->phone;
     $saved_data->{resident} = 'Yes';
 
-    my $items_list = $c->cobrand->call_hook('bulky_items_master_list');
-    my $per_item = $c->cobrand->bulky_per_item_costs;
-
     $c->stash->{form} = {
         items_extra => $c->cobrand->call_hook('bulky_items_extra'),
         saved_data  => $saved_data,
     };
 }
 
-sub cancel : PathPart('bulky_cancel') : Chained('/waste/property') : Args(0) {
-    my ( $self, $c ) = @_;
+sub cancel : Chained('setup') : Args(1) {
+    my ( $self, $c, $id ) = @_;
 
     $c->detach( '/auth/redirect' ) unless $c->user_exists;
 
+    my $collection = $c->cobrand->find_pending_bulky_collections($c->stash->{property}{uprn})->find($id);
     $c->detach('/waste/property_redirect')
-        if !$c->cobrand->call_hook('bulky_enabled')
-            || !$c->cobrand->call_hook( 'bulky_can_view_collection',
-            $c->stash->{property}{pending_bulky_collection} )
-            || !$c->cobrand->call_hook( 'bulky_collection_can_be_cancelled',
-            $c->stash->{property}{pending_bulky_collection} );
+        if !$c->cobrand->call_hook('bulky_can_view_collection', $collection)
+            || !$c->cobrand->call_hook('bulky_collection_can_be_cancelled', $collection);
 
+    $c->stash->{cancelling_booking} = $collection;
     $c->stash->{first_page} = 'intro';
     $c->stash->{form_class} = 'FixMyStreet::App::Form::Waste::Bulky::Cancel';
     $c->stash->{entitled_to_refund} = $c->cobrand->call_hook('bulky_can_refund');
@@ -190,10 +192,10 @@ sub process_bulky_data : Private {
     return 1;
 }
 
-sub process_bulky_cancellation : Private {
-    my ( $self, $c, $form ) = @_;
+sub add_cancellation_report : Private {
+    my ($self, $c) = @_;
 
-    my $collection_report = $c->stash->{property}{pending_bulky_collection};
+    my $collection_report = $c->stash->{cancelling_booking};
     my %data = (
         detail => $collection_report->detail,
         name   => $collection_report->name,
@@ -216,6 +218,13 @@ sub process_bulky_cancellation : Private {
             $collection_report->detail . " | Cancelled at user request", );
         $collection_report->update;
     }
+}
+
+sub process_bulky_cancellation : Private {
+    my ( $self, $c, $form ) = @_;
+
+    $c->forward('add_cancellation_report') or return;
+    my $collection_report = $c->stash->{cancelling_booking};
 
     # Was collection a free one? If so, reset 'FREE BULKY USED' on premises.
     $c->cobrand->call_hook('unset_free_bulky_used');

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -552,8 +552,9 @@ sub look_up_property {
 
     my %premises = map { $_->{uprn} => $_ } @$premises;
 
-    $premises{$uprn}{pending_bulky_collection}
-        = $self->find_pending_bulky_collection( $premises{$uprn} );
+    my @pending = $self->find_pending_bulky_collections($uprn)->all;
+    $self->{c}->stash->{pending_bulky_collections}
+        = @pending ? \@pending : undef;
 
     return $premises{$uprn};
 }

--- a/perllib/FixMyStreet/Cobrand/Peterborough/Bulky.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough/Bulky.pm
@@ -267,17 +267,6 @@ sub _bulky_refund_cutoff_date {
     return $cutoff_dt;
 }
 
-sub _bulky_cancellation_cutoff_date {
-    my ($self, $collection_date) = @_;
-    my $cutoff_time = $self->bulky_cancellation_cutoff_time();
-    my $dt = $collection_date->clone->subtract( days => 1 )->set(
-        hour   => $cutoff_time->{hours},
-        minute => $cutoff_time->{minutes},
-    );
-
-    return $dt;
-}
-
 sub waste_munge_bulky_data {
     my ($self, $data) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/Peterborough/Bulky.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough/Bulky.pm
@@ -232,12 +232,12 @@ sub bulky_cancellation_report {
 
     # A cancelled collection will have a corresponding cancellation report
     # linked via external_id / ORIGINAL_SR_NUMBER
-    return FixMyStreet::DB->resultset('Problem')->find(
-        {   extra => {
-                '@>' => encode_json({ _fields => [ { name => 'ORIGINAL_SR_NUMBER', value => $original_sr_number } ] })
-            },
+    return $self->problems->find({
+        category => 'Bulky cancel',
+        extra => {
+            '@>' => encode_json({ _fields => [ { name => 'ORIGINAL_SR_NUMBER', value => $original_sr_number } ] })
         },
-    );
+    });
 }
 
 sub bulky_can_refund {

--- a/perllib/FixMyStreet/Cobrand/Sutton.pm
+++ b/perllib/FixMyStreet/Cobrand/Sutton.pm
@@ -94,11 +94,11 @@ sub garden_waste_cc_munge_form_details {
 
     $c->stash->{payment_amount} = $c->stash->{amount} * 100;
 
-    my $url = $c->uri_for(
-        'pay_complete',
-        $c->stash->{report}->id,
-        $c->stash->{report}->get_extra_metadata('redirect_id')
-    );
+    my $url = $c->uri_for_action(
+        '/waste/pay_complete', [
+            $c->stash->{report}->id,
+            $c->stash->{report}->get_extra_metadata('redirect_id')
+        ]);
 
     $c->stash->{redirect_url} = $url;
 

--- a/perllib/FixMyStreet/Roles/CobrandBulkyWaste.pm
+++ b/perllib/FixMyStreet/Roles/CobrandBulkyWaste.pm
@@ -82,7 +82,6 @@ requires 'bulky_cancellation_cutoff_time';
 requires 'bulky_collection_time';
 requires 'bulky_collection_window_days';
 requires 'collection_date';
-requires '_bulky_cancellation_cutoff_date';
 requires '_bulky_refund_cutoff_date';
 requires 'bulky_free_collection_available';
 
@@ -324,6 +323,17 @@ sub bulky_nice_cancellation_cutoff_time {
     $time = DateTime->now->set(hour => $time->{hours}, minute => $time->{minutes})->strftime('%I:%M%P');
     $time =~ s/^0|:00//g;
     return $time;
+}
+
+sub _bulky_cancellation_cutoff_date {
+    my ($self, $collection_date) = @_;
+    my $cutoff_time = $self->bulky_cancellation_cutoff_time();
+    my $days_before = $cutoff_time->{days_before} || 1;
+    my $dt = $collection_date->clone->subtract( days => $days_before )->set(
+        hour   => $cutoff_time->{hours},
+        minute => $cutoff_time->{minutes},
+    );
+    return $dt;
 }
 
 sub bulky_reminders {

--- a/perllib/FixMyStreet/Roles/CobrandBulkyWaste.pm
+++ b/perllib/FixMyStreet/Roles/CobrandBulkyWaste.pm
@@ -173,14 +173,6 @@ sub find_pending_bulky_collections {
     });
 }
 
-# Originally was only a single open collection for a given property,
-# so this returns the most recent
-sub find_pending_bulky_collection {
-    my ( $self, $property ) = @_;
-
-    return $self->find_pending_bulky_collections($property->{uprn})->first;
-}
-
 sub _bulky_collection_window {
     my ($self, $last_earlier_date_str) = @_;
     my $fmt = '%F';

--- a/perllib/FixMyStreet/Roles/CobrandBulkyWaste.pm
+++ b/perllib/FixMyStreet/Roles/CobrandBulkyWaste.pm
@@ -161,18 +161,24 @@ sub bulky_total_cost {
 
 # Should only be a single open collection for a given property, but in case
 # there isn't, return the most recent
+sub find_pending_bulky_collections {
+    my ( $self, $uprn ) = @_;
+
+    return $self->problems->search({
+        category => 'Bulky collection',
+        extra => { '@>' => encode_json({ "_fields" => [ { name => 'uprn', value => $uprn } ] }) },
+        state => { '=', [ FixMyStreet::DB::Result::Problem->open_states ] },
+    }, {
+        order_by => { -desc => 'id' }
+    });
+}
+
+# Originally was only a single open collection for a given property,
+# so this returns the most recent
 sub find_pending_bulky_collection {
     my ( $self, $property ) = @_;
 
-    return FixMyStreet::DB->resultset('Problem')->to_body( $self->body )
-        ->find(
-        {   category => 'Bulky collection',
-            extra    => { '@>' => encode_json({ "_fields" => [ { name => 'uprn', value => $property->{uprn} } ] }) },
-            state =>
-                { '=', [ FixMyStreet::DB::Result::Problem->open_states ] },
-        },
-        { order_by => { -desc => 'id' } },
-        );
+    return $self->find_pending_bulky_collections($property->{uprn})->first;
 }
 
 sub _bulky_collection_window {
@@ -261,10 +267,6 @@ sub bulky_collection_can_be_cancelled {
 sub within_bulky_cancel_window {
     my ( $self, $collection ) = @_;
 
-    my $c = $self->{c};
-    $collection //= $c->stash->{property}{pending_bulky_collection};
-    return 0 unless $collection;
-
     my $now_dt = DateTime->now( time_zone => FixMyStreet->local_time_zone );
     my $collection_date = $self->collection_date($collection);
     return $self->_check_within_bulky_cancel_window($now_dt, $collection_date);
@@ -284,11 +286,7 @@ sub bulky_can_refund {
 }
 
 sub within_bulky_refund_window {
-    my $self = shift;
-    my $c    = $self->{c};
-
-    my $open_collection = $c->stash->{property}{pending_bulky_collection};
-    return 0 unless $open_collection;
+    my ($self, $open_collection) = @_;
 
     my $now_dt = DateTime->now( time_zone => FixMyStreet->local_time_zone );
     my $collection_dt = $self->collection_date($open_collection);

--- a/perllib/FixMyStreet/Roles/CobrandBulkyWaste.pm
+++ b/perllib/FixMyStreet/Roles/CobrandBulkyWaste.pm
@@ -85,6 +85,17 @@ requires 'collection_date';
 requires '_bulky_refund_cutoff_date';
 requires 'bulky_free_collection_available';
 
+sub bulky_cancel_by_update { 0 }
+
+sub bulky_is_cancelled {
+    my ($self, $p) = @_;
+    if ($self->bulky_cancel_by_update) {
+        return $p->comments->find({ extra => { '@>' => '{"bulky_cancellation":1}' } });
+    } else {
+        return $self->bulky_cancellation_report($p);
+    }
+}
+
 sub bulky_items_extra {
     my $self = shift;
 
@@ -354,17 +365,15 @@ sub bulky_reminders {
         my $r3 = $report->get_extra_metadata('reminder_3');
         next if $r1; # No reminders left to do
 
-        my $date = $self->collection_date($report);
+        my $dt = $self->collection_date($report);
 
         # Shouldn't happen, but better to be safe.
-        next unless $date;
-
-        my $dt = $self->_bulky_date_to_dt($date);
+        next unless $dt;
 
         # If booking has been cancelled (or somehow the collection date has
         # already passed) then mark this report as done so we don't see it
         # again tomorrow.
-        my $cancelled = $self->bulky_cancellation_report($report);
+        my $cancelled = $self->bulky_is_cancelled($report);
         if ( $cancelled || $dt < $now) {
             $report->set_extra_metadata(reminder_1 => 1);
             $report->set_extra_metadata(reminder_3 => 1);

--- a/perllib/FixMyStreet/Roles/SCP.pm
+++ b/perllib/FixMyStreet/Roles/SCP.pm
@@ -30,7 +30,7 @@ sub waste_cc_get_redirect_url {
     if ($back eq 'bulky') {
         # Need to pass through property ID as not sure how to work it out once we're back
         my $id = URI::Escape::uri_escape_utf8($c->stash->{property}{id});
-        $backUrl = $c->uri_for('pay_cancel', $p->id, $redirect_id ) . '?property_id=' . $id;
+        $backUrl = $c->uri_for_action('/waste/pay_cancel', [ $p->id, $redirect_id ] ) . '?property_id=' . $id;
     } else {
         $backUrl = $c->uri_for_action("/waste/$back", [ $c->stash->{property}{id} ]) . '';
     }
@@ -53,7 +53,7 @@ sub waste_cc_get_redirect_url {
         };
     }
     my $result = $payment->pay({
-        returnUrl => $c->uri_for('pay_complete', $p->id, $redirect_id ) . '',
+        returnUrl => $c->uri_for_action('/waste/pay_complete', [ $p->id, $redirect_id ] ) . '',
         backUrl => $backUrl,
         ref => $self->waste_cc_payment_sale_ref($p),
         request_id => $p->id,

--- a/t/app/controller/waste_peterborough_bulky.t
+++ b/t/app/controller/waste_peterborough_bulky.t
@@ -440,6 +440,10 @@ FixMyStreet::override_config {
         }
         sub test_payment_page {
             my $sent_params = shift;
+
+            like $sent_params->{backUrl}, qr/\/waste\/pay_cancel/;
+            like $sent_params->{returnUrl}, qr/\/waste\/pay_complete/;
+
             my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
             is $new_report->category, 'Bulky collection', 'correct category on report';

--- a/templates/email/default/waste/bulky-reminder.html
+++ b/templates/email/default/waste/bulky-reminder.html
@@ -43,7 +43,7 @@ INCLUDE '_email_top.html';
   [%~ IF staff_cancellation && cobrand.moniker == 'peterborough' %]
     If you wish to cancel your booking, please call 01733 74 74 74.
   [% ELSE %]
-    If you wish to cancel your booking, please visit <a href="[% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') | uri %]/bulky_cancel">this link</a>.
+    If you wish to cancel your booking, please visit <a href="[% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') | uri %]/bulky/cancel/[% report.id %]">this link</a>.
 
     [% IF days == 1 %]
       You can still cancel your booking, but a refund is no longer available.

--- a/templates/email/default/waste/bulky-reminder.txt
+++ b/templates/email/default/waste/bulky-reminder.txt
@@ -34,7 +34,7 @@ If you wish to cancel your booking, please call 01733 74 74 74.
 
 If you wish to cancel your booking, please visit:
 
-    [% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') | uri %]/bulky_cancel
+    [% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') | uri %]/bulky/cancel/[% report.id %]
 
 [% IF days == 1 %]
 You can still cancel your booking, but a refund is no longer available.

--- a/templates/email/default/waste/other-reported-bulky.html
+++ b/templates/email/default/waste/other-reported-bulky.html
@@ -51,7 +51,7 @@ INCLUDE '_email_top.html';
     [%~ IF staff_cancellation && cobrand.moniker == 'peterborough' %]
       If you wish to cancel your booking, please call 01733 74 74 74.
     [% ELSE %]
-      If you wish to cancel your booking, please visit <a href="[% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') | uri %]/bulky_cancel">this link</a>.
+      If you wish to cancel your booking, please visit <a href="[% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') | uri %]/bulky/cancel/[% report.id %]">this link</a>.
     [% END %]
   </p>
 

--- a/templates/email/default/waste/other-reported-bulky.txt
+++ b/templates/email/default/waste/other-reported-bulky.txt
@@ -36,7 +36,7 @@ If you wish to cancel your booking, please call 01733 74 74 74.
 
 If you wish to cancel your booking, please visit:
 
-    [% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') | uri %]/bulky_cancel
+    [% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') | uri %]/bulky/cancel/[% report.id %]
 
 [% END ~%]
 

--- a/templates/web/base/waste/bulky/_bin_days_list.html
+++ b/templates/web/base/waste/bulky/_bin_days_list.html
@@ -61,7 +61,7 @@
     <!-- #05 Should only display when: There IS a booking AND is a signed user -->
     <a class="btn btn-primary govuk-!-margin-bottom-2" href="/report/[% property.pending_bulky_collection.id %]">Check collection details</a>
     [% IF c.cobrand.bulky_collection_can_be_cancelled(property.pending_bulky_collection) %]
-      <a class="btn btn-primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky/cancel', [ property.id ]) %]">Cancel booking</a>
+      <a class="btn btn-primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky/cancel', [ property.id, property.pending_bulky_collection.id ]) %]">Cancel booking</a>
     [% END %]
     <!-- END #05 -->
   [% END %]

--- a/templates/web/base/waste/bulky/_bin_days_list.html
+++ b/templates/web/base/waste/bulky/_bin_days_list.html
@@ -1,5 +1,5 @@
-[% IF property.pending_bulky_collection AND NOT c.user_exists %]
-    [% TRY %][% PROCESS waste/_bulky_not_signed_user.html %][% CATCH file %][% END %]
+[% IF pending_bulky_collections AND NOT c.user_exists %]
+    [% PROCESS waste/_bulky_not_signed_user.html %]
 [% END %]
 
 <dl class="govuk-summary-list govuk-!-margin-bottom-0">
@@ -25,26 +25,40 @@
     </dd>
   </div>
 
-    [% IF c.cobrand.bulky_can_view_collection(property.pending_bulky_collection) %]
+  [% FOR booking IN pending_bulky_collections %]
+
+    [% IF c.cobrand.bulky_can_view_collection(booking) %]
         <!-- #01 Should only display when: There IS a booking AND is a signed user -->
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Next collection</dt>
-          <dd class="govuk-summary-list__value">[% c.cobrand.bulky_nice_collection_date(property.pending_bulky_collection) %]</dd>
+          <dd class="govuk-summary-list__value">[% c.cobrand.bulky_nice_collection_date(booking) %]</dd>
         </div>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Reference number</dt>
-          <dd class="govuk-summary-list__value">[% property.pending_bulky_collection.id %]</dd>
+          <dd class="govuk-summary-list__value">[% booking.id %]</dd>
         </div>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Items to be collected</dt>
           <dd class="govuk-summary-list__value">
-            <p class="govuk-!-margin-bottom-0">[% c.cobrand.bulky_nice_item_list(property.pending_bulky_collection).size %]</p>
+            <p class="govuk-!-margin-bottom-0">[% c.cobrand.bulky_nice_item_list(booking).size %]</p>
           </dd>
         </div>
         <!-- END #01 -->
+    [% END %]
+
+    <div class="waste-services-launch-panel">
+      [% IF c.cobrand.bulky_can_view_collection(booking) %]
+        <!-- #05 Should only display when: There IS a booking AND is a signed user -->
+        <a class="btn btn-primary govuk-!-margin-bottom-2" href="/report/[% booking.id %]">Check collection details</a>
+        [% IF c.cobrand.bulky_collection_can_be_cancelled(booking) %]
+          <a class="btn btn-primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky/cancel', [ property.id, booking.id ]) %]">Cancel booking</a>
+        [% END %]
+        <!-- END #05 -->
+      [% END %]
+    </div>
   [% END %]
 
-  [% IF c.user_exists AND NOT property.pending_bulky_collection %]
+  [% IF NOT booking AND c.user_exists %]
     <!-- #04 Should only display when: There is NO booking AND is a signed user -->
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Next collection</dt>
@@ -57,20 +71,12 @@
 <hr>
 
 <div class="waste-services-launch-panel">
-  [% IF c.cobrand.bulky_can_view_collection(property.pending_bulky_collection) %]
-    <!-- #05 Should only display when: There IS a booking AND is a signed user -->
-    <a class="btn btn-primary govuk-!-margin-bottom-2" href="/report/[% property.pending_bulky_collection.id %]">Check collection details</a>
-    [% IF c.cobrand.bulky_collection_can_be_cancelled(property.pending_bulky_collection) %]
-      <a class="btn btn-primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky/cancel', [ property.id, property.pending_bulky_collection.id ]) %]">Cancel booking</a>
-    [% END %]
-    <!-- END #05 -->
-  [% END %]
   [% UNLESS c.user_exists %]
     <!-- #07 Should be displayed when: user HASN'T signed in -->
-    <a class="btn btn-primary govuk-!-margin-bottom-2" href="/auth?r=report/[% property.pending_bulky_collection.id %]">Sign in</a>
+    <a class="btn btn-primary govuk-!-margin-bottom-2" href="/auth?r=waste/[% property.id %]">Sign in</a>
     <!-- END #07 -->
   [% END %]
-  [% UNLESS property.pending_bulky_collection %]
+  [% UNLESS pending_bulky_collections %]
     <!-- #06 Should NOT be displayed when: there is a signed user with a booking request -->
     <form method="post" action="[% c.uri_for_action('waste/bulky/index', [ property.id ]) %]">
       <input type="hidden" name="token" value="[% csrf_token %]">

--- a/templates/web/base/waste/bulky/booking_cancellation.html
+++ b/templates/web/base/waste/bulky/booking_cancellation.html
@@ -11,7 +11,7 @@
         <span class="govuk-warning-text__assistive">Important information</span>
         <h3 class="govuk-heading-l govuk-warning-text__heading">Your booking has been cancelled</h3>
         <dt><strong>Booking reference number</strong></dt>
-        <dd class="govuk-!-margin-bottom-4">[% property.pending_bulky_collection.id %]</dd>
+        <dd class="govuk-!-margin-bottom-4">[% cancelling_booking.id %]</dd>
         [% IF entitled_to_refund %]
             <p class="govuk-!-margin-bottom-2">Your refund is on its way.</p>
         [% END %]

--- a/templates/web/base/waste/bulky/cancel_intro.html
+++ b/templates/web/base/waste/bulky/cancel_intro.html
@@ -1,8 +1,8 @@
 [% USE pounds = format('%.2f') %]
 [% IF entitled_to_refund %]
 <h3>Refund</h3>
-<p class="govuk-!-margin-bottom-2">If you cancel this booking you will receive a refund of £[% pounds(property.pending_bulky_collection.get_extra_field_value('payment') / 100) %].</p>
-[% ELSIF property.pending_bulky_collection.get_extra_field_value('CHARGEABLE') == 'CHARGED' %]
+<p class="govuk-!-margin-bottom-2">If you cancel this booking you will receive a refund of £[% pounds(cancelling_booking.get_extra_field_value('payment') / 100) %].</p>
+[% ELSIF cancelling_booking.get_extra_field_value('CHARGEABLE') == 'CHARGED' %]
 <h3>No Refund Will Be Issued</h3>
 <p class="govuk-!-margin-bottom-2">If you cancel this booking you will not receive a refund as it is within 24 hours of the collection.</p>
 [% END %]

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -45,8 +45,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-5">
       [% IF problem %]
-        [% cancellation_report = cobrand.bulky_cancellation_report(problem) %]
-        [% IF cancellation_report %]
+        [% cancelled = cobrand.bulky_is_cancelled(problem) %]
+        [% IF cancelled %]
           <div class="govuk-warning-text due" style="padding:1em">
             <div class="govuk-warning-text__img">
               <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
@@ -55,8 +55,8 @@
                 <span class="govuk-warning-text__assistive">Notification of cancellation</span>
                 <p class="govuk-!-margin-bottom-0">
                   This collection has been cancelled.
-                  [% IF cobrand.bulky_can_view_cancellation(problem) %]
-                    <a href="/report/[% cancellation_report.id %]">View cancellation report.</a>
+                  [% IF NOT cobrand.bulky_cancel_by_update AND cobrand.bulky_can_view_cancellation(problem) %]
+                    <a href="/report/[% cancelled.id %]">View cancellation report.</a>
                   [% END %]
                 </p>
             </div>

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -202,7 +202,7 @@
   [% IF problem %]
     [% IF cobrand.bulky_collection_can_be_cancelled(problem) %]
       <p>
-        <a class="govuk-button govuk-button--secondary" href="[% c.uri_for_action( 'waste/bulky/cancel', [ property.id ] ) %]">Cancel this booking</a>
+        <a class="govuk-button govuk-button--secondary" href="[% c.uri_for_action( 'waste/bulky/cancel', [ property.id, problem.id ] ) %]">Cancel this booking</a>
       </p>
     [% END %]
     <p>

--- a/templates/web/peterborough/waste/_bulky_not_signed_user.html
+++ b/templates/web/peterborough/waste/_bulky_not_signed_user.html
@@ -8,7 +8,7 @@
                 You need to sign in to see the full details of this property.
             </p>
             <p class="govuk-!-margin-bottom-0">
-                <a class="btn btn-primary govuk-!-margin-bottom-2" href="/auth?r=report/[% property.pending_bulky_collection.id %]">Sign in</a>
+                <a class="btn btn-primary govuk-!-margin-bottom-2" href="/auth?r=waste/[% property.id %]">Sign in</a>
             </p>
     </div>
 </div>


### PR DESCRIPTION
Various aspects brought together to make future merging easier:
* Add a report ID to cancel URLs, and list all bookings (no change/point at present, but as/when multiple bookings are allowed, these will be used)
* Add days_before, for times when cancellation might eg be two days before (though don't think is at present).
* Add a way for cancellation to be done by adding an update rather than a new report - most non-Peterborough will work this way, it looks like.

[skip changelog]