### PR TITLE
K&S Bulky: Send email if Echo update fails

### DIFF
--- a/bin/email-bulky-payment-echo-update-failed
+++ b/bin/email-bulky-payment-echo-update-failed
@@ -1,0 +1,37 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname( File::Spec->rel2abs($0) );
+    require "$d/../setenv.pl";
+}
+
+use CronFns;
+use FixMyStreet::Cobrand;
+use Getopt::Long::Descriptive;
+
+my ($opts, $usage) = describe_options(
+    '%c %o',
+    ['nomail|n', 'do not actually send any email'],
+    ['verbose|v', 'more verbose output'],
+    ['help|h', "print usage message and exit" ],
+);
+$usage->die if $opts->help;
+
+my $site = CronFns::site(FixMyStreet->config('BASE_URL'));
+CronFns::language($site);
+
+my @monikers = qw/kingston sutton/;
+
+for (@monikers) {
+    my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker($_)->new;
+    $cobrand->send_bulky_payment_echo_update_failed(
+        {   nomail  => $opts->nomail,
+            verbose => $opts->verbose,
+        },
+    );
+}

--- a/perllib/FixMyStreet/Roles/CobrandEcho.pm
+++ b/perllib/FixMyStreet/Roles/CobrandEcho.pm
@@ -8,6 +8,7 @@ use Moo::Role;
 use Sort::Key::Natural qw(natkeysort_inplace);
 use UUID::Tiny ':std';
 use FixMyStreet::DateRange;
+use FixMyStreet::DB;
 use FixMyStreet::WorkingDays;
 use Open311::GetServiceRequestUpdates;
 
@@ -751,6 +752,83 @@ sub bulky_nice_item_list {
         },
         @fields,
     ];
+}
+
+sub send_bulky_payment_echo_update_failed {
+    my ( $self, $params ) = @_;
+
+    my $email
+        = ( $self->feature('waste_features') || {} )
+        ->{echo_update_failure_email};
+    return unless $email;
+
+    # 3 hours to allow for Echo downtime
+    my $dtf = FixMyStreet::DB->schema->storage->datetime_parser;
+    my $cutoff_date
+        = $dtf->format_datetime( DateTime->now->subtract( hours => 3 ) );
+
+    my $rs = FixMyStreet::DB->resultset('Problem')->search(
+        {   category => 'Bulky collection',
+            cobrand  => $self->moniker,
+            created  => { '<'  => $cutoff_date },
+            extra    => { '\?' => 'payment_reference' },
+            -not => {
+                extra => {
+                    '\?' => [
+                        'echo_update_failure_email_sent',
+                        'echo_update_sent',
+                    ],
+                },
+            },
+        },
+    );
+
+    while ( my $report = $rs->next ) {
+        # Ignore if there is an update in Comment table with an external_id
+        if ( $report->comments->search( { external_id => { '!=', undef } } )
+            ->count > 0
+        ) {
+            # Set flag so we don't repeatedly check the comments for this
+            # report
+            $report->set_extra_metadata( echo_update_sent => 1 );
+            $report->update;
+
+            next;
+        }
+
+        # Send email
+        my $h = {
+            report  => $report,
+            cobrand => $self,
+        };
+
+        my $result = eval {
+            FixMyStreet::Email::send_cron(
+                FixMyStreet::DB->schema,
+                'waste/bulky_payment_echo_update_failed.txt',
+                $h,
+                { To => $email },
+                undef,    # env_from
+                $params->{nomail},
+                $self,
+                $report->lang,
+            );
+        };
+
+        if ($@) {
+            warn 'Sending for report ' . $report->id . " failed: $@\n";
+        } elsif ($result) {
+            print 'Sending for report ' . $report->id . ": failed\n"
+                if $params->{verbose};
+        } else {
+            $report->set_extra_metadata(
+                echo_update_failure_email_sent => 1 );
+            $report->update;
+
+            print 'Sending for report ' . $report->id . ": succeeded\n"
+                if $params->{verbose};
+        }
+    }
 }
 
 1;

--- a/t/app/controller/waste_kands_bulky.t
+++ b/t/app/controller/waste_kands_bulky.t
@@ -74,6 +74,7 @@ FixMyStreet::override_config {
             kingston => {
                 bulky_enabled => 1,
                 bulky_tandc_link => 'tandc_link',
+                echo_update_failure_email => 'fail@example.com',
             },
         },
         echo => {
@@ -533,7 +534,47 @@ FixMyStreet::override_config {
             like $confirmation_email_html, qr/Bath/, 'Includes item 3 (html mail)';
             like $confirmation_email_html, qr#http://kingston.example.org/waste/12345/bulky/cancel#, 'Includes cancellation link (html mail)';
             $mech->clear_emails_ok;
-        }
+        };
+    };
+
+    subtest 'Email when update fails to be sent to Echo' => sub {
+        $report->unset_extra_metadata('payment_reference');
+        $report->update({ created => '2023-06-25T00:00:00' });
+
+        my $cobrand = $body->get_cobrand_handler;
+        $cobrand->send_bulky_payment_echo_update_failed;
+        ok $mech->email_count_is(0),
+            'No email if report does not have a payment_reference';
+
+        $report->set_extra_metadata( payment_reference => 123 );
+        $report->update;
+        my $ex_id_comment
+            = $mech->create_comment_for_problem( $report, $user, 'User',
+            'Test', undef, 'confirmed', undef, { external_id => 234 },
+            );
+        $cobrand->send_bulky_payment_echo_update_failed;
+        ok $mech->email_count_is(0),
+            'No email if report has comment with external_id';
+
+        $ex_id_comment->delete;
+        $report->discard_changes;
+        $report->unset_extra_metadata('echo_update_sent');
+        $report->update;
+        $cobrand->send_bulky_payment_echo_update_failed;
+        my $email = $mech->get_email;
+        like $email->as_string, qr/Collection date: 08 July/;
+        like $email->as_string, qr/40\.00/;
+
+        $mech->clear_emails_ok;
+
+        $report->discard_changes;
+        is $report->get_extra_metadata('echo_update_failure_email_sent'),
+            1, 'flag set when email sent';
+        $cobrand->send_bulky_payment_echo_update_failed;
+        ok $mech->email_count_is(0),
+            'No email if email previously sent';
+
+        $mech->clear_emails_ok;
     };
 
     subtest 'Cancellation' => sub {

--- a/templates/email/default/waste/bulky_payment_echo_update_failed.txt
+++ b/templates/email/default/waste/bulky_payment_echo_update_failed.txt
@@ -1,0 +1,38 @@
+Subject: Failure to update Echo about confirmed payment
+
+[%
+USE pounds = format('%.2f');
+PROCESS 'waste/_bulky_data.html';
+~%]
+
+We failed to update Echo about confirmed payment for the following bulky waste collection:
+
+[% report.detail %]
+
+Collection ref: [% report.id %]
+
+Collection date: [% collection_date %]
+
+Items to be collected:
+[% FOR item IN item_list %]
+    - [% item.value %]
+[% IF item.message %]
+        - [% item.message %]
+[% END %]
+[% END %]
+
+Amount paid: £[% pounds(payment / 100) %]
+
+Payment ref: [% report.get_extra_metadata('payment_reference') %]
+
+Payment type: [% report.get_extra_field_value('payment_method').replace( '_', ' ' ).ucfirst %]
+
+Customer details:
+
+    Name: [% report.name %]
+
+    Email: [% report.user.email %]
+
+    Phone: [% report.user.phone %] [% # TODO Where is this? %]
+
+Collection instructions: [% report.get_extra_field_value('Exact_Location') %]


### PR DESCRIPTION
If Echo fails to send us an update after payment has been taken for a bulky collection, we send an email to Kingston or Sutton as appropriate, so the collection can be booked manually their end.

Closes https://github.com/mysociety/societyworks/issues/3842.

[skip changelog]
