### PR TITLE
[Brent] Rename bulky goods -> small items and hide pricing

### DIFF
--- a/perllib/FixMyStreet/App/Form/Waste/SmallItems.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/SmallItems.pm
@@ -120,6 +120,7 @@ has_field submit => (
     type => 'Submit',
     value => 'Submit booking',
     element_attr => { class => 'govuk-button' },
+    order => 999,
 );
 
 has_field chosen_date => (

--- a/perllib/FixMyStreet/App/Form/Waste/SmallItems.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/SmallItems.pm
@@ -83,7 +83,8 @@ has_page summary => (
 
         my $slot_still_available
             = $c->cobrand->call_hook(
-            check_bulky_slot_available => $form->saved_data->{chosen_date} );
+            check_bulky_slot_available => $form->saved_data->{chosen_date},
+            form                       => $form );
 
         return 1 if $slot_still_available;
 

--- a/t/app/controller/waste_brent_small_items.t
+++ b/t/app/controller/waste_brent_small_items.t
@@ -174,7 +174,7 @@ FixMyStreet::override_config {
             $mech->content_contains('3 items requested for collection');
             $mech->content_contains('8 remaining slots available');
             $mech->content_lacks('No image of the location has been attached.');
-            $mech->content_contains('£0.00'); # TODO Don't show pricing at all
+            $mech->content_lacks('£0.00');
             $mech->content_contains("<dd>01 July</dd>");
             $mech->content_contains("06:00 on 01 July 2023");
         }
@@ -351,7 +351,7 @@ FixMyStreet::override_config {
             $mech->content_contains('£0.00');
             $mech->content_contains('01 July');
             $mech->content_lacks('Request a small items collection');
-            $mech->content_contains('Your bulky waste collection');
+            $mech->content_contains('Your small items collection');
             $mech->content_contains('Show upcoming bin days');
 
             # Cancellation messaging & options

--- a/t/app/controller/waste_brent_small_items.t
+++ b/t/app/controller/waste_brent_small_items.t
@@ -348,7 +348,7 @@ FixMyStreet::override_config {
             $mech->content_like(qr/<p class="govuk-!-margin-bottom-0">.*Podback/s);
             $mech->content_contains('3 items requested for collection');
             $mech->content_contains('8 remaining slots available');
-            $mech->content_contains('£0.00');
+            $mech->content_lacks('£0.00');
             $mech->content_contains('01 July');
             $mech->content_lacks('Request a small items collection');
             $mech->content_contains('Your small items collection');

--- a/t/cobrand/brent.t
+++ b/t/cobrand/brent.t
@@ -866,9 +866,9 @@ FixMyStreet::override_config {
         restore_time();
     };
 
-    subtest 'bulky waste allowed for property with domestic collection' => sub {
+    subtest 'small items allowed for property with domestic collection' => sub {
         $mech->get_ok('/waste/12345');
-        $mech->content_contains('Book bulky goods collection');
+        $mech->content_contains('Book small items collection');
     };
 
     subtest 'shows time band' => sub {

--- a/templates/web/base/waste/bin_days.html
+++ b/templates/web/base/waste/bin_days.html
@@ -166,7 +166,11 @@
 %]
   <div class="govuk-grid-row waste-service-wrapper">
     <div class="govuk-grid-column-one-quarter text-centered">
-      <h3 id="bulky-waste" class="govuk-heading-m waste-service-name">Bulky Waste</h3>
+      [% IF c.cobrand.moniker == 'brent' %]
+        <h3 id="bulky-waste" class="govuk-heading-m waste-service-name">Small items</h3>
+      [% ELSE %]
+        <h3 id="bulky-waste" class="govuk-heading-m waste-service-name">Bulky Waste</h3>
+      [% END %]
       <img src="/cobrands/peterborough/images/bulky-waste.png" alt="" class="waste-service-image">
     </div>
     <div class="govuk-grid-column-three-quarters">

--- a/templates/web/base/waste/bulky/_bin_days_list.html
+++ b/templates/web/base/waste/bulky/_bin_days_list.html
@@ -4,6 +4,7 @@
 
 <dl class="govuk-summary-list govuk-!-margin-bottom-0">
 
+  [% IF c.cobrand.moniker != 'brent' %]
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Cost</dt>
     <dd class="govuk-summary-list__value">
@@ -24,6 +25,7 @@
       [% END %]
     </dd>
   </div>
+  [% END %]
 
   [% FOR booking IN pending_bulky_collections %]
 
@@ -78,7 +80,11 @@
   [% END %]
   [% UNLESS pending_bulky_collections %]
     <!-- #06 Should NOT be displayed when: there is a signed user with a booking request -->
+    [% IF c.cobrand.moniker != 'brent' %]
     <form method="post" action="[% c.uri_for_action('waste/bulky/index', [ property.id ]) %]">
+    [% ELSE %]
+    <form method="post" action="[% c.uri_for_action('waste/bulky/index_small', [ property.id ]) %]">
+    [% END %]
       <input type="hidden" name="token" value="[% csrf_token %]">
       <input class="btn btn-primary govuk-!-margin-bottom-2" type="submit" aria-label="Book a collection" value="Book a collection">
     </form>

--- a/templates/web/base/waste/bulky/intro.html
+++ b/templates/web/base/waste/bulky/intro.html
@@ -1,8 +1,14 @@
+[% service_name = "bulky goods" %]
+
+[% IF c.cobrand.moniker == 'brent' %]
+    [% service_name = "small items" %]
+[% END %]
+
 <h3>Before you start your booking</h3>
 <ol>
-    <li>Requesting a bulky waste collection usually takes approximately <strong>10 minutes</strong></li>
+    <li>Requesting a [% service_name %] collection usually takes approximately <strong>10 minutes</strong></li>
     <li>You can request up to <strong>[% c.cobrand.bulky_items_maximum | numwords %] items per collection</strong></li>
-    <li>Please ensure you have read the <strong><a href="[% c.cobrand.call_hook('bulky_tandc_link') %]" target="_blank">bulky waste collection</a></strong> page on the council’s website</li>
+    <li>Please ensure you have read the <strong><a href="[% c.cobrand.call_hook('bulky_tandc_link') %]" target="_blank">[% service_name %] collection</a></strong> page on the council’s website</li>
     <li>In order to help us with your collection, we will ask you to optionally add pictures of the items to be collected and the location</li>
     <li>Before confirming your booking, check all the info provided is correct</li>
     [% IF cobrand.moniker == 'peterborough' -%]

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -124,6 +124,7 @@ END; END %]
   [% END %]
   <button type="button" id="add-new-item" class="btn-secondary govuk-!-margin-bottom-3" aria-label="Add item">+ Add item</button>
 
+    [% IF c.cobrand.moniker != 'brent' %]
     <p>
       [% IF c.cobrand.bulky_per_item_costs %]
         Total cost: £<span id="js-bulky-total">[% pounds(total) %]</span>
@@ -131,6 +132,7 @@ END; END %]
         Total cost: £[% pounds(total) %]
       [% END %]
     </p>
+    [% END %]
 
   [% PROCESS form override_fields = [ 'continue', 'saved_data', 'token', 'process', 'unique_id' ] %]
 </form>

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -18,10 +18,14 @@
 
 
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-9">
-  [% IF problem %]
-    Your bulky waste collection
+  [% IF cobrand.moniker == 'brent' %]
+    Your small items collection
   [% ELSE %]
-    Request a bulky waste collection
+    [% IF problem %]
+      Your bulky waste collection
+    [% ELSE %]
+      Request a bulky waste collection
+    [% END %]
   [% END %]
 </h1>
 <div class="bulky__summary">
@@ -88,7 +92,7 @@
               <span class="govuk-warning-text__assistive">Warning</span>
               <p class="govuk-!-margin-bottom-3">You can cancel this booking till
                 [% cobrand.bulky_nice_cancellation_cutoff_date(data.chosen_date) %].</p>
-              [% UNLESS cobrand.call_hook('bulky_enabled_staff_only') %]
+              [% UNLESS cobrand.call_hook('bulky_enabled_staff_only') || c.cobrand.moniker == 'brent' %]
               <p class="govuk-!-margin-bottom-0">You can get a refund if cancelled by [% cobrand.bulky_nice_collection_time %] on the day prior to your collection.</p>
               [% END %]
           </div>
@@ -108,11 +112,13 @@
         NEXT UNLESS item;
         items.push({ item => item, photo => data.$photo_key });
       END %]
+      [% IF c.cobrand.moniker != 'brent' %]
       <dl>
         <dt>Price</dt>
         [% payment = cobrand.bulky_total_cost(data) %]
         <dd>£[% pounds(payment / 100) %]</dd>
       </dl>
+      [% END %]
       <div class="govuk-!-margin-bottom-4">
         <p class="govuk-!-margin-bottom-0">[% items.size %] item[% 's' IF items.size > 1 %] requested for collection.</p>
         [% remaining = cobrand.bulky_items_maximum - items.size %]
@@ -215,7 +221,11 @@
       <a class="govuk-button" href="/waste/[% property.id %]">Show upcoming bin days</a>
     </p>
   [% ELSE %]
+    [% IF c.cobrand.moniker == 'brent' %]
+    <form class="waste" method="post" action="[% c.uri_for_action('waste/bulky/index_small', [ property.id ]) %]">
+    [% ELSE %]
     <form class="waste" method="post" action="[% c.uri_for_action('waste/bulky/index', [ property.id ]) %]">
+    [% END %]
       [% PROCESS form %]
     </form>
   [% END %]

--- a/templates/web/brent/waste/_more_services_sidebar.html
+++ b/templates/web/brent/waste/_more_services_sidebar.html
@@ -17,7 +17,7 @@
      [% END %]
      [% IF property.show_bulky_waste %]
       <li>
-          <a href="[% c.uri_for_action('waste/bulky/index', [ property.id ]) %]">Book bulky goods collection</a>
+          <a href="[% c.uri_for_action('waste/bulky/index_small', [ property.id ]) %]">Book small items collection</a>
       </li>
     [% END %]
    </ul>


### PR DESCRIPTION
Changes the Brent bulky goods flow to say "small items" where relevant. Also hides anything relating to payments and pricing.

Fixes https://github.com/mysociety/societyworks/issues/3894 and https://github.com/mysociety/societyworks/issues/3893

<!-- [skip changelog] -->