### PR TITLE
[SLWP] Make confirmation page more like other waste confirmations

### DIFF
--- a/t/app/controller/waste_kands_bulky.t
+++ b/t/app/controller/waste_kands_bulky.t
@@ -401,9 +401,14 @@ FixMyStreet::override_config {
         };
 
         subtest 'Confirmation page' => sub {
-            $mech->content_contains('Payment successful');
-
             $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+            $mech->content_contains('Bulky collection booking confirmed');
+            $mech->content_contains('Our contractor will collect the items you have requested on 08 July.');
+            $mech->content_contains('Item collection starts from 6:30am. Please have your items ready and dismantled if required.');
+            $mech->content_contains('We have emailed confirmation of your booking to pkg-tappcontrollerwaste_kands_bulkyt-bob@example.org.');
+            $mech->content_contains('If you need to contact us about your application please use the application reference:&nbsp;RBK-' . $report->id);
+            $mech->content_contains('Card payment reference: 54321');
+            $mech->content_contains('Return to property details');
             is $report->detail, "Address: 2 Example Street, Kingston, KT1 1AA";
             is $report->category, 'Bulky collection';
             is $report->title, 'Bulky goods collection';

--- a/templates/web/base/waste/bulky/confirmation.html
+++ b/templates/web/base/waste/bulky/confirmation.html
@@ -1,35 +1,50 @@
+[%
+IF report.category == 'Bulky collection';
+    title = 'Bulky collection booking confirmed';
+ELSIF report.category == 'Small items collection';
+    title = 'Small items collection booking confirmed';
+ELSE;
+    title = 'Enquiry has been submitted';
+END ~%]
+
 [% PROCESS 'waste/header.html' %]
 
-<div class="govuk-warning-text whole-page govuk-!-margin-bottom-9">
-    <div class="govuk-warning-text__img govuk-!-margin-bottom-5">
-       <span class="govuk-warning-text__icon success" aria-hidden="true">&#x2714;</span>
-    </div>
-    <div class="govuk-warning-text__content">
-        <span class="govuk-warning-text__assistive">Important information</span>
-        <h3 class="govuk-heading-l govuk-warning-text__heading">Collection booked</h3>
-        <dl>
-            <dt><strong>Booking reference number</strong></dt>
-            <dd class="govuk-!-margin-bottom-4">[% report.id %]</dd>
-            <dt><strong>Date of collection</strong></dt>
-            <dd class="govuk-!-margin-bottom-6">
-                <p class="govuk-!-margin-bottom-1">[% cobrand.bulky_nice_collection_date(report) %]</p>
-                <small style="max-width: 350px; display:block;">
-                    Item collection starts from [% cobrand.bulky_nice_collection_time %].
-                    Please have your items ready and dismantled if required.
-                </small>
-            </dd>
-          [% IF reference %]
-            <dt><strong>Payment reference</strong></dt>
-            <dd class="govuk-!-margin-bottom-4">[% reference %]</dd>
-          [% END %]
-        </dl>
-        [% message %]
+<div class="govuk-panel govuk-panel--confirmation">
+  <h1 class="govuk-panel__title">
+      [% title %]
+  </h1>
+  <div class="govuk-panel__body">
+      <p>Our contractor will collect the items you have requested on [% cobrand.bulky_nice_collection_date(report) %].</p>
+      <p>Item collection starts from [% cobrand.bulky_nice_collection_time %]. Please have your items ready and dismantled if required.</p>
       [% IF report.user.email AND report.get_extra_metadata('contributed_as') != 'anonymous_user' %]
-        <p class="govuk-!-margin-bottom-2">We have sent you an email confirming this booking.</p>
-        <p>Can’t find our email? <strong>Check your spam folder.</strong></p>
+      <p>We have emailed confirmation of your booking to [% report.user.email %].</p>
       [% END %]
-        <a href="[% c.uri_for_action('waste/bin_days', [ report.get_extra_field_value('property_id') ]) %]" class="btn btn-primary">Go back home</a>
-    </div>
+      <p>If you need to contact us about your application please use the application reference:&nbsp;
+        [%~ IF cobrand.moniker == 'sutton' ~%]
+          LBS-
+        [%~ ELSIF cobrand.moniker == 'kingston' ~%]
+          RBK-
+        [%~ END ~%]
+        [%~ report.id %]
+      </p>
+      [% IF reference %]
+        <p>
+            Card payment reference: [% reference %]
+        </p>
+      [% END %]
+  </div>
 </div>
+
+[% IF (c.cobrand.moniker == 'kingston' OR c.cobrand.moniker == 'sutton') %]
+  [% button_text = 'Return to property details' %]
+[% ELSE %]
+  [% button_text = 'Show upcoming bin days' %]
+[% END %]
+
+<p>
+  [% # sometimes we have the property on the stash, sometimes it's just the report (e.g. token confirmation)
+     property_id = property.id OR report.get_extra_field_value('property_id') %]
+  <a href="[% c.uri_for_action('waste/bin_days', [ property_id ]) %]" class="govuk-button">[% button_text %]</a>
+</p>
 
 [% INCLUDE footer.html %]

--- a/templates/web/peterborough/waste/bulky/confirmation.html
+++ b/templates/web/peterborough/waste/bulky/confirmation.html
@@ -1,0 +1,35 @@
+[% PROCESS 'waste/header.html' %]
+
+<div class="govuk-warning-text whole-page govuk-!-margin-bottom-9">
+    <div class="govuk-warning-text__img govuk-!-margin-bottom-5">
+       <span class="govuk-warning-text__icon success" aria-hidden="true">&#x2714;</span>
+    </div>
+    <div class="govuk-warning-text__content">
+        <span class="govuk-warning-text__assistive">Important information</span>
+        <h3 class="govuk-heading-l govuk-warning-text__heading">Collection booked</h3>
+        <dl>
+            <dt><strong>Booking reference number</strong></dt>
+            <dd class="govuk-!-margin-bottom-4">[% report.id %]</dd>
+            <dt><strong>Date of collection</strong></dt>
+            <dd class="govuk-!-margin-bottom-6">
+                <p class="govuk-!-margin-bottom-1">[% cobrand.bulky_nice_collection_date(report) %]</p>
+                <small style="max-width: 350px; display:block;">
+                    Item collection starts from [% cobrand.bulky_nice_collection_time %].
+                    Please have your items ready and dismantled if required.
+                </small>
+            </dd>
+          [% IF reference %]
+            <dt><strong>Payment reference</strong></dt>
+            <dd class="govuk-!-margin-bottom-4">[% reference %]</dd>
+          [% END %]
+        </dl>
+        [% message %]
+      [% IF report.user.email AND report.get_extra_metadata('contributed_as') != 'anonymous_user' %]
+        <p class="govuk-!-margin-bottom-2">We have sent you an email confirming this booking.</p>
+        <p>Can’t find our email? <strong>Check your spam folder.</strong></p>
+      [% END %]
+        <a href="[% c.uri_for_action('waste/bin_days', [ report.get_extra_field_value('property_id') ]) %]" class="btn btn-primary">Go back home</a>
+    </div>
+</div>
+
+[% INCLUDE footer.html %]


### PR DESCRIPTION
Move from bespoke Peterborough design for Kingston and Sutton and any other cobrands to more consistent waste layout for confirmation.

https://3.basecamp.com/4020879/buckets/33314444/todos/6536119405

[skip changelog]