### PR TITLE
[fms.com][Gloucestershire] Show correct message for logged-out users trying to leave an update

### DIFF
--- a/t/cobrand/gloucestershire.t
+++ b/t/cobrand/gloucestershire.t
@@ -216,6 +216,15 @@ FixMyStreet::override_config {
                         'make a new report in the same location',
                         'Lacks option to make a new report in same location',
                     );
+                } else {
+                    $mech->content_contains(
+                        'This report is now closed to updates.',
+                        'Correct message shown',
+                    );
+                    $mech->content_lacks(
+                        'Only the original reporter may leave updates',
+                        'Doesn’t mention original reporter being able to leave updates',
+                    );
                 }
 
                 note 'Original reporter';

--- a/templates/web/fixmystreet.com/report/_updates_disallowed_message.html
+++ b/templates/web/fixmystreet.com/report/_updates_disallowed_message.html
@@ -1,4 +1,7 @@
-[% IF disallowed.match('reporter') AND (NOT disallowed.match('open') OR problem.is_open) %]
+[% IF disallowed.match('reporter')
+   AND (NOT disallowed.match('open') OR problem.is_open)
+   AND NOT (disallowed.match('reporter-not-open') AND problem.is_open)
+%]
     <p>
         [% loc('Only the original reporter may leave updates.') %]
         [% IF NOT c.user_exists %]


### PR DESCRIPTION
If a logged-in user can only leave updates on their reports if they’re closed, don’t incorrectly invite them to log in on open reports.

[skip changelog]

