### PR TITLE
Switch to api.openstreetmap.org API host

### DIFF
--- a/perllib/FixMyStreet/Geocode/OSM.pm
+++ b/perllib/FixMyStreet/Geocode/OSM.pm
@@ -14,7 +14,7 @@ use Memcached;
 use XML::Simple;
 use Utils;
 
-my $osmapibase    = "https://www.openstreetmap.org/api/";
+my $osmapibase    = "https://api.openstreetmap.org/api/";
 my $nominatimbase = "https://nominatim.openstreetmap.org/";
 
 # string STRING CONTEXT


### PR DESCRIPTION
Use `api.openstreetmap.org/api/` -and HTTPS- instead of `www.openstreetmap.org/api/*`.

(Is: https://github.com/openstreetmap/operations/issues/951)

cc: @dracos 