### PR TITLE
[Glos] Show green tick pin for closed or fixed enquiries

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Gloucestershire.pm
+++ b/perllib/FixMyStreet/Cobrand/Gloucestershire.pm
@@ -219,7 +219,7 @@ sub pins_from_wfs {
             id => $fake_id--,
             latitude => @$coords[1],
             longitude => @$coords[0],
-            colour => $props->{state} eq 'open' ? 'defects' : 'green',
+            colour => 'defects',
             title => $props->{description},
         };
     } @{ $wfs->{features} };

--- a/perllib/FixMyStreet/Cobrand/Gloucestershire.pm
+++ b/perllib/FixMyStreet/Cobrand/Gloucestershire.pm
@@ -177,6 +177,20 @@ sub lookup_site_code_config {
     }
 }
 
+=head2 pin_colour
+
+Green for anything completed or closed, yellow for the rest.
+
+=cut
+
+sub pin_colour {
+    my ( $self, $p ) = @_;
+
+    return 'green' if $p->is_fixed || $p->is_closed;
+
+    return 'yellow';
+}
+
 sub extra_around_pins {
     my ($self, $bbox) = @_;
 


### PR DESCRIPTION
As requested in https://3.basecamp.com/4020879/buckets/32187059/todos/6590902908#__recording_6645587896:
- Show green tick pin for closed or fixed enquiries
- Show 'blue man' pin for all defect jobs

[skip changelog]