### PR TITLE
[TfL] Add config for including extra bodies on the site.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -96,7 +96,8 @@ sub base_url_for_report {
 
 sub categories_restriction {
     my ($self, $rs) = @_;
-    $rs = $rs->search( { 'body.name' => [ 'TfL', 'National Highways' ] } );
+    my $bodies = $self->feature('categories_restriction_bodies') || [ 'TfL', 'National Highways' ];
+    $rs = $rs->search( { 'body.name' => $bodies } );
     return $rs unless $self->{c}->stash->{categories_for_point}; # Admin page
     return $rs->search( { category => { -not_in => $self->_tfl_no_resend_categories } } );
 }


### PR DESCRIPTION
Config would then currently be `['TfL', 'National Highways', 'Dott', 'Tier', 'Lime', 'HumanForest']`

[skip changelog]
