### PR TITLE
[Bristol] Show Bristol categories on admin

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bristol.pm
+++ b/perllib/FixMyStreet/Cobrand/Bristol.pm
@@ -188,15 +188,17 @@ sub munge_overlapping_asset_bodies {
     my ($self, $bodies) = @_;
 
     my $all_areas = $self->{c}->stash->{all_areas};
-    my $in_area = scalar(%$all_areas) == 1 && (values %$all_areas)[0]->{id} eq $self->council_area_id->[0];
-    return if $in_area;
 
-    # If we get here, assume we are outside Bristol boundaries.
-    if ($self->check_report_is_on_cobrand_asset) {
-        # The report is in a park that Bristol is responsible for, so only show Bristol categories.
+    if (grep ($self->council_area_id->[0] == $_, keys %$all_areas)) {
+        # We are in the Bristol area so carry on as normal
+        return;
+    } elsif ($self->check_report_is_on_cobrand_asset) {
+        # We are not in a Bristol area but the report is in a park that Bristol is responsible for,
+        # so only show Bristol categories.
         %$bodies = map { $_->id => $_ } grep { $_->name eq $self->council_name } values %$bodies;
     } else {
-        # The report is not in a park that Bristol is responsible for, so only show other categories.
+        # We are not in a Bristol area and the report is not in a park that Bristol is responsible for,
+        # so only show other categories.
         %$bodies = map { $_->id => $_ } grep { $_->name ne $self->council_name } values %$bodies;
     }
 }

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -191,7 +191,7 @@ sub responsible_for_areas {
 
     if ($self->can('check_report_is_on_cobrand_asset')) {
         # This will need changing for two tier councils
-        if (scalar(%$councils) == 1 && (values %$councils)[0]->{id} eq $self->council_area_id->[0]) {
+        if (grep ($self->council_area_id->[0] == $_, keys %$councils)) {
             return 1;
         } elsif ($self->check_report_is_on_cobrand_asset) {
             return 1;


### PR DESCRIPTION
Bristol categories were being filtered out in the dropdown on a report's admin page for changing category.

Broaden the check on munge_overlapping_bodies to check for more that the first area as report admin uses a larger pool of areas taken from the mapit areas for the report location

https://github.com/mysociety/societyworks/issues/3942

[skip changelog]