### PR TITLE
[FMS] Change banner on report to 'Status unknown' instead of 'Unknown'

### DIFF
--- a/templates/web/base/report/banner.html
+++ b/templates/web/base/report/banner.html
@@ -10,7 +10,7 @@
 [% END %]
 
 [% IF problem.is_open AND date.now - problem.lastupdate.epoch > 8 * 7 * 24 * 60 * 60 %]
-    [% INCLUDE banner, id = 'unknown', text = loc('Unknown') %]
+    [% INCLUDE banner, id = 'unknown', text = loc('Status unknown') %]
 [% ELSIF problem.is_in_progress %]
     [% INCLUDE banner, id = 'progress', text = prettify_state(problem.state) %]
 [% END %]

--- a/templates/web/fixmystreet.com/report/banner.html
+++ b/templates/web/fixmystreet.com/report/banner.html
@@ -20,7 +20,7 @@
 [% IF NOT problem.to_body_named('Bromley') %]
 
     [% IF problem.send_method_used != 'Open311' AND problem.is_open AND date.now - problem.lastupdate.epoch > 8 * 7 * 24 * 60 * 60 %]
-        [% INCLUDE banner, id = 'unknown', text = loc('Unknown') %]
+        [% INCLUDE banner, id = 'unknown', text = loc('Status unknown') %]
     [% ELSIF problem.is_in_progress %]
         [% INCLUDE banner, id = 'progress', text = loc('In progress') %]
     [% END %]


### PR DESCRIPTION
Been pointed out that it is not clear what is unknown on a report with an unknown status - so add clarity by putting 'Status unknown'

https://github.com/mysociety/societyworks/issues/3950

[skip changelog]