### PR TITLE
Added fix for CTA footer erasing homepage styling

### DIFF
--- a/web/cobrands/fixmystreet.com/base.scss
+++ b/web/cobrands/fixmystreet.com/base.scss
@@ -373,6 +373,9 @@ html.lazyload .js-lazyload {
       background-position: left center;
       padding-left: 2.5rem;
       background-size: 2rem;
+      // Gets rid of styling for pages like contact
+      padding-top: 0;
+      border-top: none;
     }
 
     &.is__citizen {
@@ -392,6 +395,14 @@ html.lazyload .js-lazyload {
         background-image: url('/cobrands/fixmystreet.com/images/developers-icon.svg'), none;
       }
     }
+  }
+}
+
+// Gets rid of the homepage styling for pages like contact
+body.twothirdswidthpage .content {
+  footer {
+    background: none;
+    margin: 0;
   }
 }
 


### PR DESCRIPTION
Currently the new CTA in the contact page looks like this on desktop:
<img width="1051" alt="Screenshot 2023-10-24 at 11 28 31" src="https://github.com/mysociety/fixmystreet/assets/13790153/c6436840-c53b-4d22-939a-642b2ffa9180">

This PR includes a fix that gets rid of the styling for the CTA section that inherits some behaviour from the homepage and also the `.twothirdswidthpage` class.

This is how it looks with this PR

<img width="1051" alt="Screenshot 2023-10-24 at 11 28 43" src="https://github.com/mysociety/fixmystreet/assets/13790153/2279abc4-0270-415b-b31c-abe4538fc511">

[skip changelog]
