### PR TITLE
Fixed invisible .form-hint element

### DIFF
--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2430,8 +2430,8 @@ label .muted {
 
 .form-hint {
   display: block;
-  color: $form-hint-color;
   margin-bottom: 0.5em;
+  color: #666;
 
   // Reduce space between labels and their form-hints
   label + & {
@@ -2669,6 +2669,7 @@ label .muted {
   }
   .form-hint {
     margin-bottom: 0.5em;
+    color: $form-hint-color;
   }
   p {
     margin: 0.5em 0 0;

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -832,6 +832,7 @@ textarea.form-error {
   }
   .form-hint {
     margin-top: -0.25em;
+    color: $form-hint-color-desktop;
   }
   h2 {
     font-style:normal;
@@ -853,9 +854,6 @@ textarea.form-error {
   overflow:hidden;
   label {
     margin:0.5em 0;
-  }
-  .form-hint {
-      color: $form-hint-color-desktop;
   }
   div {
     width:20em;


### PR DESCRIPTION
.form-hint element wasn't been displayed when non-nested inside` #front-main`, this because of the colour` $form-hint-color `variable. This variable will now take effect only when nested inside #front-main element. Any other` .form-hint` will have #666 colours.

