### PR TITLE
[FMS] Add parent categories to dashboard categories view

### DIFF
--- a/bin/csv-export
+++ b/bin/csv-export
@@ -60,10 +60,12 @@ my $user = FixMyStreet::DB->resultset("User")->find($opts->user) if $opts->user;
 my $body = FixMyStreet::DB->resultset("Body")->find($opts->body) if $opts->body;
 my $wards = $opts->wards ? [split',', $opts->wards] : [];
 
+my $category = $opts->category ? [split'::', $opts->category] : [];
+
 my $reporting = FixMyStreet::Reporting->new(
     type => $opts->type,
     user => $user,
-    category => $opts->category,
+    category => $category,
     state => $opts->state,
     role_id => $opts->role_id,
     wards => $wards,

--- a/perllib/FixMyStreet/App/Controller/Dashboard.pm
+++ b/perllib/FixMyStreet/App/Controller/Dashboard.pm
@@ -127,7 +127,10 @@ sub index : Path : Args(0) {
         $c->forward('/report/stash_category_groups', [ $c->stash->{contacts} ]);
 
         # See if we've had anything from the body dropdowns
-        $c->stash->{category} = $c->get_param('category');
+        $c->stash->{category} = [ $c->get_param_list('category') ];
+        my %display_categories = map { $_ => 1 } @{$c->stash->{category}};
+        $c->stash->{display_categories} = \%display_categories;
+
         $c->stash->{ward} = [ $c->get_param_list('ward') ];
 
         if ($c->user_exists) {

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -237,8 +237,9 @@ sub dashboard_export_problems_add_columns {
 
     my @contacts = $csv->body->contacts->search(undef, { order_by => [ 'category' ] } )->all;
     my %extra_columns;
-    if ($csv->category) {
-        @contacts = grep { $_->category eq $csv->category } @contacts;
+    if (@{$csv->category}) {
+        my %picked_cats = map { $_ => 1} @{$csv->category};
+        @contacts = grep { $picked_cats{$_->category} } @contacts;
     }
     foreach my $contact (@contacts) {
         foreach (@{$contact->get_metadata_for_storage}) {

--- a/t/app/controller/admin/report_edit.t
+++ b/t/app/controller/admin/report_edit.t
@@ -10,8 +10,10 @@ my $superuser = $mech->create_user_ok('superuser@example.com', name => 'Super Us
 
 my $oxfordshire = $mech->create_body_ok(2237, 'Oxfordshire County Council');
 my $user3 = $mech->create_user_ok('body_user@example.com', name => 'Body User', from_body => $oxfordshire);
-my $oxfordshirecontact = $mech->create_contact_ok( body_id => $oxfordshire->id, category => 'Potholes', email => 'potholes@example.com' );
+my $oxfordshirecontact = $mech->create_contact_ok( body_id => $oxfordshire->id, category => 'Potholes', email => 'potholes@example.com', extra => { group => 'Road' } );
 $mech->create_contact_ok( body_id => $oxfordshire->id, category => 'Traffic lights', email => 'lights@example.com' );
+$mech->create_contact_ok( body_id => $oxfordshire->id, category => 'Yellow lines', email => 'yellow@example.com', extra => { group => 'Road' } );
+
 
 my $oxford = $mech->create_body_ok(2421, 'Oxford City Council');
 $mech->create_contact_ok( body_id => $oxford->id, category => 'Graffiti', email => 'graffiti@example.net' );
@@ -58,7 +60,7 @@ my $log_entries = FixMyStreet::DB->resultset('AdminLog')->search(
         object_type => 'problem',
         object_id   => $report->id
     },
-    { 
+    {
         order_by => { -desc => 'id' },
     }
 );
@@ -455,7 +457,8 @@ subtest 'change report category' => sub {
         whensent => \'current_timestamp',
     });
     $mech->get_ok("/admin/report_edit/" . $ox_report->id);
-
+    $mech->content_contains('<optgroup label="Road">');
+    $mech->content_lacks('<option value="group-Road"');
     $mech->submit_form_ok( { with_fields => { category => 'Traffic lights' } }, 'form_submitted' );
     $ox_report->discard_changes;
     is $ox_report->category, 'Traffic lights';

--- a/templates/web/base/dashboard/index.html
+++ b/templates/web/base/dashboard/index.html
@@ -56,7 +56,7 @@
             [% SET category = cat.category | html %]
                 <option value='[% cat.category | html %]'[% ' selected' IF display_categories.$category %]>[% cat.category_display | html %]</option>
             [% END %]
-            [%~ INCLUDE 'report/new/_category_select.html' ~%]
+            [%~ INCLUDE 'report/new/_category_select.html' include_group_option=1 ~%]
         </select>
     </p>
 

--- a/templates/web/base/dashboard/index.html
+++ b/templates/web/base/dashboard/index.html
@@ -51,9 +51,10 @@
 
     <p>
         <label for="category">[% loc('Category:') %]</label>
-        <select class="form-control" name="category" id="category"><option value=''>[% loc('All') %]</option>
+        <select class="form-control js-multiple" multiple name="category" id="category">
             [% BLOCK category_option %]
-                <option value='[% cat.category | html %]'[% ' selected' IF category == cat.category %]>[% cat.category_display | html %]</option>
+            [% SET category = cat.category | html %]
+                <option value='[% cat.category | html %]'[% ' selected' IF display_categories.$category %]>[% cat.category_display | html %]</option>
             [% END %]
             [%~ INCLUDE 'report/new/_category_select.html' ~%]
         </select>

--- a/templates/web/base/report/new/_category_select.html
+++ b/templates/web/base/report/new/_category_select.html
@@ -1,5 +1,10 @@
 [%~ FOREACH group IN category_groups ~%]
-    [% IF group.name %]<optgroup label="[% group.name %]">[% END %]
+    [% IF group.name AND include_group_option %]<optgroup label="[% group.name %]">
+        [% SET pseudo_category = "group-" _ group.name %]
+        <option value="group-[% group.name %]" [% ' selected' IF display_categories.$pseudo_category %]>All [% group.name %]</option>
+    [% ELSIF group.name %]
+        <optgroup label="[% group.name %]">
+    [% END %]
     [%~ FOREACH cat IN group.categories ~%]
         [% INCLUDE category_option %]
     [%~ END ~%]


### PR DESCRIPTION
Add a parent categories column to show if a category is a subcategory.

Arbitrary decision to choose the first parent category from the groups method of a contact.

https://github.com/mysociety/societyworks/issues/1458

[skip changelog]