### PR TITLE
Do not re-enable report form for non-NH categories

### DIFF
--- a/web/cobrands/highways/assets.js
+++ b/web/cobrands/highways/assets.js
@@ -89,7 +89,11 @@ function _update_category(input, he_flag) {
 function regenerate_category(he_flag) {
     if (!fixmystreet.reporting_data) return;
 
-    $('.js-reporting-page--next').prop('disabled', false);
+    if (he_flag) {
+        // We do not want to reenable the form if it has been disabled for
+        // a non-NH category
+        $('.js-reporting-page--next').prop('disabled', false);
+    }
 
     // If we have come from NH site, the server has returned all the categories to show
     if (window.location.href.indexOf('&he_referral=1') != -1) {


### PR DESCRIPTION
Fixes https://github.com/mysociety/societyworks/issues/3936.

The `regenerate_category()` function in web/cobrands/highways/assets.js was indiscriminately (re-)enabling the report form after category selection. So if user selected an NH road, selected the 'Somewhere else' option from the popup, then selected a category that should disable the form, the form would not be disabled.

[skip changelog]
