### PR TITLE
[SLWP] Bulky can only be offered if service initiated

### DIFF
--- a/perllib/FixMyStreet/Roles/CobrandSLWP.pm
+++ b/perllib/FixMyStreet/Roles/CobrandSLWP.pm
@@ -474,6 +474,7 @@ sub bin_services_for_address {
     my @to_fetch;
     my %schedules;
     my @task_refs;
+    $property->{has_no_services} = scalar @$result == 0;
     foreach (@$result) {
         my $servicetasks = $self->_get_service_tasks($_);
         foreach my $task (@$servicetasks) {
@@ -1202,6 +1203,7 @@ sub _bulky_refund_cutoff_date { }
 sub bulky_allowed_property {
     my ( $self, $property ) = @_;
 
+    return if $property->{has_no_services};
     my $cfg = $self->feature('echo');
 
     my $type = $property->{type_id} || 0;


### PR DESCRIPTION
Request that bulky not be offered if the service hasn't been initialised which may be the case on new builds

https://3.basecamp.com/4020879/buckets/33314444/todos/6713679040
