### PR TITLE
[Brent] Allow different OIDC config for WasteWorks host

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -181,7 +181,7 @@ sub categories_restriction {
     return $rs->search( { 'me.category' => { '-not_like' => 'River Piers%' } } );
 }
 
-=head2 social_auth_enabled and user_from_oidc
+=head2 social_auth_enabled, user_from_oidc, and oidc_config
 
 =over 4
 
@@ -213,6 +213,27 @@ sub user_from_oidc {
 =back
 
 =cut
+
+=item * Brent FMS and WasteWorks have separate OIDC configurations
+
+This code figures out the correct OIDC config based on the hostname used
+for the request.
+
+=cut
+
+sub oidc_config {
+    my $self = shift;
+
+    my $cfg = $self->{c}->cobrand->feature('oidc_login');
+    my $host = $self->{c}->req->uri->host;
+
+    if ($cfg->{hosts} && $cfg->{hosts}->{$host}) {
+        return $cfg->{hosts}->{$host};
+    }
+
+    return $cfg;
+}
+
 
 =head2 dashboard_export_problems_add_columns
 

--- a/t/Mock/OpenIDConnect.pm
+++ b/t/Mock/OpenIDConnect.pm
@@ -25,6 +25,12 @@ has cobrand => (
     default => '',
 );
 
+has host => (
+    is => 'rw',
+    isa => Str,
+    default => '',
+);
+
 sub dispatch_request {
     my $self = shift;
 
@@ -57,7 +63,7 @@ sub dispatch_request {
             ver => "1.0",
             iss => "https://login.example.org/12345-6789-4321-abcd-12309812309/v2.0/",
             sub => "my_cool_user_id",
-            aud => "example_client_id",
+            aud => $self->host eq "brent-wasteworks-oidc.example.org" ? "wasteworks_client_id": "example_client_id",
             iat => $now,
             auth_time => $now,
             tfp => "B2C_1_default",

--- a/t/app/controller/auth_social.t
+++ b/t/app/controller/auth_social.t
@@ -138,6 +138,53 @@ for my $test (
 {
     type => 'oidc',
     config => {
+        ALLOWED_COBRANDS => 'brent',
+        MAPIT_URL => 'http://mapit.uk/',
+        COBRAND_FEATURES => {
+            anonymous_account => {
+                brent => 'test',
+            },
+            oidc_login => {
+                brent => {
+                    client_id => 'example_client_id',
+                    secret => 'example_secret_key',
+                    auth_uri => 'http://oidc.example.org/oauth2/v2.0/authorize',
+                    token_uri => 'http://oidc.example.org/oauth2/v2.0/token',
+                    logout_uri => 'http://oidc.example.org/oauth2/v2.0/logout',
+                    password_change_uri => 'http://oidc.example.org/oauth2/v2.0/password_change',
+                    display_name => 'MyAccount',
+                    hosts => {
+                        'brent-wasteworks-oidc.example.org' => {
+                            client_id => 'wasteworks_client_id',
+                            secret => 'wasteworks_secret_key',
+                            auth_uri => 'http://brent-wasteworks-oidc.example.org/oauth2/v2.0/authorize',
+                            token_uri => 'http://brent-wasteworks-oidc.example.org/oauth2/v2.0/token',
+                            logout_uri => 'http://brent-wasteworks-oidc.example.org/oauth2/v2.0/logout',
+                            password_change_uri => 'http://brent-wasteworks-oidc.example.org/oauth2/v2.0/password_change',
+                            display_name => 'MyAccount - WasteWorks',
+                        }
+                    }
+                }
+            }
+        }
+    },
+    email => $mech->uniquify_email('oidc@example.org'),
+    uid => "brent:wasteworks_client_id:my_cool_user_id",
+    mock => 't::Mock::OpenIDConnect',
+    mock_hosts => ['brent-wasteworks-oidc.example.org'],
+    host => 'brent-wasteworks-oidc.example.org',
+    error_callback => '/auth/OIDC?error=ERROR',
+    success_callback => '/auth/OIDC?code=response-code&state=login',
+    redirect_pattern => qr{brent-wasteworks-oidc\.example\.org/oauth2/v2\.0/authorize},
+    logout_redirect_pattern => qr{brent-wasteworks-oidc\.example\.org/oauth2/v2\.0/logout},
+    password_change_pattern => qr{brent-wasteworks-oidc\.example\.org/oauth2/v2\.0/password_change},
+    report => $report3,
+    report_email => $test_email3,
+    pc => 'HA9 0FJ',
+},
+{
+    type => 'oidc',
+    config => {
         ALLOWED_COBRANDS => 'hackney',
         MAPIT_URL => 'http://mapit.uk/',
         COBRAND_FEATURES => {
@@ -207,7 +254,7 @@ for my $state ( 'refused', 'no email', 'existing UID', 'okay' ) {
             }
 
             # Set up a mock to catch (most, see below) requests to the OAuth API
-            my $mock_api = $test->{mock}->new;
+            my $mock_api = $test->{mock}->new( host => $test->{host} );
 
             if ($test->{uid} =~ /:/) {
                 my ($cobrand) = $test->{uid} =~ /^(.*?):/;

--- a/templates/web/base/auth/general.html
+++ b/templates/web/base/auth/general.html
@@ -29,10 +29,11 @@
         </button>
       </div>
     [% END %]
-    [% IF c.cobrand.feature('oidc_login') %]
+    [% oidc_config = c.cobrand.call_hook('oidc_config') OR c.cobrand.feature('oidc_login') %]
+    [% IF oidc_config %]
       <div class="form-box">
         <button name="social_sign_in" id="oidc_sign_in" value="oidc" class="btn btn--block btn--social btn--oidc">
-            [% tprintf(loc('Login with %s'), c.cobrand.feature('oidc_login').display_name) %]
+            [% tprintf(loc('Login with %s'), oidc_config.display_name) %]
         </button>
       </div>
     [% END %]


### PR DESCRIPTION
Allows Brent's `oidc_login` `COBRAND_FEATURE` to have a different set of values for whatever hostname is used for the request.

For example, to use a different config for `brent.wasteworks.example.org`:

```yaml
COBRAND_FEATURES:
  oidc_login:
    brent:
      client_id: 'fms_client_id'
      secret: 'fms_secret'
      display_name: 'Brent FMS Login'
      auth_uri: 'https://oidc.example.org/oauth2/v2.0/authorize'
      token_uri: 'https://oidc.example.org/oauth2/v2.0/token'
      hosts:
        brent.wasteworks.example.org:
          client_id: 'ww_client_id'
          secret: 'ww_secret'
          display_name: 'Brent WasteWorks Login'
          auth_uri: 'https://oidc.example.org/oauth2/v2.0/authorize'
          token_uri: 'https://oidc.example.org/oauth2/v2.0/token'

```

For FD-3395

[skip changelog]