### PR TITLE
[Bromley] [Waste] No refund text for bulky cancel confirmations with no payment.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -1045,6 +1045,7 @@ sub bulky_send_cancellation_confirmation {
             ],
 
             wasteworks_id => $collection_report->id,
+            payment_reference => $collection_report->get_extra_metadata('payment_reference'),
             refund_amount => $self->bulky_refund_amount($collection_report),
             collection_date => $self->bulky_nice_collection_date($collection_report),
         },

--- a/templates/email/bromley/waste/bulky-confirm-cancellation.txt
+++ b/templates/email/bromley/waste/bulky-confirm-cancellation.txt
@@ -3,7 +3,7 @@ Subject: Cancelled bulky goods collection [% wasteworks_id %]
 
 Bulky goods collection [% wasteworks_id %] scheduled for [%collection_date %] has been cancelled.
 
-[% IF refund_amount > 0 %]
+[% IF refund_amount > 0 && payment_reference %]
 £[% pounds(refund_amount / 100) %] will be refunded.
 [% END %]
 


### PR DESCRIPTION
[skip changelog]