### PR TITLE
[Southwark] Only display dead animal location question when not council tenant.

### DIFF
--- a/web/cobrands/fixmystreet.com/base.scss
+++ b/web/cobrands/fixmystreet.com/base.scss
@@ -509,3 +509,17 @@ body.twothirdswidthpage .content {
         margin-bottom: 0;
     }
 }
+
+/* New report conditional questions */
+
+@supports( #{"selector(:has(*))"} ) {
+    #form_southwark_dead_animal_location,
+    label[for="form_southwark_dead_animal_location"] {
+        .extra-category-questions & {
+            display: none;
+        }
+        .extra-category-questions:has(#form_southwark_dead_animal_council_tenant option[value="no"]:checked) & {
+            display: block;
+        }
+    }
+}

--- a/web/cobrands/southwark/base.scss
+++ b/web/cobrands/southwark/base.scss
@@ -694,3 +694,17 @@ border-right-width: $btn-border-width;
 .olControlAttribution {
   right: 80px !important;
 }
+
+/* New report conditional questions */
+
+@supports( #{"selector(:has(*))"} ) {
+    #form_southwark_dead_animal_location,
+    label[for="form_southwark_dead_animal_location"] {
+        .extra-category-questions & {
+            display: none;
+        }
+        .extra-category-questions:has(#form_southwark_dead_animal_council_tenant option[value="no"]:checked) & {
+            display: block;
+        }
+    }
+}


### PR DESCRIPTION
[skip changelog] [FD-3522](https://mysocietysupport.freshdesk.com/a/tickets/3522)

Works in combination with set-up for a required "Are you a council tenant?" question and an optional "Location of dead animal" question with the stopper and redirect - this set-up is configured on staging https://staging.fixmystreet.com/report/new?longitude=-0.101650&latitude=51.504550#extra.

An issue with this approach is that if the user erroneously selects 'no' for council tenant and 'other' for location, and then corrects their answer for council tenant, they will still be blocked and the location field they need to change to unblock will disappear.