### PR TITLE
Pre-compute dashboard problem CSV export

### DIFF
--- a/bin/csv-export
+++ b/bin/csv-export
@@ -71,9 +71,13 @@ my $reporting = FixMyStreet::Reporting->new(
     $opts->start_date ? (start_date => $opts->start_date) : (),
     end_date => $opts->end_date,
 );
-$reporting->construct_rs_filter;
-$reporting->csv_parameters;
-$reporting->generate_csv($fh);
+if ($reporting->premade_csv_exists) {
+    $reporting->filter_premade_csv($fh);
+} else {
+    $reporting->construct_rs_filter;
+    $reporting->csv_parameters;
+    $reporting->generate_csv($fh);
+}
 unless ($use_stdout) {
     $file->move($opts->out);
 }

--- a/bin/fixmystreet.com/all-csv-export
+++ b/bin/fixmystreet.com/all-csv-export
@@ -1,0 +1,31 @@
+#!/usr/bin/env perl
+
+# all-csv-export
+# Pre-generates all body CSV files for quicker dashboard export
+# Uses DBI directly
+
+use v5.14;
+use warnings;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use Getopt::Long::Descriptive;
+use CronFns;
+use FixMyStreet::Script::CSVExport;
+
+my $site = CronFns::site(FixMyStreet->config('BASE_URL'));
+CronFns::language($site);
+
+my ($opts, $usage) = describe_options(
+    '%c %o',
+    ['verbose|v', 'more verbose output'],
+    ['help|h', "print usage message and exit" ],
+);
+$usage->die if $opts->help;
+
+FixMyStreet::Script::CSVExport::process(verbose => $opts->verbose);

--- a/perllib/FixMyStreet/App/Controller/Dashboard.pm
+++ b/perllib/FixMyStreet/App/Controller/Dashboard.pm
@@ -158,7 +158,11 @@ sub index : Path : Args(0) {
         $reporting->csv_parameters;
         if ($export == 1) {
             # Existing method, generate and serve
-            $reporting->generate_csv_http($c);
+            if ($reporting->premade_csv_exists) {
+                $reporting->filter_premade_csv_http($c);
+            } else {
+                $reporting->generate_csv_http($c);
+            }
         } elsif ($export == 2) {
             # New offline method
             $reporting->kick_off_process;

--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -227,8 +227,8 @@ sub dashboard_export_problems_add_columns {
         (
             street_name => 'Street Name',
             location_name => 'Location Name',
-            created_by => 'Created By',
-            email => 'Email',
+            name => 'Created By',
+            user_email => 'Email',
             usrn => 'USRN',
             uprn => 'UPRN',
             external_id => 'External ID',
@@ -260,8 +260,7 @@ sub dashboard_export_problems_add_columns {
 
     my $flytipping_lookup = sub {
         my ($report, $field) = @_;
-
-        my $v = $report->get_extra_field_value($field) // return '';
+        my $v = $csv->_extra_field($report, $field) // return '';
         return $values->{$field}{$v} || '';
     };
 
@@ -269,26 +268,30 @@ sub dashboard_export_problems_add_columns {
         my $report = shift;
 
         my $data = {
-            street_name => $report->nearest_address_parts->{street},
-            location_name => $report->get_extra_field_value('location_name') || '',
-            created_by => $report->name || '',
-            email => $report->user->email || '',
-            usrn => $report->get_extra_field_value('usrn') || '',
-            uprn => $report->get_extra_field_value('uprn') || '',
-            external_id => $report->external_id || '',
-            image_included => $report->photo ? 'Y' : 'N',
+            location_name => $csv->_extra_field($report, 'location_name'),
+            $csv->dbi ? (
+                street_name => FixMyStreet::Geocode::Address->new($report->{geocode})->parts->{street},
+                image_included => $report->{photo} ? 'Y' : 'N',
+            ) : (
+                street_name => $report->nearest_address_parts->{street},
+                name => $report->name || '',
+                user_email => $report->user->email || '',
+                image_included => $report->photo ? 'Y' : 'N',
+                external_id => $report->external_id || '',
+            ),
+            usrn => $csv->_extra_field($report, 'usrn'),
+            uprn => $csv->_extra_field($report, 'uprn'),
             flytipping_did_you_see => $flytipping_lookup->($report, 'Did_you_see_the_Flytip_take_place?_'),
             flytipping_statement => $flytipping_lookup->($report, 'Are_you_willing_to_be_a_WItness?_'),
             flytipping_quantity => $flytipping_lookup->($report, 'Flytip_Size'),
             flytipping_type => $flytipping_lookup->($report, 'Flytip_Type'),
-            container_req_action => $report->get_extra_field_value('Container_Request_Action') || '',
-            container_req_type => $report->get_extra_field_value('Container_Request_Container_Type') || '',
-            container_req_reason => $report->get_extra_field_value('Container_Request_Reason') || '',
-            missed_collection_id => $report->get_extra_field_value('service_id') || '',
+            container_req_action => $csv->_extra_field($report, 'Container_Request_Action'),
+            container_req_type => $csv->_extra_field($report, 'Container_Request_Container_Type'),
+            container_req_reason => $csv->_extra_field($report, 'Container_Request_Reason'),
+            missed_collection_id => $csv->_extra_field($report, 'service_id'),
         };
 
-        my $extra = $report->get_extra_metadata;
-
+        my $extra = $csv->_extra_metadata($report);
         %$data = (%$data, map {$_ => $extra->{$_} || ''} grep { $_ =~ /^(item_\d+)$/ } keys %$extra);
 
         return $data;

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -971,6 +971,8 @@ sub dashboard_export_problems_add_columns {
         staff_role => 'Staff Role',
     );
 
+    return if $csv->dbi; # All covered already
+
     my $user_lookup = $self->csv_staff_users;
     my $userroles = $self->csv_staff_roles($user_lookup);
 

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -333,6 +333,8 @@ sub _dashboard_export_add_columns {
 
     $csv->add_csv_columns( staff_user => 'Staff User' );
 
+    return if $csv->dbi; # staff_user included by default
+
     my $user_lookup = $self->csv_staff_users;
 
     $csv->csv_extra_data(sub {

--- a/perllib/FixMyStreet/Cobrand/Camden.pm
+++ b/perllib/FixMyStreet/Cobrand/Camden.pm
@@ -143,7 +143,7 @@ sub dashboard_export_problems_add_columns {
     my ($self, $csv) = @_;
 
     $csv->add_csv_columns(
-        user_name => 'User Name',
+        name => 'User Name',
         user_email => 'User Email',
     );
 
@@ -152,11 +152,13 @@ sub dashboard_export_problems_add_columns {
         join => 'user',
     });
 
+    return if $csv->dbi; # Already covered
+
     $csv->csv_extra_data(sub {
         my $report = shift;
 
         return {
-            user_name => $report->name || '',
+            name => $report->name || '',
             user_email => $report->user->email || '',
         };
     });

--- a/perllib/FixMyStreet/Cobrand/CentralBedfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/CentralBedfordshire.pm
@@ -281,6 +281,8 @@ sub dashboard_export_problems_add_columns {
         external_id => 'CRNo',
     );
 
+    return if $csv->dbi; # Already covered
+
     $csv->csv_extra_data(sub {
         my $report = shift;
 

--- a/perllib/FixMyStreet/Cobrand/Hackney.pm
+++ b/perllib/FixMyStreet/Cobrand/Hackney.pm
@@ -349,16 +349,23 @@ sub dashboard_export_problems_add_columns {
 
         my $address = '';
         my $postcode = '';
-
-        if ( $report->geocode ) {
-            $address = $report->nearest_address;
-            $postcode = $report->nearest_address_parts->{postcode};
+        if ($csv->dbi) {
+            if ( $report->{geocode} ) {
+                my $addr = FixMyStreet::Geocode::Address->new($report->{geocode});
+                $address = $addr->summary;
+                $postcode = $addr->parts->{postcode};
+            }
+        } else {
+            if ( $report->geocode ) {
+                $address = $report->nearest_address;
+                $postcode = $report->nearest_address_parts->{postcode};
+            }
         }
 
         return {
             nearest_address => $address,
             nearest_address_postcode => $postcode,
-            extra_details => $report->get_extra_metadata('detailed_information') || '',
+            extra_details => $csv->_extra_metadata($report, 'detailed_information') || '',
         };
     });
 }

--- a/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
+++ b/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
@@ -345,7 +345,6 @@ sub dashboard_export_problems_add_columns {
         my @updates = $report->comments->all;
         @updates = sort { $a->confirmed <=> $b->confirmed || $a->id <=> $b->id } @updates;
         for my $update (@updates) {
-            next unless $update->state eq 'confirmed';
             last if $i > 5;
             $fields->{"update_text_$i"} = $update->text;
             $fields->{"update_date_$i"} = $update->confirmed;

--- a/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
@@ -165,6 +165,8 @@ sub dashboard_export_problems_add_columns {
         external_id => 'External ID',
     );
 
+    return if $csv->dbi;
+
     $csv->csv_extra_data(sub {
         my $report = shift;
 

--- a/perllib/FixMyStreet/Cobrand/Northumberland.pm
+++ b/perllib/FixMyStreet/Cobrand/Northumberland.pm
@@ -86,6 +86,16 @@ sub dashboard_export_problems_add_columns {
         assigned_to => 'Assigned To',
     );
 
+    if ($csv->dbi) {
+        $csv->csv_extra_data(sub {
+            my $report = shift;
+            return {
+                user_name_display => $report->{name},
+            };
+        });
+        return; # Rest already covered
+    }
+
     my $user_lookup = $self->csv_staff_users;
     my $userroles = $self->csv_staff_roles($user_lookup);
     my $problems_to_user = $self->csv_active_planned_reports;

--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -346,14 +346,18 @@ sub dashboard_export_problems_add_columns {
 
     $csv->csv_extra_data(sub {
         my $report = shift;
-        my $usrn = $report->get_extra_field_value('usrn') || '';
+        my $usrn = $csv->_extra_field($report, 'usrn') || '';
         # Try and get a HIAMS reference first of all
-        my $ref = $report->get_extra_metadata('customer_reference');
+        my $ref = $csv->_extra_metadata($report, 'customer_reference');
         unless ($ref) {
             # No HIAMS ref which means it's either an older Exor report
             # or a HIAMS report which hasn't had its reference set yet.
             # We detect the latter case by the id and external_id being the same.
-            $ref = $report->external_id if $report->id ne ( $report->external_id || '' );
+            if ($csv->dbi) {
+                $ref = $report->{external_id} if $report->{id} ne ( $report->{external_id} || '' );
+            } else {
+                $ref = $report->external_id if $report->id ne ( $report->external_id || '' );
+            }
         }
         return {
             external_ref => ( $ref || '' ),

--- a/perllib/FixMyStreet/Cobrand/Shropshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Shropshire.pm
@@ -192,8 +192,9 @@ sub dashboard_export_problems_add_columns {
     $csv->csv_extra_data(sub {
         my $report = shift;
 
+        my $non_public = $csv->dbi ? $report->{non_public} : $report->non_public;
         return {
-            private_report => $report->non_public ? 'Yes' : 'No'
+            private_report => $non_public ? 'Yes' : 'No'
         };
     });
 }

--- a/perllib/FixMyStreet/Script/CSVExport.pm
+++ b/perllib/FixMyStreet/Script/CSVExport.pm
@@ -1,0 +1,272 @@
+package FixMyStreet::Script::CSVExport;
+
+use v5.14;
+use warnings;
+use DBI;
+use JSON::MaybeXS;
+use Path::Tiny;
+use Text::CSV;
+use FixMyStreet;
+use FixMyStreet::Cobrand;
+use FixMyStreet::DB;
+use FixMyStreet::Reporting;
+use Utils;
+
+my $EXTRAS = {
+    reassigned => { tfl => 1 },
+    assigned_to => { northumberland => 1, tfl => 1 },
+    staff_user => { bathnes => 1, bromley => 1, buckinghamshire => 1, northumberland => 1, peterborough => 1 },
+    staff_roles => { bromley => 1, northumberland => 1 },
+    user_details => { bathnes => 1, brent => 1, camden => 1, highwaysengland => 1, kingston => 1, sutton => 1 },
+    comment_content => { highwaysengland => 1 },
+    db_state => { peterborough => 1 },
+};
+
+my $fixed_states = FixMyStreet::DB::Result::Problem->fixed_states;
+my $closed_states = FixMyStreet::DB::Result::Problem->closed_states;
+my $JSON = JSON::MaybeXS->new->allow_nonref;
+
+=head2 process
+
+Processes all bodies with a cobrand
+
+=cut
+
+sub process {
+    my %opts = @_;
+    $opts{dbh} ||= do {
+        my @args = FixMyStreet->dbic_connect_info;
+        DBI->connect(@args[0..3]) or die $!;
+    };
+    my $bodies = $opts{dbh}->selectcol_arrayref("select id from body where extra->>'cobrand' !='' order by id");
+    process_body($_, \%opts) foreach @$bodies;
+}
+
+=head2 process_body
+
+Given a body ID, queries the database for all its reports
+and outputs as CSV to a file.
+
+=cut
+
+sub process_body {
+    my ($body_id, $opts) = @_;
+    my $dbh = $opts->{dbh};
+
+    my $body = FixMyStreet::DB->resultset("Body")->find($body_id);
+    print "Processing " . $body->name . "\n" if $opts->{verbose};
+    my $start = time();
+    my $cobrand = $body->get_cobrand_handler;
+    return unless $cobrand;
+    FixMyStreet::DB->schema->cobrand($cobrand);
+
+    my $reporting = FixMyStreet::Reporting->new(
+        type => 'problems',
+        body => $body,
+        user => $body->comment_user,
+        dbi => 1, # Flag we are doing it via DBI
+    );
+    $reporting->construct_rs_filter; # So it exists
+    $reporting->csv_parameters;
+    $reporting->splice_csv_column('id', areas => 'Areas');
+    $reporting->splice_csv_column('id', roles => 'Roles');
+    if ($EXTRAS->{db_state}{$cobrand->moniker}) {
+        $reporting->splice_csv_column('id', db_state => 'DBState');
+    }
+
+    my $out = $reporting->premade_csv_filename;
+    my $file = path("$out-part");
+    my $handle = $file->openw_utf8;
+    my $csv = Text::CSV->new({ binary => 1, eol => "\n" });
+    $csv->print($handle, $reporting->csv_headers);
+
+    my $children = $body->area_children(1);
+
+    my $sql = generate_sql($body_id, $cobrand);
+    $dbh->do($sql) or die $dbh->errstr;
+
+    my $hashref;
+    while (1) {
+        my $sth = $dbh->prepare("FETCH 1000 FROM csr");
+        $sth->execute;
+        last if 0 == $sth->rows;
+        while (my $obj = $sth->fetchrow_hashref) {
+            my $extra = $JSON->decode($obj->{extra} || '{}');
+            if (ref $extra eq 'ARRAY') { $extra = { _fields => $extra }; }
+            $obj->{extra} = $extra;
+            foreach (@{$obj->{extra}{_fields}}) {
+                $obj->{extra}{_field_value}{$_->{name}} //= $_->{value};
+            }
+
+            if (!$hashref || $hashref->{id} != $obj->{id}) {
+                output($reporting, $csv, $handle, $hashref);
+                $hashref = initial_hashref($obj, $cobrand, $children);
+            }
+            process_comment($hashref, $obj);
+            if (my $fn = $reporting->csv_extra_data) {
+                my $extra = $fn->($obj);
+                $hashref = { %$hashref, %$extra };
+            }
+        }
+    }
+    output($reporting, $csv, $handle, $hashref);
+    $dbh->do("CLOSE csr");
+    my $sec = time() - $start;
+    print "Processed " . $body->name . " in $sec seconds\n" if $opts->{verbose};
+    $file->move($out);
+}
+
+=head2 generate_sql
+
+Generates the SQL to be fed to the database to export the relevant data.
+
+=cut
+
+sub generate_sql {
+    my ($body_id, $cobrand) = @_;
+
+    my @sql_select = (
+        '"me".*',
+        # (Override timestamps to truncate to the second)
+        "to_json(date_trunc('second', me.created))#>>'{}' as created",
+        "to_json(date_trunc('second', me.confirmed))#>>'{}' as confirmed",
+        # Fetch the relevant bits of comments we need for timestamps
+        "comments.id as comment_id, comments.problem_state, to_json(date_trunc('second', comments.confirmed))#>>'{}' as comment_confirmed, comments.mark_fixed",
+        # Older reports did not store the group on the report, so fetch it from contacts
+        "contact.extra->'group' AS group",
+    );
+    my @sql_with;
+    my @sql_join = (
+        '"contacts" "contact" ON CAST( "contact"."body_id" AS text ) = (regexp_split_to_array( "me"."bodies_str", \',\'))[1] AND "contact"."category" = "me"."category"',
+        '"comment" "comments" ON "comments"."problem_id" = "me"."id"',
+    );
+
+    if ($EXTRAS->{reassigned}{$cobrand->moniker}) {
+        push @sql_select, "to_json(date_trunc('second', ranked_admin_log.whenedited))#>>'{}' as reassigned_at", "admin_log_user.name as reassigned_by";
+        push @sql_with, <<EOF;
+ranked_admin_log AS (
+    select *,row_number() over (partition by object_id order by whenedited desc) as rn from admin_log where admin_log.object_type = 'problem' AND admin_log.action = 'category_change'
+)
+EOF
+        push @sql_join, 'ranked_admin_log ON ranked_admin_log.object_id = me.id AND rn = 1';
+        push @sql_join, 'users admin_log_user ON ranked_admin_log.user_id = admin_log_user.id';
+    }
+    if ($EXTRAS->{assigned_to}{$cobrand->moniker}) {
+        push @sql_select, "planned_user.name as assigned_to";
+        push @sql_join, '"user_planned_reports" ON "user_planned_reports"."report_id" = "me"."id" AND "user_planned_reports"."removed" IS NULL';
+        push @sql_join, '"users" "planned_user" ON "planned_user"."id" = "user_planned_reports"."user_id"';
+    }
+    if ($EXTRAS->{staff_user}{$cobrand->moniker}) {
+        push @sql_select, "contributed_by_user.id AS staff_user_id", "contributed_by_user.email AS staff_user";
+        push @sql_join, '"users" "contributed_by_user" ON "contributed_by_user"."id" = ("me"."extra"->>\'contributed_by\')::integer';
+    }
+    if ($EXTRAS->{staff_roles}{$cobrand->moniker}) {
+        push @sql_select, "staff_roles.role_ids AS roles", "staff_roles.role_names AS staff_role";
+        push @sql_with, <<EOF;
+staff_roles AS (
+    SELECT users.id AS user_id,
+        string_agg(roles.id::text, ',' order by roles.id) AS role_ids,
+        string_agg(roles.name, ',' order by roles.name) AS role_names
+    FROM user_roles, users, roles
+    WHERE user_roles.user_id = users.id AND user_roles.role_id = roles.id AND from_body = $body_id
+    GROUP BY users.id
+)
+EOF
+        push @sql_join, 'staff_roles ON contributed_by_user.id = staff_roles.user_id';
+    }
+    if ($EXTRAS->{user_details}{$cobrand->moniker}) {
+        push @sql_select, "problem_user.email AS user_email", "problem_user.phone AS user_phone";
+        push @sql_join, '"users" "problem_user" ON "problem_user"."id" = "me"."user_id"';
+    }
+    if ($EXTRAS->{comment_content}{$cobrand->moniker}) {
+        push @sql_select, "comments.text as comment_text", "comments.extra as comment_extra", "comment_user.name as comment_name", "row_number() over (partition by comments.problem_id order by comments.confirmed,comments.id) as comment_rn";
+        push @sql_join, '"users" "comment_user" ON "comments"."user_id" = "comment_user"."id"';
+    }
+
+    my $sql_select = join(', ', @sql_select);
+    my $sql_join = join(' ', map { "LEFT JOIN $_" } @sql_join);
+    my $sql_with = @sql_with ? "WITH " . join(', ', @sql_with) : '';
+
+    my $where_states = '';
+    my $all_states = $cobrand->call_hook('dashboard_export_include_all_states');
+    unless ($all_states) {
+        my $states = join(', ', map { "'$_'" } FixMyStreet::DB::Result::Problem->visible_states);
+        $where_states = " AND me.state IN ($states)";
+    }
+    return <<EOF;
+DECLARE csr CURSOR WITH HOLD FOR $sql_with SELECT $sql_select FROM "problem" "me" $sql_join
+WHERE regexp_split_to_array("me"."bodies_str", ',') && ARRAY['$body_id']
+    -- Ignore non-confirmed comments, and ones with no or confirmed problem_state
+    AND ("comments"."state" = 'confirmed' OR "comments"."state" IS NULL)
+    $where_states
+ORDER BY "me"."confirmed", "me"."id", "comments"."confirmed", "comments"."id";
+EOF
+}
+
+=head2 output
+
+Given a hashref of data, outputs the csv_column keys
+from it as CSV data to the filehandle.
+
+=cut
+
+sub output {
+    my ($reporting, $csv, $handle, $hashref) = @_;
+    $csv->print($handle, [ @{$hashref}{ @{$reporting->csv_columns} } ] ) if $hashref;
+}
+
+=head2 initial_hashref
+
+As well as all the data returned by the database, add some extra default data
+extracted solely from the report, including local co-ordinates, URL, ward name.
+
+=cut
+
+sub initial_hashref {
+    my ($obj, $cobrand, $children) = @_;
+
+    my ($x, $y) = Utils::convert_latlon_to_en( $obj->{latitude}, $obj->{longitude}, "G" ); # Adjust if ever NI
+
+    my $hashref = {
+        %$obj,
+        user_name_display => $obj->{anonymous} ? '(anonymous)' : $obj->{name},
+        local_coords_x => $x,
+        local_coords_y => $y,
+        url => $cobrand->base_url . "/report/" . $obj->{id},
+        device_type => $obj->{service} || 'website',
+        reported_as => $obj->{extra}->{contributed_as} || '',
+        wards => join ', ', map { $children->{$_}->{name} } grep { $children->{$_} } split ',', $obj->{areas},
+    };
+
+    my $group = $obj->{extra}->{group} || $JSON->decode($obj->{group} || '[]') || [];
+    $group = [ $group ] unless ref $group eq 'ARRAY';
+    $group = join(',', @$group);
+    if ($group) {
+        $hashref->{subcategory} = $obj->{category};
+        $hashref->{category} = $group;
+    }
+
+    return $hashref;
+}
+
+=head2 process_comment
+
+Given a result row, look at the comment entries to see if we need to set any
+row timestamps.
+
+=cut
+
+sub process_comment {
+    my ($hashref, $obj) = @_;
+    return if $hashref->{closed}; # Once closed is set, ignore further more comments
+    my $problem_state = $obj->{problem_state} or return;
+    return if $problem_state eq 'confirmed';
+    $hashref->{acknowledged} //= $obj->{comment_confirmed};
+    $hashref->{action_scheduled} //= $problem_state eq 'action scheduled' ? $obj->{comment_confirmed} : undef;
+    $hashref->{fixed} //= $fixed_states->{ $problem_state } || $obj->{mark_fixed} ?  $obj->{comment_confirmed} : undef;
+    if ($closed_states->{ $problem_state }) {
+        $hashref->{closed} = $obj->{comment_confirmed};
+    }
+}
+
+1;

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -216,6 +216,9 @@ sub dispatch_request {
                 151942 => {parent_area => 2514, id => 151942, name => "Birchfield", type => "MTW"},
             });
         }
+        if ($area eq '2508') {
+            return $self->output({144390 => {parent_area => 2508, id => 144390, name => "Brownswood", type => "LBW"}});
+        }
         if ($area eq '2326') {
             return $self->output({23261 => {parent_area => 2326, id => 23261, name => "Lansdown", type => "DIW"}});
         }

--- a/t/app/controller/dashboard.t
+++ b/t/app/controller/dashboard.t
@@ -322,6 +322,7 @@ FixMyStreet::override_config {
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => 'tester',
     MAPIT_URL => 'http://mapit.uk/',
+    PHOTO_STORAGE_OPTIONS => { UPLOAD_DIR => $UPLOAD_DIR },
 }, sub {
     subtest 'no body or export, 404' => sub {
         $mech->get('/dashboard');

--- a/t/cobrand/bathnes.t
+++ b/t/cobrand/bathnes.t
@@ -1,5 +1,7 @@
 use Test::MockModule;
 use FixMyStreet::TestMech;
+use File::Temp 'tempdir';
+use FixMyStreet::Script::CSVExport;
 my $mech = FixMyStreet::TestMech->new;
 
 # disable info logs for this test run
@@ -57,9 +59,11 @@ $mech->create_problems_for_body(1, $body->id, 'Title', {
     }
 });
 
+my $UPLOAD_DIR = tempdir( CLEANUP => 1 );
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'bathnes' ],
     MAPIT_URL => 'http://mapit.uk/',
+    PHOTO_STORAGE_OPTIONS => { UPLOAD_DIR => $UPLOAD_DIR },
 }, sub {
 
 subtest 'cobrand displays council name' => sub {
@@ -115,6 +119,13 @@ subtest 'extra CSV columns are absent if permission not granted' => sub {
             'Reported As',
         ],
         'Column headers look correct';
+
+    # And if pre-generated, is the same
+    FixMyStreet::Script::CSVExport::process(dbh => FixMyStreet::DB->schema->storage->dbh);
+    $mech->get_ok('/dashboard?export=1');
+    @rows = $mech->content_as_csv;
+    is scalar @rows, 5, '1 (header) + 4 (reports) = 5 lines';
+    is scalar @{$rows[0]}, 21, '21 columns present';
 };
 
 subtest "Custom CSV fields permission can be granted" => sub {

--- a/t/cobrand/bexley.t
+++ b/t/cobrand/bexley.t
@@ -2,6 +2,7 @@ use CGI::Simple;
 use Test::MockModule;
 use Test::MockTime qw(:all);
 use Test::Output;
+use File::Temp 'tempdir';
 use FixMyStreet::TestMech;
 use FixMyStreet::Script::Reports;
 use FixMyStreet::SendReport::Open311;
@@ -73,10 +74,12 @@ $da->set_extra_fields({
 });
 $da->update;
 
+my $UPLOAD_DIR = tempdir( CLEANUP => 1 );
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'bexley' ],
     MAPIT_URL => 'http://mapit.uk/',
     STAGING_FLAGS => { send_reports => 1, skip_checks => 0 },
+    PHOTO_STORAGE_OPTIONS => { UPLOAD_DIR => $UPLOAD_DIR },
     COBRAND_FEATURES => {
         open311_email => { bexley => {
             p1 => 'p1@bexley',

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -1,6 +1,7 @@
 use Test::MockModule;
 use FixMyStreet::TestMech;
 use FixMyStreet::Script::Reports;
+use File::Temp 'tempdir';
 
 use t::Mock::Tilma;
 my $tilma = t::Mock::Tilma->new;
@@ -67,10 +68,12 @@ $contact = $mech->create_contact_ok(body_id => $parish->id, category => 'Flypost
 $contact->set_extra_metadata(prefer_if_multiple => 1);
 $contact->update;
 
+my $UPLOAD_DIR = tempdir( CLEANUP => 1 );
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'buckinghamshire', 'fixmystreet' ],
     MAPIT_URL => 'http://mapit.uk/',
     STAGING_FLAGS => { send_reports => 1, skip_checks => 0 },
+    PHOTO_STORAGE_OPTIONS => { UPLOAD_DIR => $UPLOAD_DIR },
     COBRAND_FEATURES => {
         open311_email => {
             buckinghamshire => {

--- a/t/cobrand/camden.t
+++ b/t/cobrand/camden.t
@@ -1,6 +1,7 @@
 use Test::MockModule;
 use FixMyStreet::TestMech;
 use FixMyStreet::Script::Reports;
+use File::Temp 'tempdir';
 
 FixMyStreet::App->log->disable('info');
 END { FixMyStreet::App->log->enable('info'); }
@@ -32,9 +33,11 @@ $mech->create_contact_ok(
     group => 'Hired e-bike or e-scooter',
 );
 
+my $UPLOAD_DIR = tempdir( CLEANUP => 1 );
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'camden', 'tfl' ],
     MAPIT_URL => 'http://mapit.uk/',
+    PHOTO_STORAGE_OPTIONS => { UPLOAD_DIR => $UPLOAD_DIR },
 }, sub {
     subtest "hides the TfL River Piers category" => sub {
 

--- a/t/cobrand/centralbedfordshire.t
+++ b/t/cobrand/centralbedfordshire.t
@@ -1,6 +1,7 @@
 use CGI::Simple;
 use Test::MockModule;
 use Test::MockTime qw(:all);
+use File::Temp 'tempdir';
 use FixMyStreet::TestMech;
 use FixMyStreet::Script::Alerts;
 use FixMyStreet::Script::Reports;
@@ -224,10 +225,12 @@ subtest 'check geolocation overrides' => sub {
 
 
 subtest 'Dashboard CSV extra columns' => sub {
+    my $UPLOAD_DIR = tempdir( CLEANUP => 1 );
     $mech->log_in_ok( $staffuser->email );
     FixMyStreet::override_config {
         MAPIT_URL => 'http://mapit.uk/',
         ALLOWED_COBRANDS => 'centralbedfordshire',
+        PHOTO_STORAGE_OPTIONS => { UPLOAD_DIR => $UPLOAD_DIR },
     }, sub {
         $mech->get_ok('/dashboard?export=1');
     };

--- a/t/cobrand/northamptonshire.t
+++ b/t/cobrand/northamptonshire.t
@@ -1,5 +1,5 @@
 use Test::MockModule;
-
+use File::Temp 'tempdir';
 use FixMyStreet::TestMech;
 use Catalyst::Test 'FixMyStreet::App';
 use FixMyStreet::Script::Reports;
@@ -380,12 +380,14 @@ FixMyStreet::override_config {
 };
 
 subtest 'Dashboard CSV extra columns' => sub {
+    my $UPLOAD_DIR = tempdir( CLEANUP => 1 );
     my $staffuser = $mech->create_user_ok('counciluser@example.com', name => 'Council User',
         from_body => $nh, password => 'password');
     $mech->log_in_ok( $staffuser->email );
     FixMyStreet::override_config {
         MAPIT_URL => 'http://mapit.uk/',
         ALLOWED_COBRANDS => 'northamptonshire',
+        PHOTO_STORAGE_OPTIONS => { UPLOAD_DIR => $UPLOAD_DIR },
     }, sub {
         $mech->get_ok('/dashboard?export=1');
     };

--- a/t/cobrand/oxfordshire.t
+++ b/t/cobrand/oxfordshire.t
@@ -1,6 +1,7 @@
 use Test::MockModule;
 
 use CGI::Simple;
+use File::Temp 'tempdir';
 use FixMyStreet::TestMech;
 use FixMyStreet::Script::Alerts;
 use FixMyStreet::Script::Reports;
@@ -253,10 +254,12 @@ FixMyStreet::override_config {
     ok $mech->host('oxfordshire.fixmystreet.com');
 };
 
+my $UPLOAD_DIR = tempdir( CLEANUP => 1 );
 FixMyStreet::override_config {
     STAGING_FLAGS => { send_reports => 1, skip_checks => 1 },
     ALLOWED_COBRANDS => 'oxfordshire',
     MAPIT_URL => 'http://mapit.uk/',
+    PHOTO_STORAGE_OPTIONS => { UPLOAD_DIR => $UPLOAD_DIR },
 }, sub {
 
     subtest 'can use customer reference to search for reports' => sub {

--- a/t/cobrand/shropshire.t
+++ b/t/cobrand/shropshire.t
@@ -1,4 +1,5 @@
 use CGI::Simple;
+use File::Temp 'tempdir';
 use Test::MockModule;
 use Test::MockTime qw(:all);
 use FixMyStreet::TestMech;
@@ -170,9 +171,11 @@ subtest 'check open311_contact_meta_override' => sub {
     is $extra_fields[0][1]->{fieldtype}, undef, "not added fieldtype 'date' to 'Registration Mark'";
 };
 
+my $UPLOAD_DIR = tempdir( CLEANUP => 1 );
 FixMyStreet::override_config {
     MAPIT_URL => 'http://mapit.uk/',
     ALLOWED_COBRANDS => 'shropshire',
+    PHOTO_STORAGE_OPTIONS => { UPLOAD_DIR => $UPLOAD_DIR },
 }, sub {
     subtest 'Dashboard CSV adds column "Private" for "non_public" attribute' => sub {
         my $staffuser = $mech->create_user_ok('counciluser@example.com', name => 'Council User',

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -488,7 +488,7 @@ subtest 'Dashboard CSV extra columns' => sub {
 
     $mech->get_ok('/dashboard?export=1');
     $mech->content_contains(',12345,,no,busstops@example.com,,', "Bike number added to csv");
-    $mech->content_contains('"Council User",,98756', "Stop code added to csv for all categories report");
+    $mech->content_contains('"Council User",,,98756', "Stop code added to csv for all categories report");
     $mech->get_ok('/dashboard?export=1&category=Bus+stops');
     $mech->content_contains('"Council User",,98756', "Stop code added to csv for bus stop category report");
 };


### PR DESCRIPTION
This tries to act in an entirely backwards-compatible manner.

It adds a `bin/fixmystreet.com/all-csv-export` script that uses DBI to extract all data for CSV export, along with any per-cobrand per-row extra data required. Once those files exist, they are used by the csv-export and Dashboard controller (and thus data returned will stop at the time those files were generated) to filter the output to the relevant rows with no database access required. This speeds up CSV export an awful lot.

All the cobrands are updated to cope with being given either a Problem object or a hashref,

[skip changelog]