### PR TITLE
[Sutton] Remove link to order new bins from each bin

### DIFF
--- a/t/app/controller/waste_sutton_r.t
+++ b/t/app/controller/waste_sutton_r.t
@@ -102,7 +102,7 @@ FixMyStreet::override_config {
         $e->mock('GetTasks', sub { [] });
     };
     subtest 'Request a new bin' => sub {
-        $mech->get_ok('/waste/12345/request');
+        $mech->follow_link_ok( { text => 'Request a replacement bin, box or caddy' } );
 		# 19 (1), 24 (1), 16 (1), 1 (1)
         # missing, new_build, more
         $mech->submit_form_ok({ with_fields => { 'container-choice' => 19 }});
@@ -133,15 +133,7 @@ FixMyStreet::override_config {
         is $report->detail, "Quantity: 1\n\n2 Example Street, Sutton, SM1 1AA\n\nReason: Missing";
         is $report->title, 'Request new Mixed Recycling Green Box (55L)';
     };
-    subtest 'Request bins from front page' => sub {
-        $mech->get_ok('/waste/12345');
-        $mech->submit_form_ok({ form_number => 7 });
-        $mech->content_contains('name="container-choice" value="1"');
-        $mech->content_contains('Paper and Cardboard Green Wheelie Bin (240L)');
-        $mech->content_contains('Mixed Recycling Green Box (55L)');
-        $mech->content_contains('Large Outdoor Food Waste Caddy (23L)');
-        $mech->content_contains('Brown Rubbish Wheelie Bin (140L)');
-    };
+
     subtest 'Report missed collection' => sub {
         $mech->get_ok('/waste/12345/report');
 		$mech->content_contains('Food waste');
@@ -161,7 +153,7 @@ FixMyStreet::override_config {
     subtest 'No reporting/requesting if open request' => sub {
         $mech->get_ok('/waste/12345');
         $mech->content_contains('Report a mixed recycling collection as missed');
-        $mech->content_contains('Request a mixed recycling container');
+        $mech->content_lacks('Request a mixed recycling container');
 
         $e->mock('GetEventsForObject', sub { [ {
             # Request
@@ -211,7 +203,7 @@ FixMyStreet::override_config {
         } ] });
         $mech->get_ok('/waste/12345');
         $mech->content_contains('A mixed recycling collection has been reported as missed');
-        $mech->content_contains('Request a mixed recycling container');
+        $mech->content_lacks('Request a mixed recycling container');
 
         $e->mock('GetEventsForObject', sub { [ {
             EventTypeId => 1566,

--- a/templates/web/sutton/waste/_more_services_sidebar.html
+++ b/templates/web/sutton/waste/_more_services_sidebar.html
@@ -10,7 +10,7 @@
        <li><a href="[% c.uri_for_action('waste/report', [ property.id ]) %]">Report a missed collection</a></li>
     [% END %]
     [% IF any_request_allowed %]
-      <li><a href="[% c.uri_for_action('waste/request', [ property.id ]) %]">Request a replacement container</a></li>
+      <li><a href="[% c.uri_for_action('waste/request', [ property.id ]) %]">Request a replacement bin, box or caddy</a></li>
     [% END %]
     [% IF services.2238 %]
      [% IF c.config.STAGING_SITE %]

--- a/templates/web/sutton/waste/services.html
+++ b/templates/web/sutton/waste/services.html
@@ -1,1 +1,70 @@
-../../kingston/waste/services.html
+[% PROCESS 'waste/_service_missed.html' %]
+
+[% IF unit.requests_open.size %]
+  <span class="waste-service-descriptor">
+    A [% unit.service_name FILTER lower %] container request has been made
+  </span>
+[% ELSIF unit.request_allowed %]
+  [% any_request_allowed = 1 %]
+[% ELSIF unit.garden_waste AND NOT waste_features.garden_modify_disabled AND NOT unit.garden_due AND (c.cobrand.moniker == 'kingston' OR unit.garden_container != 28) %]
+  <form method="post" action="[% c.uri_for_action('waste/garden_modify', [ property.id ]) %]">
+    <input type="hidden" name="token" value="[% csrf_token %]">
+    <input type="submit" value="Change the number of [% unit.service_name FILTER lower %] containers" class="waste-service-descriptor waste-service-link">
+  </form>
+[% END %]
+
+[% IF unit.garden_waste %]
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Subscription</dt>
+        <dd class="govuk-summary-list__value">
+          [% IF unit.garden_container == 28 %]
+            £[% tprintf('%.2f', unit.garden_cost) %] per year
+          [% ELSE %]
+            £[% tprintf('%.2f', unit.garden_cost) %] per year ([% unit.garden_bins %] [% nget('bin', 'bins', unit.garden_bins) %])
+          [% END %]
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Renewal</dt>
+        <dd class="govuk-summary-list__value
+        [%~ ' renewal-status' IF current_payment_method != 'direct_debit' AND unit.garden_due AND NOT waste_features.garden_renew_disabled ~%]
+        ">[% date.format(unit.end_date _ ' 00:00:00', '%d %B %Y') %]
+            [%~ ' Cancellation in progress' IF pending_cancellation %]
+            [%~ ', soon due for renewal.' IF unit.garden_due AND NOT waste_features.garden_renew_disabled ~%]
+        </dd>
+      </div>
+    </dl>
+
+  [% IF ( unit.garden_due && current_payment_method != 'direct_debit' ) %]
+      [% IF current_payment_method == 'direct_debit' %]
+        <p>This property may have an existing direct debit subscription which will renew automatically, please check before renewing.</p>
+      [% END %]
+    [% IF NOT waste_features.garden_renew_disabled %]
+      <form method="post" action="[% c.uri_for_action('waste/garden_renew', [ property.id ]) %]">
+        <input type="hidden" name="token" value="[% csrf_token %]">
+        <input type="submit" value="Renew your [% unit.service_name FILTER lower %] subscription" class="waste-service-descriptor waste-service-link">
+      </form>
+    [% END %]
+  [% END %]
+
+  [% IF NOT pending_cancellation %]
+      [% IF NOT unit.garden_due AND NOT waste_features.garden_modify_disabled AND (c.cobrand.moniker == 'kingston' OR unit.garden_container != 28) %]
+          <form method="post" action="[% c.uri_for_action('waste/garden_modify', [ property.id ]) %]">
+            <input type="hidden" name="token" value="[% csrf_token %]">
+        [% IF c.cobrand.moniker == 'kingston' AND (slwp_garden_sacks AND unit.garden_container == 28) %]
+            <input type="submit" value="Order more garden sacks" class="waste-service-descriptor waste-service-link">
+        [% ELSE %]
+            <input type="submit" value="Modify your [% unit.service_name FILTER lower %] subscription" class="waste-service-descriptor waste-service-link">
+        [% END %]
+          </form>
+      [% END %]
+      [% IF c.cobrand.call_hook('waste_garden_allow_cancellation') == 'staff' AND is_staff %]
+          <form method="post" action="[% c.uri_for_action('waste/garden_cancel', [ property.id ]) %]">
+            <input type="hidden" name="token" value="[% csrf_token %]">
+            <input type="submit" value="Cancel your [% unit.service_name FILTER lower %] subscription" class="waste-service-descriptor waste-service-link">
+          </form>
+      [% END %]
+  [% END %]
+[% END %]


### PR DESCRIPTION
Request for Sutton only change to remove the link for ordering a new bin from each bin and have reworded link in the sidebar

https://mysocietysupport.freshdesk.com/a/tickets/3540

[skip changelog]