### PR TITLE
[Bromley] [Waste] No refunds for unpaid bulky bookings.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -1031,8 +1031,14 @@ sub bulky_location_text_prompt {
 
 sub bulky_minimum_charge { $_[0]->wasteworks_config->{per_item_min_collection_price} }
 
+sub bulky_booking_paid {
+    my ($self, $collection) = @_;
+    return $collection->get_extra_metadata('payment_reference');
+}
+
 sub bulky_can_refund_collection {
     my ($self, $collection) = @_;
+    return 0 if !$self->bulky_booking_paid($collection);
     return 0 if !$self->within_bulky_cancel_window($collection);
     return $self->bulky_refund_amount($collection) > 0;
 }
@@ -1047,7 +1053,7 @@ sub bulky_send_cancellation_confirmation {
             ],
 
             wasteworks_id => $collection_report->id,
-            payment_reference => $collection_report->get_extra_metadata('payment_reference'),
+            paid => $self->bulky_booking_paid($collection_report),
             refund_amount => $self->bulky_refund_amount($collection_report),
             collection_date => $self->bulky_nice_collection_date($collection_report),
         },

--- a/t/app/controller/waste_bromley_bulky.t
+++ b/t/app/controller/waste_bromley_bulky.t
@@ -456,6 +456,14 @@ FixMyStreet::override_config {
             $mech->clear_emails_ok();
 
             subtest 'Refund info' => sub {
+                # Let's just check if no payment yet made
+                $report->unset_extra_metadata('payment_reference');
+                $report->update;
+                $mech->get_ok('/waste/12345/bulky/cancel/' . $report->id);
+                $mech->content_lacks('If you cancel you will be refunded £30.00');
+                $report->set_extra_metadata(payment_reference => 12345);
+                $report->update;
+
                 $mech->get_ok('/waste/12345/bulky/cancel/' . $report->id);
                 $mech->content_contains('If you cancel you will be refunded £30.00');
 

--- a/templates/email/bromley/waste/bulky-confirm-cancellation.txt
+++ b/templates/email/bromley/waste/bulky-confirm-cancellation.txt
@@ -3,7 +3,7 @@ Subject: Cancelled bulky goods collection [% wasteworks_id %]
 
 Bulky goods collection [% wasteworks_id %] scheduled for [%collection_date %] has been cancelled.
 
-[% IF refund_amount > 0 && payment_reference %]
+[% IF refund_amount > 0 && paid %]
 £[% pounds(refund_amount / 100) %] will be refunded.
 [% END %]
 


### PR DESCRIPTION
[skip changelog] Stops a refund email being sent when a user cancels a booking that hasn't actually been paid for.