### PR TITLE
Always fetch staff role info in pre-made CSVs.

### DIFF
--- a/.cypress/cypress/integration/brent.js
+++ b/.cypress/cypress/integration/brent.js
@@ -15,6 +15,7 @@ describe('Queen’s Park', function() {
         cy.route('/report/new/ajax*').as('report-ajax');
         cy.route('**/mapserver/brent*queens_park*', 'fixture:brent-queens_park.xml').as('queens_park');
         cy.visit('/report/new?longitude=-0.211045&latitude=51.534948');
+        cy.wait('@report-ajax');
         cy.pickCategory('Dog fouling');
         cy.wait('@queens_park');
         cy.contains('maintained by the City of London').should('be.visible');

--- a/.cypress/cypress/integration/duplicates.js
+++ b/.cypress/cypress/integration/duplicates.js
@@ -1,21 +1,4 @@
 describe('Duplicate tests', function() {
-    it('does not try and fetch duplicates which will not get shown', function() {
-      cy.server();
-      cy.route('/report/new/ajax*').as('report-ajax');
-      cy.request({
-        method: 'POST',
-        url: '/auth?r=/',
-        form: true,
-        body: { username: 'admin@example.org', password_sign_in: 'password' }
-      });
-      cy.visit('http://fixmystreet.localhost:3001/report/1');
-      cy.contains('Report another problem here').click();
-      cy.wait('@report-ajax');
-      cy.pickCategory('Potholes');
-      cy.nextPageReporting();
-      cy.get('div.dropzone').should('be.visible');
-    });
-
     it('has a separate duplicate suggestions step when needed', function() {
       cy.server();
       cy.route('/report/new/ajax*').as('report-ajax');

--- a/t/cobrand/oxfordshire.t
+++ b/t/cobrand/oxfordshire.t
@@ -4,6 +4,7 @@ use CGI::Simple;
 use File::Temp 'tempdir';
 use FixMyStreet::TestMech;
 use FixMyStreet::Script::Alerts;
+use FixMyStreet::Script::CSVExport;
 use FixMyStreet::Script::Reports;
 use Open311;
 my $mech = FixMyStreet::TestMech->new;
@@ -300,6 +301,17 @@ FixMyStreet::override_config {
         is $rows[2]->[21], '', 'Report without HIAMS ref has empty ref field';
         is $rows[2]->[22], '20202020', 'USRN included in row if present';
         is $rows[3]->[21], '123098123', 'Older Exor report has correct ref';
+    };
+
+    subtest 'role filter works okay pre-generated' => sub {
+        $problems[1]->set_extra_metadata(contributed_by => $counciluser->id);
+        $problems[1]->update;
+        $problems[2]->set_extra_metadata(contributed_by => $counciluser->id);
+        $problems[2]->update;
+        FixMyStreet::Script::CSVExport::process(dbh => FixMyStreet::DB->schema->storage->dbh);
+        $mech->get_ok('/dashboard?export=1&role=' . $role->id);
+        my @rows = $mech->content_as_csv;
+        is scalar @rows, 3, '1 (header) + 2 (reports) = 3 lines';
     };
 
     $oxon->update({


### PR DESCRIPTION
This is needed for the front-end role filtering to work.
[skip changelog]