### PR TITLE
Make WasteWorks PWA name configurable in the admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
         - Text overrides for new report fields can be configured to apply when it is known the report will go to a particular cobrand. #4466, #4516
         - Improve handling cache expiry for front page statistics.
         - Add geolocation button to centre map at user's location. #4671
+        - WasteWorks PWA can now have a separate name from the FixMyStreet PWA.
     - Bugfixes:
         - Stop map panning breaking after long press. #4423
         - Fix RSS feed subscription from alert page button.

--- a/bin/update-schema
+++ b/bin/update-schema
@@ -223,6 +223,7 @@ else {
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
     return 'EMPTY' if ! table_exists('problem');
+    return '0087' if column_exists('manifest_theme', 'wasteworks_name');
     return '0086' if constraint_contains('problem_send_state_check', 'processing');
     return '0085' if column_exists('problem', 'send_state');
     return '0084' if column_type_equals('problem', 'extra', 'jsonb');

--- a/db/downgrade_0087---0086.sql
+++ b/db/downgrade_0087---0086.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE manifest_theme DROP COLUMN wasteworks_name;
+ALTER TABLE manifest_theme DROP COLUMN wasteworks_short_name;
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -614,5 +614,7 @@ CREATE TABLE manifest_theme (
     short_name text not null,
     background_colour text,
     theme_colour text,
-    images text ARRAY
+    images text ARRAY,
+    wasteworks_name text,
+    wasteworks_short_name text
 );

--- a/db/schema_0087-add-wasteworks-name-to-manifest-theme.sql
+++ b/db/schema_0087-add-wasteworks-name-to-manifest-theme.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE manifest_theme ADD wasteworks_name text;
+ALTER TABLE manifest_theme ADD wasteworks_short_name text;
+
+COMMIT;

--- a/perllib/FixMyStreet/App/Controller/Offline.pm
+++ b/perllib/FixMyStreet/App/Controller/Offline.pm
@@ -60,19 +60,24 @@ sub send_manifest: Private {
 
     $c->res->content_type('application/manifest+json');
 
-    my $start_url;
+    my $theme = $c->stash->{manifest_theme};
+
+    my $start_url = '/?pwa';
+    my $name = $theme->{name};
+    my $short_name = $theme->{short_name};
+
     if ($app eq 'ww') {
-       $start_url = '/waste?pwa';
-    } else {
-       $start_url = '/?pwa';
+        $start_url = '/waste?pwa';
+        $name = $theme->{wasteworks_name} if $theme->{wasteworks_name};
+        $short_name = $theme->{wasteworks_short_name} if $theme->{wasteworks_short_name};
     }
 
     my $data = {
-        name => $c->stash->{manifest_theme}->{name},
-        short_name => $c->stash->{manifest_theme}->{short_name},
-        background_color => $c->stash->{manifest_theme}->{background_colour},
-        theme_color => $c->stash->{manifest_theme}->{theme_colour},
-        icons => $c->stash->{manifest_theme}->{icons},
+        name => $name,
+        short_name => $short_name,
+        background_color => $theme->{background_colour},
+        theme_color => $theme->{theme_colour},
+        icons => $theme->{icons},
         lang => $c->stash->{lang_code},
         display => "minimal-ui",
         start_url => $start_url,
@@ -214,6 +219,8 @@ sub _find_manifest_theme : Private {
             theme_colour => $theme->theme_colour,
             name => $theme->name,
             short_name => $theme->short_name,
+            wasteworks_name => $theme->wasteworks_name,
+            wasteworks_short_name => $theme->wasteworks_short_name,
         };
 
         unless ($ignore_cache_and_defaults) {

--- a/perllib/FixMyStreet/App/Form/ManifestTheme.pm
+++ b/perllib/FixMyStreet/App/Form/ManifestTheme.pm
@@ -16,8 +16,10 @@ has '+widget_name_space' => ( default => sub { ['FixMyStreet::App::Form::Widget'
 has '+widget_tags' => ( default => sub { { wrapper_tag => 'p' } } );
 has '+item_class' => ( default => 'ManifestTheme' );
 has_field 'cobrand' => ( type => 'Select', empty_select => 'Select a cobrand', required => 1 );
-has_field 'name' => ( required => 1 );
-has_field 'short_name' => ( required => 1 );
+has_field 'name' => ( required => 1, label => 'FixMyStreet name' );
+has_field 'short_name' => ( required => 1, label => 'FixMyStreet short name' );
+has_field 'wasteworks_name' => ( required => 0, default => '' );
+has_field 'wasteworks_short_name' => ( required => 0, default => '' );
 has_field 'background_colour' => ( required => 0 );
 has_field 'theme_colour' => ( required => 0 );
 has_field 'icon' => ( required => 0, type => 'Upload', label => "Add icon" );

--- a/perllib/FixMyStreet/DB/Result/ManifestTheme.pm
+++ b/perllib/FixMyStreet/DB/Result/ManifestTheme.pm
@@ -35,13 +35,17 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 1 },
   "images",
   { data_type => "text[]", is_nullable => 1 },
+  "wasteworks_name",
+  { data_type => "text", is_nullable => 1 },
+  "wasteworks_short_name",
+  { data_type => "text", is_nullable => 1 },
 );
 __PACKAGE__->set_primary_key("id");
 __PACKAGE__->add_unique_constraint("manifest_theme_cobrand_key", ["cobrand"]);
 
 
-# Created by DBIx::Class::Schema::Loader v0.07035 @ 2020-10-14 22:49:08
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:el5l7426UkZ6ww/QFp1J+w
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2023-11-20 12:04:42
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:bT9i4HHYfqs/4fo23OdZJg
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/t/app/controller/admin/manifesttheme.t
+++ b/t/app/controller/admin/manifesttheme.t
@@ -58,6 +58,8 @@ subtest "cobrand admin lets you create a new theme" => sub {
     my $fields = {
         name => "Lincolnshire FixMyStreet",
         short_name => "Lincs FMS",
+        wasteworks_name => "Lincolnshire WasteWorks",
+        wasteworks_short_name => "Lincs WW",
     };
     $mech->submit_form_ok( { with_fields => $fields } );
     is $mech->uri->path, '/admin/manifesttheme/lincolnshire', "redirected to edit page";
@@ -66,6 +68,8 @@ subtest "cobrand admin lets you create a new theme" => sub {
     my $theme = FixMyStreet::DB->resultset('ManifestTheme')->find({ cobrand => 'lincolnshire' });
     is $theme->name, "Lincolnshire FixMyStreet";
     is $theme->short_name, "Lincs FMS";
+    is $theme->wasteworks_name, "Lincolnshire WasteWorks";
+    is $theme->wasteworks_short_name, "Lincs WW";
     is $theme->background_colour, undef;
 
     my $log = $superuser->admin_logs->search({}, { order_by => { -desc => 'id' } })->first;
@@ -81,12 +85,16 @@ subtest "cobrand admin lets you update an existing theme" => sub {
     my $fields = {
         background_colour => "#663399",
         theme_colour => "rgb(102, 51, 153)",
+        wasteworks_name => "Lincolnshire Waste",
+        wasteworks_short_name => "Lincs Waste",
     };
     $mech->submit_form_ok( { with_fields => $fields } );
 
     my $theme = FixMyStreet::DB->resultset('ManifestTheme')->find({ cobrand => 'lincolnshire' });
     is $theme->background_colour, "#663399";
     is $theme->theme_colour, "rgb(102, 51, 153)";
+    is $theme->wasteworks_name, "Lincolnshire Waste";
+    is $theme->wasteworks_short_name, "Lincs Waste";
 
     my $log = $superuser->admin_logs->search({}, { order_by => { -desc => 'id' } })->first;
     is $log->object_id, $theme->id;

--- a/templates/web/base/admin/manifesttheme/form.html
+++ b/templates/web/base/admin/manifesttheme/form.html
@@ -2,14 +2,24 @@
 
 <form method="post" enctype="multipart/form-data">
     <div class="admin-hint">
-      <p>[% loc("The <strong>name</strong> is a string that represents the name of the web application as it is usually displayed to the user (e.g., amongst a list of other applications, or as a label for an icon).") %]</p>
+      <p>[% loc("The <strong>FixMyStreet name</strong> is a string that represents the name of the web application as it is usually displayed to the user (e.g., amongst a list of other applications, or as a label for an icon).") %]</p>
     </div>
     [% form.field('name').render | safe %]
 
     <div class="admin-hint">
-      <p>[% loc("The <strong>short name</strong> is a string that represents the name of the web application displayed to the user if there is not enough space to display name (e.g., as a label for an icon on the phone home screen).") %]</p>
+      <p>[% loc("The <strong>FixMyStreet short name</strong> is a string that represents the name of the web application displayed to the user if there is not enough space to display name (e.g., as a label for an icon on the phone home screen).") %]</p>
     </div>
     [% form.field('short_name').render | safe %]
+
+    <div class="admin-hint">
+      <p>[% loc("The <strong>WasteWorks name</strong> is a string that represents the name of the web application as it is usually displayed to the user (e.g., amongst a list of other applications, or as a label for an icon).") %]</p>
+    </div>
+    [% form.field('wasteworks_name').render | safe %]
+
+    <div class="admin-hint">
+      <p>[% loc("The <strong>WasteWorks short name</strong> is a string that represents the name of the web application displayed to the user if there is not enough space to display name (e.g., as a label for an icon on the phone home screen).") %]</p>
+    </div>
+    [% form.field('wasteworks_short_name').render | safe %]
 
     <div class="admin-hint">
       <p>[% loc("The <strong>theme colour</strong> defines the default theme colour for the application. This sometimes affects how the OS displays the site (e.g., on Android's task switcher, the theme colour surrounds the site). Colours should be specified with CSS syntax, e.g. <strong><code>#ff00ff</code></strong> or <strong><code>rgb(255, 0, 255)</code></strong> or a named colour like <strong><code>fuchsia</code></strong>.") %]</p>

--- a/templates/web/base/admin/manifesttheme/index.html
+++ b/templates/web/base/admin/manifesttheme/index.html
@@ -4,8 +4,10 @@
   <thead>
   <tr>
       <th>  [% loc('Cobrand') %] </th>
-      <th>  [% loc('Name') %] </th>
-      <th>  [% loc('Short Name') %] </th>
+      <th>  [% loc('FixMyStreet Name') %] </th>
+      <th>  [% loc('FixMyStreet Short Name') %] </th>
+      <th>  [% loc('WasteWorks Name') %] </th>
+      <th>  [% loc('WasteWorks Short Name') %] </th>
       <th>  [% loc('Background Colour') %] </th>
       <th>  [% loc('Theme Colour') %] </th>
       <th>  &nbsp; </th>
@@ -17,6 +19,8 @@
         <td>[% theme.cobrand %]</td>
         <td>[% theme.name %]</td>
         <td>[% theme.short_name %]</td>
+        <td>[% theme.wasteworks_name %]</td>
+        <td>[% theme.wasteworks_short_name %]</td>
         <td>[% theme.background_colour %]</td>
         <td>[% theme.theme_colour %]</td>
         <td> <a href="[% c.uri_for(c.controller.action_for('edit'), [theme.cobrand]) %]" class="btn">[% loc('Edit') %]</a> </td>
@@ -30,6 +34,6 @@
 <p>
     <a href="[% c.uri_for(c.controller.action_for('create')) %]">[% loc('Create') %]</a>
   </p>
-  
+
 
 [% INCLUDE 'admin/footer.html' %]


### PR DESCRIPTION
This adds `wasteworks_name` and `wasteworks_short_name` fields to the manifest theme admin area, then uses those values when the PWA is installed for a WasteWorks site.

Fixes https://github.com/mysociety/societyworks/issues/3864


https://github.com/mysociety/fixmystreet/assets/22996/93f2cf0f-2ef8-4f6a-967f-3c8e98e9121d

