### PR TITLE
[Brent] Allow reporting of missed small items if overdue

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1600,7 +1600,9 @@ sub bulky_open_overdue {
 
 sub _bulky_collection_overdue {
     my $collection_due_date = $_[1]->{date};
+    $collection_due_date->set_hour('00')->set_minute('00')->set_second('00')->set_nanosecond('00');
     my $today = DateTime->now->set_time_zone(FixMyStreet->local_time_zone);
+    $today->set_hour('00')->set_minute('00')->set_second('00')->set_nanosecond('00');
     my $duration = $today-$collection_due_date;
     return $duration->is_positive;
 }

--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1600,9 +1600,9 @@ sub bulky_open_overdue {
 
 sub _bulky_collection_overdue {
     my $collection_due_date = $_[1]->{date};
-    $collection_due_date->set_hour('00')->set_minute('00')->set_second('00')->set_nanosecond('00');
+    $collection_due_date->truncate(to => 'day');
     my $today = DateTime->now->set_time_zone(FixMyStreet->local_time_zone);
-    $today->set_hour('00')->set_minute('00')->set_second('00')->set_nanosecond('00');
+    $today->truncate(to => 'day');
     my $duration = $today-$collection_due_date;
     return $duration->is_positive;
 }

--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1590,4 +1590,19 @@ sub waste_reconstruct_bulky_data {
     return $saved_data;
 }
 
+sub bulky_open_overdue {
+    my ($self, $event) = @_;
+
+    if ($event->{state} eq 'open' && $self->_bulky_collection_overdue($event)) {
+        return 1;
+    }
+}
+
+sub _bulky_collection_overdue {
+    my $collection_due_date = $_[1]->{date};
+    my $today = DateTime->now->set_time_zone(FixMyStreet->local_time_zone);
+    my $duration = $today-$collection_due_date;
+    return $duration->is_positive;
+}
+
 1;

--- a/perllib/FixMyStreet/Roles/CobrandEcho.pm
+++ b/perllib/FixMyStreet/Roles/CobrandEcho.pm
@@ -65,11 +65,11 @@ sub ordinal {
 }
 
 sub construct_bin_date {
-    my $str = shift;
-    return unless $str;
-    my $offset = ($str->{OffsetMinutes} || 0) * 60;
+    my $hash_ref = shift;
+    return unless $hash_ref && $hash_ref->{DateTime};
+    my $offset = ($hash_ref->{OffsetMinutes} || 0) * 60;
     my $zone = DateTime::TimeZone->offset_as_string($offset);
-    my $date = DateTime::Format::W3CDTF->parse_datetime($str->{DateTime});
+    my $date = DateTime::Format::W3CDTF->parse_datetime($hash_ref->{DateTime});
     $date->set_time_zone($zone);
     return $date;
 }

--- a/perllib/FixMyStreet/Roles/CobrandEcho.pm
+++ b/perllib/FixMyStreet/Roles/CobrandEcho.pm
@@ -145,7 +145,7 @@ sub _parse_events {
                 my $report = $self->problems->search({ external_id => $_->{Guid} })->first;
                 $events->{enquiry}->{$event_type} = {
                     report => $report,
-                    date => construct_bin_date($_->{DueDate}),
+                    date => construct_bin_date({ DateTime => $report->get_extra_field_value('Collection_Date')}),
                     resolution => $_->{ResolutionCodeId},
                     state => 'open',
                 };

--- a/t/app/controller/waste_brent_small_items.t
+++ b/t/app/controller/waste_brent_small_items.t
@@ -454,7 +454,7 @@ FixMyStreet::override_config {
     };
 
     subtest 'Missed collections' => sub {
-        # Fixed date still set to 5th July
+        # Fixed date still set to 25th June
         $mech->get_ok('/waste/12345');
         $mech->content_lacks('Report a small items collection as missed');
         $mech->get_ok('/waste/12345/report');
@@ -513,7 +513,34 @@ FixMyStreet::override_config {
         $mech->content_contains('A small items collection has been reported as missed');
         $mech->get_ok('/waste/12345/report');
         $mech->content_lacks('Small items collection');
-        $echo->mock( 'GetEventsForObject', sub { [] } );
+        $report->external_id('GUID');
+        $report->update;
+        $echo->mock( 'GetEventsForObject', sub { [ {
+            DueDate => {
+                DateTime => '2023-06-24T20:00:00Z',
+                OffsetMinutes => '0',
+            },
+            EventTypeId => 2964,
+            ResolvedDate => '',
+            ResolutionCodeId => '',
+            EventStateId => 18489,
+            Guid => 'GUID',
+        } ] } );
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('Report a small items collection as missed', 'Open collection can be reported as collection overdue');
+        $echo->mock( 'GetEventsForObject', sub { [ {
+            DueDate => {
+                DateTime => '2023-06-25T20:00:00Z',
+                OffsetMinutes => '0',
+            },
+            EventTypeId => 2964,
+            ResolvedDate => '',
+            ResolutionCodeId => '',
+            EventStateId => 18489,
+            Guid => 'GUID',
+        } ] } );
+        $mech->get_ok('/waste/12345');
+        $mech->content_lacks('Report a small items collection as missed', 'Open collection can not be reported as collection still due');
     };
 };
 


### PR DESCRIPTION
Allow open small items events through and check if they are overdue. If they are allow them to be reported as missed.

https://mysocietysupport.freshdesk.com/a/tickets/3500

[skip changelog]
