### PR TITLE
[Brent] Workaround OIDC login not working on first attempt

### DIFF
--- a/templates/web/brent/errors/generic.html
+++ b/templates/web/brent/errors/generic.html
@@ -1,0 +1,42 @@
+[% IF message == 'invalid id_token';
+    title = 'MyAccount login';
+ELSE;
+    DEFAULT title = 'Error';
+END %]
+[% INCLUDE 'header.html', bodyclass = 'fullwidthpage', title = title %]
+
+[% IF csrf_token ~%]
+<input type="hidden" name="token" value="[% csrf_token %]">
+[% END ~%]
+
+[% IF message == 'invalid id_token' %]
+    [%
+    # Very occasionally the user will run into this error when logging in, either because
+    # the redirects from B2C aren't working correctly, or the user's browser doesn't have
+    # a cookie set, or their session doesn't have the relevant oauth values stored.
+    # The exact cause is currently unknown and hard to pin down due to the transient
+    # nature of the bug.
+    # Because the login invariably works the next time the user tries, this workaround
+    # just presents the OIDC login button again (labelled as a 'continue' button...) and
+    # will thus allow them to login successfully. In theory.
+    %]
+    <div>
+        <h1>My Account login</h1>
+        <form action="/auth" method="post" name="general_auth" class="validate">
+            <input type="hidden" name="r" value="[% c.req.params.r | html %]">
+            <div class="form-box">
+                <button name="social_sign_in" id="oidc_sign_in" value="oidc" class="btn btn--block btn--social btn--oidc">
+                    Click here to continue...
+                </button>
+                </div>
+        </form>
+    </div>
+[% ELSE %]
+    <div class="confirmation-header confirmation-header--failure">
+        <h1>[% title %]</h1>
+        <p>[% message | safe %]</p>
+    </div>
+[% END %]
+
+[% INCLUDE 'footer.html' %]
+


### PR DESCRIPTION
Very occasionally the user will run into an "invalid id_token" error when logging in via Brent Azure B2C OIDC, either because the redirects from B2C aren't working correctly, or the user's browser doesn't have a cookie set, or their session doesn't have the relevant oauth values stored. The exact cause is currently unknown and hard to pin down due to the transient nature of the bug.

Because the login invariably works the next time the user tries, this workaround just presents the OIDC login button again (labelled as a 'continue' button...) and will thus allow them to login successfully. In theory.

(Brent have tested this on the staging site and it seems to solve the problem for them.)

[skip changelog]

For FD-3395.