### PR TITLE
[Northumberland] Assign user to report based on updates from Alloy

### DIFF
--- a/bin/fetch
+++ b/bin/fetch
@@ -22,6 +22,11 @@ use Getopt::Long::Descriptive;
 use Open311::GetServiceRequests;
 use Open311::GetServiceRequestUpdates;
 
+use CronFns;
+
+my $site = CronFns::site(FixMyStreet->config('BASE_URL'));
+CronFns::language($site);
+
 my ($opts, $usage) = describe_options(
     '%c %o',
     ['reports', 'fetch reports'],

--- a/perllib/Open311/UpdatesBase.pm
+++ b/perllib/Open311/UpdatesBase.pm
@@ -188,6 +188,36 @@ sub _process_update {
         $request->{comment_time} = $p->whensent + DateTime::Duration->new( seconds => 1 );
     }
 
+    # Assign admin user to report if 'assigned_user_*' fields supplied
+    if ( $request->{extras} && $request->{extras}{assigned_user_email} ) {
+        my $assigned_user_email = $request->{extras}{assigned_user_email};
+        my $assigned_user_name  = $request->{extras}{assigned_user_name};
+
+        my $assigned_user
+            = FixMyStreet::DB->resultset('User')
+            ->find( { email => $assigned_user_email } );
+
+        unless ($assigned_user) {
+            $assigned_user = FixMyStreet::DB->resultset('User')->create(
+                {   email          => $assigned_user_email,
+                    name           => $assigned_user_name,
+                    from_body      => $body->id,
+                    email_verified => 1,
+                },
+            );
+
+            # Make them an inspector
+            # TODO Other permissions required?
+            $assigned_user->user_body_permissions->create(
+                {   body_id         => $body->id,
+                    permission_type => 'report_inspect',
+                }
+            );
+        }
+
+        $assigned_user->add_to_planned_reports($p);
+    }
+
     my $comment = $self->schema->resultset('Comment')->new(
         {
             problem => $p,


### PR DESCRIPTION
Strictly speaking this code is cobrand-agnostic; the Northumberland-specific code is handled in open311-adapter.

For https://github.com/mysociety/societyworks/issues/3978.

[skip changelog]
