### PR TITLE
[Shropshire] Add relevant messaging to the no_asset_message

### DIFF
--- a/web/cobrands/fixmystreet-uk-councils/assets.js
+++ b/web/cobrands/fixmystreet-uk-councils/assets.js
@@ -1380,6 +1380,10 @@ fixmystreet.assets.shropshire.streetlight_stylemap = new OpenLayers.StyleMap({
 
 fixmystreet.assets.shropshire.streetlight_found = function(asset) {
     var controller_fn = shropshire_light(asset) ? 'asset_found' : 'asset_not_found';
+    if (asset.attributes.OWNER) {
+        this.fixmystreet.no_asset_msg_id = '#sl-owner-' + asset.attributes.OWNER.replace(/[^a-zA-Z0-9]/g, '');
+        this.fixmystreet.no_asset_message = fixmystreet.assets.shropshire.streetlight_asset_message(asset);
+    }
     fixmystreet.message_controller[controller_fn].call(this);
     fixmystreet.assets.named_select_action_found.call(this, asset);
 };


### PR DESCRIPTION
As locking the page from progressing is done using the standard no asset process, update the no_asset_message attribute to contain the same informative messaging as at the continue button.

Also solves issues of informative messaging not appearing on the subcategory screen if you get to subcategory and then choose a parish light which would mean there was no explanation on the page as to why you were blocked from going forward.

Calling "fixmystreet.assets.shropshire.streetlight_asset_message" for the text did not always update so repeated the logic of creating the message. 

https://github.com/mysociety/societyworks/issues/3996

https://github.com/mysociety/societyworks/issues/4014

[skip changelog]