### PR TITLE
[Brent] Reports should only show on map for 3 months

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -381,6 +381,13 @@ sub oidc_config {
     return $cfg;
 }
 
+=head2 Only show reports on map for last 3 months
+
+Brent only show 3 months of report history on the map rather than default 6 months
+
+=cut
+
+sub report_age { '3 months' }
 
 =head2 dashboard_export_problems_add_columns
 


### PR DESCRIPTION
Reduce time for reports to be shown on map from default 6 months down to 3 months

https://mysocietysupport.freshdesk.com/a/tickets/3554

[skip changelog]