### PR TITLE
[Echo] Try and fetch new expired slots on sending; Convert all images to JPEGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
         - Mark non-Open311 updates as processed by daemon. #4552
     - Changes:
         - Switch to OpenStreetMap for reverse geocoding. #4444
+        - Convert all uploaded images to JPEGs.
 
 * v5.0 (10th May 2023)
     - Front end improvements:

--- a/bin/fixmystreet.com/waste-echo-reservation-update
+++ b/bin/fixmystreet.com/waste-echo-reservation-update
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+#
+# Fallback manual script to be used if a report needs resending to Echo but
+# contains an expired task reservation, to fetch new data if possible
+
+use v5.14;
+use warnings;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use FixMyStreet::Cobrand;
+use FixMyStreet::DB;
+
+my $id = shift @ARGV or die "Provide a report ID";
+my $p = FixMyStreet::DB->resultset("Problem")->find($id) or die "Could not find ID $id";
+my $cobrand = $p->get_cobrand_logged;
+$cobrand->bulky_refetch_slots($p, 1);

--- a/perllib/FixMyStreet/App/Model/PhotoSet.pm
+++ b/perllib/FixMyStreet/App/Model/PhotoSet.pm
@@ -155,11 +155,8 @@ has ids => ( #  Arrayref of $fileid tuples (always, so post upload/raw data proc
                     return ();
                 }
 
-                my %params;
-                # Brent has a quite-small file size limit, make sure we convert to JPEGs
-                if ($self->c->cobrand->moniker eq 'brent') {
-                    $params{magick} = 'JPEG';
-                }
+                # Convert all images to JPEGs
+                my %params = ( magick => 'JPEG' );
 
                 # we have an image we can use - save it to storage
                 $photo_blob = try {

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -318,6 +318,9 @@ sub open311_post_send {
             $row2->state('duplicate');
             $row2->update;
             $row->discard_changes;
+        } elsif ($error =~ /Selected reservations expired/) {
+            $self->bulky_refetch_slots($row2);
+            $row->discard_changes;
         }
     });
 }

--- a/perllib/FixMyStreet/Roles/CobrandSLWP.pm
+++ b/perllib/FixMyStreet/Roles/CobrandSLWP.pm
@@ -103,6 +103,9 @@ sub open311_post_send {
             $row2->state('duplicate');
             $row2->update;
             $row->discard_changes;
+        } elsif ($error =~ /Selected reservations expired/) {
+            $self->bulky_refetch_slots($row2);
+            $row->discard_changes;
         } elsif ($error =~ /Duplicate Event! Original eventID: (\d+)/) {
             my $id = $1;
             my $cfg = $self->feature('echo');


### PR DESCRIPTION
Hopefully resolving two reasons we get stuck/problem reports:
1. Some backends have a maximum filesize for images. This has only ever been hit by PNGs people occasionally upload. Rather than limit this to those backends or PNGs, easier to convert all uploaded images to JPEGs.
2. If a report to Echo fails due to expired slots for some reason (we do check at report creation but if there's another issue sending (e.g. issue 1 above) this could happen), try and fetch new ones immediately for next retry rather than await manual interaction.