### PR TITLE
[Oxfordshire] Include 'in progress' in available states.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -110,6 +110,7 @@ sub state_groups_inspect {
     [
         [ 'New', [ 'confirmed', 'investigating' ] ],
         [ 'Scheduled', [ 'action scheduled' ] ],
+        [ 'Pending', [ 'in progress' ] ],
         [ 'Fixed', [ 'fixed - council' ] ],
         [ 'Closed', [ 'not responsible', 'duplicate', 'unable to fix' ] ],
     ]


### PR DESCRIPTION
[skip changelog]

https://github.com/mysociety/societyworks/issues/4054

Make the 'in progress' state available when editing a response template for Oxfordshire, to allow setting up an auto-response for 'Job raised' alloy updates.

The 'in progress' state was initially dropped to simplify the states list: https://github.com/mysociety/fixmystreetforcouncils/issues/129. 

This approach also makes the state available in:
* Dashboard filtering.
* Reports filtering.
* Staff report state editing.
* Updating a report.

Which seems like a good idea with the state now in use for reports via Alloy.