### PR TITLE
[Brent] Green Garden Waste calendar to show in winter

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1119,7 +1119,7 @@ sub bin_services_for_address {
         push @task_refs, $schedules->{last}{ref} if $schedules->{last};
 
         # Check calendar allocation
-        if (($_->{ServiceId} == 262 || $_->{ServiceId} == 317 || $_->{ServiceId} == 807) && $schedules->{description} =~ /every other/ && $schedules->{next}{schedule}) {
+        if (($_->{ServiceId} == 262 || $_->{ServiceId} == 317 || $_->{ServiceId} == 807) && ($schedules->{description} =~ /every other/ || $schedules->{description} =~ /every \d+(th|st|nd|rd) week/) && $schedules->{next}{schedule}) {
             my $allocation = $schedules->{next}{schedule}{Allocation};
             my $day = lc $allocation->{RoundName};
             $day =~ s/\s+//g;

--- a/t/cobrand/brent.t
+++ b/t/cobrand/brent.t
@@ -1283,6 +1283,47 @@ FixMyStreet::override_config {
         is $report->get_extra_field_value('Container_Request_Quantity'), '1';
         is $report->get_extra_field_value('service_id'), '269';
     };
+    $echo->mock('GetServiceUnitsForObject' => sub {
+    return [
+        {
+            Id => 1004,
+            ServiceId => 317,
+            ServiceName => 'Garden waste collection',
+            ServiceTasks => { ServiceTask => {
+                Id => 405,
+                TaskTypeId => 1689,
+                Data => { ExtensibleDatum => [ {
+                    DatatypeName => 'BRT - Paid Collection Container Quantity',
+                    Value => 1,
+                }, {
+                    DatatypeName => 'BRT - Paid Collection Container Type',
+                    Value => 1,
+                } ] },
+                ServiceTaskSchedules => { ServiceTaskSchedule => [ {
+                    ScheduleDescription => 'Monday every 4th week',
+                    Allocation => {
+                        RoundName => 'Monday ',
+                        RoundGroupName => 'Delta 04 Week 2',
+                    },
+                    StartDate => { DateTime => '2020-03-30T00:00:00Z' },
+                    EndDate => { DateTime => '2050-01-01T00:00:00Z' },
+                    NextInstance => {
+                        CurrentScheduledDate => { DateTime => '2020-06-01T00:00:00Z' },
+                        OriginalScheduledDate => { DateTime => '2020-06-01T00:00:00Z' },
+                    },
+                    LastInstance => {
+                        OriginalScheduledDate => { DateTime => '2020-05-18T00:00:00Z' },
+                        CurrentScheduledDate => { DateTime => '2020-05-18T00:00:00Z' },
+                        Ref => { Value => { anyType => [ 567, 890 ] } },
+                    },
+                } ] },
+            } }
+        }, ]
+    });
+    subtest 'test variation in ScheduleDescription in winter months' => sub {
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('https://example.org/media/16420712/mondayweek2', 'showing green garden waste PDF calendar');
+    }
 };
 
 subtest 'Dashboard CSV extra columns' => sub {


### PR DESCRIPTION
We check ScheduleDescription before making the link to the ggw calendar.
In the winter the format of this changes to give a more accurate representation of the collection for customer view, but looks like the rest of the details remain the same and so the logic still works for picking the calendar

https://mysocietysupport.freshdesk.com/a/tickets/3692

[skip changelog]