### PR TITLE
[Sutton] Remove ‘Request a larger/smaller refuse container’ from sidebar for staff

### DIFF
--- a/templates/web/sutton/waste/_more_services_sidebar.html
+++ b/templates/web/sutton/waste/_more_services_sidebar.html
@@ -12,7 +12,7 @@
     [% IF any_request_allowed %]
       <li><a href="[% c.uri_for_action('waste/request', [ property.id ]) %]">Request a replacement bin, box or caddy</a></li>
     [% END %]
-    [% IF services.2238 %]
+    [% IF services.2238 AND NOT c.user.from_body %]
      [% IF c.config.STAGING_SITE %]
       <li><a href="https://sutton-self.test.achieveservice.com/service/Refuse_container_maintenance_in_Sutton?uprn=[% property.uprn %]">Request a larger/smaller refuse container</a></li>
      [% ELSE %]


### PR DESCRIPTION
For FD-3686

[skip changelog]