### PR TITLE
[Brent] Increase Green Garden Waste renewal window

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1509,7 +1509,7 @@ sub waste_munge_request_form_data {
 
 =item * Cheque payments are not an option
 
-=item * Renewals can happen within 28 days
+=item * Renewals can happen within 90 days so they are available from beginning of Jan
 
 =cut
 
@@ -1524,7 +1524,7 @@ sub garden_service_name { 'Garden waste collection service' }
 sub garden_service_id { GARDEN_WASTE_SERVICE_ID }
 sub garden_current_subscription { shift->{c}->stash->{services}{+GARDEN_WASTE_SERVICE_ID} }
 sub get_current_garden_bins { shift->garden_current_subscription->{garden_bins} }
-sub garden_due_days { 28 }
+sub garden_due_days { 90 }
 
 sub garden_current_service_from_service_units {
     my ($self, $services) = @_;

--- a/t/app/controller/waste_brent_garden.t
+++ b/t/app/controller/waste_brent_garden.t
@@ -617,7 +617,7 @@ FixMyStreet::override_config {
     ) {
         subtest 'check modifying Green Garden Waste as staff' => sub {
             $mech->log_in_ok($staff_user->email);
-            set_fixed_time('2021-01-09T17:00:00Z'); # Before renewal is due so we can modify
+            set_fixed_time('2020-12-09T17:00:00Z'); # Before renewal is due so we can modify
             $echo->mock('GetServiceUnitsForObject', \&garden_waste_two_bins);
             $mech->get_ok('/waste/12345');
             $mech->content_contains('Modify your garden waste subscription');


### PR DESCRIPTION
Change Brent's ggw renewal from 28 days to 90 days so users can renew from the beginning of the year.

https://mysocietysupport.freshdesk.com/a/tickets/3693

[skip changelog]