### PR TITLE
Support different /around map display times for open/closed/fixed reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
         - WasteWorks PWA can now have a separate name from the FixMyStreet PWA.
         - Users can now opt out of questionnaires.
         - Include reference in report list emails. #4760
+        - Add support for different '/around' map display times for open/closed/fixed reports
     - Bugfixes:
         - Stop map panning breaking after long press. #4423
         - Fix RSS feed subscription from alert page button.

--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -463,17 +463,10 @@ sub lookup_by_ref : Private {
 
     my $params = {};
     my $rs = $c->cobrand->problems;
+
     $rs->non_public_if_possible($params, $c);
-    if ($params->{"-or"}) {
-        $params = {
-            -and => [
-                -or => $criteria,
-                -or => $params->{"-or"},
-            ]
-        };
-    } else {
-        $params->{"-or"} = $criteria;
-    }
+    push @{ $params->{-and} }, { -or => $criteria };
+
     my $problems = $rs->search($params);
 
     my $count = try {

--- a/perllib/FixMyStreet/Cobrand/Northumberland.pm
+++ b/perllib/FixMyStreet/Cobrand/Northumberland.pm
@@ -34,6 +34,13 @@ sub abuse_reports_only { 1 }
 
 sub cut_off_date { '2023-05-03' }
 
+sub report_age {
+    return {
+        closed => '14 days',
+        fixed  => '14 days',
+    };
+}
+
 sub reopening_disallowed {
     my ($self, $problem) = @_;
 

--- a/t/app/model/problem.t
+++ b/t/app/model/problem.t
@@ -1,3 +1,4 @@
+use Catalyst::Test 'FixMyStreet::App';
 use FixMyStreet::TestMech;
 use FixMyStreet;
 use FixMyStreet::DB;
@@ -913,6 +914,257 @@ subtest 'return how many days ago a problem was reported' => sub {
     } );
 
     is $problem->days_ago('lastupdate'), 4, 'days_ago allows other dates to be specified';
+};
+
+subtest 'around_map' => sub {
+    # Delete all previous reports
+    my @reports = $problem_rs->all;
+    for my $r (@reports) {
+        $r->comments->delete;
+        $r->questionnaires->delete;
+        $r->delete;
+    }
+
+    my $around_map_body = FixMyStreet::DB->resultset('Body')
+        ->create( { name => 'Around Map Council' } );
+
+    # Set some problems
+    my @problem_params = (
+        {   title => 'open_less_month',
+            state => 'confirmed',
+            dt    => DateTime->now->subtract( days => 14 ),
+        },
+        {   title => 'open_more_month',
+            state => 'confirmed',
+            dt    => DateTime->now->subtract( months => 2 ),
+        },
+
+        {   title => 'closed_less_week',
+            state => 'not responsible',
+            dt    => DateTime->now->subtract( days => 6 ),
+        },
+        {   title => 'closed_more_week',
+            state => 'not responsible',
+            dt    => DateTime->now->subtract( weeks => 2 ),
+        },
+
+        {   title => 'fixed_less_day',
+            state => 'fixed - council',
+            dt    => DateTime->now->subtract( hours => 23 ),
+        },
+        {   title => 'fixed_more_day',
+            state => 'fixed - council',
+            dt    => DateTime->now->subtract( days => 2 ),
+        },
+
+        {   title      => 'open_less_month_non_public',
+            state      => 'confirmed',
+            non_public => 1,
+            dt         => DateTime->now->subtract( days => 14 ),
+        },
+        {   title      => 'open_more_month_non_public',
+            state      => 'confirmed',
+            non_public => 1,
+            dt         => DateTime->now->subtract( months => 2 ),
+        },
+    );
+    for (@problem_params) {
+        $mech->create_problems_for_body( 1, $around_map_body->id,
+            $_->{title}, $_ );
+    }
+
+    # Defaults
+    my %search_params = (
+        # These cover the default lat & lon in
+        # TestMech->create_problems_for_body()
+        min_lat => 51,
+        max_lat => 52,
+        min_lon => -1,
+        max_lon => 0,
+    );
+    my $c = ctx_request('/');
+    $c->stash->{report_age_field} = 'confirmed';
+
+    subtest 'scalar report_age' => sub {
+        my $got = $problem_rs->around_map(
+            $c,
+            %search_params,
+            report_age => '1 weeks',
+        );
+
+        my @got_titles = sort map { $_->title } $got->all;
+        my @expected_titles = sort qw/
+            closed_less_week
+            fixed_less_day
+            fixed_more_day
+            /;
+        is_deeply \@got_titles, \@expected_titles;
+    };
+
+    subtest 'explicit report_ages for open, closed, and fixed' => sub {
+        my $got = $problem_rs->around_map(
+            $c,
+            %search_params,
+            report_age => {
+                open   => '1 months',
+                closed => '1 weeks',
+                fixed  => '1 days',
+            },
+        );
+
+        my @got_titles = sort map { $_->title } $got->all;
+        my @expected_titles = sort qw/
+            open_less_month
+            closed_less_week
+            fixed_less_day
+            /;
+        is_deeply \@got_titles, \@expected_titles;
+    };
+
+    subtest 'explicit report_age for open only' => sub {
+        my $got = $problem_rs->around_map(
+            $c,
+            %search_params,
+            report_age => {
+                open   => '1 months',
+            },
+        );
+
+        # NB Default report_age is 6 months
+        my @got_titles = sort map { $_->title } $got->all;
+        my @expected_titles = sort qw/
+            open_less_month
+            closed_less_week
+            closed_more_week
+            fixed_less_day
+            fixed_more_day
+            /;
+        is_deeply \@got_titles, \@expected_titles;
+    };
+
+    subtest 'states param passed in' => sub {
+        subtest 'with scalar report_age' => sub {
+            my $got = $problem_rs->around_map(
+                $c,
+                %search_params,
+                report_age => '1 weeks',
+                states     => { 'not responsible' => 1 },
+            );
+
+            my @got_titles = sort map { $_->title } $got->all;
+            my @expected_titles = sort qw/
+                closed_less_week
+                /;
+            is_deeply \@got_titles, \@expected_titles;
+        };
+
+        subtest 'with hashref report_age' => sub {
+            my $got = $problem_rs->around_map(
+                $c,
+                %search_params,
+                report_age => { open              => '1 months', },
+                states     => { 'not responsible' => 1 },
+            );
+
+            my @got_titles = sort map { $_->title } $got->all;
+            my @expected_titles = sort qw/
+                closed_less_week
+                closed_more_week
+                /;
+            is_deeply \@got_titles, \@expected_titles;
+        };
+    };
+
+    subtest 'hashref report_age interacting with non_public_if_possible' => sub {
+        # Set a report_inspect user on $c
+        my $report_inspect_user = $mech->log_in_ok( 'report_inspect@example.com' );
+        $report_inspect_user->update({ from_body => $around_map_body });
+        $report_inspect_user->user_body_permissions->find_or_create({
+            body => $around_map_body,
+            permission_type => 'report_inspect',
+        });
+        $c->user($report_inspect_user);
+
+
+        subtest 'only_non_public = 1' => sub {
+            $c->stash->{only_non_public} = 1;
+
+            subtest 'without report_age' => sub {
+                my $got = $problem_rs->around_map(
+                    $c,
+                    %search_params,
+                );
+
+                my @got_titles = sort map { $_->title } $got->all;
+                my @expected_titles = sort qw/
+                    open_less_month_non_public
+                    open_more_month_non_public
+                    /;
+                is_deeply \@got_titles, \@expected_titles;
+            };
+
+            subtest 'with report_age' => sub {
+                my $got = $problem_rs->around_map(
+                    $c,
+                    %search_params,
+                    report_age => {
+                        open => '1 months',
+                    },
+                );
+
+                my @got_titles = sort map { $_->title } $got->all;
+                my @expected_titles = sort qw/
+                    open_less_month_non_public
+                    /;
+                is_deeply \@got_titles, \@expected_titles;
+            };
+        };
+
+        subtest 'only_non_public = 0' => sub {
+            $c->stash->{only_non_public} = 0;
+
+            subtest 'without report_age' => sub {
+                my $got = $problem_rs->around_map(
+                    $c,
+                    %search_params,
+                );
+
+                my @got_titles = sort map { $_->title } $got->all;
+                my @expected_titles = sort qw/
+                    open_less_month_non_public
+                    open_more_month_non_public
+                    open_less_month
+                    open_more_month
+                    closed_less_week
+                    closed_more_week
+                    fixed_less_day
+                    fixed_more_day
+                    /;
+                is_deeply \@got_titles, \@expected_titles;
+            };
+
+            subtest 'with report_age' => sub {
+                my $got = $problem_rs->around_map(
+                    $c,
+                    %search_params,
+                    report_age => {
+                        open => '1 months',
+                    },
+                );
+
+                my @got_titles = sort map { $_->title } $got->all;
+                my @expected_titles = sort qw/
+                    open_less_month_non_public
+                    open_less_month
+                    closed_less_week
+                    closed_more_week
+                    fixed_less_day
+                    fixed_more_day
+                    /;
+                is_deeply \@got_titles, \@expected_titles;
+            };
+        };
+    };
 };
 
 END {


### PR DESCRIPTION
Closes https://github.com/mysociety/societyworks/issues/3965.

Cobrands may now have a report_age() that is a hashref of upper-level states (open, closed, fixed) mapped to time intervals.
If a state is not specified, it will default to 6 months (as specified in FixMyStreet/Cobrand/Default.pm).
