### PR TITLE
[Brent] Added Powered by SW footer

### DIFF
--- a/templates/web/brent/footer_extra.html
+++ b/templates/web/brent/footer_extra.html
@@ -98,3 +98,16 @@
     </div>
   </footer>
 </div>
+
+<div class="societyworks-footer">
+  <div class="container">
+      <p>
+          Powered by
+        [% IF bodyclass.match('waste') OR (problem AND problem.cobrand_data == 'waste') %]
+          <a class="societyworks-footer__logo" href="https://www.societyworks.org/services/waste/">SocietyWorks</a>
+        [% ELSE %]
+          <a class="societyworks-footer__logo societyworks-footer__logo--fms-pro" href="https://www.societyworks.org/services/highways/">FixMyStreet Pro</a>
+        [% END %]
+      </p>
+  </div>
+</div>

--- a/web/cobrands/brent/base.scss
+++ b/web/cobrands/brent/base.scss
@@ -371,7 +371,6 @@ dl dt {
     padding-top: 30px;
     padding-bottom: 30px;
     @extend .container;
-    max-width: 1140px;
 
     .footer__column {
       flex-basis: 100%;
@@ -605,3 +604,5 @@ background-color: transparent;
         }
     }
 }
+
+@import "../fixmystreet-uk-councils/societyworks-footer";


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4041

Also deleted max-width rule for .footer__content so the aligment between the SW and Brent logo match.

<img width="1849" alt="Screenshot 2024-01-15 at 08 36 45" src="https://github.com/mysociety/fixmystreet/assets/13790153/0aa1cfa1-24ab-4a05-a424-c45a093e562e">
<img width="339" alt="Screenshot 2024-01-15 at 08 37 18" src="https://github.com/mysociety/fixmystreet/assets/13790153/d9e12e1c-b794-4981-9f7d-55a34480f4d5">

[Skip changelog]
