### PR TITLE
Don't cache waste things in session

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -166,7 +166,7 @@ requires 'Algorithm::Diff';
 # Modules used by CSS & watcher
 requires 'CSS::Sass';
 requires 'File::ChangeNotify', '0.31';
-requires 'Path::Tiny', '0.104';
+requires 'Path::Tiny', '0.144';
 requires 'File::Find::Rule';
 
 # Modules used for development

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -6418,19 +6418,21 @@ DISTRIBUTIONS
       overload 0
       strict 0
       warnings 0
-  Path-Tiny-0.104
-    pathname: D/DA/DAGOLDEN/Path-Tiny-0.104.tar.gz
+  Path-Tiny-0.144
+    pathname: D/DA/DAGOLDEN/Path-Tiny-0.144.tar.gz
     provides:
-      Path::Tiny 0.104
-      Path::Tiny::Error 0.104
+      Path::Tiny 0.144
+      Path::Tiny::Error 0.144
     requirements:
       Carp 0
       Cwd 0
       Digest 1.03
       Digest::SHA 5.45
+      Encode 0
       Exporter 5.57
       ExtUtils::MakeMaker 6.17
       Fcntl 0
+      File::Compare 0
       File::Copy 0
       File::Glob 0
       File::Path 2.07
@@ -6438,11 +6440,11 @@ DISTRIBUTIONS
       File::Temp 0.19
       File::stat 0
       constant 0
-      if 0
       overload 0
       perl 5.008001
       strict 0
       warnings 0
+      warnings::register 0
   PerlIO-utf8_strict-0.007
     pathname: L/LE/LEONT/PerlIO-utf8_strict-0.007.tar.gz
     provides:

--- a/perllib/FixMyStreet/App/Controller/Contact/Enquiry.pm
+++ b/perllib/FixMyStreet/App/Controller/Contact/Enquiry.pm
@@ -81,7 +81,7 @@ sub handle_uploads : Private {
     my $cfg = FixMyStreet->config('PHOTO_STORAGE_OPTIONS');
     my $dir = $cfg ? $cfg->{UPLOAD_DIR} : FixMyStreet->config('UPLOAD_DIR');
     $dir = path($dir, "enquiry_files")->absolute(FixMyStreet->path_to());
-    $dir->mkpath;
+    $dir->mkdir;
 
     my $files = $c->session->{enquiry_files} || {};
     foreach ($c->req->upload) {

--- a/perllib/FixMyStreet/App/Controller/Form.pm
+++ b/perllib/FixMyStreet/App/Controller/Form.pm
@@ -10,7 +10,16 @@ sub auto : Private {
     my ( $self, $c ) = @_;
     my $cobrand_check = $c->cobrand->feature( $self->feature );
     $c->detach( '/page_error_404_not_found' ) if !$cobrand_check;
-    $c->session->{form_unique_id} ||= mySociety::AuthToken::random_token();
+    my $form_unique_id = $c->request->cookie('form_unique_id');
+    if ($form_unique_id) {
+        $c->stash->{form_unique_id} = $form_unique_id->value;
+    } else {
+        $c->stash->{form_unique_id} = mySociety::AuthToken::random_token();
+        $c->response->cookies->{form_unique_id} = {
+            value => $c->stash->{form_unique_id},
+            expires => time() + 86400,
+        };
+    }
     return 1;
 }
 
@@ -41,7 +50,7 @@ sub load_form {
         previous_form => $previous_form,
         saved_data_encoded => $c->get_param('saved_data'),
         no_preload => 1,
-        unique_id_session => $c->session->{form_unique_id},
+        unique_id_session => $c->stash->{form_unique_id},
         unique_id_form => $c->get_param('unique_id'),
     );
 

--- a/perllib/FixMyStreet/App/Controller/Photo.pm
+++ b/perllib/FixMyStreet/App/Controller/Photo.pm
@@ -40,7 +40,7 @@ sub during :LocalRegex('^(temp|fulltemp)\.([0-9a-f]{40}\.(?:jpeg|png|gif|tiff))$
     my $photo = $photoset->get_image_data(size => $size, default => $c->cobrand->default_photo_resize);
 
     if (!FixMyStreet->config('LOGIN_REQUIRED')) {
-        path(FixMyStreet->path_to('web', 'photo'))->mkpath;
+        path(FixMyStreet->path_to('web', 'photo'))->mkdir;
         my $out = FixMyStreet->path_to('web', $c->req->path);
         path($out)->spew_raw($photo->{data});
     }

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -255,6 +255,9 @@ sub pay_complete : Path('pay_complete') : Args(2) {
     $c->forward('check_payment_redirect_id', [ $id, $token ]);
     my $p = $c->stash->{report};
 
+    # Make sure form unique ID cookie is removed
+    $c->response->cookies->{form_unique_id} = { value => '', expires => 0 };
+
     my $ref = $c->cobrand->garden_cc_check_payment_status($c, $p);
 
     if ( $ref ) {

--- a/perllib/FixMyStreet/App/Form/Claims.pm
+++ b/perllib/FixMyStreet/App/Form/Claims.pm
@@ -1149,13 +1149,12 @@ sub file_upload {
     if ( $receipts ) {
         my $cfg = FixMyStreet->config('PHOTO_STORAGE_OPTIONS');
         my $dir = $cfg ? $cfg->{UPLOAD_DIR} : FixMyStreet->config('UPLOAD_DIR');
-        $dir = path($dir, "claims_files")->absolute(FixMyStreet->path_to());
-        $dir->mkpath;
+        $dir = path($dir, "claims_files")->absolute(FixMyStreet->path_to())->mkdir;
 
         FixMyStreet::PhotoStorage::base64_decode_upload($c, $receipts);
         my ($p, $n, $ext) = fileparse($receipts->filename, qr/\.[^.]*/);
         my $key = sha1_hex($receipts->slurp) . $ext;
-        my $out = path($dir, $key);
+        my $out = $dir->child($key);
         unless (copy($receipts->tempname, $out)) {
             $c->log->info('Couldn\'t copy temp file to destination: ' . $!);
             $c->stash->{photo_error} = _("Sorry, we couldn't save your file(s), please try again.");

--- a/perllib/FixMyStreet/App/Form/ManifestTheme.pm
+++ b/perllib/FixMyStreet/App/Form/ManifestTheme.pm
@@ -46,12 +46,11 @@ sub validate {
         }
 
         my $uri = '/theme/' . $cobrand;
-        my $theme_path = path(FixMyStreet->path_to('web' . $uri));
-        $theme_path->mkpath;
+        my $theme_path = path(FixMyStreet->path_to('web' . $uri))->mkdir;
         FixMyStreet::PhotoStorage::base64_decode_upload(undef, $upload);
         my ($p, $n, $ext) = fileparse($upload->filename, qr/\.[^.]*/);
         my $key = sha1_hex($upload->slurp) . $ext;
-        my $out = path($theme_path, $key);
+        my $out = $theme_path->child($key);
         unless (copy($upload->tempname, $out)) {
             $self->field('icon')->add_error( _("Sorry, we couldn't save your file(s), please try again.") );
             return;

--- a/perllib/FixMyStreet/App/Form/Wizard.pm
+++ b/perllib/FixMyStreet/App/Form/Wizard.pm
@@ -141,7 +141,8 @@ after 'validate_form' => sub {
                 $self->add_form_error('Something went wrong, please try again')
                     unless $self->has_form_errors;
             } else {
-                delete $self->c->session->{form_unique_id};
+                # Delete cookie
+                $self->c->response->cookies->{form_unique_id} = { value => '', expires => 0 };
             }
         }
     }

--- a/perllib/FixMyStreet/App/Model/PhotoSet.pm
+++ b/perllib/FixMyStreet/App/Model/PhotoSet.pm
@@ -306,7 +306,7 @@ sub cache {
     return if FixMyStreet->config('LOGIN_REQUIRED') || !$self->cacheable;
 
     my ($out, $type) = $self->_construct_path($num, $size) or return;
-    path(FixMyStreet->path_to('web', 'photo', 'c'))->mkpath;
+    path(FixMyStreet->path_to('web', 'photo', 'c'))->mkdir;
     $out->spew_raw($photo);
 }
 

--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1148,7 +1148,7 @@ sub bin_services_for_address {
 
     my $cfg = $self->feature('echo');
     my $echo = Integrations::Echo->new(%$cfg);
-    my $calls = $echo->call_api($self->{c}, 'brent', 'bin_services_for_address:' . $property->{id}, 1, @to_fetch);
+    my $calls = $echo->call_api($self->{c}, 'brent', $property->{id}, 'bin_services_for_address', 1, @to_fetch);
 
     $property->{show_bulky_waste} = $self->bulky_allowed_property($property);
 

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -635,7 +635,7 @@ sub bin_services_for_address {
 
     my $cfg = $self->feature('echo');
     my $echo = Integrations::Echo->new(%$cfg);
-    my $calls = $echo->call_api($self->{c}, 'bromley', 'bin_services_for_address:' . $property->{id}, 1, @to_fetch);
+    my $calls = $echo->call_api($self->{c}, 'bromley', $property->{id}, 'bin_services_for_address', 1, @to_fetch);
 
     my @out;
     my %task_ref_to_row;

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -22,7 +22,9 @@ use DateTime;
 use File::Path;
 use Integrations::Bartec;
 use List::Util qw(any);
+use Path::Tiny;
 use Sort::Key::Natural qw(natkeysort_inplace);
+use Storable qw(freeze thaw);
 use FixMyStreet::WorkingDays;
 use FixMyStreet::App::Form::Waste::Request::Peterborough;
 use Utils;
@@ -473,25 +475,31 @@ Functions specific to the waste product & Bartec integration.
 
 =cut
 
+sub _premises_for_postcode_cache_file {
+    my ($self, $pc) = @_;
+    my $key = "premises_for_postcode-$pc";
+    my $outdir = path(FixMyStreet->config('WASTEWORKS_BACKEND_TMP_DIR'));
+    $outdir = $outdir->child($self->moniker);
+    my $tmp = $outdir->mkdir->child($key);
+    return $tmp;
+}
+
 sub _premises_for_postcode {
     my $self = shift;
     my $pc = shift;
     my $c = $self->{c};
+    my $cfg = $self->feature('bartec');
+    my $bartec = Integrations::Bartec->new(%$cfg);
 
-    my $key = "peterborough:bartec:premises_for_postcode:$pc";
+    my $tmp = $self->_premises_for_postcode_cache_file($pc);
 
-    unless ( $c->session->{$key} ) {
-        my $cfg = $self->feature('bartec');
-        my $bartec = Integrations::Bartec->new(%$cfg);
+    my $data;
+    if ($tmp->exists && time - $tmp->stat->mtime < $bartec->api_cache_for) {
+        $data = thaw($tmp->slurp_raw);
+    }
+    unless ($data) {
         my $response = $bartec->Premises_Get($pc);
-
-        if (!$c->user_exists || !($c->user->from_body || $c->user->is_superuser)) {
-            my $blocked = $cfg->{blocked_uprns} || [];
-            my %blocked = map { $_ => 1 } @$blocked;
-            @$response = grep { !$blocked{$_->{UPRN}} } @$response;
-        }
-
-        $c->session->{$key} = [ map { {
+        $data = [ map { {
             id => $pc . ":" . $_->{UPRN},
             uprn => $_->{UPRN},
             usrn => $_->{USRN},
@@ -499,15 +507,23 @@ sub _premises_for_postcode {
             latitude => $_->{Location}->{Metric}->{Latitude},
             longitude => $_->{Location}->{Metric}->{Longitude},
         } } @$response ];
+        $tmp->spew_raw(freeze($data));
     }
 
-    return $c->session->{$key};
+    if (!$c->user_exists || !($c->user->from_body || $c->user->is_superuser)) {
+        my $blocked = $cfg->{blocked_uprns} || [];
+        my %blocked = map { $_ => 1 } @$blocked;
+        @$data = grep { !$blocked{$_->{uprn}} } @$data;
+    }
+
+    return $data;
 }
 
 sub clear_cached_lookups_postcode {
     my ($self, $pc) = @_;
-    my $key = "peterborough:bartec:premises_for_postcode:$pc";
-    delete $self->{c}->session->{$key};
+
+    my $tmp = $self->_premises_for_postcode_cache_file($pc);
+    unlink $tmp;
 }
 
 sub clear_cached_lookups_property {

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -19,6 +19,7 @@ use utf8;
 use strict;
 use warnings;
 use DateTime;
+use File::Path;
 use Integrations::Bartec;
 use List::Util qw(any);
 use Sort::Key::Natural qw(natkeysort_inplace);
@@ -515,9 +516,9 @@ sub clear_cached_lookups_property {
     # might be prefixed with postcode if it's come straight from the URL
     $uprn =~ s/^.+\://g;
 
-    foreach ( qw/look_up_property bin_services_for_address/ ) {
-        delete $self->{c}->session->{"peterborough:bartec:$_:$uprn"};
-    }
+    my $outdir = FixMyStreet->config('WASTEWORKS_BACKEND_TMP_DIR');
+    $outdir .= "/" . $self->moniker . "/$uprn";
+    File::Path::remove_tree($outdir, { safe => 1, error => \my $error });
 
     $self->clear_cached_lookups_bulky_slots($uprn);
 }
@@ -672,7 +673,7 @@ sub bin_services_for_address {
     # of going to the /bulky page.
     my $async = $self->{c}->action eq 'waste/bin_days' && $self->{c}->req->method eq 'GET';
 
-    my $results = $bartec->call_api($self->{c}, 'peterborough', 'bin_services_for_address:' . $uprn, $async, @calls);
+    my $results = $bartec->call_api($self->{c}, 'peterborough', $uprn, 'bin_services_for_address', $async, @calls);
 
     my $jobs = $results->{"Jobs_Get $uprn"};
     my $schedules = $results->{"Features_Schedules_Get $uprn"};

--- a/perllib/FixMyStreet/Geocode.pm
+++ b/perllib/FixMyStreet/Geocode.pm
@@ -105,7 +105,7 @@ sub cache {
         # uncoverable branch false
         $js = decode_utf8($js) if !utf8::is_utf8($js);
         if ($js && (!$re || $js !~ $re) && !FixMyStreet->config('STAGING_SITE')) {
-            $cache_dir->mkpath; # uncoverable statement
+            $cache_dir->mkdir; # uncoverable statement
             # uncoverable statement
             $cache_file->spew_utf8($js);
         }

--- a/perllib/FixMyStreet/Geocode/Zurich.pm
+++ b/perllib/FixMyStreet/Geocode/Zurich.pm
@@ -111,7 +111,7 @@ sub string {
             return { error => 'The geocoder appears to be down.' };
         }
         $result = $result->result;
-        $cache_dir->mkpath;
+        $cache_dir->mkdir;
         store $result, $cache_file if $result && !FixMyStreet->config('STAGING_SITE');
     }
 

--- a/perllib/FixMyStreet/PhotoStorage/FileSystem.pm
+++ b/perllib/FixMyStreet/PhotoStorage/FileSystem.pm
@@ -25,7 +25,7 @@ Creates UPLOAD_DIR and checks it's writeable.
 sub init {
     my $self = shift;
     my $cache_dir = $self->upload_dir;
-    $cache_dir->mkpath;
+    $cache_dir->mkdir;
     unless ( -d $cache_dir && -w $cache_dir ) {
         warn "\x1b[31mCan't find/write to photo cache directory '$cache_dir'\x1b[0m\n";
         return;

--- a/perllib/FixMyStreet/Reporting.pm
+++ b/perllib/FixMyStreet/Reporting.pm
@@ -359,9 +359,7 @@ sub cache_dir {
     my $dir = $cfg ? $cfg->{UPLOAD_DIR} : FixMyStreet->config('UPLOAD_DIR');
     $dir = path($dir, "dashboard_csv")->absolute(FixMyStreet->path_to());
     my $subdir = $self->user ? $self->user->id : 0;
-    $dir = $dir->child($subdir);
-    $dir->mkpath;
-    $dir;
+    $dir = $dir->child($subdir)->mkdir;
 }
 
 sub kick_off_process {
@@ -424,9 +422,7 @@ has premade_dir => ( is => 'ro', default => sub {
     my $self = shift;
     my $cfg = FixMyStreet->config('PHOTO_STORAGE_OPTIONS');
     my $dir = $cfg ? $cfg->{UPLOAD_DIR} : FixMyStreet->config('UPLOAD_DIR');
-    $dir = path($dir, "csv-export")->absolute(FixMyStreet->path_to());
-    $dir->mkpath;
-    $dir;
+    $dir = path($dir, "csv-export")->absolute(FixMyStreet->path_to())->mkdir;
 });
 
 sub premade_csv_filename {

--- a/perllib/FixMyStreet/Roles/CobrandEcho.pm
+++ b/perllib/FixMyStreet/Roles/CobrandEcho.pm
@@ -4,6 +4,7 @@ use v5.14;
 use warnings;
 use DateTime;
 use DateTime::Format::Strptime;
+use File::Path;
 use Moo::Role;
 use Sort::Key::Natural qw(natkeysort_inplace);
 use FixMyStreet::DateRange;
@@ -40,7 +41,7 @@ sub look_up_property {
     my $cfg = $self->feature('echo');
     my $echo = Integrations::Echo->new(%$cfg);
     my $calls = $echo->call_api($self->{c}, $self->moniker,
-        "look_up_property:$id",
+        $id, "look_up_property",
         1,
         GetPointAddress => [ $id ],
         GetServiceUnitsForObject => [ $id ],
@@ -582,9 +583,11 @@ sub clear_cached_lookups_property {
     # Need to call this before clearing GUID
     $self->clear_cached_lookups_bulky_slots( $id, $skip_echo );
 
+    my $outdir = FixMyStreet->config('WASTEWORKS_BACKEND_TMP_DIR');
+    $outdir .= "/" . $self->moniker . "/$id";
+    File::Path::remove_tree($outdir, { safe => 1, error => \my $error });
+
     foreach my $key (
-        $self->council_url . ":echo:look_up_property:$id",
-        $self->council_url . ":echo:bin_services_for_address:$id",
         $self->council_url . ":echo:bulky_event_guid:$id",
     ) {
         delete $self->{c}->session->{$key};

--- a/perllib/FixMyStreet/Roles/CobrandEcho.pm
+++ b/perllib/FixMyStreet/Roles/CobrandEcho.pm
@@ -730,11 +730,11 @@ sub find_available_bulky_slots {
     my $slots = $echo->ReserveAvailableSlotsForEvent($service_id, $event_type_id, $property->{id}, $guid, $window->{date_from}, $window->{date_to});
     $self->{c}->session->{first_date_returned} = undef;
     foreach (@$slots) {
-        my $date = construct_bin_date($_->{StartDate});
+        my $date = construct_bin_date($_->{StartDate})->datetime;
         push @available_slots, {
             date => $date,
             reference => $_->{Reference},
-            expiry => construct_bin_date($_->{Expiry}),
+            expiry => construct_bin_date($_->{Expiry})->datetime,
         };
         $self->{c}->session->{first_date_returned} //= $date;
     }

--- a/perllib/FixMyStreet/Roles/CobrandSLWP.pm
+++ b/perllib/FixMyStreet/Roles/CobrandSLWP.pm
@@ -473,7 +473,7 @@ sub bin_services_for_address {
 
     my $cfg = $self->feature('echo');
     my $echo = Integrations::Echo->new(%$cfg);
-    my $calls = $echo->call_api($self->{c}, $self->council_url, 'bin_services_for_address:' . $property->{id}, 1, @to_fetch);
+    my $calls = $echo->call_api($self->{c}, $self->council_url, $property->{id}, 'bin_services_for_address', 1, @to_fetch);
 
     $property->{show_bulky_waste} = $self->bulky_allowed_property($property);
 

--- a/perllib/FixMyStreet/Roles/CobrandSLWP.pm
+++ b/perllib/FixMyStreet/Roles/CobrandSLWP.pm
@@ -1253,6 +1253,7 @@ sub waste_munge_bulky_data {
     $data->{extra_Exact_Location} = $data->{location};
 
     my $first_date = $self->{c}->session->{first_date_returned};
+    $first_date = DateTime::Format::W3CDTF->parse_datetime($first_date);
     my $dt = DateTime::Format::W3CDTF->parse_datetime($date);
     $data->{'extra_First_Date_Returned_to_Customer'} = $first_date->strftime("%d/%m/%Y");
     $data->{'extra_Customer_Selected_Date_Beyond_SLA?'} = $dt > $first_date ? 1 : 0;

--- a/perllib/FixMyStreet/Roles/ParallelAPI.pm
+++ b/perllib/FixMyStreet/Roles/ParallelAPI.pm
@@ -17,15 +17,24 @@ package FixMyStreet::Roles::ParallelAPI;
 use Moo::Role;
 use JSON::MaybeXS;
 use Parallel::ForkManager;
+use Path::Tiny;
 use Storable qw(retrieve_fd retrieve);
 use Time::HiRes;
-use Digest::MD5 qw(md5_hex);
 use Try::Tiny;
 use Fcntl qw(:flock);
 
+=head2 api_cache_for
+
+Set to the amount of time a cached file on disc will
+be used to serve a matching API request.
+
+=cut
+
+has api_cache_for => ( is => 'ro', default => 3600 );
+
 =head2 call_api
 
-  call_api($c, "bromley", "look_up_property:123", 0,
+  call_api($c, "bromley", 123, "look_up_property", 0,
     GetPointAddress => [ 123 ],
     GetServiceUnitsForObject => [ 123 ],
   )
@@ -43,17 +52,17 @@ have a please loading message and auto-reload).
 
 sub call_api {
     # Shifting because the remainder of @_ is passed along further down
-    my ($self, $c, $cobrand, $key, $background) = (shift, shift, shift, shift, shift);
+    my ($self, $c, $cobrand, $property_id, $key, $background) = (shift, shift, shift, shift, shift, shift);
 
     my $type = $self->backend_type;
-    $key = "$cobrand:$type:$key";
-    return $c->session->{$key} if !FixMyStreet->test_mode && $c->session->{$key};
-
     my $calls = encode_json(\@_);
 
-    my $outdir = FixMyStreet->config('WASTEWORKS_BACKEND_TMP_DIR');
-    mkdir($outdir) unless -d $outdir;
-    my $tmp = $outdir . "/" . md5_hex("$key $calls");
+    my $outdir = path(FixMyStreet->config('WASTEWORKS_BACKEND_TMP_DIR'));
+    foreach ($cobrand, $property_id) {
+        $outdir = $outdir->child($_);
+    }
+
+    my $tmp = $outdir->mkdir->child($key);
 
     my @cmd = (
         FixMyStreet->path_to('bin/fixmystreet.com/call-wasteworks-backend'),
@@ -73,7 +82,7 @@ sub call_api {
     if (FixMyStreet->test_mode || $self->sample_data) {
         $start_call = 0;
         $data = $self->_parallel_api_calls(@_);
-    } elsif (-e $tmp) {
+    } elsif (-e $tmp && time-(stat($tmp))[9] < $self->api_cache_for) {
         $start_call = 0;
         # if output file is already there, we can only open it if it's finished with
         try {
@@ -86,12 +95,11 @@ sub call_api {
             } finally {
                 flock($fd, LOCK_UN);
                 close($fd);
-                unlink $tmp; # don't want to inadvertently cache forever
             };
         };
     }
 
-    # Either the temp file wasn't there, or it had bad data
+    # Either the temp file wasn't there, or it was old or had bad data
     if ($start_call) {
         if ($background) {
             # wrap the $calls value in single quotes
@@ -104,14 +112,12 @@ sub call_api {
             # uncoverable statement
             system(@cmd);
             $data = retrieve($tmp);
-            unlink $tmp; # don't want to inadvertently cache forever
         }
     }
 
     if ($data) {
-        $c->session->{$key} = $data;
         my $time = Time::HiRes::time() - $start;
-        $c->log->info("[$cobrand] call_api $key took $time seconds");
+        $c->log->info("[$cobrand] call_api $property_id $key took $time seconds");
     } elsif ($background) {
         # Bail out here to show loading page
         $c->stash->{template} = 'waste/async_loading.html';

--- a/perllib/FixMyStreet/TestMech.pm
+++ b/perllib/FixMyStreet/TestMech.pm
@@ -152,6 +152,23 @@ sub log_out_ok {
     $mech->not_logged_in_ok;
 }
 
+=head2 waste_submit_check
+
+Calls submit_form_ok, on a clone of itself, and runs a couple of checks.
+To be used when the submission will cause an external redirect which can
+confuse Test::WWW::Mechanize in terms of what hostname it thinks things are
+then on.
+
+=cut
+
+sub waste_submit_check {
+    my $mech = shift;
+    my $mech2 = $mech->clone;
+    $mech2->submit_form_ok(@_);
+    is $mech2->res->previous->code, 302, 'payments issues a redirect';
+    is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+}
+
 =head2 delete_user
 
     $mech->delete_user( $user );

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -229,8 +229,9 @@ FixMyStreet::override_config {
         $mech->content_contains( '<a href="/waste/12345">See your bin collections</a>' );
         $mech->content_lacks('12 A Street, XX1 1SZ');
 
+        # Setting host is not enough, specify the host in the first URL to prod $mech to update immediately
         $mech->host('www.fixmystreet.com');
-        $res = $mech->get('/report/' . $report->id);
+        $res = $mech->get('http://www.fixmystreet.com/report/' . $report->id);
         is $res->code, 404;
         $mech->log_in_ok($user->email);
         $res = $mech->get('/report/' . $report->id);
@@ -238,10 +239,11 @@ FixMyStreet::override_config {
         $mech->log_in_ok($staff_user->email);
         $res = $mech->get('/report/' . $report->id);
         is $res->code, 404;
-        $mech->host('bromley.fixmystreet.com');
     };
     subtest 'Request a new container' => sub {
-        $mech->get_ok('/waste/12345/request');
+        # Setting host is not enough, specify the host in the first URL to prod $mech to update immediately
+        $mech->host('bromley.fixmystreet.com');
+        $mech->get_ok('http://bromley.fixmystreet.com/waste/12345/request');
         $mech->submit_form_ok({ form_number => 1 });
         $mech->content_contains('Please specify what you need');
         $mech->submit_form_ok({ with_fields => { 'container-1' => 1 } });

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -1097,13 +1097,8 @@ FixMyStreet::override_config {
                 name => 'Test McTest',
                 email => 'test@example.net'
         } });
-        # external redirects make Test::WWW::Mechanize unhappy so clone
-        # the mech for the redirect
-        my $mech2 = $mech->clone;
-        $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
-
-        is $mech2->res->previous->code, 302, 'payments issues a redirect';
-        is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+        # external redirects make Test::WWW::Mechanize unhappy so clone the mech for the redirect
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
@@ -1154,13 +1149,8 @@ FixMyStreet::override_config {
         } });
         $mech->content_contains('Test McTest');
         $mech->content_contains('£20.00');
-        # external redirects make Test::WWW::Mechanize unhappy so clone
-        # the mech for the redirect
-        my $mech2 = $mech->clone;
-        $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
 
-        is $mech2->res->previous->code, 302, 'payments issues a redirect';
-        is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
@@ -1203,13 +1193,8 @@ FixMyStreet::override_config {
         } });
         $mech->content_contains('Test McTest');
         $mech->content_contains('£20.00');
-        # external redirects make Test::WWW::Mechanize unhappy so clone
-        # the mech for the redirect
-        my $mech2 = $mech->clone;
-        $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
 
-        is $mech2->res->previous->code, 302, 'payments issues a redirect';
-        is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
@@ -1320,7 +1305,8 @@ FixMyStreet::override_config {
         $mech->content_contains('<span id="cost_per_year">40.00');
         $mech->content_contains('<span id="pro_rata_cost">7.50');
         $mech->submit_form_ok({ with_fields => { current_bins => 1, bins_wanted => 2 } });
-        $mech->submit_form_ok({ with_fields => { tandc => 1 } });
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
+
         is $sent_params->{items}[0]{amount}, 750, 'correct amount used';
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
@@ -1567,11 +1553,7 @@ FixMyStreet::override_config {
             bins_wanted => 1,
             payment_method => 'credit_card',
         } });
-
-        # external redirects make Test::WWW::Mechanize unhappy so clone
-        # the mech for the redirect
-        my $mech2 = $mech->clone;
-        $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
         is $sent_params->{items}[0]{amount}, 2000, 'correct amount used';
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
@@ -1673,11 +1655,7 @@ FixMyStreet::override_config {
             email => 'test@example.net',
         } });
         $mech->content_contains('40.00');
-
-        # external redirects make Test::WWW::Mechanize unhappy so clone
-        # the mech for the redirect
-        my $mech2 = $mech->clone;
-        $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
         is $sent_params->{items}[0]{amount}, 4000, 'correct amount used';
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
@@ -1722,11 +1700,7 @@ FixMyStreet::override_config {
             email => 'test@example.net',
         } });
         $mech->content_contains('20.00');
-
-        # external redirects make Test::WWW::Mechanize unhappy so clone
-        # the mech for the redirect
-        my $mech2 = $mech->clone;
-        $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
         is $sent_params->{items}[0]{amount}, 2000, 'correct amount used';
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
@@ -1774,11 +1748,7 @@ FixMyStreet::override_config {
             email => 'test@example.net',
         } });
         $mech->content_contains('20.00');
-
-        # external redirects make Test::WWW::Mechanize unhappy so clone
-        # the mech for the redirect
-        my $mech2 = $mech->clone;
-        $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
         is $sent_params->{items}[0]{amount}, 2000, 'correct amount used';
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
@@ -1826,7 +1796,8 @@ FixMyStreet::override_config {
             email => 'test@example.net',
         } });
         $mech->content_contains('40.00');
-        $mech->submit_form_ok({ with_fields => { tandc => 1 } });
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
+
         is $sent_params->{items}[0]{amount}, 4000, 'correct amount used';
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
@@ -1903,13 +1874,8 @@ FixMyStreet::override_config {
             } });
             $mech->content_contains('Test McTest');
             $mech->content_contains('£20.00');
-            # external redirects make Test::WWW::Mechanize unhappy so clone
-            # the mech for the redirect
-            my $mech2 = $mech->clone;
-            $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
 
-            is $mech2->res->previous->code, 302, 'payments issues a redirect';
-            is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+            $mech->waste_submit_check({ with_fields => { tandc => 1 } });
 
             my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
@@ -1962,13 +1928,10 @@ FixMyStreet::override_config {
         } });
         $mech->content_contains('Test McTest');
         $mech->content_contains('£20.00');
-        # external redirects make Test::WWW::Mechanize unhappy so clone
-        # the mech for the redirect
-        my $mech2 = $mech->clone;
-        $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
 
-        is $mech2->uri->path, '/waste/12345/garden', 'no redirect occured';
-        $mech2->content_contains('Payment failed: ERROR');
+        $mech->submit_form_ok({ with_fields => { tandc => 1 } });
+        is $mech->uri->path, '/waste/12345/garden', 'no redirect occured';
+        $mech->content_contains('Payment failed: ERROR');
 
         $pay->mock(pay => sub {
             my $self = shift;
@@ -1983,9 +1946,7 @@ FixMyStreet::override_config {
             };
         });
 
-        $mech2->submit_form_ok({ form_number => 1 });
-        is $mech2->res->previous->code, 302, 'payments issues a redirect';
-        is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+        $mech->waste_submit_check({ form_number => 1 });
     };
 
     my $report = FixMyStreet::DB->resultset("Problem")->search({
@@ -2395,11 +2356,7 @@ FixMyStreet::override_config {
         } });
         $mech->content_contains('A New Name');
         $mech->content_contains('20.00');
-
-        # external redirects make Test::WWW::Mechanize unhappy so clone
-        # the mech for the redirect
-        my $mech2 = $mech->clone;
-        $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
         is $sent_params->{items}[0]{amount}, 2000, 'correct amount used';
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
@@ -2472,7 +2429,6 @@ FixMyStreet::override_config {
                 } },
             } ]
         } );
-        $mech->log_out_ok;
         set_fixed_time('2021-05-20T17:00:00Z'); # After sample data collection
         $mech->get_ok('/waste/12345');
         $mech->content_contains('subscription is now overdue');
@@ -2490,7 +2446,8 @@ FixMyStreet::override_config {
 
         } });
         $mech->content_contains('20.00');
-        $mech->submit_form_ok({ with_fields => { tandc => 1 } });
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
+
         is $sent_params->{items}[0]{amount}, 2000, 'correct amount used';
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
@@ -2559,7 +2516,6 @@ FixMyStreet::override_config {
                 } },
             } ]
         } );
-        $mech->log_out_ok;
         set_fixed_time('2021-05-20T17:00:00Z'); # After sample data collection
         $mech->log_in_ok($nameless_user->email);
         $mech->get_ok('/waste/12345/garden_renew');
@@ -2571,7 +2527,8 @@ FixMyStreet::override_config {
             email => 'nameless@example.net',
         } });
         $mech->content_contains('20.00');
-        $mech->submit_form_ok({ with_fields => { tandc => 1 } });
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
+
         is $sent_params->{items}[0]{amount}, 2000, 'correct amount used';
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
@@ -2619,7 +2576,8 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { current_bins => 1, bins_wanted => 2 } });
         $mech->content_contains('40.00');
         $mech->content_contains('7.50');
-        $mech->submit_form_ok({ with_fields => { tandc => 1 } });
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
+
         is $sent_params->{items}[0]{amount}, 750, 'correct amount used';
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
@@ -2664,7 +2622,8 @@ FixMyStreet::override_config {
         $mech->content_contains('A Name');
         $mech->content_contains('40.00');
         $mech->content_contains('7.50');
-        $mech->submit_form_ok({ with_fields => { tandc => 1 } });
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
+
         is $sent_params->{items}[0]{amount}, 750, 'correct amount used';
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );

--- a/t/app/controller/waste_brent_garden.t
+++ b/t/app/controller/waste_brent_garden.t
@@ -380,15 +380,9 @@ FixMyStreet::override_config {
                 name => 'Test McTest',
                 email => 'test@example.net'
             } });
-            # external redirects make Test::WWW::Mechanize unhappy so clone
-            # the mech for the redirect
-            my $mech2 = $mech->clone;
-            $mech2->content_contains('Continue to payment', 'Waste features text_for_waste_payment not used for non-staff payment');
-            $mech2->content_contains('valid bin sticker', 'extra T&C text');
-            $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
-
-            is $mech2->res->previous->code, 302, 'payments issues a redirect';
-            is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+            $mech->content_contains('Continue to payment', 'Waste features text_for_waste_payment not used for non-staff payment');
+            $mech->content_contains('valid bin sticker', 'extra T&C text');
+            $mech->waste_submit_check({ with_fields => { tandc => 1 } });
 
             my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
@@ -432,14 +426,7 @@ FixMyStreet::override_config {
         } });
         $mech->content_contains('Test McTest');
         $mech->content_contains('£50.00');
-
-        # external redirects make Test::WWW::Mechanize unhappy so clone
-        # the mech for the redirect
-        my $mech2 = $mech->clone;
-        $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
-
-        is $mech2->res->previous->code, 302, 'payments issues a redirect';
-        is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
@@ -471,14 +458,7 @@ FixMyStreet::override_config {
         } });
         $mech->content_contains('Test McTest');
         $mech->content_contains('£50.00');
-
-        # external redirects make Test::WWW::Mechanize unhappy so clone
-        # the mech for the redirect
-        my $mech2 = $mech->clone;
-        $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
-
-        is $mech2->res->previous->code, 302, 'payments issues a redirect';
-        is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 

--- a/t/app/controller/waste_kingston.t
+++ b/t/app/controller/waste_kingston.t
@@ -555,13 +555,7 @@ FixMyStreet::override_config {
                 name => 'Test McTest',
                 email => 'test@example.net'
         } });
-        # external redirects make Test::WWW::Mechanize unhappy so clone
-        # the mech for the redirect
-        my $mech2 = $mech->clone;
-        $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
-
-        is $mech2->res->previous->code, 302, 'payments issues a redirect';
-        is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
@@ -604,13 +598,7 @@ FixMyStreet::override_config {
         } });
         $mech->content_contains('Test McTest');
         $mech->content_contains('£20.00');
-        # external redirects make Test::WWW::Mechanize unhappy so clone
-        # the mech for the redirect
-        my $mech2 = $mech->clone;
-        $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
-
-        is $mech2->res->previous->code, 302, 'payments issues a redirect';
-        is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
@@ -644,13 +632,7 @@ FixMyStreet::override_config {
         } });
         $mech->content_contains('Test McTest');
         $mech->content_contains('£20.00');
-        # external redirects make Test::WWW::Mechanize unhappy so clone
-        # the mech for the redirect
-        my $mech2 = $mech->clone;
-        $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
-
-        is $mech2->res->previous->code, 302, 'payments issues a redirect';
-        is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
@@ -1182,13 +1164,7 @@ FixMyStreet::override_config {
             name => 'Test McTest',
             email => 'test@example.net'
         } });
-        # external redirects make Test::WWW::Mechanize unhappy so clone
-        # the mech for the redirect
-        my $mech2 = $mech->clone;
-        $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
-
-        is $mech2->res->previous->code, 302, 'payments issues a redirect';
-        is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 
@@ -1235,13 +1211,7 @@ FixMyStreet::override_config {
             name => 'Test McTest',
             email => 'test@example.net'
         } });
-        # external redirects make Test::WWW::Mechanize unhappy so clone
-        # the mech for the redirect
-        my $mech2 = $mech->clone;
-        $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
-
-        is $mech2->res->previous->code, 302, 'payments issues a redirect';
-        is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+        $mech->waste_submit_check({ with_fields => { tandc => 1 } });
 
         my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
 

--- a/t/app/controller/waste_peterborough_bulky.t
+++ b/t/app/controller/waste_peterborough_bulky.t
@@ -440,12 +440,7 @@ FixMyStreet::override_config {
             $mech->content_contains('44 07 111 111 111', 'phone shown');
         }
         sub test_summary_submission {
-            # external redirects make Test::WWW::Mechanize unhappy so clone
-            # the mech for the redirect
-            my $mech2 = $mech->clone;
-            $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
-            is $mech2->res->previous->code, 302, 'payments issues a redirect';
-            is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+            $mech->waste_submit_check({ with_fields => { tandc => 1 } });
         }
         sub test_payment_page {
             my $sent_params = shift;

--- a/templates/web/base/about/_cookies.html
+++ b/templates/web/base/about/_cookies.html
@@ -1,0 +1,17 @@
+<table class="nicetable">
+    <tr>
+        <th scope="col">Name</th>
+        <th scope="col">Typical Content</th>
+        <th scope="col">Expires</th>
+    </tr>
+    <tr>
+        <td>fixmystreet_app_session</td>
+        <td>A random unique identifier, for maintaining a user session</td>
+        <td>When browser is closed</td>
+    </tr>
+    <tr>
+        <td>form_unique_id</td>
+        <td>A random unique identifier, to help prevent double form submission</td>
+        <td>When browser is closed</td>
+    </tr>
+</table>

--- a/templates/web/base/about/privacy.html
+++ b/templates/web/base/about/privacy.html
@@ -31,17 +31,6 @@ this. We use this information to, for example, remember you have logged in so
 you don't need to do that on every page. Below, we list the cookies and
 services that this site can use.
 
-<table class="nicetable">
-    <tr>
-        <th scope="col">Name</th>
-        <th scope="col">Typical Content</th>
-        <th scope="col">Expires</th>
-    </tr>
-    <tr>
-        <td>fixmystreet_app_session</td>
-        <td nowrap>A random unique identifier</td>
-        <td>When browser is closed, or four weeks if &ldquo;Keep me signed in&rdquo; is ticked</td>
-    </tr>
-</table>
+[% INCLUDE 'about/_cookies.html' %]
 
 [% INCLUDE 'footer.html' %]

--- a/templates/web/fixmystreet-uk-councils/about/privacy.html
+++ b/templates/web/fixmystreet-uk-councils/about/privacy.html
@@ -487,18 +487,7 @@ this site
 [% END %]
 can use.
 
-<table class="nicetable">
-    <tr>
-        <th scope="col">Name</th>
-        <th scope="col">Typical Content</th>
-        <th scope="col">Expires</th>
-    </tr>
-    <tr>
-        <td>fixmystreet_app_session</td>
-        <td nowrap>A random unique identifier</td>
-        <td>When browser is closed</td>
-    </tr>
-</table>
+[% INCLUDE 'about/_cookies.html' %]
 
 [% TRY %][% INCLUDE 'about/googlecookies.html' %][% CATCH file %][% END %]
 

--- a/templates/web/fixmystreet.com/about/privacy.html
+++ b/templates/web/fixmystreet.com/about/privacy.html
@@ -377,18 +377,7 @@ you don’t need to do that on every page, or to measure how people use the
 website so we can improve it and make sure it works properly. Below, we list
 the cookies and services that this site can use.
 
-<table class="nicetable">
-    <tr>
-        <th scope="col">Name</th>
-        <th scope="col">Typical Content</th>
-        <th scope="col">Expires</th>
-    </tr>
-    <tr>
-        <td>fixmystreet_app_session</td>
-        <td nowrap>A random unique identifier</td>
-        <td>When browser is closed</td>
-    </tr>
-</table>
+[% INCLUDE 'about/_cookies.html' %]
 
 <h3>Measuring website usage (Google Analytics)</h3>
 

--- a/templates/web/highwaysengland/about/privacy.html
+++ b/templates/web/highwaysengland/about/privacy.html
@@ -217,17 +217,6 @@ you don’t need to do that on every page, or to measure how people use the
 website so we can improve it and make sure it works properly. Below, we list
 the cookies and services that this site can use.
 
-<table class="nicetable">
-    <tr>
-        <th scope="col">Name</th>
-        <th scope="col">Typical Content</th>
-        <th scope="col">Expires</th>
-    </tr>
-    <tr>
-        <td>fixmystreet_app_session</td>
-        <td nowrap>A random unique identifier</td>
-        <td>When browser is closed</td>
-    </tr>
-</table>
+[% INCLUDE 'about/_cookies.html' %]
 
 [% INCLUDE 'footer.html' %]


### PR DESCRIPTION
Currently the code stores a number of waste things in the session for caching/performance reasons. We already store most of these on disk, so instead of deleting those, use them as the cache instead. Also start storing Peterborough postcode lookup on disk to match, and move the form unique ID to its own cookie rather than create sessions purely for them as well.
[skip changelog]
