### PR TITLE
[TfL] Single sign on for staff

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Auth.pm
+++ b/perllib/FixMyStreet/App/Controller/Auth.pm
@@ -260,7 +260,7 @@ sub get_token : Private {
 sub set_oauth_token_data : Private {
     my ( $self, $c, $token_data ) = @_;
 
-    foreach (qw/facebook_id twitter_id oidc_id extra logout_redirect_uri change_password_uri/) {
+    foreach (qw/facebook_id twitter_id oidc_id extra logout_redirect_uri change_password_uri roles/) {
         $token_data->{$_} = $c->session->{oauth}{$_} if $c->session->{oauth}{$_};
     }
 }
@@ -335,7 +335,7 @@ sub process_login : Private {
         %{ $user->get_extra() },
         %{ $data->{extra} }
     }) if $data->{extra};
-
+    $c->cobrand->call_hook(roles_from_oidc => $user, $c->session->{oauth}{roles}) if $c->session->{oauth}{roles};
     $user->update_or_insert;
     $c->authenticate( { $type => $data->{$type}, $ver => 1 }, 'no_password' );
 

--- a/perllib/FixMyStreet/App/Controller/Auth.pm
+++ b/perllib/FixMyStreet/App/Controller/Auth.pm
@@ -109,7 +109,7 @@ sub sign_in : Private {
     $c->logout();
 
     my $parsed = FixMyStreet::SMS->parse_username($username);
-
+    $c->cobrand->call_hook('disable_login_for_email', $parsed->{username}) unless $c->stash->{oauth_need_email};
     $c->forward('throttle_username', [$parsed]);
 
     if ($parsed->{username} && $password && $c->forward('authenticate', [ $parsed->{type}, $parsed->{username}, $password ])) {
@@ -192,6 +192,8 @@ sub email_sign_in : Private {
         $c->stash->{username_error} = $raw_email ? $email_checker->details : 'missing_email';
         return;
     }
+
+    $c->cobrand->call_hook('disable_login_for_email', $good_email) unless $c->get_param('oauth_need_email');
 
     my $password = $c->get_param('password_register');
     if ($password) {

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1620,6 +1620,8 @@ sub process_confirmation : Private {
                 %{ $problem->user->get_extra() },
                 %{ $data->{extra} }
             }) if $data->{extra};
+            $c->cobrand->call_hook(roles_from_oidc => $problem->user, $data->{roles});
+
             $problem->user->update;
 
             # Make sure extra oauth state is restored, if applicable

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -969,6 +969,7 @@ sub process_user : Private {
     }
     $params{username} ||= '';
 
+    $c->cobrand->call_hook('disable_login_for_email', $params{username}) unless $c->get_param('oauth_need_email');
     my $anon_button = $c->cobrand->allow_anonymous_reports eq 'button' && $c->get_param('report_anonymously');
     my $anon_fallback = $c->cobrand->allow_anonymous_reports eq '1' && !$c->user_exists && !$params{username};
     if ($anon_button || $anon_fallback) {

--- a/perllib/FixMyStreet/App/Controller/Report/Update.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/Update.pm
@@ -657,6 +657,7 @@ sub process_confirmation : Private {
                 %{ $comment->user->get_extra() },
                 %{ $data->{extra} }
             }) if $data->{extra};
+            $c->cobrand->call_hook(roles_from_oidc => $comment->user, $data->{roles});
             $comment->user->password( $data->{password}, 1 ) if $data->{password};
             $comment->user->update;
             # Make sure extra oauth state is restored, if applicable

--- a/perllib/FixMyStreet/App/Controller/Report/Update.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/Update.pm
@@ -110,6 +110,7 @@ sub process_user : Private {
         $params{username} = $c->get_param('username_register');
     }
     $params{username} ||= '';
+    $c->cobrand->call_hook('disable_login_for_email', $params{username}) unless $c->get_param('oauth_need_email');
 
     my $anon_button = $c->cobrand->allow_anonymous_updates eq 'button' && $c->get_param('report_anonymously');
     if ($anon_button) {

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -159,7 +159,14 @@ sub inactive_reports_filter {
 }
 
 sub password_expiry {
+    my ($self) = @_;
+
     return if FixMyStreet->test_mode;
+
+    my $email = $self->{c}->user->email;
+    my $domain_email = $self->admin_user_domain;
+    return if $email =~ /$domain_email$/;
+
     # uncoverable statement
     86400 * 365
 }

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -161,8 +161,6 @@ sub inactive_reports_filter {
 sub password_expiry {
     my ($self) = @_;
 
-    return if FixMyStreet->test_mode;
-
     my $email = $self->{c}->user->email;
     my $domain_email = $self->admin_user_domain;
     return if $email =~ /$domain_email$/;

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -479,6 +479,16 @@ sub munge_reports_area_list {
 
 sub munge_report_new_contacts { }
 
+sub disable_login_for_email {
+    my ($self, $email) = @_;
+
+    my $staff_email = $self->admin_user_domain;
+
+    if ($email =~ /$staff_email$/) {
+        $self->{c}->detach('/page_error_403_access_denied', ['Please use the staff login option']);
+    }
+}
+
 sub munge_report_new_bodies {
     my ($self, $bodies) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -195,7 +195,7 @@ sub user_from_oidc {
     my ($self, $payload) = @_;
 
     my $name = join(" ", $payload->{given_name}, $payload->{family_name});
-    my $email = $payload->{email};
+    my $email = $payload->{email} ? lc($payload->{email}) : '';
 
     return ($name, $email);
 }

--- a/t/Mock/OpenIDConnect.pm
+++ b/t/Mock/OpenIDConnect.pm
@@ -87,7 +87,7 @@ sub dispatch_request {
         } elsif ($self->cobrand eq 'tfl') {
             $payload->{given_name} = "Andy";
             $payload->{family_name} = "Dwyer";
-            $payload->{email} = 'pkg-tappcontrollerauth_socialt-oidc@tfl.org' if $self->returns_email;
+            $payload->{email} = 'Pkg-tappcontrollerauth_socialt-oidc@TFL.org' if $self->returns_email;
             $payload->{roles} = $self->roles;
         }
         my $signature = "dummy";

--- a/t/Mock/OpenIDConnect.pm
+++ b/t/Mock/OpenIDConnect.pm
@@ -87,7 +87,7 @@ sub dispatch_request {
         } elsif ($self->cobrand eq 'tfl') {
             $payload->{given_name} = "Andy";
             $payload->{family_name} = "Dwyer";
-            $payload->{email} = 'Pkg-tappcontrollerauth_socialt-oidc@TFL.org' if $self->returns_email;
+            $payload->{email} = 'Pkg-tappcontrollerauth_socialt-oidc@TFL.gov.uk' if $self->returns_email;
             $payload->{roles} = $self->roles;
         }
         my $signature = "dummy";

--- a/t/Mock/OpenIDConnect.pm
+++ b/t/Mock/OpenIDConnect.pm
@@ -31,6 +31,12 @@ has host => (
     default => '',
 );
 
+has roles => (
+    is => 'rw',
+    isa => ArrayRef,
+    lazy => 1
+);
+
 sub dispatch_request {
     my $self = shift;
 
@@ -78,6 +84,11 @@ sub dispatch_request {
             $payload->{givenName} = "Andy";
             $payload->{surname} = "Dwyer";
             $payload->{email} = 'pkg-tappcontrollerauth_socialt-oidc@example.org' if $self->returns_email;
+        } elsif ($self->cobrand eq 'tfl') {
+            $payload->{given_name} = "Andy";
+            $payload->{family_name} = "Dwyer";
+            $payload->{email} = 'pkg-tappcontrollerauth_socialt-oidc@tfl.org' if $self->returns_email;
+            $payload->{roles} = $self->roles;
         }
         my $signature = "dummy";
         my $id_token = join(".", (

--- a/t/app/controller/admin/templates.t
+++ b/t/app/controller/admin/templates.t
@@ -1,5 +1,6 @@
 use FixMyStreet::TestMech;
 
+use Test::MockModule;
 use t::Mock::Tilma;
 my $tilma = t::Mock::Tilma->new;
 LWP::Protocol::PSGI->register($tilma->to_psgi_app, host => 'tilma.mysociety.org');
@@ -407,6 +408,8 @@ subtest "TfL cobrand only shows TfL templates" => sub {
             anonymous_account => { tfl => 'anon' },
         },
     }, sub {
+        my $tfl_mock = Test::MockModule->new('FixMyStreet::Cobrand::TfL');
+        $tfl_mock->mock('password_expiry', sub {});
         $report->update({
             category => $tflcontact->category,
             bodies_str => $tfl->id,

--- a/t/app/controller/auth_social.t
+++ b/t/app/controller/auth_social.t
@@ -18,6 +18,19 @@ END { FixMyStreet::App->log->enable('info'); }
 my $body = $mech->create_body_ok(2504, 'Westminster City Council');
 my $body2 = $mech->create_body_ok(2508, 'Hackney Council');
 my $body3 = $mech->create_body_ok(2488, 'Brent Council', {}, { cobrand => 'brent' });
+my $body4 = $mech->create_body_ok(2482, 'TfL', {}, { cobrand => 'tfl' }); # Bromley area
+
+FixMyStreet::DB->resultset("Role")->create({
+    body => $body4,
+    name => 'Streetcare - Basic Editor Viewers',
+    permissions => ['moderate', 'user_edit'],
+});
+
+FixMyStreet::DB->resultset("Role")->create({
+    body => $body4,
+    name => 'Streetcare - Admin',
+    permissions => ['moderate', 'user_edit'],
+});
 
 my ($report) = $mech->create_problems_for_body(1, $body->id, 'My Test Report');
 my $test_email = $report->user->email;
@@ -25,8 +38,11 @@ my ($report2) = $mech->create_problems_for_body(1, $body2->id, 'My Test Report')
 my $test_email2 = $report->user->email;
 my ($report3) = $mech->create_problems_for_body(1, $body3->id, 'My Test Report');
 my $test_email3 = $report3->user->email;
+my ($report4) = $mech->create_problems_for_body(1, $body4->id, 'My Test Report');
+my $test_email4 = $report4->user->email;
 
-foreach ($body->id, $body2->id, $body3->id) {
+
+foreach ($body->id, $body2->id, $body3->id, $body4->id) {
     $mech->create_contact_ok(
         body_id => $_, category => 'Damaged bin', email => 'BIN',
         group => 'Bins',
@@ -50,182 +66,7 @@ my $tilma = t::Mock::Tilma->new;
 LWP::Protocol::PSGI->register($tilma->to_psgi_app, host => 'tilma.mysociety.org');
 LWP::Protocol::PSGI->register($tilma->to_psgi_app, host => 'tilma.staging.mysociety.org');
 
-for my $test (
-    {
-    type => 'facebook',
-    config => {
-        FACEBOOK_APP_ID => 'facebook-app-id',
-        ALLOWED_COBRANDS => [ { fixmystreet => '.' } ],
-        MAPIT_URL => 'http://mapit.uk/',
-    },
-    update => 1,
-    email => $mech->uniquify_email('facebook@example.org'),
-    uid => 123456789,
-    mock => 't::Mock::Facebook',
-    mock_hosts => ['www.facebook.com', 'graph.facebook.com'],
-    host => 'www.facebook.com',
-    error_callback => '/auth/Facebook?error_code=ERROR',
-    success_callback => '/auth/Facebook?code=response-code',
-    redirect_pattern => qr{facebook\.com.*dialog/oauth.*facebook-app-id},
-}, {
-    type => 'oidc',
-    config => {
-        ALLOWED_COBRANDS => 'westminster',
-        MAPIT_URL => 'http://mapit.uk/',
-        COBRAND_FEATURES => {
-            anonymous_account => {
-                westminster => 'test',
-            },
-            oidc_login => {
-                westminster => {
-                    client_id => 'example_client_id',
-                    secret => 'example_secret_key',
-                    auth_uri => 'http://oidc.example.org/oauth2/v2.0/authorize',
-                    token_uri => 'http://oidc.example.org/oauth2/v2.0/token',
-                    logout_uri => 'http://oidc.example.org/oauth2/v2.0/logout',
-                    password_change_uri => 'http://oidc.example.org/oauth2/v2.0/password_change',
-                    display_name => 'MyWestminster'
-                }
-            }
-        }
-    },
-    email => $mech->uniquify_email('oidc@example.org'),
-    uid => "westminster:example_client_id:my_cool_user_id",
-    mock => 't::Mock::OpenIDConnect',
-    mock_hosts => ['oidc.example.org'],
-    host => 'oidc.example.org',
-    error_callback => '/auth/OIDC?error=ERROR',
-    success_callback => '/auth/OIDC?code=response-code&state=login',
-    redirect_pattern => qr{oidc\.example\.org/oauth2/v2\.0/authorize},
-    logout_redirect_pattern => qr{http://oidc\.example\.org/oauth2/v2\.0/logout\?post_logout_redirect_uri=http%3A%2F%2Foidc.example.org%2Fauth%2Fsign_out&id_token_hint=},
-    password_change_pattern => qr{oidc\.example\.org/oauth2/v2\.0/password_change},
-    user_extras => [
-        [westminster_account_id => "1c304134-ef12-c128-9212-123908123901"],
-    ],
-},
-{
-    type => 'oidc',
-    config => {
-        ALLOWED_COBRANDS => 'brent',
-        MAPIT_URL => 'http://mapit.uk/',
-        COBRAND_FEATURES => {
-            anonymous_account => {
-                brent => 'test',
-            },
-            oidc_login => {
-                brent => {
-                    client_id => 'example_client_id',
-                    secret => 'example_secret_key',
-                    auth_uri => 'http://oidc.example.org/oauth2/v2.0/authorize',
-                    token_uri => 'http://oidc.example.org/oauth2/v2.0/token',
-                    logout_uri => 'http://oidc.example.org/oauth2/v2.0/logout',
-                    password_change_uri => 'http://oidc.example.org/oauth2/v2.0/password_change',
-                    display_name => 'MyAccount'
-                }
-            }
-        }
-    },
-    email => $mech->uniquify_email('oidc@example.org'),
-    uid => "brent:example_client_id:my_cool_user_id",
-    mock => 't::Mock::OpenIDConnect',
-    mock_hosts => ['oidc.example.org'],
-    host => 'oidc.example.org',
-    error_callback => '/auth/OIDC?error=ERROR',
-    success_callback => '/auth/OIDC?code=response-code&state=login',
-    redirect_pattern => qr{oidc\.example\.org/oauth2/v2\.0/authorize},
-    logout_redirect_pattern => qr{oidc\.example\.org/oauth2/v2\.0/logout},
-    password_change_pattern => qr{oidc\.example\.org/oauth2/v2\.0/password_change},
-    report => $report3,
-    report_email => $test_email3,
-    pc => 'HA9 0FJ',
-},
-{
-    type => 'oidc',
-    config => {
-        ALLOWED_COBRANDS => 'brent',
-        MAPIT_URL => 'http://mapit.uk/',
-        COBRAND_FEATURES => {
-            anonymous_account => {
-                brent => 'test',
-            },
-            oidc_login => {
-                brent => {
-                    client_id => 'example_client_id',
-                    secret => 'example_secret_key',
-                    auth_uri => 'http://oidc.example.org/oauth2/v2.0/authorize',
-                    token_uri => 'http://oidc.example.org/oauth2/v2.0/token',
-                    logout_uri => 'http://oidc.example.org/oauth2/v2.0/logout',
-                    password_change_uri => 'http://oidc.example.org/oauth2/v2.0/password_change',
-                    display_name => 'MyAccount',
-                    hosts => {
-                        'brent-wasteworks-oidc.example.org' => {
-                            client_id => 'wasteworks_client_id',
-                            secret => 'wasteworks_secret_key',
-                            auth_uri => 'http://brent-wasteworks-oidc.example.org/oauth2/v2.0/authorize',
-                            token_uri => 'http://brent-wasteworks-oidc.example.org/oauth2/v2.0/token',
-                            logout_uri => 'http://brent-wasteworks-oidc.example.org/oauth2/v2.0/logout',
-                            password_change_uri => 'http://brent-wasteworks-oidc.example.org/oauth2/v2.0/password_change',
-                            display_name => 'MyAccount - WasteWorks',
-                        }
-                    }
-                }
-            }
-        }
-    },
-    email => $mech->uniquify_email('oidc@example.org'),
-    uid => "brent:wasteworks_client_id:my_cool_user_id",
-    mock => 't::Mock::OpenIDConnect',
-    mock_hosts => ['brent-wasteworks-oidc.example.org'],
-    host => 'brent-wasteworks-oidc.example.org',
-    error_callback => '/auth/OIDC?error=ERROR',
-    success_callback => '/auth/OIDC?code=response-code&state=login',
-    redirect_pattern => qr{brent-wasteworks-oidc\.example\.org/oauth2/v2\.0/authorize},
-    logout_redirect_pattern => qr{brent-wasteworks-oidc\.example\.org/oauth2/v2\.0/logout},
-    password_change_pattern => qr{brent-wasteworks-oidc\.example\.org/oauth2/v2\.0/password_change},
-    report => $report3,
-    report_email => $test_email3,
-    pc => 'HA9 0FJ',
-},
-{
-    type => 'oidc',
-    config => {
-        ALLOWED_COBRANDS => 'hackney',
-        MAPIT_URL => 'http://mapit.uk/',
-        COBRAND_FEATURES => {
-            anonymous_account => {
-                hackney => 'test',
-            },
-            oidc_login => {
-                hackney => {
-                    client_id => 'example_client_id',
-                    secret => 'example_secret_key',
-                    auth_uri => 'http://oidc.example.org/oauth2/v2.0/authorize_google',
-                    token_uri => 'http://oidc.example.org/oauth2/v2.0/token_google',
-                    allowed_domains => [ 'example.org' ],
-                }
-            },
-            do_not_reply_email => {
-                hackney => 'fms-hackney-DO-NOT-REPLY@hackney-example.com',
-            },
-            verp_email_domain => {
-                hackney => 'hackney-example.com',
-            },
-        }
-    },
-    email => $mech->uniquify_email('oidc_google@example.org'),
-    uid => "hackney:example_client_id:my_google_user_id",
-    mock => 't::Mock::OpenIDConnect',
-    mock_hosts => ['oidc.example.org'],
-    host => 'oidc.example.org',
-    error_callback => '/auth/OIDC?error=ERROR',
-    success_callback => '/auth/OIDC?code=response-code&state=login',
-    redirect_pattern => qr{oidc\.example\.org/oauth2/v2\.0/authorize_google},
-    pc => 'E8 1DY',
-    # Need to use a different report that's within Hackney
-    report => $report2,
-    report_email => $test_email2,
-}
-) {
+for my $test (&tst_config) {
 
 FixMyStreet::override_config $test->{config}, sub {
 
@@ -265,6 +106,7 @@ for my $state ( 'refused', 'no email', 'existing UID', 'okay' ) {
                 $mock_api->cobrand($cobrand);
             }
             $mock_api->returns_email(0) if $state eq 'no email' || $state eq 'existing UID';
+            $mock_api->roles($test->{roles}) if $test->{roles};
             for my $host (@{ $test->{mock_hosts} }) {
                 LWP::Protocol::PSGI->register($mock_api->to_psgi_app, host => $host);
             }
@@ -367,6 +209,9 @@ for my $state ( 'refused', 'no email', 'existing UID', 'okay' ) {
                         is $user->get_extra_metadata($k), $v, "User has correct $k extra field";
                     }
                 }
+                if ($test->{roles}) {
+                    &test_roles($test);
+                }
 
             } elsif ($page ne 'my') {
                 # /my auth login goes directly there, no message like this
@@ -379,6 +224,9 @@ for my $state ( 'refused', 'no email', 'existing UID', 'okay' ) {
                         is $user->get_extra_metadata($k), $v, "User has correct $k extra field";
                     }
                 }
+                if ($test->{roles}) {
+                    &test_roles($test);
+                }
             } else {
                 is $mech->uri->path, '/my', 'Successfully on /my page';
                 if ($test->{user_extras}) {
@@ -387,6 +235,9 @@ for my $state ( 'refused', 'no email', 'existing UID', 'okay' ) {
                         my ($k, $v) = @$extra;
                         is $user->get_extra_metadata($k), $v, "User has correct $k extra field";
                     }
+                }
+                if ($test->{roles}) {
+                    &test_roles($test);
                 }
                 if ($state eq 'existing UID') {
                     my $report_id = $test_report->id;
@@ -534,6 +385,269 @@ for my $tw_state ( 'refused', 'existing UID', 'no email' ) {
     }
 }
 
+};
+
+sub test_roles {
+    my $test = $_[0];
+
+    my $user = FixMyStreet::DB->resultset( 'User' )->find( { email => $test->{email} } );
+    my @roles;
+    for my $role ($user->roles->all) {
+        push @roles, $role->name;
+    };
+    my @expected_sort = sort @{$test->{expected_roles}};
+    my @roles_sort = sort @roles;
+
+    is_deeply \@expected_sort, \@roles_sort, 'Correct roles assigned to user';
+}
+
+sub tst_config {
+my @configurations = (
+    {
+        type => 'facebook',
+        config => {
+            FACEBOOK_APP_ID => 'facebook-app-id',
+            ALLOWED_COBRANDS => [ { fixmystreet => '.' } ],
+            MAPIT_URL => 'http://mapit.uk/',
+        },
+        update => 1,
+        email => $mech->uniquify_email('facebook@example.org'),
+        uid => 123456789,
+        mock => 't::Mock::Facebook',
+        mock_hosts => ['www.facebook.com', 'graph.facebook.com'],
+        host => 'www.facebook.com',
+        error_callback => '/auth/Facebook?error_code=ERROR',
+        success_callback => '/auth/Facebook?code=response-code',
+        redirect_pattern => qr{facebook\.com.*dialog/oauth.*facebook-app-id},
+    }, {
+        type => 'oidc',
+        config => {
+            ALLOWED_COBRANDS => 'westminster',
+            MAPIT_URL => 'http://mapit.uk/',
+            COBRAND_FEATURES => {
+                anonymous_account => {
+                    westminster => 'test',
+                },
+                oidc_login => {
+                    westminster => {
+                        client_id => 'example_client_id',
+                        secret => 'example_secret_key',
+                        auth_uri => 'http://oidc.example.org/oauth2/v2.0/authorize',
+                        token_uri => 'http://oidc.example.org/oauth2/v2.0/token',
+                        logout_uri => 'http://oidc.example.org/oauth2/v2.0/logout',
+                        password_change_uri => 'http://oidc.example.org/oauth2/v2.0/password_change',
+                        display_name => 'MyWestminster'
+                    }
+                }
+            }
+        },
+        email => $mech->uniquify_email('oidc@example.org'),
+        uid => "westminster:example_client_id:my_cool_user_id",
+        mock => 't::Mock::OpenIDConnect',
+        mock_hosts => ['oidc.example.org'],
+        host => 'oidc.example.org',
+        error_callback => '/auth/OIDC?error=ERROR',
+        success_callback => '/auth/OIDC?code=response-code&state=login',
+        redirect_pattern => qr{oidc\.example\.org/oauth2/v2\.0/authorize},
+        logout_redirect_pattern => qr{http://oidc\.example\.org/oauth2/v2\.0/logout\?post_logout_redirect_uri=http%3A%2F%2Foidc.example.org%2Fauth%2Fsign_out&id_token_hint=},
+        password_change_pattern => qr{oidc\.example\.org/oauth2/v2\.0/password_change},
+        user_extras => [
+            [westminster_account_id => "1c304134-ef12-c128-9212-123908123901"],
+        ],
+    },
+    {
+        type => 'oidc',
+        config => {
+            ALLOWED_COBRANDS => 'brent',
+            MAPIT_URL => 'http://mapit.uk/',
+            COBRAND_FEATURES => {
+                anonymous_account => {
+                    brent => 'test',
+                },
+                oidc_login => {
+                    brent => {
+                        client_id => 'example_client_id',
+                        secret => 'example_secret_key',
+                        auth_uri => 'http://oidc.example.org/oauth2/v2.0/authorize',
+                        token_uri => 'http://oidc.example.org/oauth2/v2.0/token',
+                        logout_uri => 'http://oidc.example.org/oauth2/v2.0/logout',
+                        password_change_uri => 'http://oidc.example.org/oauth2/v2.0/password_change',
+                        display_name => 'MyAccount'
+                    }
+                }
+            }
+        },
+        email => $mech->uniquify_email('oidc@example.org'),
+        uid => "brent:example_client_id:my_cool_user_id",
+        mock => 't::Mock::OpenIDConnect',
+        mock_hosts => ['oidc.example.org'],
+        host => 'oidc.example.org',
+        error_callback => '/auth/OIDC?error=ERROR',
+        success_callback => '/auth/OIDC?code=response-code&state=login',
+        redirect_pattern => qr{oidc\.example\.org/oauth2/v2\.0/authorize},
+        logout_redirect_pattern => qr{oidc\.example\.org/oauth2/v2\.0/logout},
+        password_change_pattern => qr{oidc\.example\.org/oauth2/v2\.0/password_change},
+        report => $report3,
+        report_email => $test_email3,
+        pc => 'HA9 0FJ',
+    },
+    {
+        type => 'oidc',
+        config => {
+            ALLOWED_COBRANDS => 'brent',
+            MAPIT_URL => 'http://mapit.uk/',
+            COBRAND_FEATURES => {
+                anonymous_account => {
+                    brent => 'test',
+                },
+                oidc_login => {
+                    brent => {
+                        client_id => 'example_client_id',
+                        secret => 'example_secret_key',
+                        auth_uri => 'http://oidc.example.org/oauth2/v2.0/authorize',
+                        token_uri => 'http://oidc.example.org/oauth2/v2.0/token',
+                        logout_uri => 'http://oidc.example.org/oauth2/v2.0/logout',
+                        password_change_uri => 'http://oidc.example.org/oauth2/v2.0/password_change',
+                        display_name => 'MyAccount',
+                        hosts => {
+                            'brent-wasteworks-oidc.example.org' => {
+                                client_id => 'wasteworks_client_id',
+                                secret => 'wasteworks_secret_key',
+                                auth_uri => 'http://brent-wasteworks-oidc.example.org/oauth2/v2.0/authorize',
+                                token_uri => 'http://brent-wasteworks-oidc.example.org/oauth2/v2.0/token',
+                                logout_uri => 'http://brent-wasteworks-oidc.example.org/oauth2/v2.0/logout',
+                                password_change_uri => 'http://brent-wasteworks-oidc.example.org/oauth2/v2.0/password_change',
+                                display_name => 'MyAccount - WasteWorks',
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        email => $mech->uniquify_email('oidc@example.org'),
+        uid => "brent:wasteworks_client_id:my_cool_user_id",
+        mock => 't::Mock::OpenIDConnect',
+        mock_hosts => ['brent-wasteworks-oidc.example.org'],
+        host => 'brent-wasteworks-oidc.example.org',
+        error_callback => '/auth/OIDC?error=ERROR',
+        success_callback => '/auth/OIDC?code=response-code&state=login',
+        redirect_pattern => qr{brent-wasteworks-oidc\.example\.org/oauth2/v2\.0/authorize},
+        logout_redirect_pattern => qr{brent-wasteworks-oidc\.example\.org/oauth2/v2\.0/logout},
+        password_change_pattern => qr{brent-wasteworks-oidc\.example\.org/oauth2/v2\.0/password_change},
+        report => $report3,
+        report_email => $test_email3,
+        pc => 'HA9 0FJ',
+    },
+    {
+        type => 'oidc',
+        config => {
+            ALLOWED_COBRANDS => 'hackney',
+            MAPIT_URL => 'http://mapit.uk/',
+            COBRAND_FEATURES => {
+                anonymous_account => {
+                    hackney => 'test',
+                },
+                oidc_login => {
+                    hackney => {
+                        client_id => 'example_client_id',
+                        secret => 'example_secret_key',
+                        auth_uri => 'http://oidc.example.org/oauth2/v2.0/authorize_google',
+                        token_uri => 'http://oidc.example.org/oauth2/v2.0/token_google',
+                        allowed_domains => [ 'example.org' ],
+                    }
+                },
+                do_not_reply_email => {
+                    hackney => 'fms-hackney-DO-NOT-REPLY@hackney-example.com',
+                },
+                verp_email_domain => {
+                    hackney => 'hackney-example.com',
+                },
+            }
+        },
+        email => $mech->uniquify_email('oidc_google@example.org'),
+        uid => "hackney:example_client_id:my_google_user_id",
+        mock => 't::Mock::OpenIDConnect',
+        mock_hosts => ['oidc.example.org'],
+        host => 'oidc.example.org',
+        error_callback => '/auth/OIDC?error=ERROR',
+        success_callback => '/auth/OIDC?code=response-code&state=login',
+        redirect_pattern => qr{oidc\.example\.org/oauth2/v2\.0/authorize_google},
+        pc => 'E8 1DY',
+        # Need to use a different report that's within Hackney
+        report => $report2,
+        report_email => $test_email2,
+    },
+);
+
+for my $setup (
+    {
+        roles => ['BasicEditorViewers'],
+        expected_roles => ['Streetcare - Basic Editor Viewers'],
+    },
+    {
+        roles => ['Admin'],
+        expected_roles => ['Streetcare - Admin'],
+    },
+    {
+        roles => ['BasicEditorViewers', 'Admin'],
+        expected_roles => ['Streetcare - Admin', 'Streetcare - Basic Editor Viewers'],
+    },
+    {
+        roles => ['Non-existant role'],
+        expected_roles => [],
+    },
+    {
+        roles => [],
+        expected_roles => [],
+    },
+    {
+        roles => undef,
+        expected_roles => [],
+    }
+
+) {
+    push @configurations,
+    {
+        type => 'oidc',
+        config => {
+            ALLOWED_COBRANDS => 'tfl',
+            MAPIT_URL => 'http://mapit.uk/',
+            COBRAND_FEATURES => {
+                anonymous_account => {
+                    tfl => 'test',
+                },
+                oidc_login => {
+                    tfl => {
+                        client_id => 'example_client_id',
+                        secret => 'example_secret_key',
+                        auth_uri => 'http://oidc.example.org/oauth2/v2.0/authorize',
+                        token_uri => 'http://oidc.example.org/oauth2/v2.0/token',
+                        logout_uri => 'http://oidc.example.org/oauth2/v2.0/logout',
+                        password_change_uri => 'http://oidc.example.org/oauth2/v2.0/password_change',
+                        display_name => 'MyAccount'
+                    }
+                }
+            }
+        },
+        email => $mech->uniquify_email('oidc@tfl.org'),
+        uid => "tfl:example_client_id:my_cool_user_id",
+        mock => 't::Mock::OpenIDConnect',
+        mock_hosts => ['oidc.example.org'],
+        host => 'oidc.example.org',
+        error_callback => '/auth/OIDC?error=ERROR',
+        success_callback => '/auth/OIDC?code=response-code&state=login',
+        redirect_pattern => qr{oidc\.example\.org/oauth2/v2\.0/authorize},
+        logout_redirect_pattern => qr{oidc\.example\.org/oauth2/v2\.0/logout},
+        password_change_pattern => qr{oidc\.example\.org/oauth2/v2\.0/password_change},
+        report => $report4,
+        report_email => $test_email4,
+        pc => 'BR1 3UH',
+        roles => $setup->{roles},
+        expected_roles => $setup->{expected_roles},
+    }
+}
+
+return @configurations;
 };
 
 done_testing();

--- a/t/app/controller/auth_social.t
+++ b/t/app/controller/auth_social.t
@@ -15,6 +15,9 @@ my $mech = FixMyStreet::TestMech->new;
 FixMyStreet::App->log->disable('info');
 END { FixMyStreet::App->log->enable('info'); }
 
+#my $tfl_mock = Test::MockModule->new('FixMyStreet::Cobrand::TfL');
+#$tfl_mock->mock('must_have_2fa', sub { 0 });
+
 my $body = $mech->create_body_ok(2504, 'Westminster City Council');
 my $body2 = $mech->create_body_ok(2508, 'Hackney Council');
 my $body3 = $mech->create_body_ok(2488, 'Brent Council', {}, { cobrand => 'brent' });
@@ -629,7 +632,7 @@ for my $setup (
                 }
             }
         },
-        email => $mech->uniquify_email('oidc@tfl.org'),
+        email => $mech->uniquify_email('oidc@tfl.gov.uk'),
         uid => "tfl:example_client_id:my_cool_user_id",
         mock => 't::Mock::OpenIDConnect',
         mock_hosts => ['oidc.example.org'],


### PR DESCRIPTION
Staff users sign on by oidc and be given their role from the role designated in the oidc payload

As it's staff users, make them from the body so a new user is automatically set to the body. 

Although it's unlikely multiple roles are sent, the roles sent is an array so makes that possible.

Remove current roles as only roles to be used are the ones from the single sign on 

https://github.com/mysociety/societyworks/issues/4046
https://github.com/mysociety/societyworks/issues/4047

[skip changelog]