### PR TITLE
[Glos] Handle custom report_age for Confirm jobs

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Gloucestershire.pm
+++ b/perllib/FixMyStreet/Cobrand/Gloucestershire.pm
@@ -79,6 +79,21 @@ sub reopening_disallowed {
     return 1;
 }
 
+=item * Jobs from Confirm that are completed (marked as fixed or closed) are not displayed after 48 hours
+
+=cut
+
+sub report_age {
+    return {
+        closed => {
+            job => '48 hours',
+        },
+        fixed => {
+            job => '48 hours',
+        },
+    };
+}
+
 =item * We do not send questionnaires.
 
 =cut


### PR DESCRIPTION
Done as part of https://github.com/mysociety/societyworks/issues/4029.

Following on from [Support different /around map display times for open/closed/fixed reports](https://github.com/mysociety/fixmystreet/pull/4790), Gloucestershire require custom report_age settings for jobs versus enquiries (standard reports). This entails fun with nested hashrefs and even more nested SQL::Abstract queries :-)

[skip changelog]
