### PR TITLE
[Cycling UK] Store extra data in metadata, not fields.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
@@ -246,7 +246,7 @@ sub edit : Path('/admin/report_edit') : Args(1) {
         }
 
         for my $key ( keys %$extra ) {
-            next if $key eq 'whensent_previous';
+            next if $key =~ /^(whensent_previous|rdi_processed|gender|variant|CyclingUK)/;
             push @fields, { name => $key, val => $extra->{$key} };
         }
 

--- a/perllib/FixMyStreet/Cobrand/CyclingUK.pm
+++ b/perllib/FixMyStreet/Cobrand/CyclingUK.pm
@@ -210,11 +210,11 @@ sub dashboard_export_problems_add_columns {
         my ($first, $last) = $name =~ /^(\S*)(?: (.*))?$/;
 
         return {
-            injury_suffered => $csv->_extra_field($report, 'CyclingUK_injury_suffered') || '',
-            property_damage => $csv->_extra_field($report, 'CyclingUK_property_damage') || '',
-            transport_mode => $csv->_extra_field($report, 'CyclingUK_transport_mode') || '',
-            transport_other => $csv->_extra_field($report, 'CyclingUK_transport_other') || '',
-            marketing => $csv->_extra_field($report, 'CyclingUK_marketing_opt_in') || '',
+            injury_suffered => $csv->_extra_metadata($report, 'CyclingUK_injury_suffered') || '',
+            property_damage => $csv->_extra_metadata($report, 'CyclingUK_property_damage') || '',
+            transport_mode => $csv->_extra_metadata($report, 'CyclingUK_transport_mode') || '',
+            transport_other => $csv->_extra_metadata($report, 'CyclingUK_transport_other') || '',
+            marketing => $csv->_extra_metadata($report, 'CyclingUK_marketing_opt_in') || '',
             first_name => $first || '',
             last_name => $last || '',
             $csv->dbi ? () : (
@@ -237,6 +237,18 @@ sub report_new_munge_before_insert {
 
     my $opt_in = $self->{c}->get_param("marketing_opt_in") ? 'yes' : 'no';
     $report->update_extra_field({ name => 'CyclingUK_marketing_opt_in', value => $opt_in });
+
+    my @keys = ('injury_suffered', 'property_damage', 'transport_mode', 'transport_other', 'marketing_opt_in');
+    my %keys = map { "CyclingUK_" . $_ => 1 } @keys;
+    my @fields;
+    foreach (@{$report->get_extra_fields}) {
+        if ($keys{$_->{name}}) {
+            $report->set_extra_metadata($_->{name} => $_->{value});
+        } else {
+            push @fields, $_;
+        }
+    }
+    $report->set_extra_fields(@fields);
 
     return $self->SUPER::report_new_munge_before_insert($report);
 }

--- a/t/cobrand/cyclinguk.t
+++ b/t/cobrand/cyclinguk.t
@@ -193,7 +193,7 @@ subtest 'New report user info fields' => sub {
     );
     $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
     is $report->name, "Brand New";
-    is $report->get_extra_field_value('CyclingUK_marketing_opt_in'), 'yes';
+    is $report->get_extra_metadata('CyclingUK_marketing_opt_in'), 'yes';
 
     $mech->get_ok('/report/new?longitude=-2.364050&latitude=51.386269');
     $mech->submit_form_ok(
@@ -215,7 +215,7 @@ subtest 'New report user info fields' => sub {
     );
     $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
     is $report->name, "Brand New";
-    is $report->get_extra_field_value('CyclingUK_marketing_opt_in'), 'no';
+    is $report->get_extra_metadata('CyclingUK_marketing_opt_in'), 'no';
 };
 
 subtest 'Dashboard CSV export' => sub {
@@ -234,27 +234,12 @@ subtest 'Dashboard CSV export' => sub {
                     name => "depth",
                     value => "25cm"
                 },
-                {
-                    name => "CyclingUK_injury_suffered",
-                    value => "no",
-                },
-                {
-                    name => "CyclingUK_property_damage",
-                    value => "yes",
-                },
-                {
-                    name => "CyclingUK_transport_mode",
-                    value => "other",
-                },
-                {
-                    name => "CyclingUK_transport_other",
-                    value => "horse",
-                },
-                {
-                    name => "CyclingUK_marketing_opt_in",
-                    value => "yes",
-                },
-            ]
+            ],
+            "CyclingUK_injury_suffered" => "no",
+            "CyclingUK_property_damage" => "yes",
+            "CyclingUK_transport_mode" => "other",
+            "CyclingUK_transport_other" => "horse",
+            "CyclingUK_marketing_opt_in" => "yes",
         }
     });
     $mech->get_ok('/dashboard?export=1');


### PR DESCRIPTION
[skip changelog]

For changing existing entries:

```
my $problems = FixMyStreet::DB->resultset("Problem")->search({ cobrand => 'cyclinguk' });
while (my $p = $problems->next) {
    my @keys = ('CyclingUK_injury_suffered', 'CyclingUK_property_damage', 'CyclingUK_transport_mode', 'CyclingUK_transport_other', 'CyclingUK_marketing_opt_in');
    my %keys = map { $_ => 1 } @keys;
    my @fields;
    foreach (@{$report->get_extra_fields}) {
        if ($keys{$_->{name}}) {
            $report->set_extra_metadata($_->{name} => $_->{value});
        } else {
            push @fields, $_;
        }
    }
    $report->set_extra_fields(@fields);
    $report->update;
}
```