### PR TITLE
[Waste] Record staff PAYE payment immediately.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
@@ -230,7 +230,11 @@ sub process_bulky_data : Private {
 
     if (!$c->cobrand->bulky_free_collection_available) {
         # Either was picked in the form, or if not present will be card
-        $c->set_param('payment_method', $data->{payment_method} || 'credit_card');
+        my $payment_method = $data->{payment_method} || 'credit_card';
+        $c->set_param('payment_method', $payment_method);
+        if ($payment_method eq 'credit_card' && $c->stash->{staff_payments_allowed} eq 'paye') {
+            $c->set_param('payment_method', 'csc');
+        }
     }
 
     $c->cobrand->call_hook("waste_munge_bulky_data", $data);

--- a/t/app/controller/waste_kands_bulky.t
+++ b/t/app/controller/waste_kands_bulky.t
@@ -883,6 +883,8 @@ FixMyStreet::override_config {
         );
         $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
         $mech->submit_form_ok({ with_fields => { tandc => 1 } });
+        my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+        is $report->get_extra_field_value('payment_method'), 'csc';
         $mech->submit_form_ok({ with_fields => { payenet_code => '54321' } });
         my $email = $mech->get_email;
         like $email->header('Subject'), qr/Your bulky waste collection - reference LBS/, "Confirmation booking email sent after staff payment process";


### PR DESCRIPTION
The report might be immediately sent at this point (eg if bulky_send_before_payment is set), so needs to be set correctly.
[skip changelog]