### PR TITLE
[TfL] Truncate whensent field in CSVExport

### DIFF
--- a/perllib/FixMyStreet/Script/CSVExport.pm
+++ b/perllib/FixMyStreet/Script/CSVExport.pm
@@ -173,6 +173,7 @@ sub generate_sql {
         # (Override timestamps to truncate to the second)
         "to_json(date_trunc('second', me.created))#>>'{}' as created",
         "to_json(date_trunc('second', me.confirmed))#>>'{}' as confirmed",
+        "to_json(date_trunc('second', me.whensent))#>>'{}' as whensent",
         # Fetch the relevant bits of comments we need for timestamps
         "comments.id as comment_id, comments.problem_state, to_json(date_trunc('second', comments.confirmed))#>>'{}' as comment_confirmed, comments.mark_fixed",
         # Older reports did not store the group on the report, so fetch it from contacts

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -512,6 +512,7 @@ subtest 'Dashboard CSV extra columns' => sub {
     $mech->get_ok('/dashboard?export=1&category=Not+present');
     is scalar(split /\n/, $mech->encoded_content), 1;
     $mech->get_ok('/dashboard?export=1&category=Bus+stops');
+    $mech->content_like(qr/"Bus stops",(\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d,){4}/, "Created, confirmed, acknowledged, and action scheduled in correct format");
     $mech->content_contains('Category,Subcategory');
     $mech->content_contains('Query,Borough');
     $mech->content_contains(',Acknowledged,"Action scheduled",Fixed');


### PR DESCRIPTION
TfL use the whensent field in their reporting and so truncate it to not include nanoseconds

https://mysocietysupport.freshdesk.com/a/tickets/3722

[skip changelog]