### PR TITLE
Added variables to control #postcodeForm color

### DIFF
--- a/web/cobrands/bathnes/_colours.scss
+++ b/web/cobrands/bathnes/_colours.scss
@@ -43,6 +43,8 @@ $col_fixed_label: $bathnes-secondary;
 $front-main-color: $primary_b;
 $front-main-color-desktop: $primary_b;
 $postcodeform-background: #fff;
+$postcodeform-color: $primary_b;
+$postcodeform-color-desktop: $primary_b;
 
 $menu-image: 'menu-black';
 $header-top-border: false;

--- a/web/cobrands/brent/_variables.scss
+++ b/web/cobrands/brent/_variables.scss
@@ -79,6 +79,11 @@ $search-help-header-font-weight: normal;
 $search-help-header-font-size-desktop: 1.25em;
 $search-help-margin-desktop: -1em -1em 0 -1em;
 
+$postcodeform-color: $primary_b;
+$postcodeform-color-desktop: $primary_b;
+$form-hint-color: $primary_b;
+$form-hint-color-desktop: $primary_b;
+
 $dropzone-border-colour: $link-color;
 $dropzone-button-text: $white;
 $dropzone-button-background: $link-color;

--- a/web/cobrands/bristol/_colours.scss
+++ b/web/cobrands/bristol/_colours.scss
@@ -48,6 +48,7 @@ $front-main-color: $base_bg;
 $form-hint-color: $base_bg;
 $front-main-h2-color: $primary_b;
 $front-main-color-desktop: $primary_b;
+$postcodeform-color: $base_bg;
 
 $mobile-sticky-sidebar-button-menu-image: "menu-white";
 

--- a/web/cobrands/bromley/_colours.scss
+++ b/web/cobrands/bromley/_colours.scss
@@ -48,6 +48,7 @@ $site-message-border: 3px solid #235e1c;
 $front-main-color: #fff;
 $front-main-background: $bromley_green;
 $postcodeform-background: $bromley_green;
+$postcodeform-color-desktop: $primary_b;
 
 
 $front-main-color-desktop: $bromley_black;

--- a/web/cobrands/buckinghamshire/_colours.scss
+++ b/web/cobrands/buckinghamshire/_colours.scss
@@ -63,6 +63,8 @@ $geolocation-link: $bucks_links;
 $front-main-color: $primary_b;
 $postcodeform-background: #fff;
 $front-main-color-desktop: $primary_b;
+$postcodeform-color: $primary_b;
+$postcodeform-color-desktop: $primary_b;
 
 
 @mixin bucks-button {

--- a/web/cobrands/fixmystreet.com/base.scss
+++ b/web/cobrands/fixmystreet.com/base.scss
@@ -85,10 +85,6 @@ body.frontpage {
   }
 }
 
-#postcodeForm .form-hint {
-    color: $primary_text;
-}
-
 .next-steps {
   margin: 0 -1em; // counteract padding on parent
   background-color: #faf7e2;

--- a/web/cobrands/gloucestershire/_variables.scss
+++ b/web/cobrands/gloucestershire/_variables.scss
@@ -120,7 +120,9 @@ $mobile-sticky-sidebar-button-menu-image: "menu-white";
   }
 }
 
-$front-main-color: #333;
+$front-main-color: $primary_b;
 $postcodeform-background: $gloucestershire_white;
-$front-main-color-desktop: #333;
+$front-main-color-desktop: $primary_b;
 $front-main-background-desktop: #fff;
+$postcodeform-color: $primary_b;
+$postcodeform-color-desktop: $primary_b;

--- a/web/cobrands/greenwich/_colours.scss
+++ b/web/cobrands/greenwich/_colours.scss
@@ -37,5 +37,9 @@ $dropzone-button-text: $contrast_text;
 
 $postcodeform-background: $greenwich_light_grey;
 $front-main-background-desktop: $greenwich_light_grey;
+$postcodeform-color: $primary;
+$postcodeform-color-desktop: $primary;
+$form-hint-color: $primary_text;
+$form-hint-color-desktop: $primary_text;
 
 $mobile-sticky-sidebar-button-menu-image: "menu-white";

--- a/web/cobrands/greenwich/base.scss
+++ b/web/cobrands/greenwich/base.scss
@@ -73,11 +73,6 @@ body.alertpage {
     }
 }
 
-label[for="pc"] {
-    color: $greenwich_red;
-    text-align: left;
-}
-
 #front_stats {
     color: $nav_colour;
 }

--- a/web/cobrands/highwaysengland/_colours.scss
+++ b/web/cobrands/highwaysengland/_colours.scss
@@ -51,6 +51,8 @@ $front-main-color-desktop: $black;
 $form-hint-color: $black;
 $form-hint-color-desktop: $black;
 $postcodeform-background: $color-he-grey-2;
+$postcodeform-color: $primary_b;
+$postcodeform-color-desktop: $primary_b;
 $front-main-background-desktop:$color-he-grey-2;
 $front-main-background: $color-he-grey-2;
 

--- a/web/cobrands/highwaysengland/base.scss
+++ b/web/cobrands/highwaysengland/base.scss
@@ -126,7 +126,6 @@ p.form-error {
 }
 
 .postcode-form-box {
-    color: $black;
     margin: 1em auto;
     font-family: inherit;
     max-width: 60em;

--- a/web/cobrands/hounslow/_colours.scss
+++ b/web/cobrands/hounslow/_colours.scss
@@ -49,6 +49,7 @@ $search-help-header-font-size-desktop: 1.25em;
 
 $front-main-color:$primary_b;
 $form-hint-color: $primary_text;
+$form-hint-color-desktop: $primary_text;
 $front-main-color-desktop:$primary_text;
 $front-main-background-desktop: $primary;
 $geolocation-link: $primary_text;

--- a/web/cobrands/hounslow/base.scss
+++ b/web/cobrands/hounslow/base.scss
@@ -11,10 +11,6 @@
     background-size: 115px 51px;
 }
 
-.postcode-form-box {
-    color: $white;
-}
-
 #map_box #map {
     background-color: white;
 }

--- a/web/cobrands/merton/_colours.scss
+++ b/web/cobrands/merton/_colours.scss
@@ -48,6 +48,7 @@ $front-main-color: #fff;
 $front-main-h2-color: $merton-headline;
 $front-main-background: $merton-jade-j3;
 $postcodeform-background: $merton-jade-j1;
+$postcodeform-color:#fff;
 $front-main-background-desktop: #fff;
 $front-main-h2-color-desktop: transparentize($merton-headline, 0.2);
 $form-hint-color-desktop: transparentize($merton-headline, 0.2);

--- a/web/cobrands/northamptonshire/_colours.scss
+++ b/web/cobrands/northamptonshire/_colours.scss
@@ -45,4 +45,6 @@ $search-help-header-font-family: inherit;
 $front-main-color-desktop: $dark;
 $front-main-color: $dark;
 $postcodeform-background: $green;
+$postcodeform-color: $white;
+$postcodeform-color-desktop: $primary_b;
 $form-hint-color: $white;

--- a/web/cobrands/northamptonshire/base.scss
+++ b/web/cobrands/northamptonshire/base.scss
@@ -16,10 +16,6 @@
     background: none;
 }
 
-.postcode-form-box {
-    color: $white;
-}
-
 #report-cta {
     color: $white;
     background-color: $primary_b;

--- a/web/cobrands/northumberland/_variables.scss
+++ b/web/cobrands/northumberland/_variables.scss
@@ -21,7 +21,7 @@ $northumber_light_grey:#f3f3f5; // For bg
 $northumber_mid_grey:#d3d3d3; // For bg
 $northumber_dark_grey: #000c24;
 $northumber_black_heading: #333a41;
-$northumber_black: #000;
+$northumber_black: #212529;
 $northumber_yellow: #ffc107; // For alerts
 
 $primary: $northumber_primary;
@@ -104,6 +104,8 @@ $postcodeform-background-desktop: transparent;
 $front-main-color: $primary_b;
 $front-main-background: $northumber_light_grey;
 $postcodeform-background: transparent;
+$postcodeform-color: $primary_b;
+$postcodeform-color-desktop: $primary_b;
 
 $container-max-width: 80em;
 

--- a/web/cobrands/oxfordshire/_colours.scss
+++ b/web/cobrands/oxfordshire/_colours.scss
@@ -54,5 +54,7 @@ $dropzone-button-border: $color-oxfordshire-dark-green;
 
 $front-main-color: #333;
 $postcodeform-background: transparent;
+$postcodeform-color: #333;
+$postcodeform-color-desktop: #333;
 
 $front-main-color-desktop: #333;

--- a/web/cobrands/peterborough/_colours.scss
+++ b/web/cobrands/peterborough/_colours.scss
@@ -56,5 +56,7 @@ $geolocation-link: $green;
 $front-main-color: $black;
 $front-main-color-desktop: $black;
 $postcodeform-background: transparent;
+$postcodeform-color: $primary_b;
+$postcodeform-color-desktop: $primary_b;
 
 $mobile-sticky-sidebar-button-menu-image: "menu-white";

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -50,8 +50,9 @@ $front-main-color: $primary_text !default;
 $front-main-background: none !default;
 // $postcodeform-background controls the background of the postcode-form-box. It excludes the h1 and h2 elements.
 $postcodeform-background: $primary !default;
+$postcodeform-color: $primary_text !default;
 $front-main-h2-color: transparentize($front-main-color, 0.1) !default;
-$form-hint-color: transparentize($front-main-color, 0.2) !default;
+$form-hint-color: transparentize($postcodeform-color, 0.2) !default;
 
 $geolocation-link: #222 !default;
 $geolocation-link-border: $geolocation-link !default;
@@ -2734,7 +2735,7 @@ label .muted {
 }
 
 .postcode-form-box {
-  color: $front-main-color;
+  color: $postcodeform-color;
   background: $postcodeform-background;
   @if not (($postcodeform-background == transparent) or ($postcodeform-background == none)) {
     padding: 1em;

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -26,7 +26,8 @@ $front-main-background-desktop: transparent !default;
 $front-main-container-background-desktop: transparent !default;
 // $postcodeform-background-desktop controls the background of the postcode-form-box. It excludes the h1 and h2 elements.
 $postcodeform-background-desktop: transparent !default;
-$form-hint-color-desktop: transparentize($front-main-color-desktop, 0.2) !default;
+$postcodeform-color-desktop: $primary_text !default;
+$form-hint-color-desktop: transparentize($postcodeform-color-desktop, 0.2) !default;
 $front-main-h2-color-desktop: transparentize($front-main-color-desktop, 0.1) !default;
 
 //This variable controls the color of .content for the front-page
@@ -842,7 +843,7 @@ textarea.form-error {
 }
 
 .postcode-form-box {
-  color: $front-main-color-desktop;
+  color: $postcodeform-color-desktop;
   background: $postcodeform-background-desktop;
   @if not (($postcodeform-background-desktop == transparent) or ($postcodeform-background-desktop == none)) {
     padding: 1em;

--- a/web/cobrands/southwark/_variables.scss
+++ b/web/cobrands/southwark/_variables.scss
@@ -35,6 +35,7 @@ $base_fg: $gray-3;
 $mainform_bg: $white-2;
 $postcodeform-background-desktop: $mainform_bg;
 $postcodeform-background: $mainform_bg;
+$form-hint-color-desktop: $gray-2;
 
 /* 
 IMPORTANT

--- a/web/cobrands/southwark/layout.scss
+++ b/web/cobrands/southwark/layout.scss
@@ -42,10 +42,6 @@ body.frontpage, body.twothirdswidthpage, body.fullwidthpage, body.authpage {
   margin: 0 auto;
   margin-top: 1em;
   padding: 0.5em 1em 2em 1em;
-
-  .form-hint {
-    color: $gray-2;
-  }
 }
 
 .nav-menu--main.nav-menu {

--- a/web/cobrands/thamesmead/_colours.scss
+++ b/web/cobrands/thamesmead/_colours.scss
@@ -58,3 +58,5 @@ $dropzone-button-border: $peabody-brick;
 
 $front-main-container-background-desktop: $peabody-white;
 $postcodeform-background: transparent;
+$postcodeform-color: $peabody-mid-grey;
+$postcodeform-color-desktop: $peabody-mid-grey;

--- a/web/cobrands/zurich/_colours.scss
+++ b/web/cobrands/zurich/_colours.scss
@@ -37,3 +37,4 @@ $front-main-background-desktop: $base_bg;
 $postcodeform-background-desktop: $primary_text;
 $postcodeform-background: $primary;
 $front-main-color-desktop: $base_fg;
+$postcodeform-color-desktop: $base_fg;


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4006

This variables will allow to avoid custom override for some cobrands for the label and .form-hint colors. In this commit the `$form-hint` variable will depend by default of the `$postcodeform-color`, usually they both share the same background colour, so it seemed like a good move in order to have both variables passing a contrast test, of course `$postcodeform-color` will need to satisfy the criteria otherwise both label and .form-hint will fail. It's imporant to note that $form-hint-color and `$form-hint-color-desktop` are being transparentize by 20%, therefore if `$postcodeform-color` and `$postcodeform-color-desktop` are passing the contrast test, by a small margin, then the label will most likely fail the test.

`$form-hint-color` and `$form-hint-color-desktop` can still be declared in each cobrands in case clients want to use a custom color for it.

[Mobile.zip](https://github.com/mysociety/fixmystreet/files/14020670/Mobile.zip)

[Desktop.zip](https://github.com/mysociety/fixmystreet/files/14020671/Desktop.zip)

[Skip changelog]
