### PR TITLE
[TfL] Remove FMS log in options for TfL

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Auth.pm
+++ b/perllib/FixMyStreet/App/Controller/Auth.pm
@@ -109,7 +109,7 @@ sub sign_in : Private {
     $c->logout();
 
     my $parsed = FixMyStreet::SMS->parse_username($username);
-
+    $c->cobrand->call_hook('disable_login_for_email', $parsed->{username}) unless $c->stash->{oauth_need_email};
     $c->forward('throttle_username', [$parsed]);
 
     if ($parsed->{username} && $password && $c->forward('authenticate', [ $parsed->{type}, $parsed->{username}, $password ])) {
@@ -192,6 +192,8 @@ sub email_sign_in : Private {
         $c->stash->{username_error} = $raw_email ? $email_checker->details : 'missing_email';
         return;
     }
+
+    $c->cobrand->call_hook('disable_login_for_email', $good_email) unless $c->get_param('oauth_need_email');
 
     my $password = $c->get_param('password_register');
     if ($password) {

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -969,6 +969,7 @@ sub process_user : Private {
     }
     $params{username} ||= '';
 
+    $c->cobrand->call_hook('disable_login_for_email', $params{username}) unless $c->get_param('oauth_need_email');
     my $anon_button = $c->cobrand->allow_anonymous_reports eq 'button' && $c->get_param('report_anonymously');
     my $anon_fallback = $c->cobrand->allow_anonymous_reports eq '1' && !$c->user_exists && !$params{username};
     if ($anon_button || $anon_fallback) {

--- a/perllib/FixMyStreet/App/Controller/Report/Update.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/Update.pm
@@ -110,6 +110,7 @@ sub process_user : Private {
         $params{username} = $c->get_param('username_register');
     }
     $params{username} ||= '';
+    $c->cobrand->call_hook('disable_login_for_email', $params{username}) unless $c->get_param('oauth_need_email');
 
     my $anon_button = $c->cobrand->allow_anonymous_updates eq 'button' && $c->get_param('report_anonymously');
     if ($anon_button) {

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -161,8 +161,6 @@ sub inactive_reports_filter {
 sub password_expiry {
     my ($self) = @_;
 
-    return if FixMyStreet->test_mode;
-
     my $email = $self->{c}->user->email;
     my $domain_email = $self->admin_user_domain;
     return if $email =~ /$domain_email$/;

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -479,6 +479,16 @@ sub munge_reports_area_list {
 
 sub munge_report_new_contacts { }
 
+sub disable_login_for_email {
+    my ($self, $email) = @_;
+
+    my $staff_email = $self->admin_user_domain;
+
+    if ($email =~ /$staff_email$/) {
+        $self->{c}->detach('/page_error_403_access_denied', ['Please use the staff login option']);
+    }
+}
+
 sub munge_report_new_bodies {
     my ($self, $bodies) = @_;
 

--- a/t/Mock/OpenIDConnect.pm
+++ b/t/Mock/OpenIDConnect.pm
@@ -87,7 +87,7 @@ sub dispatch_request {
         } elsif ($self->cobrand eq 'tfl') {
             $payload->{given_name} = "Andy";
             $payload->{family_name} = "Dwyer";
-            $payload->{email} = 'Pkg-tappcontrollerauth_socialt-oidc@TFL.org' if $self->returns_email;
+            $payload->{email} = 'Pkg-tappcontrollerauth_socialt-oidc@TFL.gov.uk' if $self->returns_email;
             $payload->{roles} = $self->roles;
         }
         my $signature = "dummy";

--- a/t/app/controller/admin/templates.t
+++ b/t/app/controller/admin/templates.t
@@ -1,5 +1,6 @@
 use FixMyStreet::TestMech;
 
+use Test::MockModule;
 use t::Mock::Tilma;
 my $tilma = t::Mock::Tilma->new;
 LWP::Protocol::PSGI->register($tilma->to_psgi_app, host => 'tilma.mysociety.org');
@@ -407,6 +408,8 @@ subtest "TfL cobrand only shows TfL templates" => sub {
             anonymous_account => { tfl => 'anon' },
         },
     }, sub {
+        my $tfl_mock = Test::MockModule->new('FixMyStreet::Cobrand::TfL');
+        $tfl_mock->mock('password_expiry', sub {});
         $report->update({
             category => $tflcontact->category,
             bodies_str => $tfl->id,

--- a/t/app/controller/auth_social.t
+++ b/t/app/controller/auth_social.t
@@ -15,6 +15,9 @@ my $mech = FixMyStreet::TestMech->new;
 FixMyStreet::App->log->disable('info');
 END { FixMyStreet::App->log->enable('info'); }
 
+#my $tfl_mock = Test::MockModule->new('FixMyStreet::Cobrand::TfL');
+#$tfl_mock->mock('must_have_2fa', sub { 0 });
+
 my $body = $mech->create_body_ok(2504, 'Westminster City Council');
 my $body2 = $mech->create_body_ok(2508, 'Hackney Council');
 my $body3 = $mech->create_body_ok(2488, 'Brent Council', {}, { cobrand => 'brent' });
@@ -629,7 +632,7 @@ for my $setup (
                 }
             }
         },
-        email => $mech->uniquify_email('oidc@tfl.org'),
+        email => $mech->uniquify_email('oidc@tfl.gov.uk'),
         uid => "tfl:example_client_id:my_cool_user_id",
         mock => 't::Mock::OpenIDConnect',
         mock_hosts => ['oidc.example.org'],

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -4,6 +4,7 @@ use FixMyStreet::Script::CSVExport;
 use FixMyStreet::Script::Reports;
 use FixMyStreet::Script::Questionnaires;
 use File::Temp 'tempdir';
+use Test::MockModule;
 
 # disable info logs for this test run
 FixMyStreet::App->log->disable('info');
@@ -331,12 +332,10 @@ subtest "test users without tfl email asked to update their FMS password" => sub
     $tfl_non_staff->set_extra_metadata('last_password_change', DateTime->now->subtract(years => 2)->epoch);
     $tfl_non_staff->update;
     $mech->get_ok('/auth');
-    FixMyStreet->test_mode(0);
     $mech->submit_form_ok(
         { with_fields => { username => $tfl_non_staff->email, password_sign_in => 'xpasswordx' } },
         "sign in using form"
     );
-    FixMyStreet->test_mode(1);
     $tfl_non_staff->set_extra_metadata('last_password_change', time());
     $tfl_non_staff->update;
     is $mech->uri->path, '/auth/expired', "logged in to create new password page";
@@ -394,6 +393,8 @@ subtest "test report creation anonymously by staff user" => sub {
 FixMyStreet::DB->resultset("Problem")->delete_all;
 
 subtest "test report creation and reference number" => sub {
+    my $tfl_mock = Test::MockModule->new('FixMyStreet::Cobrand::TfL');
+    $tfl_mock->mock('password_expiry', sub {});
     $mech->log_in_ok( $user->email );
     $mech->get_ok('/around');
     $mech->submit_form_ok( { with_fields => { pc => 'BR1 3UH', } }, "submit location" );
@@ -433,6 +434,8 @@ subtest "test bus report creation outside London, .com" => sub {
 };
 
 subtest "test bus report creation outside London" => sub {
+    my $tfl_mock = Test::MockModule->new('FixMyStreet::Cobrand::TfL');
+    $tfl_mock->mock('password_expiry', sub {});
     $mech->get_ok('/report/new?latitude=51.345714&longitude=-0.227959');
     $mech->submit_form_ok(
         {
@@ -588,6 +591,8 @@ subtest 'Inspect form state choices' => sub {
 };
 
 subtest "change category, report resent to new location" => sub {
+    my $tfl_mock = Test::MockModule->new('FixMyStreet::Cobrand::TfL');
+    $tfl_mock->mock('password_expiry', sub {});
     my $report = FixMyStreet::DB->resultset("Problem")->find({ title => 'Test Report 1'});
     my $id = $report->id;
 
@@ -615,6 +620,8 @@ for my $test (
 ) {
     my ($postcode, $host, $category, $to, $name, $ref ) = @$test;
     subtest "test report is sent to $name on $host" => sub {
+        my $tfl_mock = Test::MockModule->new('FixMyStreet::Cobrand::TfL');
+        $tfl_mock->mock('password_expiry', sub {});
         $mech->host($host);
         $mech->log_in_ok( $user->email );
         $mech->get_ok('/around');
@@ -767,6 +774,8 @@ subtest 'check report age in general' => sub {
 };
 
 subtest 'TfL admin allows inspectors to be assigned to borough areas' => sub {
+    my $tfl_mock = Test::MockModule->new('FixMyStreet::Cobrand::TfL');
+    $tfl_mock->mock('password_expiry', sub {});
     $mech->log_in_ok($superuser->email);
 
     $mech->get_ok("/admin/users/" . $staffuser->id) or diag $mech->content;
@@ -813,6 +822,8 @@ subtest 'TLRN categories cannot be renamed' => sub {
 };
 
 subtest 'Bromley staff cannot access TfL admin' => sub {
+    my $tfl_mock = Test::MockModule->new('FixMyStreet::Cobrand::TfL');
+    $tfl_mock->mock('password_expiry', sub {});
     $mech->log_in_ok( $bromleyuser->email );
     ok $mech->get('/admin');
     is $mech->res->code, 403, "got 403";

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -257,6 +257,8 @@ FixMyStreet::override_config {
 $mech->host("tfl.fixmystreet.com");
 
 subtest "creating a user on TfL creates tfl_password extra_metadata" => sub {
+    my $tfl_mock = Test::MockModule->new('FixMyStreet::Cobrand::TfL');
+    $tfl_mock->mock('disable_login_for_email', sub {});
     for my $email ('test@tfl.gov.uk', 'test@elsewhere.org') {
         $mech->get_ok('/auth/create');
         $mech->submit_form_ok({ with_fields => { username => $email, password_register => 'xpasswordx'} });
@@ -308,23 +310,6 @@ subtest "test report creation anonymously by button" => sub {
     is $alert, undef, "no alert created";
 
     $mech->not_logged_in_ok;
-};
-
-subtest "test users with tfl email not asked to update their FMS password" => sub {
-    my $tfl_staff = FixMyStreet::DB->resultset("User")->find({ email => 'test@tfl.gov.uk'});
-    $tfl_staff->set_extra_metadata('last_password_change',  DateTime->now->subtract(years => 2)->epoch);
-    $tfl_staff->update;
-    $mech->get_ok('/auth');
-    FixMyStreet->test_mode(0);
-    $mech->submit_form_ok(
-        { with_fields => { username => $tfl_staff->email, password_sign_in => 'xpasswordx' } },
-        "sign in using form"
-    );
-    FixMyStreet->test_mode(1);
-    $tfl_staff->set_extra_metadata('last_password_change', time());
-    $tfl_staff->update;
-    is $mech->uri->path, '/my', "logged in to My Account page";
-    $mech->content_lacks('Your password has expired, please create a new one below');
 };
 
 subtest "test users without tfl email asked to update their FMS password" => sub {
@@ -392,6 +377,46 @@ subtest "test report creation anonymously by staff user" => sub {
 
 FixMyStreet::DB->resultset("Problem")->delete_all;
 
+my $tfl_staff = FixMyStreet::DB->resultset("User")->find({ email => 'test@tfl.gov.uk'});
+
+subtest "test user with tfl email address can't login through standard login" => sub {
+    $mech->get_ok('/auth');
+    $mech->submit_form(
+            form_name => 'general_auth',
+            fields => { username => $tfl_staff->email, },
+            button => 'sign_in_by_code',
+    );
+    is $mech->status, '403', "status forbidden";
+    $mech->content_contains('Please use the staff login option');
+    $mech->get_ok('/auth');
+    $mech->submit_form(
+            form_name => 'general_auth',
+            fields => {
+                username => $tfl_staff->email,
+                password_sign_in => 'password'
+                },
+    );
+    is $mech->status, '403', "status forbidden";
+    $mech->content_contains('Please use the staff login option');
+};
+
+subtest "test user with tfl email address can't login by creating a report" => sub {
+    $mech->get_ok('/around');
+    $mech->submit_form_ok( { with_fields => { pc => 'BR1 3UH', } }, "submit location" );
+    $mech->follow_link_ok( { text_regex => qr/skip this step/i, }, "follow 'skip this step' link" );
+    $mech->submit_form(
+            fields => {
+                title => 'Test Report 1',
+                detail => 'Test report details.',
+                name => 'TfL Staff',
+                username_register => $tfl_staff->email,
+                category => 'Bus stops',
+            },
+    );
+    is $mech->status, '403', "status forbidden";
+    $mech->content_contains('Please use the staff login option');
+};
+
 subtest "test report creation and reference number" => sub {
     my $tfl_mock = Test::MockModule->new('FixMyStreet::Cobrand::TfL');
     $tfl_mock->mock('password_expiry', sub {});
@@ -426,7 +451,23 @@ subtest "test report creation and reference number" => sub {
     is $report->name, 'Joe Bloggs';
 };
 
+subtest "test user with tfl email address can't login by updating a report" => sub {
+    $mech->log_out_ok;
+    my $report = FixMyStreet::DB->resultset("Problem")->find({ title => 'Test Report 1'});
+    $mech->get_ok('/report/' . $report->id);
+    $mech->submit_form(
+        with_fields => {
+            update => 'This is an update',
+            username => $tfl_staff->email,
+            password_sign_in => 'xpasswordx',
+        }
+    );
+    is $mech->status, '403', "status forbidden";
+    $mech->content_contains('Please use the staff login option');
+};
+
 subtest "test bus report creation outside London, .com" => sub {
+    $mech->log_in_ok( $user->email );
     $mech->host('www.fixmystreet.com');
     $mech->get_ok('/report/new?latitude=51.345714&longitude=-0.227959');
     $mech->content_lacks('Bus things');


### PR DESCRIPTION
TfL has requested staff can only log in via single sign on.

Create a call hook and add the call to TfL to
disallow logging in on an email address not supplied for single sign on.

https://github.com/mysociety/societyworks/issues/4100

[skip changelog]
