### PR TITLE
[TfL] Azure single sign-on force email lowercase

### DIFF
--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -195,7 +195,7 @@ sub user_from_oidc {
     my ($self, $payload) = @_;
 
     my $name = join(" ", $payload->{given_name}, $payload->{family_name});
-    my $email = $payload->{email};
+    my $email = $payload->{email} ? lc($payload->{email}) : '';
 
     return ($name, $email);
 }

--- a/t/Mock/OpenIDConnect.pm
+++ b/t/Mock/OpenIDConnect.pm
@@ -87,7 +87,7 @@ sub dispatch_request {
         } elsif ($self->cobrand eq 'tfl') {
             $payload->{given_name} = "Andy";
             $payload->{family_name} = "Dwyer";
-            $payload->{email} = 'pkg-tappcontrollerauth_socialt-oidc@tfl.org' if $self->returns_email;
+            $payload->{email} = 'Pkg-tappcontrollerauth_socialt-oidc@TFL.org' if $self->returns_email;
             $payload->{roles} = $self->roles;
         }
         my $signature = "dummy";


### PR DESCRIPTION
Force consistency in log-in by keeping password to one case.

[skip changelog]