### PR TITLE
[Highways] Added fix to prevent overflowing in homepage

### DIFF
--- a/web/cobrands/highwaysengland/base.scss
+++ b/web/cobrands/highwaysengland/base.scss
@@ -109,19 +109,22 @@ p.form-error {
             color: $color-he-grey-2;
         }
     }
-}
 
-#front-main-container {
-    max-width: 100% !important;
-
-    .front-blurb {
-        color:$white;
-        max-width: 28em;
-        opacity: 0.85;
-        background: transparentize($color-he-black, $amount: 0.5);
-        padding: 1em;
-        border-radius: 4px;
-        margin: 0 -1em;
+    #front-main-container {
+        max-width: 100% !important;
+        // Both padding and margin avoid the horizontal overflowing of this element.
+        padding: 0;
+        margin: 0;
+    
+        .front-blurb {
+            color:$white;
+            max-width: 28em;
+            opacity: 0.85;
+            background: transparentize($color-he-black, $amount: 0.5);
+            padding: 1em;
+            border-radius: 4px;
+            margin: 0 -1em;
+        }
     }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4103

I added a preview of desktop as well, because I changed the nesting for `#front-main-container`, otherwise the new rules get overridden by the default behaviour of FMS, this could have affected some rules in `layout.scss`, but it wasn't the case.

https://github.com/mysociety/fixmystreet/assets/13790153/c74ad177-4a38-480c-a614-0d03ef6b4ef0

<img width="1354" alt="Screenshot 2024-02-06 at 08 08 11" src="https://github.com/mysociety/fixmystreet/assets/13790153/a461b2e8-17a1-4914-a499-1a50c2473dcc">

[Skip changelog]
