### PR TITLE
[Buckinghamshire] Send Abavus categories also by email.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -227,14 +227,10 @@ sub open311_post_send {
 
     # For certain categories, send an email also
     my $emails = $self->feature('open311_email');
-    my $addresses = {
-        'Flytipping' => [ email_list($emails->{flytipping}, "TfB") ],
-        'Blocked drain' => [ email_list($emails->{flood}, "Flood Management") ],
-        'Ditch issue' => [ email_list($emails->{flood}, "Flood Management") ],
-        'Flooded subway' => [ email_list($emails->{flood}, "Flood Management") ],
-    };
-    my $dest = $addresses->{$row->category};
+    my $group = $row->get_extra_metadata('group') || '';
+    my $dest = $emails->{$row->category} || $emails->{$group};
     return unless $dest;
+    $dest = [ email_list($dest->[0], $dest->[1] || 'FixMyStreet') ];
 
     my $sender = FixMyStreet::SendReport::Email->new( to => $dest );
     $sender->send($row, $h);

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -79,8 +79,8 @@ FixMyStreet::override_config {
     COBRAND_FEATURES => {
         open311_email => {
             buckinghamshire => {
-                flytipping => 'flytipping@example.com',
-                flood => 'floods@example.org',
+                Flytipping => [ 'flytipping@example.com', 'TfB' ],
+                'Blocked drain' => [ 'floods@example.org', 'Flood Management' ],
             }
         },
         geocoder_reverse => {


### PR DESCRIPTION
The categories currently being sent to Abavus, they also want to go by email. This adds a number of categories to the email sending (plus the future ones, commented out). ~~The configuration would be updated to have e.g.~~

```
  district_default: default@district
  dead_animal: rubbish@district
  flytipping_off_road: flytipping@district
  car_park_flytipping: flytipping@district [plus other]
```

Edit after fixup - config would now be more like this:
```
   'Dead animal (off the road)': [ 'rubbish@district' ]
   'Flytipping (off-road)': [ 'flytipping@district' ]
```

Fixes https://github.com/mysociety/societyworks/issues/4123
[skip changelog]