### PR TITLE
[Bexley] [WW] Add image for Glass 660

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -115,6 +115,7 @@ sub image_for_unit {
         'FO-23'    => 'food-waste',                    # Food 23 ltr Caddy
         'GA-140'   => 'garden-waste-brown-bin',        # Garden 140 ltr Bin
         'GA-240'   => 'garden-waste-brown-bin',        # Garden 240 ltr Bin
+        'GL-660'   => 'green-euro-bin',                # Glass 660 ltr Bin
         'GL-1100'  => 'green-euro-bin',                # Glass 1100 ltr Bin
         'GL-1280'  => 'green-euro-bin',                # Glass 1280 ltr Bin
         'GL-55'    => 'recycle-black-box',             # Glass 55 ltr Box


### PR DESCRIPTION
GL-660 'Glass 660 ltr bin' was missing an image; have added one according to https://3.basecamp.com/4020879/buckets/35109031/todos/6816011725#__recording_7058530525.
Closes https://github.com/mysociety/societyworks/issues/4067 .
[skip changelog]
