### PR TITLE
Prevent ‘new report’ pin being dragged on mobile

### DIFF
--- a/web/cobrands/fixmystreet/map.js
+++ b/web/cobrands/fixmystreet/map.js
@@ -43,6 +43,11 @@ var fixmystreet = fixmystreet || {};
             if (bool[key]) {
                 val = !!val;
             }
+            // On mobile we need to force the "new report" pin (id 0) to not be draggable
+            // as it interferes with the crosshair pinpointing mechanism.
+            if (key === "draggable" && $("html").hasClass("mobile") && arr[3] == 0) {
+                val = false;
+            }
             arr.push(val);
         });
         fixmystreet.pins.push(arr);


### PR DESCRIPTION
On first page load the green pin would be draggable out from under the crosshairs, but it shouldn’t have been. The change stops that from happening.

For https://github.com/mysociety/societyworks/issues/3638 (specifically [the bug described in this comment](https://github.com/mysociety/societyworks/issues/3638#issuecomment-1632197164))

[skip changelog]