### PR TITLE
[Peterborough] Skip site code lookup for waste.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -118,6 +118,19 @@ sub geocoder_munge_results {
     $result->{display_name} =~ s/, City of Peterborough, East of England, England//;
 }
 
+=head2 (around) open311_update_missing_data
+
+If we have a UPRN (a waste report), we do not need to look up the site code.
+This hooks around the default from Roles::ConfirmOpen311.
+
+=cut
+
+around open311_update_missing_data => sub {
+    my ($orig, $self, $row, $h, $contact) = @_;
+    return if $row->get_extra_field_value('uprn');
+    return $self->$orig($row, $h, $contact);
+};
+
 around open311_extra_data_include => sub {
     my ($orig, $self, $row, $h) = @_;
 

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -9,7 +9,7 @@ FixMyStreet::App->log->disable('info');
 END { FixMyStreet::App->log->enable('info'); }
 
 my $mock = Test::MockModule->new('FixMyStreet::Cobrand::Peterborough');
-$mock->mock('_fetch_features', sub { [] });
+$mock->mock('_fetch_features', sub { ok 0, 'This should not be called by waste'; });
 
 my $mech = FixMyStreet::TestMech->new;
 

--- a/t/app/controller/waste_peterborough_bulky.t
+++ b/t/app/controller/waste_peterborough_bulky.t
@@ -11,7 +11,7 @@ FixMyStreet::App->log->disable('info');
 END { FixMyStreet::App->log->enable('info'); }
 
 my $mock = Test::MockModule->new('FixMyStreet::Cobrand::Peterborough');
-$mock->mock('_fetch_features', sub { [] });
+$mock->mock('_fetch_features', sub { ok 0, 'This should not be called by waste'; });
 
 my $cobrand = FixMyStreet::Cobrand::Peterborough->new;
 

--- a/t/cobrand/peterborough.t
+++ b/t/cobrand/peterborough.t
@@ -21,6 +21,9 @@ $mock->mock('_fetch_features', sub {
         # adopted roads
         } elsif ( $x == 552721 && $args->{url} =~ m{7/query} ) {
             return [ { geometry => { type => 'Point' } } ];
+        } elsif ( $x == 551973 && $args->{url} =~ m{7/query} ) {
+            # site_code lookup test
+            return [ { geometry => { type => 'Polygon', coordinates => [ [ [ 551975, 298244 ], [ 551975, 298244 ] ] ] }, properties => { USRN => "ROAD" } } ];
         }
         return [];
     }
@@ -59,7 +62,7 @@ subtest 'open311 request handling', sub {
                 { description => 'Tree code', code => 'colour', required => 'True', automated => 'hidden_field' },
             ] },
         );
-        my ($p) = $mech->create_problems_for_body(1, $peterborough->id, 'Title', { category => 'Trees', latitude => 52.5608, longitude => 0.2405, cobrand => 'peterborough' });
+        my ($p) = $mech->create_problems_for_body(1, $peterborough->id, 'Title', { category => 'Trees', latitude => 52.5609, longitude => 0.2405, cobrand => 'peterborough' });
         $p->push_extra_fields({ name => 'emergency', value => 'no'});
         $p->push_extra_fields({ name => 'private_land', value => 'no'});
         $p->push_extra_fields({ name => 'PCC-light', value => 'whatever'});
@@ -82,6 +85,7 @@ subtest 'open311 request handling', sub {
         is $c->param('attribute[private_land]'), undef, 'no private_land param sent';
         is $c->param('attribute[PCC-light]'), undef, 'no pcc- param sent';
         is $c->param('attribute[tree_code]'), 'tree-42', 'tree_code param sent';
+        is $c->param('attribute[site_code]'), 'ROAD', 'site_code found';
     };
 };
 


### PR DESCRIPTION
To stop waste reports being stuck if the site code lookup isn't operational.
Refers to https://mysocietysupport.freshdesk.com/a/tickets/3859
[skip changelog]