### PR TITLE
[Brent] Enable multiple waste calendar links.

### DIFF
--- a/t/cobrand/brent.t
+++ b/t/cobrand/brent.t
@@ -975,7 +975,10 @@ FixMyStreet::override_config {
             'wednesday-B2' => 'https://example.org/media/16420712/wednesdayweek2.pdf'
         } },
         ggw_calendar_links => { brent => {
-            'monday-2' => 'https://example.org/media/16420712/mondayweek2'
+            'monday-2' => [ {
+                href => 'https://example.org/media/16420712/mondayweek2',
+                text => 'Download PDF garden waste calendar',
+            } ]
         } },
         payment_gateway => { brent => {
             cc_url => 'http://example.com',

--- a/templates/web/base/waste/bin_days_sidebar.html
+++ b/templates/web/base/waste/bin_days_sidebar.html
@@ -8,11 +8,11 @@
         [% ELSIF c.cobrand.moniker == 'sutton' %]
             <li><a href="https://sutton-self.achieveservice.com/service/In_My_Area_Results?altval=LBS&amp;displaymode=collections&amp;uprn=[% property.uprn %]">Download PDF waste calendar</a></li>
         [% ELSIF c.cobrand.moniker == 'brent' AND (calendar_link OR ggw_calendar_link) %]
-            [%- IF calendar_link -%]
-              <li><a href="[% calendar_link %]">Download PDF waste calendar</a></li>
+            [%- FOR link IN calendar_link -%]
+              <li><a href="[% link.href OR link %]">[% link.text OR 'Download PDF waste calendar' %]</a></li>
             [%- END -%]
-            [%- IF ggw_calendar_link -%]
-              <li><a href="[% ggw_calendar_link %]">Download PDF garden waste calendar</a></li>
+            [%- FOR link IN ggw_calendar_link -%]
+              <li><a href="[% link.href OR link %]">[% link.text OR 'Download PDF garden waste calendar' %]</a></li>
             [%- END -%]
         [% END %]
          </ul>


### PR DESCRIPTION
Configuration can either still be a single link, or a list of href/text objects (as in test example).
Fixes https://github.com/mysociety/societyworks/issues/4134
[skip changelog]
