### PR TITLE
[Bexley][WW] Allow reporting missed collections

### DIFF
--- a/perllib/Integrations/Whitespace.pm
+++ b/perllib/Integrations/Whitespace.pm
@@ -125,11 +125,42 @@ sub GetSiteServiceItemRoundSchedules {
 }
 
 sub GetSiteWorksheets {
-    my ($self, $uprn) = @_;
+    my ( $self, $uprn ) = @_;
 
-    my $res = $self->call('GetSiteWorksheets', worksheetInput => ixhash( Uprn => $uprn ));
+    my $res = $self->call( 'GetSiteWorksheets',
+        worksheetInput => ixhash( Uprn => $uprn ) );
 
-    return $res;
+    my $worksheets = force_arrayref( $res->{Worksheets}, 'Worksheet' );
+
+    return $worksheets;
+}
+
+# Needed to get ServiceItemIDs
+sub GetWorksheetDetailServiceItems {
+    my ( $self, $worksheet_id ) = @_;
+
+    my $res = $self->call( 'GetWorksheetDetailServiceItems',
+        worksheetDetailServiceItemsInput =>
+            ixhash( WorksheetId => $worksheet_id ) );
+
+    my $items = force_arrayref( $res->{Worksheetserviceitems},
+        'WorksheetServiceItem' );
+
+    return $items;
+}
+
+sub GetCollectionByUprnAndDate {
+    my ( $self, $uprn, $date_from ) = @_;
+
+    my $res = $self->call(
+        'GetCollectionByUprnAndDate',
+        getCollectionByUprnAndDateInput => ixhash(
+            Uprn                   => $uprn,
+            NextCollectionFromDate => $date_from,
+        ),
+    );
+
+    return force_arrayref( $res->{Collections}, 'Collection' );
 }
 
 sub GetCollectionByUprnAndDatePlus {
@@ -137,8 +168,7 @@ sub GetCollectionByUprnAndDatePlus {
 
     my $res = $self->call('GetCollectionByUprnAndDatePlus', getCollectionByUprnAndDatePlusInput => ixhash( Uprn => $uprn, NextCollectionFromDate => $date_from, NextCollectionToDate => $date_to ));
 
-    # TODO Need to force arrayref?
-    return $res->{Collections}{Collection};
+    return force_arrayref($res->{Collections}, 'Collection');
 }
 
 sub GetInCabLogsByUsrn {
@@ -146,7 +176,9 @@ sub GetInCabLogsByUsrn {
 
     my $res = $self->call('GetInCabLogs', inCabLogInput => ixhash( Usrn => $usrn, LogFromDate => $log_from_date, LogTypeID => [] ));
 
-    return $res->{InCabLogs}->{InCabLogs};
+    my $logs = force_arrayref( $res->{InCabLogs}, 'InCabLogs' );
+
+    return $logs;
 }
 
 sub GetInCabLogsByUprn {
@@ -154,7 +186,9 @@ sub GetInCabLogsByUprn {
 
     my $res = $self->call('GetInCabLogs', inCabLogInput => ixhash( Uprn => $uprn, LogFromDate => $log_from_date, LogTypeID => [] ));
 
-    return $res->{InCabLogs}->{InCabLogs};
+    my $logs = force_arrayref( $res->{InCabLogs}, 'InCabLogs' );
+
+    return $logs;
 }
 
 sub GetStreets {
@@ -166,7 +200,6 @@ sub GetStreets {
 
     return $streets;
 }
-
 
 sub GetSiteIncidents {
     my ($self, $uprn) = @_;

--- a/templates/email/bexley/site-name.txt
+++ b/templates/email/bexley/site-name.txt
@@ -1,0 +1,1 @@
+[% IF report.cobrand_data == 'waste' %]WasteWorks[% ELSE %]FixMyStreet[% END %]

--- a/templates/web/bexley/waste/_announcement.html
+++ b/templates/web/bexley/waste/_announcement.html
@@ -1,0 +1,45 @@
+[% USE date(format = c.cobrand.bin_day_format) %]
+[% IF (property.red_tags && property.red_tags.size) || (property.service_updates && property.service_updates.size) %]
+  <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Service status</h2>
+
+  [% IF property.service_updates && property.service_updates.size %]
+    <div class="govuk-inset-text">
+      <h3 class="govuk-heading-m">Service updates</h3>
+      <ul class="govuk-list">
+        [% FOREACH update IN property.service_updates %]
+          <li>[% date.format(update.date, '%A, %-d~~~ %B %Y at %l:%M%p') | replace('~~~', update.ordinal) %]: [% update.reason %]</li>
+        [% END %]
+      </ul>
+    </div>
+  [% END %]
+  [% IF property.red_tags && property.red_tags.size %]
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      Our collections teams have put a 'red-tag' on the following bins:
+    </h2>
+    <div class="govuk-error-summary__body">
+      <dl class="govuk-summary-list">
+        [% FOREACH red_tag IN property.red_tags %]
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">[% red_tag.reason %]</dt>
+            <dd class="govuk-summary-list__value">[% date.format(red_tag.date, '%A, %-d~~~ %B %Y at %l:%M%p') | replace('~~~', red_tag.ordinal) %]</dd>
+          </div>
+        [% END %]
+      </dl>
+      <p class="govuk-body">Our collection teams will put a red tag on your bin if:</p>
+      <ul class="govuk-list">
+        <li>Bins are not out when the collection team arrives</li>
+        <li>You put the wrong kind of waste in it</li>
+        <li>It was overflowing and the lid wasn’t properly shut</li>
+        <li>It was too heavy for anyone to lift safely</li>
+        <li>It’s a charged service (like garden waste) and you haven’t paid yet</li>
+      </ul>
+      <p class="govuk-body">We are unable to accept missed bin reports for bins that have been red-tagged.</p>
+      <p class="govuk-body">
+        <a target="_blank" href="https://www.bexley.gov.uk/services/rubbish-and-recycling/find-your-collection-day-and-report-missed-bin/why-your-rubbish-wasnt-collected">Find out about red-tags and what to do with rubbish that wasn’t collected.</a>
+      </p>
+    </div>
+  </div>
+  [% END %]
+
+[% END %]

--- a/templates/web/bexley/waste/_service_missed.html
+++ b/templates/web/bexley/waste/_service_missed.html
@@ -1,0 +1,23 @@
+[% IF unit.report_open %]
+  <span class="waste-service-descriptor">
+    A [% unit.service_name FILTER lower %] collection has been reported as missed
+    [% IF unit.report_open.report %] – <a href="[% unit.report_open.report.url %]" class="waste-service-link">check status</a>[% END %]
+  </span>
+[% ELSIF unit.report_locked_out %]
+<span class="waste-service-descriptor">A missed collection cannot be reported;
+  [% IF unit.report_locked_out_reason %]
+      [% unit.report_locked_out_reason %]
+  [% ELSE %]
+      please see the service status at the top of this page.
+  [% END %]
+</span>
+[% ELSIF unit.report_allowed %]
+  [% any_report_allowed = 1 %]
+  <form method="post" action="[% c.uri_for_action('waste/report', [ property.id ]) %]">
+    <input type="hidden" name="token" value="[% csrf_token %]">
+    <input type="hidden" name="service-[% unit.service_id %]" value="1">
+    <input type="submit" value="Report a [% unit.service_name FILTER lower %] collection as missed" class="waste-service-descriptor waste-service-link">
+  </form>
+[% ELSIF NOT no_default %]
+  <span class="waste-service-descriptor">Please note that missed collections can only be reported within 3 working days of your scheduled collection day.</span>
+[% END %]

--- a/templates/web/bexley/waste/services.html
+++ b/templates/web/bexley/waste/services.html
@@ -1,0 +1,1 @@
+[% PROCESS 'waste/_service_missed.html' %]

--- a/templates/web/bexley/waste/services_extra.html
+++ b/templates/web/bexley/waste/services_extra.html
@@ -1,0 +1,39 @@
+<div class="govuk-grid-row" id="in-cab-logs">
+  [%# Allow superusers to see red tags and service updates for debugging purposes %]
+  [% IF c.user.is_superuser %]
+  <details>
+    <summary>Red tags</summary>
+    [% FOREACH tag IN property.red_tags %]
+    <h3>[% tag.reason %]</h3>
+    <dl>
+      <dt>Date</dt>
+      <dd>[% tag.date %]</dd>
+
+      <dt>UPRN</dt>
+      <dd>[% tag.uprn %]</dd>
+
+      <dt>Round</dt>
+      <dd>[% tag.round %]</dd>
+    </dl>
+    <hr>
+    [% END %]
+  </details>
+  <details>
+    <summary>Service updates</summary>
+    [% IF property.service_updates && property.service_updates.size %]
+    [% FOREACH update IN property.service_updates %]
+    <h3>[% update.reason %]</h3>
+    <dl>
+      <dt>Date</dt>
+      <dd>[% date.format(update.date, '%A, %-d~~~ %B %Y at %l:%M%p') | replace('~~~', update.ordinal) %]</dd>
+
+      <dt>Round</dt>
+      <dd>[% update.round %]</dd>
+      [% END %]
+    </dl>
+    [% ELSE %]
+    <p>No service updates</p>
+    [% END %]
+  </details>
+  [% END %]
+</div>


### PR DESCRIPTION
Adds the necessary checks, templates and hooks to allow reporting missed collections to Whitespace.

Handles the gate checks that need to be done before the report can be submitted:

- Check for existing open reports
- Check that the collection happened in the past 3 working days
- Check the in-cab logs for red tags and service updates

I've also added a superuser-only section at the bottom of the services screen to allow superusers to view the "raw" in-cab logs (red tags and service exceptions), as I think that might be useful in the future.

Closes https://github.com/mysociety/societyworks/issues/4094.

[skip changelog]
