### PR TITLE
[Bromley] Waste different renewal cost

### DIFF
--- a/perllib/FixMyStreet/App/Form/Waste/Garden/Renew.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Garden/Renew.pm
@@ -31,7 +31,7 @@ has_page intro => (
         my $new_bins = $bin_count - $current_bins;
 
         my $edit_current_allowed = $c->cobrand->call_hook('waste_allow_current_bins_edit');
-        my $cost_pa = $c->cobrand->garden_waste_cost_pa($bin_count);
+        my $cost_pa = $c->cobrand->garden_waste_renewal_cost_pa($data->{end_date}, $bin_count);
         my $cost_now_admin = $c->cobrand->garden_waste_new_bin_admin_fee($new_bins);
         if ($form->saved_data->{apply_discount}) {
             ($cost_pa, $cost_now_admin) = $c->cobrand->apply_garden_waste_discount(
@@ -61,14 +61,15 @@ has_page summary => (
         my $c = $form->{c};
         my $data = $form->saved_data;
 
+        my $end_date = $c->stash->{garden_form_data}->{end_date};
         my $current_bins = $data->{current_bins} || 0;
         my $bin_count = $data->{bins_wanted} || 1;
         my $new_bins = $bin_count - $current_bins;
         my $cost_pa;
         if (($data->{container_choice}||'') eq 'sack') {
-            $cost_pa = $c->cobrand->garden_waste_sacks_cost_pa() * $bin_count;
+            $cost_pa = $c->cobrand->garden_waste_renewal_sacks_cost_pa($end_date) * $bin_count;
         } else {
-            $cost_pa = $form->{c}->cobrand->garden_waste_cost_pa($bin_count);
+            $cost_pa = $form->{c}->cobrand->garden_waste_renewal_cost_pa($end_date, $bin_count);
         }
         my $cost_now_admin = $form->{c}->cobrand->garden_waste_new_bin_admin_fee($new_bins);
         if ($data->{apply_discount}) {

--- a/perllib/FixMyStreet/App/Form/Waste/Garden/Sacks/Renew.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Garden/Sacks/Renew.pm
@@ -63,7 +63,8 @@ has_page sacks_details => (
         my $c = $form->{c};
         my $data = $form->saved_data;
         my $bin_count = $c->get_param('bins_wanted') || $data->{bins_wanted} || 1;
-        my $cost_pa = $c->cobrand->garden_waste_sacks_cost_pa() * $bin_count;
+        my $end_date = $c->stash->{garden_form_data}->{end_date};
+        my $cost_pa = $c->cobrand->garden_waste_renewal_sacks_cost_pa($end_date) * $bin_count;
         if ($data->{apply_discount}) {
             ($cost_pa) = $c->cobrand->apply_garden_waste_discount($cost_pa);
         }

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -929,14 +929,6 @@ sub waste_display_payment_method {
     return $display->{$method};
 }
 
-sub garden_waste_cost_pa {
-    my ($self, $bin_count) = @_;
-
-    $bin_count ||= 1;
-
-    return $self->feature('payment_gateway')->{ggw_cost} * $bin_count;
-}
-
 sub garden_waste_new_bin_admin_fee { 0 }
 
 sub waste_payment_ref_council_code { "LBB" }

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -929,6 +929,21 @@ sub waste_display_payment_method {
     return $display->{$method};
 }
 
+=head2 garden_waste_renewal_cost_pa
+
+The price change for a renewal is based upon the end
+date of the subscription, not the current date.
+
+=cut
+
+sub garden_waste_renewal_cost_pa {
+    my ($self, $end_date, $bin_count) = @_;
+    $bin_count ||= 1;
+    my $per_bin_cost = $self->_get_cost('ggw_cost', $end_date);
+    my $cost = $per_bin_cost * $bin_count;
+    return $cost;
+}
+
 sub garden_waste_new_bin_admin_fee { 0 }
 
 sub waste_payment_ref_council_code { "LBB" }

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -910,10 +910,9 @@ sub waste_get_pro_rata_bin_cost {
     my $weeks = $end->delta_days($start)->in_units('weeks');
     $weeks -= 1 if $weeks > 0;
 
-    my $base = $self->feature('payment_gateway')->{pro_rata_minimum};
-    my $weekly_cost = $self->feature('payment_gateway')->{pro_rata_weekly};
-
-    my $cost = $base + ( $weeks * $weekly_cost );
+    my $base = $self->_get_cost('pro_rata_minimum', $start);
+    my $weekly_cost = $self->_get_cost('pro_rata_weekly', $start);
+    my $cost = sprintf "%.0f", ($base + ( $weeks * $weekly_cost ));
 
     return $cost;
 }

--- a/templates/web/base/waste/garden/_bin_quantities.html
+++ b/templates/web/base/waste/garden/_bin_quantities.html
@@ -71,10 +71,15 @@
     </div>
     <div class="fieldset-item">
       [%# Subscribe has already applied discounts by this point %]
+      [% IF form_page == 'renew';
+            SET cost = per_bin_renewal_cost;
+        ELSE;
+            SET cost = per_bin_cost;
+        END %]
       [% IF form.saved_data.apply_discount AND form_page != 'subscribe' %]
-        <span class="cost-pa" id="total_per_year">£[% tprintf('%.2f', cobrand.apply_garden_waste_discount(per_bin_cost / 100) ) %] per bin per year</span>
+        <span class="cost-pa" id="total_per_year">£[% tprintf('%.2f', cobrand.apply_garden_waste_discount(cost / 100) ) %] per bin per year</span>
       [% ELSE %]
-        <span class="cost-pa" id="total_per_year">£[% tprintf('%.2f', per_bin_cost / 100 ) %] per bin per year</span>
+        <span class="cost-pa" id="total_per_year">£[% tprintf('%.2f', cost / 100 ) %] per bin per year</span>
       [% END %]
     </div>
   </div>

--- a/templates/web/base/waste/garden/renew.html
+++ b/templates/web/base/waste/garden/renew.html
@@ -14,11 +14,11 @@
   <hr class="fieldset-hr">
   <div class="cost-pa__total js-bin-costs"
     [% IF form.saved_data.apply_discount %]
-        data-per_bin_cost="[% c.cobrand.apply_garden_waste_discount(per_bin_cost) %]"
+        data-per_bin_cost="[% c.cobrand.apply_garden_waste_discount(per_bin_renewal_cost) %]"
         data-per_new_bin_first_cost="[% c.cobrand.apply_garden_waste_discount(per_new_bin_first_cost) %]"
         data-per_new_bin_cost="[% c.cobrand.apply_garden_waste_discount(per_new_bin_cost) %]"
     [% ELSE %]
-        data-per_bin_cost="[% per_bin_cost %]"
+        data-per_bin_cost="[% per_bin_renewal_cost %]"
         data-per_new_bin_first_cost="[% per_new_bin_first_cost %]"
         data-per_new_bin_cost="[% per_new_bin_cost %]"
     [% END %]

--- a/templates/web/base/waste/garden/sacks/renew.html
+++ b/templates/web/base/waste/garden/sacks/renew.html
@@ -15,7 +15,7 @@
 
   <hr class="fieldset-hr">
     <div class="cost-pa__total js-bin-costs"
-        data-per_bin_cost="[% per_sack_cost %]"
+        data-per_bin_cost="[% per_sack_renewal_cost %]"
     >
       <span class="cost-pa__total-costs">
           Total per year: £<span id="cost_pa">[% tprintf( '%.2f', cost_pa ) %]</span>

--- a/templates/web/kingston/waste/garden/_bin_quantities.html
+++ b/templates/web/kingston/waste/garden/_bin_quantities.html
@@ -52,6 +52,11 @@
     </div>
 
     <div class="fieldset-item">
-      <span class="cost-pa">£[% tprintf('%.2f', per_bin_cost / 100 ) %] per bin per year</span>
+      [% IF form_page == 'renew';
+            SET cost = per_bin_renewal_cost;
+        ELSE;
+            SET cost = per_bin_cost;
+        END %]
+        <span class="cost-pa">£[% tprintf('%.2f', cost / 100 ) %] per bin per year</span>
     </div>
   </div>


### PR DESCRIPTION
Adds functionality to charge renewals based on the price for subscriptions at or beyond the renewal date.

Adds functionality to check for the price of additional bins based on the price of bins by date to allow for adding changes to the configuration in advance which will take effect on the day the date set.

Adds tests.

[skip changelog]

https://github.com/mysociety/societyworks/issues/4135