### PR TITLE
Fix dashboard selected for group/category with &.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
         - Added support for 'multivaluelist' extra category questions using checkboxes.
         - Added support for 'datetime' extra category questions using a datetime picker.
         - Added option to make a phone number required for a category.
+        - Add way to pick multiple categories in the dashboard.
     - Development improvements:
         - Extra data columns now stored as JSON, not RABX. #3216
         - Cobrands can provide custom distances for duplicate lookup. #4456

--- a/perllib/FixMyStreet/App/Controller/Admin/Stats.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Stats.pm
@@ -121,6 +121,8 @@ sub questionnaire : Local : Args(0) {
 sub refused : Local : Args(0) {
     my ($self, $c) = @_;
 
+    return unless $c->cobrand->moniker eq 'fixmystreet'; # Match stats index template
+
     my $contacts = $c->model('DB::Contact')->not_deleted->search([
         { email => 'REFUSED' },
         { 'body.can_be_devolved' => 1, 'me.send_method' => 'Refused' },

--- a/perllib/FixMyStreet/App/Controller/Dashboard.pm
+++ b/perllib/FixMyStreet/App/Controller/Dashboard.pm
@@ -129,6 +129,10 @@ sub index : Path : Args(0) {
         $c->stash->{contacts} = [ $c->stash->{contacts}->all ];
         $c->forward('/report/stash_category_groups', [ $c->stash->{contacts} ]);
 
+        foreach (@{$c->stash->{category_groups}}) {
+            $_->{group_id} = "group-" . $_->{name};
+        }
+
         my %group_names = map { $_->{name} => $_->{categories} } @{$c->stash->{category_groups}};
         # See if we've had anything from the body dropdowns
         $c->stash->{category} = [ $c->get_param_list('category') ];

--- a/t/app/controller/dashboard.t
+++ b/t/app/controller/dashboard.t
@@ -37,7 +37,7 @@ my @cats = ('Litter', 'Other', 'Potholes', 'Traffic lights & bells', 'White line
 for my $contact ( @cats ) {
     my $c = $mech->create_contact_ok(body_id => $body->id, category => $contact, email => "$contact\@example.org");
     if ($contact eq 'Potholes' || $contact eq 'White lines') {
-        $c->set_extra_metadata(group => ['Road']);
+        $c->set_extra_metadata(group => ['Road & more']);
         $c->update;
     }
 }
@@ -160,10 +160,10 @@ FixMyStreet::override_config {
 
     subtest 'The correct categories and totals shown by default' => sub {
         $mech->get_ok("/dashboard");
-        my $expected_cats = [ 'Litter', 'Other', 'Traffic lights & bells', 'All Road', 'Potholes', 'White lines' ];
+        my $expected_cats = [ 'Litter', 'Other', 'Traffic lights & bells', 'All Road & more', 'Potholes', 'White lines' ];
         my $res = $categories->scrape( $mech->content );
-        $mech->content_contains('<optgroup label="Road">');
-        $mech->content_contains('<option value="group-Road"');
+        $mech->content_contains('<optgroup label="Road &amp; more">');
+        $mech->content_contains('<option value="group-Road &amp; more"');
         is_deeply( $res->{cats}, $expected_cats, 'correct list of categories' );
         # Three missing as more than a month ago
         test_table($mech->content, 1, 0, 0, 1, 0, 0, 0, 0, 2, 0, 4, 6, 7, 3, 0, 10, 1, 0, 0, 1, 11, 3, 4, 18);
@@ -183,11 +183,15 @@ FixMyStreet::override_config {
         test_table($mech->content, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 3, 0, 0, 0, 0, 3, 0, 0, 3);
         $mech->get_ok("/dashboard?category=Litter&category=Potholes");
         test_table($mech->content, 1, 0, 0, 1, 0, 0, 0, 0, 2, 0, 4, 6, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 4, 7);
-        $mech->get_ok("/dashboard?category=group-Road");
+        $mech->get_ok("/dashboard?category=Traffic+lights+%26+bells");
+        $mech->content_contains("<option value='Traffic lights &amp; bells' selected>");
+        test_table($mech->content, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 0, 10, 0, 0, 0, 0, 7, 3, 0, 10);
+        $mech->get_ok("/dashboard?category=group-Road+%26+more");
+        $mech->content_contains('<option value="group-Road &amp; more" selected>');
         test_table($mech->content, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 4, 6, 0, 0, 0, 0, 1, 0, 0, 1, 3, 0, 4, 7);
-        $mech->get_ok("/dashboard?category=group-Road&category=Potholes");
+        $mech->get_ok("/dashboard?category=group-Road+%26+more&category=Potholes");
         test_table($mech->content, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 4, 6, 0, 0, 0, 0, 1, 0, 0, 1, 3, 0, 4, 7);
-        $mech->get_ok("/dashboard?category=group-Road&category=Litter");
+        $mech->get_ok("/dashboard?category=group-Road+%26+more&category=Litter");
         test_table($mech->content, 1, 0, 0, 1, 0, 0, 0, 0, 2, 0, 4, 6, 0, 0, 0, 0, 1, 0, 0, 1, 4, 0, 4, 8);
     };
 
@@ -211,18 +215,18 @@ FixMyStreet::override_config {
     subtest 'csv for multiple categories' => sub {
         $mech->get_ok("/dashboard?category=Litter&category=Potholes&export=2");
         $mech->content_contains('www.example.org-body-' . $body->id . '-category-Litter,Potholes-start_date-2014-01-02.csv');
-        $mech->get_ok("/dashboard?category=Litter&category=Potholes&category=Traffic+lights+&amp;+bells&export=2");
+        $mech->get_ok("/dashboard?category=Litter&category=Potholes&category=Traffic+lights+%26+bells&export=2");
         $mech->content_contains('www.example.org-body-' . $body->id . '-category-multiple-categories-start_date-2014-01-02.csv');
         $mech->get_ok("/dashboard?category=Litter&category=Potholes&export=1");
         my @rows = $mech->content_as_csv;
         is scalar @rows, 8, '1 (header) + 7 (reports) found = 8 lines';
-        $mech->get_ok("/dashboard?category=group-Road&export=1");
+        $mech->get_ok("/dashboard?category=group-Road+%26+more&export=1");
         @rows = $mech->content_as_csv;
         is scalar @rows, 8, '1 (header) + 7 (reports) found = 8 lines';
-        $mech->get_ok("/dashboard?category=group-Road&category=Potholes&export=1");
+        $mech->get_ok("/dashboard?category=group-Road+%26+more&category=Potholes&export=1");
         @rows = $mech->content_as_csv;
         is scalar @rows, 8, '1 (header) + 7 (reports) found = 8 lines';
-        $mech->get_ok("/dashboard?category=group-Road&category=Litter&export=1");
+        $mech->get_ok("/dashboard?category=group-Road+%26+more&category=Litter&export=1");
         @rows = $mech->content_as_csv;
         is scalar @rows, 9, '1 (header) + 8 (reports) found = 9 lines';
     };

--- a/templates/web/base/dashboard/index.html
+++ b/templates/web/base/dashboard/index.html
@@ -53,8 +53,8 @@
         <label for="category">[% loc('Category:') %]</label>
         <select class="form-control js-multiple" multiple name="category" id="category">
             [% BLOCK category_option %]
-            [% SET category = cat.category | html %]
-                <option value='[% cat.category | html %]'[% ' selected' IF display_categories.$category %]>[% cat.category_display | html %]</option>
+            [% SET category_safe = mark_safe(cat.category) %]
+                <option value='[% cat.category | html %]'[% ' selected' IF display_categories.$category_safe %]>[% cat.category_display | html %]</option>
             [% END %]
             [%~ INCLUDE 'report/new/_category_select.html' include_group_option=1 ~%]
         </select>

--- a/templates/web/base/report/new/_category_select.html
+++ b/templates/web/base/report/new/_category_select.html
@@ -1,7 +1,7 @@
 [%~ FOREACH group IN category_groups ~%]
     [% IF group.name AND include_group_option %]<optgroup label="[% group.name %]">
-        [% SET pseudo_category = "group-" _ group.name %]
-        <option value="group-[% group.name %]" [% ' selected' IF display_categories.$pseudo_category %]>All [% group.name %]</option>
+        [% SET pseudo_category = mark_safe(group.group_id) %]
+        <option value="[% group.group_id %]"[% ' selected' IF display_categories.$pseudo_category %]>All [% group.name %]</option>
     [% ELSIF group.name %]
         <optgroup label="[% group.name %]">
     [% END %]


### PR DESCRIPTION
As the templates auto-escape & to &amp; this will not match when used as a key lookup for a hash. We can use mark_safe when fetching a variable directly, but cannot combine with another string without the escaping kicking in again, so need to construct the string in the code first. Fixes FD-3905.