### PR TITLE
4099 bexley add bin calendar links

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -114,7 +114,12 @@ sub bin_services_for_address {
         }
 
         my $containers = $self->_containers($property);
-
+        if (!$self->{c}->stash->{calendar_link} && $service->{RoundSchedule} =~ /(Wk \d+)/) {
+            my ($id) = $service->{RoundSchedule} =~ /(Wk \d+)/;
+            $id =~ s/\s+/-/;
+            my $links = $self->{c}->cobrand->feature('waste_calendar_links');
+            $self->{c}->stash->{calendar_link} = $links->{$id};
+        }
         push @site_services_filtered, {
             id             => $service->{SiteServiceID},
             service_id     => $service->{ServiceItemName},

--- a/templates/web/base/waste/bin_days_sidebar.html
+++ b/templates/web/base/waste/bin_days_sidebar.html
@@ -7,7 +7,7 @@
             <li><a href="https://kingston-self.achieveservice.com/service/In_my_Area_Results?displaymode=collections&amp;altVal=&amp;uprn=[% property.uprn %]">Download PDF waste calendar</a></li>
         [% ELSIF c.cobrand.moniker == 'sutton' %]
             <li><a href="https://sutton-self.achieveservice.com/service/In_My_Area_Results?altval=LBS&amp;displaymode=collections&amp;uprn=[% property.uprn %]">Download PDF waste calendar</a></li>
-        [% ELSIF c.cobrand.moniker == 'brent' AND (calendar_link OR ggw_calendar_link) %]
+        [% ELSIF calendar_link OR ggw_calendar_link %]
             [%- FOR link IN calendar_link -%]
               <li><a href="[% link.href OR link %]">[% link.text OR 'Download PDF waste calendar' %]</a></li>
             [%- END -%]


### PR DESCRIPTION
 If the service is the waste bin use that to work out whether the household is on rotation week one or rotation week two for PDF calendars and present the correct link.

Also assume that if a calendar_link or ggw_calendar_link is stashed then a PDF download link should be shown.

https://github.com/mysociety/societyworks/issues/4099

[skip changelog]