### PR TITLE
[Central Beds] Include housing fly-tipping types in CSV.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/CentralBedfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/CentralBedfordshire.pm
@@ -282,16 +282,25 @@ sub dashboard_export_problems_add_columns {
 
     $csv->add_csv_columns(
         external_id => 'CRNo',
+        housing_flytipping_types => 'Housing fly-tipping types',
     );
-
-    return if $csv->dbi; # Already covered
 
     $csv->csv_extra_data(sub {
         my $report = shift;
 
-        return {
-            external_id => $report->external_id,
+        my $types = $csv->_extra_field($report, 'Type') || [];
+        $types = [$types] unless ref $types;
+        $types = join(';', sort @$types);
+
+        my $data = {
+            housing_flytipping_types => $types,
         };
+
+        unless ($csv->dbi) {
+            $data->{external_id} = $report->external_id;
+        }
+
+        return $data;
     });
 }
 

--- a/t/cobrand/centralbedfordshire.t
+++ b/t/cobrand/centralbedfordshire.t
@@ -230,6 +230,8 @@ subtest 'check geolocation overrides' => sub {
 subtest 'Dashboard CSV extra columns' => sub {
     my $UPLOAD_DIR = tempdir( CLEANUP => 1 );
     $mech->log_in_ok( $staffuser->email );
+    $report->update_extra_field({ name => 'Type', value => ['Furniture', 'Bin bags'] });
+    $report->update;
     FixMyStreet::override_config {
         MAPIT_URL => 'http://mapit.uk/',
         ALLOWED_COBRANDS => 'centralbedfordshire',
@@ -238,7 +240,7 @@ subtest 'Dashboard CSV extra columns' => sub {
         $mech->get_ok('/dashboard?export=1');
     };
     $mech->content_contains('"Site Used","Reported As",CRNo');
-    $mech->content_contains('centralbedfordshire,,' . $report->external_id);
+    $mech->content_contains('centralbedfordshire,,' . $report->external_id . ',"Bin bags;Furniture"');
 };
 
 


### PR DESCRIPTION
[skip changelog] For FD-3897.