### PR TITLE
[Camden] Only try sending updates two times.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Camden.pm
+++ b/perllib/FixMyStreet/Cobrand/Camden.pm
@@ -98,6 +98,17 @@ sub open311_munge_update_params {
     $params->{service_code} = $contact->email;
 }
 
+=head2 should_skip_sending_update
+
+If we fail a couple of times to send an update, stop trying.
+
+=cut
+
+sub should_skip_sending_update {
+    my ($self, $comment) = @_;
+    return 1 if $comment->send_fail_count >= 2 && $comment->send_fail_reason =~ /Username required for notification/;
+}
+
 =head2 categories_restriction
 
 Camden don't want TfL's River Piers categories on their cobrand.


### PR DESCRIPTION
This prevents an issue where we're unable to send an update to Symology as it's closed.
[skip changelog] For FD-3926