### PR TITLE
Added autocomplete attribute to inputs

### DIFF
--- a/templates/web/base/admin/bodies/contact-form.html
+++ b/templates/web/base/admin/bodies/contact-form.html
@@ -40,7 +40,14 @@
         [% loc('An email address or service ID (Open311 or similar).') %]
       [% END %]
     </p>
-    <input type="text" class="form-control" id="destination" aria-describedby="destination-hint" name="email" size="30" value="[% contact.email | html %]" required>
+    <input 
+      [% IF body.can_be_devolved OR  body.send_method == 'Open311' %]
+        type="text"
+      [% ELSE %]
+        type="email"
+        autocomplete="email"
+      [% END %]
+      class="form-control" id="destination" aria-describedby="destination-hint" name="email" size="30" value="[% contact.email | html %]" required>
 
     [% TRY %][% PROCESS 'admin/bodies/_type_field.html' %][% CATCH file %][% END %]
 

--- a/templates/web/base/admin/bodies/contact-form.html
+++ b/templates/web/base/admin/bodies/contact-form.html
@@ -30,24 +30,20 @@
 
     <label for="destination">[% loc('Destination') %]</label>
     <p class="form-hint" id="destination-hint">
+      [% SET field_type = 'text' %]
       [% IF body.can_be_devolved %]
         [% loc('An email address or service ID (Open311 or similar).') %]
       [% ELSIF body.send_method == 'Open311' %]
         [% loc('A service ID (Open311 or similar).') %]
       [% ELSIF body.send_method.match('Email') OR NOT body.send_method %]
         [% loc('An email address.') %]
+        [% SET field_type = 'email' %]
       [% ELSE %]
         [% loc('An email address or service ID (Open311 or similar).') %]
       [% END %]
     </p>
-    <input 
-      [% IF body.can_be_devolved OR  body.send_method == 'Open311' %]
-        type="text"
-      [% ELSE %]
-        type="email"
-        autocomplete="email"
-      [% END %]
-      class="form-control" id="destination" aria-describedby="destination-hint" name="email" size="30" value="[% contact.email | html %]" required>
+    <input type="[% field_type %]" [% IF field_type == 'email' %]
+autocomplete="email" [% END %] class="form-control" id="destination" aria-describedby="destination-hint" name="email" size="30" value="[% contact.email | html %]" required>
 
     [% TRY %][% PROCESS 'admin/bodies/_type_field.html' %][% CATCH file %][% END %]
 

--- a/templates/web/base/admin/users/_form_details.html
+++ b/templates/web/base/admin/users/_form_details.html
@@ -12,7 +12,7 @@
 </li>
 
 <li><label for="email">[% loc('Email:') %]</label>
-<input type='text' class="form-control" id='email' name='email' value='[% user.email | html %]'>
+<input type='email' class="form-control" id='email' name='email' value='[% user.email | html %]' autocomplete="email">
 [% IF user %]
     <input class="btn" type="submit" name="send_login_email" value="[% loc('Send login email') %]">
 [% END %]

--- a/templates/web/base/alert/_list.html
+++ b/templates/web/base/alert/_list.html
@@ -86,7 +86,7 @@
     [% UNLESS c.user_exists AND c.user.email_verified %]
       <label for="rznvy">[% loc('Email address') %]</label>
       <div class="form-txt-submit-box">
-        <input class="form-control" type="text" id="rznvy" name="rznvy" value="[% rznvy %]">
+        <input class="form-control" type="text" id="rznvy" name="rznvy" value="[% rznvy %]" autocomplete="email">
         <input id="alert_email_button" class="btn-primary" type="submit" name="alert" value="[% loc('Subscribe') %]">
       </div>
       <p>[% tprintf(loc('We won’t use your email for anything beyond sending you alerts within this area. You can find more information in our <a href="%s">privacy policy</a>.'), c.cobrand.privacy_policy_url) %]</p>

--- a/templates/web/base/alert/_list.html
+++ b/templates/web/base/alert/_list.html
@@ -86,7 +86,7 @@
     [% UNLESS c.user_exists AND c.user.email_verified %]
       <label for="rznvy">[% loc('Email address') %]</label>
       <div class="form-txt-submit-box">
-        <input class="form-control" type="text" id="rznvy" name="rznvy" value="[% rznvy %]" autocomplete="email">
+        <input class="form-control" type="email" id="rznvy" name="rznvy" value="[% rznvy %]" autocomplete="email">
         <input id="alert_email_button" class="btn-primary" type="submit" name="alert" value="[% loc('Subscribe') %]">
       </div>
       <p>[% tprintf(loc('We won’t use your email for anything beyond sending you alerts within this area. You can find more information in our <a href="%s">privacy policy</a>.'), c.cobrand.privacy_policy_url) %]</p>

--- a/templates/web/base/alert/_updates.html
+++ b/templates/web/base/alert/_updates.html
@@ -17,7 +17,7 @@
     [% IF permissions.contribute_as_another_user %]
       <label for="alert_rznvy">[% loc('Email') %]</label>
       <div class="form-txt-submit-box">
-          <input type="email" class="form-control" name="rznvy" id="alert_rznvy" value="[% email %]" size="30">
+          <input type="email" class="form-control" name="rznvy" id="alert_rznvy" value="[% email %]" size="30" autocomplete="email">
           <input class="green-btn" type="submit" name="alert" value="[% loc('Subscribe') %]">
       </div>
     [% ELSE %]

--- a/templates/web/base/auth/change_email.html
+++ b/templates/web/base/auth/change_email.html
@@ -38,7 +38,7 @@ END
             [% loc('New email address:') %]
           [% END %]
         </label>
-        <input class="form-control" type="email" name="email" id="email" value="[% username | html %]">
+        <input class="form-control" type="email" name="email" id="email" value="[% username | html %]" autocomplete="email">
     </div>
     <div class="final-submit">
         <input type="submit" class="btn" value="[% title %]">

--- a/templates/web/base/contact/enquiry/index.html
+++ b/templates/web/base/contact/enquiry/index.html
@@ -13,7 +13,7 @@
     [% IF field_errors.name %]
        <div class="form-error">[% field_errors.name %]</div>
     [% END %]
-    <input type="text" class="form-control required" name="name" id="form_name" value="[% ( form_name OR c.user.name ) | html %]" size="30">
+    <input type="text" class="form-control required" name="name" id="form_name"  autocomplete="name" value="[% ( form_name OR c.user.name ) | html %]" size="30">
 
     <label for="form_email">[% loc('Your email') %]</label>
     [% IF field_errors.username_register %]

--- a/templates/web/base/contact/form.html
+++ b/templates/web/base/contact/form.html
@@ -66,7 +66,7 @@
     [% IF field_errors.name %]
         <div class="form-error">[% field_errors.name %]</div>
     [% END %]
-    <input type="text" class="govuk-input required" name="name" id="form_name" value="[% form_name | html %]" size="30">
+    <input type="text" class="govuk-input required" name="name"  autocomplete="name" id="form_name" value="[% form_name | html %]" size="30">
   </div>
 
   <div class="govuk-form-group">

--- a/templates/web/base/report/form/user_loggedout_by_email.html
+++ b/templates/web/base/report/form/user_loggedout_by_email.html
@@ -49,7 +49,7 @@
     [% IF field_errors.email %]
         <p class='form-error'>[% field_errors.email %]</p>
     [% END %]
-    <input type="email" name="email" id="form_email" value="[% email %]" class="form-control">
+    <input type="email" name="email" id="form_email" value="[% email %]" class="form-control" autocomplete="email">
 
     <label for="form_phone">[% loc('Phone number') %]<span class="hidden-js" id="js-optional-phone-update-method-triggered"> [% loc('(optional)') %]</span></label>
     [% IF field_errors.phone %]

--- a/templates/web/base/report/form/user_loggedout_email.html
+++ b/templates/web/base/report/form/user_loggedout_email.html
@@ -14,5 +14,10 @@
 [% END %]
 <input type="[% username_type %]" name="[% username_field %]" id="form_[% name %]"
        value="[% c.get_param(username_field) %]"
-    class="form-control required">
+    class="form-control required"
+    [% IF NOT c.cobrand.sms_authentication %]
+        autocomplete="[% username_type %]"
+    [% END %]
+>
+
 <!-- /user_loggedout_email.html -->

--- a/templates/web/base/report/form/user_name.html
+++ b/templates/web/base/report/form/user_name.html
@@ -9,5 +9,5 @@
     <p class='form-error'>[% field_errors.name %]</p>
 [% END %]
 <input type="text" class="form-control [% valid_class OR 'validName' %] js-form-name [% extra_class %]"
-    value="[% object.name || c.user.name | html %]" name="name" id="form_name">
+    value="[% object.name || c.user.name | html %]" name="name" id="form_name" autocomplete="name">
 <!-- /user_name.html -->

--- a/templates/web/base/report/new/form_user_loggedin.html
+++ b/templates/web/base/report/new/form_user_loggedin.html
@@ -62,7 +62,7 @@
 [% END %]
 [% IF NOT c.user.email_verified %]
     <label for="form_email">[% loc('Email address (optional)') %]</label>
-    <input class="form-control" type="text" value="[% report.user.email | html %]" name="email" id="form_email">
+    <input class="form-control" type="email" value="[% report.user.email | html %]" name="email" id="form_email" autocomplete="email">
 [% END %]
 
 [% IF c.user.has_permission_to("report_inspect", bodies_ids) OR c.user.has_permission_to("report_mark_private", bodies_ids) %]

--- a/templates/web/base/report/new/report_import.html
+++ b/templates/web/base/report/new/report_import.html
@@ -63,7 +63,7 @@ line each starting with <samp>ERROR:</samp>.
     <dt>email</dt>
     <dd>
         <em>Required</em>. Email address of problem reporter.
-        <input type="text" name="email" value="[% input.email %]">
+        <input type="email" name="email" value="[% input.email %]" autocomplete="email">
     </dd>
 
     <dt>phone</dt>

--- a/templates/web/bromley/report/form/user_name.html
+++ b/templates/web/bromley/report/form/user_name.html
@@ -7,7 +7,7 @@
     <p class='form-error'>[% field_errors.first_name %]</p>
 [% END %]
 <input class="js-form-name form-control" type="text"
-    name="first_name" id="form_first_name"
+    name="first_name" id="form_first_name" autocomplete="given-name"
     value="[% first_name || names.first | html %]">
 
 <label for="form_last_name">[% loc('Last Name') %]</label>
@@ -15,5 +15,5 @@
     <p class='form-error'>[% field_errors.last_name %]</p>
 [% END %]
 <input class="js-form-name form-control" type="text"
-    name="last_name" id="form_last_name"
+    name="last_name" id="form_last_name" autocomplete="family-name"
     value="[% last_name || names.last | html %]">

--- a/templates/web/cyclinguk/report/form/user_name.html
+++ b/templates/web/cyclinguk/report/form/user_name.html
@@ -7,7 +7,7 @@
     <p class='form-error'>[% field_errors.first_name %]</p>
 [% END %]
 <input class="js-form-name form-control" type="text"
-    name="first_name" id="form_first_name"
+    name="first_name" id="form_first_name" autocomplete="given-name"
     value="[% first_name || names.first | html %]">
 
 <label for="form_last_name">[% loc('Last Name') %]</label>
@@ -15,5 +15,5 @@
     <p class='form-error'>[% field_errors.last_name %]</p>
 [% END %]
 <input class="js-form-name form-control" type="text"
-    name="last_name" id="form_last_name"
+    name="last_name" id="form_last_name" autocomplete="family-name"
     value="[% last_name || names.last | html %]">

--- a/templates/web/fixmystreet-uk-councils/report/form/user_name.html
+++ b/templates/web/fixmystreet-uk-councils/report/form/user_name.html
@@ -4,5 +4,5 @@
     <p class='form-error'>[% field_errors.name %]</p>
 [% END %]
 <input type="text" class="form-control [% valid_class OR 'validName' %] js-form-name [% extra_class %]"
-    value="[% object.name || c.user.name | html %]" name="name" id="form_name">
+    value="[% object.name || c.user.name | html %]" name="name" id="form_name" autocomplete="name">
 <!-- /user_name.html -->

--- a/templates/web/hart/footer_extra.html
+++ b/templates/web/hart/footer_extra.html
@@ -15,7 +15,7 @@
                     <div class="form-wrapper">
                       <div class="js-form-item form-item js-form-type-email form-item-email js-form-item-email">
                         <label for="edit-email">Email</label>
-                        <input data-drupal-selector="edit-email" type="email" id="edit-email" name="email" value="" size="60" maxlength="254" placeholder="Enter email address..." class="form-email">
+                        <input data-drupal-selector="edit-email" type="email" id="edit-email" name="email" value="" size="60" maxlength="254" placeholder="Enter email address..." class="form-email" autocomplete="email">
                       </div>
                       <div data-drupal-selector="edit-actions--2" class="form-actions webform-actions js-form-wrapper form-wrapper" id="edit-actions--2">
                         <input class="webform-button--submit button button--primary js-form-submit form-submit" data-drupal-selector="edit-actions-submit" type="submit" id="edit-actions-submit" name="op" value="Subscribe">

--- a/templates/web/zurich/admin/bodies/contact-form.html
+++ b/templates/web/zurich/admin/bodies/contact-form.html
@@ -21,7 +21,7 @@
     </p>
 
     <p><strong>[% loc('Email:') %] </strong>
-    <input type="text" class="form-control" name="email" value="[% contact.email | html %]" size="30">
+    <input type="email" class="form-control" name="email" value="[% contact.email | html %]" size="30" autocomplete="email">
 
     <p>
       <strong>[% loc('Extra fields:') %]</strong>

--- a/templates/web/zurich/report/new/fill_in_details_form.html
+++ b/templates/web/zurich/report/new/fill_in_details_form.html
@@ -34,7 +34,7 @@
                 [% IF field_errors.name %]
                     <p class='form-error'>[% field_errors.name %]</p>
                 [% END %]
-                <input class="form-control js-form-name" type="text" value="[% report.name | html %]" name="name" id="form_name">
+                <input class="form-control js-form-name" type="text" value="[% report.name | html %]" name="name" id="form_name" autocomplete="name">
 
                 <label for="form_phone">[% loc('Phone number') %]</label>
                 [% IF field_errors.phone %]


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4208

- [x] For [Added autocomplete attribute to email types elements](https://github.com/mysociety/fixmystreet/commit/b09ae82509128631e84df4c7e713b4fdc33eb111) I noticed that some elements instead of using `type="email"` use `type="text"` however they are intended for emails. Is there a reason not to use `type="email"`?

- [x] [PENDING] TFL used this element `input id="form_username_register"` as an example of the problem in [issue 4208](https://github.com/mysociety/societyworks/issues/4208). However, I could only find it on the Zurich cobrand. But there is no trace in the default templates, so I still need to change that instance. Do you know where I can find that piece of code `input id="form_username_register`

NOTES:
CyclingUK and Bromley have first and last names in their forms, so they were tackled in this commit:
[Added autocomplete attribute to first and last name](https://github.com/mysociety/fixmystreet/commit/2665a014b61c03b152421139b9db0dcc34c31255)

[Skip changelog]