### PR TITLE
[TFL] Added 2px outline off-set for focus state for TFL button

### DIFF
--- a/web/cobrands/tfl/_colours.scss
+++ b/web/cobrands/tfl/_colours.scss
@@ -75,6 +75,7 @@ $mobile-sticky-sidebar-button-menu-image: "menu-white";
     background: transparent;
     background-color: $blue-dark;
     color: $white !important;
+    outline-offset: 2px;
   }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4188
This allows that the outline has enough contrast with the background color.

<img width="482" alt="Screenshot 2024-03-14 at 08 35 48" src="https://github.com/mysociety/fixmystreet/assets/13790153/0d988aee-c14c-44ca-87ff-bf219c10c365">


[skip changelog]