### PR TITLE
Improved contrast for #skiplink element

### DIFF
--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -744,18 +744,19 @@ ul.error {
 /*** LAYOUT ***/
 
 .skiplink {
+  @extend .btn;
   display: inline-block;
   padding: 1em;
   position: absolute;
   left: -9999em;
 }
+
 .skiplink:focus {
-  outline: 3px solid transparent;
-  color: $primary_text;
-  background-color: $primary;
-  text-decoration: none;
-  left: 0;
+  // 2px in case there are outlines
+  left: 2px;
+  top: 2px; 
   z-index: 2;
+  border-radius: 0;
 }
 
 .dev-site-notice {


### PR DESCRIPTION
Fixes: [#4210](https://github.com/mysociety/societyworks/issues/4210)

This element will now behave like the `.btn` element in terms of styling. This way we don't need to worry about contrast and we can still use the branding of each cobrand.

<img width="1920" alt="Screenshot 2024-03-14 at 09 07 53" src="https://github.com/mysociety/fixmystreet/assets/13790153/1a01a7d3-7d11-42cb-afab-c21a87b94615">
<img width="1920" alt="Screenshot 2024-03-14 at 09 07 57" src="https://github.com/mysociety/fixmystreet/assets/13790153/f0aad825-089a-450a-ae5c-076cde1c2e15">
<img width="1920" alt="Screenshot 2024-03-14 at 09 08 10" src="https://github.com/mysociety/fixmystreet/assets/13790153/f0b0db4a-688d-477f-8277-a20b9ef97af2">
