### PR TITLE
Added skip map button

### DIFF
--- a/templates/web/base/maps/openlayers.html
+++ b/templates/web/base/maps/openlayers.html
@@ -42,6 +42,7 @@
 <div id="map_box">
     [% pre_map %]
     <div id="map">
+      <a href="#map_sidebar" class="skiplink">Skip map</a>
       [% IF noscript_map_template == 'maps/noscript_map_base_wmx.html' %]
           [% INCLUDE 'maps/noscript_map_base_wmx.html' js = 1 %]
       [% ELSE %]

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -752,11 +752,12 @@ ul.error {
 }
 
 .skiplink:focus {
-  // 2px in case there are outlines
-  left: 2px;
-  top: 2px; 
-  z-index: 2;
-  border-radius: 0;
+  outline: 3px solid transparent;
+  color: $primary_text;
+  background-color: $primary;
+  text-decoration: none;
+  left: 0;
+  z-index: 999; //Higher value than the map
 }
 
 .dev-site-notice {


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4211

This has been added after header elements and before any focusable map elements, that way the user doesn't need to go through the map links and compass to be able to go to skip the map.

- [x] I added the link in the `openlayers.html` file. Assuming that is the right place to put should I also include it on the google one?

<img width="1920" alt="Screenshot 2024-03-14 at 10 42 24" src="https://github.com/mysociety/fixmystreet/assets/13790153/276243db-eb17-4554-a565-7247f87f7fb4">

IMPORTANT: https://github.com/mysociety/fixmystreet/pull/4879 should be merged so the styling of the button is contrast accessible.
