### PR TITLE
"Can't use the map" Link always visible.

### DIFF
--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2669,7 +2669,7 @@ label .muted {
 }
 
 .map-alternatives, .map-alternatives__display {
-  margin: 16px 0;
+  margin: 0;
   font-size: 14px;
   color: #666;
 }

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -392,12 +392,11 @@ body.mappage.admin {
 .map-alternatives {
   display: block;
   color: inherit;
-  //margin: 0 -15px;
+  margin: 0 -1rem;
   padding: 16px;
-  font-size: 18px;
+  font-size: 1rem;
   line-height: 20px;
-  border-bottom: 1px solid #E7E1C0;
-  background: #FDF4C5;
+  background: transparentize($primary, 0.8);
 
   em {
     font-style: normal;
@@ -407,19 +406,6 @@ body.mappage.admin {
 
   &:hover {
     text-decoration: none;
-  }
-
-  html.js & {
-    // If javascript is enabled, hide the skip link off-screen,
-    // but keep it visible for screen readers.
-    position: absolute;
-    top: -999px;
-
-    &:focus,
-    &:focus-within {
-      // And show it again if it receives focus (eg: via tab key)
-      position: static;
-    }
   }
 }
 


### PR DESCRIPTION
Fixes part of: https://github.com/mysociety/societyworks/issues/4211

This improvement was advised as an "ideal" point during the TFL audit. Having it always visible can help reduce the cognitive load for users with cognitive difficulties by easing decision-making. I tried to make it visible enough, but at the same time, it doesn't use much vertical space. To avoid/reduce potential issues with the cobrands, I used the `$primary` variable instead of the yellow we were using.

<img width="1920" alt="Screenshot 2024-03-14 at 11 41 42" src="https://github.com/mysociety/fixmystreet/assets/13790153/ec94eac1-b395-41ce-9605-68f902d068f0">
