### PR TITLE
[Bucks] Change .site-message background-colour

### DIFF
--- a/web/cobrands/buckinghamshire/_colours.scss
+++ b/web/cobrands/buckinghamshire/_colours.scss
@@ -8,6 +8,7 @@
 $menu-image: 'menu-white';
 
 $bucks_indigo: #2C2D84;
+$bucks_light_indigo: #D7DCFE; //Created by SW for Bucks
 $bucks_charcoal: #3C3C3B;
 $bucks_grass_green: #9FC63B;
 $bucks_orange: #ED7004;

--- a/web/cobrands/buckinghamshire/base.scss
+++ b/web/cobrands/buckinghamshire/base.scss
@@ -139,7 +139,7 @@ label {
 
 .site-message {
   margin: 1em -20px;
-  background-color: #f79f73;
+  background-color: $bucks_light_indigo;
   color: #000;
   border: none;
 }


### PR DESCRIPTION
Requested by client: https://mysocietysupport.freshdesk.com/a/tickets/3973
 
Client requested to change the `background-colour `of the `.site-message` from orange to light blue.

Preview here:

https://buckinghamshire.staging.fixmystreet.com/

<img width="1920" alt="Screenshot 2024-03-14 at 16 17 40" src="https://github.com/mysociety/fixmystreet/assets/13790153/756b124f-c00b-4196-adf2-1023ee0deb68">
