### PR TITLE
[Bexley][WW] Refactor iCal code to use GetCollectionByUprnAndDate

### DIFF
--- a/perllib/Integrations/Whitespace.pm
+++ b/perllib/Integrations/Whitespace.pm
@@ -163,14 +163,6 @@ sub GetCollectionByUprnAndDate {
     return force_arrayref( $res->{Collections}, 'Collection' );
 }
 
-sub GetCollectionByUprnAndDatePlus {
-    my ($self, $uprn, $date_from, $date_to) = @_;
-
-    my $res = $self->call('GetCollectionByUprnAndDatePlus', getCollectionByUprnAndDatePlusInput => ixhash( Uprn => $uprn, NextCollectionFromDate => $date_from, NextCollectionToDate => $date_to ));
-
-    return force_arrayref($res->{Collections}, 'Collection');
-}
-
 sub GetInCabLogsByUsrn {
     my ($self, $usrn, $log_from_date) = @_;
 


### PR DESCRIPTION
Since newer GetCollectionByUprnAndDatePlus method is not currently supported on Bexley's live system.

Closes https://github.com/mysociety/societyworks/issues/4156.

[skip changelog]