### PR TITLE
Fix CSV export with category with brackets.

### DIFF
--- a/perllib/FixMyStreet/Reporting.pm
+++ b/perllib/FixMyStreet/Reporting.pm
@@ -487,7 +487,7 @@ sub filter_premade_csv {
         }
 
         my $category = $row->{Subcategory} || $row->{Category};
-        next if @{$self->category} && !grep { /$category/ } @{$self->category};
+        next if @{$self->category} && !grep { /\Q$category\E/ } @{$self->category};
 
         if ( $self->state && $fixed_states->{$self->state} ) { # Probably fixed - council
             next unless $fixed_states->{$row->{$state_column}};

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -639,6 +639,9 @@ subtest 'Dashboard CSV extra columns' => sub {
         { name => 'stop_code', value => '98756' }, { name => 'Question', value => '12345' });
     $report->update;
 
+    $contact5->update({ category => 'Trees (brown)' });
+    my ($problem) = $mech->create_problems_for_body(1, $body->id, 'Trees test', { category => "Trees (brown)", cobrand => 'tfl' });
+
     FixMyStreet::Script::CSVExport::process(dbh => FixMyStreet::DB->schema->storage->dbh);
 
     $mech->get_ok('/dashboard?export=1&category=Not+present');
@@ -661,6 +664,11 @@ subtest 'Dashboard CSV extra columns' => sub {
     $mech->content_contains('(anonymous ' . $report->id . ')');
     $mech->content_contains($dt . ',,,confirmed,51.4021');
     $mech->content_contains(',12345,,yes,busstops@example.com,,' . $dt . ',"Council User",Yes,,98756');
+
+    $mech->get_ok('/dashboard?export=1&category=Trees+(brown)');
+    $mech->content_contains('Trees (brown)');
+    $contact5->update({ category => 'Trees' });
+    $problem->delete;
 };
 
 subtest 'Inspect form state choices' => sub {


### PR DESCRIPTION
If the CSV export was acting on a pre-made CSV, and a category with brackets was explicitly specified in the query, it would not match. [skip changelog] For FD-3976.