### PR TITLE
[Peterborough][WW] Add text messaging option for bulky waste

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1043,7 +1043,8 @@ sub process_user : Private {
 
     my $parsed = FixMyStreet::SMS->parse_username($params{username});
     my $type = $parsed->{type} || 'email';
-    $type = 'email' unless $c->cobrand->sms_authentication || $c->stash->{contributing_as_another_user};
+    $type = 'email' unless $c->cobrand->sms_authentication || $c->stash->{contributing_as_another_user}
+            || $report->get_extra_field_value('bulky_text_updates');
     $report->user( $c->model('DB::User')->find_or_new( { $type => $parsed->{username} } ) );
 
     $c->stash->{phone_may_be_mobile} = $type eq 'phone' && $parsed->{may_be_mobile};

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1044,7 +1044,7 @@ sub process_user : Private {
     my $parsed = FixMyStreet::SMS->parse_username($params{username});
     my $type = $parsed->{type} || 'email';
     $type = 'email' unless $c->cobrand->sms_authentication || $c->stash->{contributing_as_another_user}
-            || $report->get_extra_field_value('bulky_text_updates');
+            || $report->get_extra_field_value('bulky_text_reminders');
     $report->user( $c->model('DB::User')->find_or_new( { $type => $parsed->{username} } ) );
 
     $c->stash->{phone_may_be_mobile} = $type eq 'phone' && $parsed->{may_be_mobile};

--- a/perllib/FixMyStreet/App/Form/Waste.pm
+++ b/perllib/FixMyStreet/App/Form/Waste.pm
@@ -59,7 +59,7 @@ sub validate {
     my $email = $self->field('email');
     my $phone = $self->field('phone');
     return 1 unless $email && $phone;
-    my $text_updates = $self->field('extra_bulky_text_updates');
+    my $text_updates = $self->field('extra_bulky_text_reminders');
 
     my $c = $self->c;
     my $cobrand = $c->cobrand->moniker;

--- a/perllib/FixMyStreet/App/Form/Waste.pm
+++ b/perllib/FixMyStreet/App/Form/Waste.pm
@@ -1,5 +1,6 @@
 package FixMyStreet::App::Form::Waste;
 
+use FixMyStreet::SMS;
 use HTML::FormHandler::Moose;
 extends 'FixMyStreet::App::Form::Wizard';
 
@@ -58,6 +59,7 @@ sub validate {
     my $email = $self->field('email');
     my $phone = $self->field('phone');
     return 1 unless $email && $phone;
+    my $text_updates = $self->field('extra_bulky_text_updates');
 
     my $c = $self->c;
     my $cobrand = $c->cobrand->moniker;
@@ -65,10 +67,17 @@ sub validate {
     my $staff_provide_email = (ref $self) =~ /Garden/ && $c->cobrand->call_hook('garden_staff_provide_email');
 
     $email->add_error('Please provide an email address')
-        unless $email->is_inactive || $email->value || ($is_staff_user && !$staff_provide_email);
-
+        unless $email->is_inactive || $email->value || ($is_staff_user && !$staff_provide_email)
+        || $c->cobrand->call_hook('report_can_have_text_only_notifcations' => $phone, $text_updates);
     $email->add_error('Please provide email and/or phone')
         unless $phone->is_inactive || $phone->value || $email->value || !($is_staff_user && !$staff_provide_email) || $cobrand eq 'bromley';
+
+    if ($text_updates && $text_updates->value) {
+        my $parsed = FixMyStreet::SMS->parse_username($phone->value);
+        if (!($phone->value && $parsed->{may_be_mobile} )) {
+            $text_updates->add_error('Please enter a mobile phone number to receive text updates');
+        };
+    }
 }
 
 1;

--- a/perllib/FixMyStreet/App/Form/Waste/AboutYou.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/AboutYou.pm
@@ -62,7 +62,7 @@ has_field email => (
     },
 );
 
-has_field extra_bulky_text_updates => (
+has_field extra_bulky_text_reminders => (
     type => 'Checkbox',
     label => 'Bulky text reminders',
     option_label => 'Do you want to receive reminders about this collection by text message?',

--- a/perllib/FixMyStreet/App/Form/Waste/AboutYou.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/AboutYou.pm
@@ -62,6 +62,14 @@ has_field email => (
     },
 );
 
+has_field extra_bulky_text_updates => (
+    type => 'Checkbox',
+    label => 'Bulky text reminders',
+    option_label => 'Do you want to receive reminders about this collection by text message?',
+    inactive => 1,
+);
+
+
 sub default_email {
     my $self = shift;
     if (my $user = $self->non_staff_user) {

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -39,10 +39,10 @@ has_page about_you => (
     next => 'choose_date_earlier',
     update_field_list => sub {
         my $form = shift;
-        if ($form->{c}->stash->{waste_features}->{bulky_offer_text_updates}) {
+        my $c = $form->{c};
+        if ($c->stash->{waste_features}->{bulky_offer_text_updates} && $c->stash->{is_staff}) {
             my $fields = {};
             $fields->{phone}{tags}{hint} = 'Providing a phone number will allow Aragon Direct Services (who provide the service on behalf of the council) to contact you if there are any issues with the service.';
-            $form->field('extra_bulky_text_updates')->inactive(0);
             $form->field('extra_bulky_text_reminders')->inactive(0);
             return $fields;
         };

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -34,7 +34,7 @@ has_page cannot_book => (
 
 has_page about_you => (
     intro => 'bulky/about_you_preamble.html',
-    fields => ['name', 'email', 'phone', 'extra_bulky_text_updates', 'continue'],
+    fields => ['name', 'email', 'phone', 'extra_bulky_text_reminders', 'continue'],
     title => 'About you',
     next => 'choose_date_earlier',
     update_field_list => sub {
@@ -43,6 +43,7 @@ has_page about_you => (
             my $fields = {};
             $fields->{phone}{tags}{hint} = 'Providing a phone number will allow Aragon Direct Services (who provide the service on behalf of the council) to contact you if there are any issues with the service.';
             $form->field('extra_bulky_text_updates')->inactive(0);
+            $form->field('extra_bulky_text_reminders')->inactive(0);
             return $fields;
         };
     },

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky.pm
@@ -34,16 +34,17 @@ has_page cannot_book => (
 
 has_page about_you => (
     intro => 'bulky/about_you_preamble.html',
-    fields => ['name', 'email', 'phone', 'continue'],
+    fields => ['name', 'email', 'phone', 'extra_bulky_text_updates', 'continue'],
     title => 'About you',
     next => 'choose_date_earlier',
     update_field_list => sub {
         my $form = shift;
-        my $c = $form->c;
-        my $fields = {};
-        $fields->{phone}{tags}{hint} = 'Providing a phone number will allow Aragon Direct Services (who provide the service on behalf of the council) to contact you if there are any issues with the service.'
-            if $c->cobrand->moniker eq 'peterborough';
-        return $fields;
+        if ($form->{c}->stash->{waste_features}->{bulky_offer_text_updates}) {
+            my $fields = {};
+            $fields->{phone}{tags}{hint} = 'Providing a phone number will allow Aragon Direct Services (who provide the service on behalf of the council) to contact you if there are any issues with the service.';
+            $form->field('extra_bulky_text_updates')->inactive(0);
+            return $fields;
+        };
     },
 );
 

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -303,6 +303,10 @@ sub open311_post_send {
         my $sender = FixMyStreet::SendReport::Email->new( to => [ $dest ] );
         $sender->send($row, $h);
     }
+
+    if ($h->{report}->get_extra_field_value('bulky_text_updates')) {
+        $self->call_hook('_bulky_send_optional_text' => $h->{report}, $h->{url}, { text_type => 'confirmed' });
+    };
 }
 
 sub suppress_report_sent_email {

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -304,7 +304,7 @@ sub open311_post_send {
         $sender->send($row, $h);
     }
 
-    if ($h->{report}->get_extra_field_value('bulky_text_updates')) {
+    if ($h->{report}->get_extra_field_value('bulky_text_reminders')) {
         $self->call_hook('_bulky_send_optional_text' => $h->{report}, $h->{url}, { text_type => 'confirmed' });
     };
 }

--- a/perllib/FixMyStreet/Cobrand/Peterborough/Bulky.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough/Bulky.pm
@@ -330,6 +330,7 @@ sub waste_reconstruct_bulky_data {
     $saved_data->{email} = $p->user->email;
     $saved_data->{phone} = $p->phone_waste;
     $saved_data->{resident} = 'Yes';
+    $saved_data->{extra_bulky_text_updates} = $p->get_extra_field_value('bulky_text_updates');
 
     return $saved_data;
 }

--- a/perllib/FixMyStreet/Cobrand/Peterborough/Bulky.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough/Bulky.pm
@@ -330,7 +330,7 @@ sub waste_reconstruct_bulky_data {
     $saved_data->{email} = $p->user->email;
     $saved_data->{phone} = $p->phone_waste;
     $saved_data->{resident} = 'Yes';
-    $saved_data->{extra_bulky_text_updates} = $p->get_extra_field_value('bulky_text_updates');
+    $saved_data->{extra_bulky_text_reminders} = $p->get_extra_field_value('bulky_text_reminders');
 
     return $saved_data;
 }

--- a/perllib/FixMyStreet/Cobrand/Peterborough/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough/Waste.pm
@@ -865,4 +865,32 @@ sub _format_address {
 
 sub bin_day_format { '%A, %-d~~~ %B %Y' }
 
+sub _bulky_send_optional_text {
+    my ($self, $report, $h, $params) = @_;
+
+    my %message_data = ();
+    my $title;
+    if ($params->{text_type} eq 'confirmed') {
+        $title = 'Bulky waste booking';
+    } else {
+        $title = 'Bulky waste reminder';
+    }
+    $message_data{to} = $report->phone_waste;
+    my $address = $report->detail;
+    $address =~ s/\s\|.*?$//; # Address may contain ref to Bartec report
+    $message_data{body} =
+    sprintf("Bulky waste collection reminder\n\n
+        Date: %s
+        Items: %d
+        %s
+        View more details or cancel: %s",
+        $self->bulky_nice_collection_date($report->get_extra_field_value('DATE')),
+        scalar grep ({ $_->{name} =~ /^ITEM/ && $_->{value} } @{$report->get_extra_fields}),
+        $address,
+        $h->{url});
+    FixMyStreet::SMS->new(cobrand => $self, notify_choice => 'waste')->send(
+        %message_data,
+    );
+}
+
 1;

--- a/perllib/FixMyStreet/Cobrand/Peterborough/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough/Waste.pm
@@ -883,12 +883,13 @@ sub _bulky_send_optional_text {
             Date: %s
             Items: %d
             %s
-            View more details or cancel: %s",
+            Reference: %d
+            Please note the items put out for collection must be the items you specified when you booked.",
             $title,
             $self->bulky_nice_collection_date($report->get_extra_field_value('DATE')),
             scalar grep ({ $_->{name} =~ /^ITEM/ && $_->{value} } @{$report->get_extra_fields}),
             $address,
-            $url);
+            $report->id);
     FixMyStreet::SMS->new(cobrand => $self, notify_choice => 'waste')->send(
         %message_data,
     );

--- a/perllib/FixMyStreet/Cobrand/Peterborough/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough/Waste.pm
@@ -866,7 +866,7 @@ sub _format_address {
 sub bin_day_format { '%A, %-d~~~ %B %Y' }
 
 sub _bulky_send_optional_text {
-    my ($self, $report, $h, $params) = @_;
+    my ($self, $report, $url, $params) = @_;
 
     my %message_data = ();
     my $title;
@@ -879,15 +879,16 @@ sub _bulky_send_optional_text {
     my $address = $report->detail;
     $address =~ s/\s\|.*?$//; # Address may contain ref to Bartec report
     $message_data{body} =
-    sprintf("Bulky waste collection reminder\n\n
-        Date: %s
-        Items: %d
-        %s
-        View more details or cancel: %s",
-        $self->bulky_nice_collection_date($report->get_extra_field_value('DATE')),
-        scalar grep ({ $_->{name} =~ /^ITEM/ && $_->{value} } @{$report->get_extra_fields}),
-        $address,
-        $h->{url});
+    sprintf("%s\n\n
+            Date: %s
+            Items: %d
+            %s
+            View more details or cancel: %s",
+            $title,
+            $self->bulky_nice_collection_date($report->get_extra_field_value('DATE')),
+            scalar grep ({ $_->{name} =~ /^ITEM/ && $_->{value} } @{$report->get_extra_fields}),
+            $address,
+            $url);
     FixMyStreet::SMS->new(cobrand => $self, notify_choice => 'waste')->send(
         %message_data,
     );

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -105,6 +105,15 @@ sub problems_on_map_restriction {
     }
 }
 
+sub report_can_have_text_only_notifcations {
+    my ($self, $phone, $text_updates) = @_;
+
+    return unless $phone && $text_updates;
+
+    return 1 if $text_updates->value && FixMyStreet::SMS->parse_username($phone->value)->{may_be_mobile};
+
+}
+
 sub updates_restriction {
     my ($self, $rs) = @_;
     return $rs if FixMyStreet->staging_flag('skip_checks');

--- a/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
@@ -660,7 +660,7 @@ sub _bulky_send_reminder_email {
 sub _bulky_send_reminder_text {
     my ($self, $report, $h, $params) = @_;
 
-    return unless $report->get_extra_field_value('bulky_text_updates');
+    return unless $report->get_extra_field_value('bulky_text_reminders');
     $h->{url} = $self->base_url_for_report($report) . $report->tokenised_url($report->user);
     $self->call_hook('_bulky_send_optional_text' => $report, $h->{url}, {text_type => 'reminder'});
 }

--- a/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
@@ -620,11 +620,13 @@ sub bulky_reminders {
         if (!$r3 && $now >= $d3 && $now < $d1) {
             $h->{days} = 3;
             $self->_bulky_send_reminder_email($report, $h, $params);
+            $self->_bulky_send_reminder_text($report, $h, $params);
             $report->set_extra_metadata(reminder_3 => 1);
             $report->update;
         } elsif ($now >= $d1 && $now < $dt) {
             $h->{days} = 1;
             $self->_bulky_send_reminder_email($report, $h, $params);
+            $self->_bulky_send_reminder_text($report, $h, $params);
             $report->set_extra_metadata(reminder_1 => 1);
             $report->update;
         }
@@ -653,6 +655,14 @@ sub _bulky_send_reminder_email {
     } else {
         print " ...failed\n" if $params->{verbose};
     }
+}
+
+sub _bulky_send_reminder_text {
+    my ($self, $report, $h, $params) = @_;
+
+    return unless $report->get_extra_field_value('bulky_text_updates');
+    $h->{url} = $self->base_url_for_report($report) . $report->tokenised_url($report->user);
+    $self->call_hook('_bulky_send_optional_text' => $report, $h->{url}, {text_type => 'reminder'});
 }
 
 sub bulky_send_before_payment { 0 }

--- a/perllib/FixMyStreet/SMS.pm
+++ b/perllib/FixMyStreet/SMS.pm
@@ -33,13 +33,31 @@ has twilio => (
     },
 );
 
+has notify_choice => (
+    is => 'ro',
+    default => '',
+);
+
 has notify => (
     is => 'lazy',
     default => sub {
         my $self = shift;
         my $cfg = $self->cobrand->feature('govuk_notify');
-        my $key = $cfg->{key};
-        return unless $key;
+        my @cfg;
+        my $key;
+        if (ref $cfg eq 'ARRAY') {
+            if ($self->notify_choice) {
+                @cfg = grep { $_->{type} eq $self->notify_choice} @$cfg;
+            } else {
+                @cfg = grep { $_->{type} eq 'default' } @$cfg;
+            }
+            $cfg = $cfg[0];
+            $key = $cfg->{key};
+            return unless $key;
+        } else {
+            $key = $cfg->{key};
+            return unless $key;
+        }
         my $api = GovUkNotify->new(
             key => $key,
             template_id => $cfg->{template_id},

--- a/perllib/FixMyStreet/Script/Alerts.pm
+++ b/perllib/FixMyStreet/Script/Alerts.pm
@@ -456,7 +456,9 @@ sub _send_aggregated_alert_email {
 
 sub _send_aggregated_alert_phone {
     my %data = @_;
-    my $result = FixMyStreet::SMS->new(cobrand => $data{cobrand})->send(
+    # Use waste config if any of the things being alerted on are waste
+    my $cfg = (grep { $_->{cobrand_data} eq 'waste' } @{ $data{data} } ) ? 'waste' : 'default';
+    my $result = FixMyStreet::SMS->new(cobrand => $data{cobrand}, notify_choice => $cfg)->send(
         to => $data{alert_user}->phone,
         body => sprintf(_("Your report (%d) has had an update; to view: %s\n\nTo stop: %s"), $data{id}, $data{problem_url}, $data{unsubscribe_url}),
     );

--- a/t/app/controller/waste_peterborough_bulky.t
+++ b/t/app/controller/waste_peterborough_bulky.t
@@ -9,6 +9,8 @@ use File::Temp 'tempdir';
 FixMyStreet::App->log->disable('info');
 END { FixMyStreet::App->log->enable('info'); }
 
+my $notify = Test::MockModule->new('FixMyStreet::SMS');
+
 my $mock = Test::MockModule->new('FixMyStreet::Cobrand::Peterborough');
 $mock->mock('_fetch_features', sub { ok 0, 'This should not be called by waste'; });
 
@@ -64,6 +66,7 @@ create_contact(
     { code => 'payment' },
     { code => 'payment_method' },
     { code => 'property_id' },
+    { code => 'bulky_text_updates' },
 );
 create_contact(
     { category => 'Bulky cancel', email => 'Bartec-545' },
@@ -107,7 +110,8 @@ FixMyStreet::override_config {
             bulky_amend_enabled => 'staff',
             bulky_multiple_bookings => 1,
             bulky_retry_bookings => 1,
-            bulky_tandc_link => 'peterborough-bulky-waste-tandc.com'
+            bulky_tandc_link => 'peterborough-bulky-waste-tandc.com',
+            bulky_offer_text_updates => 1,
         } },
         payment_gateway => { peterborough => {
             cc_url => 'https://example.org/scp/',
@@ -118,6 +122,10 @@ FixMyStreet::override_config {
             hmac_id => 789,
             hmac => 'bmV2ZXIgZ29ubmEgZ2l2ZSB5b3UgdXAKbmV2ZXIgZ29ubmEgbGV0IHlvdSBkb3duCm5ldmVyIGdvbm5hIHJ1bg==',
         } },
+        govuk_notify => { peterborough => [
+            { type => 'default', key => 'default_key', template_id => 'default_template' },
+            { type => 'waste', key => 'waste_key', template_id => 'waste_template' },
+        ]},
     },
     STAGING_FLAGS => {
         send_reports => 1,
@@ -887,6 +895,20 @@ FixMyStreet::override_config {
     subtest 'Bulky goods email confirmation and reminders' => sub {
 
         my $report_id = $report->id;
+
+        $notify->mock('send', sub {
+            my $self = shift;
+            my %params = @_;
+
+            is $params{'to'} eq '44 07 111 111 111', 1, "Correct text 'to' value";
+            is $params{'body'} =~ /^Bulky waste booking/, 1, 'Correct text title';
+            is $params{'body'} =~ /Date: Friday 26 August 2022/, 1, 'Correct text date';
+            is $params{'body'} =~ /Items: 2/, 1, 'Correct text item count';
+            is $params{'body'} =~ /Address: 1 Pope Way, Peterborough, PE1 3NA/, 1, 'Correct text address';
+            is $params{'body'} =~ m#View more details or cancel: http://peterborough.example.org/report/$report_id#, 1, 'Correct text link';
+            return 1;
+        });
+
         subtest 'Email confirmation of booking' => sub {
             FixMyStreet::Script::Reports::send();
             my $email = $mech->get_email->as_string;
@@ -897,6 +919,21 @@ FixMyStreet::override_config {
         };
 
         sub reminder_check {
+
+            $notify->mock('send', sub {
+            my $self = shift;
+            my %params = @_;
+
+            is $params{'to'} eq '44 07 111 111 111', 1, "Correct text 'to' value";
+            is $params{'body'} =~ /^Bulky waste reminder/, 1, 'Correct text title';
+            is $params{'body'} =~ /Date: Friday 26 August 2022/, 1, 'Correct text date';
+            is $params{'body'} =~ /Items: 2/, 1, 'Correct text item count';
+            is $params{'body'} =~ /Address: 1 Pope Way, Peterborough, PE1 3NA/, 1, 'Correct text address';
+            is $params{'body'} =~ m#View more details or cancel: http://peterborough.example.org/M.*#, 1, 'Correct text link';
+            is $params{'body'} =~ /^Bulky waste reminder/, 1, 'Correct text title';
+            return 1;
+        });
+
             my ($day, $time, $days, $report_id) = @_;
             set_fixed_time("2022-08-$day" . "T$time:00:00Z");
             $cobrand->bulky_reminders;

--- a/t/app/controller/waste_peterborough_bulky.t
+++ b/t/app/controller/waste_peterborough_bulky.t
@@ -362,7 +362,15 @@ FixMyStreet::override_config {
             $mech->content_contains('Aragon Direct Services may contact you to obtain more');
             $mech->submit_form_ok({ with_fields => { name => 'Bob Marge' } });
             $mech->content_contains('Please provide an email address');
-            $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
+            $mech->content_contains('Do you want to receive reminders about this collection by text message?');
+            $mech->submit_form(with_fields => { name => 'Bob Marge', email => '', phone => '44 07 111 111 111' });
+            $mech->content_contains('Please provide an email address', 'Can not proceed without email if text notifications unchecked');
+            $mech->submit_form(with_fields => { name => 'Bob Marge', email => $user->email, phone => '', extra_bulky_text_updates => '1' });
+            $mech->content_contains('Please enter a mobile phone number to receive text updates', 'Can not proceed without mobile number if text notifications checked');
+            $mech->submit_form(with_fields => { name => 'Bob Marge', email => '', phone => '44 07 111 111 111', extra_bulky_text_updates => '1' });
+            $mech->content_contains('Choose date for collection', "Can proceed without email if mobile number and text notifications checked");
+            $mech->back;
+            $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111', extra_bulky_text_updates => '1' }});
         };
 
         subtest 'Choose date page' => sub {

--- a/t/app/controller/waste_peterborough_bulky.t
+++ b/t/app/controller/waste_peterborough_bulky.t
@@ -66,7 +66,7 @@ create_contact(
     { code => 'payment' },
     { code => 'payment_method' },
     { code => 'property_id' },
-    { code => 'bulky_text_updates' },
+    { code => 'bulky_text_reminders' },
 );
 create_contact(
     { category => 'Bulky cancel', email => 'Bartec-545' },
@@ -373,12 +373,12 @@ FixMyStreet::override_config {
             $mech->content_contains('Do you want to receive reminders about this collection by text message?');
             $mech->submit_form(with_fields => { name => 'Bob Marge', email => '', phone => '44 07 111 111 111' });
             $mech->content_contains('Please provide an email address', 'Can not proceed without email if text notifications unchecked');
-            $mech->submit_form(with_fields => { name => 'Bob Marge', email => $user->email, phone => '', extra_bulky_text_updates => '1' });
+            $mech->submit_form(with_fields => { name => 'Bob Marge', email => $user->email, phone => '', extra_bulky_text_reminders => '1' });
             $mech->content_contains('Please enter a mobile phone number to receive text updates', 'Can not proceed without mobile number if text notifications checked');
-            $mech->submit_form(with_fields => { name => 'Bob Marge', email => '', phone => '44 07 111 111 111', extra_bulky_text_updates => '1' });
+            $mech->submit_form(with_fields => { name => 'Bob Marge', email => '', phone => '44 07 111 111 111', extra_bulky_text_reminders => '1' });
             $mech->content_contains('Choose date for collection', "Can proceed without email if mobile number and text notifications checked");
             $mech->back;
-            $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111', extra_bulky_text_updates => '1' }});
+            $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111', extra_bulky_text_reminders => '1' }});
         };
 
         subtest 'Choose date page' => sub {


### PR DESCRIPTION
Adds text box to opt into text updates for bulky waste bookings.

Allows multiple govuk_notify templates/keys to be added in array


https://github.com/mysociety/societyworks/issues/3782

[skip changelog]