### PR TITLE
[Bexley][Whitespace] Add extra fields for missed reports

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1577,7 +1577,7 @@ sub add_report : Private {
     $c->set_param('category', $data->{category});
     $c->set_param('title', $data->{title});
     $c->set_param('detail', $data->{detail});
-    $c->set_param('uprn', $c->stash->{property}{uprn});
+    $c->set_param('uprn', $c->stash->{property}{uprn}) unless $c->get_param('uprn');
     $c->set_param('property_id', $c->stash->{property}{id});
 
     # Data may contain duplicate photo data under different keys e.g.

--- a/perllib/FixMyStreet/Cobrand/Bexley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley.pm
@@ -139,6 +139,12 @@ sub open311_update_missing_data {
                 $row->update_extra_field({ name => 'uprn', description => 'UPRN', value => $ref });
             }
         }
+    } elsif ($contact->email =~ /^Whitespace/) {
+        if (!$row->get_extra_field_value('uprn')) {
+            if (my $ref = $feature->{properties}{UPRN}) {
+                $row->update_extra_field({ name => 'uprn', description => 'UPRN', value => $ref });
+            }
+        }
     } else { # Symology
         # Reports made via the app probably won't have a NSGRef because we don't
         # display the road layer. Instead we'll look up the closest asset from the

--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -575,6 +575,12 @@ sub waste_munge_report_data {
     $data->{title} = "Report missed $service";
     $data->{detail} = "$data->{title}\n\n$address";
     $c->set_param('service_id', $id);
+    $c->set_param('location_of_containers', $data->{extra_detail}) if $data->{extra_detail};
+    $c->set_param('service_item_name', $c->stash->{services}{$id}{service_id});
+
+    # Check if this property has assisted collections
+    my $contracts = $self->whitespace->GetSiteContracts($c->stash->{property}{uprn});
+    $c->set_param('assisted_yn', (grep { $_->{ContractID} == 7 } @$contracts) ? 'Yes' : 'No');
 }
 
 sub waste_munge_report_form_fields {

--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -585,8 +585,10 @@ sub waste_munge_report_data {
 
     my $address = $c->stash->{property}->{address};
     my $service = $c->stash->{services}{$id}{service_name};
+    my $uprn = $c->stash->{property}{parent_property} ? $c->stash->{property}{parent_property}{uprn} : $c->stash->{property}{uprn};
     $data->{title} = "Report missed $service";
     $data->{detail} = "$data->{title}\n\n$address";
+    $c->set_param('uprn', $uprn);
     $c->set_param('service_id', $id);
     $c->set_param('location_of_containers', $data->{extra_detail}) if $data->{extra_detail};
     $c->set_param('service_item_name', $c->stash->{services}{$id}{service_id});

--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -161,6 +161,19 @@ sub bin_services_for_address {
             };
         }
 
+        my $existing_report_id = $property->{missed_collection_reports}{ $filtered_service->{service_id} };
+
+        my $report;
+        if ($existing_report_id) {
+            $filtered_service->{report_open} = 1;
+            $report = $self->problems->search({ external_id => "Whitespace-$existing_report_id" })->first;
+            if ($report) {
+                $filtered_service->{report_url} = $report->url;
+            }
+        } else {
+            $filtered_service->{report_open} = 0;
+        }
+
         $filtered_service->{report_open}
             = $property->{missed_collection_reports}{ $filtered_service->{service_id} } ? 1 : 0;
 
@@ -223,7 +236,7 @@ sub _missed_collection_reports {
             for ( @{  $self->whitespace->GetWorksheetDetailServiceItems(
                         $ws->{WorksheetID} ) } )
             {
-                $missed_collection_reports{ $_->{ServiceItemName} } = 1;
+                $missed_collection_reports{ $_->{ServiceItemName} } = $ws->{WorksheetID};
             }
         }
     }

--- a/templates/web/bexley/waste/_service_missed.html
+++ b/templates/web/bexley/waste/_service_missed.html
@@ -1,7 +1,7 @@
 [% IF unit.report_open %]
   <span class="waste-service-descriptor">
     A [% unit.service_name FILTER lower %] collection has been reported as missed
-    [% IF unit.report_open.report %] – <a href="[% unit.report_open.report.url %]" class="waste-service-link">check status</a>[% END %]
+    [% IF unit.report_url %] – <a href="[% unit.report_url %]" class="waste-service-link">check status</a>[% END %]
   </span>
 [% ELSIF unit.report_locked_out %]
 <span class="waste-service-descriptor">A missed collection cannot be reported;


### PR DESCRIPTION
Adds some extra fields that are used when creating missed collection reports in Whitespace.

See also the related Open311 adapter changes: https://github.com/mysociety/open311-adapter/pull/331

Part of https://github.com/mysociety/societyworks/issues/4051

Also related to https://github.com/mysociety/societyworks/issues/4098

<!-- [skip changelog] -->