### PR TITLE
Bexley ww misc fixes

### DIFF
--- a/perllib/BexleyAddresses.pm
+++ b/perllib/BexleyAddresses.pm
@@ -141,17 +141,17 @@ sub _join_extended {
 }
 
 sub _sort_addresses {
-    ( $a->{pao_start_number} // 0 ) <=> ( $b->{pao_start_number} // 0 )
+    ( $a->{pao_start_number} || 0 ) <=> ( $b->{pao_start_number} || 0 )
     or
-    ( $a->{pao_start_suffix} // '' ) cmp ( $b->{pao_start_suffix} // '' )
+    ( $a->{pao_start_suffix} || '' ) cmp ( $b->{pao_start_suffix} || '' )
     or
-    ( $a->{pao_text} // '' ) cmp ( $b->{pao_text} // '' )
+    ( $a->{pao_text} || '' ) cmp ( $b->{pao_text} || '' )
     or
-    ( $a->{sao_start_number} // 0 ) <=> ( $b->{sao_start_number} // 0 )
+    ( $a->{sao_start_number} || 0 ) <=> ( $b->{sao_start_number} || 0 )
     or
-    ( $a->{sao_start_suffix} // '' ) cmp ( $b->{sao_start_suffix} // '' )
+    ( $a->{sao_start_suffix} || '' ) cmp ( $b->{sao_start_suffix} || '' )
     or
-    ( $a->{sao_text} // '' ) cmp ( $b->{sao_text} // '' )
+    ( $a->{sao_text} || '' ) cmp ( $b->{sao_text} || '' )
 }
 
 # Fields needed to build an address string

--- a/perllib/BexleyAddresses.pm
+++ b/perllib/BexleyAddresses.pm
@@ -84,7 +84,7 @@ sub build_address_string {
     my $sao;
     if ( $row->{parent_uprn} ) {
         $sao = _join_extended(
-            ' ',
+            ', ',
             $row->{sao_text},
             _join_extended(
                 '-',
@@ -102,7 +102,7 @@ sub build_address_string {
     }
 
     my $pao = _join_extended(
-        ' ',
+        ', ',
         $row->{pao_text},
         _join_extended(
             '-',
@@ -121,7 +121,8 @@ sub build_address_string {
 
     return _join_extended(
         ', ',
-        _join_extended( ' ', $sao, $pao, $row->{street_descriptor} ),
+        $sao,
+        _join_extended( ' ', $pao, $row->{street_descriptor} ),
         $row->{locality_name},
         $row->{town_name},
         mySociety::PostcodeUtil::canonicalise_postcode( $row->{postcode} ),

--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -188,6 +188,15 @@ sub bin_services_for_address {
             };
         }
 
+        # Frequency of collection
+        if ( @round_schedules > 1 ) {
+            $filtered_service->{schedule} = 'Twice Weekly';
+        } elsif ( $round_schedules[0] =~ /Wk \d+$/ ) {
+            $filtered_service->{schedule} = 'Fortnightly';
+        } else {
+            $filtered_service->{schedule} = 'Weekly';
+        }
+
         my $existing_report_id = $property->{missed_collection_reports}{ $filtered_service->{service_id} };
 
         my $report;

--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -57,7 +57,8 @@ sub look_up_property {
         # and 'uprn' in others, we set both here
         id => $site->{AccountSiteUPRN},
         uprn => $site->{AccountSiteUPRN},
-        address => FixMyStreet::Template::title($site->{Site}->{SiteShortAddress}),
+        address => FixMyStreet::Template::title(
+            BexleyAddresses::address_for_uprn($uprn) ),
         latitude => $site->{Site}->{SiteLatitude},
         longitude => $site->{Site}->{SiteLongitude},
 

--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -72,10 +72,16 @@ sub bin_services_for_address {
     my $site_services = $self->whitespace->GetSiteCollections($property->{uprn});
 
     # Get parent property services if no services found
-    $site_services = $self->whitespace->GetSiteCollections(
-        $property->{parent_property}{uprn} )
-        if !@{ $site_services // [] }
-        && $property->{parent_property};
+    if ( !@{ $site_services // [] }
+        && $property->{parent_property} )
+    {
+        $site_services = $self->whitespace->GetSiteCollections(
+            $property->{parent_property}{uprn} );
+
+        # A property is only communal if it has a parent property AND doesn't
+        # have its own list of services
+        $property->{is_communal} = 1;
+    }
 
     # TODO Call these in parallel
     $property->{missed_collection_reports}
@@ -426,7 +432,7 @@ sub image_for_unit {
 
     my $property = $self->{c}->stash->{property};
 
-    my $is_communal = $property->{parent_property};
+    my $is_communal = $property->{is_communal};
 
     my $images = {
         'FO-140'   => 'communal-food-wheeled-bin',     # Food 140 ltr Bin
@@ -501,7 +507,7 @@ sub ordinal {
 sub _containers {
     my ( $self, $property ) = @_;
 
-    my $is_communal = $property->{parent_property};
+    my $is_communal = $property->{is_communal};
 
     return {
         'FO-140'   => 'Communal Food Bin',

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -40,17 +40,43 @@ $dbi_mock->mock( 'connect', sub {
         } elsif ( $postcode eq 'DA13NP' ) {
             return [
                 {   uprn              => 10001,
+                    sao_start_number  => 98,
+                    sao_start_suffix  => 'A',
+                    sao_end_number    => 99,
+                    sao_end_suffix    => 'B',
+                    sao_text          => 'Flat',
                     pao_start_number  => 1,
+                    pao_start_suffix  => 'a',
+                    pao_end_number    => 2,
+                    pao_end_suffix    => 'b',
+                    pao_text          => 'The Court',
                     street_descriptor => 'THE AVENUE',
+                    locality_name     => 'Little Bexlington',
+                    town_name         => 'Bexley',
+
+                    parent_uprn => 999999,
                 },
             ];
         }
     } );
     $dbh->mock( 'selectrow_hashref', sub {
         return {
-            postcode => 'DA13NP',
+            postcode          => 'DA13NP',
+            sao_start_number  => 98,
+            sao_start_suffix  => 'A',
+            sao_end_number    => 99,
+            sao_end_suffix    => 'B',
+            sao_text          => 'Flat',
             pao_start_number  => 1,
+            pao_start_suffix  => 'a',
+            pao_end_number    => 2,
+            pao_end_suffix    => 'b',
+            pao_text          => 'The Court',
             street_descriptor => 'THE AVENUE',
+            locality_name     => 'Little Bexlington',
+            town_name         => 'Bexley',
+
+            parent_uprn => 999999,
         };
     } );
     return $dbh;
@@ -177,7 +203,9 @@ FixMyStreet::override_config {
         $mech->get_ok('/waste');
         $mech->submit_form_ok( { with_fields => { postcode => 'DA1 3NP' } } );
         $mech->content_contains('Select an address');
-        $mech->content_contains('<option value="10001">1 The Avenue</option>');
+        $mech->content_contains(
+            '<option value="10001">Flat, 98a-99b, The Court, 1a-2b The Avenue, Little Bexlington, Bexley</option>'
+        );
     };
 
     $whitespace_mock->mock( 'GetSiteContracts', sub {
@@ -199,7 +227,7 @@ FixMyStreet::override_config {
         test_services($mech);
 
         $mech->content_contains(
-            '<dd class="waste__address__property">1 The Avenue, DA1 3NP</dd>',
+            '<dd class="waste__address__property">Flat, 98a-99b, The Court, 1a-2b The Avenue, Little Bexlington, Bexley, DA1 3NP</dd>',
             'Correct address string displayed',
         );
         $mech->content_contains(

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -228,7 +228,7 @@ FixMyStreet::override_config {
                 {   id             => 8,
                     service_id     => 'PC-55',
                     service_name   => 'Blue Recycling Box',
-                    round_schedule => 'RND-8-9 Mon',
+                    round_schedule => 'RND-8-9 Mon, RND-8-9 Wed',
                     round          => 'RND-8-9',
                     report_allowed => 0,
                     report_open    => 1,
@@ -240,7 +240,7 @@ FixMyStreet::override_config {
                 {   id             => 9,
                     service_id     => 'PA-55',
                     service_name   => 'Green Recycling Box',
-                    round_schedule => 'RND-8-9 Mon',
+                    round_schedule => 'RND-8-9 Mon, RND-8-9 Wed',
                     round          => 'RND-8-9',
                     report_allowed => 0,
                     report_open    => 1,
@@ -272,6 +272,16 @@ FixMyStreet::override_config {
                     %defaults,
                 },
             ];
+
+            my %expected_last_dates = (
+                8 => '2024-03-28T00:00:00',
+                9 => '2024-03-28T00:00:00',
+                1 => '2024-03-24T00:00:00',
+                6 => '2024-03-27T00:00:00',
+            );
+            for (@sorted) {
+                is $_->{last}{date}, $expected_last_dates{ $_->{id} };
+            }
         };
     };
 
@@ -308,7 +318,7 @@ FixMyStreet::override_config {
         my @events = split /BEGIN:VEVENT/, $mech->encoded_content;
         shift @events; # Header
 
-        my $expected_num = 14;
+        my $expected_num = 20;
         is @events, $expected_num, "$expected_num events in calendar";
 
         my $i = 0;
@@ -317,14 +327,20 @@ FixMyStreet::override_config {
             $i++ if /DTSTART;VALUE=DATE:20240401/ && /SUMMARY:Green Recycling Box/;
             $i++ if /DTSTART;VALUE=DATE:20240402/ && /SUMMARY:Communal Food Bin/;
             $i++ if /DTSTART;VALUE=DATE:20240403/ && /SUMMARY:Clear Sack\(s\)/;
+            $i++ if /DTSTART;VALUE=DATE:20240403/ && /SUMMARY:Blue Recycling Box/;
+            $i++ if /DTSTART;VALUE=DATE:20240403/ && /SUMMARY:Green Recycling Box/;
 
             $i++ if /DTSTART;VALUE=DATE:20240408/ && /SUMMARY:Blue Recycling Box/;
             $i++ if /DTSTART;VALUE=DATE:20240408/ && /SUMMARY:Green Recycling Box/;
+            $i++ if /DTSTART;VALUE=DATE:20240410/ && /SUMMARY:Blue Recycling Box/;
+            $i++ if /DTSTART;VALUE=DATE:20240410/ && /SUMMARY:Green Recycling Box/;
 
             $i++ if /DTSTART;VALUE=DATE:20240415/ && /SUMMARY:Blue Recycling Box/;
             $i++ if /DTSTART;VALUE=DATE:20240415/ && /SUMMARY:Green Recycling Box/;
             $i++ if /DTSTART;VALUE=DATE:20240416/ && /SUMMARY:Communal Food Bin/;
             $i++ if /DTSTART;VALUE=DATE:20240417/ && /SUMMARY:Clear Sack\(s\)/;
+            $i++ if /DTSTART;VALUE=DATE:20240417/ && /SUMMARY:Blue Recycling Box/;
+            $i++ if /DTSTART;VALUE=DATE:20240417/ && /SUMMARY:Green Recycling Box/;
 
             $i++ if /DTSTART;VALUE=DATE:20240501/ && /SUMMARY:Clear Sack\(s\)/;
 
@@ -544,7 +560,7 @@ sub _site_collections {
                 SiteServiceValidFrom => '2024-03-31T00:59:59',
                 SiteServiceValidTo   => '0001-01-01T00:00:00',
 
-                RoundSchedule => 'RND-8-9 Mon',
+                RoundSchedule => 'RND-8-9 Mon, RND-8-9 Wed',
             },
             {   SiteServiceID          => 8,
                 ServiceItemDescription => 'Service 8',
@@ -554,7 +570,7 @@ sub _site_collections {
                 SiteServiceValidFrom => '2024-03-31T00:59:59',
                 SiteServiceValidTo   => '0001-01-01T00:00:00',
 
-                RoundSchedule => 'RND-8-9 Mon',
+                RoundSchedule => 'RND-8-9 Mon, RND-8-9 Wed',
             },
             {   SiteServiceID          => 9,
                 ServiceItemDescription => 'Another service (9)',
@@ -564,7 +580,7 @@ sub _site_collections {
                 SiteServiceValidFrom => '2024-03-31T00:59:59',
                 SiteServiceValidTo   => '0001-01-01T00:00:00',
 
-                RoundSchedule => 'RND-8-9 Mon',
+                RoundSchedule => 'RND-8-9 Mon, RND-8-9 Wed',
             },
         ],
         10003 => [
@@ -609,6 +625,11 @@ sub _collection_by_uprn_date {
                 Service  => 'Service 1 Collection',
             },
             {   Date     => '03/04/2024 00:00:00',
+                Round    => 'RND-8-9',
+                Schedule => 'Wed',
+                Service  => 'Services 8 & 9 Collection',
+            },
+            {   Date     => '03/04/2024 00:00:00',
                 Round    => 'RND-6',
                 Schedule => 'Wed Wk 2',
                 Service  => 'Service 6 Collection',
@@ -617,6 +638,11 @@ sub _collection_by_uprn_date {
             {   Date     => '08/04/2024 00:00:00',
                 Round    => 'RND-8-9',
                 Schedule => 'Mon',
+                Service  => 'Services 8 & 9 Collection',
+            },
+            {   Date     => '10/04/2024 00:00:00',
+                Round    => 'RND-8-9',
+                Schedule => 'Wed',
                 Service  => 'Services 8 & 9 Collection',
             },
 
@@ -629,6 +655,11 @@ sub _collection_by_uprn_date {
                 Round    => 'RND-1',
                 Schedule => 'Tue Wk 1',
                 Service  => 'Service 1 Collection',
+            },
+            {   Date     => '17/04/2024 00:00:00',
+                Round    => 'RND-8-9',
+                Schedule => 'Wed',
+                Service  => 'Services 8 & 9 Collection',
             },
             {   Date     => '17/04/2024 00:00:00',
                 Round    => 'RND-6',
@@ -681,6 +712,11 @@ sub _collection_by_uprn_date {
                 Round    => 'RND-6',
                 Schedule => 'Wed Wk 2',
                 Service  => 'Service 6 Collection',
+            },
+            {   Date     => '27/03/2024 00:00:00',
+                Round    => 'RND-8-9',
+                Schedule => 'Wed',
+                Service  => 'Services 8 & 9 Collection',
             },
             {   Date     => '28/03/2024 00:00:00',
                 Round    => 'RND-8-9',

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -235,6 +235,7 @@ FixMyStreet::override_config {
                     report_url     => '/report/' . $existing_missed_collection_report1->id,
                     report_locked_out => 0,
                     assisted_collection => 1, # Has taken precedence over PC-55 non-assisted collection
+                    schedule => 'Twice Weekly',
                     %defaults,
                 },
                 {   id             => 9,
@@ -247,6 +248,7 @@ FixMyStreet::override_config {
                     report_url     => '/report/' . $existing_missed_collection_report2->id,
                     report_locked_out => 0,
                     assisted_collection => 0,
+                    schedule => 'Twice Weekly',
                     %defaults,
                 },
                 {   id             => 1,
@@ -258,6 +260,7 @@ FixMyStreet::override_config {
                     report_open    => 0,
                     report_locked_out => 1,
                     assisted_collection => 0,
+                    schedule => 'Fortnightly',
                     %defaults,
                 },
                 {   id             => 6,
@@ -269,6 +272,7 @@ FixMyStreet::override_config {
                     report_open    => 0,
                     report_locked_out => 0,
                     assisted_collection => 0,
+                    schedule => 'Fortnightly',
                     %defaults,
                 },
             ];

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -202,6 +202,10 @@ FixMyStreet::override_config {
             '<dd class="waste__address__property">1 The Avenue, DA1 3NP</dd>',
             'Correct address string displayed',
         );
+        $mech->content_contains(
+            'Your rotation schedule is Week 1',
+            'Correct rotation schedule displayed',
+        );
 
         subtest 'service_sort sorts correctly' => sub {
             my $cobrand = FixMyStreet::Cobrand::Bexley->new;
@@ -361,6 +365,10 @@ FixMyStreet::override_config {
             $mech->get_ok('/waste');
             $mech->submit_form_ok( { with_fields => { postcode => 'DA1 3LD' } } );
             $mech->submit_form_ok( { with_fields => { address => $test->{address} } } );
+            $mech->content_contains(
+                "Your rotation schedule is Week $test->{link}",
+                'Correct rotation schedule displayed',
+            );
             $mech->content_contains('<li><a href="PDF '. $test->{link} . '">Download PDF waste calendar', 'PDF link ' . $test->{link} . ' shown');
         }
     };

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -46,6 +46,13 @@ $dbi_mock->mock( 'connect', sub {
             ];
         }
     } );
+    $dbh->mock( 'selectrow_hashref', sub {
+        return {
+            postcode => 'DA13NP',
+            pao_start_number  => 1,
+            street_descriptor => 'THE AVENUE',
+        };
+    } );
     return $dbh;
 } );
 
@@ -190,6 +197,11 @@ FixMyStreet::override_config {
         $mech->submit_form_ok( { with_fields => { address => 10001 } } );
 
         test_services($mech);
+
+        $mech->content_contains(
+            '<dd class="waste__address__property">1 The Avenue, DA1 3NP</dd>',
+            'Correct address string displayed',
+        );
 
         subtest 'service_sort sorts correctly' => sub {
             my $cobrand = FixMyStreet::Cobrand::Bexley->new;

--- a/templates/web/base/waste/bin_days.html
+++ b/templates/web/base/waste/bin_days.html
@@ -10,6 +10,7 @@
 
 [% TRY %][% PROCESS waste/_service_navigation_bar.html %][% CATCH file %][% END %]
 [% INCLUDE 'waste/_address_display.html' %]
+[% TRY %][% PROCESS waste/_rotation_schedule.html %][% CATCH file %][% END %]
 [% TRY %][% PROCESS waste/_announcement.html %][% CATCH file %][% END %]
 <div class="waste__collections">
  [% IF c.cobrand.moniker != 'peterborough' %]

--- a/templates/web/bexley/waste/_rotation_schedule.html
+++ b/templates/web/bexley/waste/_rotation_schedule.html
@@ -1,0 +1,14 @@
+[% IF service_data.size %]
+  [% ft = property.frequency_types %]
+  <dl class="waste__address">
+    <dd class="waste__address__property">
+      [% IF ft.fortnightly %]
+        Your rotation schedule is Week [% ft.fortnightly %]
+      [% ELSIF ft.weekly %]
+        Your bins are collected every week
+      [% ELSE %]
+        Your bins are collected twice a week
+      [% END %]
+    </dd>
+  </dl>
+[% END %]


### PR DESCRIPTION
Done as part of https://github.com/mysociety/societyworks/issues/4206 .

- Do not mark child address as 'communal' if it has its own services - for https://3.basecamp.com/4020879/buckets/35109031/todos/7182351792
- Use LLPG data for address on collection page - https://3.basecamp.com/4020879/buckets/35109031/todos/7182204348
- Handle biweekly collections - https://3.basecamp.com/4020879/buckets/35109031/todos/7182331622
- Display collection frequency - https://3.basecamp.com/4020879/buckets/35109031/todos/7182127728
- Display rotation schedule for property - https://3.basecamp.com/4020879/buckets/35109031/todos/7183494892

[skip changelog]
