### PR TITLE
[Northumberland] Being able to filter on one category in multiple parent categories

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Dashboard.pm
+++ b/perllib/FixMyStreet/App/Controller/Dashboard.pm
@@ -198,6 +198,7 @@ sub index : Path : Args(0) {
         })->active->translated->with_area_count->all_sorted;
         $c->stash->{ward} = [];
         $c->stash->{bodies} = \@bodies;
+        $c->stash->{groups_selected_from} = [];
     }
 
     my $days30 = DateTime->now(time_zone => FixMyStreet->time_zone || FixMyStreet->local_time_zone)->subtract(days => 30);

--- a/perllib/FixMyStreet/Reporting.pm
+++ b/perllib/FixMyStreet/Reporting.pm
@@ -95,7 +95,7 @@ has filename => ( is => 'rw', isa => Str, lazy => 1, default => sub {
         start_date => $self->start_date,
         end_date => $self->end_date,
     );
-    $where{category} = @{$self->category} < 3 ? join(',', @{$self->category}) : 'multiple-categories';
+    $where{category} = @{$self->category} < 3 ? join(',', sort @{$self->category}) : 'multiple-categories';
     $where{body} = $self->body->id if $self->body;
     $where{role} = $self->role_id if $self->role_id;
     my $host = URI->new($self->cobrand->base_url)->host;

--- a/t/app/controller/dashboard.t
+++ b/t/app/controller/dashboard.t
@@ -37,7 +37,7 @@ my @cats = ('Litter', 'Other', 'Potholes', 'Traffic lights & bells', 'White line
 for my $contact ( @cats ) {
     my $c = $mech->create_contact_ok(body_id => $body->id, category => $contact, email => "$contact\@example.org");
     if ($contact eq 'Potholes' || $contact eq 'White lines') {
-        $c->set_extra_metadata(group => ['Road & more']);
+        $c->set_extra_metadata(group => ['Road & more', 'Pavements']);
         $c->update;
     }
 }
@@ -161,7 +161,7 @@ FixMyStreet::override_config {
 
     subtest 'The correct categories and totals shown by default' => sub {
         $mech->get_ok("/dashboard");
-        my $expected_cats = [ 'Litter', 'Other', 'Traffic lights & bells', 'All Road & more', 'Potholes', 'White lines' ];
+        my $expected_cats = [ 'Litter', 'Other', 'Traffic lights & bells', 'All Pavements', 'Potholes', 'White lines', 'All Road & more', 'Potholes', 'White lines' ];
         my $res = $categories->scrape( $mech->content );
         $mech->content_contains('<optgroup label="Road &amp; more">');
         $mech->content_contains('<option value="group-Road &amp; more"');
@@ -182,21 +182,41 @@ FixMyStreet::override_config {
         my $end = DateTime->now->subtract(months => 1)->strftime('%Y-%m-%d');
         $mech->submit_form_ok({ with_fields => { state => '', start_date => $start, end_date => $end } });
         test_table($mech->content, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 3);
-        $mech->get_ok("/dashboard?category=Litter&category=Potholes");
+        $mech->get_ok("/dashboard?category=Litter-group-&category=Potholes-group-");
         test_table($mech->content, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 4, 6, 0, 0, 0, 0, 3, 0, 4, 7);
-        $mech->get_ok("/dashboard?category=Traffic+lights+%26+bells");
-        $mech->content_contains("<option value='Traffic lights &amp; bells' selected>");
+        $mech->get_ok("/dashboard?category=Traffic+lights+%26+bells-group-");
+        $mech->content_contains("<option value='Traffic lights &amp; bells-group-' selected>");
         test_table($mech->content, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 0, 10);
         $mech->get_ok("/dashboard?category=group-Road+%26+more");
         $mech->content_contains('<option value="group-Road &amp; more" selected>');
         test_table($mech->content, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 4, 6, 1, 0, 0, 1, 3, 0, 4, 7);
-        $mech->get_ok("/dashboard?category=group-Road+%26+more&category=Potholes");
+        $mech->get_ok("/dashboard?category=group-Road+%26+more&category=Potholes-group-");
         test_table($mech->content, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 4, 6, 1, 0, 0, 1, 3, 0, 4, 7);
-        $mech->get_ok("/dashboard?category=group-Road+%26+more&category=Litter");
+        $mech->get_ok("/dashboard?category=group-Road+%26+more&category=Litter-group-");
         test_table($mech->content, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 4, 6, 1, 0, 0, 1, 4, 0, 4, 8);
+        my ($sub_pothole_pavement) = $mech->create_problems_for_body(1, $body->id, 'Title', { areas => ",$area_id,2651,", category => 'Potholes', cobrand => 'no2fat' });
+        $sub_pothole_pavement->set_extra_metadata( group => 'Pavements');
+        $sub_pothole_pavement->update;
+        $mech->get_ok("/dashboard?category=group-Road+%26+more&category=Litter-group-");
+        test_table($mech->content, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 4, 6, 1, 0, 0, 1, 4, 0, 4, 8);
+        my ($sub_pothole_road) = $mech->create_problems_for_body(1, $body->id, 'Title', { areas => ",$area_id,2651,", category => 'Potholes', cobrand => 'no2fat' });
+        $sub_pothole_road->set_extra_metadata( group => 'Road & more');
+        $sub_pothole_road->state('closed');
+        $sub_pothole_road->update;
+        $mech->get_ok("/dashboard?category=group-Road+%26+more&category=Litter-group-");
+        test_table($mech->content, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 2, 0, 4, 6, 1, 0, 0, 1, 4, 1, 4, 9);
+        $sub_pothole_pavement->delete;
+        $sub_pothole_road->delete;
     };
 
     subtest 'test grouping' => sub {
+        my $contacts = FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } );
+        while (my $contact = $contacts->next) {
+            if ($contact->category eq 'Potholes' || $contact->category eq 'White lines') {
+                $contact->set_extra_metadata(group => ['Road & more']);
+                $contact->update;
+            }
+        }
         $mech->get_ok("/dashboard?group_by=category");
         my $top_level = test_table($mech->content, 1, 0, 10, 6, 1, 18);
         is_deeply $top_level, ['Road & more'], 'Road group created';

--- a/templates/web/base/dashboard/index.html
+++ b/templates/web/base/dashboard/index.html
@@ -52,8 +52,9 @@
         <label for="category">[% loc('Category:') %]</label>
         <select class="form-control js-multiple" multiple name="category" id="category">
             [% BLOCK category_option %]
-            [% SET category_safe = mark_safe(cat.category) %]
-                <option value='[% cat.category | html %]'[% ' selected' IF display_categories.$category_safe %]>[% cat.category_display | html %]</option>
+            [% SET category_built = cat.category _ '-' _ group.group_id %]
+            [% SET category_safe = mark_safe(category_built) %]
+               <option value='[% cat.category %]-[% group.group_id | html %]'[% ' selected' IF display_categories.$category_safe %]>[% cat.category_display %]</option>
             [% END %]
             [%~ INCLUDE 'report/new/_category_select.html' include_group_option=1 ~%]
         </select>
@@ -155,19 +156,21 @@
     </tr>
   [% SET current_category = '' %]
   [% FOR k IN rows %][% k_safe = mark_safe(k) %]
-    [% IF category_to_group.$k_safe AND category_to_group.$k_safe != current_category %]
-    [% SET current_category = category_to_group.$k_safe %]
+    [% IF category_to_group.$k_safe.group AND category_to_group.$k_safe.group != current_category %]
+    [% SET current_category = category_to_group.$k_safe.group %]
       <tr>
-        [% IF group_by == 'category+state' %]
-        <th colspan="5" scope="colgroup">[% category_to_group.$k_safe %]</th>
+        [% IF group_by == 'category+state' OR group_by == 'category' %]
+        <th colspan="5" scope="colgroup">[% category_to_group.$k_safe.group %]</th>
         [% ELSE %]
-        <th colspan="2" scope="colgroup">[% category_to_group.$k_safe %]</th>
+        <th colspan="2" scope="colgroup">[% $k_safe %]</th>
         [% END %]
       </tr>
     [% END %]
     <tr>
       [% IF group_by == 'state' %]
         <th scope="row">[% prettify_state(k) %]</th>
+      [% ELSIF group_by == 'category' OR group_by == 'category+state' %]
+        <th scope="row">[% category_to_group.$k_safe.display_name %]</th>
       [% ELSE %]
         <th scope="row">[% k %]</th>
       [% END %]


### PR DESCRIPTION
Set up categories in index to include name of their group.

Use this group name to check if a report is in the selected category (through extra->group).

If there are reports that don't identify as being in that category, then still use a 'Multiple' category.

Fixes https://github.com/mysociety/societyworks/issues/4039

[skip changelog]