### PR TITLE
[Waste] [Echo] Check event before/after sending.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -749,9 +749,16 @@ sub open311_extra_data_exclude {
     return [];
 }
 
+=head2 open311_pre_send
+
+We check in Echo to see if something has already been sent there first.
+
+=cut
+
 sub open311_pre_send {
     my ($self, $row, $open311) = @_;
     return 'SKIP' if $row->category eq 'Request new container' && $row->get_extra_field_value('request_referral');
+    return 'SENT' if $self->open311_pre_send_check($row, 'FMS');
 }
 
 =head2 open311_post_send
@@ -787,6 +794,8 @@ sub open311_post_send {
         if ($error =~ /Selected reservations expired|Invalid reservation reference/) {
             $self->bulky_refetch_slots($row2);
             $row->discard_changes;
+        } elsif ($error =~ /Internal error/) {
+            $self->open311_post_send_error_check("FMS", $row, $row2, $sender);
         }
     });
 }

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -358,6 +358,8 @@ sub open311_pre_send {
             $row->detail($text);
         }
     }
+
+    return 'SENT' if $self->open311_pre_send_check($row, 'FMS');
 }
 
 sub _include_user_title_in_extra {
@@ -535,6 +537,8 @@ sub open311_post_send {
         } elsif ($error =~ /Selected reservations expired|Invalid reservation reference/) {
             $self->bulky_refetch_slots($row2);
             $row->discard_changes;
+        } elsif ($error =~ /Internal error/) {
+            $self->open311_post_send_error_check("FMS", $row, $row2, $sender);
         }
     });
 }

--- a/perllib/FixMyStreet/Roles/Cobrand/SLWP.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/SLWP.pm
@@ -528,6 +528,23 @@ sub open311_extra_data_include {
     return $open311_only;
 }
 
+sub echo_reference_prefix {
+    my $self = shift;
+    return 'LBS' if $self->moniker eq 'sutton';
+    return 'RBK' if $self->moniker eq 'kingston';
+    return 'MRT' if $self->moniker eq 'merton';
+}
+
+=item * We check in Echo to see if something has already been sent there first
+
+=cut
+
+sub open311_pre_send {
+    my ($self, $row, $open311) = @_;
+
+    return 'SENT' if $self->open311_pre_send_check($row, $self->echo_reference_prefix);
+}
+
 =item * If Echo errors, we try and deal with standard issues - a renewal on an expired subscription, or a duplicate event
 
 =cut
@@ -553,13 +570,9 @@ sub open311_post_send {
             $row->discard_changes;
         } elsif ($error =~ /Duplicate Event! Original eventID: (\d+)/) {
             my $id = $1;
-            my $cfg = $self->feature('echo');
-            my $echo = Integrations::Echo->new(%$cfg);
-            my $event = $echo->GetEvent($id, 'Id');
-            $row2->external_id($event->{Guid});
-            $sender->success(1);
-            $row2->update;
-            $row->discard_changes;
+            $self->open311_post_send_check($id, "Id", $row, $row2, $sender);
+        } elsif ($error =~ /Internal error/) {
+            $self->open311_post_send_error_check($self->echo_reference_prefix, $row, $row2, $sender);
         }
     });
 }

--- a/perllib/FixMyStreet/SendReport/Open311.pm
+++ b/perllib/FixMyStreet/SendReport/Open311.pm
@@ -77,7 +77,7 @@ sub send {
     my $open311 = Open311->new( %open311_params );
 
     my $skip = $cobrand->call_hook(open311_pre_send => $row, $open311);
-    $skip = $skip && $skip eq 'SKIP';
+    $skip = $skip && ($skip eq 'SKIP' || $skip eq 'SENT');
 
     my $resp;
     if (!$skip) {
@@ -89,7 +89,7 @@ sub send {
 
     if ( $skip || $resp ) {
         $row->unset_extra_metadata('open311_category_override'); # If we were overridden, we don't want to keep that for future
-        $row->update({ external_id => $resp });
+        $row->update({ external_id => $resp }) if $resp;
         $self->success( 1 );
     } else {
         $self->error( "Failed to send over Open311\n" ) unless $self->error;

--- a/t/app/controller/waste_bromley_bulky.t
+++ b/t/app/controller/waste_bromley_bulky.t
@@ -161,6 +161,7 @@ FixMyStreet::override_config {
     $echo->mock( 'CancelReservedSlotsForEvent', sub { [] } );
     $echo->mock( 'GetTasks', sub { [] } );
     $echo->mock( 'GetEventsForObject', sub { [] } );
+    $echo->mock( 'GetEvent', sub { {} } );
     $echo->mock( 'FindPoints',sub { [
         {
             Description => '2 Example Street, Bromley, BR1 1AF',

--- a/t/app/controller/waste_kingston_r.t
+++ b/t/app/controller/waste_kingston_r.t
@@ -508,6 +508,7 @@ sub shared_echo_mocks {
     });
     $e->mock('GetServiceUnitsForObject', sub { $bin_data });
     $e->mock('GetEventsForObject', sub { [] });
+    $e->mock('GetEvent', sub { {} });
     $e->mock('GetTasks', sub { [] });
     $e->mock( 'CancelReservedSlotsForEvent', sub {
         my (undef, $guid) = @_;

--- a/t/app/controller/waste_sutton_r.t
+++ b/t/app/controller/waste_sutton_r.t
@@ -632,6 +632,7 @@ sub shared_echo_mocks {
     });
     $e->mock('GetServiceUnitsForObject', sub { $bin_data });
     $e->mock('GetEventsForObject', sub { [] });
+    $e->mock('GetEvent', sub { {} });
     $e->mock('GetTasks', sub { [] });
     $e->mock( 'CancelReservedSlotsForEvent', sub {
         my (undef, $guid) = @_;

--- a/t/cobrand/brent.t
+++ b/t/cobrand/brent.t
@@ -222,6 +222,8 @@ create_contact({ category => 'Additional collection', email => 'general@brent.go
     { code => 'service_id', required => 1, automated => 'hidden_field' },
 );
 
+my $echo = shared_echo_mocks();
+
 subtest "title is labelled 'location of problem' in open311 extended description" => sub {
     my ($problem) = $mech->create_problems_for_body(1, $brent->id, 'title', {
         category => 'Graffiti' ,
@@ -697,6 +699,8 @@ FixMyStreet::override_config {
     $mech->host("brent.fixmystreet.com");
 };
 
+undef $echo; # Otherwise tests below fail
+
 package SOAP::Result;
 sub result { return $_[0]->{result}; }
 sub new { my $c = shift; bless { @_ }, $c; }
@@ -888,6 +892,8 @@ FixMyStreet::override_config {
         is $closest->summary, 'Studio 1, 29, Buckingham Road, London, Brent, NW10 4RP';
     }
 };
+
+$echo = shared_echo_mocks();
 
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'brent', 'tfl' ],
@@ -1685,6 +1691,7 @@ sub shared_echo_mocks {
         };
     });
     $e->mock('GetEventsForObject', sub { [] });
+    $e->mock('GetEvent', sub { {} });
     $e->mock('GetTasks', sub { [] });
     return $e;
 }

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -160,6 +160,9 @@ subtest 'Updates from staff with no text but with private comments are sent' => 
     };
 };
 
+my $echo = Test::MockModule->new('Integrations::Echo');
+$echo->mock(GetEvent => sub { {} });
+
 for my $test (
     {
         desc => 'testing special Open311 behaviour',

--- a/t/cobrand/bromley_waste.t
+++ b/t/cobrand/bromley_waste.t
@@ -92,6 +92,9 @@ subtest 'check footer is powered by SocietyWorks' => sub {
 };
 
 subtest 'test waste duplicate' => sub {
+    my $echo = Test::MockModule->new('Integrations::Echo');
+    $echo->mock(GetEvent => sub { {} });
+
     my $sender = FixMyStreet::SendReport::Open311->new(
         bodies => [ $body ], body_config => { $body->id => $body },
     );
@@ -109,6 +112,9 @@ subtest 'test waste duplicate' => sub {
 };
 
 subtest 'test DD taking so long it expires' => sub {
+    my $echo = Test::MockModule->new('Integrations::Echo');
+    $echo->mock(GetEvent => sub { {} });
+
     my $title = $report->title;
     $report->update({ title => "Garden Subscription - Renew" });
     my $sender = FixMyStreet::SendReport::Open311->new(

--- a/t/sendreport/open311.t
+++ b/t/sendreport/open311.t
@@ -16,6 +16,9 @@ $ukc->mock('lookup_site_code', sub {
     return "Road ID";
 });
 
+my $echo = Test::MockModule->new('Integrations::Echo');
+$echo->mock(GetEvent => sub { {} });
+
 package main;
 sub test_overrides; # defined below
 


### PR DESCRIPTION
If we get an internal error from Echo when sending, try and look up the event directly to see if it has actually been created. Also do the same before sending as an extra check. [skip changelog]
