### PR TITLE
[Hackney] Fix display of skip map link.

### DIFF
--- a/templates/web/base/maps/openlayers.html
+++ b/templates/web/base/maps/openlayers.html
@@ -42,7 +42,7 @@
 <div id="map_box">
     [% pre_map %]
     <div id="map">
-      <a href="#map_sidebar" class="skiplink">Skip map</a>
+      <a href="#map_sidebar" class="skiplink">[% loc('Skip map') %]</a>
       [% IF noscript_map_template == 'maps/noscript_map_base_wmx.html' %]
           [% INCLUDE 'maps/noscript_map_base_wmx.html' js = 1 %]
       [% ELSE %]

--- a/web/cobrands/hackney/base.scss
+++ b/web/cobrands/hackney/base.scss
@@ -101,7 +101,6 @@
   line-height: 1.4375em;
   vertical-align: top;
   display: inline-block;
-  position: relative;
   border: 1px solid $dark_green;
   box-shadow: inset #003d2f 0 -2px 0 0;
   &:hover {


### PR DESCRIPTION
Introduced by https://github.com/mysociety/fixmystreet/pull/4880
I don't think any other cobrands change .btn like this
Alternatively - can the position relative be removed from the .btn above, or some other simplification?
[skip changelog]