### PR TITLE
Include translation for 'Skip map' button

### DIFF
--- a/templates/web/base/maps/openlayers.html
+++ b/templates/web/base/maps/openlayers.html
@@ -42,7 +42,7 @@
 <div id="map_box">
     [% pre_map %]
     <div id="map">
-      <a href="#map_sidebar" class="skiplink">Skip map</a>
+      <a href="#map_sidebar" class="skiplink">[% loc('Skip map') %]</a>
       [% IF noscript_map_template == 'maps/noscript_map_base_wmx.html' %]
           [% INCLUDE 'maps/noscript_map_base_wmx.html' js = 1 %]
       [% ELSE %]


### PR DESCRIPTION
Introduced by: https://github.com/mysociety/fixmystreet/pull/4880

The "Skip map" button introduced in this [PR 4880](https://github.com/mysociety/fixmystreet/pull/4880) did not include a translation of a new base string in English.

[skip changelog]