### PR TITLE
[Bromley][WW] Send multiple photos through on all categories

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -273,7 +273,7 @@ sub open311_pre_send {
     if (my $comment_id = $row->get_extra_metadata('echo_report_reopened_with_comment')) {
         my $comment = FixMyStreet::DB->resultset('Comment')->find($comment_id);
         if ($comment && $comment->text) {
-            my $text = "Closed report has a new comment: " . $comment->text . "\n\n" . $row->detail;
+            my $text = 'Closed report has a new comment: ' . $comment->text . "\r\n" . $comment->user->name . ' ' . $comment->user->email . "\r\n" . $row->detail;
             $row->detail($text);
         }
     }

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -176,8 +176,7 @@ sub available_permissions {
 
 Sets options for what data will be sent to the open311 integrations.
 
-Bromley require all images to be sent for reports - in Echo, these
-will be sent as binaries for upload, in open311 they will be sent as urls.
+Bromley require all images to be sent for Echo reports, as binaries for upload.
 
 We do not 'always_send_latlong' or 'extended_description'
 
@@ -188,7 +187,9 @@ We do 'send_notpinpointed'
 sub open311_config {
     my ($self, $row, $h, $params, $contact) = @_;
 
-    $params->{multi_photos} = 1;
+    if ($contact->email =~ /^\d+$/) {
+        $params->{multi_photos} = 1;
+    }
     if ($contact->get_extra_metadata('group') eq 'Waste') {
         $params->{upload_files} = 1;
     }

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -490,7 +490,7 @@ sub should_skip_sending_update {
     my ($self, $update) = @_;
 
     my $report = $update->problem;
-    if ($report->is_closed && $self->_has_report_been_sent_to_echo($report)) {
+    if (($report->is_closed || $report->is_fixed) && $self->_has_report_been_sent_to_echo($report)) {
         $report->set_extra_metadata('open311_category_override' => REFERRED_TO_VEOLIA);
         $report->set_extra_metadata('echo_report_reopened_with_comment' => $update->id);
         $report->state('confirmed');

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -172,11 +172,24 @@ sub available_permissions {
     return $perms;
 }
 
+=item * open311_config
+
+Sets options for what data will be sent to the open311 integrations.
+
+Bromley require all images to be sent for reports - in Echo, these
+will be sent as binaries for upload, in open311 they will be sent as urls.
+
+We do not 'always_send_latlong' or 'extended_description'
+
+We do 'send_notpinpointed'
+
+=cut
+
 sub open311_config {
     my ($self, $row, $h, $params, $contact) = @_;
 
-    if ($contact->category eq 'Bulky collection') {
-        $params->{multi_photos} = 1;
+    $params->{multi_photos} = 1;
+    if ($contact->get_extra_metadata('group') eq 'Waste') {
         $params->{upload_files} = 1;
     }
 

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -261,6 +261,11 @@ sub open311_pre_send {
         my $text = $row->detail . "\n\nPrivate comments: $private_comments";
         $row->detail($text);
     }
+
+    if (my $handover_notes = $row->get_extra_metadata('handover_notes')) {
+        my $text = $row->detail . " | Handover notes - $handover_notes";
+        $row->detail($text);
+    }
 }
 
 sub _include_user_title_in_extra {
@@ -293,6 +298,9 @@ sub open311_post_send_updates {
     $row->text($self->{bromley_original_update_text});
 }
 
+use constant REFERRED_TO_BROMLEY => 'Referred to LB Bromley Streets';
+use constant REFERRED_TO_VEOLIA => 'Referred to Veolia Streets';
+
 sub open311_munge_update_params {
     my ($self, $params, $comment, $body) = @_;
 
@@ -300,6 +308,70 @@ sub open311_munge_update_params {
     $params->{public_anonymity_required} = $comment->anonymous ? 'TRUE' : 'FALSE',
     $params->{update_id_ext} = $comment->id;
     $params->{service_request_id_ext} = $comment->problem->id;
+
+    if ($comment->problem_state eq REFERRED_TO_BROMLEY) {
+        $params->{status} = 'REFERRED_TO_LBB_STREETS';
+        if (my $handover_notes = $comment->problem->get_extra_metadata('handover_notes')) {
+            $params->{description} .= " | Handover notes - $handover_notes";
+        }
+    }
+}
+
+=head2 open311_get_update_munging
+
+This is used to perform Bromley's custom redirecting between Confirm and Echo
+backends. If we receive an update with a particular status/resolution, we need
+to make some changes to the update and associated report so that it is resent
+appropriately.
+
+=cut
+
+sub open311_get_update_munging {
+    my ($self, $comment, $state) = @_;
+
+    # An update from Bromley with a special referral state
+    if ($state eq 'referred to veolia streets') {
+        my $problem = $comment->problem;
+        # Do we want to store the old category somewhere for display?
+        $problem->category(REFERRED_TO_VEOLIA); # Will be an Echo Event Type ID
+        $problem->state('in progress');
+        $comment->problem_state('in progress');
+        $problem->set_extra_metadata( original_bromley_external_id => $problem->external_id );
+        $problem->update_extra_field({ name => 'Notes', value => $comment->text });
+        # Resending report, don't need comment to be public
+        $comment->state('hidden');
+        $problem->resend;
+        return;
+    }
+
+    # An update from Echo with resolution code 1252
+    my $code = $comment->get_extra_metadata('external_status_code') || '';
+    if ($code eq '1252,,') {
+        my $problem = $comment->problem;
+        $problem->category(REFERRED_TO_BROMLEY); # Will be LBB_RRE_FROM_VEOLIA_STREETS
+        $problem->state('in progress');
+        $comment->problem_state('in progress');
+
+        # Fetch outgoing notes
+        my $echo = $self->feature('echo');
+        $echo = Integrations::Echo->new(%$echo);
+        my $event = $echo->GetEvent($problem->external_id);
+        my $data = Integrations::Echo::force_arrayref($event->{Data}, 'ExtensibleDatum');
+        my $notes;
+        foreach (@$data) {
+            $notes = $_->{Value} if $_->{DatatypeName} eq 'Veolia Notes';
+        }
+        $problem->set_extra_metadata(handover_notes => $notes) if $notes;
+        if (my $original_external_id = $problem->get_extra_metadata('original_bromley_external_id')) {
+            $problem->external_id($original_external_id);
+            $comment->problem_state(REFERRED_TO_BROMLEY);
+            $comment->send_state('unprocessed');
+        } else {
+            # Resending report, don't need comment to be public
+            $comment->state('hidden');
+            $problem->resend;
+        }
+    }
 }
 
 sub open311_post_send {

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -325,6 +325,25 @@ sub open311_munge_update_params {
     }
 }
 
+=head2 open311_waste_update_extra
+
+Ingore any updates from Echo that don't have a resolution code
+
+=cut
+
+sub open311_waste_update_extra {
+    my ($self, $cfg, $event) = @_;
+
+    my $override_status;
+    if (!$event->{ResolutionCodeId}) {
+        $override_status = "";
+    }
+
+    return (
+        defined $override_status ? (status => $override_status ) : (),
+    );
+}
+
 =head2 open311_get_update_munging
 
 This is used to perform Bromley's custom redirecting between Confirm and Echo

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -354,7 +354,7 @@ sub open311_get_update_munging {
 
     # An update from Echo with resolution code 1252
     my $code = $comment->get_extra_metadata('external_status_code') || '';
-    if ($code eq '1252,,') {
+    if ($code eq '1252') {
         my $problem = $comment->problem;
         $problem->category(REFERRED_TO_BROMLEY); # Will be LBB_RRE_FROM_VEOLIA_STREETS
         $problem->state('in progress');

--- a/perllib/FixMyStreet/SendReport/Open311.pm
+++ b/perllib/FixMyStreet/SendReport/Open311.pm
@@ -30,7 +30,7 @@ sub send {
         fixmystreet_body => $body,
     );
 
-    my $contact = $self->fetch_category($body, $row) or return;
+    my $contact = $self->fetch_category($body, $row, $row->get_extra_metadata('open311_category_override')) or return;
 
     my $cobrand = $body->get_cobrand_handler || $row->get_cobrand_logged;
     $cobrand->call_hook(open311_config => $row, $h, \%open311_params, $contact);

--- a/perllib/Open311/UpdatesBase.pm
+++ b/perllib/Open311/UpdatesBase.pm
@@ -285,7 +285,7 @@ sub _process_update {
         || ($comment->problem_state && $state ne $old_state);
 
     my $cobrand = $body->get_cobrand_handler;
-    $cobrand->call_hook(open311_get_update_munging => $comment)
+    $cobrand->call_hook(open311_get_update_munging => $comment, $state)
         if $cobrand;
 
     # As comment->created has been looked at above, its time zone has been shifted

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -800,6 +800,7 @@ subtest "comment on a closed echo report result in a resend under 'Referred to V
 
     $echo->mock('GetEvent', sub { {
         Guid => $event_guid,
+        ResolvedDate => { DateTime => '2024-03-21T12:00:00Z' },
         Id => $event_id,
     } } );
 

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -10,6 +10,7 @@ use FixMyStreet::TestMech;
 use FixMyStreet::Script::CSVExport;
 use FixMyStreet::Script::Reports;
 use Open311::PostServiceRequestUpdates;
+use Open311::GetServiceRequestUpdates;
 use Open311::PopulateServiceList;
 my $mech = FixMyStreet::TestMech->new;
 
@@ -611,5 +612,184 @@ for my $test (
         is $extra_fields[0][2]->{code}, $test->{result}, $test->{description};
     };
 }
+
+package SOAP::Result;
+sub result { return $_[0]->{result}; }
+sub new { my $c = shift; bless { @_ }, $c; }
+
+package main;
+
+subtest 'redirecting of reports between backends' => sub {
+    my $integ = Test::MockModule->new('SOAP::Lite');
+    $integ->mock(call => sub {
+        my ($cls, @args) = @_;
+        my $method = $args[0]->name;
+        if ($method eq 'GetEventType') {
+            return SOAP::Result->new(result => {
+                Workflow => { States => { State => [
+                    { CoreState => 'New', Name => 'New', Id => 15001 },
+                    { CoreState => 'Pending', Name => 'Unallocated', Id => 15002 },
+                    { CoreState => 'Pending', Name => 'Allocated to Crew', Id => 15003 },
+                    { CoreState => 'Closed', Name => 'Completed', Id => 15004,
+                      ResolutionCodes => { StateResolutionCode => [
+                        { ResolutionCodeId => 201, Name => '' },
+                        { ResolutionCodeId => 202, Name => 'Spillage on Arrival' },
+                      ] } },
+                    { CoreState => 'Closed', Name => 'Not Completed', Id => 15005,
+                      ResolutionCodes => { StateResolutionCode => [
+                        { ResolutionCodeId => 203, Name => 'Nothing Found' },
+                        { ResolutionCodeId => 204, Name => 'Too Heavy' },
+                        { ResolutionCodeId => 205, Name => 'Inclement Weather' },
+                      ] } },
+                    { CoreState => 'Closed', Name => 'Rejected', Id => 15006,
+                      ResolutionCodes => { StateResolutionCode => [
+                        { ResolutionCodeId => 206, Name => 'Out of Time' },
+                        { ResolutionCodeId => 207, Name => 'Duplicate' },
+                      ] } },
+                ] } },
+            });
+        } elsif ($method eq 'GetEvent') {
+            return SOAP::Result->new(result => {
+                Guid => 'hmm',
+                Id => 'id',
+                Data => {
+                    ExtensibleDatum => [
+                        {
+                            DatatypeId => 55418,
+                            DatatypeName => "Veolia Notes",
+                            Value => "Outgoing notes from Echo",
+                        },
+                    ],
+                },
+            });
+        } else {
+            is $method, 'UNKNOWN';
+        }
+    });
+
+    $mech->create_contact_ok(
+        body_id => $body->id,
+        category => 'Referred to LB Bromley Streets',
+        email => 'LBB_RRE_FROM_VEOLIA_STREETS',
+    );
+    $mech->create_contact_ok(
+        body_id => $body->id,
+        category => 'Referred to Veolia Streets',
+        email => '3045',
+    );
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'bromley',
+        COBRAND_FEATURES => {
+            echo => { bromley => {
+                url => 'https://www.example.org/',
+                receive_action => 'action',
+                receive_username => 'un',
+                receive_password => 'password',
+            } },
+            waste => { bromley => 1 },
+        },
+        STAGING_FLAGS => { send_reports => 1 },
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        my ($report) = $mech->create_problems_for_body(1, $body->id, 'Street issue', {
+            category => 'Street issue',
+            whensent => DateTime->now,
+        });
+
+        my $in = <<EOF;
+<?xml version="1.0" encoding="UTF-8"?>
+<Envelope>
+  <Header>
+    <Action>action</Action>
+    <Security><UsernameToken><Username>un</Username><Password>password</Password></UsernameToken></Security>
+  </Header>
+  <Body>
+    <NotifyEventUpdated>
+      <event>
+        <Guid>guid</Guid>
+        <EventTypeId>2104</EventTypeId>
+        <EventStateId>15004</EventStateId>
+        <ResolutionCodeId>1252</ResolutionCodeId>
+      </event>
+    </NotifyEventUpdated>
+  </Body>
+</Envelope>
+EOF
+
+        subtest 'A report sent to Confirm, then redirected to Echo' => sub {
+            $report->update({ external_id => 12345 });
+
+            my $requests_xml = qq{<?xml version="1.0" encoding="utf-8"?>
+                <service_requests_updates>
+                <request_update>
+                <update_id>UPDATE_1</update_id>
+                <service_request_id>12345</service_request_id>
+                <status>REFERRED_TO_VEOLIA_STREETS</status>
+                <description>This is a handover note</description>
+                <updated_datetime>UPDATED_DATETIME</updated_datetime>
+                </request_update>
+                </service_requests_updates>
+            };
+            my $update_dt = DateTime->now(formatter => DateTime::Format::W3CDTF->new);
+            $requests_xml =~ s/UPDATED_DATETIME/$update_dt/g;
+
+            my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com');
+            Open311->_inject_response('/servicerequestupdates.xml', $requests_xml);
+
+            my $update = Open311::GetServiceRequestUpdates->new(
+                system_user => $staffuser,
+                current_open311 => $o,
+                current_body => $body,
+            );
+            $update->process_body;
+            $report->discard_changes;
+            is $report->comments->count, 1;
+            is $report->whensent, undef;
+            is $report->get_extra_field_value('Notes'), 'This is a handover note';
+            is $report->category, 'Referred to Veolia Streets';
+        };
+        subtest '...then redirected back to Confirm' => sub {
+            $report->update({ external_id => 'guid', whensent => DateTime->now, send_method_used => 'Open311' });
+            $mech->post('/waste/echo', Content_Type => 'text/xml', Content => $in);
+            is $report->comments->count, 2, 'A new update';
+            $report->discard_changes;
+            is $report->external_id, 12345, 'ID changed back';
+            is $report->state, 'in progress', 'A state change';
+            is $report->category, 'Referred to LB Bromley Streets';
+            isnt $report->whensent, undef;
+
+        Open311->_inject_response('/servicerequestupdates.xml', '<?xml version="1.0" encoding="utf-8"?><service_request_updates><request_update><update_id>42</update_id></request_update></service_request_updates>');
+
+            my $updates = Open311::PostServiceRequestUpdates->new();
+            $updates->send;
+
+            my $req = Open311->test_req_used;
+            my $c = CGI::Simple->new($req->content);
+            is $c->param('status'), 'REFERRED_TO_LBB_STREETS';
+            is $c->param('service_code'), 'LBB_RRE_FROM_VEOLIA_STREETS';
+            like $c->param('description'), qr/Handover notes - Outgoing notes from Echo/;
+        };
+        subtest 'A report sent to Echo, redirected to Confirm' => sub {
+            $report->comments->delete;
+            $report->unset_extra_metadata('original_bromley_external_id');
+            $report->update({ external_id => 'guid' });
+            $mech->post('/waste/echo', Content_Type => 'text/xml', Content => $in);
+            is $report->comments->count, 1, 'A new update';
+            $report->discard_changes;
+            is $report->whensent, undef;
+            is $report->external_id, 'guid', 'ID not changed';
+            is $report->state, 'in progress', 'A state change';
+            is $report->category, 'Referred to LB Bromley Streets';
+            FixMyStreet::Script::Reports::send();
+
+            my $req = Open311->test_req_used;
+            my $c = CGI::Simple->new($req->content);
+            is $c->param('service_code'), 'LBB_RRE_FROM_VEOLIA_STREETS';
+            like $c->param('description'), qr/Handover notes - Outgoing notes from Echo/;
+        };
+    };
+
+};
 
 done_testing();

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -845,8 +845,9 @@ subtest "comment on a closed echo report result in a resend under 'Referred to V
 
     my $req = Open311->test_req_used;
     my $c = CGI::Simple->new($req->content);
+    my $detail = $report->detail;
     is $c->param('attribute[Event_ID]'), $event_id, 'old event ID included in attributes';
-    like $c->param('description'), qr/Closed report has a new comment: comment on closed event/, 'private comments included in description';
+    like $c->param('description'), qr/Closed report has a new comment: comment on closed event\r\nBromley pkg-tcobrandbromleyt-bromley\@example.com\r\n$detail/, 'Comment on closed report included in new report description';
 };
 
 done_testing();

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -792,4 +792,60 @@ EOF
 
 };
 
+subtest "comment on a closed echo report result in a resend under 'Referred to Veolia Streets'" => sub {
+    my $event_guid = '05a10cb2-44c9-48d9-92a2-cc6788994bae';
+    my $event_id = 123;
+
+    my $echo = Test::MockModule->new('Integrations::Echo');
+
+    $echo->mock('GetEvent', sub { {
+        Guid => $event_guid,
+        Id => $event_id,
+    } } );
+
+    my ($report) = $mech->create_problems_for_body(1, $body->id, 'echo report', {
+            cobrand => 'bromley',
+            whensent => 'now()',
+            send_state => 'sent',
+            send_method_used => 'Open311',
+            external_id => $event_guid,
+        });
+    $report->state('closed');
+    my $comment = $report->add_to_comments({
+        text => 'comment on closed event',
+        user => $user,
+        mark_open => 1,
+    });
+    $report->update;
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'bromley',
+    }, sub {
+        my $updates = Open311::PostServiceRequestUpdates->new();
+        $updates->send;
+    };
+
+    $report->discard_changes;
+    is $report->get_extra_metadata('open311_category_override'), 'Referred to Veolia Streets', 'category override applied';
+    is $report->send_state, 'unprocessed', 'report set to be resent';
+
+    $comment->discard_changes;
+    is $comment->send_state, 'skipped', "skipped sending comment";
+
+    FixMyStreet::override_config {
+        STAGING_FLAGS => { send_reports => 1 },
+        ALLOWED_COBRANDS => [ 'bromley' ],
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        FixMyStreet::Script::Reports::send();
+    };
+
+    $report->discard_changes;
+    is $report->send_state, 'sent', 'report was resent';
+
+    my $req = Open311->test_req_used;
+    my $c = CGI::Simple->new($req->content);
+    is $c->param('attribute[Event_ID]'), $event_id, 'old event ID included in attributes';
+    like $c->param('description'), qr/Closed report has a new comment: comment on closed event/, 'private comments included in description';
+};
+
 done_testing();

--- a/t/cobrand/bromley_waste.t
+++ b/t/cobrand/bromley_waste.t
@@ -587,6 +587,14 @@ subtest 'updating of waste reports' => sub {
         $report->update({ external_id => 'waste-15003-' });
         stdout_like {
             $cobrand->waste_fetch_events({ verbose => 1 });
+        } qr/Fetching data for report/;
+        $report->discard_changes;
+        is $report->comments->count, 0, 'No new update';
+        is $report->state, 'confirmed', 'No state change';
+
+        $report->update({ external_id => 'waste-15003-123' });
+        stdout_like {
+            $cobrand->waste_fetch_events({ verbose => 1 });
         } qr/Updating report to state action scheduled, Allocated to Crew/;
         $report->discard_changes;
         is $report->comments->count, 1, 'A new update';
@@ -594,7 +602,7 @@ subtest 'updating of waste reports' => sub {
         is $update->text, 'This has been allocated';
         is $report->state, 'action scheduled', 'A state change';
 
-        $report->update({ external_id => 'waste-15003-' });
+        $report->update({ external_id => 'waste-15003-123' });
         stdout_like {
             $cobrand->waste_fetch_events({ verbose => 1 });
         } qr/Latest update matches fetched state/;


### PR DESCRIPTION
Adds sending of photos for all categories. Assume all Waste is Echo. Echo set up for receiving photos but think general open311 just receiving urls

https://github.com/mysociety/societyworks/issues/4233

[skip changelog]

