### PR TITLE
Added role button to span.report-a-problem-btn and "Current page" indicator to navbar

### DIFF
--- a/templates/web/base/main_nav.html
+++ b/templates/web/base/main_nav.html
@@ -6,7 +6,9 @@
 [% BLOCK navitem ~%]
     <li [% liattrs | safe %]>
       [%~ IF c.req.uri.path == uri AND NOT always_url ~%]
-          <span [% attrs | safe %]>[% label %]</span>
+          <span [% attrs | safe %]>[% label %]
+            <span class="screen-reader-only">(current page)</span>
+          </span>
       [%~ ELSE ~%]
           <a href="[% uri %][% suffix IF suffix %]" [% attrs | safe %]>[% label %]</a>
       [%~ END ~%]

--- a/web/js/front.js
+++ b/web/js/front.js
@@ -79,6 +79,8 @@ document.getElementById('pc').focus();
 
     var lk = document.querySelector('span.report-a-problem-btn');
     if (lk && lk.addEventListener) {
+        lk.setAttribute('role', 'button');
+        lk.setAttribute('tabindex', '0');
         lk.addEventListener('click', function(e){
             e.preventDefault();
             scrollTo(0,0);


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4257

- [x] Added `role="button"` to `span.report-a-problem-btn` this should give context to screen readers about this element considering that pressing it takes you to the postcode input `#pc` in the homepage.
- [x] I also added a `tabindex="0"` to make the `span.report-a-problem-btn` focusable with keyboard. We can drop this commit if we think is too redundant with the behaviour on `front.js`. I added it because it seemed confusing to have an element with `role="button"` that can't be focused.
- [x] Added `<span>Current page</span>` inside `span` elements contained in `nav-menu nav-menu--main`. This will allow users using screen reader to know which page they currently are.

Let me know if you'd rather me to create a PR to put the "Current page" bit, considering it is not directly related with the issue.

[Skip changelog]
