### PR TITLE
Added error_color variable and decreased lightness of default error color.

### DIFF
--- a/web/cobrands/bexley/_colours.scss
+++ b/web/cobrands/bexley/_colours.scss
@@ -7,6 +7,7 @@ $mappage-header-height: 128px;
 $white: #fff;
 
 $red: #B10E1E;
+$error_color: $red;
 
 $royal: #2E358B;
 $fuchsia: #912B88;

--- a/web/cobrands/brent/_variables.scss
+++ b/web/cobrands/brent/_variables.scss
@@ -43,6 +43,8 @@ $yellow-2: #fbfad5;
 $red: #d5281b; // Error
 $orange: #d34b1f;
 
+$error_color: $red;
+
 // END of color palette
 
 $accent-color: #248660;

--- a/web/cobrands/brent/base.scss
+++ b/web/cobrands/brent/base.scss
@@ -109,14 +109,6 @@ a {
   box-shadow: 0 0 0 4px $link-focus-color;
 }
 
-input.form-error, textarea.form-error {
-  border-color: $red;
-}
-
-div.form-error, p.form-error {
-  background: $red;
-}
-
 .form-section-description, .change_location {
   color: $primary_b;
 }

--- a/web/cobrands/camden/_variables.scss
+++ b/web/cobrands/camden/_variables.scss
@@ -25,7 +25,7 @@ $green: #006135;
 $primary: $gray-2;
 $primary_b: $gray-1;
 $primary_text: $gray-1;
-$error-color: $red;
+$error_color: $red;
 $base_bg: $white;
 $base_fg: $gray-1;
 

--- a/web/cobrands/camden/base.scss
+++ b/web/cobrands/camden/base.scss
@@ -303,14 +303,6 @@ body:not(.admin, .mappage.with-actions) {
   max-width: 8em;
 }
 
-input.form-error, textarea.form-error {
-  border-color: $error-color;
-}
-
-div.form-error, p.form-error {
-  background: $error-color;
-}
-
 .form-section-description, .change_location {
   color: $gray-2;
 }

--- a/web/cobrands/lincolnshire/_colours.scss
+++ b/web/cobrands/lincolnshire/_colours.scss
@@ -38,6 +38,8 @@ $nav_background_colour: #eee;
 $nav_colour: #000;
 $nav_hover_background_colour: $primary;
 
+$error_color: $lincs-plum;
+
 // Colour used for front page 'how to report a problem' steps
 $col_big_numbers: $lincs-text-2nd;
 

--- a/web/cobrands/lincolnshire/base.scss
+++ b/web/cobrands/lincolnshire/base.scss
@@ -94,16 +94,6 @@ h1, h2, h3 {
   color: $lincs-plum;
 }
 
-input.form-error, 
-textarea.form-error {
-  border-color: $lincs-plum;
-}
-
-div.form-error, 
-p.form-error {
-  background-color: $lincs-plum;
-}
-
 body.mappage .big-green-banner {
   background-color: $lincs-pop;
 }

--- a/web/cobrands/merton/_colours.scss
+++ b/web/cobrands/merton/_colours.scss
@@ -22,6 +22,8 @@ $primary_text: #676767;
 $base_bg: $merton-grey-g2;
 $base_fg: #000;
 
+$error_color: #e00;
+
 $nav_background_colour: #fff;
 $nav_colour: #676767;
 $nav_hover_background_colour: #f4f4f4;

--- a/web/cobrands/merton/base.scss
+++ b/web/cobrands/merton/base.scss
@@ -149,11 +149,6 @@ html .nav-menu a.report-a-problem-btn { // overloaded selector to beat _layout.s
     &:focus {}
 }
 
-p.form-error, div.form-error, input.form-error {
-    background-color: #e00;
-    border-color: #e00;
-}
-
 #report-cta {
     padding: 0.4em 0.6em;
 }

--- a/web/cobrands/northnorthants/_variables.scss
+++ b/web/cobrands/northnorthants/_variables.scss
@@ -69,6 +69,8 @@ $button-secondary-focus-text: $primary_b;
 $base_bg: $white;
 $base_fg: $black;
 
+$error_color: $red;
+
 // FONTS
 $arial-font: Arial, Helvetica, sans-serif;
 

--- a/web/cobrands/northnorthants/base.scss
+++ b/web/cobrands/northnorthants/base.scss
@@ -168,15 +168,6 @@ input {
   background: $primary_b;
 }
 
-// form errors
-div.form-error, 
-p.form-error, 
-input.form-error, 
-textarea.form-error {
-  background: $red;
-  border-color: $red;
-}
-
 // FOOTER
 .northnorthants-footer {
   background: $black;

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -12,6 +12,8 @@ $link-visited-color: $link-color !default;
 $link-text-decoration: none !default;
 $link-hover-text-decoration: underline !default;
 
+$error_color: #D50404 !default;
+
 $primary_link_decoration: underline !default;
 $primary_link_hover_decoration: $primary_link_decoration !default;
 
@@ -639,7 +641,7 @@ small.or:after {
 div.form-error,
 p.form-error {
   @include inline-block;
-  background: #ff0000;
+  background: $error_color;
   color: #fff;
   padding: 0 0.5em;
   @include border-radius(0.25em 0.25em 0 0);
@@ -654,18 +656,18 @@ p.form-error {
 
 input.form-error,
 textarea.form-error {
-  border-color: #ff0000;
+  border-color: $error_color;
   @include border-radius(0 0.25em 0.25em 0.25em);
 }
 
 .form-error__box {
-  border: solid 2px #ff0000;
+  border: solid 2px $error_color;
   padding: 0.5em;
   margin-bottom: 0.5em;
 }
 
 ul.error {
-  background: #ff0000;
+  background: $error_color;
   color: #fff;
   padding: 0 0.5em;
   @include border-radius(0.25em);
@@ -2644,7 +2646,7 @@ label .muted {
 
 .alert {
   margin: 0 -1em 1em;
-  background: #ff0000;
+  background: $error_color;
   padding: 1em;
   color: #fff;
   a,

--- a/web/cobrands/southwark/_variables.scss
+++ b/web/cobrands/southwark/_variables.scss
@@ -28,7 +28,7 @@ $primary: $gray-2;
 $primary_b: $gray-1;
 $primary_text: $gray-1;
 $subtext: $gray-2;
-$error-color: $red;
+$error_color: $red;
 $base_bg: $white;
 $base_fg: $gray-3;
 // From here https://www.southwark.gov.uk/myarea

--- a/web/cobrands/southwark/base.scss
+++ b/web/cobrands/southwark/base.scss
@@ -202,14 +202,6 @@ input#pc,
   @include cobrand-body;
 }
 
-input.form-error, textarea.form-error {
-  border-color: $error-color;
-}
-
-div.form-error, p.form-error {
-  background: $error-color;
-}
-
 .form-section-description, .change_location {
   color: $gray-2;
 }

--- a/web/cobrands/tfl/_colours.scss
+++ b/web/cobrands/tfl/_colours.scss
@@ -20,6 +20,8 @@ $green: #00A95D;
 $red-light: #FBE9E8;
 $red: #DC241F;
 
+$error_color: $red;
+
 $mappage-header-height: 60px;
 
 $body-font: Johnston100-Light, Arial, Helvetica, sans-serif;

--- a/web/cobrands/tfl/base.scss
+++ b/web/cobrands/tfl/base.scss
@@ -69,15 +69,6 @@ h3 {
     padding: 2.5em 0.5em;
 }
 
-div.form-error, p.form-error {
-    background: $red;
-}
-
-input.form-error, textarea.form-error {
-    border-color: $red;
-}
-
-
 .btn--back,
 .btn--forward,
 .btn--cancel,

--- a/web/cobrands/westnorthants/_variables.scss
+++ b/web/cobrands/westnorthants/_variables.scss
@@ -16,6 +16,7 @@ $white: #fff;
 $black: #000;
 $yellow: #e2ca76;
 
+$error_color: $red;
 
 $primary: $blue;
 $primary_b: $black;

--- a/web/cobrands/westnorthants/base.scss
+++ b/web/cobrands/westnorthants/base.scss
@@ -81,17 +81,6 @@ a,
   background: $primary_b;
 }
 
-// form errors
-div.form-error,
-p.form-error {
-  background: $red;
-}
-
-input.form-error, 
-textarea.form-error {
-  border-color: $red;
-}
-
 // FOOTER
 .westnorthants-footer {
   background: $black;


### PR DESCRIPTION
Fixes part of:  https://github.com/mysociety/societyworks/issues/4268

Red color `(#FF0000)` wasn't passing contrast test against white text so now it's a bit darker(with this PR the contrast test is 5.45). I have also made it a variable `error_color`, that should help the styling process for cobrands reducing the need for overrides.

<img width="437" alt="Screenshot 2024-04-15 at 15 17 20" src="https://github.com/mysociety/fixmystreet/assets/13790153/4ef9babb-c59f-4144-b4b2-ba8446d062d9">

The second commit is a tidy up, so now instead of having the overrides for the cobrands that were using their own red, now use the variable instead.

[Skip changelog]
