### PR TITLE
[Merton] Initial bulky waste functionality

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1567,14 +1567,6 @@ sub collection_date {
 
 sub _bulky_refund_cutoff_date { }
 
-sub _bulky_date_to_dt {
-    my ($self, $date) = @_;
-    $date = (split(";", $date))[0];
-    my $parser = DateTime::Format::Strptime->new( pattern => '%FT%T', time_zone => FixMyStreet->local_time_zone);
-    my $dt = $parser->parse_datetime($date);
-    return $dt ? $dt->truncate( to => 'day' ) : undef;
-}
-
 sub waste_munge_bulky_data {
     my ($self, $data) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -944,14 +944,6 @@ sub collection_date {
 
 sub _bulky_refund_cutoff_date { }
 
-sub _bulky_date_to_dt {
-    my ($self, $date) = @_;
-    $date = (split(";", $date))[0];
-    my $parser = DateTime::Format::Strptime->new( pattern => '%FT%T', time_zone => FixMyStreet->local_time_zone);
-    my $dt = $parser->parse_datetime($date);
-    return $dt ? $dt->truncate( to => 'day' ) : undef;
-}
-
 sub waste_munge_bulky_data {
     my ($self, $data) = @_;
 

--- a/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
@@ -100,7 +100,7 @@ sub image_for_unit {
     my $service_id = $unit->{service_id};
     my $time_banded = $self->{c}->stash->{property_time_banded};
 
-    return "$base/sack-black" if $service_id == 2242 && $time_banded;
+    return "$base/sack-black" if $service_id eq 2242 && $time_banded;
     if (my $container = $unit->{request_containers}[0]) {
         return "$base/sack-purple" if $container == 17;
     }
@@ -128,9 +128,6 @@ sub _closed_event {
     return 1 if $event->{ResolutionCodeId} && $event->{ResolutionCodeId} != 584; # Out of Stock
     return 0;
 }
-
-# TODO
-sub waste_bulky_missed_blocked_codes {}
 
 sub garden_collection_time { '6:30am' }
 sub garden_waste_new_bin_admin_fee { 0 }
@@ -270,5 +267,20 @@ sub waste_post_report_creation {
         $report->update({ external_id => 'no_echo' });
     }
 }
+
+=head2 Bulky waste collection
+
+Merton has a 6am collection and cut-off for cancellation time.
+Everything else is configured in SLWPEcho.pm
+
+=cut
+
+sub bulky_collection_time { { hours => 6, minutes => 0 } }
+sub bulky_cancellation_cutoff_time { { hours => 6, minutes => 0 } }
+sub bulky_allowed_property {
+    my ( $self, $property ) = @_;
+    return 1 if $self->bulky_enabled && $property->{has_bulky_service};
+}
+sub bulky_collection_window_days { 28 }
 
 1;

--- a/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
@@ -283,4 +283,25 @@ sub bulky_allowed_property {
 }
 sub bulky_collection_window_days { 28 }
 
+=item bulky_open_overdue
+
+Returns true if the booking is open and after 6pm on the day of the collection.
+
+=cut
+
+sub bulky_open_overdue {
+    my ($self, $event) = @_;
+
+    if ($event->{state} eq 'open' && $self->_bulky_collection_overdue($event)) {
+        return 1;
+    }
+}
+
+sub _bulky_collection_overdue {
+    my $collection_due_date = $_[1]->{date};
+    $collection_due_date->truncate(to => 'day')->set_hour(18);
+    my $today = DateTime->now->set_time_zone(FixMyStreet->local_time_zone);
+    return $today > $collection_due_date;
+}
+
 1;

--- a/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
@@ -346,7 +346,6 @@ sub _parse_events {
         # Only care about open requests/enquiries
         my $closed = $self->_closed_event($_);
         next if $type ne 'missed' && $type ne 'bulky' && $closed;
-        next if $type eq 'bulky' && !$closed;
 
         if ($type eq 'request') {
             my $report = $self->problems->search({ external_id => $_->{Guid} })->first;
@@ -364,13 +363,20 @@ sub _parse_events {
             $self->parse_event_missed($_, $closed, $events);
         } elsif ($type eq 'bulky') {
             my $report = $self->problems->search({ external_id => $_->{Guid} })->first;
-            my $resolved_date = construct_bin_date($_->{ResolvedDate});
-            $events->{enquiry}{$event_type}{$_->{Guid}} = {
-                date => $resolved_date,
-                report => $report,
-                resolution => $_->{ResolutionCodeId},
-                state => $_->{EventStateId},
-            };
+            if ($report) {
+                my $row = {
+                    report => $report,
+                    resolution => $_->{ResolutionCodeId},
+                };
+                if ($closed) {
+                    $row->{date} = construct_bin_date($_->{ResolvedDate});
+                    $row->{state} = $_->{EventStateId};
+                } else {
+                    $row->{date} = $self->collection_date($report);
+                    $row->{state} = 'open';
+                }
+                $events->{enquiry}{$event_type}{$_->{Guid}} = $row;
+            }
         } else { # General enquiry of some sort
             $events->{enquiry}->{$event_type} = 1;
         }
@@ -1052,10 +1058,15 @@ sub bulky_check_missed_collection {
                 }
             }
         }
+
+        # Open events are coming through and we only want to continue under specific circumstances with an open event
+        next unless (!$event->{state} || $event->{state} ne 'open') || $self->{c}->cobrand->call_hook('bulky_open_overdue', $event);
+
         $row->{report_allowed} = $in_time && !$row->{report_locked_out};
 
         my $recent_events = $self->_events_since_date($event->{date}, $missed_events);
         $row->{report_open} = $recent_events->{open} || $recent_events->{closed};
+
         $self->{c}->stash->{bulky_missed}{$guid} = $row;
     }
 }

--- a/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
@@ -1281,4 +1281,12 @@ sub per_photo_size_limit_for_report_in_bytes {
     return min($max_size_per_image, $max_size_per_image_from_total);
 };
 
+sub _bulky_date_to_dt {
+    my ($self, $date) = @_;
+    $date = (split(";", $date))[0];
+    my $parser = DateTime::Format::Strptime->new( pattern => '%FT%T', time_zone => FixMyStreet->local_time_zone);
+    my $dt = $parser->parse_datetime($date);
+    return $dt ? $dt->truncate( to => 'day' ) : undef;
+}
+
 1;

--- a/perllib/FixMyStreet/Roles/Cobrand/KingstonSutton.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/KingstonSutton.pm
@@ -10,7 +10,6 @@ package FixMyStreet::Roles::Cobrand::KingstonSutton;
 
 use Moo::Role;
 with 'FixMyStreet::Roles::Cobrand::SLWP';
-with 'FixMyStreet::Roles::Cobrand::BulkyWaste';
 
 use FixMyStreet::App::Form::Waste::Garden::Sacks;
 use FixMyStreet::App::Form::Waste::Garden::Sacks::Renew;
@@ -216,29 +215,6 @@ sub waste_quantity_max {
     );
 }
 
-sub waste_bulky_missed_blocked_codes {
-    return {
-        # Partially completed
-        12399 => {
-            507 => 'Not all items presented',
-            380 => 'Some items too heavy',
-        },
-        # Completed
-        12400 => {
-            606 => 'More items presented than booked',
-        },
-        # Not Completed
-        12401 => {
-            460 => 'Nothing out',
-            379 => 'Item not as described',
-            100 => 'No access',
-            212 => 'Too heavy',
-            473 => 'Damage on site',
-            234 => 'Hazardous waste',
-        },
-    };
-}
-
 sub waste_munge_bin_services_open_requests {
     my ($self, $open_requests) = @_;
     if ($open_requests->{+CONTAINER_REFUSE_140}) { # Sutton
@@ -431,166 +407,6 @@ sub dashboard_export_problems_add_columns {
             quantity => $fields{Subscription_Details_Quantity},
         };
     });
-}
-
-=head2 Bulky waste collection
-
-SLWP looks 8 weeks ahead for collection dates, and cancels by sending an
-update, not a new report. It sends the event to the backend before collecting
-payment, and does not refund on cancellations. It has a hard-coded list of
-property types allowed to book collections.
-
-=cut
-
-sub bulky_collection_window_days { 56 }
-
-sub bulky_cancel_by_update { 1 }
-sub bulky_send_before_payment { 1 }
-sub bulky_show_location_field_mandatory { 1 }
-
-sub bulky_can_refund { 0 }
-sub _bulky_refund_cutoff_date { }
-
-=head2 bulky_collection_window_start_date
-
-K&S have an 11pm cut-off for looking to book next day collections.
-
-=cut
-
-sub bulky_collection_window_start_date {
-    my $self = shift;
-    my $now = DateTime->now( time_zone => FixMyStreet->local_time_zone );
-    my $start_date = $now->clone->truncate( to => 'day' )->add( days => 1 );
-    # If past 11pm, push start date one day later
-    if ($now->hour >= 23) {
-        $start_date->add( days => 1 );
-    }
-    return $start_date;
-}
-
-sub bulky_allowed_property {
-    my ( $self, $property ) = @_;
-
-    return if $property->{has_no_services};
-    my $cfg = $self->feature('echo');
-
-    my $type = $property->{type_id} || 0;
-    my $valid_type = grep { $_ == $type } @{ $cfg->{bulky_address_types} || [] };
-    my $domestic_farm = $type != 7 || $property->{domestic_refuse_bin};
-    return $self->bulky_enabled && $valid_type && $domestic_farm;
-}
-
-sub collection_date {
-    my ($self, $p) = @_;
-    return $self->_bulky_date_to_dt($p->get_extra_field_value('Collection_Date'));
-}
-
-sub bulky_free_collection_available { 0 }
-
-sub bulky_hide_later_dates { 1 }
-
-sub _bulky_date_to_dt {
-    my ($self, $date) = @_;
-    $date = (split(";", $date))[0];
-    my $parser = DateTime::Format::Strptime->new( pattern => '%FT%T', time_zone => FixMyStreet->local_time_zone);
-    my $dt = $parser->parse_datetime($date);
-    return $dt ? $dt->truncate( to => 'day' ) : undef;
-}
-
-=head2 Sending to Echo
-
-We use the reserved slot GUID and reference,
-and the provided date/location information.
-Items are sent through with their notes as individual entries
-
-=cut
-
-sub waste_munge_bulky_data {
-    my ($self, $data) = @_;
-
-    my $c = $self->{c};
-    my ($date, $ref, $expiry) = split(";", $data->{chosen_date});
-
-    my $guid_key = $self->council_url . ":echo:bulky_event_guid:" . $c->stash->{property}->{id};
-    $data->{extra_GUID} = $self->{c}->session->{$guid_key};
-    $data->{extra_reservation} = $ref;
-
-    $data->{title} = "Bulky goods collection";
-    $data->{detail} = "Address: " . $c->stash->{property}->{address};
-    $data->{category} = "Bulky collection";
-    $data->{extra_Collection_Date} = $date;
-    $data->{extra_Exact_Location} = $data->{location};
-
-    my $first_date = $self->{c}->session->{first_date_returned};
-    $first_date = DateTime::Format::W3CDTF->parse_datetime($first_date);
-    my $dt = DateTime::Format::W3CDTF->parse_datetime($date);
-    $data->{'extra_First_Date_Returned_to_Customer'} = $first_date->strftime("%d/%m/%Y");
-    $data->{'extra_Customer_Selected_Date_Beyond_SLA?'} = $dt > $first_date ? 1 : 0;
-
-    my @items_list = @{ $self->bulky_items_master_list };
-    my %items = map { $_->{name} => $_->{bartec_id} } @items_list;
-
-    my @notes;
-    my @ids;
-    my @photos;
-
-    my $max = $self->bulky_items_maximum;
-    for (1..$max) {
-        if (my $item = $data->{"item_$_"}) {
-            push @notes, $data->{"item_notes_$_"} || '';
-            push @ids, $items{$item};
-            push @photos, $data->{"item_photos_$_"} || '';
-        };
-    }
-    $data->{extra_Bulky_Collection_Notes} = join("::", @notes);
-    $data->{extra_Bulky_Collection_Bulky_Items} = join("::", @ids);
-    $data->{extra_Image} = join("::", @photos);
-    $self->bulky_total_cost($data);
-}
-
-sub waste_reconstruct_bulky_data {
-    my ($self, $p) = @_;
-
-    my $saved_data = {
-        "chosen_date" => $p->get_extra_field_value('Collection_Date'),
-        "location" => $p->get_extra_field_value('Exact_Location'),
-        "location_photo" => $p->get_extra_metadata("location_photo"),
-    };
-
-    my @fields = split /::/, $p->get_extra_field_value('Bulky_Collection_Bulky_Items');
-    my @notes = split /::/, $p->get_extra_field_value('Bulky_Collection_Notes');
-    for my $id (1..@fields) {
-        $saved_data->{"item_$id"} = $p->get_extra_metadata("item_$id");
-        $saved_data->{"item_notes_$id"} = $notes[$id-1];
-        $saved_data->{"item_photo_$id"} = $p->get_extra_metadata("item_photo_$id");
-    }
-
-    $saved_data->{name} = $p->name;
-    $saved_data->{email} = $p->user->email;
-    $saved_data->{phone} = $p->phone_waste;
-
-    return $saved_data;
-}
-
-=head2 suppress_report_sent_email
-
-For Bulky Waste reports, we want to send the email after payment has been confirmed, so we
-suppress the email here.
-
-=cut
-
-sub suppress_report_sent_email {
-    my ($self, $report) = @_;
-
-    if ($report->cobrand_data eq 'waste' && $report->category eq 'Bulky collection') {
-        return 1;
-    }
-
-    return 0;
-}
-
-sub bulky_location_photo_prompt {
-    'Help us by attaching a photo of where the items will be left for collection.';
 }
 
 1;

--- a/perllib/FixMyStreet/Roles/Cobrand/SLWP.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/SLWP.pm
@@ -10,6 +10,7 @@ package FixMyStreet::Roles::Cobrand::SLWP;
 
 use Moo::Role;
 with 'FixMyStreet::Roles::Cobrand::Echo';
+with 'FixMyStreet::Roles::Cobrand::BulkyWaste';
 
 use Integrations::Echo;
 use JSON::MaybeXS;
@@ -113,9 +114,15 @@ sub waste_relevant_serviceunits {
 sub waste_extra_service_info_all_results {
     my ($self, $property, $result) = @_;
 
+    my $cfg = $self->feature('echo');
+
     if (!(@$result && grep { $_->{ServiceId} == 409 } @$result)) {
         # No garden collection possible
         $self->{c}->stash->{waste_features}->{garden_disabled} = 1;
+    }
+
+    if (@$result && $cfg->{bulky_service_id} && grep { $_->{ServiceId} == $cfg->{bulky_service_id} } @$result) {
+        $property->{has_bulky_service} = 1;
     }
 
     $property->{has_no_services} = scalar @$result == 0;
@@ -518,5 +525,181 @@ around updates_disallowed => sub {
 
     return $orig->($self, $problem);
 };
+
+=head2 Bulky waste collection
+
+SLWP looks 8 weeks ahead for collection dates, and cancels by sending an
+update, not a new report. It sends the event to the backend before collecting
+payment, and does not refund on cancellations. It has a hard-coded list of
+property types allowed to book collections.
+
+=cut
+
+sub waste_bulky_missed_blocked_codes {
+    return {
+        # Partially completed
+        12399 => {
+            507 => 'Not all items presented',
+            380 => 'Some items too heavy',
+        },
+        # Completed
+        12400 => {
+            606 => 'More items presented than booked',
+        },
+        # Not Completed
+        12401 => {
+            460 => 'Nothing out',
+            379 => 'Item not as described',
+            100 => 'No access',
+            212 => 'Too heavy',
+            473 => 'Damage on site',
+            234 => 'Hazardous waste',
+        },
+    };
+}
+
+sub bulky_collection_window_days { 56 }
+
+sub bulky_cancel_by_update { 1 }
+sub bulky_send_before_payment { 1 }
+sub bulky_show_location_field_mandatory { 1 }
+
+sub bulky_can_refund { 0 }
+sub _bulky_refund_cutoff_date { }
+
+=head2 bulky_collection_window_start_date
+
+K&S have an 11pm cut-off for looking to book next day collections.
+
+=cut
+
+sub bulky_collection_window_start_date {
+    my $self = shift;
+    my $now = DateTime->now( time_zone => FixMyStreet->local_time_zone );
+    my $start_date = $now->clone->truncate( to => 'day' )->add( days => 1 );
+    # If past 11pm, push start date one day later
+    if ($now->hour >= 23) {
+        $start_date->add( days => 1 );
+    }
+    return $start_date;
+}
+
+sub bulky_allowed_property {
+    my ( $self, $property ) = @_;
+
+    return if $property->{has_no_services};
+    my $cfg = $self->feature('echo');
+
+    my $type = $property->{type_id} || 0;
+    my $valid_type = grep { $_ == $type } @{ $cfg->{bulky_address_types} || [] };
+    my $domestic_farm = $type != 7 || $property->{domestic_refuse_bin};
+    return $self->bulky_enabled && $valid_type && $domestic_farm;
+}
+
+sub collection_date {
+    my ($self, $p) = @_;
+    return $self->_bulky_date_to_dt($p->get_extra_field_value('Collection_Date'));
+}
+
+sub bulky_free_collection_available { 0 }
+
+sub bulky_hide_later_dates { 1 }
+
+=head2 Sending to Echo
+
+We use the reserved slot GUID and reference,
+and the provided date/location information.
+Items are sent through with their notes as individual entries
+
+=cut
+
+sub waste_munge_bulky_data {
+    my ($self, $data) = @_;
+
+    my $c = $self->{c};
+    my ($date, $ref, $expiry) = split(";", $data->{chosen_date});
+
+    my $guid_key = $self->council_url . ":echo:bulky_event_guid:" . $c->stash->{property}->{id};
+    $data->{extra_GUID} = $self->{c}->session->{$guid_key};
+    $data->{extra_reservation} = $ref;
+
+    $data->{title} = "Bulky goods collection";
+    $data->{detail} = "Address: " . $c->stash->{property}->{address};
+    $data->{category} = "Bulky collection";
+    $data->{extra_Collection_Date} = $date;
+    $data->{extra_Exact_Location} = $data->{location};
+
+    my $first_date = $self->{c}->session->{first_date_returned};
+    $first_date = DateTime::Format::W3CDTF->parse_datetime($first_date);
+    my $dt = DateTime::Format::W3CDTF->parse_datetime($date);
+    $data->{'extra_First_Date_Returned_to_Customer'} = $first_date->strftime("%d/%m/%Y");
+    $data->{'extra_Customer_Selected_Date_Beyond_SLA?'} = $dt > $first_date ? 1 : 0;
+
+    my @items_list = @{ $self->bulky_items_master_list };
+    my %items = map { $_->{name} => $_->{bartec_id} } @items_list;
+
+    my @notes;
+    my @ids;
+    my @photos;
+
+    my $max = $self->bulky_items_maximum;
+    for (1..$max) {
+        if (my $item = $data->{"item_$_"}) {
+            push @notes, $data->{"item_notes_$_"} || '';
+            push @ids, $items{$item};
+            push @photos, $data->{"item_photos_$_"} || '';
+        };
+    }
+    $data->{extra_Bulky_Collection_Notes} = join("::", @notes);
+    $data->{extra_Bulky_Collection_Bulky_Items} = join("::", @ids);
+    $data->{extra_Image} = join("::", @photos);
+    $self->bulky_total_cost($data);
+}
+
+sub waste_reconstruct_bulky_data {
+    my ($self, $p) = @_;
+
+    my $saved_data = {
+        "chosen_date" => $p->get_extra_field_value('Collection_Date'),
+        "location" => $p->get_extra_field_value('Exact_Location'),
+        "location_photo" => $p->get_extra_metadata("location_photo"),
+    };
+
+    my @fields = split /::/, $p->get_extra_field_value('Bulky_Collection_Bulky_Items');
+    my @notes = split /::/, $p->get_extra_field_value('Bulky_Collection_Notes');
+    for my $id (1..@fields) {
+        $saved_data->{"item_$id"} = $p->get_extra_metadata("item_$id");
+        $saved_data->{"item_notes_$id"} = $notes[$id-1];
+        $saved_data->{"item_photo_$id"} = $p->get_extra_metadata("item_photo_$id");
+    }
+
+    $saved_data->{name} = $p->name;
+    $saved_data->{email} = $p->user->email;
+    $saved_data->{phone} = $p->phone_waste;
+
+    return $saved_data;
+}
+
+=head2 suppress_report_sent_email
+
+For Bulky Waste reports, we want to send the email after payment has been confirmed, so we
+suppress the email here.
+
+=cut
+
+sub suppress_report_sent_email {
+    my ($self, $report) = @_;
+
+    if ($report->cobrand_data eq 'waste' && $report->category eq 'Bulky collection') {
+        return 1;
+    }
+
+    return 0;
+}
+
+sub bulky_location_photo_prompt {
+    'Help us by attaching a photo of where the items will be left for collection.';
+}
+
 
 1;

--- a/t/app/controller/waste_merton_bulky.t
+++ b/t/app/controller/waste_merton_bulky.t
@@ -1,0 +1,766 @@
+use utf8;
+use Test::MockModule;
+use Test::MockTime qw(:all);
+use FixMyStreet::TestMech;
+use Path::Tiny;
+use FixMyStreet::Script::Reports;
+use FixMyStreet::Script::Alerts;
+
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
+my $mech = FixMyStreet::TestMech->new;
+my $sample_file = path(__FILE__)->parent->child("sample.jpg");
+
+my $user
+    = $mech->create_user_ok( 'bob@example.org', name => 'Original Name' );
+my $body_user = $mech->create_user_ok('body@example.org');
+
+my $body = $mech->create_body_ok( 2500, 'Merton Council',
+    { comment_user => $body_user }, { cobrand => 'merton' } );
+
+my $contact = $mech->create_contact_ok(body => $body, ( category => 'Report missed collection', email => 'missed@example.org' ), group => ['Waste'], extra => { type => 'waste' });
+  $contact->set_extra_fields(
+        { code => 'uprn', required => 1, automated => 'hidden_field' },
+        { code => 'property_id', required => 1, automated => 'hidden_field' },
+        { code => 'service_id', required => 0, automated => 'hidden_field' },
+        { code => 'Exact_Location', required => 0, automated => 'hidden_field' },
+        { code => 'Original_Event_ID', required => 0, automated => 'hidden_field' },
+        { code => 'Notes', required => 0, automated => 'hidden_field' },
+    );
+$contact->update;
+
+my $contact_centre_user = $mech->create_user_ok('contact@example.org', from_body => $body, email_verified => 1, name => 'Contact 1');
+
+for ($body) {
+    add_extra_metadata($_);
+    create_contact($_);
+}
+
+FixMyStreet::override_config {
+    MAPIT_URL => 'http://mapit.uk/',
+    ALLOWED_COBRANDS => 'merton',
+    COBRAND_FEATURES => {
+        waste => { merton => 1 },
+        waste_features => {
+            merton => {
+                bulky_enabled => 1,
+                bulky_missed => 1,
+                bulky_tandc_link => 'tandc_link',
+                echo_update_failure_email => 'fail@example.com',
+            },
+        },
+        echo => {
+            merton => {
+                bulky_address_types => [ 1, 7 ],
+                bulky_service_id => 413,
+                bulky_event_type_id => 1636,
+                url => 'http://example.org',
+                nlpg => 'https://example.com/%s',
+            },
+        },
+        payment_gateway => { merton => {
+            adelante => {
+                username => 'un',
+                password => 'pw',
+                pre_shared_key => 'key',
+                url => 'https://adelante.example.net/',
+                channel => 'channel',
+                fund_code => 32,
+                cost_code => '20180282880000000000000',
+            },
+        } },
+    },
+}, sub {
+    my $lwp = Test::MockModule->new('LWP::UserAgent');
+    $lwp->mock(
+        'get',
+        sub {
+            my ( $ua, $url ) = @_;
+            return $lwp->original('get')->(@_) unless $url =~ /example.com/;
+            my ( $uprn, $area ) = ( 1000000002, "MERTON" );
+            my $j
+                = '{ "results": [ { "LPI": { "UPRN": '
+                . $uprn
+                . ', "LOCAL_CUSTODIAN_CODE_DESCRIPTION": "'
+                . $area
+                . '" } } ] }';
+            return HTTP::Response->new( 200, 'OK', [], $j );
+        }
+    );
+
+    my $echo = Test::MockModule->new('Integrations::Echo');
+    $echo->mock( 'GetServiceUnitsForObject', sub { [{'ServiceId' => 2238}] } );
+    $echo->mock( 'GetTasks',                 sub { [] } );
+    $echo->mock( 'GetEventsForObject',       sub { [] } );
+    $echo->mock( 'CancelReservedSlotsForEvent', sub {
+        my (undef, $guid) = @_;
+        ok $guid, 'non-nil GUID passed to CancelReservedSlotsForEvent';
+    } );
+    $echo->mock(
+        'FindPoints',
+        sub {
+            [   {   Description => '2 Example Street, Merton, KT1 1AA',
+                    Id          => '12345',
+                    SharedRef   => { Value => { anyType => 1000000002 } }
+                },
+            ]
+        }
+    );
+    $echo->mock('ReserveAvailableSlotsForEvent', sub {
+        my ($self, $service, $event_type, $property, $guid, $start, $end) = @_;
+        is $service, 413;
+        is $event_type, 1636;
+        is $property, 12345;
+        return [
+        {
+            StartDate => { DateTime => '2023-07-01T00:00:00Z' },
+            EndDate => { DateTime => '2023-07-02T00:00:00Z' },
+            Expiry => { DateTime => '2023-06-25T10:10:00Z' },
+            Reference => 'reserve1==',
+        }, {
+            StartDate => { DateTime => '2023-07-08T00:00:00Z' },
+            EndDate => { DateTime => '2023-07-09T00:00:00Z' },
+            Expiry => { DateTime => '2023-06-25T10:10:00Z' },
+            Reference => 'reserve2==',
+        }, {
+            StartDate => { DateTime => '2023-07-15T00:00:00Z' },
+            EndDate => { DateTime => '2023-07-16T00:00:00Z' },
+            Expiry => { DateTime => '2023-06-25T10:10:00Z' },
+            Reference => 'reserve3==',
+        },
+    ] });
+
+    subtest 'Ineligible property as no bulky service' => sub {
+    $echo->mock(
+        'GetPointAddress',
+            sub {
+                return {
+                    PointAddressType => {
+                        Id   => 1,
+                        Name => 'Detached',
+                    },
+
+                    Id        => '12345',
+                    SharedRef => { Value => { anyType => '1000000002' } },
+                    PointType => 'PointAddress',
+                    Coordinates => {
+                        GeoPoint =>
+                            { Latitude => 51.400975, Longitude => -0.19655 }
+                    },
+                    Description => '2 Example Street, Merton, KT1 1AA',
+                };
+            }
+        );
+        $mech->get_ok('/waste');
+        $mech->submit_form_ok( { with_fields => { postcode => 'KT1 1AA' } } );
+        $mech->submit_form_ok( { with_fields => { address => '12345' } } );
+        $mech->content_lacks('Bulky Waste');
+    };
+
+    subtest 'Eligible property as has bulky service' => sub {
+        $echo->mock( 'GetServiceUnitsForObject', sub { [{'ServiceId' => 2238}, {'ServiceId' => 413}] } );
+        $echo->mock(
+            'GetPointAddress',
+            sub {
+                return {
+                    PointAddressType => {
+                        Id   => 1,
+                        Name => 'Detached',
+                    },
+
+                    Id        => '12345',
+                    SharedRef => { Value => { anyType => '1000000002' } },
+                    PointType => 'PointAddress',
+                    Coordinates => {
+                        GeoPoint =>
+                            { Latitude => 51.400975, Longitude => -0.19655 }
+                    },
+                    Description => '2 Example Street, Merton, KT1 1AA',
+                };
+            }
+        );
+
+        $mech->get_ok('/waste');
+        $mech->submit_form_ok( { with_fields => { postcode => 'KT1 1AA' } } );
+        $mech->submit_form_ok( { with_fields => { address => '12345' } } );
+
+        $mech->content_contains('Bulky Waste');
+        $mech->submit_form_ok; # 'Book Collection'
+        $mech->content_contains( 'Before you start your booking',
+            'Should be able to access the booking form' );
+    };
+
+    my $sent_params;
+    my $call_params;
+    my $pay = Test::MockModule->new('Integrations::Adelante');
+
+    $pay->mock(call => sub {
+        my $self = shift;
+        my $method = shift;
+        $call_params = shift;
+    });
+    $pay->mock(pay => sub {
+        my $self = shift;
+        $sent_params = shift;
+        $pay->original('pay')->($self, $sent_params);
+        return {
+            UID => '12345',
+            Link => 'http://example.org/faq',
+        };
+    });
+    my $query_return = { Status => 'Authorised', PaymentID => '54321' };
+    $pay->mock(query => sub {
+        my $self = shift;
+        $sent_params = shift;
+        return $query_return;
+    });
+
+    my $report;
+    subtest 'Bulky goods collection booking' => sub {
+        $mech->get_ok('/waste/12345/bulky');
+
+        subtest 'Intro page' => sub {
+            $mech->content_contains('Book bulky goods collection');
+            $mech->content_contains('Before you start your booking');
+            $mech->content_contains('You can request up to <strong>six items per collection');
+            $mech->content_contains('The price you pay depends how many items you would like collected:');
+            $mech->content_contains('Up to 3 items = £37.00');
+            $mech->content_contains('Up to 6 items = £60.75');
+            $mech->submit_form_ok;
+        };
+        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
+        $mech->content_contains('01 July');
+        $mech->content_contains('08 July');
+        $mech->submit_form_ok(
+            { with_fields => { chosen_date => '2023-07-01T00:00:00;reserve1==;2023-06-25T10:10:00' } }
+        );
+
+        subtest 'higher band try' => sub {
+            $mech->submit_form_ok(
+                {   with_fields => {
+                        'item_1' => 'BBQ',
+                        'item_photo_1' => [ $sample_file, undef, Content_Type => 'image/jpeg' ],
+                        'item_2' => 'Bicycle',
+                        'item_3' => 'Bath',
+                        'item_4' => 'Bath',
+                        'item_5' => 'Bath',
+                    },
+                },
+            );
+            $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
+            $mech->content_contains('5 items requested for collection');
+            $mech->content_contains('£60.75');
+            $mech->back;
+            $mech->back;
+        };
+
+        $mech->submit_form_ok(
+            {   with_fields => {
+                    'item_1' => 'BBQ',
+                    'item_photo_1' => [ $sample_file, undef, Content_Type => 'image/jpeg' ],
+                    'item_2' => 'Bicycle',
+                    'item_3' => 'Bath',
+                },
+            },
+        );
+        $mech->content_contains('Items must be out for collection by 6am on the collection day.');
+        $mech->submit_form_ok({ with_fields => { location => '' } }, 'Will error with a blank location');
+        $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
+
+        sub test_summary {
+            $mech->content_contains('Booking Summary');
+            $mech->content_like(qr/<p class="govuk-!-margin-bottom-0">.*Bicycle/s);
+            $mech->content_contains('<img class="img-preview is--small" alt="Preview image successfully attached" src="/photo/temp.74e3362283b6ef0c48686fb0e161da4043bbcc97.jpeg">');
+            $mech->content_like(qr/<p class="govuk-!-margin-bottom-0">.*BBQ/s);
+            $mech->content_like(qr/<p class="govuk-!-margin-bottom-0">.*Bath/s);
+            $mech->content_contains('3 items requested for collection');
+            $mech->content_contains('£37.00');
+            $mech->content_contains("<dd>Saturday 01 July 2023</dd>");
+            $mech->content_contains("06:00 on 30 June 2023", 'Can cancel up until 6am previous day');
+            $mech->content_contains('Bob Marge', 'name shown');
+            $mech->content_contains('44 07 111 111 111', 'phone shown');
+        }
+        sub test_summary_submission {
+            # external redirects make Test::WWW::Mechanize unhappy so clone
+            # the mech for the redirect
+            my $mech2 = $mech->clone;
+            $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
+            is $mech2->res->previous->code, 302, 'payments issues a redirect';
+            is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+        }
+
+        subtest 'Summary page' => \&test_summary;
+
+        subtest 'Chosen date expired, no matching slot available' => sub {
+            set_fixed_time('2023-06-25T10:10:01');
+            $echo->mock( 'ReserveAvailableSlotsForEvent', sub { [
+                {
+                    StartDate => { DateTime => '2023-07-08T00:00:00Z' },
+                    EndDate => { DateTime => '2023-07-09T00:00:00Z' },
+                    Expiry => { DateTime => '2023-06-25T10:20:00Z' },
+                    Reference => 'reserve4==',
+                },
+            ] } );
+
+            # Submit summary form
+            $mech->submit_form_ok( { with_fields => { tandc => 1 } } );
+            $mech->content_contains(
+                'Unfortunately, the slot you originally chose has become fully booked. Please select another date.',
+                'Redirects to slot selection page',
+            );
+
+            $mech->submit_form_ok(
+                {   with_fields => {
+                        chosen_date =>
+                            '2023-07-08T00:00:00;reserve4==;2023-06-25T10:20:00'
+                    }
+                },
+                'submit new slot selection',
+            );
+
+            subtest 'submit items & location again' => sub {
+                $mech->submit_form_ok;
+                $mech->submit_form_ok;
+            };
+
+            subtest 'date info has changed on summary page' => sub {
+                $mech->content_contains("<dd>Saturday 08 July 2023</dd>");
+                $mech->content_contains("06:00 on 07 July 2023", "Can cancel up until 6am previous day");
+            };
+        };
+
+        subtest 'Chosen date expired, but matching slot is available' => sub {
+            set_fixed_time('2023-06-25T10:20:01');
+            $echo->mock( 'ReserveAvailableSlotsForEvent', sub { [
+                {
+                    StartDate => { DateTime => '2023-07-08T00:00:00Z' },
+                    EndDate => { DateTime => '2023-07-09T00:00:00Z' },
+                    Expiry => { DateTime => '2023-06-25T10:30:00Z' },
+                    Reference => 'reserve5==',
+                },
+            ] } );
+
+            subtest 'Summary submission' => \&test_summary_submission;
+        };
+
+        my $catch_email;
+        subtest 'Payment page' => sub {
+            my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
+
+            is $new_report->category, 'Bulky collection', 'correct category on report';
+            is $new_report->title, 'Bulky goods collection', 'correct title on report';
+            is $new_report->get_extra_field_value('payment_method'), 'credit_card', 'correct payment method on report';
+            is $new_report->state, 'confirmed', 'report confirmed';
+
+            is $sent_params->{items}[0]{amount}, 3700, 'correct amount used';
+            is $sent_params->{items}[0]{cost_code}, '20180282880000000000000';
+            is $sent_params->{items}[0]{reference}, 'LBM-BWC-' . $new_report->id;
+
+            $mech->log_in_ok($new_report->user->email);
+            $mech->get_ok("/waste/12345");
+            $mech->content_lacks('Items to be collected');
+            $mech->log_out_ok;
+
+            $new_report->discard_changes;
+            is $new_report->get_extra_metadata('scpReference'), '12345', 'correct scp reference on report';
+            $mech->clear_emails_ok;
+            FixMyStreet::Script::Reports::send();
+            $mech->email_count_is(1); # Only email is 'email' to council
+            $mech->clear_emails_ok;
+            $mech->get_ok("/waste/pay_complete/$report_id/$token");
+            is $sent_params->{reference}, 12345, 'correct scpReference sent';
+            FixMyStreet::Script::Reports::send();
+            $catch_email = $mech->get_email;
+            $mech->clear_emails_ok;
+            $new_report->discard_changes;
+            is $new_report->get_extra_metadata('payment_reference'), '54321', 'correct payment reference on report';
+
+            my $update = $new_report->comments->first;
+            is $update->state, 'confirmed';
+            is $update->text, 'Payment confirmed, reference 54321, amount £37.00';
+            FixMyStreet::Script::Alerts::send_updates();
+            $mech->email_count_is(0);
+        };
+
+        subtest 'Bulky goods email confirmation' => sub {
+            my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+            my $today = $report->confirmed->strftime('%A %d %B %Y');
+            my $id = $report->id;
+            is $catch_email->header('Subject'), "Bulky waste collection service - reference $id";
+            my $confirmation_email_txt = $mech->get_text_body_from_email($catch_email);
+            my $confirmation_email_html = $mech->get_html_body_from_email($catch_email);
+            like $confirmation_email_txt, qr/Reference: $id/, 'Includes reference number';
+            like $confirmation_email_txt, qr/Items to be collected:/, 'Includes header for items';
+            like $confirmation_email_txt, qr/- BBQ/, 'Includes item 1';
+            like $confirmation_email_txt, qr/- Bicycle/, 'Includes item 2';
+            like $confirmation_email_txt, qr/- Bath/, 'Includes item 3';
+            like $confirmation_email_txt, qr/Total cost: £37.00/, 'Includes price';
+            like $confirmation_email_txt, qr/Address: 2 Example Street, Merton, KT1 1AA/, 'Includes collection address';
+            like $confirmation_email_txt, qr/Collection date: Saturday 08 July 2023/, 'Includes collection date';
+            like $confirmation_email_txt, qr#http://merton.example.org/waste/12345/bulky/cancel#, 'Includes cancellation link';
+            like $confirmation_email_txt, qr/Please check you have read the terms and conditions tandc_link/, 'Includes terms and conditions';
+            like $confirmation_email_html, qr#Reference: <strong>$id</strong>#, 'Includes reference number (html mail)';
+            like $confirmation_email_html, qr/Items to be collected:/, 'Includes header for items (html mail)';
+            like $confirmation_email_html, qr/BBQ/, 'Includes item 1 (html mail)';
+            like $confirmation_email_html, qr/Bicycle/, 'Includes item 2 (html mail)';
+            like $confirmation_email_html, qr/Bath/, 'Includes item 3 (html mail)';
+            like $confirmation_email_html, qr/Total cost: £37.00/, 'Includes price (html mail)';
+            like $confirmation_email_html, qr/Address: 2 Example Street, Merton, KT1 1AA/, 'Includes collection address (html mail)';
+            like $confirmation_email_html, qr/Collection date: Saturday 08 July 2023/, 'Includes collection date (html mail)';
+            like $confirmation_email_html, qr#http://merton.example.org/waste/12345/bulky/cancel#, 'Includes cancellation link (html mail)';
+            like $confirmation_email_html, qr/a href="tandc_link"/, 'Includes terms and conditions (html mail)';
+        };
+
+        subtest 'Confirmation page' => sub {
+            $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+            $mech->content_contains('Bulky collection booking confirmed');
+            $mech->content_contains('Our contractor will collect the items you have requested on Saturday 08 July 2023.');
+            $mech->content_contains('Item collection starts from 6am.&nbsp;Please have your items ready');
+            $mech->content_contains('We have emailed confirmation of your booking to pkg-tappcontrollerwaste_merton_bulkyt-bob@example.org.');
+            $mech->content_contains('If you need to contact us about your application please use the application reference:&nbsp;' . $report->id);
+            $mech->content_contains('Card payment reference: 54321');
+            $mech->content_contains('Show upcoming bin days');
+            is $report->detail, "Address: 2 Example Street, Merton, KT1 1AA";
+            is $report->category, 'Bulky collection';
+            is $report->title, 'Bulky goods collection';
+            is $report->get_extra_field_value('uprn'), 1000000002;
+            is $report->get_extra_field_value('Collection_Date'), '2023-07-08T00:00:00';
+            is $report->get_extra_field_value('Bulky_Collection_Bulky_Items'), '3::85::83';
+            is $report->get_extra_field_value('property_id'), '12345';
+            is $report->get_extra_field_value('Customer_Selected_Date_Beyond_SLA?'), '0';
+            is $report->get_extra_field_value('First_Date_Returned_to_Customer'), '08/07/2023';
+            like $report->get_extra_field_value('GUID'), qr/^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/;
+            is $report->get_extra_field_value('reservation'), 'reserve5==';
+            is $report->photo, '74e3362283b6ef0c48686fb0e161da4043bbcc97.jpeg';
+
+            is $report->name, 'Bob Marge', 'correct name on report';
+            is $report->get_extra_metadata('phone'), '44 07 111 111 111',
+                'correct phone on report';
+            is $report->user->name, 'Original Name',
+                'name on report user unchanged';
+            is $report->user->phone, undef, 'no phone on report user';
+            is $report->user->email, $user->email,
+                'correct email on report user';
+        };
+    };
+
+    # Collection date: 2023-07-08T00:00:00
+    # Time/date that is within the cancellation window:
+    my $good_date = '2023-07-02T05:44:59Z'; # 06:44:59 UK time
+
+    subtest 'Bulky goods collection viewing' => sub {
+        subtest 'View own booking' => sub {
+            $mech->log_in_ok($report->user->email);
+            $mech->get_ok('/report/' . $report->id);
+
+            $mech->content_contains('Booking Summary');
+            $mech->content_contains('2 Example Street, Merton, KT1 1AA');
+            $mech->content_lacks('Please read carefully all the details');
+            $mech->content_lacks('You will be redirected to the council’s card payments provider.');
+            $mech->content_like(qr/<p class="govuk-!-margin-bottom-0">.*Bath/s);
+            $mech->content_like(qr/<p class="govuk-!-margin-bottom-0">.*Bicycle/s);
+            $mech->content_like(qr/<p class="govuk-!-margin-bottom-0">.*BBQ/s);
+            $mech->content_contains('3 items requested for collection');
+            $mech->content_contains('£37.00');
+            $mech->content_contains('08 July');
+            $mech->content_lacks('Request a bulky waste collection');
+            $mech->content_contains('Your bulky waste collection');
+            $mech->content_contains('Show upcoming bin days');
+            $mech->content_contains('Bob Marge', 'name shown');
+            $mech->content_contains('44 07 111 111 111', 'phone shown');
+
+            # Cancellation messaging & options
+            $mech->content_lacks('This collection has been cancelled');
+            $mech->content_lacks('View cancellation report');
+
+            set_fixed_time($good_date);
+            $mech->get_ok('/report/' . $report->id);
+            $mech->content_contains("08 July 2023");
+
+            # Presence of external_id in report implies we have sent request
+            # to Echo
+            $mech->content_lacks('/waste/12345/bulky/cancel');
+            $mech->content_lacks('Cancel this booking');
+            $report->external_id('Echo-123');
+            $report->update;
+            $mech->get_ok('/report/' . $report->id);
+            $mech->content_contains('/waste/12345/bulky/cancel');
+            $mech->content_contains('Cancel this booking');
+        };
+
+        subtest "Can follow link to booking from bin days page" => sub {
+            $mech->get_ok('/waste/12345');
+            $mech->follow_link_ok( { text_regex => qr/Check collection details/i, }, "follow 'Check collection...' link" );
+            is $mech->uri->path, '/report/' . $report->id , 'Redirected to waste base page';
+        };
+    };
+
+    subtest 'Bulky goods email reminders' => sub {
+        set_fixed_time('2023-07-05T05:44:59Z');
+        my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+        my $cobrand = $body->get_cobrand_handler;
+        # Check no payment reference, no email
+        $report->unset_extra_metadata('payment_reference');
+        $report->update;
+        $cobrand->bulky_reminders;
+        $mech->email_count_is(0);
+        $report->set_extra_metadata('payment_reference', 54321);
+        $report->update;
+        $cobrand->bulky_reminders;
+        my $email = $mech->get_email;
+        my $reminder_email_txt = $mech->get_text_body_from_email($email);
+        my $reminder_email_html = $mech->get_html_body_from_email($email);
+        like $reminder_email_txt, qr/Address: 2 Example Street, Merton, KT1 1AA/, 'Includes collection address';
+        like $reminder_email_txt, qr/Saturday 08 July 2023/, 'Includes collection date';
+        like $reminder_email_txt, qr#http://merton.example.org/waste/12345/bulky/cancel#, 'Includes cancellation link';
+        like $reminder_email_html, qr/Thank you for booking a bulky waste collection with Merton Council/, 'Includes Merton greeting (html mail)';
+        like $reminder_email_html, qr/Address: 2 Example Street, Merton, KT1 1AA/, 'Includes collection address (html mail)';
+        like $reminder_email_html, qr/Saturday 08 July 2023/, 'Includes collection date (html mail)';
+        like $reminder_email_html, qr#http://merton.example.org/waste/12345/bulky/cancel#, 'Includes cancellation link (html mail)';
+        $mech->clear_emails_ok;
+    };
+
+    subtest 'Email when update fails to be sent to Echo' => sub {
+        $report->unset_extra_metadata('payment_reference');
+        $report->update({ created => '2023-06-25T00:00:00' });
+
+        my $cobrand = $body->get_cobrand_handler;
+        $cobrand->send_bulky_payment_echo_update_failed;
+        ok $mech->email_count_is(0),
+            'No email if report does not have a payment_reference';
+
+        $report->set_extra_metadata( payment_reference => 123 );
+        $report->update;
+        my $ex_id_comment
+            = $mech->create_comment_for_problem( $report, $user, 'User',
+            'Test', undef, 'confirmed', undef, { external_id => 234 },
+            );
+        $cobrand->send_bulky_payment_echo_update_failed;
+        ok $mech->email_count_is(0),
+            'No email if report has comment with external_id';
+
+        $ex_id_comment->delete;
+        $report->discard_changes;
+        $report->unset_extra_metadata('echo_update_sent');
+        $report->update;
+        $cobrand->send_bulky_payment_echo_update_failed;
+        my $email = $mech->get_email;
+        like $email->as_string, qr/Collection date: Saturday 08 July 2023/;
+        like $email->as_string, qr/37\.00/;
+
+        $mech->clear_emails_ok;
+
+        $report->discard_changes;
+        is $report->get_extra_metadata('echo_update_failure_email_sent'),
+            1, 'flag set when email sent';
+        $cobrand->send_bulky_payment_echo_update_failed;
+        ok $mech->email_count_is(0),
+            'No email if email previously sent';
+
+        $mech->clear_emails_ok;
+    };
+
+    subtest 'Cancellation' => sub {
+        # Collection date: 2023-07-08T00:00:00
+        my $base_path = '/waste/12345';
+        set_fixed_time('2023-07-07T06:00:00');
+        $mech->get_ok($base_path);
+        $mech->content_lacks('Cancel booking', "Can't cancel day before collection due");
+        set_fixed_time($good_date);
+        $mech->get_ok($base_path);
+        $mech->content_contains('Cancel booking');
+        $mech->get_ok("$base_path/bulky/cancel/" . $report->id);
+        $mech->submit_form_ok( { with_fields => { confirm => 1 } } );
+        $mech->content_contains('Your booking has been cancelled');
+        $mech->follow_link_ok( { text => 'Show upcoming bin days' } );
+        is $mech->uri->path, $base_path, 'Returned to bin days';
+        $mech->content_lacks('Cancel booking');
+
+        $report->discard_changes;
+        is $report->state, 'closed', 'Original report closed';
+        like $report->detail, qr/Cancelled at user request/, 'Original report detail field updated';
+
+        subtest 'Viewing original report summary after cancellation' => sub {
+            my $id   = $report->id;
+            $mech->get_ok("/report/$id");
+            $mech->content_contains('This collection has been cancelled');
+            $mech->content_lacks("You can cancel this booking till");
+            $mech->content_lacks('Cancel this booking');
+        };
+    };
+
+    subtest 'Missed collections' => sub {
+        set_fixed_time('2023-07-05T05:44:59Z');
+        $report->update({ state => 'fixed - council', external_id => 'a-guid' });
+
+        # Fixed date still set to 5th July
+        $mech->get_ok('/waste/12345');
+        $mech->content_lacks('Report a bulky waste collection as missed');
+        $mech->get_ok('/waste/12345/report');
+        $mech->content_lacks('Bulky waste collection');
+        $echo->mock( 'GetEventsForObject', sub { [ {
+            Guid => 'a-guid',
+            EventTypeId => 1636,
+            ResolvedDate => { DateTime => '2023-07-02T00:00:00Z' },
+            ResolutionCodeId => 232,
+            EventStateId => 12400,
+        } ] } );
+        $mech->get_ok('/waste/12345');
+        $mech->content_lacks('Report a bulky waste collection as missed', 'Too long ago');
+        $mech->get_ok('/waste/12345/report');
+        $mech->content_lacks('Bulky waste collection');
+        $echo->mock( 'GetEventsForObject', sub { [ {
+            Guid => 'a-guid',
+            EventTypeId => 1636,
+            ResolvedDate => { DateTime => '2023-07-05T00:00:00Z' },
+            ResolutionCodeId => 232,
+            EventStateId => 12400,
+        } ] } );
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('Report a bulky waste collection as missed', 'In time, normal completion');
+        $mech->submit_form_ok({ form_number => 1 }, "Follow link for reporting a missed bulky collection");
+        $mech->content_contains('Bulky waste collection');
+        $mech->submit_form_ok({ form_number => 1 });
+        #$mech->submit_form_ok({ with_fields => { extra_detail => "They left the mattress" } });
+        $mech->submit_form_ok({ form_number => 1 });
+        $mech->submit_form_ok({ form_number => 3 });
+
+        my $missed = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+        is $missed->get_extra_field_value('Exact_Location'), 'in the middle of the drive';
+        is $missed->title, 'Report missed bulky collection';
+        is $missed->get_extra_field_value('Original_Event_ID'), 'a-guid';
+        #is $missed->get_extra_field_value('Notes'), 'They left the mattress';
+
+        $echo->mock( 'GetEventsForObject', sub { [ {
+            Guid => 'a-guid',
+            EventTypeId => 1636,
+            ResolvedDate => { DateTime => '2023-07-05T00:00:00Z' },
+            ResolutionCodeId => 379,
+            EventStateId => 12401,
+        } ] } );
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('A missed collection cannot be reported', 'Not completed');
+        $mech->content_contains('Item not as described');
+        $mech->get_ok('/waste/12345/report');
+        $mech->content_lacks('Bulky waste collection');
+        $echo->mock( 'GetEventsForObject', sub { [ {
+            Guid => 'a-guid',
+            EventTypeId => 1636,
+            ResolvedDate => { DateTime => '2023-07-05T00:00:00Z' },
+            ResolutionCodeId => 100,
+            EventStateId => 12401,
+        }, {
+            EventTypeId => 1571,
+            ServiceId => 413,
+            Guid => 'guid',
+            EventDate => { DateTime => '2023-07-05T00:00:00Z' },
+        } ] } );
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('A bulky waste collection has been reported as missed');
+        $mech->get_ok('/waste/12345/report');
+        $mech->content_lacks('Bulky waste collection');
+        $echo->mock( 'GetEventsForObject', sub { [] } );
+    };
+
+    # subtest 'Bulky goods cheque payment by contact centre' => sub {
+    #     $mech->log_in_ok($contact_centre_user->email);
+    #     $mech->get_ok('/waste/12345/bulky');
+    #     $mech->submit_form_ok;
+    #     $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
+    #     $mech->submit_form_ok(
+    #         { with_fields => { chosen_date => '2023-07-08T00:00:00;reserve4==;2023-06-25T10:20:00' } }
+    #     );
+    #     $mech->submit_form_ok(
+    #         {   with_fields => {
+    #             'item_1' => 'BBQ',
+    #             'item_photo_1' => [ $sample_file, undef, Content_Type => 'image/jpeg' ],
+    #             'item_2' => 'Bicycle',
+    #             'item_3' => 'Bath',
+    #             'item_4' => 'Bath',
+    #             'item_5' => 'Bath',
+    #             },
+    #         },
+    #     );
+    #     $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
+    #     $mech->content_contains('How do you want to pay');
+    #     $mech->content_contains('Debit or Credit Card');
+    #     $mech->content_contains('Cheque payment');
+    #     $mech->content_contains('Payment reference');
+    #     $mech->submit_form_ok({ with_fields => { tandc => 1, payment_method => 'cheque' } });
+    #     $mech->content_contains('Payment reference field is required');
+    #     $mech->submit_form_ok({ with_fields => { tandc => 1, payment_method => 'cheque', cheque_reference => '12345' } });
+    #     $mech->content_contains('Bulky collection booking confirmed');
+    #     my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+    #     is $report->get_extra_metadata('chequeReference'), 12345;
+    #     is $report->get_extra_field_value('payment_method'), 'cheque';
+    # }
+};
+
+done_testing;
+
+sub get_report_from_redirect {
+    my $url = shift;
+
+    my ($report_id, $token) = ( $url =~ m#/(\d+)/([^/]+)$# );
+    my $new_report = FixMyStreet::DB->resultset('Problem')->find( {
+            id => $report_id,
+    });
+
+    return undef unless $new_report->get_extra_metadata('redirect_id') eq $token;
+    return ($token, $new_report, $report_id);
+}
+
+sub add_extra_metadata {
+    my $body = shift;
+
+    $body->set_extra_metadata(
+        wasteworks_config => {
+            base_price => '6075',
+            band1_price => '3700',
+            band1_max => 3,
+            items_per_collection_max => 6,
+            per_item_costs => 0,
+            show_location_page => 'users',
+            item_list => [
+                { bartec_id => '83', name => 'Bath' },
+                { bartec_id => '84', name => 'Bathroom Cabinet /Shower Screen' },
+                { bartec_id => '85', name => 'Bicycle' },
+                { bartec_id => '3', name => 'BBQ' },
+                { bartec_id => '6', name => 'Bookcase, Shelving Unit' },
+            ],
+        },
+    );
+    $body->update;
+}
+
+sub create_contact {
+    my ($body) = @_;
+    my ($params, @extra) = &_contact_extra_data;
+
+    my $contact = $mech->create_contact_ok(body => $body, %$params, group => ['Waste'], extra => { type => 'waste' });
+    $contact->set_extra_fields(
+        { code => 'uprn', required => 1, automated => 'hidden_field' },
+        { code => 'property_id', required => 1, automated => 'hidden_field' },
+        { code => 'service_id', required => 0, automated => 'hidden_field' },
+        @extra,
+    );
+    $contact->update;
+}
+
+sub _contact_extra_data {
+    return (
+        { category => 'Bulky collection', email => '1636@test.com' },
+        { code => 'payment' },
+        { code => 'payment_method' },
+        { code => 'Payment_Type' },
+        { code => 'Collection_Date' },
+        { code => 'Bulky_Collection_Bulky_Items' },
+        { code => 'Bulky_Collection_Notes' },
+        { code => 'Exact_Location' },
+        { code => 'GUID' },
+        { code => 'reservation' },
+        { code => 'Customer_Selected_Date_Beyond_SLA?' },
+        { code => 'First_Date_Returned_to_Customer' },
+    );
+}

--- a/t/integrations/adelante.t
+++ b/t/integrations/adelante.t
@@ -5,8 +5,6 @@ use Test::MockModule;
 
 use_ok 'Integrations::Adelante';
 
-my %sent;
-
 my $lwp = Test::MockModule->new('LWP::UserAgent');
 $lwp->mock(request => sub {
     my ($self, $req) = @_;

--- a/templates/web/base/waste/bulky/_bin_days_list.html
+++ b/templates/web/base/waste/bulky/_bin_days_list.html
@@ -2,7 +2,7 @@
     [% PROCESS waste/_bulky_not_signed_user.html %]
 [% END %]
 
-[% FOR booking IN pending_bulky_collections %]
+[% FOR booking IN pending_bulky_collections; booking_guid = booking.external_id %]
     [% NEXT UNLESS c.cobrand.bulky_can_view_collection(booking) %]
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
@@ -33,6 +33,8 @@
             <a class="btn btn-primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky/cancel_small', [ property.id, booking.id ]) %]">Cancel booking</a>
           [% END %]
         [% END %]
+        [% PROCESS 'waste/_service_missed.html' unit=bulky_missed.$booking_guid original_booking=booking.id no_default=1 %]
+      </div>
     </div>
   [% END %]
 

--- a/templates/web/base/waste/bulky/intro.html
+++ b/templates/web/base/waste/bulky/intro.html
@@ -10,10 +10,12 @@
   [% IF c.cobrand.moniker != 'brent' AND c.cobrand.moniker != 'bromley' %]
     <li>You can request up to <strong>[% c.cobrand.bulky_items_maximum | numwords %] items per collection</strong></li>
   [% END %]
-  [% IF cobrand.moniker == 'kingston' || cobrand.moniker == 'sutton' %]
-    [%
+    [%~
         USE pounds = format('%.2f');
         SET cfg = c.cobrand.wasteworks_config;
+    ~%]
+  [% IF cfg.band1_price %]
+    [%
         SET band1_items = cfg.band1_max;
         SET max_items = cfg.items_per_collection_max;
         SET base_price = cfg.base_price / 100;
@@ -36,10 +38,8 @@
     <li>Householders will be able to book up to <strong>three</strong> categories per collection. For example, a collection could include 10 AA batteries, two x 5 litre paint tins, one black sack of textiles.
     <li>To see your options for coffee pod recycling please visit
         <a href="https://www.podback.org/recycle-checker" target="_blank">https://www.podback.org/recycle-checker</a>
-  [% ELSIF cobrand.moniker == 'kingston' || cobrand.moniker == 'sutton' %]
-    <li>In order to help us with your collection, you may wish to add pictures of the items to be collected and the location</li>
   [% ELSE %]
-    <li>In order to help us with your collection, we will ask you to optionally add pictures of the items to be collected and the location</li>
+    <li>In order to help us with your collection, you may wish to add pictures of the items to be collected and the location</li>
   [% END %]
     <li>Before confirming your booking, you need to check all the information provided is correct</li>
     [% IF cobrand.moniker == 'peterborough' -%]

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -117,7 +117,7 @@ END; END %]
     <hr>
   </div>
   [% END %]
-  [% IF c.cobrand.moniker == 'kingston' OR c.cobrand.moniker == 'sutton' %]
+  [% IF c.cobrand.bulky_pricing_strategy.strategy == 'banded' %]
   <p id="band-pricing-info"></p>
   [% END %]
   <button type="button" id="add-new-item" class="btn-secondary govuk-!-margin-bottom-3" aria-label="Add item">+

--- a/templates/web/base/waste/bulky/location.html
+++ b/templates/web/base/waste/bulky/location.html
@@ -1,4 +1,4 @@
-[% IF c.cobrand.moniker == 'sutton' || c.cobrand.moniker == 'kingston' %]
+[% IF c.cobrand.moniker == 'sutton' || c.cobrand.moniker == 'kingston' || c.cobrand.moniker == 'merton' %]
 [% SET collection_time = c.cobrand.bulky_nice_collection_time %]
     <p>
         <strong>Houses:</strong>


### PR DESCRIPTION
Starts off by renaming the various payment Roles, moving those with no relevance to FixMyStreet under Integrations/Roles directly, and moving the cobrand-based payment roles under FixMyStreet/Roles/Cobrand/. Then adds a new payment integration provider (operates very similarly to the existing SCP one). Then adds the basic bulky waste code for Merton.

For https://github.com/mysociety/societyworks/issues/4270 [skip changelog]
