### PR TITLE
[Bexley] [WasteWorks] Add bank holiday notice

### DIFF
--- a/templates/web/bexley/waste/_announcement.html
+++ b/templates/web/bexley/waste/_announcement.html
@@ -1,3 +1,11 @@
+[% IF property.upcoming_bank_holiday %]
+<div class="bank-holiday-notice site-message">
+  <p>
+    Collections will be a day later than usual in the week following the bank holiday.
+  </p>
+</div>
+[% END %]
+
 [% USE date(format = c.cobrand.bin_day_format) %]
 [% IF (property.red_tags && property.red_tags.size) || (property.service_updates && property.service_updates.size) %]
   <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Service status</h2>


### PR DESCRIPTION
Shows a notice to users warning them of an upcoming bank holiday for a two weeks prior to and a week after bank holidays.

Can also be triggered manually by including `?show_bank_holiday_message=1` in the query string.

Part of https://github.com/mysociety/societyworks/issues/4206

[Basecamp todo item](https://3.basecamp.com/4020879/buckets/35109031/todos/7168045358)

## Screenshot

<img width="964" alt="image" src="https://github.com/mysociety/fixmystreet/assets/22996/7f704371-7b5a-4703-b130-98efe25a2191">



<!-- [skip changelog] -->
