### PR TITLE
[Brent] [Waste] Add upcoming renewal email opt-in control for garden sub and renew.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1363,6 +1363,7 @@ sub setup_garden_sub_params : Private {
     } else {
         $service_id = $c->cobrand->garden_service_id;
     }
+    $c->set_param('email_renewal_reminders_opt_in', $data->{email_renewal_reminders} eq 'Yes' ? 'Y' : 'N') if $data->{email_renewal_reminders};
     $c->set_param('service_id', $service_id);
     $c->set_param('current_containers', $data->{current_bins});
     $c->set_param('new_containers', $data->{new_bins});

--- a/perllib/FixMyStreet/App/Form/Waste/Garden.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Garden.pm
@@ -84,13 +84,15 @@ has_page existing => (
 has_page details => (
     title_ggw => 'Subscribe to the %s',
     template => 'waste/garden/subscribe_details.html',
-    fields => ['current_bins', 'bins_wanted', 'payment_method', 'cheque_reference', 'name', 'email', 'phone', 'password', 'continue_review'],
+    fields => ['current_bins', 'bins_wanted', 'payment_method', 'cheque_reference', 'name', 'email', 'phone', 'password', 'email_renewal_reminders', 'continue_review'],
     field_ignore_list => sub {
         my $page = shift;
         my $c = $page->form->c;
-        return ['payment_method', 'cheque_reference', 'password'] if $c->stash->{staff_payments_allowed} && !$c->cobrand->waste_staff_choose_payment_method;
-        return ['password'] if $c->stash->{staff_payments_allowed};
-        return ['password'] if $c->cobrand->call_hook('waste_password_hidden');
+        my @fields;
+        push @fields, 'email_renewal_reminders' if !$c->cobrand->garden_subscription_email_renew_reminder_opt_in;
+        push @fields, 'password' if $c->stash->{staff_payments_allowed} or $c->cobrand->call_hook('waste_password_hidden');
+        push @fields, ('payment_method', 'cheque_reference') if $c->stash->{staff_payments_allowed} && !$c->cobrand->waste_staff_choose_payment_method;
+        return \@fields;
     },
     update_field_list => \&details_update_fields,
     next => 'summary',
@@ -227,6 +229,8 @@ has_field password => (
         hint => 'Choose a password to sign in and manage your account in the future. If you don’t pick a password, you will still be able to sign in by clicking a link in an email we send to you.',
     },
 );
+
+with 'FixMyStreet::App::Form::Waste::Garden::EmailRenewalReminders';
 
 with 'FixMyStreet::App::Form::Waste::GardenTandC';
 

--- a/perllib/FixMyStreet/App/Form/Waste/Garden/EmailRenewalReminders.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Garden/EmailRenewalReminders.pm
@@ -1,0 +1,18 @@
+package FixMyStreet::App::Form::Waste::Garden::EmailRenewalReminders;
+
+use utf8;
+use HTML::FormHandler::Moose::Role;
+
+has_field email_renewal_reminders => (
+    type => 'Select',
+    label => 'Would you like an email renewal reminder for next year?',
+    default => 'No',
+    options => [
+        { label => 'No', value => 'No' },
+        { label => 'Yes', value => 'Yes' },
+    ],
+    widget => 'RadioGroup',
+    required => 1,
+);
+
+1;

--- a/perllib/FixMyStreet/App/Form/Waste/Garden/Renew.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Garden/Renew.pm
@@ -14,11 +14,12 @@ has_page discount => (
 has_page intro => (
     title => 'Renew your green garden waste subscription',
     template => 'waste/garden/renew.html',
-    fields => ['current_bins', 'bins_wanted', 'payment_method', 'cheque_reference', 'name', 'phone', 'email', 'continue_review'],
+    fields => ['current_bins', 'bins_wanted', 'payment_method', 'cheque_reference', 'name', 'phone', 'email', 'email_renewal_reminders', 'continue_review'],
     field_ignore_list => sub {
         my $page = shift;
         my $c = $page->form->c;
         my @exclude;
+        push @exclude, 'email_renewal_reminders' if !$c->cobrand->garden_subscription_email_renew_reminder_opt_in;
         push @exclude, ('payment_method', 'cheque_reference') if $c->stash->{staff_payments_allowed} && !$c->cobrand->waste_staff_choose_payment_method;
         return \@exclude;
     },
@@ -51,6 +52,8 @@ has_page intro => (
     },
     next => 'summary',
 );
+
+with 'FixMyStreet::App::Form::Waste::Garden::EmailRenewalReminders';
 
 has_page summary => (
     fields => ['tandc', 'submit'],

--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -426,6 +426,8 @@ sub dashboard_export_problems_add_columns {
             container_req_type => 'Container Request Container Type',
             container_req_reason => 'Container Request Reason',
 
+            email_renewal_reminders_opt_in => 'Email Renewal Reminders Opt-In',
+
             missed_collection_id => 'Service ID',
             map { "item_" . $_ => "Small Item $_" } (1..11)
         )
@@ -495,6 +497,7 @@ sub dashboard_export_problems_add_columns {
             container_req_action => $container_req_action,
             container_req_type => $container_req_type,
             container_req_reason => $container_req_reason,
+            email_renewal_reminders_opt_in => $csv->_extra_field($report, 'email_renewal_reminders_opt_in'),
             missed_collection_id => $csv->_extra_field($report, 'service_id'),
         };
 
@@ -1068,6 +1071,15 @@ sub waste_bulky_missed_blocked_codes {
         },
     };
 }
+
+=head2 garden_subscription_email_renew_reminder_opt_in
+
+Gives users the option to opt-in or out of a reminder email for renewal
+when they first subscribe or renew.
+
+=cut
+
+sub garden_subscription_email_renew_reminder_opt_in { 1 }
 
 sub garden_collection_time { '6:30am' }
 

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -480,6 +480,7 @@ sub garden_service_id { 545 }
 sub garden_service_name { 'Green Garden Waste collection service' }
 sub garden_subscription_type_field { 'Subscription_Type' }
 sub garden_subscription_container_field { 'Subscription_Details_Container_Type' }
+sub garden_subscription_email_renew_reminder_opt_in { 0 }
 sub garden_echo_container_name { 'LBB - GW Container' }
 sub garden_due_days { 48 }
 

--- a/perllib/FixMyStreet/Roles/CobrandSLWP.pm
+++ b/perllib/FixMyStreet/Roles/CobrandSLWP.pm
@@ -259,6 +259,8 @@ sub garden_service_id { 2247 }
 sub garden_echo_container_name { 'SLWP - Containers' }
 sub garden_due_days { 30 }
 
+sub garden_subscription_email_renew_reminder_opt_in { 0 }
+
 sub garden_current_service_from_service_units {
     my ($self, $services) = @_;
 

--- a/t/cobrand/brent.t
+++ b/t/cobrand/brent.t
@@ -1358,7 +1358,7 @@ subtest 'Dashboard CSV extra columns' => sub {
         areas => "2488", category => 'Request new container', cobrand => 'brent', user => $user1, state => 'confirmed'});
     $mech->log_in_ok( $staff_user->email );
     $mech->get_ok('/dashboard?export=1');
-    ok $mech->content_contains('"Created By",Email,USRN,UPRN,"External ID","Does the report have an image?","Inspection date","Grade for Litter","Grade for Detritus","Grade for Graffiti","Grade for Fly-posting","Grade for Weeds","Overall Grade","Did you see the fly-tipping take place","If \'Yes\', are you willing to provide a statement?","How much waste is there","Type of waste","Container Request Action","Container Request Container Type","Container Request Reason","Service ID","Small Item 1","Small Item 2"', "New columns added");
+    ok $mech->content_contains('"Created By",Email,USRN,UPRN,"External ID","Does the report have an image?","Inspection date","Grade for Litter","Grade for Detritus","Grade for Graffiti","Grade for Fly-posting","Grade for Weeds","Overall Grade","Did you see the fly-tipping take place","If \'Yes\', are you willing to provide a statement?","How much waste is there","Type of waste","Container Request Action","Container Request Container Type","Container Request Reason","Email Renewal Reminders Opt-In","Service ID","Small Item 1","Small Item 2"', "New columns added");
     ok $mech->content_like(qr/Flexible problem.*?"Test User",pkg-tcobrandbrentt/, "User and email added");
     ok $mech->content_like(qr/Flexible problem.*?,,,,Y,,,,,,,,/, "All fields empty but photo exists");
     $flexible_problem->set_extra_fields(
@@ -1372,7 +1372,7 @@ subtest 'Dashboard CSV extra columns' => sub {
     $flexible_problem->external_id('121');
     $flexible_problem->update;
     $mech->get_ok('/dashboard?export=1');
-    ok $mech->content_like(qr/Flexible problem.*?,1234,4321,121,Y,,,,,,,,,,,,Deliver,"Blue rubbish sack",Missing,1/, "Bin request values added");
+    ok $mech->content_like(qr/Flexible problem.*?,1234,4321,121,Y,,,,,,,,,,,,Deliver,"Blue rubbish sack",Missing,,1/, "Bin request values added");
     $flexible_problem->category('Fly-tipping');
     $flexible_problem->set_extra_fields(
         {name => 'Did_you_see_the_Flytip_take_place?_', value => 1},
@@ -1392,7 +1392,7 @@ subtest 'Dashboard CSV extra columns' => sub {
     $flexible_problem->set_extra_metadata('item_1' => 'Sofa', 'item_2' => 'Wardrobe');
     $flexible_problem->update;
     $mech->get_ok('/dashboard?export=1');
-    ok $mech->content_like(qr/Flexible problem.*?,,,"Test Park","Test User",.*?,,,121,Y,,,,,,,,,,,,,,,,Sofa,Wardrobe,,,,,,,/, "Bulky items added") or diag $mech->content;
+    ok $mech->content_like(qr/Flexible problem.*?,,,"Test Park","Test User",.*?,,,121,Y,,,,,,,,,,,,,,,,,Sofa,Wardrobe,,,,,,,/, "Bulky items added") or diag $mech->content;
   }
 };
 
@@ -1429,11 +1429,11 @@ subtest 'Dashboard CSV pre-generation' => sub {
     $problems[2]->update;
     FixMyStreet::Script::CSVExport::process(dbh => FixMyStreet::DB->schema->storage->dbh);
     $mech->get_ok('/dashboard?export=1');
-    $mech->content_contains('"Created By",Email,USRN,UPRN,"External ID","Does the report have an image?","Inspection date","Grade for Litter","Grade for Detritus","Grade for Graffiti","Grade for Fly-posting","Grade for Weeds","Overall Grade","Did you see the fly-tipping take place","If \'Yes\', are you willing to provide a statement?","How much waste is there","Type of waste","Container Request Action","Container Request Container Type","Container Request Reason","Service ID","Small Item 1","Small Item 2"', "New columns added");
+    $mech->content_contains('"Created By",Email,USRN,UPRN,"External ID","Does the report have an image?","Inspection date","Grade for Litter","Grade for Detritus","Grade for Graffiti","Grade for Fly-posting","Grade for Weeds","Overall Grade","Did you see the fly-tipping take place","If \'Yes\', are you willing to provide a statement?","How much waste is there","Type of waste","Container Request Action","Container Request Container Type","Container Request Reason","Email Renewal Reminders Opt-In","Service ID","Small Item 1","Small Item 2"', "New columns added");
     $mech->content_like(qr/Pregen problem Test 3.*?"Test User",pkg-tcobrandbrentt/, "User and email added");
-    $mech->content_like(qr/Pregen problem Test 3.*?,1234,4321,121,Y,,,,,,,,,,,,Collect\+Deliver,"Food waste caddy",Damaged,1/, "Bin request values added");
+    $mech->content_like(qr/Pregen problem Test 3.*?,1234,4321,121,Y,,,,,,,,,,,,Collect\+Deliver,"Food waste caddy",Damaged,,1/, "Bin request values added");
     $mech->content_like(qr/Pregen problem Test 2.*?,,Y,,,,,,,,Yes,No,"Small van load",Appliance,/, "Flytip request values added");
-    $mech->content_like(qr/Pregen problem Test 1.*?,,,"Test Park","Test User",.*?,,,,Y,,,,,,,,,,,,,,,,Sofa,Wardrobe,,,,,,,/, "Bulky items added");
+    $mech->content_like(qr/Pregen problem Test 1.*?,,,"Test Park","Test User",.*?,,,,Y,,,,,,,,,,,,,,,,,Sofa,Wardrobe,,,,,,,/, "Bulky items added");
 
     $mech->get_ok('/dashboard?export=1&state=investigating');
     $mech->content_contains('Pregen problem Test 2');

--- a/templates/web/base/waste/garden/renew.html
+++ b/templates/web/base/waste/garden/renew.html
@@ -47,6 +47,11 @@
   [% END %]
 
   [% PROCESS form override_fields=['name', 'email', 'phone'] %]
+
+  [% IF c.cobrand.garden_subscription_email_renew_reminder_opt_in %]
+  [% PROCESS form override_fields=['email_renewal_reminders'] %]
+  [% END %]
+
   [% PROCESS form override_fields=['continue_review'] %]
   [% PROCESS form override_fields=['saved_data', 'token', 'process', 'unique_id'] %]
 

--- a/templates/web/base/waste/garden/subscribe_details.html
+++ b/templates/web/base/waste/garden/subscribe_details.html
@@ -42,13 +42,18 @@
   </dl>
   [% END %]
 
-  [% IF staff_payments_allowed OR c.cobrand.waste_password_hidden %]
-  [% PROCESS form override_fields=['name', 'email', 'phone', 'continue_review' ] %]
-  [% ELSE %]
-  [% PROCESS form override_fields=['name', 'email', 'phone', 'password', 'continue_review' ] %]
+  [% PROCESS form override_fields=['name', 'email', 'phone'] %]
+
+  [% IF !(staff_payments_allowed OR c.cobrand.waste_password_hidden) %]
+  [% PROCESS form override_fields=['password'] %]
   [% END %]
 
-  [% PROCESS form override_fields=['saved_data', 'token', 'process', 'service_id', 'unique_id'] %]
+  [% IF c.cobrand.garden_subscription_email_renew_reminder_opt_in %]
+  [% PROCESS form override_fields=['email_renewal_reminders'] %]
+  [% END %]
+
+
+  [% PROCESS form override_fields=['continue_review', 'saved_data', 'token', 'process', 'service_id', 'unique_id'] %]
 
 </form>
 

--- a/templates/web/base/waste/summary.html
+++ b/templates/web/base/waste/summary.html
@@ -62,6 +62,20 @@
         <dd class="govuk-summary-list__value">[% data.email %]</dd>
     </div>
 
+  [% IF data.email_renewal_reminders %]
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Email notifications
+    </dt>
+    <dd class="govuk-summary-list__value">
+    </dd>
+  </div>
+    <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key govuk-summary-list__key--sub">Upcoming renewal reminders</dt>
+        <dd class="govuk-summary-list__value">[% data.email_renewal_reminders %]</dd>
+    </div>
+   [% END %]
+
 </dl>
 
 <form class="waste" method="post">


### PR DESCRIPTION
[skip changelog]

closes https://github.com/mysociety/societyworks/issues/4202

# Preview

<img width="818" alt="renewal control" src="https://github.com/mysociety/fixmystreet/assets/9289297/106371ba-c79b-4090-887e-c08408c41608">

<img width="608" alt="renewal summary" src="https://github.com/mysociety/fixmystreet/assets/9289297/71bf1fbf-b693-473c-9032-f69c9894e52f">
