### PR TITLE
Improved area-label for filters in around page

### DIFF
--- a/templates/web/base/js/translation_strings.html
+++ b/templates/web/base/js/translation_strings.html
@@ -104,8 +104,8 @@
             update_plural: '[% loc('updates', "JS") %]'
         },
 
-        select_status_aria_label: '[% loc('Select report status', "JS") %]',
-        select_category_aria_label: '[% loc('Select a category to display', "JS") %]',
+        select_status_aria_label: '[% loc('Report status - Select an option status to display', "JS") %]',
+        select_category_aria_label: '[% loc('Category - Select a report category to display', "JS") %]',
 
         in_the_past: '[% loc('Please select a time in the past', "JS") %]'
 

--- a/templates/web/base/reports/_list-filters.html
+++ b/templates/web/base/reports/_list-filters.html
@@ -34,7 +34,7 @@
 [% END %]
 
         <p class="report-list-filters">
-          [% tprintf(loc('<label for="statuses">Show</label> %s reports <label for="filter_categories">about</label> %s', "The first %s is a dropdown of all/fixed/etc, the second is a dropdown of categories"), mark_safe(select_status), mark_safe(select_category)) %]
+          [% tprintf(loc('<label for="statuses">Report status</label> %s <label for="filter_categories">Category</label> %s', "The first %s is a dropdown of all/fixed/etc, the second is a dropdown of categories"), mark_safe(select_status), mark_safe(select_category)) %]
           <input type="submit" name="filter_update" value="[% loc('Go') %]">
         </p>
 


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4214

As part of the TFL audit. This commit fixes the issue where the `label` and `aria-label` weren't matching causing issues for speech-input users. To comply with [2.5.3 ](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name) the `aria-label` for the status and categories have been updated, so now part of the visible text is contained in the `aria-label`.

Also the `labels` have been modify to give the user more context about each option without the need for them to open each filter to understand what is about. For example, by itself the label "Show" doesn't explain what is actually showing, specially if the "All" option is selected. For a new user or an unfrequent visitor, they'll need to open up the dropdown to understand what is actually being filtered. Let me know if you think there is a better approach.

The implementation of this PR follows the criteria:
> [Users typically have a much better experience if the words and characters in the visible label of a control match or are **contained within the accessible name**](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name)

And using the example 3 of [technique G208](https://www.w3.org/WAI/WCAG21/Techniques/general/G208#example-3-link-text-included-in-aria-label)


[Skip changelog]