### PR TITLE
[SLWP] Use service unit ID when checking events.

### DIFF
--- a/perllib/FixMyStreet/Roles/CobrandSLWP.pm
+++ b/perllib/FixMyStreet/Roles/CobrandSLWP.pm
@@ -420,7 +420,7 @@ sub waste_relevant_serviceunits {
             next if $self->moniker eq 'kingston' && !$schedules->{next} && $service_id != $self->garden_service_id;
 
             push @rows, {
-                Id => $task->{Id},
+                Id => $_->{Id},
                 ServiceId => $task->{TaskTypeId},
                 ServiceTask => $task,
                 Schedules => $schedules,


### PR DESCRIPTION
For https://mysocietysupport.freshdesk.com/a/tickets/4118
[skip changelog]