### PR TITLE
[Bristol] Remove category search for Bristol

### DIFF
--- a/templates/web/fixmystreet.com/report/new/category_filter.html
+++ b/templates/web/fixmystreet.com/report/new/category_filter.html
@@ -1,4 +1,4 @@
-<div class="hidden-nojs">
+<div class="hidden-nojs" id="category-filter-div">
     <p>[% loc('What would you like to report?') %]
         [% loc('Type in the search box to find an available category or choose from the list below.') %]
     <div class="category-filter-box">

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1776,6 +1776,10 @@ fixmystreet.fetch_reporting_data = function() {
             fixmystreet.body_overrides.clear();
         }
 
+        if (data.bodies && data.bodies.indexOf('Bristol City Council') > -1) {
+            $('#category-filter-div').hide();
+        }
+
         fixmystreet.update_councils_text(data);
         $('#js-top-message').html(data.top_message || '');
 


### PR DESCRIPTION
As Bristol are using extra questions for some categories (types of pothole) the filter doesn't pick these up and presents the only available category of pothole which is in a park.

Will be resolved by Bristol making changes to their categories which they will do in the future.

In the meantime, we remove the category filter for them.

Conversation: https://mysociety.slack.com/archives/C3TR0SSS3/p1714130879949719

https://mysocietysupport.freshdesk.com/a/tickets/4112

[skip changelog]