### PR TITLE
Improvements to focus order 

### DIFF
--- a/.cypress/cypress/integration/simple_spec.js
+++ b/.cypress/cypress/integration/simple_spec.js
@@ -65,9 +65,10 @@ describe('Clicking the map', function() {
 describe('Leaving updates', function() {
     function leave_update() {
         cy.get('[name=update]').type('Update');
+        // [id=].last() due to #2341
         cy.get('.js-new-report-user-show').last().click();
         cy.get('.js-new-report-show-sign-in').last().should('be.visible').click();
-        // [id=].last() due to #2341
+        cy.wait(500);
         cy.get('[id=form_username_sign_in]').last().type('user@example.org');
         cy.get('[name=password_sign_in]').last().type('password');
         cy.get('[name=password_sign_in]').last().parents('form').first().submit();

--- a/templates/web/base/alert/list.html
+++ b/templates/web/base/alert/list.html
@@ -32,7 +32,7 @@
 </div>
 [% END %]
 
-<form id="alerts" class="js-alert-list" name="alerts" method="post" action="/alert/subscribe">
+<form id="alerts" class="validate js-alert-list" name="alerts" method="post" action="/alert/subscribe">
 
   [% INCLUDE 'alert/_list.html' %]
 

--- a/templates/web/base/report/update/form_user.html
+++ b/templates/web/base/report/update/form_user.html
@@ -3,7 +3,7 @@
 
 <div class="hidden-js js-new-report-user-shown">
     <div class="hidden-nojs form-section-preview">
-        <h2 class="form-section-heading">[% loc('Your update') %]</h2>
+        <h2 class="form-section-heading" tabindex="-1">[% loc('Your update') %]</h2>
         <p class="js-form-section-preview" data-source="#form_update"></p>
         <button type="button" class="btn btn--block js-new-report-user-hide">[% loc('Edit your update') %]</button>
     </div>

--- a/templates/web/bromley/report/update/form_user.html
+++ b/templates/web/bromley/report/update/form_user.html
@@ -3,7 +3,7 @@
 
 <div class="hidden-js js-new-report-user-shown">
     <div class="hidden-nojs form-section-preview">
-        <h2 class="form-section-heading">[% loc('Your update') %]</h2>
+        <h2 class="form-section-heading" tabindex="-1">[% loc('Your update') %]</h2>
         <p class="js-form-section-preview" data-source="#form_update"></p>
         <button type="button" class="btn btn--block js-new-report-user-hide">[% loc('Edit your update') %]</button>
     </div>

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1352,7 +1352,7 @@ $.extend(fixmystreet.set_up, {
         $('.js-new-report-user-hidden')[0].scrollIntoView({behavior: "smooth"});
         hide('.js-new-report-user-hidden');
         show('.js-new-report-user-shown').then(function(){
-            focusFirstVisibleInput();
+            $(this).find('.form-section-preview h2').trigger('focus');
         });
     });
 

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1512,12 +1512,23 @@ $.extend(fixmystreet.set_up, {
     });
     $('body').on('click', '#alert_email_button', function(e) {
         e.preventDefault();
+
+        var emailInput = $(this).closest('.js-alert-list').find('input[type=email]');
+        emailInput[0].required = true;
+
+        if (!$(this).closest('form').validate().form()) {
+            emailInput.focus();
+            return;
+        }
+
         var form = $('<form/>').attr({ method:'post', action:"/alert/subscribe" });
         form.append($('<input name="alert" value="Subscribe me to an email alert" type="hidden" />'));
+
         $(this).closest('.js-alert-list').find('textarea, input[type=email], input[type=text], input[type=hidden], input[type=radio]:checked').each(function() {
             var $v = $(this);
             $('<input/>').attr({ name:$v.attr('name'), value:$v.val(), type:'hidden' }).appendTo(form);
         });
+
         $('body').append(form);
         form.trigger('submit');
     });

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -619,6 +619,10 @@ small.or:after {
     padding-top: 0.6em;
     padding-bottom: 0.5em;
   }
+
+  &:has(.form-error) {
+    @include flex-direction(column);
+  }
 }
 
 .checkbox-group {


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4212

Both of these fixes should improve how users using assistive devices travel across inputs by modifying which focus element we are focusing, making it easier to rectify errors or previous steps.

### List of commits

[Added fix to email input focus behaviour when there is an error](https://github.com/mysociety/fixmystreet/commit/23a43e2081971a375207bc490e7b7a680d4512bb) 
First commit fixes:
SW ref 30: Local RSS feeds and email alerts - part 2
- [x] When the Subscribe by email form is submitted with an error, focus should be sent to the "Email address' input element.

- [x] SW ref 41:  Local RSS feeds and email alerts - part 2
An error message is provided in text, but it is not programmatically associated with the email address input element.

[Added fix for focus behaviour in pages with a .form-section-preview](https://github.com/mysociety/fixmystreet/commit/28c761324c203c0506657cef8be38c5c89b9041d)
SW ref 29: Reported issue - provide an update form - tell us about you (step 2)
- [x] When the second part of the form loads, focus is sent to the Full Name input element. This bypasses the Your Update component, and the opportunity to review the first part of the form.



[Skip changelog]