### PR TITLE
[Bexley WW] Email template for missed collections

### DIFF
--- a/templates/email/bexley/waste/_council_reference.html
+++ b/templates/email/bexley/waste/_council_reference.html
@@ -1,0 +1,3 @@
+<p style="[% p_style %]">
+Your reference number is <strong>[% problem.id %]</strong>.
+</p>

--- a/templates/email/bexley/waste/_sidebar_content.html
+++ b/templates/email/bexley/waste/_sidebar_content.html
@@ -1,0 +1,11 @@
+[% # Hacky string munging :-( %]
+[%
+  title = report.title;
+  address = report.detail.remove(".+\n\n");
+  title = title.remove('Report missed ');
+%]
+<h2 style="[% h2_style %]">Bins reported as missed:</h2>
+[% title | html_para_email(secondary_p_style) %]
+<br>
+<h2 style="[% h2_style %]">Address:</h2>
+[% address | html_para_email(secondary_p_style) %]

--- a/templates/email/default/alert-update.html
+++ b/templates/email/default/alert-update.html
@@ -1,3 +1,4 @@
+[% is_missed_collection = report.category == 'Report missed collection' %]
 [%
 
 title = report.title | html;
@@ -21,8 +22,12 @@ INCLUDE '_email_top.html';
   [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
-    <h2 style="[% h2_style %]">[% title %]</h2>
-    [% report.detail | html_para_email(secondary_p_style) %]
+    [% IF cobrand.moniker == 'bexley' && is_missed_collection %]
+      [% INCLUDE 'waste/_sidebar_content.html' %]
+    [% ELSE  %]
+      <h2 style="[% h2_style %]">[% title %]</h2>
+      [% report.detail | html_para_email(secondary_p_style) %]
+    [% END %]
     [% TRY %][% INCLUDE '_council_reference_alert_update.html' problem=report p_style=secondary_p_style %][% CATCH file %][% END %]
 [% END %]
 

--- a/templates/email/default/waste/other-reported.html
+++ b/templates/email/default/waste/other-reported.html
@@ -1,6 +1,10 @@
+[% is_missed_collection = report.category == 'Report missed collection' %]
 [%
 
-email_summary = "Thanks for logging your report";
+email_summary
+  = cobrand.moniker == 'bexley' && is_missed_collection
+  ? "Your reference number is " _ report.id
+  : "Thanks for logging your report";
 email_columns = 2;
 
 PROCESS '_email_settings.html';
@@ -18,14 +22,22 @@ INCLUDE '_email_top.html';
       <h1 style="[% h1_style %]">Your request has been&nbsp;logged</h1>
     [% END %]
   [% ELSE %]
-    <h1 style="[% h1_style %]">Your report has been&nbsp;logged</h1>
+    [% IF cobrand.moniker == 'bexley' && is_missed_collection %]
+      <h1 style="[% h1_style %]">Thank you for reporting a missed collection</h1>
+    [% ELSE %]
+      <h1 style="[% h1_style %]">Your report has been&nbsp;logged</h1>
+    [% END %]
   [% END %]
 
   [% IF cobrand.moniker == 'sutton' %]
   <p style="[% p_style %]">Thank you for contacting the London Borough of Sutton.</p>
   [% END %]
 
-[% INCLUDE '_council_reference.html' problem=report %]
+[% IF cobrand.moniker == 'bexley' && is_missed_collection %]
+  [% INCLUDE 'waste/_council_reference.html' problem=report %]
+[% ELSE  %]
+  [% INCLUDE '_council_reference.html' problem=report %]
+[% END %]
 
 [% IF cobrand.moniker == 'bromley' %]
 
@@ -59,6 +71,20 @@ INCLUDE '_email_top.html';
     <strong>Use track your request link to check for your scheduled delivery date.</strong>
   </p>
 
+[% ELSIF cobrand.moniker == 'bexley' && is_missed_collection %]
+  <p style="[% p_style %]">
+    Our waste contractor will return within 2 working days to collect your bin(s).
+    <br><br>
+    Please leave your bin(s) out until our contractor returns.
+    <br><br>
+    If you need to contact us about this report, please quote your reference number.
+  </p>
+  <p style="margin: 20px auto; text-align: center">
+    <a style="[% button_style %]" href="https://mybexley.bexley.gov.uk/service/rubbish_and_recycling_enquiries">
+      Contact us
+    </a>
+  </p>
+
 [% ELSE %]
 
     [% IF report.category == 'Report missed collection' %]
@@ -75,12 +101,16 @@ INCLUDE '_email_top.html';
   [% end_padded_box | safe %]
 </th>
 [% WRAPPER '_email_sidebar.html' object = report %]
+  [% IF cobrand.moniker == 'bexley' && is_missed_collection %]
+    [% INCLUDE 'waste/_sidebar_content.html' %]
+  [% ELSE  %]
     <h2 style="[% h2_style %]">[% report.title | html %]</h2>
     [% report.detail | html_para_email(secondary_p_style) %]
 
     [% IF cobrand.moniker == 'kingston' AND report.category == 'Request new container' %]
       <a style="[% button_style %]" href="[% cobrand.feature('waste_features').track_request_url %]?client_ref=RBK-[% report.id %]">Track your request</a>
     [% END %]
+  [% END %]
 [% END %]
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/default/waste/other-reported.txt
+++ b/templates/email/default/waste/other-reported.txt
@@ -6,7 +6,8 @@
     [% END ~%]
 [% ELSIF cobrand.moniker == 'sutton' %][% SET prefix = 'LBS-' ~%]
 [% ELSE %][% SET prefix = '' %][% END ~%]
-Subject: [% subject_text ~%], reference [% prefix %][% report.id %]
+[% is_missed_collection = report.category == 'Report missed collection' ~%]
+Subject: [% IF cobrand.moniker == 'bexley' && is_missed_collection %]Thank you for reporting a missed collection[% ELSE %][% subject_text ~%], reference [% prefix %][% report.id %][% END %]
 
 Dear [% report.name %],
 


### PR DESCRIPTION
Update the wording on the confirmation email for missed collection reports, as per this thread: https://3.basecamp.com/4020879/buckets/35109031/todos/7259735553.

Email sidebar changes also made for update alert email.

![Screenshot 2024-05-09 at 09 50 41](https://github.com/mysociety/fixmystreet/assets/11098355/5b18388b-cd1e-4bc9-84c1-a10b60eaa3fb)

[skip changelog]
