### PR TITLE
[Merton][WW] Add staff features for requesting new containers

### DIFF
--- a/perllib/FixMyStreet/App/Form/Waste/Request/Merton.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Request/Merton.pm
@@ -12,9 +12,17 @@ has_page about_you => (
 );
 
 has_page replacement => (
-    fields => ['request_reason', 'continue'],
+    fields => ['request_reason', 'request_reason_text', 'continue'],
     title => 'Reason for request',
     next => 'about_you',
+    field_ignore_list => sub {
+        my $page = shift;
+        if (!$page->form->{c}->stash->{is_staff}) {
+            return ['request_reason_text'];
+        } else {
+            return [];
+        };
+    },
 );
 
 has_field request_reason => (
@@ -22,6 +30,14 @@ has_field request_reason => (
     type => 'Select',
     widget => 'RadioGroup',
     label => 'Why do you need a replacement container?',
+);
+
+has_field request_reason_text => (
+    required => 0,
+    type => 'Text',
+    widget => 'Textarea',
+    label => 'Additional details',
+    tags => { hint => 'Please enter any additional details that will help us with the request' },
 );
 
 sub options_request_reason {

--- a/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
@@ -167,6 +167,16 @@ sub waste_garden_sub_payment_params {
     }
 }
 
+sub staff_override_request_options {
+    my ($self, $rows) = @_;
+    return unless $self->{c}->stash->{is_staff};
+
+    foreach my $row (@$rows) {
+        $row->{'request_allowed'} = 1;
+        $row->{'request_max'} = 3;
+    }
+}
+
 sub waste_request_form_first_next {
     my $self = shift;
     return sub {
@@ -182,7 +192,7 @@ sub waste_munge_request_data {
     my $c = $self->{c};
     my $address = $c->stash->{property}->{address};
     my $container = $c->stash->{containers}{$id};
-    my $quantity = 1;
+    my $quantity = $data->{"quantity-$id"} || 1;
     my $reason = $data->{request_reason} || '';
     my $nice_reason = $c->stash->{label_for_field}->($form, 'request_reason', $reason);
 

--- a/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
@@ -167,14 +167,43 @@ sub waste_garden_sub_payment_params {
     }
 }
 
+=item staff_override_request_options
+
+Merton want staff to be able to request any domestic container
+for a property and also to not be restricted to only ordering
+one container.
+
+=cut
+
 sub staff_override_request_options {
     my ($self, $rows) = @_;
     return unless $self->{c}->stash->{is_staff};
 
+    my @containers_on_property;
+
     foreach my $row (@$rows) {
-        $row->{'request_allowed'} = 1;
-        $row->{'request_max'} = 3;
+        push @containers_on_property, @{$row->{request_containers}};
+        $row->{request_allowed} = 1;
+        $row->{request_max} = 3;
     }
+
+    my %new_row = (
+        service_id => 'other_containers',
+        service_name => 'Other containers',
+        request_containers => [],
+        request_only => 1,
+        request_allowed => 1,
+        request_max => 3,
+    );
+
+    my %all_containers = %{$self->waste_containers};
+    foreach my $k (sort { $a <=> $b } keys %all_containers) {
+        next if $all_containers{$k} =~ /Communal/;
+        next if grep { $k == $_ } @containers_on_property;
+        push @{$new_row{request_containers}}, $k;
+    }
+
+    push @$rows, \%new_row;
 }
 
 sub waste_request_form_first_next {

--- a/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
@@ -215,7 +215,10 @@ sub waste_munge_request_data {
     }
     $data->{detail} = "Quantity: $quantity\n\n$address";
     $data->{detail} .= "\n\nReason: $nice_reason" if $nice_reason;
-
+    if ($data->{request_reason_text}) {
+        $data->{detail} .= "\n\nAdditional details: " . $data->{request_reason_text};
+        $c->set_param('Notes', $data->{request_reason_text});
+    }
     $c->set_param('Action', join('::', ($action_id) x $quantity));
     $c->set_param('Reason', join('::', ($reason_id) x $quantity));
     $c->set_param('Container_Type', $id);

--- a/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
@@ -236,6 +236,7 @@ sub bin_services_for_address {
     }
 
     $self->waste_task_resolutions($calls->{GetTasks}, \%task_ref_to_row);
+    $self->call_hook('staff_override_request_options' => \@out);
 
     return \@out;
 

--- a/t/app/controller/waste_merton.t
+++ b/t/app/controller/waste_merton.t
@@ -279,20 +279,20 @@ FixMyStreet::override_config {
     subtest 'Request new build container as staff' => sub {
         $mech->log_in_ok($staff_user->email);
         $mech->get_ok('/waste/12345/request');
-        $mech->submit_form_ok({ with_fields => { 'container-1' => 1 } });
+        $mech->submit_form_ok({ with_fields => { 'container-1' => 1, 'quantity-1' => 2 } });
         $mech->submit_form_ok({ with_fields => { 'request_reason' => 'new_build', 'request_reason_text' => 'Large household' }});
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
         $mech->submit_form_ok({ with_fields => { process => 'summary' } });
         $mech->content_contains('request has been sent');
         my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
         is $report->get_extra_field_value('uprn'), 1000000002;
-        is $report->detail, "Quantity: 1\n\n2 Example Street, Merton, KT1 1AA\n\nReason: I am a new resident without a container\n\nAdditional details: Large household";
+        is $report->detail, "Quantity: 2\n\n2 Example Street, Merton, KT1 1AA\n\nReason: I am a new resident without a container\n\nAdditional details: Large household";
         is $report->title, 'Request new Black rubbish bin (140L)';
         FixMyStreet::Script::Reports::send();
         my $req = Open311->test_req_used;
         my $cgi = CGI::Simple->new($req->content);
-        is $cgi->param('attribute[Action]'), '1';
-        is $cgi->param('attribute[Reason]'), '4';
+        is $cgi->param('attribute[Action]'), '1::1';
+        is $cgi->param('attribute[Reason]'), '4::4';
         $mech->log_out_ok;
     };
 

--- a/t/app/controller/waste_merton.t
+++ b/t/app/controller/waste_merton.t
@@ -260,6 +260,7 @@ FixMyStreet::override_config {
     subtest 'Request new build container' => sub {
         $mech->get_ok('/waste/12345/request');
         $mech->submit_form_ok({ with_fields => { 'container-1' => 1 } });
+        $mech->content_lacks('request_reason_text', 'Staff only field for extra information absent');
         $mech->submit_form_ok({ with_fields => { 'request_reason' => 'new_build' }});
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
         $mech->submit_form_ok({ with_fields => { process => 'summary' } });
@@ -273,6 +274,26 @@ FixMyStreet::override_config {
         my $cgi = CGI::Simple->new($req->content);
         is $cgi->param('attribute[Action]'), '1';
         is $cgi->param('attribute[Reason]'), '4';
+    };
+
+    subtest 'Request new build container as staff' => sub {
+        $mech->log_in_ok($staff_user->email);
+        $mech->get_ok('/waste/12345/request');
+        $mech->submit_form_ok({ with_fields => { 'container-1' => 1 } });
+        $mech->submit_form_ok({ with_fields => { 'request_reason' => 'new_build', 'request_reason_text' => 'Large household' }});
+        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
+        $mech->submit_form_ok({ with_fields => { process => 'summary' } });
+        $mech->content_contains('request has been sent');
+        my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+        is $report->get_extra_field_value('uprn'), 1000000002;
+        is $report->detail, "Quantity: 1\n\n2 Example Street, Merton, KT1 1AA\n\nReason: I am a new resident without a container\n\nAdditional details: Large household";
+        is $report->title, 'Request new Black rubbish bin (140L)';
+        FixMyStreet::Script::Reports::send();
+        my $req = Open311->test_req_used;
+        my $cgi = CGI::Simple->new($req->content);
+        is $cgi->param('attribute[Action]'), '1';
+        is $cgi->param('attribute[Reason]'), '4';
+        $mech->log_out_ok;
     };
 
     subtest 'Report missed collection' => sub {

--- a/t/app/controller/waste_merton.t
+++ b/t/app/controller/waste_merton.t
@@ -259,6 +259,8 @@ FixMyStreet::override_config {
     };
     subtest 'Request new build container' => sub {
         $mech->get_ok('/waste/12345/request');
+        $mech->content_lacks('Other containers', 'Does not contain "other" section if not staff');
+        $mech->content_lacks('Blue lid paper and cardboard bin (360L)', 'Container not associated with service not available ');
         $mech->submit_form_ok({ with_fields => { 'container-1' => 1 } });
         $mech->content_lacks('request_reason_text', 'Staff only field for extra information absent');
         $mech->submit_form_ok({ with_fields => { 'request_reason' => 'new_build' }});
@@ -295,6 +297,30 @@ FixMyStreet::override_config {
         is $cgi->param('attribute[Reason]'), '4::4';
         $mech->log_out_ok;
     };
+
+    subtest 'Request large paper bin as staff' => sub {
+        $mech->log_in_ok($staff_user->email);
+        $mech->get_ok('/waste/12345/request');
+        $mech->content_contains('Other containers', 'Staff can select from list of containers not associated with a service');
+        $mech->content_contains('Blue lid paper and cardboard bin (360L)', 'Domestic service available');
+        $mech->content_lacks('Communal Refuse bin (240L)', 'Communal service not available');
+        $mech->submit_form_ok({ with_fields => { 'container-20' => 1, 'quantity-20' => 2 } });
+        $mech->submit_form_ok({ with_fields => { 'request_reason' => 'new_build', 'request_reason_text' => 'Large household' }});
+        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
+        $mech->submit_form_ok({ with_fields => { process => 'summary' } });
+        $mech->content_contains('request has been sent');
+        my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+        is $report->get_extra_field_value('uprn'), 1000000002;
+        is $report->detail, "Quantity: 2\n\n2 Example Street, Merton, KT1 1AA\n\nReason: I am a new resident without a container\n\nAdditional details: Large household";
+        is $report->title, 'Request new Blue lid paper and cardboard bin (360L)';
+        FixMyStreet::Script::Reports::send();
+        my $req = Open311->test_req_used;
+        my $cgi = CGI::Simple->new($req->content);
+        is $cgi->param('attribute[Action]'), '1::1';
+        is $cgi->param('attribute[Reason]'), '4::4';
+        $mech->log_out_ok;
+    };
+
 
     subtest 'Report missed collection' => sub {
         $mech->get_ok('/waste/12345/report');

--- a/t/app/controller/waste_merton.t
+++ b/t/app/controller/waste_merton.t
@@ -396,7 +396,21 @@ FixMyStreet::override_config {
     };
 
     subtest 'test failure to deliver' => sub {
+        $e->mock('GetEventsForObject', sub { [ {
+            # Request
+            EventTypeId => 1635,
+            Data => { ExtensibleDatum => [
+                { Value => 2, DatatypeName => 'Source' },
+                {
+                    ChildData => { ExtensibleDatum => [
+                        { Value => 1, DatatypeName => 'Action' },
+                        { Value => 16, DatatypeName => 'Container Type' },
+                    ] },
+                },
+            ] },
+        } ] });
         $mech->get_ok('/waste/12345');
+        $mech->content_lacks('Report a failure to deliver a food waste container');
         $mech->follow_link_ok({ text => 'Report a failure to deliver a mixed recycling container' });
         $mech->submit_form_ok({ with_fields => { extra_Notes => 'It never turned up' } });
         $mech->submit_form_ok({ with_fields => { name => "Anne Assist", email => 'anne@example.org' } });
@@ -409,6 +423,7 @@ FixMyStreet::override_config {
         is $report->detail, "It never turned up\n\n2 Example Street, Merton, KT1 1AA";
         is $report->user->email, 'anne@example.org';
         is $report->name, 'Anne Assist';
+        $e->mock('GetEventsForObject', sub { [] }); # reset
     };
 
     subtest 'test staff-only additional collection' => sub {

--- a/templates/web/base/waste/services.html
+++ b/templates/web/base/waste/services.html
@@ -5,6 +5,13 @@
   <span class="waste-service-descriptor">
     A [% unit.service_name FILTER lower %] container request has been made
   </span>
+
+    [% IF c.cobrand.moniker == 'merton' %]
+        [% IF NOT (property_time_banded AND unit.service_id == 2242) %]
+            <a href="[% c.uri_for_action('waste/enquiry', [ property.id ]) %]?category=Failure+to+deliver&amp;service_id=[% unit.service_id %]" class="waste-service-link waste-service-descriptor">Report a failure to deliver a [% unit.service_name FILTER lower %] container</a>
+        [% END %]
+    [% END %]
+
 [% ELSIF unit.request_allowed %]
   [% any_request_allowed = 1 %]
   [% PROCESS 'waste/_services_request.html' %]
@@ -12,17 +19,12 @@
   [% PROCESS 'waste/_services_garden_modify.html' %]
 [% END %]
 
-
 [% IF c.cobrand.moniker == 'merton' %]
-
     [% IF property_time_banded AND unit.service_id == 2242 %]
     <span class="waste-service-descriptor">
         You need to buy your own black sacks from a supermarket or other shop. If you have some blue general rubbish bags with a Merton Council logo, you can continue to use these until they run out, but we no longer provide new ones.
     </span>
-    [% ELSE %]
-        <a href="[% c.uri_for_action('waste/enquiry', [ property.id ]) %]?category=Failure+to+deliver&amp;service_id=[% unit.service_id %]" class="waste-service-link waste-service-descriptor">Report a failure to deliver a [% unit.service_name FILTER lower %] container</a>
     [% END %]
-
     [% IF is_staff %]
         <a href="[% c.uri_for_action('waste/report', [ property.id ]) %]?additional=1&amp;service-[% unit.service_id %]=1" class="waste-service-link waste-service-descriptor">Request an additional [% unit.service_name FILTER lower %] collection</a>
     [% END %]


### PR DESCRIPTION
Staff can select any available domestic container when doing a request 

They are not restricted to ordering only one container (they can order 3).

They can leave an optional note when ordering a container.

https://github.com/mysociety/societyworks/issues/4273

[skip changelog]