### PR TITLE
Include status change line in update emails using auto response templates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
         - Switch to OpenStreetMap for reverse geocoding. #4444
         - Convert all uploaded images to JPEGs.
         - Redirect after POST when creating reports. #4362
+        - Include status change line in report update emails using auto response templates.
 
 * v5.0 (10th May 2023)
     - Front end improvements:

--- a/perllib/FixMyStreet/Script/Alerts.pm
+++ b/perllib/FixMyStreet/Script/Alerts.pm
@@ -133,6 +133,9 @@ sub send_alert_type {
                 $row->{item_text_original} = $row->{item_text};
                 $row->{item_text} = $row->{item_text} ? $row->{item_text} . "\n\n" . $update :
                                                         $update;
+                if ($row->{item_private_email_text} && $report->cobrand_data ne 'waste') {
+                    $row->{item_private_email_text} = $row->{item_private_email_text} . "\n\n" . $update;
+                }
                 $last_problem_state = $row->{item_problem_state};
             }
             next unless $row->{item_text};


### PR DESCRIPTION
Except for waste categories.

closes https://github.com/mysociety/fixmystreet/issues/4901
