### PR TITLE
[Bexley][WW] Make sure default value is passed for hidden container location field

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -948,8 +948,8 @@ sub waste_munge_report_form_fields {
         };
     } else {
         push @$field_list, extra_detail => {
-            type => 'Hidden',
-            value => 'Front of property',
+            type    => 'Hidden',
+            default => 'Front of property',
         };
     }
 }


### PR DESCRIPTION
Turns out 'Hidden' formhandler fields take 'default', not 'value'.

[skip changelog]
