### PR TITLE
Added Dual box-shadow colour for .skiplink

### DIFF
--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -754,12 +754,14 @@ ul.error {
 }
 
 .skiplink:focus {
-  outline: 3px solid transparent;
+  outline: none; // Using box-shadow instead. This will allows us to have a dual-color outline, that will cover scenarios where the navbar bg colour and the outline have a similar brightness.
   color: $primary_text;
   background-color: $primary;
   text-decoration: none;
-  left: 0;
+  left: 0.4375rem; // Box-shadow will be completely visible
+  top: 0.4375rem; // Box-shadow will be completely visible
   z-index: 999; //Higher value than the map
+  box-shadow:  0 0 0 0.125rem $button-primary-focus-bg-top, 0 0 0 0.3125rem $button-primary-focus-text, 0 0 0 0.4375rem; // If .button-primary in focus state is accessible. Then using these two colours will make sure at least one of the outline colours will have a good contrast with the navigation bar.
 }
 
 .dev-site-notice {


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4213

This should improve the accessibility contrast of the `.skip-link` element against the navigation bar.

<img width="955" alt="Screenshot 2024-05-29 at 10 48 32" src="https://github.com/mysociety/fixmystreet/assets/13790153/a899ee41-7273-42fc-8ce8-325cd2553541">


Part of TFL audit. This should improve the following criteria:

https://www.w3.org/WAI/WCAG21/Understanding/focus-visible

[Skip changelog]


