### PR TITLE
[Bexley WW] Simplify in-cab logs code to use USRN logs only

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -492,23 +492,16 @@ sub _in_cab_logs {
     my $dt_from = $self->_subtract_working_days(WORKING_DAYS_WINDOW);
     my $cab_logs;
     if ( !$self->{c}->stash->{cab_logs} ) {
-        my $cab_logs_uprn = $self->whitespace->GetInCabLogsByUprn(
-            $property->{uprn},
-            $dt_from->stringify,
-        );
-
-        my $cab_logs_usrn
+        # Property should always have a USRN, but return UPRN logs in case not
+        $cab_logs
             = $property->{usrn}
             ? $self->whitespace->GetInCabLogsByUsrn(
                 $property->{usrn},
                 $dt_from->stringify,
-            ) : [];
-
-        $cab_logs = [ @$cab_logs_uprn, @$cab_logs_usrn ];
-
-        # Make cab logs unique by LogID and Reason
-        my %seen;
-        @$cab_logs = grep { !$seen{ $_->{LogID} . $_->{Reason} }++ } @$cab_logs;
+            ) : $self->whitespace->GetInCabLogsByUprn(
+                $property->{uprn},
+                $dt_from->stringify,
+            );
 
         $self->{c}->stash->{cab_logs} = $cab_logs;
     } else {

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -101,10 +101,6 @@ sub default_mocks {
             return _site_collections()->{$uprn};
         }
     );
-    $whitespace_mock->mock( 'GetInCabLogsByUprn', sub {
-        my ( $self, $uprn ) = @_;
-        return [ grep { $_->{Uprn} eq $uprn } @{ _in_cab_logs() } ];
-    });
     $whitespace_mock->mock( 'GetInCabLogsByUsrn', sub {
         my ( $self, $usrn ) = @_;
         return _in_cab_logs();
@@ -455,7 +451,6 @@ FixMyStreet::override_config {
                 },
             ];
         } );
-        $whitespace_mock->mock( 'GetInCabLogsByUprn', sub { [] } );
         $whitespace_mock->mock( 'GetInCabLogsByUsrn', sub { [] } );
 
         set_fixed_time('2024-04-01T07:00:00'); # April 1st, 08:00 BST
@@ -488,7 +483,7 @@ FixMyStreet::override_config {
         $mech->content_contains('Collection completed or attempted earlier today');
 
         note 'Property has red tag on collection attempted earlier today';
-        $whitespace_mock->mock( 'GetInCabLogsByUprn', sub {
+        $whitespace_mock->mock( 'GetInCabLogsByUsrn', sub {
             return [
                 {
                     LogID => 1,
@@ -500,7 +495,6 @@ FixMyStreet::override_config {
                 },
             ];
         });
-        $whitespace_mock->mock( 'GetInCabLogsByUsrn', sub { [] } );
         $mech->get_ok('/waste/10001');
         $mech->content_contains('Service status');
         $mech->content_contains(
@@ -510,7 +504,6 @@ FixMyStreet::override_config {
         $mech->content_contains('Collection completed or attempted earlier today');
 
         note 'Red tag on other property on same street';
-        $whitespace_mock->mock( 'GetInCabLogsByUprn', sub { [] } );
         $whitespace_mock->mock( 'GetInCabLogsByUsrn', sub {
             return [
                 {
@@ -529,7 +522,6 @@ FixMyStreet::override_config {
         $mech->content_contains('Collection completed or attempted earlier today');
 
         note 'Service update on street';
-        $whitespace_mock->mock( 'GetInCabLogsByUprn', sub { [] } );
         $whitespace_mock->mock( 'GetInCabLogsByUsrn', sub {
             return [
                 {

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -459,7 +459,8 @@ FixMyStreet::override_config {
         $mech->get_ok('/waste/10001');
         $mech->content_lacks('Service status');
         $mech->content_contains('Being collected today');
-        $mech->content_lacks('Collection completed or attempted earlier today');
+        $mech->content_lacks('Reported as collected today');
+        $mech->content_lacks('Could not be collected today because it was red-tagged. See reason below.');
 
         # Set time to later in the day
         set_fixed_time('2024-04-01T16:01:00'); # April 1st, 17:01 BST
@@ -480,14 +481,15 @@ FixMyStreet::override_config {
         $mech->get_ok('/waste/10001');
         $mech->content_lacks('Service status');
         $mech->content_lacks('Being collected today');
-        $mech->content_contains('Collection completed or attempted earlier today');
+        $mech->content_contains('Reported as collected today');
+        $mech->content_lacks('Could not be collected today because it was red-tagged. See reason below.');
 
         note 'Property has red tag on collection attempted earlier today';
         $whitespace_mock->mock( 'GetInCabLogsByUsrn', sub {
             return [
                 {
                     LogID => 1,
-                    Reason => 'Bin has gone feral',
+                    Reason => 'Paper & Card - Bin has gone feral',
                     RoundCode => 'RND-8-9',
                     LogDate => '2024-04-01T12:00:00.417',
                     Uprn => '10001',
@@ -501,14 +503,15 @@ FixMyStreet::override_config {
             'Our collection teams have reported the following problems with your bins:'
         );
         $mech->content_lacks('Being collected today');
-        $mech->content_contains('Collection completed or attempted earlier today');
+        $mech->content_lacks('Reported as collected today');
+        $mech->content_contains('Could not be collected today because it was red-tagged. See reason below.');
 
         note 'Red tag on other property on same street';
         $whitespace_mock->mock( 'GetInCabLogsByUsrn', sub {
             return [
                 {
                     LogID => 1,
-                    Reason => 'Bin has gone feral',
+                    Reason => 'Paper & Card - Bin has gone feral',
                     RoundCode => 'RND-8-9',
                     LogDate => '2024-04-01T12:00:00.417',
                     Uprn => '19991',
@@ -519,7 +522,8 @@ FixMyStreet::override_config {
         $mech->get_ok('/waste/10001');
         $mech->content_lacks('Service status');
         $mech->content_lacks('Being collected today');
-        $mech->content_contains('Collection completed or attempted earlier today');
+        $mech->content_contains('Reported as collected today');
+        $mech->content_lacks('Could not be collected today because it was red-tagged. See reason below.');
 
         note 'Service update on street';
         $whitespace_mock->mock( 'GetInCabLogsByUsrn', sub {
@@ -541,7 +545,8 @@ FixMyStreet::override_config {
             'Our collection teams have reported the following problems with your bins:'
         );
         $mech->content_lacks('Being collected today');
-        $mech->content_contains('Collection completed or attempted earlier today');
+        $mech->content_contains('Reported as collected today');
+        $mech->content_lacks('Could not be collected today because it was red-tagged. See reason below.');
 
         # Reinstate original mocks
         set_fixed_time('2024-03-31T01:00:00'); # March 31st, 02:00 BST

--- a/templates/web/base/waste/bin_days.html
+++ b/templates/web/base/waste/bin_days.html
@@ -121,7 +121,11 @@
           <dd class="govuk-summary-list__value">
             [% IF unit.next %]
               [% IF unit.next.already_collected %]
-                <strong>Collection completed or attempted earlier today</strong>
+                [% IF unit.report_locked_out %]
+                  <strong>Could not be collected today because it was red-tagged. See reason below.</strong>
+                [% ELSE  %]
+                  <strong>Reported as collected today</strong>
+                [% END %]
               [% ELSIF unit.next.is_today %]
                 <strong>Being collected today</strong>
               [% ELSE %]


### PR DESCRIPTION
We are pretty certain that UPRN logs are always a subset of USRN logs, so I have simplified the code so we only fetch USRN logs.

[skip changelog]