### PR TITLE
Added aria-live search results in around page

### DIFF
--- a/templates/web/base/around/_on_map_empty.html
+++ b/templates/web/base/around/_on_map_empty.html
@@ -1,1 +1,1 @@
-<p>[% loc('There are no reports to show.') %]</p>
+<p aria-live="polite">[% loc('There are no reports to show.') %]</p>

--- a/templates/web/base/around/tabbed_lists.html
+++ b/templates/web/base/around/tabbed_lists.html
@@ -2,7 +2,7 @@
 
 <h2 class="hidden-js">[% loc('Reports') %]</h2>
 
-<div class="js-pagination">
+<div class="js-pagination" aria-live="polite">
 [% INCLUDE 'pagination.html' param = 'p' %]
 </div>
 


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4219

This commit helps screen reader to notify the user once the number of results in the map have been updated.

### Note:
The reason to not add `aria-live="polite"` on the `js-reports-list` that contains messages like 'No reports to show on map, here are some nearby:' is because after testing I realised it also starts reading all the reports found, one by one. So this commit cover cases where:

- There are reports in the map
- No reports in the map

However it doesn't cover the scenario where: "No reports to show on map, here are some nearby:", because that one is nested inside `.js-reports-list` and the text is not dynamic, is basically hidden if the condition is not met, therefore `aria-live` doesn't have an effect. As an idea we could add a screen-reader only label, that gets displayed when there are not results, but there are some nearby. This label would be nested  inside `.js-pagination` and would let the user no "No results found, but there are some nearby reports instead"

[Skip changelog]
