### PR TITLE
[Bromley] Add Delayed check on state

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -461,7 +461,7 @@ sub image_for_unit {
 
 =head2 waste_on_the_day_criteria
 
-If it's before 5pm on the day of collection, treat an Outstanding task as if
+If it's before 5pm on the day of collection, treat an Outstanding/Delayed task as if
 it's the next collection and in progress, and do not allow missed collection
 reporting if the task is not completed.
 
@@ -471,7 +471,7 @@ sub waste_on_the_day_criteria {
     my ($self, $completed, $state, $now, $row) = @_;
 
     return unless $now->hour < 17;
-    if ($state eq 'Outstanding') {
+    if ($state eq 'Outstanding' || $state eq 'Delayed') {
         $row->{next} = $row->{last};
         $row->{next}{state} = 'In progress';
         delete $row->{last};


### PR DESCRIPTION
If a waste pickup is delayed, set to in progress and don't allow reporting of missed collection

https://mysocietysupport.freshdesk.com/a/tickets/4185

[skip changelog]
