### PR TITLE
Prevent hidden missed collection selection if given service is no longer eligible

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -943,8 +943,22 @@ sub construct_bin_report_form {
     my $field_list = [];
 
     foreach (@{$c->stash->{service_data}}) {
-        next unless ( $_->{last} && $_->{report_allowed} && !$_->{report_open}) || $_->{report_only};
         my $id = $_->{service_id};
+
+        unless (
+            ( $_->{last}
+            && $_->{report_allowed}
+            && !$_->{report_open} )
+            || $_->{report_only} )
+        {
+            # Missed collection link may have passed in a hidden param for
+            # a service that is no longer eligible for collection (e.g. if
+            # user hasn't refreshed page), so unset that
+            $c->set_param( "service-$id", undef );
+
+            next;
+        }
+
         my $name = $_->{service_name};
         push @$field_list, "service-$id" => {
             type => 'Checkbox',

--- a/templates/web/bexley/waste/_service_missed.html
+++ b/templates/web/bexley/waste/_service_missed.html
@@ -13,7 +13,7 @@
 </div>
 [% ELSIF unit.report_allowed %]
   [% any_report_allowed = 1 %]
-  <form method="post" action="[% c.uri_for_action('waste/report', [ property.id ]) %]">
+  <form method="post" name="[% unit.service_id %]-missed" action="[% c.uri_for_action('waste/report', [ property.id ]) %]">
     <input type="hidden" name="token" value="[% csrf_token %]">
     <input type="hidden" name="service-[% unit.service_id %]" value="1">
     <input type="submit" value="Report a [% unit.service_name FILTER lower %] collection as missed" class="waste-service-descriptor waste-service-link">


### PR DESCRIPTION
Fixes https://github.com/mysociety/societyworks/issues/4342 .

Touches code shared between all cobrands, so presumably fixes the issue across all cobrands. (At the very least, doesn't break existing behaviour - see screengrab below).

https://github.com/mysociety/fixmystreet/assets/11098355/2fc562a9-944f-44d9-b48b-99045c86a7e3

[skip changelog]
