### PR TITLE
[Bexley] Collected today check should check scheduled collections

### DIFF
--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -812,6 +812,9 @@ FixMyStreet::override_config {
                 next => {
                     is_today => 1,
                 },
+                last => {
+                    date => DateTime->today,
+                }
             },
             # Had a collection earlier today
             'FO-140' => {
@@ -821,34 +824,52 @@ FixMyStreet::override_config {
                 next => {
                     is_today => 1,
                 },
+                last => {
+                    date => DateTime->today,
+                },
             },
             # Collection due last working day but it did not happen
             'RES-180' => {
                 service_id => 'RES-180',
                 round => 'RES-R2',
                 round_schedule => 'RES-R2 Fri',
+                last => {
+                    date => DateTime->today->subtract( days => 3 ),
+                },
             },
             # Collections due last working day and they happened
             'RES-240' => {
                 service_id => 'RES-240',
                 round => 'RES-R3',
                 round_schedule => 'RES-R3 Fri',
+                last => {
+                    date => DateTime->today->subtract( days => 3 ),
+                },
             },
             'RES-660' => {
                 service_id => 'RES-660',
                 round => 'RES-R4',
                 round_schedule => 'RES-R4 Fri',
+                last => {
+                    date => DateTime->today->subtract( days => 3 ),
+                },
             },
             # Collection too old
             'GA-240' => {
                 service_id => 'GA-240',
                 round => 'GDN-R1',
                 round_schedule => 'GDN-R1 Tue',
+                last => {
+                    date => DateTime->today->subtract( days => 6 ),
+                },
             },
             'PG-240' => {
                 service_id => 'PG-240',
                 round => 'RCY-R2',
                 round_schedule => 'RCY-R2 Mon PG Wk 2',
+                last => {
+                    date => DateTime->today->subtract( days => 7 ),
+                },
             },
         );
 
@@ -856,17 +877,6 @@ FixMyStreet::override_config {
             uprn => 10001,
             missed_collection_reports => {
                 'RES-SACK' => 1,
-            },
-            recent_collections => {
-                'RCY-R1 Mon' => DateTime->today, # FO-23
-                'RCY-R2 Mon' => DateTime->today, # FO-140
-                'RES-R2 Fri' => DateTime->today->subtract( days => 3 ), # RES-180
-                'RES-R3 Fri' => DateTime->today->subtract( days => 3 ), # RES-240
-                'RES-R4 Fri' => DateTime->today->subtract( days => 3 ), # RES-240
-                'GDN-R1 Tue' => DateTime->today->subtract( days => 6 ), # GA-240
-                'RCY-R2 Mon PG Wk 2' => DateTime->today->subtract( days => 7 ), # PG-240
-                'RCY-R1 Mon' => DateTime->today->subtract( days => 14 ), # FO-23
-                'RCY-R2 Mon' => DateTime->today->subtract( days => 14 ), # FO-140
             },
         };
 

--- a/templates/web/bexley/waste/services_extra.html
+++ b/templates/web/bexley/waste/services_extra.html
@@ -38,7 +38,56 @@
   [%# Allow superusers to see red tags and service updates for debugging purposes %]
   [% IF c.user.is_superuser %]
   <details>
-    <summary>Red tags</summary>
+    <summary>🐞 Superuser debugging</summary>
+    <h2>Property</h2>
+    <dl>
+      <dt>UPRN</dt>
+      <dd>[% property.uprn %]</dd>
+      [% IF property.parent_property %]
+      <dt>Parent UPRN</dt>
+      <dd>[% property.parent_property.uprn %]</dd>
+      [% END %]
+      <dt>USRN</dt>
+      <dd>[% property.usrn %]</dd>
+    </dl>
+    <h2>Services</h2>
+    [% FOREACH service IN service_data %]
+    <dl>
+      <dt>ID</dt>
+      <dd>[% service.service_id %]</dd>
+      <dt>Name</dt>
+      <dd>[% service.service_name %]</dd>
+      <dt>Description</dt>
+      <dd>[% service.service_description %]</dd>
+      <dt>Round schedule</dt>
+      <dd>[% service.round_schedule %]</dd>
+    </dl>
+    <hr>
+    [% END %]
+    <h2>Recent scheduled collections</h2>
+    [% FOREACH round IN property.recent_collections.keys %]
+    <dl>
+      <dt>[% round %]</dt>
+      <dd>[% property.recent_collections.$round %]</dd>
+    </dl>
+    [% END %]
+    <h2>Completed or attempted collections</h2>
+    [% FOREACH round IN property.completed_or_attempted_collections.keys %]
+    <dl>
+      <dt>[% round %]</dt>
+      <dd>[% property.completed_or_attempted_collections.$round %]</dd>
+    </dl>
+    [% END %]
+    <h2>Missed collection reports</h2>
+    [% IF property.missed_collection_reports && property.missed_collection_reports.size %]
+    [% FOREACH report IN property.missed_collection_reports %]
+        <p>[% report.key %]: [% report.value %]</p>
+      [% END %]
+    [% ELSE %]
+    <p>No existing missed collection reports</p>
+    [% END %]
+    <h2>Red tags</h2>
+    [% IF property.red_tags && property.red_tags.size %]
     [% FOREACH tag IN property.red_tags %]
     <h3>[% tag.reason %]</h3>
     <dl>
@@ -56,9 +105,10 @@
     </dl>
     <hr>
     [% END %]
-  </details>
-  <details>
-    <summary>Service updates</summary>
+    [% ELSE %]
+    <p>No red tags</p>
+    [% END %]
+    <h2>Service updates</h2>
     [% IF property.service_updates && property.service_updates.size %]
     [% FOREACH update IN property.service_updates %]
     <h3>[% update.reason %]</h3>


### PR DESCRIPTION
In-cab logs only have a RoundCode, but that can't be matched directly to a collection's RoundSchedule because both weekly and fortnightly collections share a RoundCode in the logs. So we need to do this extra check to ensure we were actually expecting a collection in the past three days.

For https://3.basecamp.com/4020879/buckets/35109031/todos/7468948862

<!-- [skip changelog] -->