### PR TITLE
Added varius stying fixes to .js-post-category-messages element

### DIFF
--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -3365,6 +3365,29 @@ $site-message-border: 1px solid #525252 !default;
   }
 }
 
+.js-post-category-messages,
+.extra-category-questions {
+  h2 {
+    font-size: 1.3rem;
+  }
+
+  h3 {
+    font-size: 1.2rem;
+  }
+
+  h3, h4 {
+    font-weight: bold;
+  }
+
+  img {
+    margin-bottom: 1rem;
+  }
+
+  :first-child {
+    margin-top: 0; //Avoids extra spacing caused by inherited margins
+  }
+}
+
 .keyboard-instructions-wrapper, .keyboard-pin {
   display: none;
 }


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4308

Added some spacing and sizing fixes for elements inside `.js-post-category-messages`.


<img width="548" alt="Screenshot 2024-06-05 at 11 52 30" src="https://github.com/mysociety/fixmystreet/assets/13790153/a999dfb8-3464-4ec9-8817-b7a0216c842b">

https://github.com/mysociety/fixmystreet/assets/13790153/136a6c8f-6ad4-46ad-b7c9-abd64a786f06


[Skip changelog]
