### PR TITLE
[TfL] Add admin heads for changing red route categories.

### DIFF
--- a/templates/web/base/admin/bodies/body.html
+++ b/templates/web/base/admin/bodies/body.html
@@ -33,6 +33,13 @@
     <a href="[% c.uri_for_action( 'admin/bodies/edit', [ body_id ], { text => 1 } ) %]">[% loc('Text only version') %]</a>
 </p>
 
+[% IF body.name == 'TfL' AND c.user.is_superuser %]
+<p class="fms-admin-warning">
+    Renaming, adding, or removing categories that can only be made on red routes requires extra steps. See
+    <a href="https://wiki.mysociety.org/wiki/Transport_for_London_(TfL)#TLRN_categories">wiki</a>.
+</p>
+[% END %]
+
 
 [% IF body.send_method == 'Open311' %]
   <h2>
@@ -138,6 +145,13 @@
 <div class="admin-box">
   [% IF NOT contact %]
     <h2>[% loc('Add new category') %]</h2>
+  [% END %]
+
+  [% IF body.name == 'TfL' AND c.user.is_superuser %]
+  <p class="fms-admin-warning">
+      Renaming, adding, or removing categories that can only be made on red routes requires extra steps. See
+      <a href="https://wiki.mysociety.org/wiki/Transport_for_London_(TfL)#TLRN_categories">wiki</a>.
+  </p>
   [% END %]
 
   [% IF errors %]

--- a/templates/web/base/admin/bodies/category.html
+++ b/templates/web/base/admin/bodies/category.html
@@ -20,6 +20,13 @@
 [% END %]
 </p>
 
+[% IF body.name == 'TfL' AND c.user.is_superuser %]
+<p class="fms-admin-warning">
+    Renaming, adding, or removing categories that can only be made on red routes requires extra steps. See
+    <a href="https://wiki.mysociety.org/wiki/Transport_for_London_(TfL)#TLRN_categories">wiki</a>.
+</p>
+[% END %]
+
 [% INCLUDE 'admin/bodies/contact-form.html' %]
 
 <h2>[% loc('History') %]</h2>


### PR DESCRIPTION
[skip changelog]

Placed at top of category list, above add category form and in category edit form.

<img width="796" alt="tfl red route heads up" src="https://github.com/mysociety/fixmystreet/assets/9289297/98b67127-64b3-4ffe-baed-72235382be8b">

Could maybe restrict to showing in category edit form for ones that are already red route (something like `body.cobrand._tlrn_categories.grep(contact.category).size`) but thought it better to just include for all.