### PR TITLE
[FMS] Make sure contributed_by recorded if not logged in

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1633,7 +1633,15 @@ sub process_confirmation : Private {
                 }
             }
         }
+
+        if ($problem->user->is_superuser || $problem->user->from_body) {
+            if (!$problem->get_extra_metadata('contributed_by')) {
+                $problem->set_extra_metadata( contributed_by => $problem->user->id );
+                $problem->update;
+            }
+        }
     }
+
     # log the problem creation user in to the site
     if ($problem->user->email_verified) {
         $c->authenticate( { email => $problem->user->email, email_verified => 1 }, 'no_password' );


### PR DESCRIPTION
contributed_by is now set if a user logs in during report making process.

Results in dashboard report now showing roles filter correctly when staff user logs in as part of report making process.

https://github.com/mysociety/societyworks/issues/4234

[skip changelog]