### PR TITLE
[Bexley] Add form for properties with no collections

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1037,7 +1037,7 @@ sub enquiry : Chained('property') : Args(0) {
 
     my $category = $c->get_param('category');
     my $service = $c->get_param('service_id');
-    $c->detach('property_redirect') unless $category && $service && $c->stash->{services}{$service};
+    $c->detach('property_redirect') unless $category;
 
     my ($contact) = grep { $_->category eq $category } @{$c->stash->{contacts}};
     $c->detach('property_redirect') unless $contact;
@@ -1047,11 +1047,17 @@ sub enquiry : Chained('property') : Args(0) {
     foreach (@{$contact->get_metadata_for_input}) {
         $staff_form = 1 if $_->{code} eq 'staff_form';
         next if ($_->{automated} || '') eq 'hidden_field';
-        my $type = 'Text';
-        $type = 'TextArea' if 'text' eq ($_->{datatype} || '');
+        my %config = (type => 'Text');
+        my $datatype = $_->{datatype} || '';
+        if ($datatype eq 'text') {
+            %config = (type => 'TextArea');
+        } elsif ($datatype eq 'multivaluelist') {
+            my @options = map { { label => $_->{name}, value => $_->{key} } } @{$_->{values}};
+            %config = (type => 'Multiple', widget => 'CheckboxGroup', options => \@options);
+        }
         my $required = $_->{required} eq 'true' ? 1 : 0;
         push @$field_list, "extra_$_->{code}" => {
-            type => $type, label => $_->{description}, required => $required
+            %config, label => $_->{description}, required => $required
         };
     }
 

--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -1049,6 +1049,26 @@ sub waste_munge_report_form_fields {
     }
 }
 
+sub waste_munge_enquiry_data {
+    my ($self, $data) = @_;
+
+    my $address = $self->{c}->stash->{property}->{address};
+    $data->{title} = $data->{category};
+
+    my $detail;
+    foreach (sort grep { /^extra_/ } keys %$data) {
+        my $extra = $data->{$_};
+        if (ref $extra eq 'ARRAY') {
+            my $value = join(', ', @$extra);
+            $detail .= "$value\n\n";
+        } else {
+            $detail .= "$extra\n\n";
+        }
+    }
+    $detail .= $address;
+    $data->{detail} = $detail;
+}
+
 sub _bin_location_options {
     return {
         staff_or_assisted => [

--- a/templates/web/base/waste/enquiry.html
+++ b/templates/web/base/waste/enquiry.html
@@ -5,17 +5,19 @@
 
 [% INCLUDE 'waste/_address_display.html' %]
 
+[% IF services.$service_id %]
 <dl class="waste__address">
     <dt class="waste__address__title">Service</dt>
     <dd class="waste__address__property">[% services.$service_id.service_name %]</dd>
 </dl>
+[% END %]
 
 <form class="waste" method="get" action="[% c.uri_for_action('waste/enquiry', [ property.id ]) %]">
     <div class="govuk-form-group">
     [% PROCESS radio field = {
       id = 'category',
       html_name = 'category',
-      label = 'Category',
+      label = field_label || 'Category',
       options = field_options
     }
     %]

--- a/templates/web/base/waste/summary_enquiry.html
+++ b/templates/web/base/waste/summary_enquiry.html
@@ -8,10 +8,14 @@ step1 = 'enquiry';
 [% BLOCK answers %]
   [% FOR extra IN data.keys.grep('^extra_') %]
     [% NEXT UNLESS data.$extra %]
-    [% SET extra_name = extra.replace('extra_', '') %]
+    [% SET extra_name = extra.replace('extra_', '').replace('_', ' ') %]
     <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key govuk-summary-list__key--sub">[% extra_name | title %]</dt>
+      [% IF data.$extra.size %]
+        <dd class="govuk-summary-list__value">[% data.$extra.join(', ') %]</dd>
+      [% ELSE %]
         <dd class="govuk-summary-list__value">[% data.$extra %]</dd>
+      [% END %]
     </div>
   [% END %]
 [% END %]

--- a/templates/web/bexley/waste/_bin_days_no_collections.html
+++ b/templates/web/bexley/waste/_bin_days_no_collections.html
@@ -1,0 +1,1 @@
+<p>There are currently no collections at this property. Please <a href="[% c.uri_for_action('waste/enquiry', [ property.id ]) %]?template=no-collections">use this form to report a missed collection</a>.</p>

--- a/templates/web/bexley/waste/enquiry-no-collections.html
+++ b/templates/web/bexley/waste/enquiry-no-collections.html
@@ -1,0 +1,8 @@
+[% PROCESS waste/enquiry.html
+    title = 'No collections'
+    field_label = 'Are you trying to report a missed collection from a business, school, community group or place of worship?',
+    field_options = [
+      { label = 'Yes', value = 'Business or organisation missed collection enquiry' },
+      { label = 'No', value = 'Missed collection enquiry'},
+    ];
+%]


### PR DESCRIPTION
Makes some changes to the enquiry form to allow properties with no collections to report a missed collection via email to one of two categories.

- Removes the check for a valid service in the `enquiry` sub in the Waste controller, think this is ok, as nothing breaks if there isn't a service, it just isn't recorded if it's missing.
- Adds support for checkboxes in extra data on enquiry categories
- Changes to support enquiry checkboxes
- Changes to support service no longer being required

For https://3.basecamp.com/4020879/buckets/35109031/todos/7182401179

<!-- [skip changelog] -->
