### PR TITLE
[Northumberland] Skip sending updates on reports fetched from Alloy.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Northamptonshire.pm
@@ -135,10 +135,6 @@ sub should_skip_sending_update {
         return 1;
     }
 
-    if ($self->is_defect($p)) {
-        return 1;
-    }
-
     my $move = DateTime->new(year => 2022, month => 9, day => 12, hour => 9, minute => 30, time_zone => FixMyStreet->local_time_zone);
     return 1 if $p->whensent < $move;
 

--- a/perllib/FixMyStreet/Cobrand/Northumberland.pm
+++ b/perllib/FixMyStreet/Cobrand/Northumberland.pm
@@ -41,6 +41,11 @@ sub disambiguate_location {
 
 sub admin_user_domain { 'northumberland.gov.uk' }
 
+sub is_defect {
+    my ($self, $p) = @_;
+    return $p->service eq 'Open311';
+}
+
 =item * The default map zoom is a bit more zoomed-in
 
 =cut
@@ -206,6 +211,16 @@ sub dashboard_export_problems_add_columns {
             response_time => $response_time->($hashref),
         };
     });
+}
+
+=item * Updates on reports fetched from Alloy are not sent.
+
+=cut
+
+sub should_skip_sending_update {
+    my ($self, $comment) = @_;
+    my $p = $comment->problem;
+    return $self->is_defect($p);
 }
 
 =back


### PR DESCRIPTION
And remove the code that accidentally set this up on the Northamptonshire cobrand.

[skip changelog]