### PR TITLE
Form error identification improvements

### DIFF
--- a/templates/web/base/alert/_index_text.html
+++ b/templates/web/base/alert/_index_text.html
@@ -10,12 +10,6 @@ within a certain distance of a particular location.', "%s is the site name"), si
 [% END %]
 </p>
 
-[% IF location_error %]
-  <div class="error">[% location_error | safe %]</div>
-[% ELSE %]
-  [% INCLUDE 'errors.html' %]
-[% END %]
-
 <p>
 [% IF c.cobrand.is_council %]
 [% tprintf(loc('To find out what local alerts we have for you, please enter your %s postcode or street name and area:'), c.cobrand.council_area) %]

--- a/templates/web/base/alert/index.html
+++ b/templates/web/base/alert/index.html
@@ -16,7 +16,7 @@
       [% INCLUDE 'errors.html' %]
     [% END %]
     <div>
-      <input type="text" id="pc" name="pc" value="[% pc | html %]" aria-describedby="pc-hint [% IF location_error %]email-error[% END %]">
+      <input type="text" id="pc" name="pc" value="[% pc | html %]" aria-describedby="pc-hint [% IF location_error %]email-error[% END %]" required>
       [% INCLUDE 'around/_postcode_submit_button.html' %]
     </div>
   </fieldset>

--- a/templates/web/base/alert/index.html
+++ b/templates/web/base/alert/index.html
@@ -10,8 +10,13 @@
     <legend class="visuallyhidden">[% loc('Search for location of email alert or RSS feed') %]</legend>
     <label for="pc">[% loc('Postcode or street name and area') %]</label>
     <p class="form-hint" id="pc-hint">[% tprintf(loc('e.g. ‘%s’ or ‘%s’'), c.cobrand.example_places) %]</p>
+    [% IF location_error %]
+      <p id="email-error" class="form-error">[% location_error | safe %]</p>
+    [% ELSE %]
+      [% INCLUDE 'errors.html' %]
+    [% END %]
     <div>
-      <input type="text" id="pc" name="pc" value="[% pc | html %]" aria-describedby="pc-hint">
+      <input type="text" id="pc" name="pc" value="[% pc | html %]" aria-describedby="pc-hint [% IF location_error %]email-error[% END %]">
       [% INCLUDE 'around/_postcode_submit_button.html' %]
     </div>
   </fieldset>

--- a/templates/web/base/around/postcode_form.html
+++ b/templates/web/base/around/postcode_form.html
@@ -19,8 +19,14 @@
         <form action="[% c.uri_for('/around') %]" method="get" name="postcodeForm" id="postcodeForm" class="postcode-form-box js-geolocate">
             <label for="pc">[% question %]:</label>
             [% INCLUDE 'around/_postcode_form_examples.html' %]
+            [% IF location_error_pc_lookup %]
+            <p id="pc-error" class="form-error">
+                <span class="visuallyhidden">Error:</span>
+                [% loc('Please enter a valid postcode or area') %]
+            </p>
+            [% END %]
             <div>
-                <input type="text" name="pc" value="[% pc | html %]" id="pc" size="10" maxlength="200" required aria-describedby="pc-hint"
+                <input type="text" name="pc" value="[% pc | html %]" id="pc" size="10" maxlength="200" required aria-describedby="pc-hint [% IF location_error_pc_lookup %]search-help pc-error[% END %]"
                 [%~ IF c.cobrand.moniker == 'oxfordshire' %] placeholder="[% tprintf(loc('e.g. ‘%s’ or ‘%s’'), c.cobrand.example_places) %]"[% END %]>
                 [% INCLUDE 'around/_postcode_submit_button.html' %]
             </div>

--- a/templates/web/fixmystreet.com/around/location_error.html
+++ b/templates/web/fixmystreet.com/around/location_error.html
@@ -1,6 +1,6 @@
 [% IF location_error_pc_lookup %]
 
-    <div class="search-help">
+    <div id="search-help" class="search-help">
         <h2 class="search-help__header" role="alert">
             [% location_error | safe %]
         </h2>

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -644,6 +644,7 @@ p.form-error {
   background: $error_color;
   color: #fff;
   padding: 0 0.5em;
+  margin-bottom: 0;
   @include border-radius(0.25em 0.25em 0 0);
   a {
     color: white;

--- a/web/cobrands/sass/_search-help.scss
+++ b/web/cobrands/sass/_search-help.scss
@@ -3,7 +3,7 @@ $search-help-background: transparent !default;
 $search-help-color: inherit !default;
 $search-help-margin: -1em -1em 0 -1em !default; // overlap .container padding
 $search-help-margin-desktop: -1em -1em -2em -1em !default; // overlap .content and .tablewrapper padding-bottoms
-$search-help-header-background: #DB3914 !default;
+$search-help-header-background: $error_color !default;
 $search-help-header-color: #fff !default;
 $search-help-header-font-weight: bold !default;
 $search-help-header-font-size: 1em !default;


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4217

- [x] SW ref 39: Landing page
In Firefox, the error message remains in the same place when the page is scrolled, so you lose the visual relationship between it and the form field that is in error. Use a text error message, as has been done on other pages.

For this one I added an extra commit:
https://github.com/mysociety/fixmystreet/pull/5000/commits/6c34076c32de98c8018808aaddba2508d17ed9c6
making the  search-help component having the same colour as an error, It's a bit confusing that both of them are related, but they have different colours. Also some cobrands are already using the same colour for errors and "search-help" so I thought standardised wouldn't be a bad idea.

<img width="1185" alt="Screenshot 2024-06-11 at 11 38 21" src="https://github.com/mysociety/fixmystreet/assets/13790153/edda8a13-c07c-4b9b-93e7-86c8584ab9d2">
<img width="1185" alt="Screenshot 2024-06-11 at 11 38 08" src="https://github.com/mysociety/fixmystreet/assets/13790153/c1bf9d4c-d988-434f-887e-cae75cf7b932">

- [x] SW ref 40: Local RSS feeds and email alerts
If the input is left empty, no error message is provided.

This has two commits:
[One that covers scenarios where an invalid area has been added.](https://github.com/mysociety/fixmystreet/pull/5000/commits/a507cdb93360e0c2b9ad3741a391eff39bd5b29e)
[the other one to tackle the main issue, when the input has been left empty](https://github.com/mysociety/fixmystreet/pull/5000/commits/5f653c42e59af56a06c32aee13c51aa8e205c6e4)

[Skip changelog]
