### PR TITLE
[FMS] Adds stop to reporting if all categories filtered out

### DIFF
--- a/.cypress/cypress/integration/category_tests.js
+++ b/.cypress/cypress/integration/category_tests.js
@@ -90,5 +90,18 @@ describe('Basic categories', function() {
         cy.get('[value="Road traffic signs"]').should('be.visible');
         cy.get('[value="Street lighting"]').should('be.visible');
         cy.get('[value="Traffic lights"]').should('not.be.visible');
+        cy.get('#category-filter').type('{selectAll}Abad');
+        cy.contains('Please try another search');
+        cy.get('[value="Abandoned vehicles"]').should('not.be.visible');
+        cy.get('.js-reporting-page--next:visible').should('be.disabled');
+        cy.get('#category-filter').type('{backspace}');
+        cy.get('[value="Abandoned vehicles"]').should('be.visible');
+        cy.get('#filter-category-error').should('not.exist'); // Contains the text for 'Please try another search'
+        cy.get('.js-reporting-page--next:visible').should('not.be.disabled');
+        cy.get('#category-filter').type('{selectAll}Abad');
+        cy.get('[value="Abandoned vehicles"]').should('not.be.visible');
+        cy.get('#category-filter').type('{selectAll}{backspace}');
+        cy.get('#filter-category-error').should('not.exist'); // Contains the text for 'Please try another search'
+
     });
 });

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -851,6 +851,7 @@ $.extend(fixmystreet.set_up, {
              * a bug in the web browser but I doubt it is going to be fixed any
              * time soon. Introduce some padding so this does not happen. */
             category_row.style.paddingBottom = window.innerHeight + 'px';
+            disable_on_empty();
         } else {
             // Hide all the copied subcategories
             document.querySelectorAll('.js-filter-subcategory').forEach(function(fieldset) {
@@ -861,6 +862,19 @@ $.extend(fixmystreet.set_up, {
                 items[i].classList.remove('js-filter-disabled');
             }
             category_row.style.paddingBottom = null;
+            disable_on_empty();
+        }
+
+        function disable_on_empty() {
+            // If there are no items found, give a message and disable the Continue button
+            if (items.length === document.querySelectorAll(".hidden-category-filter").length) {
+                $('#js-top-message').html('<p class="form-error" id="filter-category-error">Please try another search or delete your search and choose from the categories</p>');
+                $('.js-reporting-page--next').prop("disabled",true);
+                category_row.style.paddingBottom = null;
+            } else {
+                $('#filter-category-error').remove();
+                $('.js-reporting-page--next').prop("disabled",false);
+            }
         }
     };
 


### PR DESCRIPTION
If there are no categories after filtering has taken place then prevent continuing with the report and add a message to tell the user to search again.

https://github.com/mysociety/societyworks/issues/4314

[skip changelog]