### PR TITLE
[Surrey] CSV export includes subscribers to the report

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Surrey.pm
+++ b/perllib/FixMyStreet/Cobrand/Surrey.pm
@@ -67,4 +67,32 @@ sub get_town {
     return $town;
 }
 
+=head2 dashboard_export_problems_add_columns
+
+Surrey has an extra column in their stats export showing the number of subscribers to a report.
+They are set up not to subscribe the original reporter to their own report so the alert number
+is the number of users who have subscribed to the report for updates
+
+=cut
+
+sub dashboard_export_problems_add_columns {
+    my ($self, $csv) = @_;
+
+    $csv->add_csv_columns(
+        alerts_count => "Subscribers",
+    );
+
+    my $alerts_lookup = $csv->dbi ? undef : $self->csv_update_alerts;
+
+    $csv->csv_extra_data(sub {
+        my $report = shift;
+
+        if ($alerts_lookup) {
+            return { alerts_count => ($alerts_lookup->{$report->id} || 0) };
+        } else {
+            return { alerts_count => ($report->{alerts_count} || 0) };
+        }
+    });
+}
+
 1;

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -721,6 +721,24 @@ sub csv_active_planned_reports {
     return \%reports_to_user;
 }
 
+sub csv_update_alerts {
+    my ($self) = @_;
+
+    my %ids_to_alert;
+
+    my @results = FixMyStreet::DB->resultset('Alert')->search({
+        alert_type => 'new_updates',
+        confirmed => 1,
+        whendisabled => undef,
+    }, {columns => ['parameter']})->all;
+
+    if (@results) {
+        %ids_to_alert = map { $_->parameter, ++$ids_to_alert{$_->parameter} } @results;
+    };
+
+    return \%ids_to_alert;
+}
+
 sub nearby_distances {
     my $self = shift;
     return $self->feature('nearby_distances') || $self->next::method();

--- a/perllib/FixMyStreet/Script/CSVExport.pm
+++ b/perllib/FixMyStreet/Script/CSVExport.pm
@@ -59,6 +59,7 @@ my $EXTRAS = {
     user_details => { bathnes => 1, bexley => 1, brent => 1, camden => 1, cyclinguk => 1, highwaysengland => 1, kingston => 1, sutton => 1 },
     comment_content => { highwaysengland => 1 },
     db_state => { peterborough => 1 },
+    alerts_count => { surrey => 1 },
 };
 
 my $fixed_states = FixMyStreet::DB::Result::Problem->fixed_states;
@@ -223,6 +224,11 @@ EOF
     if ($EXTRAS->{comment_content}{$cobrand->moniker}) {
         push @sql_select, "comments.text as comment_text", "comments.extra as comment_extra", "comment_user.name as comment_name", "row_number() over (partition by comments.problem_id order by comments.confirmed,comments.id) as comment_rn";
         push @sql_join, '"users" "comment_user" ON "comments"."user_id" = "comment_user"."id"';
+    }
+    if ($EXTRAS->{alerts_count}{$cobrand->moniker}) {
+        push @sql_select, '"alerts_table"."alerts_count"';
+        push @sql_join, '"alerts_table" ON CAST("alerts_table"."parameter" AS INTEGER) = "me"."id"';
+        push @sql_with, "alerts_table AS (select parameter, count(*) AS alerts_count FROM alert WHERE alert_type='new_updates' AND confirmed IS NOT NULL AND whendisabled IS NULL GROUP BY 1)";
     }
 
     my $sql_select = join(', ', @sql_select);

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -116,6 +116,7 @@ my @PLACES = (
     [ 'NE61 1BE', 55.169081, -1.691012, 2248, 'Northumberland County Council', 'UTA' ],
     [ 'SG17 5TQ', 52.03553, -0.36067, 21070, 'Central Bedfordshire Council', 'UTA' ],
     [ '?', 51.558568, -0.207702, 2489, 'Barnet Borough Council', 'DIS' ],
+    [ '?', 51.293415, -0.441269, 2242, 'Surrey County Council', 'DIS'],
 );
 
 sub dispatch_request {

--- a/t/cobrand/surrey.t
+++ b/t/cobrand/surrey.t
@@ -1,0 +1,66 @@
+use FixMyStreet::TestMech;
+use FixMyStreet::Script::Reports;
+use FixMyStreet::Script::CSVExport;
+use File::Temp 'tempdir';
+
+my $mech = FixMyStreet::TestMech->new;
+
+use_ok 'FixMyStreet::Cobrand::Surrey';
+
+my $surrey = $mech->create_body_ok(2242, 'Surrey County Council', {}, { cobrand => 'surrey' });
+my $surrey_staff_user = $mech->create_user_ok( 'staff@example.com', name => 'Staff User', from_body => $surrey );
+$mech->create_contact_ok(body_id => $surrey->id, category => 'Potholes', email => 'potholes@example.org');
+(my $report) = $mech->create_problems_for_body(1, $surrey->id, 'Pothole', {
+            category => 'Potholes', cobrand => 'surrey',
+            latitude => 51.293415, longitude => -0.441269, areas => '2242',
+        });
+
+my $UPLOAD_DIR = tempdir( CLEANUP => 1 );
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => [ 'surrey' ],
+    MAPIT_URL => 'http://mapit.uk/',
+    PHOTO_STORAGE_OPTIONS => { UPLOAD_DIR => $UPLOAD_DIR },
+}, sub {
+        subtest 'CSV has Subscribers column populated by "alerts" registered on problem' => sub {
+            $mech->log_in_ok($surrey_staff_user->email);
+            $mech->get_ok("/dashboard?export=1");
+            $mech->content_contains('"Site Used","Reported As",Subscribers', 'CSV content contains "Subscribers" column');
+            $mech->content_contains('website,surrey,,0', 'CSV has 0 subscribers to report as reporter is not subscribed');
+            $mech->log_out_ok;
+            for my $update (
+                {
+                    name => 'John Groats',
+                    email => 'notify@example.org',
+                    text => 'Still there',
+                    update_no => 1,
+                },
+                {
+                    name => 'Joan Smith',
+                    email => 'tome@example.org',
+                    text => 'And still there',
+                    update_no => 2,
+                }
+            ) {
+                $mech->get_ok('/report/' . $report->id);
+                $mech->submit_form_ok({ with_fields => {update => $update->{text}, name => $update->{name}, username_register => $update->{email}} });
+                FixMyStreet::Script::Reports::send();
+                my @emails = $mech->get_email;
+                my $link = $mech->get_link_from_email($emails[0]); # Most recent email to confirm update
+                $mech->get_ok( $link );
+                $mech->log_in_ok($surrey_staff_user->email);
+                $mech->get_ok("/dashboard?export=1");
+                $mech->content_contains('website,surrey,,' . $update->{update_no}, 'CSV Subscriber number is ' . $update->{update_no});
+                $mech->log_out_ok;
+                $mech->clear_emails_ok;
+            }
+            FixMyStreet::Script::CSVExport::process(dbh => FixMyStreet::DB->schema->storage->dbh);
+            $mech->log_in_ok($surrey_staff_user->email);
+            $mech->get_ok("/dashboard?export=1");
+            $mech->content_contains('website,surrey,,2', 'CSV Subscriber number is 2 from pre-generated csv');
+            $mech->log_out_ok;
+        }
+};
+
+
+
+done_testing();


### PR DESCRIPTION
Adds a column, "Subscribers" which uses the problem alert method to populate the number for subscribers.

The original reporter is not automatically subscribed to their own report for Surrey so the figure is those that have subscribed after the report has been created.

Also adds initial test file

https://github.com/mysociety/societyworks/issues/4369

[skip changelog]