### PR TITLE
[Notts Police] Prevent reports being made if they contain email

### DIFF
--- a/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
+++ b/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
@@ -186,12 +186,9 @@ sub report_new_munge_after_insert {
 sub _redact {
     my $s = shift;
 
-    my $atext = "[A-Za-z0-9!#\$%&'*+\-/=?^_`{|}~]";
-    my $atom = "$atext+";
-    my $local_part = "$atom(\\s*\\.\\s*$atom)*";
-    my $sub_domain = '[A-Za-z0-9][A-Za-z0-9-]*';
-    my $domain = "$sub_domain(\\s*\\.\\s*$sub_domain)*";
-    $s =~ s/$local_part\@$domain/[email removed]/g;
+    my $regex = Utils::email_regex;
+
+    $s =~ s/$regex/[email removed]/g;
 
     $s =~ s/\(?\+?[0-9](?:[\s()-]*[0-9]){9,}/[phone removed]/g;
     return $s;

--- a/perllib/FixMyStreet/Cobrand/NottinghamshirePolice.pm
+++ b/perllib/FixMyStreet/Cobrand/NottinghamshirePolice.pm
@@ -73,4 +73,16 @@ sub pin_colour {
     return 'yellow';
 }
 
+sub report_validation {
+    my ($self, $report, $errors) = @_;
+
+    my $regex = Utils::email_regex;
+
+    if ($report->detail =~ /$regex/ || $report->title =~ /$regex/) {
+        $errors->{detail} = 'Please remove any email addresses from report';
+    }
+
+    return $errors;
+}
+
 1;

--- a/perllib/Utils.pm
+++ b/perllib/Utils.pm
@@ -257,4 +257,29 @@ sub _part {
     }
 }
 
+=head2 Regular expressions
+
+Useful regular expressions
+
+=over 4
+=cut
+
+=item email_regex
+
+Pattern for matching email addresses. Email::Utils can test an email
+address but doesn't provide a method for matching one
+
+=back
+=cut
+
+sub email_regex {
+    my $atext = "[A-Za-z0-9!#\$%&'*+\-/=?^_`{|}~]";
+    my $atom = "$atext+";
+    my $local_part = "$atom(\\s*\\.\\s*$atom)*";
+    my $sub_domain = '[A-Za-z0-9][A-Za-z0-9-]*';
+    my $domain = "$sub_domain(\\s*\\.\\s*$sub_domain)*";
+
+    return "$local_part\@$domain";
+}
+
 1;

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -117,6 +117,7 @@ my @PLACES = (
     [ 'SG17 5TQ', 52.03553, -0.36067, 21070, 'Central Bedfordshire Council', 'UTA' ],
     [ '?', 51.558568, -0.207702, 2489, 'Barnet Borough Council', 'DIS' ],
     [ '?', 51.418776, 0.005357, 2492, 'Lewisham Borough Council', 'DIS' ],
+    [ '?', 52.956196, -1.151204, 2236, 'Nottinghamshire County Council', 'DIS' ],
 
 );
 

--- a/t/cobrand/nottinghamshirepolice.t
+++ b/t/cobrand/nottinghamshirepolice.t
@@ -1,0 +1,29 @@
+use FixMyStreet::TestMech;
+
+my $mech = FixMyStreet::TestMech->new;
+
+# disable info logs for this test run
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
+my $notts_police = $mech->create_body_ok(2236, 'Immediate Justice', {}, { cobrand => 'nottinghamshirepolice' });
+my $contact = $mech->create_contact_ok( body_id => $notts_police->id, category => 'Graffiti', email => 'graffiti@example.org' );
+
+subtest 'Get error when email included in report' => sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'nottinghamshirepolice',
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $mech->get_ok('/report/new?longitude=-1.151204&latitude=52.956196');
+        $mech->submit_form_ok({ with_fields => { category => 'Graffiti', title => 'Graffiti', detail => 'On subway wall', name => 'Bob Betts', username_register => 'user@example.org' } });
+        $mech->content_contains('Click the link in our confirmation email to publish your problem', 'Detail field without email proceeds normally');
+        $mech->get_ok('/report/new?longitude=-1.151204&latitude=52.956196');
+        $mech->submit_form_ok({ with_fields => { category => 'Graffiti', title => 'Graffiti', detail => 'On subway wall. Contact me at user@example.org', name => 'Bob Betts', username_register => 'user@example.org' } });
+        $mech->content_contains("<p class='form-error'>Please remove any email addresses from report", "Report detail with email gives error");
+        $mech->get_ok('/report/new?longitude=-1.151204&latitude=52.956196');
+        $mech->submit_form_ok({ with_fields => { category => 'Graffiti', title => 'Graffiti contact me me@me.co.uk', detail => 'On subway wall', name => 'Bob Betts', username_register => 'user@example.org' } });
+        $mech->content_contains("<p class='form-error'>Please remove any email addresses from report", "Report title with email gives error");
+    }
+};
+
+done_testing();


### PR DESCRIPTION
Checks report for email address and returns error requesting removal if found in title or detail.
Fixes https://github.com/mysociety/societyworks/issues/4338

Also moves Highways England code regex match into Utils for general use.

[skip changelog]