### PR TITLE
Create report alert before first auto-update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
         - Fixes default status report filter text on Your Account page. #4558
         - Don't zoom to bounds when searching for a postcode.
         - Fix restoring a draft with no location.
+        - Create reporter alert before creating first unconfirmed auto-update.
     - Admin improvements:
         - Rename emergency message to site message.
         - Added a category control for overriding the text of the new report details field.

--- a/perllib/FixMyStreet/Queue/Item/Report.pm
+++ b/perllib/FixMyStreet/Queue/Item/Report.pm
@@ -337,7 +337,8 @@ sub _add_confirmed_update {
     my $problem = $self->report;
     my $existing = $problem->comments->search({ external_id => 'auto-internal' })->first;
     if ($existing) {
-        $existing->update({ state => 'confirmed' });
+        $existing->confirm;
+        $existing->update;
     }
 }
 

--- a/t/app/controller/report_new_update.t
+++ b/t/app/controller/report_new_update.t
@@ -77,7 +77,6 @@ subtest "test report creation with initial auto-update and alternative email tex
     $mech->clear_emails_ok;
 
     my $user3 = $mech->log_in_ok('test-3@example.com');
-    $mech->log_in_ok($user3->email);
     $mech->get_ok("/report/$report_id");
     $mech->submit_form_ok({ button => 'alert', with_fields => { type => 'updates' } });
     $mech->log_out_ok;


### PR DESCRIPTION
Don't use the Open311 update generating code, so the update is created
unconfirmed rather than confirmed (with timestamp) then changed, and
create the alert first, in the unlikely case the comment somehow gets
confirmed in the time between the alert and the comment. FD-4237