### PR TITLE
Load Devel::Dwarn in dev server and tests.

### DIFF
--- a/perllib/FixMyStreet/DB/Result/ModerationOriginalData.pm
+++ b/perllib/FixMyStreet/DB/Result/ModerationOriginalData.pm
@@ -76,7 +76,6 @@ __PACKAGE__->belongs_to(
 use Moo;
 use FixMyStreet::Template::SafeString;
 use Text::Diff;
-use Data::Dumper;
 
 with 'FixMyStreet::Roles::DB::Extra',
      'FixMyStreet::Roles::DB::PhotoSet';

--- a/perllib/FixMyStreet/Test.pm
+++ b/perllib/FixMyStreet/Test.pm
@@ -5,6 +5,7 @@ use parent qw(Exporter);
 use strict;
 use warnings FATAL => 'all';
 use utf8;
+use Data::Dumper::Concise::Sugar;
 use Test::More;
 use mySociety::Locale;
 
@@ -22,6 +23,7 @@ sub import {
     strict->import;
     warnings->import(FATAL => 'all');
     utf8->import;
+    Data::Dumper::Concise::Sugar->export_to_level(1);
     Test::More->export_to_level(1);
     $db->txn_begin;
 }

--- a/perllib/FixMyStreet/TestMech.pm
+++ b/perllib/FixMyStreet/TestMech.pm
@@ -7,6 +7,7 @@ sub import {
     strict->import;
     warnings->import(FATAL => 'all');
     utf8->import;
+    Data::Dumper::Concise::Sugar->export_to_level(1);
     Test::More->export_to_level(1);
 }
 

--- a/script/server
+++ b/script/server
@@ -12,4 +12,9 @@ if [ -z "$1" ]; then
     set -- --listen :3000 --Reload perllib,conf
 fi
 
-bin/cron-wrapper local/bin/plackup -s Starman $@
+DWARN=""
+if [ -n "$FIXMYSTREET_APP_DEBUG" -a "$FIXMYSTREET_APP_DEBUG" != "0" ]; then
+    DWARN="-MDevel::Dwarn"
+fi
+
+bin/cron-wrapper perl $DWARN local/bin/plackup -s Starman $@


### PR DESCRIPTION
This means you can use `::Dwarn $var` in both code and tests without needing to add any other import or code.