### PR TITLE
[Bexley] Various post go-live text changes

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -960,10 +960,11 @@ sub construct_bin_report_form {
         }
 
         my $name = $_->{service_name};
+        my $description = $_->{service_description};
         push @$field_list, "service-$id" => {
             type => 'Checkbox',
             label => $name,
-            option_label => $name,
+            option_label => $description ? $description : $name,
         };
     }
 

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -638,6 +638,11 @@ FixMyStreet::override_config {
                 ->{staff_or_assisted} };
     };
 
+    subtest 'Correct labels used when reporting missed collection' => sub {
+        $mech->get_ok('/waste/10001/report');
+        $mech->content_contains('Non-recyclable waste', 'includes service description in the checkbox label');
+    };
+
     subtest 'Making a missed collection report' => sub {
         $mech->get_ok('/waste/10001/report');
         $mech->submit_form_ok(

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -284,7 +284,7 @@ FixMyStreet::override_config {
             'Correct address string displayed',
         );
         $mech->content_contains(
-            'Your rotation schedule is Week 1',
+            'Your collection schedule is Week 1',
             'Correct rotation schedule displayed',
         );
 
@@ -458,7 +458,7 @@ FixMyStreet::override_config {
             $mech->submit_form_ok( { with_fields => { postcode => 'DA1 3LD' } } );
             $mech->submit_form_ok( { with_fields => { address => $test->{address} } } );
             $mech->content_contains(
-                "Your rotation schedule is Week $test->{link}",
+                "Your collection schedule is Week $test->{link}",
                 'Correct rotation schedule displayed',
             );
             $mech->content_contains('<li><a target="_blank" href="PDF '. $test->{link} . '">View and download collection calendar', 'PDF link ' . $test->{link} . ' shown');

--- a/templates/web/base/waste/_address_display.html
+++ b/templates/web/base/waste/_address_display.html
@@ -2,3 +2,6 @@
   <dt class="waste__address__title">Address</dt>
   <dd class="waste__address__property">[% property.address %]</dd>
 </dl>
+[% IF c.cobrand.moniker == 'bexley' %]
+<div><p><b><a class="link-no-visited-style" href="[% c.uri_for_action('waste/index') %]">Change address</a></b></p></div>
+[% END %]

--- a/templates/web/bexley/waste/_more_services_sidebar.html
+++ b/templates/web/bexley/waste/_more_services_sidebar.html
@@ -1,9 +1,6 @@
 [% USE date(format='%Y%m%d') %]
 <h3>More services</h3>
 <ul>
-  [% IF any_report_allowed %]
-    <li><a href="[% c.uri_for_action('waste/report', [ property.id ]) %]">Report a missed collection</a></li>
-  [% END %]
   [% IF any_request_allowed %]
     <li><a href="[% c.uri_for_action('waste/request', [ property.id ]) %]">Request a new container</a></li>
   [% END %]
@@ -11,4 +8,8 @@
     <li><a href="[% c.uri_for_action('waste/garden', [ property.id ]) %]">Subscribe to [% c.cobrand.garden_service_name %]</a></li>
   [% END %]
   <li><a [% external_new_tab | safe %] href="https://mybexley.bexley.gov.uk/service/rubbish_and_recycling_enquiries">Report an issue with your collection service</a></li>
+  <li><a [% external_new_tab | safe %] href="https://www.bexley.gov.uk/services/rubbish-and-recycling/find-your-collection-day-and-report-missed-bin/replace-damaged-or-missing-bins">Order replacement bins, boxes or sacks</a></li>
+  <li><a [% external_new_tab | safe %] href="https://www.bexley.gov.uk/services/rubbish-and-recycling/recycling/which-bin-should-i-use">Which bin should I use?</a></li>
+  <li><a [% external_new_tab | safe %] href="https://www.bexley.gov.uk/services/rubbish-and-recycling/bulky-or-large-item-collections/arrange-bulky-or-large-item-collection">Arrange a bulky waste collection</a></li>
+  <li><a [% external_new_tab | safe %] href="https://www.bexley.gov.uk/services/rubbish-and-recycling/assisted-collections/help-putting-bins-out">Get help with putting your bins out</a></li>
 </ul>

--- a/templates/web/bexley/waste/_rotation_schedule.html
+++ b/templates/web/bexley/waste/_rotation_schedule.html
@@ -3,7 +3,7 @@
   <dl class="waste__address">
     <dd class="waste__address__property">
       [% IF ft.fortnightly %]
-        Your rotation schedule is Week [% ft.fortnightly %]
+        Your collection schedule is Week [% ft.fortnightly %]
       [% ELSIF ft.weekly %]
         Your bins are collected every week
       [% ELSE %]

--- a/templates/web/bexley/waste/_service_missed.html
+++ b/templates/web/bexley/waste/_service_missed.html
@@ -1,6 +1,6 @@
 [% IF unit.report_open %]
   <span class="waste-service-descriptor">
-    A [% unit.service_name FILTER lower %] collection has been reported as missed
+    A [% unit.service_name FILTER lower %] collection has already been reported, our waste contractor will return shortly to complete this collection
     [% IF unit.report_url %] – <a href="[% unit.report_url %]" class="waste-service-link">check status</a>[% END %]
   </span>
 [% ELSIF unit.report_locked_out %]

--- a/web/cobrands/bexley/base.scss
+++ b/web/cobrands/bexley/base.scss
@@ -103,3 +103,17 @@ ol.big-numbers > li:before {
     background: url(/cobrands/bexley/images/logo.png) 0 50% no-repeat;
     background-size: 150px 60px;
 }
+
+/* WasteWorks */
+.waste__address {
+    margin-bottom: 1em;
+}
+
+.link-no-visited-style {
+    &:visited {
+        color: $link-color;
+        &:hover {
+            color: $link-hover-color;
+        }
+    }
+}


### PR DESCRIPTION
Fixes the following Basecamp todos, which are all text changes or similar.

- [Review bin type labels on the 'select your missed bin' page](https://3.basecamp.com/4020879/buckets/35109031/todos/7465372000)
- [Rotation text](https://3.basecamp.com/4020879/buckets/35109031/todos/7349248069)
- [Change 'already reported' text](https://3.basecamp.com/4020879/buckets/35109031/todos/7514472576)
- [Include more links in the 'more services' section](https://3.basecamp.com/4020879/buckets/35109031/todos/7514438414)
- [Add Change address link](https://3.basecamp.com/4020879/buckets/35109031/todos/7512718726)

<!-- [skip changelog] -->