### PR TITLE
[Waste] Add ability to expire session cache entries.

### DIFF
--- a/bin/expire-sessions
+++ b/bin/expire-sessions
@@ -25,6 +25,7 @@ GetOptions(
 
 my $rs = FixMyStreet::DB->resultset("Session")->search(undef, { cursor_page_size => 1000 });
 my $now = time();
+my $waste_cutoff = $now - 86400;
 
 # Delete expired sessions (including from in User object)
 # And update last active time of current sessions
@@ -47,6 +48,24 @@ while (my $session = $rs->next) {
     if ($user) {
         update_user_last_active($user, $expires);
         $user->update;
+    }
+
+    next unless $session->in_storage;
+
+    # Check old waste cache
+    my $any = 0;
+    my $data = $session->data;
+    my $waste_data = $data->{waste};
+    foreach (keys %$waste_data) {
+        my $time = $waste_data->{$_}[0];
+        if ($time < $waste_cutoff) {
+            delete $waste_data->{$_};
+            $any = 1;
+        }
+    }
+    if ($any) {
+        $session->data($data);
+        $session->update;
     }
 }
 

--- a/perllib/Catalyst/Plugin/FixMyStreet/Session/WasteCache.pm
+++ b/perllib/Catalyst/Plugin/FixMyStreet/Session/WasteCache.pm
@@ -1,0 +1,21 @@
+package Catalyst::Plugin::FixMyStreet::Session::WasteCache;
+use Moose::Role;
+use namespace::autoclean;
+
+sub waste_cache_set {
+    my ($c, $key, $data) = @_;
+    $c->session->{waste}{$key} = [ time, $data ];
+    return $data;
+}
+
+sub waste_cache_get {
+    my ($c, $key) = @_;
+    $c->session->{waste}{$key} && $c->session->{waste}{$key}[1];
+}
+
+sub waste_cache_delete {
+    my ($c, $key) = @_;
+    delete $c->session->{waste}{$key};
+}
+
+__PACKAGE__;

--- a/perllib/FixMyStreet/App.pm
+++ b/perllib/FixMyStreet/App.pm
@@ -29,6 +29,7 @@ use Catalyst (
     'SmartURI',
     'FixMyStreet::Session::RotateSession',
     'FixMyStreet::Session::StoreSessions',
+    'FixMyStreet::Session::WasteCache',
 );
 
 extends 'Catalyst';

--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1584,7 +1584,7 @@ sub waste_munge_bulky_data {
     my ($date, $ref, $expiry) = split(";", $data->{chosen_date});
 
     my $guid_key = $self->council_url . ":echo:bulky_event_guid:" . $c->stash->{property}->{id};
-    $data->{extra_GUID} = $self->{c}->session->{$guid_key};
+    $data->{extra_GUID} = $self->{c}->waste_cache_get($guid_key);
     $data->{extra_reservation} = $ref;
 
     $data->{title} = "Small items collection";

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -986,7 +986,7 @@ sub waste_munge_bulky_data {
     my ($date, $ref, $expiry) = split(";", $data->{chosen_date});
 
     my $guid_key = $self->council_url . ":echo:bulky_event_guid:" . $c->stash->{property}->{id};
-    $data->{extra_GUID} = $self->{c}->session->{$guid_key};
+    $data->{extra_GUID} = $self->{c}->waste_cache_get($guid_key);
     $data->{extra_reservation} = $ref;
 
     $data->{title} = "Bulky goods collection";

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -494,34 +494,35 @@ sub _premises_for_postcode {
 
     my $key = "peterborough:bartec:premises_for_postcode:$pc";
 
-    unless ( $c->session->{$key} ) {
-        my $cfg = $self->feature('bartec');
-        my $bartec = Integrations::Bartec->new(%$cfg);
-        my $response = $bartec->Premises_Get($pc);
+    my $data = $c->waste_cache_get($key);
+    return $data if $data;
 
-        if (!$c->user_exists || !($c->user->from_body || $c->user->is_superuser)) {
-            my $blocked = $cfg->{blocked_uprns} || [];
-            my %blocked = map { $_ => 1 } @$blocked;
-            @$response = grep { !$blocked{$_->{UPRN}} } @$response;
-        }
+    my $cfg = $self->feature('bartec');
+    my $bartec = Integrations::Bartec->new(%$cfg);
+    my $response = $bartec->Premises_Get($pc);
 
-        $c->session->{$key} = [ map { {
-            id => $pc . ":" . $_->{UPRN},
-            uprn => $_->{UPRN},
-            usrn => $_->{USRN},
-            address => $self->_format_address($_),
-            latitude => $_->{Location}->{Metric}->{Latitude},
-            longitude => $_->{Location}->{Metric}->{Longitude},
-        } } @$response ];
+    if (!$c->user_exists || !($c->user->from_body || $c->user->is_superuser)) {
+        my $blocked = $cfg->{blocked_uprns} || [];
+        my %blocked = map { $_ => 1 } @$blocked;
+        @$response = grep { !$blocked{$_->{UPRN}} } @$response;
     }
 
-    return $c->session->{$key};
+    $data = [ map { {
+        id => $pc . ":" . $_->{UPRN},
+        uprn => $_->{UPRN},
+        usrn => $_->{USRN},
+        address => $self->_format_address($_),
+        latitude => $_->{Location}->{Metric}->{Latitude},
+        longitude => $_->{Location}->{Metric}->{Longitude},
+    } } @$response ];
+
+    return $c->waste_cache_set($key, $data);
 }
 
 sub clear_cached_lookups_postcode {
     my ($self, $pc) = @_;
     my $key = "peterborough:bartec:premises_for_postcode:$pc";
-    delete $self->{c}->session->{$key};
+    $self->{c}->waste_cache_delete($key);
 }
 
 sub clear_cached_lookups_property {
@@ -530,8 +531,8 @@ sub clear_cached_lookups_property {
     # might be prefixed with postcode if it's come straight from the URL
     $uprn =~ s/^.+\://g;
 
-    foreach ( qw/look_up_property bin_services_for_address/ ) {
-        delete $self->{c}->session->{"peterborough:bartec:$_:$uprn"};
+    foreach ( qw/bin_services_for_address/ ) {
+        $self->{c}->waste_cache_delete("peterborough:bartec:$_:$uprn");
     }
 
     $self->clear_cached_lookups_bulky_slots($uprn);
@@ -544,8 +545,7 @@ sub clear_cached_lookups_bulky_slots {
     $uprn =~ s/^.+\://g;
 
     for (qw/earlier later/) {
-        delete $self->{c}
-            ->session->{"peterborough:bartec:available_bulky_slots:$_:$uprn"};
+        $self->{c}->waste_cache_delete("peterborough:bartec:available_bulky_slots:$_:$uprn");
     }
 }
 

--- a/perllib/FixMyStreet/Cobrand/Peterborough/Bulky.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough/Bulky.pm
@@ -96,7 +96,8 @@ sub find_available_bulky_slots {
         = 'peterborough:bartec:available_bulky_slots:'
         . ( $last_earlier_date_str ? 'later' : 'earlier' ) . ':'
         . $property->{uprn};
-    return $c->session->{$key} if $c->session->{$key};
+    my $data = $c->waste_cache_get($key);
+    return $data if $data;
 
     my $bartec = $self->feature('bartec');
     $bartec = Integrations::Bartec->new(%$bartec);
@@ -176,9 +177,7 @@ sub find_available_bulky_slots {
         }
     }
 
-    $c->session->{$key} = \@available_slots;
-
-    return \@available_slots;
+    return $c->waste_cache_set($key, \@available_slots);
 }
 
 sub collection_date {

--- a/perllib/FixMyStreet/DB/Result/Session.pm
+++ b/perllib/FixMyStreet/DB/Result/Session.pm
@@ -31,22 +31,37 @@ __PACKAGE__->set_primary_key("id");
 
 use Storable;
 use MIME::Base64;
+use Moo;
 
-sub id_code {
-    my $self = shift;
-    my $id = $self->id;
-    $id =~ s/^session://;
-    $id =~ s/\s+$//;
-    return $id;
-}
+has data => (
+    is => 'rw',
+    lazy => 1,
+    default => sub {
+        Storable::thaw(MIME::Base64::decode($_[0]->session_data));
+    },
+    trigger => sub {
+        $_[0]->session_data(MIME::Base64::encode(Storable::nfreeze($_[1] || '')));
+    },
+);
 
-sub user {
-    my $self = shift;
-    return unless $self->session_data;
-    my $data = Storable::thaw(MIME::Base64::decode($self->session_data));
-    return unless $data->{__user};
-    my $user = $self->result_source->schema->resultset("User")->find($data->{__user}{id});
-    return $user;
-}
+has id_code => (
+    is => 'lazy',
+    default => sub {
+        my $id = $_[0]->id;
+        $id =~ s/^session://;
+        $id =~ s/\s+$//;
+        return $id;
+    }
+);
+
+has user => (
+    is => 'lazy',
+    default => sub {
+        my $data = $_[0]->data or return;
+        return unless $data->{__user};
+        my $user = $_[0]->result_source->schema->resultset("User")->find($data->{__user}{id});
+        return $user;
+    }
+);
 
 1;

--- a/perllib/FixMyStreet/Roles/Cobrand/KingstonSutton.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/KingstonSutton.pm
@@ -576,7 +576,7 @@ sub waste_munge_bulky_data {
     my ($date, $ref, $expiry) = split(";", $data->{chosen_date});
 
     my $guid_key = $self->council_url . ":echo:bulky_event_guid:" . $c->stash->{property}->{id};
-    $data->{extra_GUID} = $self->{c}->session->{$guid_key};
+    $data->{extra_GUID} = $self->{c}->waste_cache_get($guid_key);
     $data->{extra_reservation} = $ref;
 
     $data->{title} = "Bulky goods collection";

--- a/perllib/Integrations/Roles/ParallelAPI.pm
+++ b/perllib/Integrations/Roles/ParallelAPI.pm
@@ -47,7 +47,10 @@ sub call_api {
 
     my $type = $self->backend_type;
     $key = "$cobrand:$type:$key";
-    return $c->session->{$key} if !FixMyStreet->test_mode && $c->session->{$key};
+    if (!FixMyStreet->test_mode) {
+        my $cached = $c->waste_cache_get($key);
+        return $cached if $cached;
+    }
 
     my $calls = encode_json(\@_);
 
@@ -109,7 +112,7 @@ sub call_api {
     }
 
     if ($data) {
-        $c->session->{$key} = $data;
+        $c->waste_cache_set($key, $data);
         my $time = Time::HiRes::time() - $start;
         $c->log->info("[$cobrand] call_api $key took $time seconds");
     } elsif ($background) {

--- a/t/cobrand/peterborough/bulky-goods/unit.t
+++ b/t/cobrand/peterborough/bulky-goods/unit.t
@@ -7,6 +7,7 @@ use DateTime;
 use DateTime::Format::Strptime;
 use FixMyStreet::TestMech;
 use FixMyStreet::Cobrand::Peterborough;
+use Catalyst::Plugin::FixMyStreet::Session::WasteCache;
 
 subtest '_bulky_collection_window' => sub {
     my $mock_pbro = Test::MockModule->new('FixMyStreet::Cobrand::Peterborough');
@@ -65,6 +66,12 @@ subtest 'find_available_bulky_slots' => sub {
     my $cobrand = FixMyStreet::Cobrand::Peterborough->new;
     $cobrand->{c} = Test::MockObject->new;
     my %session_hash;
+    $cobrand->{c}->mock( waste_cache_get => sub {
+        Catalyst::Plugin::FixMyStreet::Session::WasteCache::waste_cache_get(@_);
+    });
+    $cobrand->{c}->mock( waste_cache_set => sub {
+        Catalyst::Plugin::FixMyStreet::Session::WasteCache::waste_cache_set(@_);
+    });
     $cobrand->{c}->mock( session => sub { \%session_hash } );
     $cobrand->{c}->mock( stash => sub { {} } );
 
@@ -104,7 +111,7 @@ subtest 'find_available_bulky_slots' => sub {
     );
 
     is_deeply(
-        [ sort keys %session_hash ],
+        [ sort keys %{$session_hash{waste}} ],
         [   'peterborough:bartec:available_bulky_slots:earlier:123456789',
             'peterborough:bartec:available_bulky_slots:later:123456789',
         ],


### PR DESCRIPTION
We're not expiring property lookups in the session cache (they get replaced if the same property is looked up again, but otherwise will just stick around) which was causing issues as people built up thousands of cached unneeded properties in the session. Factor out the cache stuff to a plugin that can store the time of setting, then add to the expire script something to remove things older than a day.

[skip changelog]
