### PR TITLE
[Bexley] Disable questionnaires

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1628,6 +1628,9 @@ sub add_report : Private {
 
     my $report = $c->stash->{report};
 
+    # Never send questionnaires for waste reports
+    $report->send_questionnaire(0);
+
     # store photos
     foreach (grep { /^(item|location)_photo/ } keys %$data) {
         next unless $data->{$_};

--- a/perllib/FixMyStreet/Cobrand/Bexley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley.pm
@@ -15,6 +15,7 @@ sub council_name { 'London Borough of Bexley' }
 sub council_url { 'bexley' }
 sub get_geocoder { 'Bexley' }
 sub default_map_zoom { 4 }
+sub send_questionnaires { 0 }
 
 sub disambiguate_location {
     my $self    = shift;

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -136,6 +136,8 @@ FixMyStreet::override_config {
         $mech->content_contains('A paper &amp; cardboard collection has been reported as missed'); # as part of service unit, not property
     };
     subtest 'Report a missed bin' => sub {
+        my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Bromley');
+        $cobrand->mock('send_questionnaires', sub { 1 }); # To test that questionnaires aren't sent, despite being enabled on the cobrand.
         $mech->content_contains('service-531', 'Can report, last collection was 27th');
         $mech->content_lacks('service-537', 'Cannot report, last collection was 27th but the service unit has a report');
         $mech->content_lacks('service-535', 'Cannot report, last collection was 20th');
@@ -193,6 +195,9 @@ FixMyStreet::override_config {
 
         is $user->alerts->count, 1;
         $mech->clear_emails_ok;
+
+        my $report = FixMyStreet::DB->resultset("Problem")->order_by('-id')->first;
+        is $report->send_questionnaire, 0;
     };
     subtest 'About You form is pre-filled when logged in' => sub {
         $mech->log_in_ok($user->email);

--- a/t/app/model/questionnaire.t
+++ b/t/app/model/questionnaire.t
@@ -208,12 +208,12 @@ for my $test (
 ) {
     subtest "correct questionnaire behaviour for state $test->{state} when $test->{user} $test->{description_string}" => sub {
         FixMyStreet::override_config {
-            ALLOWED_COBRANDS => 'bexley',
+            ALLOWED_COBRANDS => 'brent',
             COBRAND_FEATURES => {
-                updates_allowed => { bexley => $test->{user} },
+                updates_allowed => { brent => $test->{user} },
             },
         }, sub {
-            $problem->cobrand( 'bexley' );
+            $problem->cobrand( 'brent' );
             $problem->state( $test->{state} );
             $problem->send_questionnaire( 1 );
             $problem->update;

--- a/t/cobrand/bexley.t
+++ b/t/cobrand/bexley.t
@@ -417,19 +417,6 @@ FixMyStreet::override_config {
         }, "submit details");
         like $mech->get_text_body_from_email, qr/The report's reference number is $id/, 'Update confirmation email contains id number';
 };
-
-subtest 'test ID in questionnaire email' => sub {
-        $mech->clear_emails_ok;
-        (my $report) = $mech->create_problems_for_body(1, $body->id, 'On Road', {
-            category => 'Lamp post', cobrand => 'bexley',
-            latitude => 51.408484, longitude => 0.074653, areas => '2494',
-            whensent => DateTime->now->subtract(years => 1),
-        });
-        FixMyStreet::DB->resultset('Questionnaire')->send_questionnaires();
-        my $text = $mech->get_text_body_from_email;
-        my $id = $report->id;
-        like $text, qr/The report's reference number is $id/, 'Questionnaire email contains id number';
-    };
 };
 
 subtest 'nearest road returns correct road' => sub {


### PR DESCRIPTION
Bexley have requested that we turn off questionnaires for FMS. (See [this doc](https://docs.google.com/document/d/13xu4LLEDuZKt216aIloTNaSZZeFOvUu5IrEM9eHrICo/edit#heading=h.93j3fbds4ycb) point 5 under general notes.)

See also commit 837d357448d7da0fa5ce56f1dff0ffaa38e7b453 in mysociety-servers.

Also stops questionnaires for being sent for all waste report, as they don't make sense in the context of WasteWorks.

Fixes https://github.com/mysociety/societyworks/issues/4388

<!-- [skip changelog] -->
