### PR TITLE
Staff cannot update name reporting when logged out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
         - Added support for 'datetime' extra category questions using a datetime picker.
         - Added option to make a phone number required for a category.
         - Add way to pick multiple categories in the dashboard.
+        - Staff cannot update name reporting when logged out. #5031
     - Development improvements:
         - Extra data columns now stored as JSON, not RABX. #3216
         - Cobrands can provide custom distances for duplicate lookup. #4456

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1615,8 +1615,11 @@ sub process_confirmation : Private {
                 $problem->user->phone( $data->{phone} ) if $data->{phone};
             }
             $problem->user->password( $data->{password}, 1 ) if $data->{password};
-            for (qw(name title facebook_id twitter_id)) {
+            for (qw(title facebook_id twitter_id)) {
                 $problem->user->$_( $data->{$_} ) if $data->{$_};
+            }
+            if ($data->{name} && !$problem->user->from_body) {
+                $problem->user->name($data->{name});
             }
             $problem->user->add_oidc_id($data->{oidc_id}) if $data->{oidc_id};
             $problem->user->extra({


### PR DESCRIPTION
We have had a few cases where staff forget they are not logged in, report on behalf of someone else when logged out, and have their own account name updated when clicking the confirmation link.
