### PR TITLE
[Lincolnshire] Move and restyle site messages on home page

### DIFF
--- a/templates/web/base/around/postcode_form.html
+++ b/templates/web/base/around/postcode_form.html
@@ -1,7 +1,7 @@
 <main id="front-main">
     <div id="front-main-container">
         [% UNLESS possible_location_matches %]
-            [% INCLUDE 'around/intro.html' %]
+            [% PROCESS 'around/intro.html' %]
         [% END %]
 
         [%

--- a/templates/web/base/front/site-message.html
+++ b/templates/web/base/front/site-message.html
@@ -1,6 +1,7 @@
 [% site_message = c.cobrand.site_message %]
-[% IF site_message %]
+[% IF site_message && !rendered_site_message %]
 <div class="site-message">
   [% site_message | html_para %]
 </div>
 [% END %]
+[% rendered_site_message = 1 %]

--- a/templates/web/base/index.html
+++ b/templates/web/base/index.html
@@ -1,3 +1,4 @@
+[% rendered_site_message = 0 %]
 [% pre_container_extra = PROCESS 'around/postcode_form.html' %]
 [% SET bodyclass = 'frontpage fullwidthpage' %]
 [% INCLUDE 'header.html', title = '', inline_css = 1 %]

--- a/templates/web/base/report/new/form_after_heading.html
+++ b/templates/web/base/report/new/form_after_heading.html
@@ -1,5 +1,7 @@
 [% site_message = c.cobrand.site_message('reporting') %]
 [% IF site_message %]
-    [% site_message | safe %]
+<div class="site-message__reporting">
+    [% site_message | safe | html_para %]
+</div>
 [% END %]
 

--- a/templates/web/lincolnshire/around/intro.html
+++ b/templates/web/lincolnshire/around/intro.html
@@ -1,2 +1,4 @@
+[% PROCESS 'front/site-message.html' %]
+
 <h1>Report, view, or discuss local problems</h1>
 <h2>(like potholes, broken paving slabs, or street lighting)</h2>

--- a/web/cobrands/lincolnshire/base.scss
+++ b/web/cobrands/lincolnshire/base.scss
@@ -26,6 +26,19 @@ h1, h2, h3 {
   background-image: url(/cobrands/lincolnshire/images/logo.png);
 }
 
+.site-message {
+  background-color: $lincs-pop;
+  color: #fff;
+  border: 0;
+}
+
+.site-message__reporting {
+  background-color: $lincs-pop;
+  color: #fff;
+  padding: 1em;
+  margin: 1em 0;
+}
+
 .body.frontpage, body.twothirdswidthpage, body.fullwidthpage, body.authpage {
   #site-logo {
     @media (min-width: 48em) {
@@ -81,7 +94,7 @@ h1, h2, h3 {
   }
 }
 
-.form-box, 
+.form-box,
 .alerts__cta-box {
   background-color: $lincs-panel;
 }
@@ -130,7 +143,7 @@ body.mappage .big-green-banner {
 }
 
 .fms-admin-warning {
-  background-color: $lincs-error; 
+  background-color: $lincs-error;
   border-color: darken($lincs-error, 10%);
 }
 


### PR DESCRIPTION
Lincolnshire have asked for the site message on the homepage to be moved above the postcode form, and for it to have a red background with white text.

Fixes FD-4059

<img width="1095" alt="image" src="https://github.com/mysociety/fixmystreet/assets/22996/76b8a0e6-e568-4466-89b0-419d9e2b705e">


<!-- [skip changelog] -->
