### PR TITLE
[Brent] Add Staff Role column to csv export

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -443,9 +443,9 @@ sub dashboard_export_problems_add_columns {
             container_req_reason => 'Container Request Reason',
 
             email_renewal_reminders_opt_in => 'Email Renewal Reminders Opt-In',
-
             missed_collection_id => 'Service ID',
-            map { "item_" . $_ => "Small Item $_" } (1..11)
+            staff_role => 'Staff Role',
+            map { "item_" . $_ => "Small Item $_" } (1..11),
         )
     );
 
@@ -485,6 +485,14 @@ sub dashboard_export_problems_add_columns {
         $id = $csv->_extra_field($report, 'Container_Request_Reason') || '';
         my $container_req_reason = $request_lookups->{reason}{$id} || $id;
 
+        my ($by, $userroles, $staff_role);
+        if (!$csv->dbi) {
+            $by = $report->get_extra_metadata('contributed_by');
+            my $user_lookup = $self->csv_staff_users;
+            $userroles = $self->csv_staff_roles($user_lookup);
+            $staff_role = join(',', @{$userroles->{$by} || []}) if $by;
+        }
+
         my $data = {
             location_name => $csv->_extra_field($report, 'location_name'),
             $csv->dbi ? (
@@ -496,6 +504,7 @@ sub dashboard_export_problems_add_columns {
                 user_email => $report->user->email || '',
                 image_included => $report->photo ? 'Y' : 'N',
                 external_id => $report->external_id || '',
+                staff_role => $staff_role || '',
             ),
             usrn => $csv->_extra_field($report, 'usrn'),
             uprn => $csv->_extra_field($report, 'uprn'),

--- a/perllib/FixMyStreet/Script/CSVExport.pm
+++ b/perllib/FixMyStreet/Script/CSVExport.pm
@@ -55,7 +55,7 @@ my $EXTRAS = {
     reassigned => { tfl => 1 },
     assigned_to => { northumberland => 1, tfl => 1 },
     staff_user => { bathnes => 1, bromley => 1, buckinghamshire => 1, northumberland => 1, peterborough => 1 },
-    staff_roles => { bromley => 1, northumberland => 1, oxfordshire => 1 },
+    staff_roles => { brent => 1, bromley => 1, northumberland => 1, oxfordshire => 1 },
     user_details => { bathnes => 1, bexley => 1, brent => 1, camden => 1, cyclinguk => 1, highwaysengland => 1, kingston => 1, sutton => 1 },
     comment_content => { highwaysengland => 1 },
     db_state => { peterborough => 1 },

--- a/t/cobrand/brent.t
+++ b/t/cobrand/brent.t
@@ -1459,7 +1459,7 @@ subtest 'Dashboard CSV extra columns' => sub {
         areas => "2488", category => 'Request new container', cobrand => 'brent', user => $user1, state => 'confirmed'});
     $mech->log_in_ok( $staff_user->email );
     $mech->get_ok('/dashboard?export=1');
-    ok $mech->content_contains('"Created By",Email,USRN,UPRN,"External ID","Does the report have an image?","Inspection date","Grade for Litter","Grade for Detritus","Grade for Graffiti","Grade for Fly-posting","Grade for Weeds","Overall Grade","Did you see the fly-tipping take place","If \'Yes\', are you willing to provide a statement?","How much waste is there","Type of waste","Container Request Action","Container Request Container Type","Container Request Reason","Email Renewal Reminders Opt-In","Service ID","Small Item 1","Small Item 2"', "New columns added");
+    ok $mech->content_contains('"Created By",Email,USRN,UPRN,"External ID","Does the report have an image?","Inspection date","Grade for Litter","Grade for Detritus","Grade for Graffiti","Grade for Fly-posting","Grade for Weeds","Overall Grade","Did you see the fly-tipping take place","If \'Yes\', are you willing to provide a statement?","How much waste is there","Type of waste","Container Request Action","Container Request Container Type","Container Request Reason","Email Renewal Reminders Opt-In","Service ID","Staff Role","Small Item 1","Small Item 2"', "New columns added");
     ok $mech->content_like(qr/Flexible problem.*?"Test User",pkg-tcobrandbrentt/, "User and email added");
     ok $mech->content_like(qr/Flexible problem.*?,,,,Y,,,,,,,,/, "All fields empty but photo exists");
     $flexible_problem->set_extra_fields(
@@ -1493,7 +1493,11 @@ subtest 'Dashboard CSV extra columns' => sub {
     $flexible_problem->set_extra_metadata('item_1' => 'Sofa', 'item_2' => 'Wardrobe');
     $flexible_problem->update;
     $mech->get_ok('/dashboard?export=1');
-    ok $mech->content_like(qr/Flexible problem.*?,,,"Test Park","Test User",.*?,,,121,Y,,,,,,,,,,,,,,,,,Sofa,Wardrobe,,,,,,,/, "Bulky items added") or diag $mech->content;
+    ok $mech->content_like(qr/Flexible problem.*?,,,"Test Park","Test User",.*?,,,121,Y,,,,,,,,,,,,,,,,,,Sofa,Wardrobe,,,,,,,/, "Bulky items added") or diag $mech->content;
+    $flexible_problem->set_extra_metadata('contributed_by' => $staff_user->id);
+    $flexible_problem->update;
+    $mech->get_ok('/dashboard?export=1');
+    ok $mech->content_like(qr/Flexible problem.*?,,,"Test Park","Test User",.*?,,,121,Y,,,,,,,,,,,,,,,,,Role,Sofa,Wardrobe,,,,,,,/, "Role added") or diag $mech->content;
   }
 };
 
@@ -1530,12 +1534,16 @@ subtest 'Dashboard CSV pre-generation' => sub {
     $problems[2]->update;
     FixMyStreet::Script::CSVExport::process(dbh => FixMyStreet::DB->schema->storage->dbh);
     $mech->get_ok('/dashboard?export=1');
-    $mech->content_contains('"Created By",Email,USRN,UPRN,"External ID","Does the report have an image?","Inspection date","Grade for Litter","Grade for Detritus","Grade for Graffiti","Grade for Fly-posting","Grade for Weeds","Overall Grade","Did you see the fly-tipping take place","If \'Yes\', are you willing to provide a statement?","How much waste is there","Type of waste","Container Request Action","Container Request Container Type","Container Request Reason","Email Renewal Reminders Opt-In","Service ID","Small Item 1","Small Item 2"', "New columns added");
+    $mech->content_contains('"Created By",Email,USRN,UPRN,"External ID","Does the report have an image?","Inspection date","Grade for Litter","Grade for Detritus","Grade for Graffiti","Grade for Fly-posting","Grade for Weeds","Overall Grade","Did you see the fly-tipping take place","If \'Yes\', are you willing to provide a statement?","How much waste is there","Type of waste","Container Request Action","Container Request Container Type","Container Request Reason","Email Renewal Reminders Opt-In","Service ID","Staff Role","Small Item 1","Small Item 2"', "New columns added");
     $mech->content_like(qr/Pregen problem Test 3.*?"Test User",pkg-tcobrandbrentt/, "User and email added");
     $mech->content_like(qr/Pregen problem Test 3.*?,1234,4321,121,Y,,,,,,,,,,,,Collect\+Deliver,"Food waste caddy",Damaged,,1/, "Bin request values added");
     $mech->content_like(qr/Pregen problem Test 2.*?,,Y,,,,,,,,Yes,No,"Small van load",Appliance,/, "Flytip request values added");
-    $mech->content_like(qr/Pregen problem Test 1.*?,,,"Test Park","Test User",.*?,,,,Y,,,,,,,,,,,,,,,,,Sofa,Wardrobe,,,,,,,/, "Bulky items added");
-
+    $mech->content_like(qr/Pregen problem Test 1.*?,,,"Test Park","Test User",.*?,,,,Y,,,,,,,,,,,,,,,,,,Sofa,Wardrobe,,,,,,,/, "Bulky items added");
+    $problems[2]->set_extra_metadata('contributed_by' => $staff_user->id);
+    $problems[2]->update;
+    FixMyStreet::Script::CSVExport::process(dbh => FixMyStreet::DB->schema->storage->dbh);
+    $mech->get_ok('/dashboard?export=1');
+    $mech->content_like(qr/Pregen problem Test 1.*?,,,"Test Park","Test User",.*?,,,,Y,,,,,,,,,,,,,,,,,Role,Sofa,Wardrobe,,,,,,,/, "Role added");
     $mech->get_ok('/dashboard?export=1&state=investigating');
     $mech->content_contains('Pregen problem Test 2');
     $mech->get_ok('/dashboard?export=1&state=fixed');


### PR DESCRIPTION
If a report is by a member of staff then check if they have a role and set that in the exported data.

https://mysocietysupport.freshdesk.com/a/tickets/4306

[skip changelog]