### PR TITLE
[Notts Police] Change body name to Immediate Justice Team

### DIFF
--- a/perllib/FixMyStreet/Cobrand/NottinghamshirePolice.pm
+++ b/perllib/FixMyStreet/Cobrand/NottinghamshirePolice.pm
@@ -30,7 +30,7 @@ sub admin_show_creation_graph { 0 }
 
 sub council_area_id { [ 2236, 2565 ] }
 sub council_area { 'Nottinghamshire'; }
-sub council_name { 'Nottinghamshire Police' }
+sub council_name { 'Immediate Justice Team' }
 
 =item * Any superuser or staff user can access the admin
 
@@ -52,7 +52,7 @@ sub area_check {
     foreach (@{$self->council_area_id}) {
         return 1 if defined $councils->{$_};
     }
-    return ( 0, "That location is not covered by Nottinghamshire Police." );
+    return ( 0, "That location is not covered by the Immediate Justice Team." );
 }
 
 sub disambiguate_location {

--- a/templates/email/nottinghamshirepolice/signature.txt
+++ b/templates/email/nottinghamshirepolice/signature.txt
@@ -1,0 +1,1 @@
+Immediate Justice Team

--- a/templates/web/nottinghamshirepolice/report/new/form_public_councils_text.html
+++ b/templates/web/nottinghamshirepolice/report/new/form_public_councils_text.html
@@ -1,0 +1,9 @@
+[% BLOCK public_councils_text %]
+<h2 class="form-section-heading">[% loc( 'Report details' ) %]</h2>
+<div class="form-section-description">
+  <p>
+    These will be sent to the <strong>Immediate Justice Team</strong> and may be published online,
+    in accordance with our <a href="[% c.cobrand.privacy_policy_url %]">privacy policy</a>.
+  </p>
+</div>
+[% END %]

--- a/web/cobrands/nottinghamshirepolice/js.js
+++ b/web/cobrands/nottinghamshirepolice/js.js
@@ -13,7 +13,7 @@
 })();
 
 body_validation_rules = {
-    'Nottinghamshire Police': {
+    'Immediate Justice Team': {
         title: {
             required: true,
             notContainsEmail: true


### PR DESCRIPTION
And update the relevant templates to match.

I've overridden the whole `report/new/form_public_councils_text.html` template, which means the same message is now shown for reports in public and private categories.

Fixes https://github.com/mysociety/societyworks/issues/4405

## Notes to deployer

- [ ] Update the name of the body to "Immediate Justice Team" just before/after deploying this change

<!-- [skip changelog] -->
