### PR TITLE
Avoid displaying the translation banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
         - Convert all uploaded images to JPEGs.
         - Redirect after POST when creating reports. #4362
         - Include status change line in report update emails using auto response templates.
+        - Don't display a translation banner in front of important UI elements on Android. #4153
 
 * v5.0 (10th May 2023)
     - Front end improvements:

--- a/templates/web/base/common_header_tags.html
+++ b/templates/web/base/common_header_tags.html
@@ -80,5 +80,7 @@ if ('serviceWorker' in navigator) {
 <link rel="icon" href="/cobrands/[% c.cobrand.moniker %]/favicon.ico">
 [% END %]
 
+<meta name="google" content="notranslate">
+
 [% INCLUDE 'header_opengraph.html' %]
 [% TRY %][% PROCESS 'header_extra.html' %][% CATCH file %][% END %]


### PR DESCRIPTION
Here's a suggestion to avoid displaying the translation banner as discussed [here](https://github.com/mysociety/fixmystreet/issues/4153#issuecomment-1365780882). We've been disabling the translation banner for about one and a half years in Sweden and no one has complained.

- [ ] Has the code POD documentation been added or updated?
- [ ] Whether this PR should include changes to any public documentation, or the FAQ;
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [ ] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [ ] Will cobrand-specific changes require additional work to ensure consistent behaviour on www.fixmystreet.com? 
- [ ] Are the changes tested for accessibility?
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog