### PR TITLE
Added H2 title for list reports in 'All reports' page

### DIFF
--- a/templates/web/base/reports/_problem-list.html
+++ b/templates/web/base/reports/_problem-list.html
@@ -3,6 +3,7 @@
 %]
 
 [% BLOCK column %]
+    <h2 class="hidden-js">[% loc('Reports') %]</h2>
     <ul class="item-list item-list--reports" data-user-name="[% c.user.name %]" data-user-email="[% c.user.email %]">
         [% IF problems %]
             [% FOREACH problem IN problems %]


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4239

This is a title we have added to improve accessibility and avoid the jumping from `h1` straight to `h3`

[Skip changelog]
