### PR TITLE
[Bexley] Surface only one waste service if multiple share a name.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -227,11 +227,22 @@ sub bin_services_for_address {
 
     my @site_services_filtered;
 
+    my %seen_containers;
+
     for my $service (@$site_services) {
         next if !$service->{NextCollectionDate};
 
         my $container = $containers->{ $service->{ServiceItemName} };
         next unless $container;
+
+        # There may be duplicate container types; skip if container has been
+        # seen before.
+        # EXCEPTION for assisted collections, which are handled further down.
+        my $assisted_collection = $service->{ServiceName}
+            && $service->{ServiceName} eq 'Assisted Collection' ? 1 : 0;
+        next
+            if !$assisted_collection
+            && $seen_containers{ $container->{name} };
 
         my $next_dt = eval {
             DateTime::Format::W3CDTF->parse_datetime(
@@ -319,7 +330,7 @@ sub bin_services_for_address {
                 is_today          => $scheduled_for_today,
                 already_collected => $collected_today,
             },
-            assisted_collection => $service->{ServiceName} && $service->{ServiceName} eq 'Assisted Collection' ? 1 : 0,
+            assisted_collection => $assisted_collection,
         };
 
         if ($last_dt) {
@@ -374,6 +385,7 @@ sub bin_services_for_address {
             = $self->can_report_missed( $property, $filtered_service );
 
         push @site_services_filtered, $filtered_service;
+        $seen_containers{ $container->{name} } = 1;
     }
 
     $property->{frequency_types} = \%frequency_types;
@@ -390,6 +402,7 @@ sub bin_services_for_address {
     }
 
     @site_services_filtered = $self->_remove_service_if_assisted_exists(@site_services_filtered);
+
     @site_services_filtered = $self->service_sort(@site_services_filtered);
 
     return \@site_services_filtered;

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -1566,6 +1566,18 @@ sub _site_collections {
             },
         ],
         10006 => [],
+        10007 => [ # Filtered out because we already have a Brown Wheelie Bin service'.
+            {   SiteServiceID          => 2,
+                ServiceItemDescription => 'Service 4',
+                ServiceItemName => 'GA-240', # Brown Wheelie Bin
+
+                NextCollectionDate   => '2024-04-30T00:00:00',
+                SiteServiceValidFrom => '2024-03-31T00:59:59',
+                SiteServiceValidTo   => '2024-03-31T03:00:00',
+
+                RoundSchedule => 'N/A',
+            },
+        ],
     };
 }
 


### PR DESCRIPTION
[skip changelog]

closes https://github.com/mysociety/societyworks/issues/4346

This also includes a small change that removes the word 'rotation' before 'schedule'.