### PR TITLE
[Bexley] Add link to address lookup page to waste navbar.

### DIFF
--- a/templates/web/bexley/main_nav_items.html
+++ b/templates/web/bexley/main_nav_items.html
@@ -1,4 +1,6 @@
 [%~ IF bodyclass.match('waste') OR (problem AND problem.cobrand_data == 'waste') ~%]
+    [% INCLUDE navitem uri='/waste' label='Look up address' %]
+
     [%~ IF c.user_exists ~%]
         [%~ INCLUDE navitem uri='/my' label=loc('Your account') ~%]
     [%~ ELSE ~%]


### PR DESCRIPTION
[skip changelog]

closes https://github.com/mysociety/societyworks/issues/4406

<img width="335" alt="navbar" src="https://github.com/mysociety/fixmystreet/assets/9289297/fc1b0fa2-309a-4aef-a637-981f55ff577a">
