### PR TITLE
Remove fixmystreet-mobile references

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -4,11 +4,6 @@ about: Create a report to help us improve
 
 ---
 
-Note if the bug is about the mobile native app (not the website, whether that
-is desktop or mobile), please leave it in the
-[https://github.com/mysociety/fixmystreet-mobile/issues](fixmystreet-mobile
-repository).
-
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,6 @@ suitable for that situation, though please do search through the other issues
 to see if what you're after has been suggested or discussed - or feel free to
 add your own issue if not.
 
-## Mobile apps
-
-We've extracted all of the mobile apps from this repository into the
-[fixmystreet-mobile repository](https://github.com/mysociety/fixmystreet-mobile).
-
 ## Acknowledgements
 
 Thanks to [Browserstack](https://www.browserstack.com/) who let us use their


### PR DESCRIPTION
The fixmystreet-mobile app has been replaced by the PWA app.

- [ ] Has the code POD documentation been added or updated?
- [ ] Whether this PR should include changes to any public documentation, or the FAQ;
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [ ] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [ ] Will cobrand-specific changes require additional work to ensure consistent behaviour on www.fixmystreet.com? 
- [ ] Are the changes tested for accessibility?
- [ ] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]