### PR TITLE
[Bexley] Use force_arrayref on Whitespace site contracts

### DIFF
--- a/perllib/Integrations/Whitespace.pm
+++ b/perllib/Integrations/Whitespace.pm
@@ -208,7 +208,9 @@ sub GetSiteContracts {
 
     my $res = $self->call('GetSiteContracts', sitecontractInput => ixhash( Uprn => $uprn ));
 
-    return $res->{SiteContracts}->{SiteContract};
+    my $contracts = force_arrayref($res->{SiteContracts}, 'SiteContract');
+
+    return $contracts;
 }
 
 sub GetFullWorksheetDetails {


### PR DESCRIPTION
Fixes these errors that are appearing in the logs:

```
Caught exception in FixMyStreet::App::Controller::Waste->process_report_data "Not an ARRAY reference at /data/vhost/www.fixmystreet.com/fixmystreet-2024-07-10T10-44-33/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm line 1015.", referer: /waste/10011843743/report
```

[Basecamp todo](https://3.basecamp.com/4020879/buckets/35109031/todos/7591740937)

<!-- [skip changelog] -->
