### PR TITLE
[Waste] Only allow through valid first page fields.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -943,22 +943,16 @@ sub construct_bin_report_form {
     my $field_list = [];
 
     foreach (@{$c->stash->{service_data}}) {
-        my $id = $_->{service_id};
-
         unless (
             ( $_->{last}
             && $_->{report_allowed}
             && !$_->{report_open} )
             || $_->{report_only} )
         {
-            # Missed collection link may have passed in a hidden param for
-            # a service that is no longer eligible for collection (e.g. if
-            # user hasn't refreshed page), so unset that
-            $c->set_param( "service-$id", undef );
-
             next;
         }
 
+        my $id = $_->{service_id};
         my $name = $_->{service_name};
         my $description = $_->{service_description};
         push @$field_list, "service-$id" => {

--- a/perllib/FixMyStreet/App/Form/Waste.pm
+++ b/perllib/FixMyStreet/App/Form/Waste.pm
@@ -45,8 +45,11 @@ before after_build => sub {
 
     my $c = $self->c;
 
-    map { $saved_data->{$_} = 1 } grep { /^(service|container)-/ && $c->req->params->{$_} } keys %{$c->req->params};
-    $saved_data->{'container-choice'} = $c->get_param('container-choice') if $c->get_param('container-choice');
+    my %fields = map { $_->name => 1 } @{$self->fields};
+    map { $saved_data->{$_} = 1 } grep { /^(service|container)-/ && $fields{$_} && $c->req->params->{$_} } keys %{$c->req->params};
+    if (my $choice = $c->get_param('container-choice')) {
+        $saved_data->{'container-choice'} = $choice if $fields{'container-choice'};
+    }
 };
 
 sub validate {


### PR DESCRIPTION
It is possible you might be sent a bad service/container parameter (perhaps it has expired). Ignore it if so to prevent it being kept until the final processing. FD-4334. [skip changelog]

@nephila-nacrea For info, I think this is a slightly better way of achieving your aim with https://github.com/mysociety/fixmystreet/pull/4986 