### PR TITLE
Added fix for select element in bulk assign report section

### DIFF
--- a/templates/web/base/reports/_bulk-assign.html
+++ b/templates/web/base/reports/_bulk-assign.html
@@ -3,12 +3,12 @@
     IF c.user.has_body_permission_to('assign_report_to_user')
         && inspectors
 %]
-<form id='bulk-assign-form' name='bulk-assign-form' method='post' action='/my/planned/bulk_assign'>
+<form id='bulk-assign-form' name='bulk-assign-form' method='post' action='/my/planned/bulk_assign' class="govuk-fieldset-wrapper">
     <label for='inspector'>[% loc('Assign to') %]</label>
     <input type="hidden" name="token" value="[% csrf_token %]">
-    <select class="form-control report-list-filters multi-select-button" name="inspector" id="inspector">
+    <select class="govuk-select" name="inspector" id="inspector">
         [% INCLUDE 'report/inspect/_assignment-options.html' %]
     </select>
-    <button id='bulk-assign-btn' class='multi-select-button' type='submit' name='bulk-assign-btn' value='bulk-assign'>[% loc('Assign') %]</button>
+    <button id='bulk-assign-btn' class='btn' type='submit' name='bulk-assign-btn' value='bulk-assign'>[% loc('Assign') %]</button>
 </form>
 [% END %]

--- a/web/cobrands/sass/_report_list.scss
+++ b/web/cobrands/sass/_report_list.scss
@@ -20,7 +20,7 @@ $govuk-input-focus-box-shadow: #fd0 !default;
   }
 }
 
-.report-list-filters, #bulk-assign-form {
+.report-list-filters {
   margin-bottom: 0;
   font-size: 14px;
   line-height: 1.8em;
@@ -100,6 +100,10 @@ $govuk-input-focus-box-shadow: #fd0 !default;
 
 #bulk-assign-form {
   padding: 16px;
+
+  label {
+    margin-top: 0;
+  }
 }
 
 input.bulk-assign {


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4434

This PR gives the GOVUK layout to the `#bulk-assign-form`

<img width="417" alt="Screenshot 2024-07-10 at 16 23 44" src="https://github.com/mysociety/fixmystreet/assets/13790153/4212b96c-1fae-4ce2-baa2-a0a742176154">

[Skip changelog]