### PR TITLE
[Brent] Bulky waste missed can be reported if no event by 6pm

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1654,6 +1654,25 @@ sub waste_reconstruct_bulky_data {
     return $saved_data;
 }
 
+=item bulky_open_overdue
+Returns true if the booking is open and after 6pm on the day of the collection.
+=cut
+
+sub bulky_open_overdue {
+    my ($self, $event) = @_;
+
+    if ($event->{state} eq 'open' && $self->_bulky_collection_overdue($event)) {
+        return 1;
+    }
+}
+
+sub _bulky_collection_overdue {
+    my $collection_due_date = $_[1]->{date};
+    $collection_due_date->truncate(to => 'day')->set_hour(18);
+    my $today = DateTime->now->set_time_zone(FixMyStreet->local_time_zone);
+    return $today > $collection_due_date;
+}
+
 sub _barnet_non_street {
     return [
         'Abandoned vehicles',


### PR DESCRIPTION
If the bulky waste collection hasn't been marked as missed from Echo can be reported as missed/collected after 6pm by the booker.

https://mysocietysupport.freshdesk.com/a/tickets/3500

[skip changelog]