### PR TITLE
Added $body-font variable to input, select and textarea elements

### DIFF
--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -236,6 +236,7 @@ select,
 input,
 textarea {
   font-size: 99%;
+  font-family: $meta-font;
 }
 
 // To deal with bug from drop-down being wider than holder


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4415

UI Improvement: Currently, FMS and cobrands use the system default. Depending on the font the cobrand and system use, this can feel quite disjointed.

### Preview:
<img width="1072" alt="Screenshot 2024-07-25 at 08 54 15" src="https://github.com/user-attachments/assets/5d0bd436-397a-45a2-a187-c502adacde65">

[Skip changelog]
