### PR TITLE
[Bexley][WW] Preserve HTML in specific container description(s)

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -982,10 +982,20 @@ sub construct_bin_report_form {
         my $id = $_->{service_id};
         my $name = $_->{service_name};
         my $description = $_->{service_description};
+        my $contains_html = $_->{service_description_contains_html};
         push @$field_list, "service-$id" => {
             type => 'Checkbox',
             label => $name,
-            option_label => $description ? $description : $name,
+
+            build_option_label_method => sub {
+                return $name
+                    unless $description;
+
+                return $description
+                    unless $contains_html;
+
+                return FixMyStreet::Template::SafeString->new($description);
+            },
         };
     }
 

--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -322,6 +322,8 @@ sub bin_services_for_address {
             service_id     => $service->{ServiceItemName},
             service_name        => $container->{name},
             service_description => $container->{description},
+            service_description_contains_html =>
+                $container->{description_contains_html},
             round_schedule => $service->{RoundSchedule},
             round          => $round,
             next => {
@@ -886,8 +888,9 @@ HTML
             description => 'Glass bottles and jars',
         },
         'MDR-SACK' => {
-            name => 'Clear Sack(s)',
-            description => $clear_sack_desc,
+            name                      => 'Clear Sack(s)',
+            description               => $clear_sack_desc,
+            description_contains_html => 1,
         },
         'PA-1100' => {
             name        => 'Blue Recycling Bin',

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -328,6 +328,7 @@ FixMyStreet::override_config {
                 }
             );
             my %defaults = (
+                service_description_contains_html => undef,
                 next => {
                     changed => 0,
                     ordinal => ignore(),


### PR DESCRIPTION
Currently only applies to Clear Sack(s) but could apply to others in future.

For https://3.basecamp.com/4020879/buckets/35109031/todos/7648636722.

[skip changelog]
