### PR TITLE
[Bexley] Make Whitespace API calls in parallel

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -56,6 +56,23 @@ use constant WHITESPACE_UNDEF_DATE => '0001-01-01T00:00:00';
 use constant MISSED_COLLECTION_SERVICE_PROPERTY_ID => 68;
 use constant REQUEST_SERVICE_PROPERTY_ID => 69;
 
+sub fetch_whitespace_data {
+    my ($self, $method, $uprn) = @_;
+
+    my $c = $self->{c};
+
+    my $data = $self->whitespace->call_api(
+        $c,
+        "bexley",
+        "bin_days_page:$uprn",
+        0,
+        GetSiteInfo        => [$uprn],
+        GetSiteCollections => [$uprn],
+    );
+
+    return $data->{"$method $uprn"};
+}
+
 sub waste_fetch_events {
     my ( $self, $params ) = @_;
 
@@ -182,7 +199,7 @@ sub bin_addresses_for_postcode {
 sub look_up_property {
     my ( $self, $uprn ) = @_;
 
-    my $site = $self->whitespace->GetSiteInfo($uprn);
+    my $site = $self->fetch_whitespace_data('GetSiteInfo', $uprn);
 
     # We assume USRN is the same between parent and child addresses
     my $usrn = BexleyAddresses::usrn_for_uprn($uprn);
@@ -240,14 +257,14 @@ sub bin_services_for_address {
     my $property = shift;
 
     my $uprn = $property->{uprn};
-    my $site_services = $self->whitespace->GetSiteCollections($uprn);
+    my $site_services = $self->fetch_whitespace_data('GetSiteCollections', $uprn);
 
     # Get parent property services if no services found
     if ( !@{ $site_services // [] }
         && $property->{parent_property} )
     {
         $uprn = $property->{parent_property}{uprn};
-        $site_services = $self->whitespace->GetSiteCollections($uprn);
+        $site_services = $self->fetch_whitespace_data('GetSiteCollections', $uprn);
 
         # A property is only communal if it has a parent property AND doesn't
         # have its own list of services

--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -61,11 +61,14 @@ sub fetch_whitespace_data {
 
     my $c = $self->{c};
 
+    my $async = $c->action eq 'waste/bin_days'
+        && $c->req->method eq 'GET';
+
     my $data = $self->whitespace->call_api(
         $c,
         "bexley",
         "bin_days_page:$uprn",
-        0,
+        $async,
         GetSiteInfo        => [$uprn],
         GetSiteCollections => [$uprn],
     );

--- a/perllib/Integrations/Whitespace.pm
+++ b/perllib/Integrations/Whitespace.pm
@@ -203,16 +203,6 @@ sub GetSiteIncidents {
     return $res->{RoundIncidents}->{RoundIncidents};
 }
 
-sub GetSiteContracts {
-    my ($self, $uprn) = @_;
-
-    my $res = $self->call('GetSiteContracts', sitecontractInput => ixhash( Uprn => $uprn ));
-
-    my $contracts = force_arrayref($res->{SiteContracts}, 'SiteContract');
-
-    return $contracts;
-}
-
 sub GetFullWorksheetDetails {
     my ( $self, $ws_id ) = @_;
 

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -337,8 +337,26 @@ FixMyStreet::override_config {
         subtest 'service_sort sorts correctly' => sub {
             my $cobrand = FixMyStreet::Cobrand::Bexley->new;
             $cobrand->{c} = Test::MockObject->new;
-            $cobrand->{c}->mock( stash => sub { {} } );
+
+            my %session_hash;
+            $cobrand->{c}->mock( session => sub { \%session_hash } );
+            $cobrand->{c}->mock( waste_cache_set => sub {
+                Catalyst::Plugin::FixMyStreet::Session::WasteCache::waste_cache_set(@_);
+            });
+
+            my $log = Test::MockObject->new;
+            $log->mock( info => sub {} );
+            $cobrand->{c}->mock( log => sub { $log } );
+
+            $cobrand->{c}->mock( stash => sub { {
+                whitespace_data => {
+                    'GetSiteCollections 10001' => _site_collections()->{10001},
+                    'GetSiteInfo 10001' => _site_info()->{10001},
+                },
+            } } );
+
             $cobrand->{c}->mock( cobrand => sub { $cobrand });
+
             my @sorted = $cobrand->service_sort(
                 @{  $cobrand->bin_services_for_address(
                         { uprn => 10001, usrn => 321 }


### PR DESCRIPTION
To speed up the loading of a bin days page this changes some of the Whitespace API calls to be made in parallel, and then cached.

Closes https://github.com/mysociety/societyworks/issues/4384

[skip changelog]

## Todo

- [ ] How long are things cached for?
- [x] Should we be cacheing worksheet lookups? Might want those to be up-to-date
- [x] Tests not passing

<!-- [skip changelog] -->
