### PR TITLE
[Merton] Send through all payment details

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Merton.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton.pm
@@ -118,6 +118,13 @@ sub open311_extra_data_include {
             my $ids = join('::', @ids);
             $row->update_extra_field({ name => 'Bulky_Collection_Bulky_Items', value => $ids });
             push @$open311_only, { name => 'Current_Item_Count', value => scalar @ids };
+
+            if (my $previous = $row->get_extra_metadata('previous_booking_id')) {
+                $previous = FixMyStreet::DB->resultset("Problem")->find($previous);
+                push @$open311_only, { name => 'previous_booking_id', value => $previous->id };
+                my $echo_id = $previous->get_extra_field_value('echo_id');
+                push @$open311_only, { name => 'previous_echo_id', value => $echo_id };
+            }
         }
         # Do not want to send multiple Action/Reason codes
         foreach (qw(Action Reason)) {

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -1572,6 +1572,7 @@ sub waste_confirm_payment {
     }
 
     if ($already_confirmed) {
+        $self->discard_changes;
         $self->bulky_add_payment_confirmation_update($reference);
     }
 
@@ -1596,9 +1597,14 @@ sub bulky_add_payment_confirmation_update {
     } else {
         $reference_text .= $reference;
     }
+    my $payments = $cobrand->get_all_payments($self);
+    $payments = join('|', map { "$_->{ref}|$_->{amount}" } @$payments);
     my $comment = $self->add_to_comments({
         text => "Payment confirmed, $reference_text, amount £$payment",
         user => $cobrand->body->comment_user || $self->user,
+        extra => {
+            fms_extra_payments => $payments,
+        }
     });
     $self->cancel_update_alert($comment->id);
 }

--- a/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
@@ -244,6 +244,30 @@ sub get_total_paid {
     return $total;
 }
 
+=head2 get_all_payments
+
+Recursively locate the payments made.
+
+=cut
+
+sub get_all_payments {
+    my ($self, $p, $refs) = @_;
+
+    return $refs unless $p;
+
+    my $payment = $p->get_extra_field_value('payment') || 0;
+    $payment = sprintf( '%.2f', $payment / 100 );
+    my $ref = $p->get_extra_metadata('chequeReference') || $p->get_extra_metadata('payment_reference') || '';
+    push @$refs, { ref => $ref, amount => $payment };
+
+    if (my $previous_id = $p->get_extra_metadata('previous_booking_id')) {
+        my $previous = FixMyStreet::DB->schema->resultset('Problem')->find($previous_id);
+        $self->get_all_payments($previous, $refs)
+    }
+
+    return $refs;
+}
+
 sub find_unconfirmed_bulky_collections {
     my ( $self, $uprn ) = @_;
 

--- a/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
@@ -210,7 +210,7 @@ sub bulky_total_cost {
     my $previous = $c->stash->{amending_booking};
     my $already_paid;
     if ($previous && $c->stash->{payment}) {
-        $already_paid = get_total_paid($previous);
+        $already_paid = $self->get_total_paid($previous);
         my $new_cost = $c->stash->{payment} - $already_paid;
         # no refunds if they've already paid more than the new booking would cost
         $c->stash->{payment} = max(0, $new_cost);
@@ -229,7 +229,7 @@ versions of it.
 =cut
 
 sub get_total_paid {
-    my $previous = shift;
+    my ($self, $previous) = @_;
 
     return 0 unless $previous;
 
@@ -238,7 +238,7 @@ sub get_total_paid {
     if ($previous->get_extra_metadata('previous_booking_id')) {
         my $previous_id = $previous->get_extra_metadata('previous_booking_id');
         my $previous_report = FixMyStreet::DB->schema->resultset('Problem')->find($previous_id);
-        $total += get_total_paid($previous_report);
+        $total += $self->get_total_paid($previous_report);
     }
 
     return $total;

--- a/perllib/FixMyStreet/Script/Merton/SendWaste.pm
+++ b/perllib/FixMyStreet/Script/Merton/SendWaste.pm
@@ -106,12 +106,15 @@ sub set_echo_id {
         my $event = $echo->GetEvent($problem->external_id);
         return unless $event && $event->{Id};
 
-        my $row2 = FixMyStreet::DB->resultset('Problem')->search({ id => $problem->id }, { for => \'UPDATE' })->single;
-        $row2->update_extra_field({
-            name => 'echo_id',
-            value => $event->{Id},
+        my $db = FixMyStreet::DB->schema->storage;
+        $db->txn_do(sub {
+            my $row2 = FixMyStreet::DB->resultset('Problem')->search({ id => $problem->id }, { for => \'UPDATE' })->single;
+            $row2->update_extra_field({
+                name => 'echo_id',
+                value => $event->{Id},
+            });
+            $row2->update;
         });
-        $row2->update;
     }
 
     return 1;

--- a/t/app/controller/waste_merton_bulky.t
+++ b/t/app/controller/waste_merton_bulky.t
@@ -386,6 +386,7 @@ FixMyStreet::override_config {
             my $update = $new_report->comments->first;
             is $update->state, 'confirmed';
             is $update->text, 'Payment confirmed, reference 54321, amount £37.00';
+            is $update->get_extra_metadata('fms_extra_payments'), '54321|37.00';
             FixMyStreet::Script::Alerts::send_updates();
             $mech->email_count_is(0);
 
@@ -655,6 +656,7 @@ FixMyStreet::override_config {
             is $new_report->comments->count, 1; # Payment confirmed update
             my $comment = $new_report->comments->first;
             is $comment->text, 'Payment confirmed, reference 54321, amount £0.00';
+            is $comment->get_extra_metadata('fms_extra_payments'), '54321|0.00|54321|37.00';
             FixMyStreet::Script::Alerts::send_updates();
             $mech->email_count_is(0);
 
@@ -781,6 +783,7 @@ FixMyStreet::override_config {
             my $update = $new_report->comments->first;
             is $update->state, 'confirmed';
             is $update->text, 'Payment confirmed, reference 54321, amount £23.75';
+            is $update->get_extra_metadata('fms_extra_payments'), '54321|23.75|6789|0.00|54321|37.00';
             FixMyStreet::Script::Alerts::send_updates();
             $mech->email_count_is(0); # No cancellation update
             $mech->clear_emails_ok;

--- a/t/app/controller/waste_merton_bulky.t
+++ b/t/app/controller/waste_merton_bulky.t
@@ -1051,6 +1051,10 @@ FixMyStreet::override_config {
     #     is $report->get_extra_field_value('payment_method'), 'cheque';
     # }
     #
+
+    $report->update_extra_field({ name => 'echo_id', value => 'EchoID' });
+    $report->update;
+    my $previous_id = $report->id;
     subtest 'Test sending of bulky report to other endpoint' => sub {
         use_ok 'FixMyStreet::Script::Merton::SendWaste';
 
@@ -1072,6 +1076,7 @@ FixMyStreet::override_config {
             dt => $dt,
         });
         $report->update_extra_field({ name => 'Bulky_Collection_Bulky_Items', value => '3::83::3' });
+        $report->set_extra_metadata(previous_booking_id => $previous_id);
         $report->set_extra_metadata( item_1 => 'BBQ', item_2 => 'Bath', item_3 => 'BBQ' );
         $report->update;
 
@@ -1086,6 +1091,9 @@ FixMyStreet::override_config {
         is $cgi->param('api_key'), 'api_key';
         is $cgi->param('attribute[Bulky_Collection_Bulky_Items]'), 'BBQ::Bath::BBQ';
         is $cgi->param('attribute[Current_Item_Count]'), 3;
+        is $cgi->param('attribute[previous_booking_id]'), $previous_id;
+        is $cgi->param('attribute[previous_echo_id]'), 'EchoID';
+
         $report->discard_changes;
         is $report->get_extra_metadata('sent_to_crimson'), 1;
         is $report->get_extra_metadata('crimson_external_id'), "359";

--- a/t/app/controller/waste_merton_bulky.t
+++ b/t/app/controller/waste_merton_bulky.t
@@ -695,6 +695,7 @@ FixMyStreet::override_config {
             $mech->get_ok($path);
             $mech->content_lacks('This collection has been cancelled');
             $mech->content_lacks('Booking cancelled by customer');
+            $mech->content_contains('£0.00 (£37.00 already paid)');
         };
 
         $report->set_extra_metadata('payment_reference' => '6789'); # So will be changed
@@ -798,6 +799,7 @@ FixMyStreet::override_config {
             $mech->content_contains('Updates');
             $mech->content_contains('This collection has been cancelled');
             $mech->content_contains('Booking cancelled due to amendment');
+            $mech->content_contains('£0.00 (£37.00 already paid)');
             $report->discard_changes;
             is $report->state, 'cancelled';
         };
@@ -823,6 +825,7 @@ FixMyStreet::override_config {
             $mech->get_ok($path);
             $mech->content_lacks('This collection has been cancelled');
             $mech->content_lacks('Booking cancelled by customer');
+            $mech->content_contains('£23.75 (£37.00 already paid)');
         };
     };
 

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -163,13 +163,14 @@ SET data = form.saved_data;
       [% IF c.cobrand.moniker != 'brent' %]
       <dl>
         <dt>Price</dt>
-        [% IF problem %]
-            [% payment = problem.get_extra_field_value('payment') OR 0 %]
-        [% ELSE %]
-            [% payments = cobrand.bulky_total_cost(data);
+        [% IF problem;
+            payment = problem.get_extra_field_value('payment') OR 0;
+            already_paid = cobrand.get_total_paid(problem) - payment;
+        ELSE;
+            payments = cobrand.bulky_total_cost(data);
             payment = payments.amount;
-            already_paid = payments.already_paid; %]
-        [% END %]
+            already_paid = payments.already_paid;
+        END %]
         <dd>£[% pounds(payment / 100) %] [% IF already_paid ~%]
                 (£[% pounds(already_paid / 100) %] already paid)
             [%~ END %]


### PR DESCRIPTION
[skip changelog]
If we're confirming payment by an update (SLWP), store the payment as extra data on the update, so that it'll be sent through to the backend. Also store *all* payments, so for amendments the full history is sent through with the amended new booking.