### PR TITLE
[Surrey] Remove category and subcategory on received reports

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Surrey.pm
+++ b/perllib/FixMyStreet/Cobrand/Surrey.pm
@@ -262,18 +262,4 @@ sub open311_pre_send {
     $row->set_extra_fields( @$extra ) if @$extra;
 }
 
-=head2 open311_contacts_for_fetched_report
-
-Surrey matches category based on category name, not service code.
-
-=cut
-
-sub open311_contacts_for_fetched_report {
-    my ($self, $request, $contacts) = @_;
-
-    my @contacts = grep { $request->{service_name} eq $_->category } $contacts->all;
-
-    return @contacts;
-}
-
 1;

--- a/perllib/Open311/GetServiceRequests.pm
+++ b/perllib/Open311/GetServiceRequests.pm
@@ -176,13 +176,7 @@ sub create_problems {
             $request->{description} = $filtered if defined $filtered;
         }
 
-        my @contacts = do {
-            if ( $cobrand && $cobrand->can('open311_contacts_for_fetched_report') ) {
-                $cobrand->call_hook('open311_contacts_for_fetched_report', $request, $contacts);
-            } else {
-                grep { $request->{service_code} eq $_->email } $contacts->all;
-            }
-        };
+        my @contacts = grep { $request->{service_code} eq $_->email } $contacts->all;
         my $contact = $contacts[0] ? $contacts[0]->category : 'Other';
 
         my $state = $open311->map_state($request->{status});


### PR DESCRIPTION
Stop receiving category/subcategory as no longer sent

https://3.basecamp.com/4020879/buckets/36546415/todos/7648793252#__recording_7674131654 https://mysociety.slack.com/archives/C06SKSH5KQT/p1722624461300599?thread_ts=1722616474.424329&cid=C06SKSH5KQT

