### PR TITLE
[Surrey] Remove council id from site and emails

### DIFF
--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -959,7 +959,7 @@ Note: this only makes sense when called on a problem that has been sent!
 
 sub can_display_external_id {
     my $self = shift;
-    if ( $self->external_id && $self->to_body_named('Lincolnshire|Isle of Wight|East Sussex|Central Bedfordshire|Shropshire|Merton|Surrey County') ) {
+    if ( $self->external_id && $self->to_body_named('Lincolnshire|Isle of Wight|East Sussex|Central Bedfordshire|Shropshire|Merton') ) {
         return 1;
     }
     return 0;

--- a/templates/email/surrey/_council_reference.html
+++ b/templates/email/surrey/_council_reference.html
@@ -1,4 +1,0 @@
-[% IF problem.external_id ~%]
-<p style="[% p_style %]">The report's reference number is <strong>[% problem.external_id %]</strong>.
-  Please quote this if you need to contact the council about this report.</p>
-[%~ END %]

--- a/templates/email/surrey/_council_reference.txt
+++ b/templates/email/surrey/_council_reference.txt
@@ -1,2 +1,0 @@
-[% IF problem.external_id %]The report's reference number is [% problem.external_id %]. Please quote this if
-you need to contact the council about this report.[% END %]

--- a/templates/email/surrey/_council_reference_alert_update.html
+++ b/templates/email/surrey/_council_reference_alert_update.html
@@ -1,1 +1,0 @@
-_council_reference.html

--- a/templates/email/surrey/_council_reference_alert_update.txt
+++ b/templates/email/surrey/_council_reference_alert_update.txt
@@ -1,1 +1,0 @@
-_council_reference.txt

--- a/templates/web/base/report/_council_sent_info.html
+++ b/templates/web/base/report/_council_sent_info.html
@@ -36,7 +36,7 @@
             [%- END -%]
         [%- ELSIF c.cobrand.moniker == 'nottinghamshirepolice' %]
         [%- ELSIF c.cobrand.moniker == 'surrey' %]
-            [% # don't display anything until report is sent to Surrey %]
+            [% # don't display anything - problem.can_display_external_id not set so external id will not show either %]
         [%- ELSIF problem.cobrand_data == 'waste' %]
             [%- tprintf('WasteWorks ref:&nbsp;%s', problem.id) %].
         [%- ELSE %]


### PR DESCRIPTION
Surrey don't want to show their backend ids to anybody so remove those from the email and site

https://3.basecamp.com/4020879/buckets/36546415/todos/7611442254#__recording_7688243427
