### PR TITLE
Improved focus state for img nested inside alerts-rss-link

### DIFF
--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2896,6 +2896,17 @@ a#geolocate_link {
     margin-#{$left}: 0.5em;
     float: $right;
   }
+
+  &:focus {
+    outline: none;
+    img {
+      outline: 0.1rem solid $button-primary-focus-bg-top;
+      outline-offset: 0.1rem;
+      -webkit-box-shadow: 0px 0px 0px 5px #000;
+      -moz-box-shadow: 0px 0px 0px 5px #000;
+      box-shadow: 0px 0px 0px 5px #000;
+    }
+  }
 }
 
 .alerts__nearby-activity {


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4481

Added outline and box-shadow. This change should make more obvious that the element `.alerts-rss-link` is being focused.

<img width="453" alt="Screenshot 2024-08-14 at 08 09 21" src="https://github.com/user-attachments/assets/7403686a-8666-402f-9e90-281a9e654aa8">

[skip changelog]
