### PR TITLE
Improved focus state for map buttons

### DIFF
--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1958,6 +1958,13 @@ html.js #map .noscript {
   filter: none !important; // Override OpenLayers PNG handling of the navigation
   background-color: #222222;
   color: transparent !important;
+
+  &:focus {
+    background-color: #222; // In case there is rule in a cobrand overriding the background of links.
+    filter: invert(1) !important; // See filter rule for the default state.
+    outline: 2px solid #fff;
+    outline-offset: -2px;
+  }
 }
 
 #ns_fms_pan_zoom_panup,
@@ -2105,6 +2112,14 @@ html.js #map .noscript {
       white-space: nowrap;
     }
   }
+
+  a:focus {
+    background-color: #222; // In case there is rule in a cobrand overriding the background of links.
+    filter: invert(1);
+    outline: 2px solid #fff;
+    outline-offset: -2px;
+  }
+
 
   .map-layer-toggle {
     @include svg-background-image("/cobrands/fixmystreet/images/map-layer-aerial");


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4482

This includes the following buttons:
-Up, down, left, right
-Zoom in and Zoom out
-aerial
-re-centre

This PR tackles any cobrand where rules changing the colour of `a:focus` were generating a contrast issue, for example Chesire East and Surrey.

Important: When this PR is approved we should add it in `commercial-staging` and `Surrey-cobrand`

<img width="186" alt="Screenshot 2024-08-14 at 09 01 36" src="https://github.com/user-attachments/assets/02c99acd-f7b5-4d7b-9ab9-028ea55187fe">

[skip changelog]
