### PR TITLE
Added max-width to govuk-select class

### DIFF
--- a/web/cobrands/sass/_dashboard.scss
+++ b/web/cobrands/sass/_dashboard.scss
@@ -297,8 +297,7 @@
 
 .dashboard-filters {
     .multi-select-button {
-        height: 28px;
-        line-height: 100%;
+        max-width: 10em;
     }
 }
 

--- a/web/cobrands/sass/_dashboard.scss
+++ b/web/cobrands/sass/_dashboard.scss
@@ -299,6 +299,11 @@
     .multi-select-button {
         max-width: 10em;
     }
+
+    .form-control {
+        // To make them have the same height as the .multi-select-button
+        height: 3.3em;
+    }
 }
 
 .dashboard-options-tabs {

--- a/web/cobrands/sass/_govuk.scss
+++ b/web/cobrands/sass/_govuk.scss
@@ -15,9 +15,11 @@
 }
 
 .govuk-select {
+  // This class also affects .multi-select-button
   font-family: $body-font;
   font-size: 0.875rem;
   line-height: 150%;
+  padding: flip(0.4em 1.5em 0.4em 0.6em, 0.4em 0.6em 0.4em 1.5em);
   @media (min-width: 48em) {
     font-size: 1rem;
   }

--- a/web/cobrands/sass/_report_list.scss
+++ b/web/cobrands/sass/_report_list.scss
@@ -67,7 +67,6 @@ $govuk-input-focus-box-shadow: #fd0 !default;
 
   .multi-select-button {
     box-sizing: border-box;
-    padding: flip(0.4em 1.5em 0.4em 0.6em, 0.4em 0.6em 0.4em 1.5em);
     vertical-align: top;
   }
 


### PR DESCRIPTION
**Fixes:**
The multi-select has lost its maximum width at some point so e.g. if you’re on the dashboard for a council and pick a number of different wards, see how it gets bigger and bigger (or on a body admin page if you pick a number of areas to cover, etc)
![Screenshot 2024-08-14 at 22 34 13](https://github.com/user-attachments/assets/b3307d4c-88e0-4d6c-a856-922c843fb5bd)

**Preview**
This PR adds `max-width` to  the class `.govuk-select` 

https://github.com/user-attachments/assets/58239b8c-2fa9-4834-8e90-71f2bbf8c5b8

