### PR TITLE
[Brent] Check for 3rd contamination event.

### DIFF
--- a/perllib/FixMyStreet/App/Form/Waste/Request/Brent.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Request/Brent.pm
@@ -55,8 +55,7 @@ has_page replacement => (
 
         return 'about_you' if $choice == $CONTAINER_CLEAR_SACK;
         return 'how_long_lived' if $reason eq 'new_build';
-        return 'request_extra_refusal' if $reason eq 'extra' && $data->{ordered_previously};
-        # return 'request_extra_refusal' if $reason eq 'extra' && $data->{contamination_reports} >= 3;
+        return 'request_extra_refusal' if $reason eq 'extra' && ($data->{ordered_previously} || $data->{contamination_reports});
         return 'about_you';
     },
 );
@@ -86,33 +85,14 @@ has_field request_reason => (
         return unless $months;
 
         my $events = $echo->GetEventsForObject(PointAddress => $c->stash->{property}{id}, 2936, $months);
-        $events = $c->cobrand->_parse_events($events, { include_closed_requests => 1 });
+        $events = $c->cobrand->_parse_events($events, { include_closed_events => 1 });
         $saved_data->{ordered_previously} = $events->{request}{$choice} ? 1 : 0;
 
         if ($value eq 'extra' || $value eq 'missing') {
-            my $services = $c->stash->{service_data};
-            my @tasks;
-            foreach (@$services) {
-                my $container = $_->{request_containers}->[0];
-                push @tasks, $_->{service_task_id} if $container == $choice;
-            }
-
-            # The below is not currently in use, FD-3672
-            # my $months = $refusal_contamination_months{$choice};
-            # my $end = DateTime->now->set_time_zone(FixMyStreet->local_time_zone)->truncate( to => 'day' );
-            # my $start = $end->clone->add(months => -$months);
-
-            # my $result = $echo->GetServiceTaskInstances($start, $end, @tasks);
-
-            # my $num = 0;
-            # foreach (@$result) {
-            #     my $task_id = $_->{ServiceTaskRef}{Value}{anyType};
-            #     my $tasks = Integrations::Echo::force_arrayref($_->{Instances}, 'ScheduledTaskInfo');
-            #     foreach (@$tasks) {
-            #         $num++ if ($_->{Resolution}||0) == 1148;
-            #     }
-            # }
-            # $saved_data->{contamination_reports} = $num;
+            my $months = $refusal_contamination_months{$choice};
+            my $events = $echo->GetEventsForObject(PointAddress => $c->stash->{property}{id}, 2923, $months);
+            $events = $c->cobrand->_parse_events($events, { include_closed_events => 1 });
+            $saved_data->{contamination_reports} = $events->{enquiry}{2923} ? 1 : 0;
         }
     },
 );

--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1374,7 +1374,7 @@ sub waste_munge_request_data {
 sub request_referral {
     my ($id, $data) = @_;
 
-    # return 1 if ($data->{contamination_reports} || 0) >= 3; # Will be present on missing only
+    return 1 if $data->{contamination_reports}; # Will be present on missing only
     return 1 if ($data->{how_long_lived} || '') eq '3more'; # Will be present on new build only
     return 1 if $data->{ordered_previously};
 }

--- a/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
@@ -395,8 +395,7 @@ sub _parse_events {
 
         # Only care about open requests/enquiries
         my $closed = $self->_closed_event($_);
-        next if $type eq 'request' && $closed && !$params->{include_closed_requests};
-        next if $type eq 'enquiry' && $closed;
+        next if ($type eq 'request' || $type eq 'enquiry') && $closed && !$params->{include_closed_events};
 
         if ($type eq 'request') {
             my $report = $self->problems->search({ external_id => $_->{Guid} })->first;

--- a/t/cobrand/brent.t
+++ b/t/cobrand/brent.t
@@ -1273,7 +1273,7 @@ FixMyStreet::override_config {
             is $report->get_extra_field_value('request_referral'), $referral;
             is $report->get_extra_field_value('request_how_long_lived'), $duration;
             is $report->get_extra_field_value('request_ordered_previously'), $test_name eq 'Ordered' ? 1 : '';
-            is $report->get_extra_field_value('request_contamination_reports'), $test_name eq 'Contaminated' ? 3 : '';
+            is $report->get_extra_field_value('request_contamination_reports'), $test_name eq 'Contaminated' ? 1 : '';
             FixMyStreet::Script::Reports::send();
             my @email = $mech->get_email;
             is @email, $emails;
@@ -1309,17 +1309,13 @@ FixMyStreet::override_config {
         make_request("Not ordered", 'missing', '', '', 1);
         make_request("Not ordered", 'extra', '', '', 1);
 
-        # $echo->mock('GetServiceTaskInstances', sub { [
-        #     { ServiceTaskRef => { Value => { anyType => '401' } },
-        #         Instances => { ScheduledTaskInfo => [
-        #             { Resolution => 1148, CurrentScheduledDate => { DateTime => '2020-07-01T00:00:00Z' } },
-        #             { Resolution => 1148, CurrentScheduledDate => { DateTime => '2020-07-01T00:00:00Z' } },
-        #             { Resolution => 1148, CurrentScheduledDate => { DateTime => '2020-07-01T00:00:00Z' } },
-        #         ] }
-        #     },
-        # ] });
-        # make_request("Contaminated", 'missing', '', 1, 2);
-        # make_request("Contaminated", 'extra', '', 'refuse');
+        $echo->mock('GetEventsForObject', sub { [ {
+            Guid => 'b-guid',
+            EventTypeId => 2923,
+            ResolvedDate => { DateTime => '2024-05-17T12:00:00Z' },
+        } ] } );
+        make_request("Contaminated", 'missing', '', 1, 2);
+        make_request("Contaminated", 'extra', '', 'refuse');
     };
 
     subtest 'test staff-only assisted collection form' => sub {


### PR DESCRIPTION
For FD-3672
Given info was: "With regards to your contamination events you would need to look for any properties that have had a 3rd, 4th or 5th contamination in the last X months. Use the GetEvents call with EventIDs: 2923, 2924 and 2925."
Am only checking for 3rd, as presumably that means they've had 3, so no need to check 4th/5th.
[skip changelog]