### PR TITLE
Added navigation links to footer

### DIFF
--- a/templates/web/bathnes/footer_extra.html
+++ b/templates/web/bathnes/footer_extra.html
@@ -24,3 +24,4 @@
         </div>
     </div>
 </footer>
+[% PROCESS '_footer_main_nav.html' %]

--- a/templates/web/bexley/footer_extra.html
+++ b/templates/web/bexley/footer_extra.html
@@ -1,1 +1,2 @@
+[% PROCESS '_footer_main_nav.html' %]
 [% PROCESS '_footer_extra_powered_by.html' %]

--- a/templates/web/brent/footer_extra.html
+++ b/templates/web/brent/footer_extra.html
@@ -98,5 +98,5 @@
     </div>
   </footer>
 </div>
-
+[% PROCESS '_footer_main_nav.html' %]
 [% PROCESS '_footer_extra_powered_by.html' %]

--- a/templates/web/bristol/footer_extra.html
+++ b/templates/web/bristol/footer_extra.html
@@ -58,3 +58,4 @@
 
     </footer>
 </div>
+[% PROCESS '_footer_main_nav.html' %]

--- a/templates/web/bromley/footer_extra.html
+++ b/templates/web/bromley/footer_extra.html
@@ -37,5 +37,5 @@
         </nav>
     </div>
 </footer>
-
+[% PROCESS '_footer_main_nav.html' %]
 [% PROCESS '_footer_extra_powered_by.html' %]

--- a/templates/web/camden/footer_extra.html
+++ b/templates/web/camden/footer_extra.html
@@ -22,3 +22,4 @@
     </div>
   </div>
 </footer>
+[% PROCESS '_footer_main_nav.html' %]

--- a/templates/web/cheshireeast/footer_extra.html
+++ b/templates/web/cheshireeast/footer_extra.html
@@ -6,6 +6,7 @@
         </ul>
     </div>
 </footer>
+[% PROCESS '_footer_main_nav.html' %]
 
 [% IF c.config.BASE_URL == "https://www.fixmystreet.com" %]
 <script src="https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js"></script>

--- a/templates/web/cyclinguk/footer_extra.html
+++ b/templates/web/cyclinguk/footer_extra.html
@@ -71,3 +71,4 @@
     </div>
   </div>
 </footer>
+[% PROCESS '_footer_main_nav.html' %]

--- a/templates/web/eastherts/footer_extra.html
+++ b/templates/web/eastherts/footer_extra.html
@@ -27,3 +27,4 @@
 
     </div>
 </footer>
+[% PROCESS '_footer_main_nav.html' %]

--- a/templates/web/fixamingata/footer_extra.html
+++ b/templates/web/fixamingata/footer_extra.html
@@ -66,3 +66,4 @@
         </div>
     </div>
 </div>
+[% PROCESS '_footer_main_nav.html' %]

--- a/templates/web/fixmystreet-uk-councils/_footer_main_nav.html
+++ b/templates/web/fixmystreet-uk-councils/_footer_main_nav.html
@@ -1,0 +1,5 @@
+<div class="footer-main-nav">
+    <div class="container">
+        [% INCLUDE 'main_nav.html' ul_class="nav-footer" omit_wrapper=1 %]
+    </div>
+</div>

--- a/templates/web/gloucestershire/footer_extra.html
+++ b/templates/web/gloucestershire/footer_extra.html
@@ -56,5 +56,5 @@
         </div>
     </div>
 </footer>
-
+[% PROCESS '_footer_main_nav.html' %]
 [% PROCESS '_footer_extra_powered_by.html' %]

--- a/templates/web/greenwich/footer_extra.html
+++ b/templates/web/greenwich/footer_extra.html
@@ -31,5 +31,5 @@
         </div>
     </div>
 </footer>
-
+[% PROCESS '_footer_main_nav.html' %]
 [% PROCESS '_footer_extra_powered_by.html' %]

--- a/templates/web/hackney/footer_extra.html
+++ b/templates/web/hackney/footer_extra.html
@@ -3,5 +3,5 @@
         <a href="https://hackney.gov.uk/" alt="Hackney.gov.uk" class="hackney-footer__logo">Hackney</a>
     </div>
 </div>
-
+[% PROCESS '_footer_main_nav.html' %]
 [% PROCESS '_footer_extra_powered_by.html' %]

--- a/templates/web/hart/footer_extra.html
+++ b/templates/web/hart/footer_extra.html
@@ -134,5 +134,5 @@
     </div>
   </div>
 </footer>
-
+[% PROCESS '_footer_main_nav.html' %]
 [% PROCESS '_footer_extra_powered_by.html' %]

--- a/templates/web/highwaysengland/footer_extra.html
+++ b/templates/web/highwaysengland/footer_extra.html
@@ -3,7 +3,7 @@
         <a href="https://highwaysengland.co.uk/" class="site-logo">National Highways</a>
     </div>
 </footer>
-
+[% PROCESS '_footer_main_nav.html' %]
 [% PROCESS '_footer_extra_powered_by.html' %]
 
 [% IF c.config.BASE_URL == "https://www.fixmystreet.com" %]

--- a/templates/web/kingston/footer_extra.html
+++ b/templates/web/kingston/footer_extra.html
@@ -19,5 +19,5 @@
         </ul>
     </nav>
 </footer>
-
+[% PROCESS '_footer_main_nav.html' %]
 [% PROCESS '_footer_extra_powered_by.html' %]

--- a/templates/web/merton/footer_extra.html
+++ b/templates/web/merton/footer_extra.html
@@ -14,3 +14,4 @@
         </span>
     </div>
 </div>
+[% PROCESS '_footer_main_nav.html' %]

--- a/templates/web/northamptonshire/footer_extra.html
+++ b/templates/web/northamptonshire/footer_extra.html
@@ -23,3 +23,4 @@
         </a></li>
     </ul>
 </div>
+[% PROCESS '_footer_main_nav.html' %]

--- a/templates/web/northnorthants/footer_extra.html
+++ b/templates/web/northnorthants/footer_extra.html
@@ -23,5 +23,5 @@
         </div>
     </div>
 </footer>
-
+[% PROCESS '_footer_main_nav.html' %]
 [% PROCESS '_footer_extra_powered_by.html' %]

--- a/templates/web/northumberland/footer_extra.html
+++ b/templates/web/northumberland/footer_extra.html
@@ -37,5 +37,5 @@
         </div>
     </div>
 </footer>
-
+[% PROCESS '_footer_main_nav.html' %]
 [% PROCESS '_footer_extra_powered_by.html' %]

--- a/templates/web/nottinghamshirepolice/footer_extra.html
+++ b/templates/web/nottinghamshirepolice/footer_extra.html
@@ -126,3 +126,4 @@
       </p>
   </div>
 </div>
+[% PROCESS '_footer_main_nav.html' %]

--- a/templates/web/oxfordshire/footer_extra.html
+++ b/templates/web/oxfordshire/footer_extra.html
@@ -11,3 +11,4 @@
     </footer>
 
 </div> <!-- oxford-wrapper -->
+[% PROCESS '_footer_main_nav.html' %]

--- a/templates/web/peterborough/footer_extra.html
+++ b/templates/web/peterborough/footer_extra.html
@@ -37,6 +37,7 @@ may be contacted or blocked from using the site.
         </div>
     [% END %]
 </div>
+[% PROCESS '_footer_main_nav.html' %]
 
 [% IF c.config.BASE_URL == "https://www.fixmystreet.com" %]
 <script src="https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js" type="text/javascript"></script>

--- a/templates/web/rutland/footer_extra.html
+++ b/templates/web/rutland/footer_extra.html
@@ -1,1 +1,2 @@
+[% PROCESS '_footer_main_nav.html' %]
 [% PROCESS '_footer_extra_powered_by.html' %]

--- a/templates/web/shropshire/footer_extra.html
+++ b/templates/web/shropshire/footer_extra.html
@@ -48,5 +48,5 @@
         <small class="copy">© Shropshire Council 2022. Made in Shropshire by <a href="https://shropshire.gov.uk/projectwip" title="Project WIP homepage">Project WIP</a>.</small>
     </div>
 </div>
-
+[% PROCESS '_footer_main_nav.html' %]
 [% PROCESS '_footer_extra_powered_by.html' %]

--- a/templates/web/southwark/footer_extra.html
+++ b/templates/web/southwark/footer_extra.html
@@ -47,3 +47,4 @@
     </div>
   </div>
 </footer>
+[% PROCESS '_footer_main_nav.html' %]

--- a/templates/web/sutton/footer_extra.html
+++ b/templates/web/sutton/footer_extra.html
@@ -132,5 +132,5 @@
       </div>
     </div>
   </footer>
-
+[% PROCESS '_footer_main_nav.html' %]
 [% PROCESS '_footer_extra_powered_by.html' %]

--- a/templates/web/tfl/footer_extra.html
+++ b/templates/web/tfl/footer_extra.html
@@ -8,4 +8,4 @@
     </div>
   </div>
 </div>
-
+[% PROCESS '_footer_main_nav.html' %]

--- a/templates/web/thamesmead/footer_extra.html
+++ b/templates/web/thamesmead/footer_extra.html
@@ -7,5 +7,5 @@
         </ul>
     </div>
 </div>
-
+[% PROCESS '_footer_main_nav.html' %]
 [% PROCESS '_footer_extra_powered_by.html' %]

--- a/templates/web/westminster/footer_extra.html
+++ b/templates/web/westminster/footer_extra.html
@@ -39,3 +39,4 @@
   </div>
 
 </footer>
+[% PROCESS '_footer_main_nav.html' %]

--- a/templates/web/westnorthants/footer_extra.html
+++ b/templates/web/westnorthants/footer_extra.html
@@ -20,5 +20,5 @@
         </div>
     </div>
 </footer>
-
+[% PROCESS '_footer_main_nav.html' %]
 [% PROCESS '_footer_extra_powered_by.html' %]

--- a/web/cobrands/fixmystreet-uk-councils/_societyworks-footer.scss
+++ b/web/cobrands/fixmystreet-uk-councils/_societyworks-footer.scss
@@ -11,6 +11,7 @@ $societyworks-footer-logo-vertical-align: -7px !default;
     background: $societyworks-footer-background;
     box-shadow: 0 1000px 0 1000px $societyworks-footer-background;
     color: $societyworks-footer-color;
+    text-align: center;
 
     p {
         margin: 0;

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -60,6 +60,11 @@ $geolocation-link: #222 !default;
 $geolocation-link-border: $geolocation-link !default;
 $geolocation-link-background-color: transparent !default;
 
+$footer-main-nav-font-size: 1rem !default;
+$footer-main-nav-padding: 2em 0 !default;
+$footer-main-nav-background: #2E3033 !default;
+$footer-main-nav-color: #fff !default;
+
 @import "_mixins";
 @import "_report_list";
 
@@ -1075,6 +1080,34 @@ footer {
         font-size: 0.75em;
         margin-bottom: 0;
       }
+    }
+  }
+}
+
+.footer-main-nav {
+  padding: $footer-main-nav-padding;
+  background-color: $footer-main-nav-background;
+  .nav-footer {
+    display: flex;
+    column-gap: 2rem;
+    row-gap: 1rem;
+    font-size: $footer-main-nav-font-size;
+    justify-content: center;
+    margin: 0;
+    flex-wrap: wrap;
+  
+    li {
+        list-style: none;
+        margin-bottom: 0;
+    }
+
+    a {
+        color: $footer-main-nav-color;
+  
+        &:focus {
+            background-color: #ffff00;
+            color: #000;
+        }
     }
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4486

Adding navigation links to footer. With this PR we would be complying with [WCAG 2.4.5: Multiple Ways](https://www.w3.org/WAI/WCAG22/Understanding/multiple-ways), so users can access webpages using a different method that is not the navigation bar at the top.

### Desktop
<img width="1002" alt="Screenshot 2024-08-15 at 14 46 54" src="https://github.com/user-attachments/assets/5a82f364-d033-45ef-96b7-a5d04940cdb6">


### Mobile
<img width="690" alt="Screenshot 2024-08-15 at 14 48 54" src="https://github.com/user-attachments/assets/a6fd228d-f91e-4df5-9514-3458d619874d">


[Skip changelog]
