### PR TITLE
Added text-indent property to pan_zoom map buttons

### DIFF
--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1958,6 +1958,7 @@ html.js #map .noscript {
   filter: none !important; // Override OpenLayers PNG handling of the navigation
   background-color: #222222;
   color: transparent !important;
+  text-indent: -9999px; // This prevent the odd extra rectangles when the button is being focused. Screen readers still announce the content.
 
   &:focus {
     background-color: #222; // In case there is rule in a cobrand overriding the background of links.


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4487

This PR prevents the odd extra rectangles when focusing one of the `pan_zoom` buttons

### Preview
https://github.com/user-attachments/assets/caf46fcd-75cb-4655-8752-9d18e8b23b1c


[Skip changelog]