### PR TITLE
Added tabindex to .js-recentre-map element

### DIFF
--- a/templates/web/base/maps/openlayers.html
+++ b/templates/web/base/maps/openlayers.html
@@ -73,7 +73,7 @@
     [% ELSE %]
       <a class="map-pins-toggle" rel="nofollow" href="[% c.uri_with( { no_pins => 1 } ) %]"><span class="map-link-label">[% loc('Hide pins') %]</span></a>
     [% END %]
-    <a class="js-recentre-map hidden-nojs">
+    <a class="js-recentre-map hidden-nojs" tabindex="0">
       <span class="map-link-label">[% loc('Re-centre map') %]</span>
     </a>
   [% END %]


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4488

Currently `.js-recentre-map` is the only control element in the map that can't be focused. By adding a `tabindex="0"` we allow keyboard users to be able to use that element.

Preview here:

https://github.com/user-attachments/assets/4efb1a2b-d266-4915-bf83-fcc6c77bf82a


[Skip changelog]