### PR TITLE
Hide span.report-a-problem button

### DIFF
--- a/templates/web/base/navigation/_report.html
+++ b/templates/web/base/navigation/_report.html
@@ -14,6 +14,6 @@
     [% END  %]
 [%~ ELSIF homepage_template ~%]
     [%~ INCLUDE navitem uri='/report' label=loc('Report a problem') attrs='class="report-a-problem-btn"' ~%]
-[%~ ELSE ~%]
+[%~ ELSIF c.req.uri.path != '/'  ~%]
     [%~ INCLUDE navitem uri='/' label=loc('Report a problem') attrs='class="report-a-problem-btn"' ~%]
 [%~ END ~%]

--- a/web/cobrands/bexley/layout.scss
+++ b/web/cobrands/bexley/layout.scss
@@ -33,7 +33,6 @@
         }
     }
     a.report-a-problem-btn,
-    span.report-a-problem-btn,
     span {
         background-color: $nav_hover_background_colour;
         color: $text_black;

--- a/web/cobrands/borsetshire/layout.scss
+++ b/web/cobrands/borsetshire/layout.scss
@@ -27,7 +27,7 @@
         color: $nav_colour;
     }
 
-    span, span:hover, span.report-a-problem-btn:hover {
+    span, span:hover {
         color: $color-societyworks-pink;
     }
 

--- a/web/cobrands/bromley/layout.scss
+++ b/web/cobrands/bromley/layout.scss
@@ -72,15 +72,6 @@ body.fullwidthpage, body.twothirdswidthpage, body.authpage, body.waste {
     }
   }
 
-  span.report-a-problem-btn {
-    cursor:auto;
-    border-radius: 0.25em;
-    &:hover, &:focus {
-      color: $nav_colour !important;
-      background-color: $nav_hover_background_colour !important;
-    }
-  }
-
   span {
     color: $nav_colour;
     background-color: $nav_hover_background_colour;

--- a/web/cobrands/cyclinguk/base.scss
+++ b/web/cobrands/cyclinguk/base.scss
@@ -46,10 +46,6 @@ $site-logo-height: 76px;
 .nav-menu--main {
     text-align: right;
 
-    span.report-a-problem-btn {
-        display: none;
-    }
-
     li {
         background: $white;
     }

--- a/web/cobrands/eastherts/layout.scss
+++ b/web/cobrands/eastherts/layout.scss
@@ -63,8 +63,7 @@
         font-size: 1em;
     }
 
-    span,
-    span.report-a-problem-btn {
+    span {
         cursor: default;
     }
 
@@ -75,8 +74,7 @@
         text-decoration: underline;
     }
 
-    a.report-a-problem-btn,
-    span.report-a-problem-btn {
+    a.report-a-problem-btn {
         padding: 0.75em;
         margin: 0;
         color: $eh_green;

--- a/web/cobrands/fixamingata/layout.scss
+++ b/web/cobrands/fixamingata/layout.scss
@@ -129,9 +129,7 @@ body.mappage {
     	 color: $primary_text;
     	 font-weight: bold;
     }
-    span.report-a-problem-btn {
-	display: none;
-    }
+
     a.report-a-problem-btn {
 	display: none;
     }

--- a/web/cobrands/gloucestershire/layout.scss
+++ b/web/cobrands/gloucestershire/layout.scss
@@ -30,8 +30,7 @@
     }
   }
 
-  span,
-  span.report-a-problem-btn {
+  span {
     text-decoration: underline;
     &:hover {
       color: $nav_colour;

--- a/web/cobrands/hart/base.scss
+++ b/web/cobrands/hart/base.scss
@@ -69,8 +69,7 @@
     padding-bottom: 1em;
 
     a,
-    span,
-    span.report-a-problem-btn {
+    span {
 
         font-size: 18px;
         text-decoration: none;
@@ -93,8 +92,7 @@
 
     :first-child {
         a,
-        span,
-        span.report-a-problem-btn {
+        span {
             margin-top: 0;
         }
     }
@@ -103,10 +101,6 @@
         a, span{
             border-bottom: 0;
         }
-    }
-
-    span.report-a-problem-btn {
-        cursor: pointer;
     }
 }
 

--- a/web/cobrands/hart/layout.scss
+++ b/web/cobrands/hart/layout.scss
@@ -10,8 +10,7 @@
     padding-bottom: 0;
     a,
     span,
-    a.report-a-problem-btn,
-    span.report-a-problem-btn {
+    a.report-a-problem-btn {
         line-height: 1em;
         font-size: 18px;
         cursor: pointer;
@@ -20,7 +19,7 @@
         margin-left: 0.5em;
     }
 
-    span.report-a-problem-btn, span {
+    span {
         background-color: $primary_b;
         color: $nav_colour;
 
@@ -33,8 +32,7 @@
 
     :first-child {
         a,
-        span,
-        span.report-a-problem-btn {
+        span {
             margin-top: 1em;
         }
     }

--- a/web/cobrands/highwaysengland/layout.scss
+++ b/web/cobrands/highwaysengland/layout.scss
@@ -39,11 +39,6 @@
             background-color: transparent;
         }
     }
-
-    span.report-a-problem-btn,
-    span.report-a-problem-btn:hover {
-        color: $nav_colour;
-    }
 }
 
 div.form-error,

--- a/web/cobrands/kingston/layout.scss
+++ b/web/cobrands/kingston/layout.scss
@@ -32,8 +32,7 @@
     }
 
     a,
-    span,
-    span.report-a-problem-btn {
+    span {
         padding: 0.5em 0.75em;
         font-size: 18px;
         font-weight: 700;

--- a/web/cobrands/northamptonshire/layout.scss
+++ b/web/cobrands/northamptonshire/layout.scss
@@ -43,11 +43,6 @@
     span {
         color: $nav_header_colour;
     }
-    span.report-a-problem-btn {
-        &:hover {
-            color: $nav_header_colour;
-        }
-    }
 }
 
 footer.northamptonshire {

--- a/web/cobrands/nottinghamshirepolice/layout.scss
+++ b/web/cobrands/nottinghamshirepolice/layout.scss
@@ -24,8 +24,7 @@
   padding: 1em;
 }
 
-.nav-menu--main span,
-.nav-menu--main span.report-a-problem-btn:hover {
+.nav-menu--main span {
   background-color: $blue-1000;
   color: $primary_text;
   text-decoration: none;

--- a/web/cobrands/peterborough/layout.scss
+++ b/web/cobrands/peterborough/layout.scss
@@ -60,13 +60,6 @@ body.mappage #site-header {
             color: #fff;
         }
     }
-    span.report-a-problem-btn {
-        &:hover,
-        &:active,
-        &:focus {
-            color: $primary_b;
-        }
-    }
 }
 
 .pboro-footer {

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -921,14 +921,6 @@ html.mobile.js-nav-open #js-menu-open-modal {
   span {
     background-color: mix(#fff, $primary, 70%);
   }
-  span.report-a-problem-btn {
-    cursor: pointer;
-  }
-  span.report-a-problem-btn:hover {
-    background-color: #333;
-    color: #fff;
-    text-decoration: none;
-  }
 }
 
 .shadow-wrap {

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -164,14 +164,6 @@ h1 {
   span {
     color:$primary;
   }
-  /* Stop mobile-only things */
-  span.report-a-problem-btn {
-    cursor: auto;
-  }
-  span.report-a-problem-btn:hover {
-    background-color: transparent;
-    color: $primary;
-  }
 }
 
 // .content Is the white box

--- a/web/cobrands/shropshire/layout.scss
+++ b/web/cobrands/shropshire/layout.scss
@@ -25,8 +25,7 @@ body {
 
     a,
     span,
-    a.report-a-problem-btn,
-    span.report-a-problem-btn {
+    a.report-a-problem-btn {
         padding: 0.5em 0.4em;
         margin: 0 4px;
         border-radius: 4px;
@@ -53,8 +52,7 @@ body {
     }
 
     // darken background for selected nav item
-    span,
-    span.report-a-problem-btn {
+    span {
         &, &:hover {
             background-color: $nav_hover_background_colour;
         }

--- a/web/cobrands/sutton/layout.scss
+++ b/web/cobrands/sutton/layout.scss
@@ -28,8 +28,7 @@ body {
 
     a,
     span,
-    a.report-a-problem-btn,
-    span.report-a-problem-btn {
+    a.report-a-problem-btn {
         padding: 0.5em 0.75em;
         font-size: 18px;
         font-weight: 700;
@@ -50,8 +49,7 @@ body {
     }
 
     // darken background for selected nav item
-    span,
-    span.report-a-problem-btn {
+    span {
         &, &:hover {
             background-color: $nav_hover_background_colour;
         }

--- a/web/cobrands/thamesmead/layout.scss
+++ b/web/cobrands/thamesmead/layout.scss
@@ -66,7 +66,7 @@ $mappage-navbar-height: 64px;
     }
 
     // Active state
-    span, span.report-a-problem-btn {
+    span {
         color: $peabody-brick-d1;
         background-color: $peabody-white;
         border-bottom: 1.5px solid $peabody-orange;
@@ -98,14 +98,6 @@ $mappage-navbar-height: 64px;
             text-decoration: underline;
         }
     }
-
-    // darken background for selected nav item
-    // span,
-    // span.report-a-problem-btn {
-    //     &, &:hover {
-    //         background-color: $nav_hover_background_colour;
-    //     }
-    // }
 
     // Add right border
     li {

--- a/web/cobrands/westminster/layout.scss
+++ b/web/cobrands/westminster/layout.scss
@@ -98,12 +98,6 @@ body.mappage {
         }
     }
 
-    // Make it look unclickable (because it is).
-    span.report-a-problem-btn:hover {
-        color: inherit;
-        cursor: default;
-    }
-
     // Make it not look like a button any more.
     a.report-a-problem-btn,
     a.report-a-problem-btn:hover {


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4490

Hiding this element, because users can't interact with it. It is also not very clear that is an active state to reflect that is the current page(homepage), but also the page where a user can start the process to report a problem.

The second commit is removing all the styling for `span.report-a-problem` from all cobrands.

[Skip changelog]
