### PR TITLE
Added word-break attribute to confirmation-header paragraph

### DIFF
--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -3011,6 +3011,7 @@ a#geolocate_link {
     color: #666666;
     font-size: 1.2em;
     margin-bottom: 0.5em;
+    word-break: break-word; // It prevents screen overflow when there is a long url, when a page has not been found.
   }
 
   & > :last-child {

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -903,6 +903,10 @@ textarea.form-error {
     text-align: $left;
     padding: flip(3em 0 3em 132px, 3em 132px 3em 0); // for tick icon
     background-position: $left 2em;
+
+    p {
+      word-break: normal;
+    }
 }
 
 // Offline reporting UI


### PR DESCRIPTION
Minor bug, but currently on mobile the not found page has some overflow if the url is longer than the screen.

https://github.com/user-attachments/assets/d3be1c4e-c5fe-4b97-ad56-864636af3577

Added `word-break` attribute to `p` elements nested inside `.confirmation-header`


### Preview here:

<img width="578" alt="Screenshot 2024-08-19 at 15 08 05" src="https://github.com/user-attachments/assets/5e737358-c9c8-4491-9d4b-cc71458920f0">

[Skip changelog]