### PR TITLE
Add aria-label to dropzone's hidden file input

### DIFF
--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1037,6 +1037,10 @@ $.extend(fixmystreet.set_up, {
               $originalInput.show();
             },
             init: function() {
+              // Add aria-label for accessibility
+              // From https://github.com/dropzone/dropzone/pull/2214
+              this.hiddenFileInput.setAttribute("aria-label", "hidden file upload");
+
               this.on("addedfile", function(file) {
                 if (max_photos == 1 && prevFile) {
                     this.removeFile(prevFile);


### PR DESCRIPTION
There are two open PRs in the dropzone repo which fix this (see [the original issue](https://github.com/mysociety/societyworks/issues/4493#issuecomment-2288259642) for details), but at the time of writing neither had been merged.

Could have forked dropzone and applied the fix to our fork, but seemed easier to just apply it in our custom init method for now.

Fixes https://github.com/mysociety/societyworks/issues/4493

<!-- [skip changelog] -->