### PR TITLE
Include same-day data in pre-generated CSV exports

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Dashboard.pm
+++ b/perllib/FixMyStreet/App/Controller/Dashboard.pm
@@ -181,12 +181,12 @@ sub index : Path : Args(0) {
     my $reporting = $c->forward('construct_rs_filter', [ $c->get_param('updates') ]);
 
     if ( my $export = $c->get_param('export') ) {
-        $reporting->csv_parameters;
         if ($export == 1) {
             # Existing method, generate and serve
             if ($reporting->premade_csv_exists) {
                 $reporting->filter_premade_csv_http($c);
             } else {
+                $reporting->csv_parameters;
                 $reporting->generate_csv_http($c);
             }
         } elsif ($export == 2) {

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -452,10 +452,6 @@ sub dashboard_export_problems_add_columns {
 
     my @contacts = $csv->body->contacts->order_by('category')->all;
     my %extra_columns;
-    if (@{$csv->category}) {
-        my %picked_cats = map { $_ => 1} @{$csv->category};
-        @contacts = grep { $picked_cats{$_->category} } @contacts;
-    }
     foreach my $contact (@contacts) {
         foreach (@{$contact->get_metadata_for_storage}) {
             next if $_->{code} eq 'safety_critical';

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -662,7 +662,7 @@ subtest 'Dashboard CSV extra columns' => sub {
     $mech->content_contains(',12345,,no,busstops@example.com,,', "Bike number added to csv");
     $mech->content_contains('"Council User",,,98756', "Stop code added to csv for all categories report");
     $mech->get_ok('/dashboard?export=1&category=Bus+stops');
-    $mech->content_contains('"Council User",,98756', "Stop code added to csv for bus stop category report");
+    $mech->content_contains('"Council User",,,98756', "Stop code added to csv for bus stop category report");
 
     $report->set_extra_fields({ name => 'leaning', value => 'Yes' }, { name => 'safety_critical', value => 'yes' },
         { name => 'stop_code', value => '98756' }, { name => 'Question', value => '12345' });


### PR DESCRIPTION
If a request for a CSV export includes the current day, stop the pre-generated export at midnight and switch to a live export for the current day. [skip changelog]
Fixes https://github.com/mysociety/societyworks/issues/4170
