### PR TITLE
[Camden] Adds boundary check against neighbours

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -221,8 +221,15 @@ sub munge_overlapping_asset_bodies {
                 $_->name ne 'Harrow Borough Council'
                 } values %$bodies;
         } else {
+            # Camden wants sole responsibility of Camden agreed areas
+            if ($cobrand eq 'Camden') {
+                %$bodies = map { $_->id => $_ } grep {
+                    $_->name eq 'Camden Borough Council' || $_->name eq 'TfL' || $_->name eq 'National Highways'
+                } values %$bodies;
+                return;
+            }
             # ...someone else's responsibility, take out the ones definitely not responsible
-            my %cobrands = (Harrow => 'Harrow Borough Council', Camden => 'Camden Borough Council', Barnet => 'Barnet Borough Council');
+            my %cobrands = (Harrow => 'Harrow Borough Council', Barnet => 'Barnet Borough Council');
             my $selected = $cobrands{$cobrand};
             %$bodies = map { $_->id => $_ } grep {
                 $_->name eq $selected || $_->name eq 'Brent Council' || $_->name eq 'TfL' || $_->name eq 'National Highways'
@@ -236,7 +243,12 @@ sub munge_overlapping_asset_bodies {
                 $_->name ne 'Brent Council'
                 } values %$bodies;
         } else {
-            # ...Brent's responsibility - leave (both) bodies alone
+            # If it's for Brent shared with Camden, make wholly Brent's responsibility
+            if (grep { $_->name eq 'Camden Borough Council' } values %$bodies) {
+                %$bodies = map { $_->id => $_ } grep {
+                    $_->name eq 'Brent Council' || $_->name eq 'TfL' || $_->name eq 'National Highways'
+                } values %$bodies;
+            }
         }
     }
 }
@@ -254,7 +266,6 @@ sub munge_cobrand_asset_categories {
     my %bodies = map { $_->body->name => $_->body } @$contacts;
     my %non_street = (
         'Barnet' => { map { $_ => 1 } @{ $self->_barnet_non_street } },
-        'Camden' => { map { $_ => 1 } @{ $self->_camden_non_street } },
         'Harrow' => { map { $_ => 1 } @{ $self->_harrow_non_street } },
     );
 
@@ -262,14 +273,16 @@ sub munge_cobrand_asset_categories {
     my $in_area = grep ($self->council_area_id->[0] == $_, keys %{$self->{c}->stash->{all_areas}});
     # cobrand will be true if the point is within an area of different responsibility from the norm
     my $cobrand = $self->check_report_is_on_cobrand_asset || '';
+
     return unless $cobrand;
 
     my $brent_body = $self->body->id;
     if (!$in_area && $cobrand eq 'Brent') {
         # Outside the area of Brent, but Brent's responsibility
         my $area;
+        # Camden do not mix categories with Brent
         if (grep {$_->{name} eq 'Camden Borough Council'} values %{$self->{c}->stash->{all_areas}}){
-            $area = 'Camden';
+            return;
         } elsif (grep {$_->{name} eq 'Harrow Borough Council'} values %{$self->{c}->stash->{all_areas}}) {
             $area = 'Harrow';
         }  elsif (grep {$_->{name} eq 'Barnet Borough Council'} values %{$self->{c}->stash->{all_areas}}) {
@@ -283,6 +296,9 @@ sub munge_cobrand_asset_categories {
         @$contacts = grep { !(!$non_street{$area}{$_->category} && $_->body_id == $other_body->id) } @$contacts
             if $other_body;
     } elsif ($in_area && $cobrand ne 'Brent') {
+        if ($cobrand eq 'Camden') {
+            return;
+        }
         # Inside the area of Brent, but not Brent's responsibility
         my $other_body = $bodies{$cobrand . " Borough Council"};
         # Remove the street contacts of Brent
@@ -1665,20 +1681,6 @@ sub _barnet_non_street {
         'Overhanging foliage',
     ]
 };
-
-sub _camden_non_street {
-    return [
-        'Abandoned Vehicles',
-        'Dead animal',
-        'Flyposting',
-        'Public toilets',
-        'Recycling & rubbish (Missed bin)',
-        'Dott e-bike / e-scooter',
-        'Human Forest e-bike',
-        'Lime e-bike / e-scooter',
-        'Tier e-bike / e-scooter',
-    ]
-}
 
 sub _harrow_non_street {
     return [

--- a/perllib/FixMyStreet/Cobrand/Camden.pm
+++ b/perllib/FixMyStreet/Cobrand/Camden.pm
@@ -15,7 +15,17 @@ use parent 'FixMyStreet::Cobrand::Whitelabel';
 use strict;
 use warnings;
 
-sub council_area_id { return [2505, 2488]; }
+sub council_area_id {
+    return [
+        2505, # Camden
+        2488, # Brent
+        2489, # Barnet
+        2504, # Westminster
+        2507, # Islington
+        2509, # Haringey
+        2512, # City of London
+    ];
+}
 sub council_area { return 'Camden'; }
 sub council_name { return 'Camden Council'; }
 sub council_url { return 'camden'; }
@@ -146,7 +156,7 @@ sub user_from_oidc {
 
 If the location is covered by an area of differing responsibility (e.g. Brent
 in Camden, or Camden in Brent), return true (either 1 if an area name is
-provided, or the name of the area if not). Identical to function in Brent.pm
+provided, or the name of the area if not).
 
 =cut
 
@@ -159,9 +169,9 @@ sub check_report_is_on_cobrand_asset {
     my $host = FixMyStreet->config('STAGING_SITE') ? "tilma.staging.mysociety.org" : "tilma.mysociety.org";
 
     my $cfg = {
-        url => "https://$host/mapserver/brent",
+        url => "https://$host/mapserver/camden",
         srsname => "urn:ogc:def:crs:EPSG::27700",
-        typename => "BrentDiffs",
+        typename => "AgreementBoundaries",
         filter => "<Filter><Contains><PropertyName>Geometry</PropertyName><gml:Point><gml:coordinates>$x,$y</gml:coordinates></gml:Point></Contains></Filter>",
         outputformat => 'GML3',
     };
@@ -170,11 +180,11 @@ sub check_report_is_on_cobrand_asset {
 
     if ($$features[0]) {
         if ($council_area) {
-            if ($$features[0]->{'ms:BrentDiffs'}->{'ms:name'} eq $council_area) {
+            if ($$features[0]->{'ms:AgreementBoundaries'}->{'ms:RESPBOROUG'} eq $council_area) {
                 return 1;
             }
         } else {
-            return $$features[0]->{'ms:BrentDiffs'}->{'ms:name'};
+            return $$features[0]->{'ms:AgreementBoundaries'}->{'ms:RESPBOROUG'};
         }
     }
 }
@@ -182,8 +192,9 @@ sub check_report_is_on_cobrand_asset {
 =head2 munge_overlapping_asset_bodies
 
 Alters the list of available bodies for the location,
-depending on calculated responsibility. Here, we remove the
-Brent body if we're inside Camden and it's not a Brent area.
+depending on calculated responsibility. Here, we remove
+any other council bodies if we're inside Camden or on the
+Camden boundaries layer.
 
 =cut
 
@@ -194,50 +205,37 @@ sub munge_overlapping_asset_bodies {
     my $in_area = grep ($self->council_area_id->[0] == $_, keys %{$self->{c}->stash->{all_areas}});
     # cobrand will be true if the point is within an area of different responsibility from the norm
     my $cobrand = $self->check_report_is_on_cobrand_asset;
-    if ($in_area && !$cobrand) {
-        # Within Camden, and Camden's responsibility
-        %$bodies = map { $_->id => $_ } grep {
-            $_->name ne 'Brent Council'
+
+    if ($in_area) {
+        if ($in_area && !$cobrand) {
+            # Within Camden, and Camden's responsibility
+            %$bodies = map { $_->id => $_ } grep {
+                $_->name ne 'Brent Council' &&
+                $_->name ne 'Barnet Borough Council' &&
+                $_->name ne 'Westminster City Council' &&
+                $_->name ne 'Islington Borough Council' &&
+                $_->name ne 'Haringey Borough Council' &&
+                $_->name ne 'City of London Corporation'
+                } values %$bodies;
+        } else {
+            # ...read from the asset layer whose responsibility it is and keep them and TfL and National Highways
+            my $selected = &_boundary_councils->{$cobrand};
+            %$bodies = map { $_->id => $_ } grep {
+                $_->name eq $selected || $_->name eq 'TfL' || $_->name eq 'National Highways'
             } values %$bodies;
+        }
+    } else {
+        # Not in the area of Camden...
+        if (!$cobrand || $cobrand ne 'LB Camden') {
+            # ...not Camden's responsibility - remove Camden
+            %$bodies = map { $_->id => $_ } grep {
+                $_->name ne 'Camden Borough Council'
+                } values %$bodies;
+        } else {
+            # ...Camden's responsibility - leave bodies alone
+        }
     }
 };
-
-=head2 munge_cobrand_asset_categories
-
-If we're in an overlapping area, we want to take the street categories
-of one body, and the non-street categories of the other.
-
-=cut
-
-sub munge_cobrand_asset_categories {
-    my ($self, $contacts) = @_;
-
-    # in_area will be true if the point is within the administrative area of Camden
-    my $in_area = grep ($self->council_area_id->[0] == $_, keys %{$self->{c}->stash->{all_areas}});
-    # cobrand will be true if the point is within an area of different responsibility from the norm
-    my $cobrand = $self->check_report_is_on_cobrand_asset || '';
-
-    my $brent = FixMyStreet::Cobrand::Brent->new();
-    my %non_street = map { $_ => 1 } @{ $brent->_camden_non_street } ;
-    my $brent_body = $brent->body;
-    my $camden_body = $self->body;
-
-    if ($in_area && $cobrand eq 'Brent') {
-        # Within Camden, but Brent's responsibility
-        # Remove the non-street contacts of Brent
-        @$contacts = grep { !($_->email !~ /^Symology/ && $_->body_id == $brent_body->id) } @$contacts
-            if $brent_body;
-        # Remove the street contacts of Camden
-        @$contacts = grep { !(!$non_street{$_->category} && $_->body_id == $camden_body->id) } @$contacts;
-    } elsif (!$in_area && $cobrand eq 'Camden') {
-        # Outside Camden, but Camden's responsibility
-        # Remove the street contacts of Brent
-        @$contacts = grep { !($_->email =~ /^Symology/ && $_->body_id == $brent_body->id) } @$contacts
-            if $brent_body;
-        # Remove the non-street contacts of Camden
-        @$contacts = grep { !($non_street{$_->category} && $_->body_id == $camden_body->id) } @$contacts;
-    }
-}
 
 =head2 dashboard_export_problems_add_columns
 
@@ -285,6 +283,19 @@ sub post_report_sent {
 
     if ($groups{'Hired e-bike or e-scooter'}) {
         $self->_post_report_sent_close($problem, 'report/new/close_bike.html');
+    }
+}
+
+sub _boundary_councils {
+    return {
+        'LB Brent' => 'Brent Council',
+        'LB Barnet' => 'Barnet Borough Council',
+        'LB Camden' => 'Camden Borough Council',
+        'LB Westminster' => 'Westminster City Council',
+        'LB Islington' => 'Islington Borough Council',
+        'LB Haringey' => 'Haringey Borough Council',
+        'City Of London' => 'City of London Corporation',
+        'TfL' => 'Transport for London',
     }
 }
 

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -211,6 +211,11 @@ sub munge_report_new_bodies {
         $brent->munge_overlapping_asset_bodies($bodies);
     }
 
+    if ( $bodies{'Camden Borough Council'} ) {
+        my $camden = FixMyStreet::Cobrand::Camden->new({ c => $self->{c} });
+        $camden->munge_overlapping_asset_bodies($bodies);
+    }
+
     if ( $bodies{'Lewisham Borough Council'} ) {
         my $bromley = FixMyStreet::Cobrand::Bromley->new({ c => $self->{c} });
         $bromley->munge_overlapping_asset_bodies($bodies);

--- a/perllib/FixMyStreet/Cobrand/Westminster.pm
+++ b/perllib/FixMyStreet/Cobrand/Westminster.pm
@@ -25,7 +25,7 @@ use URI;
 
 =cut
 
-sub council_area_id { return 2504; }
+sub council_area_id { return [2504, 2505] } # 2505 Camden
 sub council_area { return 'Westminster'; }
 sub council_name { return 'Westminster City Council'; }
 sub council_url { return 'Westminster'; }

--- a/t/cobrand/brent.t
+++ b/t/cobrand/brent.t
@@ -529,12 +529,13 @@ FixMyStreet::override_config {
                 subtest "categories on $host cobrand in Brent on Camden cobrand layer" => sub {
                     $mech->host("$host.fixmystreet.com");
                     $brent_mock->mock('_fetch_features', sub { [{ 'ms:BrentDiffs' => { 'ms:name' => 'Camden' } } ]});
+                    $camden_mock->mock('_fetch_features', sub { [ { 'ms:AgreementBoundaries' => { 'ms:RESPBOROUG' => 'LB Camden' } } ] });
                     $mech->get_ok("/report/new/ajax?longitude=-0.28168&latitude=51.55904");
-                    is $mech->content_contains("Potholes"), 1, 'Brent category present';
+                    is $mech->content_lacks("Potholes"), 1, 'Brent category not present';
                     is $mech->content_lacks("Gully grid missing"), 1, 'Brent Symology category not present';
                     is $mech->content_contains("Sweeping"), 1, 'TfL category present';
                     is $mech->content_contains("Fly-tipping"), 1, 'Camden category present';
-                    is $mech->content_lacks("Dead animal"), 1, 'Camden non-street category not present';
+                    is $mech->content_contains("Dead animal"), 1, 'Camden non-street category present';
                     is $mech->content_lacks("Abandoned vehicles"), 1, 'Barnet non-street category not present';
                     is $mech->content_lacks("Parking"), 1, 'Barnet street category not present';
                 }
@@ -576,13 +577,13 @@ FixMyStreet::override_config {
                     $brent_mock->mock('_fetch_features',
                         sub { [ { 'ms:BrentDiffs' => { 'ms:name' => 'Brent' } } ] });
                     $camden_mock->mock('_fetch_features',
-                        sub { [ { 'ms:BrentDiffs' => { 'ms:name' => 'Brent' } } ] });
+                        sub { [ { 'ms:AgreementBoundaries' => { 'ms:RESPBOROUG' => 'LB Brent' } } ] });
                     $mech->get_ok("/report/new/ajax?longitude=-0.124514&latitude=51.529432");
-                    is $mech->content_lacks("Potholes"), 1, 'Brent category not present';
+                    is $mech->content_contains("Potholes"), 1, 'Brent category present';
                     is $mech->content_contains("Gully grid missing"), 1, 'Brent Symology category present';
                     is $mech->content_contains("Sweeping"), 1, 'TfL category present';
                     is $mech->content_lacks("Fly-tipping"), 1, 'Camden street category not present';
-                    is $mech->content_contains("Dead animal"), 1, 'Camden non-street category present';
+                    is $mech->content_lacks("Dead animal"), 1, 'Camden non-street category not present';
                 }
             };
 
@@ -615,20 +616,6 @@ FixMyStreet::override_config {
                     sub { [{ 'ms:BrentDiffs' => { 'ms:name' => 'Brent' } }] });
                 $mech->get_ok("/report/new?longitude=-0.124514&latitude=51.529432");
                 is $mech->content_lacks('That location is not covered by Brent Council'), 1, 'Can not make report in Camden off asset';
-            };
-
-            subtest "can access Brent from Camden on Camden asset layer" => sub {
-                $mech->host("camden.fixmystreet.com");
-                $camden_mock->mock('_fetch_features', sub { [{ 'ms:BrentDiffs' => { 'ms:name' => 'Camden' } }] });
-                $mech->get_ok("/report/new?longitude=-0.28168&latitude=51.55904");
-                is $mech->content_lacks('That location is not covered by Camden Council'), 1, "Can make a report on Camden asset";
-            };
-
-            subtest "can not access Brent from Camden not on asset layer" => sub {
-                $mech->host("camden.fixmystreet.com");
-                $camden_mock->mock('_fetch_features', sub { [] });
-                $mech->get_ok("/report/new?longitude=-0.28168&latitude=51.55904");
-                is $mech->content_contains('That location is not covered by Camden Council'), 1, "Can make a report on Camden asset";
             };
 
             for my $test (


### PR DESCRIPTION
Camden have provided a responsibility layer around boundary areas - we check against this to see who is responsible for a location that may be outside their defined boundary area and set the body responsible accordingly. Alternatively, it may be inside their boundary area but not be their responsibility.

They do not divide up responsibilities by category type

Camden needs to be set to be covered by, and to cover, all of its boundary areas.

https://github.com/mysociety/societyworks/issues/4399

[skip changelog]