### PR TITLE
Add aria-required attributes to new report form

### DIFF
--- a/templates/web/base/report/form/user_loggedout_email.html
+++ b/templates/web/base/report/form/user_loggedout_email.html
@@ -15,6 +15,7 @@
 <input type="[% username_type %]" name="[% username_field %]" id="form_[% name %]"
        value="[% c.get_param(username_field) %]"
     class="form-control required"
+    aria-required="true"
     [% IF NOT c.cobrand.sms_authentication %]
         autocomplete="[% username_type %]"
     [% END %]

--- a/templates/web/bromley/report/form/user_loggedout_email.html
+++ b/templates/web/bromley/report/form/user_loggedout_email.html
@@ -17,4 +17,4 @@
 [% END %]
 <input type="[% username_type %]" name="[% username_field %]" id="form_[% name %]"
        value="[% c.get_param(username_field) %]"
-    class="form-control required">
+    class="form-control required" aria-required="true">

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -495,11 +495,11 @@ $.extend(fixmystreet.set_up, {
 
     /* set correct required status depending on what we submit */
     $('.js-submit_sign_in').on('click', function(e) {
-        $('.js-form-name').removeClass('required');
+        $('.js-form-name').removeClass('required').removeAttr('aria-required');
     } );
 
     $('.js-submit_register').on('click', function(e) {
-        $('.js-form-name').addClass('required');
+        $('.js-form-name').addClass('required').attr('aria-required', true);
     } );
 
     $('#facebook_sign_in, #twitter_sign_in, #oidc_sign_in').on('click', function(e){
@@ -926,6 +926,9 @@ $.extend(fixmystreet.set_up, {
                   $el.attr('maxlength', rule.maxlength);
                 } else {
                   $el.removeAttr('maxlength');
+                }
+                if (rule.required) {
+                  $el.attr('aria-required', true);
                 }
             }
         });


### PR DESCRIPTION
Adds aria-required attributes to the name and email fields, as well as any other fields marked as required in `web/js/validation_rules.js`.

Fixes https://github.com/mysociety/societyworks/issues/4492

<!-- [skip changelog] -->
