### PR TITLE
[Admin] Move add body/category forms to own pages, limit history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
         - Tweak config page display. #5139
         - Minor display improvements to report/update pages. #5141
         - Minor display and performance improvements to user pages. #5138
+        - Move add new body/category to their own admin pages.
     - Development improvements:
         - Extra data columns now stored as JSON, not RABX. #3216
         - Cobrands can provide custom distances for duplicate lookup. #4456

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
         - Fix display of user in assignment dropdown. #4855
         - Fix setting of fixed timestamp in CSV export. #5119
         - Fix CSV export of reports with only hidden/unconfirmed updates. #5119
+        - Fix displaying category page if over 1,000 history entries.
     - Admin improvements:
         - Rename emergency message to site message.
         - Added a category control for overriding the text of the new report details field.

--- a/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
@@ -157,9 +157,10 @@ sub category : Chained('body') : PathPart('') {
             contact_id => $c->stash->{contact}->id,
         },
         {
-            order_by => ['contacts_history_id']
+            rows => 1000,
         },
-    );
+    )->order_by('-contacts_history_id')->as_subselect_rs->order_by('contacts_history_id');
+
     $c->stash->{history} = $history;
     my @methods = map { $_ =~ s/FixMyStreet::SendReport:://; $_ } sort keys %{ FixMyStreet::SendReport->get_senders };
     $c->stash->{send_methods} = \@methods;

--- a/t/app/controller/admin/reportextrafields.t
+++ b/t/app/controller/admin/reportextrafields.t
@@ -90,6 +90,7 @@ FixMyStreet::override_config {
         is_deeply $contact->get_extra_fields, $contact_extra_fields, 'new string field was added';
 
         note 'attempt to add code with spaces';
+        $mech->get_ok("/admin/body/" . $body->id . "/" . $contact->category);
         $mech->submit_form_ok( { with_fields => {
             "metadata[9999].code" => "space test",
 

--- a/t/app/controller/admin/translations.t
+++ b/t/app/controller/admin/translations.t
@@ -56,6 +56,7 @@ subtest 'check add category with translation' => sub {
 
     $mech->content_contains('DE Arun');
 
+    $mech->follow_link_ok({ text => 'Add new category' });
     $mech->submit_form_ok( { with_fields => {
         category => 'Potholes',
         translation_de => 'DE potholes',
@@ -166,7 +167,7 @@ subtest 'delete body translation' => sub {
 };
 
 subtest 'check add body with translation' => sub {
-    $mech->get_ok('/admin/bodies/');
+    $mech->get_ok('/admin/bodies/add');
     $mech->submit_form_ok( { with_fields => {
         area_ids => 2643,
         send_method => 'email',
@@ -183,7 +184,6 @@ subtest 'check add body with translation' => sub {
         translation_de => 'DE A Body',
     } } );
 
-    $mech->follow_link_ok({ text => 'A body' });
     $mech->content_contains( 'DE A Body' );
 }
 };

--- a/t/cobrand/highwaysengland.t
+++ b/t/cobrand/highwaysengland.t
@@ -264,7 +264,7 @@ FixMyStreet::override_config {
 
         my $expected_error = 'Category must end with (NH).';
 
-        $mech->get_ok('/admin/body/' . $highways->id);
+        $mech->get_ok('/admin/body/' . $highways->id . '/_add');
         $mech->submit_form_ok( { with_fields => {
             category   => 'no suffix category',
             title_hint => 'test',

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -1420,7 +1420,7 @@ FixMyStreet::override_config {
 subtest 'check contact creation allows email from borough email addresses' => sub {
 
     $mech->log_in_ok($staffuser->email);
-    $mech->get_ok('/admin/body/' . $body->id);
+    $mech->get_ok('/admin/body/' . $body->id . '/_add');
 
     $mech->submit_form_ok( { with_fields => {
         category   => 'test category',

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -269,6 +269,7 @@ subtest "private categories" => sub {
     $mech->log_in_ok( 'super@example.org' );
     $mech->get_ok('/admin/bodies');
     $mech->follow_link_ok({ text => 'Division 1' });
+    $mech->follow_link_ok({ text => 'Füge neue Kategorie hinzu' });
     $mech->submit_form_ok({ with_fields => {
         category => 'Allgemein',
         state => 'inactive',

--- a/templates/web/base/admin/bodies/add.html
+++ b/templates/web/base/admin/bodies/add.html
@@ -1,0 +1,9 @@
+[% INCLUDE 'admin/header.html' title=loc('Add body') -%]
+
+[% IF body_errors.size %]
+    <p class="error">[% loc('Please correct the errors below') %]</p>
+[% END %]
+
+[% INCLUDE 'admin/bodies/form.html' %]
+
+[% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/admin/bodies/body.html
+++ b/templates/web/base/admin/bodies/body.html
@@ -10,9 +10,7 @@
 
 [% IF body_errors.size %]
     <p class="error">[% loc('Please correct the errors below') %]</p>
-[% END %]
-
-[% IF NOT errors %]
+[% ELSE %]
 
 <p>
   [% IF example_pc %]
@@ -73,7 +71,7 @@
   </p>
 [% END %]
 
-<form method="post" action="[% c.uri_for_action('admin/bodies/edit', [ body_id ] ) %]" enctype="application/x-www-form-urlencoded" accept-charset="utf-8">
+<form method="post" action="[% c.uri_for_action('admin/bodies/confirm_contacts', [ body_id ] ) %]">
 
   <table cellspacing="0" cellpadding="2" border="1" id="admin_contacts">
     <tr>
@@ -88,7 +86,7 @@
 
     [% BLOCK category_row %]
       <tr [% IF cat.state == 'deleted' %]class="is-deleted"[% END %]>
-        <td class="contact-category"><a href="[% c.uri_for_action( '/admin/bodies/edit', [ body_id ], cat.category_safe ) %]">[% cat.category_display %]</a>
+        <td class="contact-category"><a href="[% c.uri_for_action( '/admin/bodies/category', [ body_id ], cat.category_safe ) %]">[% cat.category_display %]</a>
             <br>[% cat.email.replace('([;,])', '$1 ') %]</td>
         <td>
             [% cat.state %]
@@ -126,7 +124,6 @@
 
   [% IF any_not_confirmed %]
   <p>
-    <input type="hidden" name="posted" value="update">
     <input type="hidden" name="token" value="[% csrf_token %]">
     <input type="submit" class="btn" name="Update statuses" value="[% loc('Update statuses') %]">
   </p>
@@ -140,35 +137,17 @@
     ") %]
 </p>
 
+[% IF NOT contact %]
+<a class="btn" href="[% c.uri_for_action('/admin/bodies/add_category', [ body.id ]) %]">[% loc('Add new category') %]</a>
+[% END %]
+
 [% END %][%# Only show all the above if no errors with below form %]
 
-<div class="admin-box">
-  [% IF NOT contact %]
-    <h2>[% loc('Add new category') %]</h2>
-  [% END %]
-
-  [% IF body.name == 'TfL' AND c.user.is_superuser %]
-  <p class="fms-admin-warning">
-      Renaming, adding, or removing categories that can only be made on red routes requires extra steps. See
-      <a href="https://wiki.mysociety.org/wiki/Transport_for_London_(TfL)#TLRN_categories">wiki</a>.
-  </p>
-  [% END %]
-
-  [% IF errors %]
-  <div class="fms-admin-warning">
-    [% FOR error IN errors.values %][% error %][% IF NOT loop.last %]<br>[% END %][% END %]
-  </div>
-  [% INCLUDE 'admin/bodies/contact-form.html' translations=contact_translations %]
-  [% ELSE  %]
-  [% INCLUDE 'admin/bodies/contact-form.html' translations={} %]
-  [% END %]
-</div>
-
-[% IF NOT errors and c.user.is_superuser %]
+[% IF c.user.is_superuser %]
 <div class="admin-box">
   <h2>[% loc('Edit body details') %]</h2>
   [% INCLUDE 'admin/bodies/form.html' %]
 </div>
-[% END %][%# Only show all the above if no errors with category form %]
+[% END %]
 
 [% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/admin/bodies/category.html
+++ b/templates/web/base/admin/bodies/category.html
@@ -14,11 +14,9 @@
 <em>[% updated %]</em>
 </p>
 
-<p>
-[% IF example_pc %]
-<a href="[% c.uri_for_email( '/around', { pc => example_pc } ) %]" class="admin-offsite-link">[% tprintf( loc('Example postcode %s'), example_pc ) | html %]</a>
+[% IF NOT contact %]
+    <h2>[% loc('Add new category') %]</h2>
 [% END %]
-</p>
 
 [% IF body.name == 'TfL' AND c.user.is_superuser %]
 <p class="fms-admin-warning">
@@ -27,8 +25,14 @@
 </p>
 [% END %]
 
+[% IF errors %]
+  <div class="fms-admin-warning">
+    [% FOR error IN errors.values %][% error %][% IF NOT loop.last %]<br>[% END %][% END %]
+  </div>
+[% END %]
 [% INCLUDE 'admin/bodies/contact-form.html' %]
 
+[% IF history %]
 <h2>[% loc('History') %]</h2>
 <table border="1">
     <tr>
@@ -50,5 +54,6 @@
         [%- prev = contact %]
     [%- END %]
 </table>
+[% END %]
 
 [% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/admin/bodies/contact-form.html
+++ b/templates/web/base/admin/bodies/contact-form.html
@@ -1,4 +1,4 @@
-<form method="post" action="[% c.uri_for_action('admin/bodies/edit', [ body_id ] ) %]" enctype="application/x-www-form-urlencoded" accept-charset="utf-8" id="category_edit">
+<form method="post" id="category_edit">
 
   [% PROCESS 'admin/bodies/_category_field.html' %]
 
@@ -200,7 +200,6 @@
     </p>
 
   <p>
-    <input type="hidden" name="posted" value="new" >
     <input type="hidden" name="token" value="[% csrf_token %]" >
     <input type="submit" class="btn" name="Create category" value="[% contact.in_storage ? loc('Save changes') : loc('Create category') %]" >
   </p>

--- a/templates/web/base/admin/bodies/form.html
+++ b/templates/web/base/admin/bodies/form.html
@@ -1,4 +1,4 @@
-    <form method="post" action="[% body ? c.uri_for_action('admin/bodies/edit', [ body.id ]) : c.uri_for_action('admin/bodies/index') %]" enctype="application/x-www-form-urlencoded" accept-charset="utf-8">
+<form method="post">
     <div class="fms-admin-info">
         [% loc(
           "Add a <strong>body</strong> for each administrative body, such as a council or department
@@ -149,9 +149,7 @@
     </p>
 
     <p>
-    <input type="hidden" name="posted" value="body">
     <input type="hidden" name="token" value="[% csrf_token %]">
     <input type="submit" class="btn" value="[% body ? loc('Update body') : loc('Add body') %]">
     </p>
-    </form>
-
+</form>

--- a/templates/web/base/admin/bodies/index.html
+++ b/templates/web/base/admin/bodies/index.html
@@ -1,9 +1,5 @@
 [% INCLUDE 'admin/header.html' title=loc('Bodies') -%]
 
-[% IF body_errors.size %]
-    <p class="error">[% loc('Please correct the errors below') %]</p>
-[% END %]
-
 [% IF bodies.size == 0 %]
   <p class="fms-admin-info">
     [% loc('Currently no bodies have been created.') %]
@@ -74,10 +70,9 @@
 [% END %]
 
 [% IF (c.cobrand.moniker == 'zurich' AND admin_type == 'super') OR c.user.is_superuser %]
-    <div class="admin-box">
-      <h2>[% loc('Add body') %]</h2>
-      [% INCLUDE 'admin/bodies/form.html', body='' %]
-    </div>
+<p>
+    <a class="btn" href="[% c.uri_for_action('/admin/bodies/add') %]">[% loc('Add body') %]</a>
+</p>
 [% END %]
 
 [% INCLUDE 'admin/bodies/edit-league.html' %]

--- a/templates/web/zurich/admin/bodies/body.html
+++ b/templates/web/zurich/admin/bodies/body.html
@@ -8,7 +8,7 @@
 [% END %]
 
 [% IF admin_type == 'super' AND body.parent AND NOT body.parent.parent # A division %]
-  [% IF NOT errors %]
+  [% IF NOT body_errors %]
     <table cellspacing="0" cellpadding="2" border="1">
         <tr>
             <th>[% loc('Category') %]</th>
@@ -33,19 +33,13 @@
     <h2>[% loc('Add new category') %]</h2>
   [% END %][%# Only show all the above if no errors with below form %]
 
-  [% IF errors %]
-    <div class="fms-admin-warning">
-        [% FOR error IN errors.values %][% error %][% IF NOT loop.last %]<br>[% END %][% END %]
-    </div>
+  [% IF NOT contact %]
+    <a class="btn" href="[% c.uri_for_action('/admin/bodies/add_category', [ body.id ]) %]">[% loc('Add new category') %]</a>
   [% END %]
 
-  [% INCLUDE 'admin/bodies/contact-form.html' %]
-
 [% END %]
 
-[% IF NOT errors %]
-    <h2>[% loc('Edit body details') %]</h2>
-    [% INCLUDE 'admin/bodies/form.html' %]
-[% END %]
+<h2>[% loc('Edit body details') %]</h2>
+[% INCLUDE 'admin/bodies/form.html' %]
 
 [% INCLUDE 'admin/footer.html' %]

--- a/templates/web/zurich/admin/bodies/contact-form.html
+++ b/templates/web/zurich/admin/bodies/contact-form.html
@@ -1,4 +1,4 @@
-<form method="post" action="[% c.uri_for_action('admin/bodies/edit', [ body_id ] ) %]" enctype="application/x-www-form-urlencoded" accept-charset="utf-8" id="category_edit">
+<form method="post" id="category_edit">
 
   [% IF contact.in_storage %]
     <h1>[% contact.category_display | html %]</h1>
@@ -46,7 +46,6 @@
 
     <p><strong>[% loc('Note:') %] </strong><textarea class="form-control" name="note" rows="3" cols="40"></textarea>
 
-    <input type="hidden" name="posted" value="new">
     <input type="hidden" name="token" value="[% csrf_token %]" >
     <p><input type="submit" class="btn" name="Create category" value="[% contact.in_storage ? loc('Save changes') : loc('Create category') %]">
   </p>

--- a/templates/web/zurich/admin/bodies/form.html
+++ b/templates/web/zurich/admin/bodies/form.html
@@ -1,4 +1,4 @@
-    <form method="post" action="[% body ? c.uri_for_action('admin/bodies/edit', [ body.id ]) : c.uri_for_action('admin/bodies/index') %]" enctype="application/x-www-form-urlencoded" accept-charset="utf-8">
+<form method="post">
 
     <p>
         <label for="name">[% loc('Name') %]</label>
@@ -57,10 +57,8 @@
         <input type="hidden" id="can_be_devolved" name="can_be_devolved" value="[% body.can_be_devolved %]">
 
     <p>
-    <input type="hidden" name="posted" value="body">
     <input type="hidden" name="token" value="[% csrf_token %]">
     <p>
     <input type="submit" class="btn" value="[% body ? loc('Update body') : loc('Add body') %]">
     </p>
-    </form>
-
+</form>


### PR DESCRIPTION
One very old 'bug', in that we can now view those pages (and then separately deal with whatever is creating 1000s of log entries), and then I was fed up of being confused by two forms on one page.