### PR TITLE
Consolidate primary button CSS classes.

### DIFF
--- a/templates/web/base/admin/triage/_inspect.html
+++ b/templates/web/base/admin/triage/_inspect.html
@@ -81,7 +81,7 @@
 
         <p>
           <input type="hidden" name="token" value="[% csrf_token %]" />
-          <input class="btn btn-primary" type="submit" value="[% loc('Save changes') %]" data-value-original="[% loc('Save changes') %]" data-value-duplicate="[% loc('Save + close as duplicate') %]" name="save" />
+          <input class="btn btn--primary" type="submit" value="[% loc('Save changes') %]" data-value-original="[% loc('Save changes') %]" data-value-duplicate="[% loc('Save + close as duplicate') %]" name="save" />
         </p>
       </div>
 

--- a/templates/web/base/alert/_list.html
+++ b/templates/web/base/alert/_list.html
@@ -87,11 +87,11 @@
       <label for="rznvy">[% loc('Email address') %]</label>
       <div class="form-txt-submit-box">
         <input class="form-control" type="email" id="rznvy" name="rznvy" value="[% rznvy %]" autocomplete="email">
-        <input id="alert_email_button" class="btn-primary" type="submit" name="alert" value="[% loc('Subscribe') %]">
+        <input id="alert_email_button" class="btn btn--primary" type="submit" name="alert" value="[% loc('Subscribe') %]">
       </div>
       <p>[% tprintf(loc('We won’t use your email for anything beyond sending you alerts within this area. You can find more information in our <a href="%s">privacy policy</a>.'), c.cobrand.privacy_policy_url) %]</p>
     [% ELSE %]
-      <input id="alert_email_button" class="btn-primary" type="submit" name="alert" value="[% loc('Subscribe') %]">
+      <input id="alert_email_button" class="btn btn--primary" type="submit" name="alert" value="[% loc('Subscribe') %]">
     [% END %]
   </div>
 

--- a/templates/web/base/alert/_updates.html
+++ b/templates/web/base/alert/_updates.html
@@ -18,17 +18,17 @@
       <label for="alert_rznvy">[% loc('Email') %]</label>
       <div class="form-txt-submit-box">
           <input type="email" class="form-control" name="rznvy" id="alert_rznvy" value="[% email %]" size="30" autocomplete="email">
-          <input class="green-btn" type="submit" name="alert" value="[% loc('Subscribe') %]">
+          <input class="btn btn--primary" type="submit" name="alert" value="[% loc('Subscribe') %]">
       </div>
     [% ELSE %]
-      <input class="green-btn" type="submit" name="alert" value="[% loc('Subscribe') %]">
+      <input class="btn btn--primary" type="submit" name="alert" value="[% loc('Subscribe') %]">
     [% END %]
   [% ELSE %]
     <label for="alert_rznvy">[% loc('Your email') %]</label>
 
     <div class="form-txt-submit-box">
         <input type="email" class="form-control" name="rznvy" id="alert_rznvy" value="[% email %]" size="30">
-        <input class="green-btn" type="submit" name="alert" value="[% loc('Subscribe') %]">
+        <input class="btn btn--primary" type="submit" name="alert" value="[% loc('Subscribe') %]">
     </div>
   [% END %]
 

--- a/templates/web/base/auth/2fa/form-add.html
+++ b/templates/web/base/auth/2fa/form-add.html
@@ -11,7 +11,7 @@
 <label for="2fa_code">[% loc('Code') %]</label>
 <div class="form-txt-submit-box">
     <input autofocus class="form-control" type="number" id="2fa_code" name="2fa_code" value="" required>
-    <input type="submit" value="[% loc('Submit') %]" class="btn-primary">
+    <input type="submit" value="[% loc('Submit') %]" class="btn btn--primary">
 </div>
 <input type="hidden" name="secret32" value="[% secret32 %]">
 <input type="hidden" name="2fa_action" value="confirm">

--- a/templates/web/base/auth/2fa/form.html
+++ b/templates/web/base/auth/2fa/form.html
@@ -17,7 +17,7 @@
         <label for="2fa_code">[% loc('Code') %]</label>
         <div class="form-txt-submit-box">
             <input autofocus class="form-control" type="number" id="2fa_code" name="2fa_code" value="" required>
-            <input type="submit" value="[% loc('Submit') %]" class="btn-primary">
+            <input type="submit" value="[% loc('Submit') %]" class="btn btn--primary">
         </div>
     </form>
   </div>

--- a/templates/web/base/auth/2fa/intro.html
+++ b/templates/web/base/auth/2fa/intro.html
@@ -17,7 +17,7 @@ INCLUDE 'header.html', title = loc('Two-factor authentication'), bodyclass = 'fu
       [% ELSE # stage is intro %]
       <p align="center">[% loc('Your account requires two-factor authentication to be set up.') %]</p>
         <p align="center">
-            <input class="btn-primary" type="submit" value="[% loc('Activate two-factor authentication') %]">
+            <input class="btn btn--primary" type="submit" value="[% loc('Activate two-factor authentication') %]">
         </p>
         <input type="hidden" name="2fa_action" value="activate">
       [% END %]

--- a/templates/web/base/auth/create.html
+++ b/templates/web/base/auth/create.html
@@ -76,7 +76,7 @@ INCLUDE 'header.html', bodyclass='authpage' %]
 
     <div class="form-txt-submit-box">
         <input class="required form-control js-password-validate" type="password" name="password_register" id="password_register" value="" autocomplete="new-password">
-        <input class="green-btn" type="submit" name="sign_in_by_code" value="[% expired_password ? loc('Reset') : forgotten ? loc('Sign in') : loc('Create your account') %]">
+        <input class="btn btn--primary" type="submit" name="sign_in_by_code" value="[% expired_password ? loc('Reset') : forgotten ? loc('Sign in') : loc('Create your account') %]">
     </div>
 
 </form>

--- a/templates/web/base/auth/general.html
+++ b/templates/web/base/auth/general.html
@@ -94,7 +94,7 @@
 
         <div class="form-txt-submit-box">
             <input type="password" name="password_sign_in" class="form-control required" id="password_sign_in" value="" autocomplete="current-password">
-            <input class="green-btn" type="submit" name="sign_in_by_password" value="[% loc('Sign in') %]">
+            <input class="btn btn--primary" type="submit" name="sign_in_by_password" value="[% loc('Sign in') %]">
         </div>
 
         <p>

--- a/templates/web/base/auth/smsform.html
+++ b/templates/web/base/auth/smsform.html
@@ -24,7 +24,7 @@
         <label for="code">[% loc('Code') %]</label>
         <div class="form-txt-submit-box">
             <input class="form-control" type="number" id="code" name="code" value="" required>
-            <input type="submit" value="[% loc('Submit') %]" class="btn-primary">
+            <input type="submit" value="[% loc('Submit') %]" class="btn btn--primary">
         </div>
     </form>
   </div>

--- a/templates/web/base/contact/enquiry/index.html
+++ b/templates/web/base/contact/enquiry/index.html
@@ -73,7 +73,7 @@
         <p><input type="file" name="photo3" id="form_photo3"></p>
      </div>
 
-    <input class="final-submit green-btn" type="submit" value="[% loc('Send') %]">
+    <input class="final-submit btn btn--primary" type="submit" value="[% loc('Send') %]">
 
 </form>
 

--- a/templates/web/base/contact/form.html
+++ b/templates/web/base/contact/form.html
@@ -105,6 +105,6 @@
 
   [% PROCESS 'auth/form_extra.html' %]
 
-  <input class="final-submit green-btn" type="submit" value="[% loc('Send') %]">
+  <input class="final-submit btn btn--primary" type="submit" value="[% loc('Send') %]">
 
 </form>

--- a/templates/web/base/my/anonymize.html
+++ b/templates/web/base/my/anonymize.html
@@ -7,13 +7,13 @@
 
   [% IF update %]
     <input type="hidden" name="update" value="[% update.id %]">
-    <input class="btn-primary" type="submit" name="hide" value="[% loc('Hide my name in this update') %]">
+    <input class="btn btn--primary" type="submit" name="hide" value="[% loc('Hide my name in this update') %]">
   [% ELSIF problem %]
     [% IF problem.bodies_str %]
       <p>[% tprintf(loc('Your name has already been sent to %s, but we can hide it on this page:'), problem.body) %]</p>
     [% END %]
     <input type="hidden" name="problem" value="[% problem.id %]">
-    <input class="btn-primary" type="submit" name="hide" value="[% loc('Hide my name on this report') %]">
+    <input class="btn btn--primary" type="submit" name="hide" value="[% loc('Hide my name on this report') %]">
   [% END %]
 
   [% IF NOT c.user.from_body %]

--- a/templates/web/base/offline/fallback.html
+++ b/templates/web/base/offline/fallback.html
@@ -54,7 +54,7 @@
     </form>
     <p id="draft_save_message" class="hidden"><small>[% tprintf(loc('Draft report saved on %s'), '<span></span>') %]</small></p>
     <p class="submit-and-cancel">
-        <button class="btn btn-primary js-save-draft">[% loc('Save draft') %]</button>
+        <button class="btn btn--primary js-save-draft">[% loc('Save draft') %]</button>
     </p>
 </div>
 

--- a/templates/web/base/report/_inspect.html
+++ b/templates/web/base/report/_inspect.html
@@ -77,7 +77,7 @@
           [% IF permissions.planned_reports %]
             <input type="hidden" name="post_inspect_url" value="[% post_inspect_url | html %]" />
           [% END %]
-          <input class="btn btn-primary" type="submit" value="[% loc('Save changes') %]" data-value-original="[% loc('Save changes') %]" data-value-duplicate="[% loc('Save + close as duplicate') %]" name="save" />
+          <input class="btn btn--primary" type="submit" value="[% loc('Save changes') %]" data-value-original="[% loc('Save changes') %]" data-value-duplicate="[% loc('Save + close as duplicate') %]" name="save" />
         </p>
       </div>
 

--- a/templates/web/base/report/_main.html
+++ b/templates/web/base/report/_main.html
@@ -113,7 +113,7 @@ can_moderate_title = c.user.can_moderate_title(problem, can_moderate)
             <input type="text" class="form-control" name="moderation_reason" value="[% (c.req.params.moderation_reason || '') | html %]">
         </p>
         <p>
-            <input type="submit" class="green-btn" value="[% loc('Save changes') %]">
+            <input type="submit" class="btn btn--primary" value="[% loc('Save changes') %]">
             <input type="button" class="hidden-nojs btn cancel" value="[% loc('Discard changes') %]">
         </p>
     </div>

--- a/templates/web/base/report/_support.html
+++ b/templates/web/base/report/_support.html
@@ -9,7 +9,7 @@
 
     [% IF c.user AND c.user.from_body %]
     <form action="/report/[% problem.id %]/support">
-        <p id="supporter"><small>[% text %] <input type="submit" class="green-btn" value="Add support"></small></p>
+        <p id="supporter"><small>[% text %] <input type="submit" class="btn btn--primary" value="Add support"></small></p>
     </form>
     [% ELSE %]
         <p id="supporter"><small>[% text %]</small></p>

--- a/templates/web/base/report/update.html
+++ b/templates/web/base/report/update.html
@@ -51,7 +51,7 @@
                 <div class="moderate-edit">
                     <label for="moderation_reason">[% loc('Describe why you are moderating this') %]</label>
                     <input type="text" class="form-control" name="moderation_reason">
-                    <input type="submit" class="green-btn" value="[% loc('Save changes') %]">
+                    <input type="submit" class="btn btn--primary" value="[% loc('Save changes') %]">
                     <input type="button" class="hidden-nojs btn cancel" value="[% loc('Discard changes') %]">
                 </div>
                 </form>

--- a/templates/web/base/tokens/confirm_problem.html
+++ b/templates/web/base/tokens/confirm_problem.html
@@ -40,7 +40,7 @@
 [% TRY %][% INCLUDE 'tokens/_extras_confirm.html' %][% CATCH file %][% END %]
 
   <p class="confirmation-again">
-    <a href="/report/new?latitude=[% report.latitude %]&amp;longitude=[% report.longitude %]" class="btn btn-primary">
+    <a href="/report/new?latitude=[% report.latitude %]&amp;longitude=[% report.longitude %]" class="btn btn--primary">
       [% loc('Report another problem here') %]
     </a>
   </p>

--- a/templates/web/base/waste/bulky/_bin_days_list.html
+++ b/templates/web/base/waste/bulky/_bin_days_list.html
@@ -22,17 +22,17 @@
     </dl>
 
     <div class="waste-services-launch-panel">
-        <a class="btn btn-primary govuk-!-margin-bottom-2" href="/report/[% booking.id %]">Check collection details</a>
+        <a class="btn btn--primary govuk-!-margin-bottom-2" href="/report/[% booking.id %]">Check collection details</a>
         [% IF c.cobrand.bulky_can_amend_collection(booking) %]
-          <a class="btn btn-primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky/amend', [ property.id, booking.id ]) %]">Amend booking</a>
+          <a class="btn btn--primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky/amend', [ property.id, booking.id ]) %]">Amend booking</a>
         [% ELSIF c.cobrand.moniker == 'merton' %]
           <p>If you would like to make any changes to your booking, call us on 020 8274 4902 at least 2 working days before your collection day.</p>
         [% END %]
         [% IF c.cobrand.bulky_can_cancel_collection(booking) %]
           [% IF c.cobrand.moniker != 'brent' %]
-            <a class="btn btn-primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky/cancel', [ property.id, booking.id ]) %]">Cancel booking</a>
+            <a class="btn btn--primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky/cancel', [ property.id, booking.id ]) %]">Cancel booking</a>
           [% ELSE %]
-            <a class="btn btn-primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky/cancel_small', [ property.id, booking.id ]) %]">Cancel booking</a>
+            <a class="btn btn--primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky/cancel_small', [ property.id, booking.id ]) %]">Cancel booking</a>
           [% END %]
         [% END %]
         [% PROCESS 'waste/_service_missed.html' unit=bulky_missed.$booking_guid original_booking=booking.id no_default=1 %]
@@ -69,7 +69,7 @@
       </div>
     </dl>
     <div class="waste-services-launch-panel">
-        <a class="btn btn-primary govuk-!-margin-bottom-2" href="/report/[% booking.id %]">Check collection details</a>
+        <a class="btn btn--primary govuk-!-margin-bottom-2" href="/report/[% booking.id %]">Check collection details</a>
         [% PROCESS 'waste/_service_missed.html' unit=bulky_missed.$booking_guid original_booking=booking.id no_default=1 %]
     </div>
   [% END %]
@@ -95,7 +95,7 @@
         </div>
       </dl>
       <div class="waste-services-launch-panel">
-        <a class="btn btn-primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/index', { continue_id => booking.id }) %]">Retry booking</a>
+        <a class="btn btn--primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/index', { continue_id => booking.id }) %]">Retry booking</a>
       </div>
     [% END %]
   [% END %]
@@ -128,7 +128,7 @@
 <div class="waste-services-launch-panel">
   [% IF NOT c.user_exists AND (pending_bulky_collections OR recent_bulky_collections) %]
     <!-- #07 Should be displayed when: user HASN'T signed in -->
-    <a class="btn btn-primary govuk-!-margin-bottom-2" href="/auth?r=waste/[% property.id %]">View existing bookings</a>
+    <a class="btn btn--primary govuk-!-margin-bottom-2" href="/auth?r=waste/[% property.id %]">View existing bookings</a>
     <!-- END #07 -->
   [% END %]
   [% IF waste_features.bulky_multiple_bookings OR NOT pending_bulky_collections %]
@@ -138,7 +138,7 @@
     <form method="post" action="[% c.uri_for_action('waste/bulky/index_small', [ property.id ]) %]">
     [% END %]
       <input type="hidden" name="token" value="[% csrf_token %]">
-      <input class="btn btn-primary govuk-!-margin-bottom-2" type="submit" aria-label="Book a collection" value="Book a collection">
+      <input class="btn btn--primary govuk-!-margin-bottom-2" type="submit" aria-label="Book a collection" value="Book a collection">
     </form>
   [% END %]
 </div>

--- a/templates/web/bathnes/contact/index.html
+++ b/templates/web/bathnes/contact/index.html
@@ -138,7 +138,7 @@
 
     [% PROCESS 'auth/form_extra.html' %]
 
-    <input class="final-submit green-btn" type="submit" value="[% loc('Send') %]">
+    <input class="final-submit btn btn--primary" type="submit" value="[% loc('Send') %]">
 
 </form>
 

--- a/templates/web/bexley/waste/services_extra.html
+++ b/templates/web/bexley/waste/services_extra.html
@@ -29,7 +29,7 @@
           If you're a keen gardener, we can take away your garden waste. We'll
           deliver a bin you can use, and empty it every two weeks.
         </p>
-        <a class="btn-primary btn" [% external_new_tab | safe %] href="https://www.bexley.gov.uk/services/rubbish-and-recycling/garden-waste-collection-service/sign-garden-waste-collection">Sign up for a garden waste collection</a>
+        <a class="btn btn--primary" [% external_new_tab | safe %] href="https://www.bexley.gov.uk/services/rubbish-and-recycling/garden-waste-collection-service/sign-garden-waste-collection">Sign up for a garden waste collection</a>
       </div>
     </div>
   </div>

--- a/templates/web/buckinghamshire/reports/cobrand_stats.html
+++ b/templates/web/buckinghamshire/reports/cobrand_stats.html
@@ -1,3 +1,3 @@
 <div class="parish-all-reports">
-  <p><a class="btn-primary" href="/about/parishes">View reports sent to Parish/Town Councils</a></p>
+  <p><a class="btn btn--primary" href="/about/parishes">View reports sent to Parish/Town Councils</a></p>
 </div>

--- a/templates/web/camden/auth/general.html
+++ b/templates/web/camden/auth/general.html
@@ -58,7 +58,7 @@
 
         <div class="form-txt-submit-box">
             <input type="password" name="password_sign_in" class="form-control" id="password_sign_in" value="" autocomplete="current-password">
-            <input class="green-btn" type="submit" name="sign_in_by_password" value="[% loc('Sign in') %]">
+            <input class="btn btn--primary" type="submit" name="sign_in_by_password" value="[% loc('Sign in') %]">
         </div>
 
         <p>

--- a/templates/web/cheshireeast/tokens/confirm_problem.html
+++ b/templates/web/cheshireeast/tokens/confirm_problem.html
@@ -27,7 +27,7 @@
   at any other time, quoting your reference number [% report.id %].</p>
 
   <p class="confirmation-again">
-    <a href="/report/new?latitude=[% report.latitude %]&amp;longitude=[% report.longitude %]" class="btn btn-primary">
+    <a href="/report/new?latitude=[% report.latitude %]&amp;longitude=[% report.longitude %]" class="btn btn--primary">
       [% loc('Report another problem here') %]
     </a>
   </p>

--- a/templates/web/cyclinguk/next_steps.html
+++ b/templates/web/cyclinguk/next_steps.html
@@ -45,7 +45,7 @@
         <span class="text-orange">Incredible</span>
       </h3>
       <p>Join our 70,000 strong membership today, and help us make a better world by bike tomorrow</p>
-      <a href="https://www.cyclinguk.org/join-cycling-uk-today" class="btn-primary">Join today</a>
+      <a href="https://www.cyclinguk.org/join-cycling-uk-today" class="btn btn--primary">Join today</a>
     </div>
   </div>
 </div>

--- a/templates/web/cyclinguk/tokens/confirm_problem.html
+++ b/templates/web/cyclinguk/tokens/confirm_problem.html
@@ -11,7 +11,7 @@
     [% TRY %][% INCLUDE 'tokens/_extras_confirm.html' %][% CATCH file %][% END %]
 
     <p class="confirmation-again">
-      <a href="/report/new?latitude=[% report.latitude %]&amp;longitude=[% report.longitude %]" class="btn-primary">
+      <a href="/report/new?latitude=[% report.latitude %]&amp;longitude=[% report.longitude %]" class="btn btn--primary">
         [% loc('Report another problem here') %]
       </a>
     </p>

--- a/templates/web/hackney/auth/general.html
+++ b/templates/web/hackney/auth/general.html
@@ -60,7 +60,7 @@
 
         <div class="form-txt-submit-box">
             <input type="password" name="password_sign_in" class="form-control" id="password_sign_in" value="" autocomplete="current-password">
-            <input class="green-btn" type="submit" name="sign_in_by_password" value="[% loc('Sign in') %]">
+            <input class="btn btn--primary" type="submit" name="sign_in_by_password" value="[% loc('Sign in') %]">
         </div>
 
         <p>

--- a/templates/web/highwaysengland/tokens/confirm_problem.html
+++ b/templates/web/highwaysengland/tokens/confirm_problem.html
@@ -10,7 +10,7 @@
   <a href="/">main page</a> and enter the above reference in the search box.</p>
 
   <p class="confirmation-again">
-    <a href="/report/new?latitude=[% report.latitude %]&amp;longitude=[% report.longitude %]" class="btn btn-primary">
+    <a href="/report/new?latitude=[% report.latitude %]&amp;longitude=[% report.longitude %]" class="btn btn--primary">
       [% loc('Report another problem here') %]
     </a>
   </p>

--- a/templates/web/kingston/auth/general.html
+++ b/templates/web/kingston/auth/general.html
@@ -27,7 +27,7 @@
 
      <div class="form-txt-submit-box">
          <input type="password" name="password_sign_in" class="form-control" id="password_sign_in" value="" autocomplete="current-password">
-         <input class="green-btn" type="submit" name="sign_in_by_password" value="[% loc('Sign in') %]">
+         <input class="btn btn--primary" type="submit" name="sign_in_by_password" value="[% loc('Sign in') %]">
      </div>
 
     <p>

--- a/templates/web/peterborough/waste/_announcement.html
+++ b/templates/web/peterborough/waste/_announcement.html
@@ -3,7 +3,7 @@
     <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-2">
         <div class="cta-announcement">
             <span>Now you can arrange a bulky waste collection online</span>
-            <a class="btn btn-primary" href="#bulky-waste" aria-label="Book a bulky waste collection">Book now</a>
+            <a class="btn btn--primary" href="#bulky-waste" aria-label="Book a bulky waste collection">Book now</a>
         </div>
     </div>
 </div>

--- a/templates/web/peterborough/waste/_bulky_not_signed_user.html
+++ b/templates/web/peterborough/waste/_bulky_not_signed_user.html
@@ -8,7 +8,7 @@
                 You need to sign in to see the full details of this property.
             </p>
             <p class="govuk-!-margin-bottom-0">
-                <a class="btn btn-primary govuk-!-margin-bottom-2" href="/auth?r=waste/[% property.id %]">Sign in</a>
+                <a class="btn btn--primary govuk-!-margin-bottom-2" href="/auth?r=waste/[% property.id %]">Sign in</a>
             </p>
     </div>
 </div>

--- a/templates/web/peterborough/waste/_service_missed.html
+++ b/templates/web/peterborough/waste/_service_missed.html
@@ -45,7 +45,7 @@
       <input type="hidden" name="token" value="[% csrf_token %]">
       <input type="hidden" name="service-[% unit.service_id %]" value="1">
       [% IF c.cobrand.call_hook('bulky_enabled') %]
-        <input class="btn btn-primary govuk-!-margin-bottom-2" type="submit" aria-label="Report a [% unit.service_name FILTER lower %] collection as missed" value="Report a missed collection" class="waste-service-descriptor waste-service-link">
+        <input class="btn btn--primary govuk-!-margin-bottom-2" type="submit" aria-label="Report a [% unit.service_name FILTER lower %] collection as missed" value="Report a missed collection" class="waste-service-descriptor waste-service-link">
       [% ELSE %]
         <input type="submit" value="Report a [% unit.service_name FILTER lower %] collection as missed" class="waste-service-descriptor waste-service-link">
       [% END %]

--- a/templates/web/peterborough/waste/bulky/booking_cancellation.html
+++ b/templates/web/peterborough/waste/bulky/booking_cancellation.html
@@ -15,6 +15,6 @@
         [% IF entitled_to_refund %]
             <p class="govuk-!-margin-bottom-2">Your refund is on its way.</p>
         [% END %]
-        <a href="[% c.uri_for_action('waste/bin_days', [ property.id ]) %]" class="btn btn-primary">Go back home</a>
+        <a href="[% c.uri_for_action('waste/bin_days', [ property.id ]) %]" class="btn btn--primary">Go back home</a>
     </div>
 </div>

--- a/templates/web/peterborough/waste/bulky/confirmation.html
+++ b/templates/web/peterborough/waste/bulky/confirmation.html
@@ -28,7 +28,7 @@
         <p class="govuk-!-margin-bottom-2">We have sent you an email confirming this booking.</p>
         <p>Can’t find our email? <strong>Check your spam folder.</strong></p>
       [% END %]
-        <a href="[% c.uri_for_action('waste/bin_days', [ report.get_extra_field_value('property_id') ]) %]" class="btn btn-primary">Go back home</a>
+        <a href="[% c.uri_for_action('waste/bin_days', [ report.get_extra_field_value('property_id') ]) %]" class="btn btn--primary">Go back home</a>
     </div>
 </div>
 

--- a/templates/web/peterborough/waste/index.html
+++ b/templates/web/peterborough/waste/index.html
@@ -20,7 +20,7 @@
  [% IF is_staff AND waste_features.bulky_retry_bookings %]
     <form method="post" style="display:flex;gap:0.25em;align-items:center">
         Unpaid booking reference: <input type="text" name="continue_id" value="[% continue_id %]" style="max-width:10em;">
-        <input type="submit" value="Retry bulky payment" class="btn btn-primary">
+        <input type="submit" value="Retry bulky payment" class="btn btn--primary">
     </form>
  [% END %]
 

--- a/templates/web/peterborough/waste/pay_error.html
+++ b/templates/web/peterborough/waste/pay_error.html
@@ -13,7 +13,7 @@
         <form method="POST" action="[% c.uri_for_action('waste/pay_retry') %]">
             <input type="hidden" name="id" value="[% report.id %]">
             <input type="hidden" name="token" value="[% report.get_extra_metadata('redirect_id') %]">
-            <input class="btn btn-primary" type="submit" value="Retry payment">
+            <input class="btn btn--primary" type="submit" value="Retry payment">
         </form>
       [% END %]
     </div>

--- a/templates/web/peterborough/waste/services.html
+++ b/templates/web/peterborough/waste/services.html
@@ -9,7 +9,7 @@
   <form method="post" action="[% c.uri_for_action('waste/problem', [ property.id ]) %]">
     <input type="hidden" name="token" value="[% csrf_token %]">
     [% IF c.cobrand.call_hook('bulky_enabled') %]
-      <input class="btn btn-primary govuk-!-margin-bottom-2" type="submit" aria-label="Report a problem with a [% unit.service_name FILTER lower %]" value="Report a problem" class="waste-service-descriptor waste-service-link">
+      <input class="btn btn--primary govuk-!-margin-bottom-2" type="submit" aria-label="Report a problem with a [% unit.service_name FILTER lower %]" value="Report a problem" class="waste-service-descriptor waste-service-link">
     [% ELSE %]
       <input type="submit" value="Report a problem with a [% unit.service_name FILTER lower %]" class="waste-service-descriptor waste-service-link">
     [% END %]
@@ -28,7 +28,7 @@
       <input type="hidden" name="container-[% unit.request_containers.0 %]" value="1">
       <input type="hidden" name="skip_bags" value="1">
       [% IF c.cobrand.call_hook('bulky_enabled') %]
-        <input class="btn btn-primary govuk-!-margin-bottom-2" type="submit" aria-label="Request a new [% unit.service_name FILTER lower %]" value="Request a new bin" class="waste-service-descriptor waste-service-link">
+        <input class="btn btn--primary govuk-!-margin-bottom-2" type="submit" aria-label="Request a new [% unit.service_name FILTER lower %]" value="Request a new bin" class="waste-service-descriptor waste-service-link">
       [% ELSE %]
         <input type="submit" value="Request a new [% unit.service_name FILTER lower %]" class="waste-service-descriptor waste-service-link">
       [% END %]

--- a/templates/web/sutton/auth/general.html
+++ b/templates/web/sutton/auth/general.html
@@ -27,7 +27,7 @@
 
      <div class="form-txt-submit-box">
          <input type="password" name="password_sign_in" class="form-control" id="password_sign_in" value="" autocomplete="current-password">
-         <input class="green-btn" type="submit" name="sign_in_by_password" value="[% loc('Sign in') %]">
+         <input class="btn btn--primary" type="submit" name="sign_in_by_password" value="[% loc('Sign in') %]">
      </div>
 
     <p>

--- a/templates/web/tfl/tokens/confirm_problem.html
+++ b/templates/web/tfl/tokens/confirm_problem.html
@@ -8,7 +8,7 @@
   <p>Your reference for this report is FMS[% report.id %], please quote it in any enquiries.</p>
 
   <p class="confirmation-again">
-    <a href="/report/new?latitude=[% report.latitude %]&amp;longitude=[% report.longitude %]" class="btn btn-primary">
+    <a href="/report/new?latitude=[% report.latitude %]&amp;longitude=[% report.longitude %]" class="btn btn--primary">
       [% loc('Report another problem here') %]
     </a>
   </p>

--- a/templates/web/westminster/auth/general.html
+++ b/templates/web/westminster/auth/general.html
@@ -69,7 +69,7 @@
 
         <div class="form-txt-submit-box">
             <input type="password" name="password_sign_in" class="form-control" id="password_sign_in" value="" autocomplete="current-password">
-            <input class="green-btn" type="submit" name="sign_in_by_password" value="[% loc('Sign in') %]">
+            <input class="btn btn--primary" type="submit" name="sign_in_by_password" value="[% loc('Sign in') %]">
         </div>
 
         <p>

--- a/templates/web/zurich/auth/general.html
+++ b/templates/web/zurich/auth/general.html
@@ -19,7 +19,7 @@
         <label for="password_sign_in">[% loc('Password (optional)') %]</label>
         <div class="form-txt-submit-box">
             <input type="password" class="required" name="password_sign_in" id="password_sign_in" value="">
-            <input class="green-btn" type="submit" name="sign_in_by_password" value="[% loc('Sign in') %]">
+            <input class="btn btn--primary" type="submit" name="sign_in_by_password" value="[% loc('Sign in') %]">
         </div>
 
     </div>
@@ -47,7 +47,7 @@
       [% END %]
         <div class="form-txt-submit-box">
             <input type="password" class="required js-password-validate" name="password_register" id="password_register" value="" aria-describedby="password_notes">
-            <input class="green-btn" type="submit" name="sign_in_by_code" value="Registrieren">
+            <input class="btn btn--primary" type="submit" name="sign_in_by_code" value="Registrieren">
         </div>
 
         <div class="general-notes" id="password_notes">

--- a/templates/web/zurich/report/new/fill_in_details_form.html
+++ b/templates/web/zurich/report/new/fill_in_details_form.html
@@ -45,8 +45,8 @@
                 <div class="form-txt-submit-box">
                     [%# class of submit_sign_in so name can be optional, name of submit_register so it doesn't try and sign us in %]
                     <p>
-                    <input class="desk-only green-btn js-submit_sign_in" type="submit" name="submit_register" value="[% loc('Submit') %]">
-                    <input class="mob-only green-btn js-submit_sign_in" type="submit" name="submit_register_mobile" value="[% loc('Submit') %]">
+                    <input class="desk-only btn btn--primary js-submit_sign_in" type="submit" name="submit_register" value="[% loc('Submit') %]">
+                    <input class="mob-only btn btn--primary js-submit_sign_in" type="submit" name="submit_register_mobile" value="[% loc('Submit') %]">
                     </p>
                 </div>
 

--- a/web/cobrands/bexley/base.scss
+++ b/web/cobrands/bexley/base.scss
@@ -77,8 +77,6 @@ a,
   }
 }
 
-.btn-primary,
-.green-btn,
 .btn--primary {
     border: none;
     background: $col_button;

--- a/web/cobrands/brent/base.scss
+++ b/web/cobrands/brent/base.scss
@@ -40,7 +40,7 @@ a {
   background-color: $link-focus-color;
 }
 
-.btn, .btn--primary, .btn-primary, .green-btn, #report-cta {
+.btn, .btn--primary, #report-cta {
   @include brent-btn-primary;
 }
 

--- a/web/cobrands/bromley/base.scss
+++ b/web/cobrands/bromley/base.scss
@@ -178,19 +178,10 @@ input.field, input.text,
   font-family: $body-font;
 }
 
-.btn-primary,
-.green-btn,
 .btn--primary {
   $bg: $bromley_blue;
   $hover-bg: darken($bromley_blue, 10%);
   @include button-variant($bg, $bg, false, #fff, $hover-bg, $hover-bg, false, #fff);
-  border-color: $bromley_blue !important;
-}
-
-.btn-primary--bg-white {
-  $bg: #fff;
-  $hover-bg: darken($bromley_blue, 10%);
-  @include button-variant($bg, $bg, false, $bromley_blue, $hover-bg, $hover-bg, false, $bg);
   border-color: $bromley_blue !important;
 }
 

--- a/web/cobrands/buckinghamshire/base.scss
+++ b/web/cobrands/buckinghamshire/base.scss
@@ -111,7 +111,7 @@ dl dt {
 }
 
 
-.btn-primary, .green-btn, .btn--primary {
+.btn--primary {
   background: none;
   color: $bucks_charcoal !important;
   @include bucks-button();

--- a/web/cobrands/camden/base.scss
+++ b/web/cobrands/camden/base.scss
@@ -105,7 +105,7 @@ a {
   background-color: $link-focus-background-colour;
 }
 
-.btn, .btn--primary, .btn-primary, .green-btn, #report-cta {
+.btn, .btn--primary, #report-cta {
   @include cobrand-btn-primary;
 }
 

--- a/web/cobrands/cheshireeast/base.scss
+++ b/web/cobrands/cheshireeast/base.scss
@@ -75,8 +75,6 @@ a,
     }
 }
 
-.btn-primary,
-.green-btn,
 .btn--primary {
     border: none;
     background: $col_button;

--- a/web/cobrands/cyclinguk/_variables.scss
+++ b/web/cobrands/cyclinguk/_variables.scss
@@ -89,7 +89,7 @@ $button-border-radius: 2rem; // This var doesn't exist in other cobrands
 
 // Usage 
 /*
-  .btn, .btn--primary, .btn--primary {
+  .btn--primary {
       @include border-radius($button-border-radius);
       @include button-variant($bg-top: $button-primary-bg-top, $bg-bottom: $button-primary-bg-bottom, $border: $button-primary-border, $text: $button-primary-text, $hover-bg-bottom: $button-primary-hover-bg-bottom, $hover-bg-top: $button-primary-hover-bg-top, $hover-border: $button-primary-hover-border, $hover-text: $button-primary-hover-text,$focus-bg-bottom: $button-primary-focus-bg-bottom, $focus-bg-top: $button-primary-focus-bg-top, $focus-border: $button-primary-focus-border, $focus-text: $button-primary-focus-text);
   }
@@ -108,7 +108,7 @@ $button-primary-focus-border: $yellow-600;
 $button-primary-focus-text: $primary_text;
 
 /*
-  .btn, .btn--secondary, .btn--secondary {
+  .btn, .btn-secondary {
       @include border-radius($button-border-radius);
       @include button-variant($bg-top: $button-secondary-bg-top, $bg-bottom: $button-secondary-bg-bottom, $border: $button-secondary-border, $text: $button-secondary-text, $hover-bg-bottom: $button-secondary-hover-bg-bottom, $hover-bg-top: $button-secondary-hover-bg-top, $hover-border: $button-secondary-hover-border, $hover-text: $button-secondary-hover-text,$focus-bg-bottom: $button-secondary-focus-bg-bottom, $focus-bg-top: $button-secondary-focus-bg-top, $focus-border: $button-secondary-focus-border, $focus-text: $button-secondary-focus-text);
   }

--- a/web/cobrands/cyclinguk/base.scss
+++ b/web/cobrands/cyclinguk/base.scss
@@ -83,12 +83,10 @@ $site-logo-height: 76px;
 
 //  BUTTONS
 .btn,
-.btn-primary, 
-.btn--primary, 
-.btn--secondary, 
-.btn--secondary,
+.btn--primary,
+.btn-secondary,
 .postcode-form-box div input#sub,
-.nav-menu--main a.btn-primary,
+.nav-menu--main a.btn--primary,
 .nav-menu--main a.btn-secondary,
 a#geolocate_link,
 #report-cta,
@@ -112,21 +110,18 @@ a#geolocate_link,
     }
 }
 
-.btn, 
-.btn-primary, 
-.btn--primary, 
+.btn,
+.btn-secondary,
+.nav-menu a.btn-secondary,
+a#geolocate_link {
+    @include button-variant($bg-top: $button-secondary-bg-top, $bg-bottom: $button-secondary-bg-bottom, $border: $button-secondary-border, $text: $button-secondary-text, $hover-bg-bottom: $button-secondary-hover-bg-bottom, $hover-bg-top: $button-secondary-hover-bg-top, $hover-border: $button-secondary-hover-border, $hover-text: $button-secondary-hover-text,$focus-bg-bottom: $button-secondary-focus-bg-bottom, $focus-bg-top: $button-secondary-focus-bg-top, $focus-border: $button-secondary-focus-border, $focus-text: $button-secondary-focus-text);
+}
+
+.btn--primary,
 .postcode-form-box div input#sub,
 #report-cta,
 .nav-menu--main a.report-a-problem-btn  {
     @include button-variant($bg-top: $button-primary-bg-top, $bg-bottom: $button-primary-bg-bottom, $border: $button-primary-border, $text: $button-primary-text, $hover-bg-bottom: $button-primary-hover-bg-bottom, $hover-bg-top: $button-primary-hover-bg-top, $hover-border: $button-primary-hover-border, $hover-text: $button-primary-hover-text,$focus-bg-bottom: $button-primary-focus-bg-bottom, $focus-bg-top: $button-primary-focus-bg-top, $focus-border: $button-primary-focus-border, $focus-text: $button-primary-focus-text);
-}
-
-.btn, 
-.btn--secondary, 
-.btn-secondary, 
-.nav-menu a.btn-secondary,
-a#geolocate_link {
-    @include button-variant($bg-top: $button-secondary-bg-top, $bg-bottom: $button-secondary-bg-bottom, $border: $button-secondary-border, $text: $button-secondary-text, $hover-bg-bottom: $button-secondary-hover-bg-bottom, $hover-bg-top: $button-secondary-hover-bg-top, $hover-border: $button-secondary-hover-border, $hover-text: $button-secondary-hover-text,$focus-bg-bottom: $button-secondary-focus-bg-bottom, $focus-bg-top: $button-secondary-focus-bg-top, $focus-border: $button-secondary-focus-border, $focus-text: $button-secondary-focus-text);
 }
 
 // GENERAL COMPONENTS

--- a/web/cobrands/fixamingata/base.scss
+++ b/web/cobrands/fixamingata/base.scss
@@ -216,8 +216,6 @@ $grid-breakpoint-sm: $mysoc-footer-breakpoint-sm;
     padding: 0;
 }
 
-.btn-primary,
-.green-btn,
 .btn--primary {
     @include button-variant(#1a9ab8, #05617a, #05617a, #fff, #045369, #1a9ab8, #05617a, #fff);
 }

--- a/web/cobrands/fixmystreet.com/base.scss
+++ b/web/cobrands/fixmystreet.com/base.scss
@@ -189,7 +189,6 @@ body.frontpage {
 }
 
 // Yellow primary buttons on FMS.com, rather than green.
-.btn-primary,
 .btn--primary {
     @include button-variant(
         mix($primary, #fff, 50%),

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1045,10 +1045,10 @@ $.extend(fixmystreet.set_up, {
                 if (max_photos == 1 && prevFile) {
                     this.removeFile(prevFile);
                 }
-                $('input[type=submit]', $context).prop("disabled", true).removeClass('green-btn');
+                $('input[type=submit]', $context).prop("disabled", true);
               });
               this.on("queuecomplete", function() {
-                $('input[type=submit]', $context).prop('disabled', false).addClass('green-btn');
+                $('input[type=submit]', $context).prop('disabled', false);
               });
               this.on("success", function(file, xhrResponse) {
                 var $upload_fileids = $('input[name="' + $fileid_input + '"]', $context);

--- a/web/cobrands/gloucestershire/base.scss
+++ b/web/cobrands/gloucestershire/base.scss
@@ -56,7 +56,7 @@ a#geolocate_link {
     border-color: $primary_text;
 }
 
-.green-btn {
+.btn--primary {
     @include button-variant($bg-top: $gloucestershire_blue_button, $bg-bottom: $gloucestershire_blue_button, $border: $gloucestershire_blue_button, $text: $primary_text, $hover-bg-bottom: $primary_text, $hover-bg-top: $primary_text, $hover-border: $button-primary-hover-border, $hover-text: $gloucestershire_blue_button);
     border-width: $button-border-width;
     @include focus-state;

--- a/web/cobrands/greenwich/base.scss
+++ b/web/cobrands/greenwich/base.scss
@@ -107,9 +107,7 @@ h2 {
     line-height: 1.3;
 }
 
-button,
-.btn,
-.green-btn {
+button, .btn {
     border: none;
     color: white !important;
     background: $greenwich_red;

--- a/web/cobrands/hackney/base.scss
+++ b/web/cobrands/hackney/base.scss
@@ -93,7 +93,6 @@
   color: #fff;
 }
 
-.green-btn,
 .btn {
   border-radius: 4px;
   font-size: 1.1875em;
@@ -118,9 +117,7 @@
   }
 }
 
-.btn--primary,
-.btn-primary,
-.green-btn {
+.btn--primary {
   background: $dark_green;
   border: 2px solid transparent;
   color: #ffffff;

--- a/web/cobrands/hart/hart.scss
+++ b/web/cobrands/hart/hart.scss
@@ -117,23 +117,23 @@ a {
 }
 
 .btn, 
-.btn--primary, .btn--primary,
-.btn--secondary, .btn--secondary,
+.btn--primary,
+.btn-secondary,
 #front-main #postcodeForm div input#sub {
   @include border-radius($button-border-radius);
   @extend .h6;
 }
 
-.btn ,.btn--primary, .btn--primary, .green-btn {
+.btn, .btn--primary {
   @include button-variant($bg-top: $button-primary-bg-top, $bg-bottom: $button-primary-bg-bottom, $border: $button-primary-border, $text: $button-primary-text, $hover-bg-bottom: $button-primary-hover-bg-bottom, $hover-bg-top: $button-primary-hover-bg-top, $hover-border: $button-primary-hover-border, $hover-text: $button-primary-hover-text);
   @include hart-boxshadow(6px, 6px, 0 , 0, $hart_primary_light);
 }
 
-.btn--secondary, .btn--secondary, .form-submit {
+.btn-secondary, .form-submit {
   @include button-variant($bg-top: $button-primary-bg-top, $bg-bottom: $button-primary-bg-bottom, $border: $button-primary-border, $text: $button-primary-text, $hover-bg-bottom: $button-primary-hover-bg-bottom, $hover-bg-top: $button-primary-hover-bg-top, $hover-border: $button-primary-hover-border, $hover-text: $button-primary-hover-text);
 }
 
-// Green button not the same as .green-btn
+// Green button not the same as .btn--primary
 .postcode-form-box div input#sub {
   @include button-variant($bg-top: $primary, $bg-bottom: $primary, $border: $primary, $text: $primary_text, $hover-bg-bottom: $primary_b, $hover-bg-top: $primary_b, $hover-border: $primary_text, $hover-text: $primary_text);
 }

--- a/web/cobrands/highwaysengland/base.scss
+++ b/web/cobrands/highwaysengland/base.scss
@@ -215,8 +215,6 @@ p.form-error {
     margin: 0 0 0.5em 1em;
 }
 
-.btn-primary,
-.green-btn,
 .btn--primary {
     background: $color-he-blue;
     border: none;

--- a/web/cobrands/hounslow/base.scss
+++ b/web/cobrands/hounslow/base.scss
@@ -15,8 +15,6 @@
     background-color: white;
 }
 
-.btn-primary,
-.green-btn,
 .btn--primary {
     border: none;
     background: $green;

--- a/web/cobrands/kingston/_colours.scss
+++ b/web/cobrands/kingston/_colours.scss
@@ -80,7 +80,8 @@ $postcodeform-background: transparent;
     border-radius: 25px;
     border: 4px solid $primary;
     background: $primary;
-    color: $white;
+    // Ovverides inherit !important on button-variant mixin
+    color: $white !important;
     text-decoration: none;
 
     // This gets rid of the .govuk-button box-shadow

--- a/web/cobrands/kingston/base.scss
+++ b/web/cobrands/kingston/base.scss
@@ -230,8 +230,7 @@ p.form-error {
     background: transparent;
 }
 
-.btn,
-.green-btn {
+.btn {
     @include kingston-button-primary();
 }
 

--- a/web/cobrands/lincolnshire/base.scss
+++ b/web/cobrands/lincolnshire/base.scss
@@ -79,8 +79,6 @@ h1, h2, h3 {
   }
 }
 
-.btn-primary,
-.green-btn,
 .btn--primary {
   background: none; // remove gradient bg
   background-color: $primary;

--- a/web/cobrands/merton/base.scss
+++ b/web/cobrands/merton/base.scss
@@ -36,8 +36,6 @@ a:focus,
 input:focus,
 button:focus,
 .btn:focus,
-.green-btn:focus,
-.btn-primary:focus,
 select:focus,
 textarea:focus,
 .multi-select-button:focus,
@@ -49,9 +47,6 @@ textarea:focus,
     box-shadow: 0 0 0 5px #333 !important;
 }
 
-.button,
-.green-btn,
-.btn-primary,
 input[type=button],
 input[type=reset],
 input[type=submit] :not(.item-list__item__shortlist-add) :not(item-list__item__shortlist-remove),
@@ -68,7 +63,7 @@ a#geolocate_link,
     padding: 12px 15px 10px;
 }
 
-.btn-primary, .govuk-button {
+.btn--primary, .govuk-button {
     padding: 12px 15px 10px;
     margin-bottom: 32px;
     line-height: 1;

--- a/web/cobrands/northamptonshire/base.scss
+++ b/web/cobrands/northamptonshire/base.scss
@@ -21,8 +21,6 @@
     background-color: $primary_b;
 }
 
-.btn-primary,
-.green-btn,
 .btn--primary {
     border: none;
     background: $purple;

--- a/web/cobrands/northnorthants/base.scss
+++ b/web/cobrands/northnorthants/base.scss
@@ -90,7 +90,6 @@ h1 {
 }
 
 .btn, 
-.btn-primary, 
 .btn--primary, 
 .postcode-form-box div input#sub,
 #report-cta,
@@ -105,7 +104,6 @@ h1 {
     }
 }
 
-.btn--secondary, 
 .btn-secondary, 
 .nav-menu a.btn-secondary,
 a#geolocate_link,

--- a/web/cobrands/northumberland/base.scss
+++ b/web/cobrands/northumberland/base.scss
@@ -58,7 +58,7 @@ a#geolocate_link {
     padding: 0.75em;
 }
 
-.green-btn {
+.btn--primary {
     @include button-variant($bg-top: $northumber_blue_button, $bg-bottom: $northumber_blue_button, $border: $northumber_blue_button, $text: $primary_text, $hover-bg-bottom: $primary_text, $hover-bg-top: $primary_text, $hover-border: $button-primary-hover-border, $hover-text: $northumber_blue_button);
     border-width: $button-border-width;
     @include focus-state;

--- a/web/cobrands/nottinghamshirepolice/base.scss
+++ b/web/cobrands/nottinghamshirepolice/base.scss
@@ -16,7 +16,6 @@ h1, h2, h3 {
 }
 
 /* BUTTONS */
-.btn-primary,
 .btn--primary,
 .postcode-form-box div input#sub,
 #report-cta {
@@ -28,7 +27,6 @@ h1, h2, h3 {
   @include nott-focus-state;
 }
 
-.btn--secondary,
 .btn-secondary,
 .nav-menu a.btn-secondary,
 a#geolocate_link,

--- a/web/cobrands/oxfordshire/base.scss
+++ b/web/cobrands/oxfordshire/base.scss
@@ -165,8 +165,6 @@ dd, p {
 // No border and slightly different padding for *all* types of button.
 .btn,
 .postcode-form-box div input#sub,
-.green-btn,
-.btn-primary,
 .occlss-button--primary {
     border: none;
     padding: 0.7em 1em 0.85em 1em;
@@ -186,8 +184,6 @@ dd, p {
 
 // Override all the "primary" buttons across the site!
 .postcode-form-box div input#sub,
-.green-btn,
-.btn-primary,
 .occlss-button--primary,
 .btn--primary {
     @include button-variant(

--- a/web/cobrands/peterborough/base.scss
+++ b/web/cobrands/peterborough/base.scss
@@ -33,8 +33,6 @@ h1, h2 {
     color: $alt-green;
 }
 
-.btn-primary,
-.green-btn,
 .btn--primary, .btn-secondary {
     border: 0.2em solid $primary;
     padding: 0.55em 1em;
@@ -64,8 +62,6 @@ h1, h2 {
     }
 }
 
-.btn-primary,
-.green-btn,
 .btn--primary {
     background: $primary;
 

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1120,8 +1120,6 @@ footer {
 
 // Deprecated
 // Try to use `btn btn--primary` etc instead of `btn-primary` where possible.
-.btn-primary,
-.green-btn,
 .btn-danger,
 .red-btn {
   @include button-size();
@@ -1132,8 +1130,6 @@ footer {
   margin-#{$left}: 0.5em;
 }
 
-.btn-primary,
-.green-btn,
 .btn--primary {
   @include button-variant($button-primary-bg-top, $button-primary-bg-bottom, $button-primary-border, $button-primary-text, $button-primary-hover-bg-top, $button-primary-hover-bg-bottom, $button-primary-hover-border, $button-primary-hover-text,$button-primary-focus-bg-bottom,$button-primary-focus-bg-top, $button-primary-focus-border, $button-primary-focus-text);
 }
@@ -2606,8 +2602,7 @@ label .muted {
     margin-bottom: 0;
   }
 
-  .btn,
-  .btn-primary {
+  .btn {
     margin: 0.5em 0 1em 0;
 
     &:first-child {

--- a/web/cobrands/shropshire/base.scss
+++ b/web/cobrands/shropshire/base.scss
@@ -242,8 +242,7 @@ p.form-error {
     padding: 1.5em;
 }
 
-.btn,
-.green-btn {
+.btn {
     @include shropshire-button-primary();
 }
 

--- a/web/cobrands/southwark/base.scss
+++ b/web/cobrands/southwark/base.scss
@@ -103,7 +103,7 @@ a {
   background-color: $link-focus-background-colour;
 }
 
-.btn, .btn--primary, .btn-primary, .green-btn {
+.btn, .btn--primary {
   @include cobrand-btn-primary;
 }
 

--- a/web/cobrands/sutton/base.scss
+++ b/web/cobrands/sutton/base.scss
@@ -254,7 +254,6 @@ p.form-error {
 }
 
 .btn,
-.green-btn,
 .lbs-button--tertiary {
     @include sutton-button;
 }

--- a/web/cobrands/tfl/base.scss
+++ b/web/cobrands/tfl/base.scss
@@ -55,9 +55,7 @@ h3 {
     line-height: 1.238095238em; //26px
 }
 
-.btn--primary,
-.btn,
-.green-btn {
+.btn--primary, .btn {
     @include tflbutton;
 }
 

--- a/web/cobrands/thamesmead/base.scss
+++ b/web/cobrands/thamesmead/base.scss
@@ -172,8 +172,7 @@ p.form-error {
     font-weight: 800;
 }
 
-.btn,
-.green-btn {
+.btn {
     @include peabody-button-primary();
 }
 

--- a/web/cobrands/westminster/base.scss
+++ b/web/cobrands/westminster/base.scss
@@ -263,12 +263,12 @@ body.authpage, body.twothirdswidthpage {
 
 body.alertpage, body.authpage, body.twothirdswidthpage {
     .form-txt-submit-box {
-        input.green-btn, input.btn-primary {
+        input.btn--primary {
             @include btn-medium-primary
         }
     }
 
-    input.green-btn {
+    input.btn--primary {
         @include btn-medium-primary
     }
 }


### PR DESCRIPTION
Gets rid of `green-btn` and `btn-primary` so all primary buttons across the board are `btn btn--primary`.

Ran `node check.js --base http://{s}.localhost:3000 --path /about/buttons --width 375 --height 600 --out before` (and after) with a small manual `templates/web/base/about/buttons.html` to show the buttons  - may be edge cases but hopefully no more than now/before: [buttons-before.pdf](https://github.com/user-attachments/files/16795587/buttons-before.pdf) [buttons-after.pdf](https://github.com/user-attachments/files/16795588/buttons-after.pdf)

Northumberland might be the only one to think about - its old green-btn and btn--primary were different, i kept the green-btn one but perhaps it shouldn't be that and they should all be the same?

For info, from my notes, live usage before this PR:
*    'btn btn-primary' (triage save, save draft, inspector save changes, bulky check/amend/cancel/retry/book now buttons, Pboro report missed/request new, Report another problem, Bexley garden waste subscribe button)
*    'btn-primary' alone (Subscribe on alert page, 2FA/text code pages, "Hide my name" button, Bucks view parish reports, Cycling Join Today and Cycling report another problem)
*    'green-btn' (Subscribe on problem updates, create account/forgot password, Sign in button, contact Send, moderate Save, Add support, Zurich report submit)
*    'btn btn--primary' (bulky admin items, 'Sign in with password', Creator fixed button, Report form submission)