### PR TITLE
Improved image keyboard focus view on Alert Page

### DIFF
--- a/templates/web/base/common_scripts.html
+++ b/templates/web/base/common_scripts.html
@@ -20,6 +20,7 @@ IF bodyclass.match('frontpage');
 ELSIF bodyclass.match('alertpage');
     scripts.push(
         version('/js/geolocation.js'),
+        version('/cobrands/fixmystreet/img_gallery_keyboard_view.js'),
     );
 ELSIF bodyclass.match('offlinepage');
     scripts.push(

--- a/web/cobrands/fixmystreet/img_gallery_keyboard_view.js
+++ b/web/cobrands/fixmystreet/img_gallery_keyboard_view.js
@@ -1,0 +1,5 @@
+document.querySelector('.alerts__nearby-activity__photos').addEventListener('focus', function(e) {
+    if (e.target.tagName === 'A') {
+        e.target.scrollIntoView();
+    }
+}, true);


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4518

Currently the browser doesn't scroll into view on images that are partially visible, which is causing a bit of a confusing navigation. This fix makes automatically scroll to the focused image.

https://github.com/user-attachments/assets/e275984d-2724-4d72-b582-223f88826fdb

At the beginning I was adding this fix to `FixMyStreet.js` but then I noticed that `/alert` page doesn't use it, so I ended up creating a file exclusively for it. Let me know if you think there is a more appropriate place to put it. 

[skip changelog]



