### PR TITLE
Improved image keyboard focus view on Alert Page

### DIFF
--- a/templates/web/base/alert/index.html
+++ b/templates/web/base/alert/index.html
@@ -24,7 +24,9 @@
 </form>
 
 [% IF photos.size %]
+<script type="module" src="[% version('/js/overflow-focus-scroll.js') %]"></script>
 <h2>[% loc('Some photos of recent reports') %]</h2>
+<overflow-focus-scroll>
 <div class="alerts__nearby-activity__photos">
   [% FOREACH p IN photos %]
     <a href="/report/[% p.id %]">
@@ -33,6 +35,7 @@
     </a>
   [% END %]
 </div>
+</overflow-focus-scroll>
 [% END %]
 
 [% INCLUDE 'footer.html' %]

--- a/templates/web/base/alert/list.html
+++ b/templates/web/base/alert/list.html
@@ -19,8 +19,10 @@
 <h1>[% title %]</h1>
 
 [% IF photos.size %]
+<script type="module" src="[% version('/js/overflow-focus-scroll.js') %]"></script>
 <div class="alerts__nearby-activity">
     <h2>[% loc('Photos of recent nearby reports') %]</h2>
+    <overflow-focus-scroll>
     <div class="alerts__nearby-activity__photos">
       [% FOREACH p IN photos %]
         <a href="/report/[% p.id %]">
@@ -29,6 +31,7 @@
         </a>
       [% END %]
     </div>
+    </overflow-focus-scroll>
 </div>
 [% END %]
 

--- a/web/js/overflow-focus-scroll.js
+++ b/web/js/overflow-focus-scroll.js
@@ -1,0 +1,20 @@
+/*
+ * If you tab to something entirely out of view, the browser scrolls to include it,
+ * but if it is half in view (say a row of photos with overflow-x: scroll), it does
+ * not. This custom element will make sure anything scrolls into view on focus.
+ */
+
+// jshint esversion: 6
+
+function focused(e) {
+    e.target.scrollIntoView({ block: "nearest", inline: "nearest" });
+}
+
+class OverflowFocusScroll extends HTMLElement {
+  constructor() {
+    super();
+    this.addEventListener('focus', focused, true);
+  }
+}
+
+window.customElements.define('overflow-focus-scroll', OverflowFocusScroll);


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4518

Currently the browser doesn't scroll into view on images that are partially visible, which is causing a bit of a confusing navigation. This fix makes automatically scroll to the focused image.

https://github.com/user-attachments/assets/e275984d-2724-4d72-b582-223f88826fdb

At the beginning I was adding this fix to `FixMyStreet.js` but then I noticed that `/alert` page doesn't use it, so I ended up creating a file exclusively for it. Let me know if you think there is a more appropriate place to put it. 

[skip changelog]