### PR TITLE
Detect if a report was made via PWA.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1198,6 +1198,10 @@ sub process_report : Private {
         $report->service('desktop');
     }
 
+    if (($report->service eq 'mobile' || $report->service eq 'desktop') && $c->get_param('probably_pwa')) {
+        $report->service($report->service  . " (probably PWA)");
+    }
+
     # set these straight from the params
     $report->category( _ $params{category} ) if $params{category};
     $report->set_extra_metadata(group => $params{group}) if $params{group};

--- a/t/app/controller/report_new_pwa.t
+++ b/t/app/controller/report_new_pwa.t
@@ -1,0 +1,67 @@
+use FixMyStreet::TestMech;
+use LWP::Protocol::PSGI;
+use t::Mock::MapItZurich;
+
+my $mech = FixMyStreet::TestMech->new;
+
+# disable info logs for this test run
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
+my $body = $mech->create_body_ok(2651, 'Edinburgh', {}, {});
+my $user = $mech->create_user_ok('publicuser@example.com', name => 'Not Fred Again');
+
+$mech->create_contact_ok(
+    body_id => $body->id,
+    category => 'Street lighting',
+    email => 'highways@example.com',
+);
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => 'fixmystreet',
+    MAPIT_URL => 'http://mapit.uk/',
+}, sub {
+    for my $test (
+        { service => 'desktop' },
+        { service => 'mobile' },
+    ) {
+        $mech->log_in_ok($user->email);
+        subtest "Appends '(probably PWA)' to service if probably PWA" => sub {
+            FixMyStreet::DB->resultset("Problem")->delete_all;
+            $mech->get_ok('/around');
+            $mech->submit_form_ok( { with_fields => { pc => 'EH1 1BB', } }, "submit location" );
+            $mech->follow_link_ok( { text_regex => qr/skip this step/i, }, "follow 'skip this step' link" );
+
+            # Enable the probably PWA form - normally the javascript would do this for us.
+            my $form = $mech->current_form();
+            my $probably_pwa_field = $form->find_input('probably_pwa');
+            $probably_pwa_field->disabled(0);
+
+            $mech->submit_form_ok(
+                {
+                    button => 'submit_register',
+                    with_fields => {
+                        service => $test->{service},
+                        title => 'Test Report',
+                        detail => 'Test report details.',
+                        category => 'Street lighting',
+                        probably_pwa => 1,
+                    }
+                },
+                "submit good details"
+            );
+            $mech->content_contains('Thank you');
+            is_deeply $mech->page_errors, [], "check there were no errors";
+
+            my $report = FixMyStreet::DB->resultset("Problem")->first;
+            ok $report, "Found the report";
+
+            is $report->state, 'confirmed', "report confirmed";
+            is $report->service, $test->{service} . " (probably PWA)", "service is correct value";
+            $mech->log_out_ok;
+        };
+    }
+};
+
+END {
+    done_testing();
+}

--- a/templates/web/base/report/form/submit.html
+++ b/templates/web/base/report/form/submit.html
@@ -1,2 +1,3 @@
+<input class="enabled-if-probably-pwa" type="hidden" name="probably_pwa" value="1" disabled>
 <input class="desk-only btn btn--primary btn--block btn--final js-submit_register" type="submit" name="submit_register" value="[% loc('Submit') %]">
 <input class="mob-only btn btn--primary btn--block btn--final js-submit_register" type="submit" name="submit_register_mobile" value="[% loc('Submit') %]">

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -476,6 +476,11 @@ $.extend(fixmystreet.set_up, {
         submitHandler: function(form) {
             if (form.submit_problem) {
                 $('input[type=submit]', form).prop("disabled", true);
+                if (window.matchMedia('(display-mode: minimal-ui)').matches) {
+                    $('.enabled-if-probably-pwa', form).prop("disabled", false);
+                } else {
+                    $('.enabled-if-probably-pwa', form).prop("disabled", true);
+                }
             }
             form.submit();
         },


### PR DESCRIPTION
[skip changelog]

This took far longer than it needed to 😄.

Appends '(probably PWA)' to the service if we detect the display-mode is minimal-ui. 
Wasn't able to find a more robust way to determine if the frontend is a PWA or not.

Closes https://github.com/mysociety/societyworks/issues/4052