### PR TITLE
[eastherts] Added fix to vertical position of eh-header__nav-link

### DIFF
--- a/web/cobrands/eastherts/base.scss
+++ b/web/cobrands/eastherts/base.scss
@@ -85,7 +85,7 @@ button:focus {
 .eh-header__nav-link {
     position: absolute;
     right: 1em;
-    // top: 40px; // vertically centre alongside logo
+    top: 2.5em;
     display: block;
     overflow: hidden;
     width: 40px;


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4524
There wasn't any top property, therefore the hamburger was seating at the bottom, clashing with searhbar

<img width="541" alt="Screenshot 2024-09-05 at 11 23 36" src="https://github.com/user-attachments/assets/036c1143-5dbf-492b-b742-5b5d77b6e938">

[Skip changelog]
