### PR TITLE
[Central Beds] Adds council ref to alert update

### DIFF
--- a/templates/email/bexley/_council_reference_alert_update.html
+++ b/templates/email/bexley/_council_reference_alert_update.html
@@ -1,2 +1,1 @@
-<p style="[% p_style %]">The report's reference number is <strong>[% problem.id %]</strong>.
-  Please quote this if you need to contact the council about this report.</p>
+_council_reference.html

--- a/templates/email/bexley/_council_reference_alert_update.txt
+++ b/templates/email/bexley/_council_reference_alert_update.txt
@@ -1,2 +1,1 @@
-The report's reference number is [% problem.id %]. Please quote this if
-you need to contact the council about this report.
+_council_reference.txt

--- a/templates/email/centralbedfordshire/_council_reference_alert_update.html
+++ b/templates/email/centralbedfordshire/_council_reference_alert_update.html
@@ -1,0 +1,1 @@
+_council_reference.html

--- a/templates/email/centralbedfordshire/_council_reference_alert_update.txt
+++ b/templates/email/centralbedfordshire/_council_reference_alert_update.txt
@@ -1,0 +1,1 @@
+_council_reference.txt

--- a/templates/email/cheshireeast/_council_reference_alert_update.html
+++ b/templates/email/cheshireeast/_council_reference_alert_update.html
@@ -1,2 +1,1 @@
-<p style="[% p_style %]">The report's reference number is <strong>[% problem.id %]</strong>.
-  Please quote this if you need to contact the council about this report.</p>
+_council_reference.html

--- a/templates/email/cheshireeast/_council_reference_alert_update.txt
+++ b/templates/email/cheshireeast/_council_reference_alert_update.txt
@@ -1,2 +1,1 @@
-The report's reference number is [% problem.id %]. Please quote this if
-you need to contact the council about this report.
+_council_reference.txt

--- a/templates/email/hounslow/_council_reference_alert_update.html
+++ b/templates/email/hounslow/_council_reference_alert_update.html
@@ -1,4 +1,1 @@
-[% IF problem.external_id ~%]
-<p style="[% p_style %]">The report's reference number is <strong>[% problem.external_id %]</strong>.
-  Please quote this if you need to contact Hounslow Highways about this report.</p>
-[%~ END %]
+_council_reference.html

--- a/templates/email/hounslow/_council_reference_alert_update.txt
+++ b/templates/email/hounslow/_council_reference_alert_update.txt
@@ -1,2 +1,1 @@
-[% IF problem.external_id %]The report's reference number is [% problem.external_id %]. Please quote this if
-you need to contact Hounslow Highways about this report.[% END %]
+_council_reference.txt

--- a/templates/email/isleofwight/_council_reference_alert_update.html
+++ b/templates/email/isleofwight/_council_reference_alert_update.html
@@ -1,4 +1,1 @@
-[% IF problem.external_id ~%]
-<p style="[% p_style %]">The report's reference number is <strong>[% problem.external_id %]</strong>.
-  Please quote this if you need to contact Island Roads about this report.</p>
-[%~ END %]
+_council_reference.html

--- a/templates/email/isleofwight/_council_reference_alert_update.txt
+++ b/templates/email/isleofwight/_council_reference_alert_update.txt
@@ -1,2 +1,1 @@
-[% IF problem.external_id %]The report's reference number is [% problem.external_id %]. Please quote this if
-you need to contact Island Roads about this report.[% END %]
+_council_reference.txt

--- a/templates/email/northamptonshire/_council_reference_alert_update.html
+++ b/templates/email/northamptonshire/_council_reference_alert_update.html
@@ -1,2 +1,1 @@
-<p style="[% p_style %]">The report's reference number is <strong>[% problem.id %]</strong>.
-  Please quote this if you need to contact the council about this report.</p>
+_council_reference.html

--- a/templates/email/northamptonshire/_council_reference_alert_update.txt
+++ b/templates/email/northamptonshire/_council_reference_alert_update.txt
@@ -1,2 +1,1 @@
-The report's reference number is [% problem.id %]. Please quote this if
-you need to contact the council about this report.
+_council_reference.txt

--- a/templates/email/peterborough/_council_reference_alert_update.html
+++ b/templates/email/peterborough/_council_reference_alert_update.html
@@ -1,2 +1,1 @@
-<p style="[% p_style %]">The report's reference number is <strong>[% problem.id %]</strong>.
-  Please quote this if you need to contact the council about this report.</p>
+_council_reference.html

--- a/templates/email/peterborough/_council_reference_alert_update.txt
+++ b/templates/email/peterborough/_council_reference_alert_update.txt
@@ -1,2 +1,1 @@
-The report's reference number is [% problem.id %]. Please quote this if
-you need to contact the council about this report.
+_council_reference.txt

--- a/templates/email/tfl/_council_reference_alert_update.html
+++ b/templates/email/tfl/_council_reference_alert_update.html
@@ -1,1 +1,1 @@
-[% INCLUDE '_council-reference.html' %]
+_council_reference.html

--- a/templates/email/tfl/_council_reference_alert_update.txt
+++ b/templates/email/tfl/_council_reference_alert_update.txt
@@ -1,1 +1,1 @@
-[% INCLUDE '_council-reference.txt' %]
+_council_reference.txt


### PR DESCRIPTION
For FD-4535. And making consistent use of symlinks in this bit. [skip changelog]
Guess there's a question as to whether we should do this consistently everywhere automatically rather than needing a template, something to discuss perhaps.