### PR TITLE
Add reporter/staff/notopen311-open option for updates_allowed

### DIFF
--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -499,6 +499,8 @@ sub _updates_disallowed_check {
         return $cfg unless !$body_comment_user && $open;
     } elsif ($cfg eq 'reporter-not-open/staff-open') {
         return $cfg unless ( $reporter && !$open ) || ( $staff && $open );
+    } elsif ($cfg eq 'reporter/staff/notopen311-open') {
+        return $cfg unless ($reporter || $staff || !$body_comment_user) && $open;
     }
     return '';
 }


### PR DESCRIPTION
North Northants already had notopen311-open, but asked to also have the reporter/staff-open option, which didn't exist.

This change combines the notopen311-open and reporter/staff-open options into one.

For FD-4419

<!-- [skip changelog] -->