### PR TITLE
[Bexley] Look up service description

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -1091,18 +1091,23 @@ sub waste_munge_report_data {
 
     my $c = $self->{c};
 
-    my $address = $c->stash->{property}->{address};
-    my $service = $c->stash->{services}{$id}{service_name};
+    my $property = $c->stash->{property};
+    my $address = $property->{address};
+    my $service_id = $c->stash->{services}{$id}{service_id};
+    my $service_name = $c->stash->{services}{$id}{service_name};
     my $uprn = $c->stash->{services}{$id}{uprn};
-    $data->{title} = "Report missed $service";
+    my $containers = $self->_containers($property);
+    my $service_description = $containers->{$service_id}->{description};
+    $service_description = 'Various' if $service_description =~ /<li>/;
+    $data->{title} = "$service_name ($service_description)";
     $data->{detail} = "$data->{title}\n\n$address";
     $c->set_param('uprn', $uprn);
     $c->set_param('service_id', $id);
     $c->set_param('location_of_containers', $data->{extra_detail}) if $data->{extra_detail};
-    $c->set_param('service_item_name', $c->stash->{services}{$id}{service_id});
+    $c->set_param('service_item_name', $service_id);
 
     # Check if this property has assisted collections
-    my $contracts = $self->whitespace->GetSiteContracts($c->stash->{property}{uprn});
+    my $contracts = $self->whitespace->GetSiteContracts($property->{uprn});
     $c->set_param('assisted_yn', (grep { $_->{ContractID} == 7 } @$contracts) ? 'Yes' : 'No');
 }
 

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -6,6 +6,7 @@ use Test::MockTime 'set_fixed_time';
 use Test::Output;
 use FixMyStreet::TestMech;
 use FixMyStreet::Script::Reports;
+use FixMyStreet::Script::Alerts;
 
 FixMyStreet::App->log->disable('info');
 END { FixMyStreet::App->log->enable('info'); }
@@ -846,7 +847,13 @@ FixMyStreet::override_config {
             'Submitting missed collection report'
         );
         $mech->content_contains('Missed collection has been reported');
-
+        FixMyStreet::Script::Reports::send();
+        my @emails = $mech->get_email;
+        my $email;
+        for my $mail (@emails) {
+            $email = $mail->as_string if $mail->header('To') =~ 'test@example.com';
+        };
+        like $email, qr/Brown Caddy \(Food waste\)/, 'Service added to title';
         my @reports = FixMyStreet::DB->resultset("Problem")->all;
         is @reports, 1, 'only one report created';
 

--- a/templates/email/bexley/waste/_sidebar_content.html
+++ b/templates/email/bexley/waste/_sidebar_content.html
@@ -6,7 +6,7 @@
     title = title.remove(address);
   ELSIF is_missed_collection;
     title = report.title;
-    title = title.remove('Report missed ');
+    title = title.remove('Report missed '); # For any older reports
   END
 %]
 <h2 style="[% h2_style %]">Bins reported as missed:</h2>


### PR DESCRIPTION
Adds the service description to the template email so the service and container are shown.

https://mysocietysupport.freshdesk.com/a/tickets/4449
[skip changelog]
