### PR TITLE
Process answered questionnaires in CSV export.

### DIFF
--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -253,6 +253,18 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+__PACKAGE__->has_many(
+  answered_questionnaires => "FixMyStreet::DB::Result::Questionnaire",
+  sub {
+      my $args = shift;
+      return {
+          "$args->{foreign_alias}.problem_id" => { -ident => "$args->{self_alias}.id" },
+          "$args->{foreign_alias}.whenanswered" => { '!=' => undef },
+      };
+  },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
 __PACKAGE__->might_have(
   contributed_by => "FixMyStreet::DB::Result::User",
   sub {

--- a/perllib/FixMyStreet/Reporting.pm
+++ b/perllib/FixMyStreet/Reporting.pm
@@ -288,7 +288,7 @@ sub generate_csv {
             ? '(anonymous)' : $obj->name;
 
         if ($asked_for{acknowledged}) {
-            my @updates = $obj->comments->all;
+            my @updates = $obj->confirmed_comments->all;
             @updates = sort { $a->confirmed <=> $b->confirmed || $a->id <=> $b->id } @updates;
             for my $comment (@updates) {
                 next unless $comment->problem_state || $comment->mark_fixed;

--- a/perllib/FixMyStreet/Reporting.pm
+++ b/perllib/FixMyStreet/Reporting.pm
@@ -197,8 +197,9 @@ sub _csv_parameters_problems {
     my $self = shift;
 
     my $groups = $self->cobrand->enable_category_groups ? 1 : 0;
-    my $join = ['confirmed_comments'];
-    my $columns = ['confirmed_comments.id', 'confirmed_comments.problem_state', 'confirmed_comments.confirmed', 'confirmed_comments.mark_fixed'];
+    my $join = ['confirmed_comments', 'answered_questionnaires'];
+    my $columns = ['confirmed_comments.id', 'confirmed_comments.problem_state', 'confirmed_comments.confirmed', 'confirmed_comments.mark_fixed',
+        'answered_questionnaires.id', 'answered_questionnaires.whenanswered', 'answered_questionnaires.new_state'];
     if ($groups) {
         push @$join, 'contact';
         push @$columns, 'contact.id', 'contact.extra';
@@ -301,6 +302,16 @@ sub generate_csv {
                 if ($closed_states->{ $problem_state }) {
                     $hashref->{closed} = $comment->confirmed;
                     last;
+                }
+            }
+            my @questionnaires = $obj->answered_questionnaires->all;
+            @questionnaires = sort { $a->whenanswered <=> $b->whenanswered || $a->id <=> $b->id } @questionnaires;
+            for my $questionnaire (@questionnaires) {
+                my $problem_state = $questionnaire->new_state || '';
+                if ($fixed_states->{ $problem_state }) {
+                    if (!$hashref->{fixed} || $questionnaire->whenanswered lt $hashref->{fixed}) {
+                        $hashref->{fixed} = $questionnaire->whenanswered;
+                    }
                 }
             }
         }


### PR DESCRIPTION
It is possible to have a questionnaire response, which marks a report as fixed, without a corresponding update. To ensure we have all the correct fixed timestamps, fetch answered questionnaires as well to check for any fixed responses. [skip changelog]