### PR TITLE
[Surrey] Move feedback script to different template

### DIFF
--- a/templates/web/surrey/footer_extra.html
+++ b/templates/web/surrey/footer_extra.html
@@ -39,3 +39,6 @@
 </footer>
 [% PROCESS '_footer_main_nav.html' %]
 [% PROCESS '_footer_extra_powered_by.html' %]
+
+<script type="text/javascript" src=https://feedback.happy-or-not.com/v1/bootloader/5D00DED5BC398A41C871E62A08F7CAC0/bootloaderjs/?lang=fi-FI&init=false></script>
+<script type="text/javascript" nonce="[% csp_nonce %]"> window.HappyOrNot && window.HappyOrNot.init({ token: "5D00DED5BC398A41C871E62A08F7CAC0", embedTo: document.getElementById('happy-or-not-smiley-digital-embed') }); </script>

--- a/templates/web/surrey/footer_extra_js.html
+++ b/templates/web/surrey/footer_extra_js.html
@@ -1,4 +1,1 @@
 [% PROCESS 'footer_extra_js_base.html' highways=1 validation=1 %]
-
-<script type="text/javascript" src=https://feedback.happy-or-not.com/v1/bootloader/5D00DED5BC398A41C871E62A08F7CAC0/bootloaderjs/?lang=fi-FI&init=false></script>
-<script type="text/javascript" nonce="[% csp_nonce %]"> window.HappyOrNot && window.HappyOrNot.init({ token: "5D00DED5BC398A41C871E62A08F7CAC0", embedTo: document.getElementById('happy-or-not-smiley-digital-embed') }); </script>


### PR DESCRIPTION
I noticed that the <script> tags for Surrey's HappyOrNot feedback script were appearing [in service-worker.js](https://tellus.surreycc.gov.uk/service-worker.js) on their cobrand.

<img width="948" alt="image" src="https://github.com/user-attachments/assets/a058b1e7-3741-4b94-9da6-c52577609dcf">

This fixes it by moving those scripts out of footer_extra_js and into footer_extra.

<!-- [skip changelog] -->
