### PR TITLE
[Admin] Restrict width of multi-select

### DIFF
--- a/web/cobrands/sass/_admin.scss
+++ b/web/cobrands/sass/_admin.scss
@@ -86,6 +86,9 @@ $button_bg_col: #a1a1a1;  // also search bar (tables)
     h2 { // only really want on first-child
         margin-top: 0;
     }
+    .multi-select-button {
+        white-space: normal;
+    }
 }
 
 .admin-offsite-link {


### PR DESCRIPTION
For bodies covering a lot of areas, like National Highways, this resulted in an extremely wide body edit page.

[skip changelog]