### PR TITLE
Added max-width to multi-select-button

### DIFF
--- a/web/cobrands/sass/_dashboard.scss
+++ b/web/cobrands/sass/_dashboard.scss
@@ -296,10 +296,6 @@
 }
 
 .dashboard-filters {
-    .multi-select-button {
-        max-width: 10em;
-    }
-
     .form-control {
         // To make them have the same height as the .multi-select-button
         height: 3.3em;

--- a/web/cobrands/sass/_multiselect.scss
+++ b/web/cobrands/sass/_multiselect.scss
@@ -126,6 +126,8 @@
     position: relative;
     white-space: nowrap;
     line-height: 1.5rem;
+    // .govuk-select has a max-width of 100%, this makes the multi-select-button to get wider and wider the more options the users clicks.
+    max-width: 12.5em !important;
 }
 
 .multi-select-container--open {


### PR DESCRIPTION
Because of its usage(multi-select) this element can get quite long the more options are added. This PR replaces the max-width(100%) from GOVUK and changes to 12.5em

[Skip changelog]

**Preview**
<img width="1148" alt="Screenshot 2024-09-17 at 12 19 54" src="https://github.com/user-attachments/assets/26030a1e-25e9-4349-bcd9-f3924b8036aa">

<img width="1148" alt="Screenshot 2024-09-17 at 12 19 31" src="https://github.com/user-attachments/assets/ad686b46-c533-4a24-92ce-4b0086f99281">

<img width="1148" alt="Screenshot 2024-09-17 at 12 23 30" src="https://github.com/user-attachments/assets/9ca3a7fc-ccf9-4084-a497-1d991dfe40d1">
