### PR TITLE
[Open311] Add --exclude to bin/open311-populate-service-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
         - Cobrands can provide per-category custom distances for duplicate lookup. #4746 #5162
         - Add perl 5.38 support.
         - Add plain text template previews to /_dev/email. #5105
+        - Add --exclude option to bin/open311-populate-service-list
     - Performance improvements:
         - Reduce database queries on shortlist page.
         - Provide ResultSet fallback translation in lookup.

--- a/bin/open311-populate-service-list
+++ b/bin/open311-populate-service-list
@@ -17,6 +17,7 @@ use Getopt::Long::Descriptive;
 my ($opt, $usage) = describe_options(
     '%c %o',
     ['body|b:s',   "body name to only fetch this body"],
+    ['exclude|e:s@', 'body name(s) to exclude from fetching' ],
     ['verbose|v',  "print out all services as they are found"],
     ['warn|w',     "output warnings about any issues"],
     ['help',       "print usage message and exit" ],
@@ -28,6 +29,9 @@ my $bodies = FixMyStreet::DB->resultset('Body')->search( {
 } );
 if ($opt->body) {
     $bodies = $bodies->search({ name => $opt->body });
+}
+if (my $exclude = $opt->exclude) {
+    $bodies = $bodies->search({ name => { -not_in => $exclude } });
 }
 
 my $verbose = 0;


### PR DESCRIPTION
Allows bodies to be excluded from Open311 service list fetching.

This seemed like the simplest approach and matches what we do for `bin/fetch`. Other options I considered were adding a "skip service list fetch" checkbox to the body admin edit page, and adding a cobrand hook to allow cobrand to opt-out of service list fetching.