### PR TITLE
[Island Roads] Default 'CONFIRM Subject' to be a blank selection

### DIFF
--- a/templates/web/base/admin/triage/_inspect.html
+++ b/templates/web/base/admin/triage/_inspect.html
@@ -1,27 +1,61 @@
 [% BLOCK category_list %]
-<select class="form-control" name="[% field_name %]" id="[% field_name %]">
-  [% IF category_options.size %]
-        [%~ IF category_groups.size ~%]
-            [%~ FOREACH group IN category_groups ~%]
-                [% IF group.name %]<optgroup label="[% group.name %]">[% END %]
-                [% group_select = 0 %]
-                [% selected = 0 %]
-                [%~ FOREACH cat_op IN group.categories ~%]
+  [%
+    # Isle of Wight selects a blank option by default,
+    # to force admin user to select a triage category
+  %]
+  [% IF c.cobrand.moniker == 'isleofwight' %]
+    <select class="form-control" name="[% field_name %]" id="[% field_name %]">
+      [% IF category_options.size %]
+            [%~ IF category_groups.size ~%]
+                [%~ FOREACH group IN category_groups ~%]
+                    [% IF group.name %]<optgroup label="[% group.name %]">[% END %]
+                    [% group_select = 0 %]
+                    [% selected = 0 %]
+
                     [% IF group_select == 0 AND problem.category == group.name %]
                         [% selected = 1; group_select = 1 %]
                     [% END %]
-                    <option value="[% cat_op.id %]"[% ' selected' IF selected OR problem.contact.id == cat_op.id %]>[% cat_op.category_display %] ([% cat_op.email %])</option>
-                    [% selected = 0 %]
-                [%~ END ~%]
-                [% IF group.name %]</optgroup>[% END %]
-            [%~ END =%]
-        [% ELSE %]
-              [% FOREACH cat IN category_options %]
-                <option value="[% cat.id %]"[% ' selected' IF problem.contact.id == cat.id %]>[% cat.category_display %]</option>
-              [% END %]
+
+                    <option value="" [% ' selected' IF selected %]>[% loc('-- Please select --') %]</option>
+
+                    [%~ FOREACH cat_op IN group.categories ~%]
+                        <option value="[% cat_op.id %]"[% ' selected' IF problem.contact.id == cat_op.id %]>[% cat_op.category_display %] ([% cat_op.email %])</option>
+                        [% selected = 0 %]
+                    [%~ END ~%]
+                    [% IF group.name %]</optgroup>[% END %]
+                [%~ END =%]
+            [% ELSE %]
+                  [% FOREACH cat IN category_options %]
+                    <option value="[% cat.id %]"[% ' selected' IF problem.contact.id == cat.id %]>[% cat.category_display %]</option>
+                  [% END %]
+          [% END %]
       [% END %]
+    </select>
+    [% ELSE %]
+    <select class="form-control" name="[% field_name %]" id="[% field_name %]">
+      [% IF category_options.size %]
+            [%~ IF category_groups.size ~%]
+                [%~ FOREACH group IN category_groups ~%]
+                    [% IF group.name %]<optgroup label="[% group.name %]">[% END %]
+                    [% group_select = 0 %]
+                    [% selected = 0 %]
+                    [%~ FOREACH cat_op IN group.categories ~%]
+                        [% IF group_select == 0 AND problem.category == group.name %]
+                            [% selected = 1; group_select = 1 %]
+                        [% END %]
+                        <option value="[% cat_op.id %]"[% ' selected' IF selected OR problem.contact.id == cat_op.id %]>[% cat_op.category_display %] ([% cat_op.email %])</option>
+                        [% selected = 0 %]
+                    [%~ END ~%]
+                    [% IF group.name %]</optgroup>[% END %]
+                [%~ END =%]
+            [% ELSE %]
+                  [% FOREACH cat IN category_options %]
+                    <option value="[% cat.id %]"[% ' selected' IF problem.contact.id == cat.id %]>[% cat.category_display %]</option>
+                  [% END %]
+          [% END %]
+      [% END %]
+    </select>
   [% END %]
-</select>
 [% END %]
 
 [% second_column = BLOCK -%]


### PR DESCRIPTION
A 'Please select' option with a blank value is added under every group header in the dropdown; this is selected by default (under the relevant header) to force the admin user to choose a triage category (rather than it defaulting to the first category in the group).

[skip changelog]

![Screenshot 2024-09-25 at 14 54 00](https://github.com/user-attachments/assets/347c5781-bf3f-40a7-9659-0c346cc50386)
