### PR TITLE
Add logging of slow/failed DB queries to healthcheck page

### DIFF
--- a/t/app/controller/status.t
+++ b/t/app/controller/status.t
@@ -1,4 +1,5 @@
 use FixMyStreet::TestMech;
+use Test::Output;
 use Test::MockModule;
 
 
@@ -12,16 +13,27 @@ my $surrey = $mech->create_body_ok(2242, 'Surrey County Council');
 
 
 subtest 'Health page returns 200 when things are OK' => sub {
-    $mech->get_ok('/status/health');
+    stderr_is { $mech->get_ok('/status/health') } "";
     is $mech->content, 'OK: ' . $report->id, 'Got correct content for status page';
     is $mech->res->code, 200, 'Got 200 for status page';
 };
 
-subtest 'Health page returns 500 when things are not OK' => sub {
+subtest 'Health page returns 500 and logs when things are not OK' => sub {
     my $rs = Test::MockModule->new('FixMyStreet::DB::ResultSet::Problem');
-    $rs->mock('first', sub { die 'DB error' });
-    $mech->get('/status/health');
+    $rs->mock('first', sub { die "DB error\n" });
+    stderr_is { $mech->get('/status/health') } "[info] Health check DB lookup failed: DB error\n";
     is $mech->res->code, 500, 'Got 500 for status page';
+};
+
+subtest 'Health page logs when query is slow' => sub {
+    my $rs = Test::MockModule->new('FixMyStreet::DB::ResultSet::Problem');
+    $rs->mock('first', sub {
+        sleep(2);
+        return $report;
+    });
+    stderr_like { $mech->get_ok('/status/health') } qr/Health check DB lookup took \d+\.\d+ seconds/;
+    is $mech->content, 'OK: ' . $report->id, 'Got correct content for status page';
+    is $mech->res->code, 200, 'Got 200 for status page';
 };
 
 


### PR DESCRIPTION
Trying to narrow down if the slow responses are due to DB contention or some other cause.