### PR TITLE
[Waste] Calendar performance improvements

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -568,9 +568,14 @@ sub csc_payment_failed : Path('csc_payment_failed') : Args(0) {
     $c->detach;
 }
 
-sub property : Chained('/') : PathPart('waste') : CaptureArgs(1) {
+sub property_id : Chained('/') : PathPart('waste') : CaptureArgs(1) {
     my ($self, $c, $id) = @_;
+    $c->stash->{property_id} = $id;
+}
 
+sub property : Chained('property_id') : PathPart('') : CaptureArgs(0) {
+    my ($self, $c) = @_;
+    my $id = $c->stash->{property_id};
 
     # Some actions chained off /waste/property require user to be logged in.
     # The redirect to /auth does not work if it follows the asynchronous
@@ -670,9 +675,8 @@ sub bin_day_deny : Private {
     $c->detach('/page_error_403_access_denied', [ $msg ]);
 }
 
-sub calendar : Chained('property') : Args(0) {
+sub calendar : Chained('property_id') : Args(0) {
     my ($self, $c) = @_;
-
     $c->forward('/about/page', ['waste-calendar']);
 }
 

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -679,6 +679,7 @@ sub calendar : Chained('property') : Args(0) {
 sub calendar_ics : Chained('property') : PathPart('calendar.ics') : Args(0) {
     my ($self, $c) = @_;
     $c->res->header(Content_Type => 'text/calendar');
+    $c->res->header(Cache_Control => 'max-age=86400');
     require Data::ICal::RFC7986;
     require Data::ICal::Entry::Event;
     my $calendar = Data::ICal::RFC7986->new(

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -221,6 +221,7 @@ FixMyStreet::override_config {
         $mech->get_ok('/waste/PE1 3NA:100090215480/calendar.ics');
         $mech->content_contains('DTSTART;VALUE=DATE:20210808');
         $mech->content_contains('DTSTART;VALUE=DATE:20210819');
+        is $mech->response->header('Cache-Control'), 'max-age=86400', 'Cache-Control header set';
     };
     subtest 'No reporting/requesting if open request' => sub {
         $mech->log_in_ok($staff->email);

--- a/templates/web/fixmystreet-uk-councils/about/waste-calendar.html
+++ b/templates/web/fixmystreet-uk-councils/about/waste-calendar.html
@@ -1,6 +1,6 @@
 [%
 PROCESS 'waste/header.html', title = 'Add your waste collection days to your online calendar';
-SET ics_link = c.uri_for_action('waste/calendar_ics', [ property.id ]);
+SET ics_link = c.uri_for_action('waste/calendar_ics', [ property_id ]);
 %]
 
 <script type="module" src="[% version('/vendor/clipboard-copy-element.js') %]"></script>


### PR DESCRIPTION
 - Adds `Cache-Control` header to `calendar.ics` responses
 - No longer hits backend APIs for calendar help page

[skip changelog]