### PR TITLE
Add parish councils

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
@@ -228,7 +228,7 @@ sub body_form_dropdowns : Private {
     # Some cobrands may want to add extra areas at runtime beyond those
     # available via MAPIT_WHITELIST or MAPIT_TYPES. This can be used for,
     # e.g., parish councils on a particular council cobrand.
-    $areas = $c->cobrand->call_hook("add_extra_areas" => $areas) || $areas;
+    $areas = $c->cobrand->call_hook("add_extra_areas_for_admin" => $areas) || $areas;
 
     $c->stash->{areas} = [ sort { strcoll($a->{name}, $b->{name}) } values %$areas ];
 

--- a/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Bodies.pm
@@ -222,7 +222,7 @@ sub body_form_dropdowns : Private {
     if ( $whitelist && ref $whitelist eq 'ARRAY' && @$whitelist ) {
         $areas = FixMyStreet::MapIt::call('areas', $whitelist);
     } else {
-        $areas = FixMyStreet::MapIt::call('areas', $c->cobrand->area_types);
+        $areas = FixMyStreet::MapIt::call('areas', $c->cobrand->area_types_for_admin);
     }
 
     # Some cobrands may want to add extra areas at runtime beyond those

--- a/perllib/FixMyStreet/App/Controller/Council.pm
+++ b/perllib/FixMyStreet/App/Controller/Council.pm
@@ -53,11 +53,8 @@ sub load_and_check_areas : Private {
 
     # Cobrand may wish to add area types to look up for a point at runtime.
     # This can be used for, e.g., parish councils on a particular council
-    # cobrand. NB three-tier councils break the alerts pages, so don't run the
-    # hook if we're on an alerts page.
-    unless ($c->stash->{area_check_action} eq 'alert') {
-        $area_types = $c->cobrand->call_hook("add_extra_area_types" => $area_types) || $area_types;
-    }
+    # cobrand.
+    $area_types = $c->cobrand->call_hook("add_extra_area_types" => $area_types) || $area_types;
 
     my $all_areas;
 

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -296,15 +296,6 @@ sub rss_area_ward : Path('/rss/area') : Args(2) {
     $url .= '/' . $c->cobrand->short_name( $c->stash->{ward} ) if $c->stash->{ward};
     $c->stash->{qs} = "/$url";
 
-    if ($c->cobrand->moniker eq 'fixmystreet' && $c->stash->{area}{type} ne 'DIS' && $c->stash->{area}{type} ne 'CTY') {
-        # UK-specific types - two possibilites are the same for one-tier councils, so redirect one to the other
-        # With bodies, this should presumably redirect if only one body covers
-        # the area, and then it will need that body's name (rather than
-        # assuming as now it is the same as the area)
-        $c->stash->{body} = $c->stash->{area};
-        $c->detach( 'redirect_body' );
-    }
-
     $c->stash->{type} = 'area_problems';
     if ( $c->stash->{ward} ) {
         # All problems within a particular ward

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -575,7 +575,7 @@ sub _parish_ids {
 }
 
 # Enable adding/editing of parish councils in the admin
-sub add_extra_areas {
+sub add_extra_areas_for_admin {
     my ($self, $areas) = @_;
 
     my $ids_string = join ",", @{ $self->_parish_ids };

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -589,17 +589,6 @@ sub add_extra_areas {
     return \%all_areas;
 }
 
-# Make sure CPC areas are included in point lookups for new reports
-sub add_extra_area_types {
-    my ($self, $types) = @_;
-
-    my @types = (
-        @$types,
-        'CPC',
-    );
-    return \@types;
-}
-
 sub is_two_tier { 1 }
 
 =head2 should_skip_sending_update
@@ -746,22 +735,6 @@ around 'munge_sendreport_params' => sub {
 
     $row->areas($original_areas);
 };
-
-sub council_rss_alert_options {
-    my ($self, @args) = @_;
-    my ($options) = super();
-
-    # rename old district councils to 'area' and remove 'ward' from their wards
-    # remove 'County' from Bucks Council name
-    for my $area (@$options) {
-        for my $key (qw(rss_text text)) {
-            $area->{$key} =~ s/District Council/area/ && $area->{$key} =~ s/ ward//;
-            $area->{$key} =~ s/ County//;
-        }
-    }
-
-    return ($options);
-}
 
 sub car_park_wfs_query {
     my ($self, $row) = @_;

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -828,6 +828,7 @@ The MaPit types this site handles
 
 sub area_types          { FixMyStreet->config('MAPIT_TYPES') || [ 'ZZZ' ] }
 sub area_types_children { FixMyStreet->config('MAPIT_TYPES_CHILDREN') || [] }
+sub area_types_for_admin { $_[0]->area_types }
 
 =item fetch_area_children
 

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -600,19 +600,6 @@ sub reopening_disallowed {
     return $self->next::method($problem);
 }
 
-# Make sure CPC areas are included in point lookups for new reports
-# This is so that parish bodies (e.g. in Buckinghamshire) are available
-# for reporting to on .com
-sub add_extra_area_types {
-    my ($self, $types) = @_;
-
-    my @types = (
-        @$types,
-        'CPC',
-    );
-    return \@types;
-}
-
 =head2 fetch_area_children
 
 If we are looking at the All Reports page for one of the extra London (TfL)

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -600,6 +600,26 @@ sub reopening_disallowed {
     return $self->next::method($problem);
 }
 
+=head2 add_extra_areas_for_admin
+
+Add the parish IDs from Buckinghamshire's cobrand, plus any other IDs from
+configuration, so that we can manually add specific parish councils.
+
+=cut
+
+sub add_extra_areas_for_admin {
+    my ($self, $areas) = @_;
+
+    my $bucks = FixMyStreet::Cobrand::Buckinghamshire->new;
+    my @extra = @{ $bucks->_parish_ids };
+    my $extra = $self->feature('extra_parishes') || [];
+    push @extra, @$extra;
+    my $ids_string = join ",", @extra;
+    my $extra_areas = mySociety::MaPit::call('areas', [ $ids_string ]);
+    my %all_areas = ( %$areas, %$extra_areas );
+    return \%all_areas;
+}
+
 =head2 fetch_area_children
 
 If we are looking at the All Reports page for one of the extra London (TfL)

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -189,9 +189,15 @@ sub dispatch_request {
         }
     },
 
-    sub (POST + /areas) {
+    sub (POST + /areas + %*) {
         my ($self, $areas) = @_;
-        $self->output({53319 => {parent_area => 2217, id => 53319, name => "Bradenham", type => "CPC"}});
+        my $out = {
+            53319 => { parent_area => 2217, id => 53319, name => "Bradenham", type => "CPC" },
+        };
+        if ($areas->{URL} =~ /59087/) {
+            $out->{59087} = { parent_area => 2538, id => 59087, name => "Castle Bromwich", type => "CPC" },
+        }
+        $self->output($out);
     },
 
     sub (GET + .geojson) {

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -34,22 +34,15 @@ my @PLACES = (
     [ '?', 51.615499, -0.556667, 163793, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED', 53822, 'Adstock', 'CPC' ],
     [ '?', 51.615965, -0.556367, 163793, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED', 53822, 'Adstock', 'CPC' ],
     [ '?', 51.615439, -0.558362, 163793, 'Buckinghamshire Council', 'CTY', 2257, 'Chiltern District Council', 'DIS', 2796, 'Chalfont Common', 'DIW', 143422, 'Chalfont St Peter', 'CED' ],
-    [ 'HP19 8FF', 51.822364, -0.826409, 163793, 'Buckinghamshire Council', 'CTY', 2258, 'Aylesbury Vale District Council', 'DIS', 144545, 'Gatehouse', 'DIW', 143444, 'Aylesbury North-West', 'CED' ],
-    [ '?', 51.995, -0.986 , 163793, 'Buckinghamshire Council', 'CTY', 2258, 'Aylesbury Vale District Council', 'DIS', 144539, 'Buckingham South', 'DIW', 143424, 'Buckingham West', 'CED' ],
-    [ '?', 51.940, -0.887, 163793, 'Buckinghamshire Council', 'CTY', 2258, 'Aylesbury Vale District Council', 'DIS', 144531, 'Winslow', 'DIW', 143404, 'Winslow', 'CED' ],
-    [ '?', 51.563, -0.499, 163793, 'Buckinghamshire Council', 'CTY', 2256, 'South Bucks District Council', 'DIS', 144508, 'Denham', 'DIW', 143412, 'Denham', 'CED' ],
-    [ 'HP9 2PJ', 51.611, -0.644, 163793, 'Buckinghamshire Council', 'CTY', 2256, 'South Bucks District Council', 'DIS', 144516, 'Beaconsfield North', 'DIW', 143415, 'Beaconsfield', 'CED' ],
-    [ '?', 51.628661, -0.748238, 163793, 'Buckinghamshire Council', 'CTY', 2255, 'Wycombe District Council', 'DIS', 2744, 'Abbey', 'DIW', 143428, 'Abbey', 'CED' ],
-    [ '?', 51.566667, -0.766667, 163793, 'Buckinghamshire Council', 'CTY', 2255, 'Wycombe District Council', 'DIS', 2752, 'Marlow South East', 'DIW', 143427, 'Marlow', 'CED' ],
     [ 'SW1A 1AA', 51.501009, -0.141588, 2504, 'Westminster City Council', 'LBO' ],
     [ '?', 51.507461, -0.126890, 2504, 'Westminster City Council', 'LBO' ],
     [ '?', 51.49228, -0.1488, 2504, 'Westminster City Council', 'LBO' ],
     [ 'GL50 2PR', 51.896268, -2.093063, 2226, 'Gloucestershire County Council', 'CTY', 2326, 'Cheltenham Borough Council', 'DIS', 4544, 'Lansdown', 'DIW', 143641, 'Lansdown and Park', 'CED' ],
     [ 'OX20 1SZ', 51.754926, -1.256179, 2237, 'Oxfordshire County Council', 'CTY', 2421, 'Oxford City Council', 'DIS' ],
     [ 'OX16 9UP', 52.038712, -1.346397, 2237, 'Oxfordshire County Council', 'CTY', 2419, 'Cherwell District Council', 'DIS', 151767, "Banbury, Calthorpe & Easington", "DIW" ],
-    [ 'RG9 6TL', 51.561705, -0.868388, 163793, 'Buckinghamshire Council', 'CTY'],
+    [ 'RG9 6TL', 51.561705, -0.868388, 163793, 'Buckinghamshire Council', 'UTA'],
     [ 'PE9 2GX', 52.656144, -0.502566, 2232, 'Lincolnshire County Council', 'CTY'],
-    [ 'LE15 0GJ', 52.670447, -0.727877, 2600, 'Rutland County Council', 'CTY'],
+    [ 'LE15 0GJ', 52.670447, -0.727877, 2600, 'Rutland County Council', 'UTA'],
     [ 'BR1 3UH', 51.4021, 0.01578, 2482, 'Bromley Council', 'LBO' ],
     [ 'BR1 3UH', 51.402096, 0.015784, 2482, 'Bromley Council', 'LBO' ],
     [ 'BR1 3UH', 51.402092, 0.015783, 2482, 'Bromley Council', 'LBO', 8141, 'Bromley Town', 'LBW' ],
@@ -181,6 +174,8 @@ sub dispatch_request {
         } elsif ($areas eq 'UTA') {
             $self->output({2650 => {parent_area => undef, id => 2650, name => "Aberdeen Council", type => "UTA"}});
         } elsif ($areas eq 'DIS,LBO,MTD,UTA,CTY,COI,LGD') {
+            $self->output({2508 => {parent_area => undef, id => 2508, name => "Hackney Council", type => "LBO"}});
+        } elsif ($areas eq 'DIS,LBO,MTD,UTA,CTY,COI,LGD,CPC') {
             $self->output({2508 => {parent_area => undef, id => 2508, name => "Hackney Council", type => "LBO"}});
         } elsif ($areas eq 'GRE') {
             $self->output({2493 => {parent_area => undef, id => 2493, name => "Greenwich Borough Council", type => "LBO"}});

--- a/t/cobrand/bucks.t
+++ b/t/cobrand/bucks.t
@@ -125,6 +125,17 @@ subtest 'cobrand displays correct categories' => sub {
     is @{$json->{bodies}}, 2, 'Still Bucks and parish returned';
 };
 
+subtest 'parish alert signup' => sub {
+    $mech->get_ok('/alert/list?latitude=51.615559&longitude=-0.556903');
+    $mech->content_contains('Buckinghamshire Council');
+    $mech->content_contains('Chiltern District Council');
+    $mech->content_contains('All reports within Adstock parish');
+    $mech->content_contains('Only reports sent to Adstock Parish Council');
+    $mech->submit_form_ok({ with_fields => {
+        feed => 'area:53822',
+    } });
+};
+
 subtest 'privacy page contains link to Bucks privacy policy' => sub {
     $mech->get_ok('/about/privacy');
     $mech->content_contains('privacy-and-buckinghamshire-highways');
@@ -387,40 +398,6 @@ subtest 'extra CSV columns are present' => sub {
 
     is $rows[1]->[8], $counciluser->email, 'Staff User is correct if made on behalf of body';
     is $rows[2]->[8], $counciluser->email, 'Staff User is correct if made on behalf of another user';
-};
-
-subtest 'old district council names are now just "areas"' => sub {
-
-    my %points = (
-       'Aylesbury Vale' => [
-           [ 51.822364, -0.826409 ], # AVDC offices
-           [ 51.995, -0.986 ], # Buckingham
-           [ 51.940, -0.887 ], # Winslow
-       ],
-        'Chiltern' => [
-           [ 51.615559, -0.556903, ],
-        ],
-        'South Bucks' => [
-            [ 51.563, -0.499 ], # Denham
-            [ 51.611, -0.644 ], # Beaconsfield Railway Station
-        ],
-         'Wycombe' => [
-             [ 51.628661, -0.748238 ], # High Wycombe
-             [ 51.566667, -0.766667 ], # Marlow
-         ],
-    );
-
-    for my $area (sort keys %points) {
-        for my $loc (@{$points{$area}}) {
-            $mech->get("/alert/list?latitude=$loc->[0];longitude=$loc->[1]");
-            $mech->content_contains("$area area");
-            $mech->content_lacks("$area District Council");
-            $mech->content_lacks("ward, $area District Council");
-            $mech->content_lacks('County Council');
-            $mech->content_contains('Buckinghamshire Council');
-        }
-    }
-
 };
 
 my $bucks = Test::MockModule->new('FixMyStreet::Cobrand::Buckinghamshire');


### PR DESCRIPTION
Fixes https://github.com/mysociety/fixmystreet/issues/160 [skip changelog]

This adds the ability to add parish council bodies to .com (with a manual allow list rather than having them all appear in the area dropdown on the body page), and also allows parish council alert updates everywhere, regardless of if bodies exist for them or not.

~~It updates the alert sign up page to have it one column, ordered by area rather than destination, and fixes a bug where you signed up for a different body than it said in Brent/Camden type areas.~~ This part has been merged.