### PR TITLE
[Bexley][WW] Display additional missed report details on confirmation page

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Develop.pm
+++ b/perllib/FixMyStreet/App/Controller/Develop.pm
@@ -241,6 +241,36 @@ sub alert_confirm_previewer : Path('/_dev/confirm_alert') : Args(1) {
     $c->stash->{template} = 'tokens/confirm_alert.html';
 }
 
+sub waste_confirmation : Path('/_dev/confirm_waste') : Args(1) {
+    my ( $self, $c, $confirm_type ) = @_;
+
+    my $category =
+        $confirm_type eq 'missed' ? 'Report missed collection'
+        : $confirm_type eq 'request' ? 'Request new container'
+        : $confirm_type eq 'bulky' ? 'Bulky collection'
+        : '';
+
+    my $report = $c->stash->{report} = FixMyStreet::DB->resultset("Problem")->new({
+        id => 123456,
+        category => $category,
+        user => { email => 'test@example.org' },
+        extra => {
+            # For bulky confirmation page
+            _fields => [
+                { name => 'Collection_Date', value => DateTime->now },
+                { name => 'DATE', value => DateTime->now },
+            ],
+        },
+    });
+    $c->stash->{reference} = 'payment-ref'; # For payment mention
+    $c->stash->{action} = 'new_subscription'; # Garden
+    $c->stash->{template} =
+        $confirm_type eq 'bulky' ? 'waste/bulky/confirmation.html'
+        : $confirm_type eq 'garden' ? 'waste/garden/subscribe_confirm.html'
+        : $confirm_type eq 'request-paid' ? 'waste/request_confirm.html'
+        : 'waste/confirmation.html';
+}
+
 =item contact_submit_previewer
 
 Displays the contact submission page, with success based on the

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -840,6 +840,8 @@ sub group_reports {
     my $report = shift @reports;
     if (@reports) {
         $report->set_extra_metadata(grouped_ids => [ map { $_->id } @reports ]);
+        $report->set_extra_metadata(
+            grouped_titles => [ map { $_->title } @reports ] );
         $report->update;
     }
     $c->stash->{report} = $report;

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -181,7 +181,7 @@ FixMyStreet::override_config {
 
         $mech->clear_emails_ok;
         $mech->get_ok($link);
-        $mech->content_contains('Your missed collection has been reported');
+        $mech->content_contains('Thank you for reporting a missed collection');
         $mech->content_contains('Show upcoming bin days');
         $mech->content_contains('/waste/12345"');
         FixMyStreet::Script::Reports::send();

--- a/t/app/controller/waste_brent_small_items.t
+++ b/t/app/controller/waste_brent_small_items.t
@@ -502,7 +502,7 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { 'service-787' => 1 } });
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
         $mech->submit_form_ok({ with_fields => { process => 'summary' } });
-        $mech->content_contains('Your missed collection has been reported');
+        $mech->content_contains('Thank you for reporting a missed collection');
         my $report = FixMyStreet::DB->resultset("Problem")->order_by('-id')->first;
         is $report->category, 'Report missed collection';
         is $report->get_extra_field_value('service_id'), 787;

--- a/t/app/controller/waste_kingston_r.t
+++ b/t/app/controller/waste_kingston_r.t
@@ -336,7 +336,7 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { 'service-2239' => 1 } });
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
         $mech->submit_form_ok({ with_fields => { process => 'summary' } });
-        $mech->content_contains('collection has been reported');
+        $mech->content_contains('Thank you for reporting a missed collection');
         my $report = FixMyStreet::DB->resultset("Problem")->order_by('-id')->first;
         is $report->get_extra_field_value('uprn'), 1000000002;
         is $report->detail, "Report missed Food waste\n\n2 Example Street, Kingston, KT1 1AA";

--- a/t/app/controller/waste_merton.t
+++ b/t/app/controller/waste_merton.t
@@ -377,7 +377,7 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { 'service-2239' => 1 } });
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
         $mech->submit_form_ok({ with_fields => { process => 'summary' } });
-        $mech->content_contains('collection has been reported');
+        $mech->content_contains('Thank you for reporting a missed collection');
         my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
         is $report->get_extra_field_value('uprn'), 1000000002;
         is $report->detail, "Report missed Food waste\n\n2 Example Street, Merton, KT1 1AA";

--- a/t/app/controller/waste_sutton_r.t
+++ b/t/app/controller/waste_sutton_r.t
@@ -228,7 +228,7 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { 'service-2239' => 1 } });
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
         $mech->submit_form_ok({ with_fields => { process => 'summary' } });
-        $mech->content_contains('collection has been reported');
+        $mech->content_contains('Thank you for reporting a missed collection');
         my $report = FixMyStreet::DB->resultset("Problem")->order_by('-id')->first;
         is $report->get_extra_field_value('uprn'), 1000000002;
         is $report->detail, "Report missed Food waste\n\n2 Example Street, Sutton, SM1 1AA";

--- a/t/cobrand/brent.t
+++ b/t/cobrand/brent.t
@@ -1307,7 +1307,7 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { extra_Notes => 'Behind the garden gate' } });
         $mech->submit_form_ok({ with_fields => { name => "Anne Assist", email => 'anne@example.org' } });
         $mech->submit_form_ok({ with_fields => { process => 'summary' } });
-        $mech->content_contains('Enquiry has been submitted');
+        $mech->content_contains('enquiry has been submitted');
         my $report = FixMyStreet::DB->resultset("Problem")->order_by('-id')->first;
         is $report->detail, "Behind the garden gate\n\n2 Example Street, Brent, NW2 1AA";
         is $report->user->email, 'anne@example.org';
@@ -1325,7 +1325,7 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { extra_Notes => 'Please do another collection for this address' } });
         $mech->submit_form_ok({ with_fields => { name => "Anne Assist", email => 'anne@example.org' } });
         $mech->submit_form_ok({ with_fields => { process => 'summary' } });
-        $mech->content_contains('Enquiry has been submitted');
+        $mech->content_contains('enquiry has been submitted');
         my $report = FixMyStreet::DB->resultset("Problem")->order_by('-id')->first;
         is $report->detail, "Please do another collection for this address\n\n2 Example Street, Brent, NW2 1AA";
         is $report->user->email, 'anne@example.org';
@@ -1343,7 +1343,7 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { extra_Notes => 'Domestic rubbish often missed at this address' } });
         $mech->submit_form_ok({ with_fields => { name => "Staff User", email => 'staff@example.org' } });
         $mech->submit_form_ok({ with_fields => { process => 'summary' } });
-        $mech->content_contains('Enquiry has been submitted');
+        $mech->content_contains('enquiry has been submitted');
         my $report = FixMyStreet::DB->resultset("Problem")->order_by('-id')->first;
         is $report->detail, "Domestic rubbish often missed at this address\n\n2 Example Street, Brent, NW2 1AA";
         is $report->user->email, 'staff@example.org';

--- a/templates/web/base/develop/index.html
+++ b/templates/web/base/develop/index.html
@@ -23,6 +23,15 @@
 <li><a href="/_dev/confirm_alert/unsubscribe">Alert unsubscribe</a>
 </ul></dd>
 
+<dt>Waste confirmation pages</dt>
+<dd><ul>
+<li><a href="/_dev/confirm_waste/missed">Missed collection</a>
+<li><a href="/_dev/confirm_waste/request">Container request</a>
+<li><a href="/_dev/confirm_waste/request-paid">Paid container request</a>
+<li><a href="/_dev/confirm_waste/garden">Garden subscription</a>
+<li><a href="/_dev/confirm_waste/bulky">Bulky collection</a>
+</ul></dd>
+
 <dt>Contact form</dt>
 <dd><ul>
 <li><a href="/_dev/contact_submit/1">Success</a>

--- a/templates/web/base/waste/confirmation.html
+++ b/templates/web/base/waste/confirmation.html
@@ -1,12 +1,12 @@
 [%
 IF report.category == 'Request new container';
-    title = 'Container request has been sent';
+    title = 'Your container request has been sent';
 ELSIF report.category == 'Report missed collection';
-    title = 'Missed collection has been reported';
+    title = 'Thank you for reporting a missed collection';
 ELSIF report.category == 'Request additional collection';
-    title = 'Additional collection has been requested';
+    title = 'Your additional collection has been requested';
 ELSE;
-    title = 'Enquiry has been submitted';
+    title = 'Your enquiry has been submitted';
 END ~%]
 [% PROCESS 'waste/header.html' %]
 
@@ -15,10 +15,10 @@ END ~%]
         [% title %]
     </h1>
     <div class="govuk-panel__body">
-        <p>Your [% title | lower %];
-          [% IF report.user.email && report.get_extra_metadata('contributed_as') != 'anonymous_user' %]
-            a copy has been sent to your email address, [% report.user.email %].
-          [% END %]
+        <p>
+            [% IF report.user.email && report.get_extra_metadata('contributed_as') != 'anonymous_user' %]
+                A copy has been sent to your email address, [% report.user.email %].
+            [% END %]
         </p>
         <p>
           [% IF report.category == 'Request new container' AND c.cobrand.wasteworks_config.request_timeframe %]

--- a/templates/web/bexley/waste/_confirmation_after.html
+++ b/templates/web/bexley/waste/_confirmation_after.html
@@ -1,0 +1,27 @@
+[% IF report.category == 'Report missed collection' %]
+
+  <h2>Bins reported as missed:</h2>
+  <p>
+    <ul>
+      [% titles = [ report.title ]; titles.import( report.get_extra_metadata('grouped_titles') ) %]
+      [% FOR title IN titles %]
+        <li>[% title %]</li>
+      [% END %]
+    </ul>
+  </p>
+
+  <h2>Address:</h2>
+  <p>[% property.address %]</p>
+
+  <h2>What happens next?</h2>
+  <p>
+    Our waste contractor will return within 2 working days to collect your bin(s).
+    <br>
+    Please leave your bin(s) out until our contractor returns.
+    <br>
+    If you need to contact us about this report, please quote your reference number.
+  </p>
+
+  <br>
+
+[% END %]


### PR DESCRIPTION
Similar to what we display in the emails.

For https://mysocietysupport.freshdesk.com/a/tickets/4606.

[skip changelog]
