### PR TITLE
[Zurich][FMS] Adds a filter_description url argument

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1228,6 +1228,9 @@ sub process_report : Private {
 
     if ( $report->category ) {
         my @contacts = grep { $_->category eq $report->category } @{$c->stash->{contacts}};
+        if (!@contacts) {
+            @contacts = @{ $c->cobrand->call_hook('report_on_private_contacts' => $report->category) || [] };
+        }
         unless ( @contacts ) {
             $c->stash->{field_errors}->{category} = _('Please choose a category');
             $report->bodies_str( -1 );
@@ -1861,7 +1864,10 @@ sub check_for_category : Private {
     # Just check to see if the filter had an option
     $category ||= $c->get_param('filter_category') || '';
     $c->stash->{category} = $category;
-
+    if ($c->cobrand->moniker eq 'zurich') {
+        $c->stash->{prefill_category} = $c->get_param('prefill_category') if $c->get_param('prefill_category');
+        $c->stash->{report}->detail($c->get_param('prefill_description')) if $c->get_param('prefill_description');
+    }
     # Bit of a copy of set_report_extras, because we need the results here, but
     # don't want to run all of that fn until later as it e.g. alters field
     # errors at that point. Also, the report might already have some answers in

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -1438,4 +1438,13 @@ sub report_on_private_contacts {
     return [ FixMyStreet::DB->resultset('Contact')->not_deleted->search({category => $category})->all ];
 }
 
+sub munge_around_filter_category_list {
+    my $self = shift;
+
+    my $c = $self->{c};
+
+    $c->stash->{prefill_category} = $c->get_param('prefill_category') if $c->get_param('prefill_category');
+    $c->stash->{prefill_description} = $c->get_param('prefill_description') if $c->get_param('prefill_description');
+}
+
 1;

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -691,7 +691,7 @@ sub admin_report_edit {
         }
 
         if (
-            ($state eq 'confirmed') 
+            ($state eq 'confirmed')
             && $new_cat
             && $new_cat ne $problem->category
         ) {
@@ -1064,7 +1064,7 @@ sub stash_states {
 
     # stash details about the public response
     $c->stash->{default_public_response} = "\nFreundliche Grüsse\n\nIhre Stadt Zürich\n";
-    $c->stash->{show_publish_response} = 
+    $c->stash->{show_publish_response} =
         ($problem->state eq 'feedback pending');
 }
 
@@ -1185,7 +1185,7 @@ sub admin_stats {
         $c->stash->{start_date} = DateTime->new( year => $y, month => $m, day => 1 );
         $c->stash->{end_date} = $c->stash->{start_date} + DateTime::Duration->new( months => 1 );
         $optional_params{'me.created'} = {
-            '>=', DateTime::Format::Pg->format_datetime($c->stash->{start_date}), 
+            '>=', DateTime::Format::Pg->format_datetime($c->stash->{start_date}),
             '<',  DateTime::Format::Pg->format_datetime($c->stash->{end_date}),
         };
     }
@@ -1430,6 +1430,12 @@ sub report_new_munge_before_insert {
     if ($report->user->flagged) {
         $report->non_public(1);
     }
+}
+
+sub report_on_private_contacts {
+    my ($self, $category) = @_;
+
+    return [ FixMyStreet::DB->resultset('Contact')->not_deleted->search({category => $category})->all ];
 }
 
 1;

--- a/templates/web/base/around/display_location.html
+++ b/templates/web/base/around/display_location.html
@@ -27,6 +27,20 @@
         }
     );
 
+    IF c.cobrand.moniker == 'zurich' AND ( prefill_category OR prefill_description );
+        url_skip = c.uri_for(
+            '/report/new',
+            {
+                pc                  => pc
+                latitude            => latitude,
+                longitude           => longitude,
+                skipped             => 1,
+                prefill_category    => prefill_category,
+                prefill_description => prefill_description,
+            }
+        );
+    END;
+
     PROCESS "report/photo-js.html";
     PROCESS "maps/${map.type}.html";
 

--- a/templates/web/base/around/postcode_form.html
+++ b/templates/web/base/around/postcode_form.html
@@ -41,11 +41,19 @@
             [% ELSIF c.user_exists AND c.user.categories.size %]
               <input type="hidden" name="filter_category" value="[% c.user.categories_string | html %]">
             [% END %]
+            [% IF c.cobrand.moniker == 'zurich' AND ( c.get_param('prefill_category') OR c.get_param('prefill_description') ) %]
+                <input type="hidden" name="prefill_category" value="[% c.get_param('prefill_category') %]">
+                <input type="hidden" name="prefill_description" value="[% c.get_param('prefill_description') %]">
+            [% END %]
             [%~ SET link_params = {
                     geolocate = 1
                 };
                 IF c.get_param('filter_category'); link_params.filter_category = c.get_param('filter_category'); END;
                 IF c.get_param('filter_group'); link_params.filter_group = c.get_param('filter_group'); END;
+                IF c.cobrand.moniker == 'zurich';
+                    IF c.get_param('prefill_category'); link_params.prefill_category = c.get_param('prefill_category'); END;
+                    IF c.get_param('prefill_description'); link_params.prefill_description = c.get_param('prefill_description'); END;
+                END;
             %]
             [% INCLUDE 'around/_postcode_form_geolocation.html' url=c.uri_for('/around', link_params) %]
 

--- a/templates/web/zurich/report/new/fill_in_details_form.html
+++ b/templates/web/zurich/report/new/fill_in_details_form.html
@@ -13,7 +13,12 @@
                 <p class='form-error'>[% field_errors.bodies %]</p>
             [% END %]
 
+            [% IF !prefill_category %]
             [% PROCESS "report/new/category_wrapper.html" %]
+            [% ELSE %]
+            <input type="hidden" name="category" id="category" value="[% prefill_category | html %]">
+            <input type="hidden" name="prefill_category" id="prefill_category" value="[% prefill_category | html %]">
+            [% END %]
 
             [% PROCESS 'report/form/photo_upload.html' %]
             [% PROCESS 'report/new/after_photo.html' %]

--- a/templates/web/zurich/report/new/fill_in_details_form.html
+++ b/templates/web/zurich/report/new/fill_in_details_form.html
@@ -16,8 +16,8 @@
             [% IF !prefill_category %]
             [% PROCESS "report/new/category_wrapper.html" %]
             [% ELSE %]
-            <input type="hidden" name="category" id="category" value="[% prefill_category | html %]">
-            <input type="hidden" name="prefill_category" id="prefill_category" value="[% prefill_category | html %]">
+            <input type="hidden" name="category" id="category" value="[% prefill_category %]">
+            <input type="hidden" name="prefill_category" id="prefill_category" value="[% prefill_category %]">
             [% END %]
 
             [% PROCESS 'report/form/photo_upload.html' %]
@@ -27,7 +27,18 @@
             [% IF field_errors.detail %]
                 <p class='form-error'>[% field_errors.detail %]</p>
             [% END %]
-            <textarea class="form-control" rows="7" cols="26" name="detail" id="form_detail" required>[% report.detail | html %]</textarea>
+            <textarea class="form-control" rows="7" cols="26" name="detail" id="form_detail" required>[%
+                IF report.detail;
+                    report.detail;
+                ELSIF prefill_description;
+                    prefill_description;
+                END;
+            %]</textarea>
+
+                [% IF prefill_description %]
+                    [%# need this hidden field for non-JS users so value gets from /around to /report/new %]
+                    <input type="hidden" name="prefill_description" id="prefill_description" value="[% prefill_description %]">
+                [% END %]
 
                 <label for="form_username_register">[% loc('Your email') %]</label>
                 [% IF field_errors.username_register %]

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -766,9 +766,9 @@ textarea.form-error {
   // If the parent is .with-notes we know we have space to
   // float the sidebar content to the side of the form.
   .with-notes & {
-    float: #{$right};
+    position: absolute;
+    #{$right}: 1em;
     width: 13em;
-    margin-#{$right}: -15em;
   }
 
   div {


### PR DESCRIPTION
For Zurich, can add a prefill_description to the url arguments which will fill the description of a report.

Can also add a prefill_category, and it will remove the category choice, so category can not be changed - also provides a call hook used by Zurich to allow reports to be made in not active categories.

https://github.com/mysociety/societyworks/issues/4517

[skip changelog]
