### PR TITLE
[Bexley][WW] Only skip parent addresses if they are marked as 'shell' properties

### DIFF
--- a/bin/bexley/make-bexley-ww-postcode-db
+++ b/bin/bexley/make-bexley-ww-postcode-db
@@ -205,11 +205,17 @@ while( my $row = $csv->getline($fh) ) {
         @row_h{@columns_blpu} = @$row;
 
         $uprn_extra_data{ $row_h{UPRN} }{has_parent} = !!$row_h{PARENT_UPRN};
+        $uprn_extra_data{ $row_h{UPRN} }{blpu_class} = $row_h{BLPU_CLASS};
     } elsif ( $record_id == $id_lpi ) {
         @row_h{@columns_lpi} = @$row;
 
         next if ( $row_h{LOGICAL_STATUS} || 0 ) != 1;
         next unless $row_h{POSTCODE};
+
+        # 'P' or 'PP' mean the property is a 'parent shell' and so should not be
+        # offered as a selectable address.
+        my $blpu_class = $uprn_extra_data{ $row_h{UPRN} }{blpu_class} // '';
+        next if $blpu_class eq 'P' || $blpu_class eq 'PP';
 
         # Remove whitespace from postcode
         my $postcode = $row_h{POSTCODE} =~ s/ //gr;

--- a/bin/bexley/make-bexley-ww-postcode-db
+++ b/bin/bexley/make-bexley-ww-postcode-db
@@ -52,13 +52,6 @@ CREATE VIRTUAL TABLE street_descriptors USING fts4 (
 )
 SQL
 
-$db->do(<<SQL) or die;
-CREATE VIRTUAL TABLE child_uprns USING fts4 (
-    uprn        INTEGER NOT NULL,
-    parent_uprn INTEGER NOT NULL
-)
-SQL
-
 # PAO = 'Primary Addressable Object'
 # SAO = 'Secondary Addressable Object' - used for child addresses
 $db->do(<<SQL) or die;
@@ -77,7 +70,9 @@ CREATE VIRTUAL TABLE postcodes USING fts4 (
     sao_start_suffix TEXT,
     sao_end_number   TEXT,
     sao_end_suffix   TEXT,
-    sao_text         TEXT
+    sao_text         TEXT,
+
+    has_parent       INTEGER
 )
 SQL
 
@@ -93,16 +88,6 @@ my $query_sd = $db->prepare(
         town_name
     )
     VALUES (?,?,?,?)
-SQL
-);
-
-my $query_cu = $db->prepare(
-<<SQL
-    INSERT OR IGNORE INTO child_uprns (
-        uprn,
-        parent_uprn
-    )
-    VALUES (?,?)
 SQL
 );
 
@@ -123,11 +108,14 @@ my $query_postcodes = $db->prepare(
         sao_start_suffix,
         sao_end_number,
         sao_end_suffix,
-        sao_text
+        sao_text,
+
+        has_parent
     )
     VALUES (?,?,?,
             ?,?,?,?,?,
-            ?,?,?,?,?)
+            ?,?,?,?,?,
+            ?)
 SQL
 );
 
@@ -195,6 +183,8 @@ my @columns_lpi = (
 
 say 'Populating tables...';
 
+my %uprn_extra_data;
+
 # Cannot set column names / headers in usual way as CSV contains multiple
 # record types
 while( my $row = $csv->getline($fh) ) {
@@ -214,13 +204,7 @@ while( my $row = $csv->getline($fh) ) {
     } elsif ( $record_id == $id_blpu ) {
         @row_h{@columns_blpu} = @$row;
 
-        next if ( $row_h{LOGICAL_STATUS} || 0 ) != 1;
-        next unless $row_h{PARENT_UPRN};
-
-        $query_cu->execute(
-            $row_h{UPRN},
-            $row_h{PARENT_UPRN},
-        );
+        $uprn_extra_data{ $row_h{UPRN} }{has_parent} = !!$row_h{PARENT_UPRN};
     } elsif ( $record_id == $id_lpi ) {
         @row_h{@columns_lpi} = @$row;
 
@@ -229,6 +213,8 @@ while( my $row = $csv->getline($fh) ) {
 
         # Remove whitespace from postcode
         my $postcode = $row_h{POSTCODE} =~ s/ //gr;
+
+        my $has_parent = $uprn_extra_data{ $row_h{UPRN} }{has_parent} // 0;
 
         $query_postcodes->execute(
             $postcode,
@@ -246,20 +232,10 @@ while( my $row = $csv->getline($fh) ) {
             $row_h{SAO_END_NUMBER},
             $row_h{SAO_END_SUFFIX},
             $row_h{SAO_TEXT},
+
+            $has_parent,
         );
     }
 }
-
-# It is possible for UPRNs in child_uprns to not occur in the postcodes table
-# (an 'empty' address).
-# At least one address, UPRN 100020276242, was not being picked up
-# by Bexley WW's address lookup, because it appeared as a parent_uprn in this
-# table, but its 'child' addresses were empty.
-$db->do(<<SQL);
-DELETE FROM child_uprns
-      WHERE uprn NOT IN (
-        SELECT uprn FROM postcodes
-      )
-SQL
 
 say 'Tables populated';

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -56,7 +56,7 @@ $dbi_mock->mock( 'connect', sub {
                     locality_name     => 'Little Bexlington',
                     town_name         => 'Bexley',
 
-                    parent_uprn => 999999,
+                    has_parent => 1,
                 },
             ];
         }
@@ -85,7 +85,7 @@ $dbi_mock->mock( 'connect', sub {
                 locality_name     => 'Little Bexlington',
                 town_name         => 'Bexley',
 
-                parent_uprn => 999999,
+                has_parent => 1,
             };
         }
     } );


### PR DESCRIPTION
We were skipping over all parent addresses on the assumption that all were 'shell' addresses that shouldn't be displayed. But the 'shell' status only applies to some parents.

For https://mysocietysupport.freshdesk.com/a/tickets/4432.
Closes https://github.com/mysociety/societyworks/issues/4498.

[skip changelog]
