### PR TITLE
[offline] Cache inspector reports sequentially, not in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
         - Reduce database queries on shortlist page.
         - Provide ResultSet fallback translation in lookup.
         - Mark non-Open311 updates as processed by daemon. #4552
+        - Inspector/planned offline report caching now fetches URLs sequentially, not in parallel.
     - Changes:
         - Switch to OpenStreetMap for reverse geocoding. #4444
         - Convert all uploaded images to JPEGs.


### PR DESCRIPTION
For extremely long lists of planned reports this was causing load issues.

