### PR TITLE
[offline] On desktop /my/planned don’t cache reports automatically

### DIFF
--- a/.cypress/cypress/integration/borsetshire.js
+++ b/.cypress/cypress/integration/borsetshire.js
@@ -18,7 +18,9 @@ it('logs in without fuss', function() {
     cy.contains('Inspector').click();
     cy.url().should('include', '/my/planned');
     // Wait for offline stuff, which can take time
+    cy.contains('Save to this device for offline use').should('be.visible').click();
     cy.get('.top_banner--offline', { timeout: 10000 }).contains('Reports saved offline', { timeout: 10000 });
+    cy.contains('Save to this device for offline use').should('not.be.visible');
 
     cy.contains('Your account').click();
     cy.contains('Sign out').click();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
         - Provide ResultSet fallback translation in lookup.
         - Mark non-Open311 updates as processed by daemon. #4552
         - Inspector/planned offline report caching now fetches URLs sequentially, not in parallel.
+        - Desktop browsers won't automatically cache reports offline when visiting /my/planned.
     - Changes:
         - Switch to OpenStreetMap for reverse geocoding. #4444
         - Convert all uploaded images to JPEGs.

--- a/templates/web/base/my/planned.html
+++ b/templates/web/base/my/planned.html
@@ -29,6 +29,12 @@
 <div id="js-reports-list">
 [% INCLUDE 'my/_problem-list.html' shortlist = 1 %]
 </div>
+<div class="shadow-wrap hidden-nojs">
+    <ul id="key-tools">
+        <li><a class="offline js-cache-reports" href="#">[% loc("Save to this device for offline use") %]</a></li>
+    </ul>
+</div>
+
 </section>
 
         </div>

--- a/web/cobrands/fixmystreet/images/cloud-download.svg
+++ b/web/cobrands/fixmystreet/images/cloud-download.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 9.5V15.5M12 15.5L10 13.5M12 15.5L14 13.5M8.4 19C5.41766 19 3 16.6044 3 13.6493C3 11.2001 4.8 8.9375 7.5 8.5C8.34694 6.48637 10.3514 5 12.6893 5C15.684 5 18.1317 7.32251 18.3 10.25C19.8893 10.9449 21 12.6503 21 14.4969C21 16.9839 18.9853 19 16.5 19L8.4 19Z" stroke="#C1C1C1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/web/cobrands/fixmystreet/offline.js
+++ b/web/cobrands/fixmystreet/offline.js
@@ -419,9 +419,19 @@ if ($('#offline_list').length) {
 } else {
     fixmystreet.offlineBanner.make(false);
 
-    // On /my/planned, when online, cache all shortlisted
+    // On /my/planned, when online, cache all shortlisted automatically on mobile.
+    // On desktop, show a button to cache them.
     if (location.pathname === '/my/planned') {
-        fixmystreet.offline.updateCachedReports();
+        if ($("html").hasClass("mobile")) {
+            $(".js-cache-reports").closest(".shadow-wrap").hide();
+            fixmystreet.offline.updateCachedReports();
+        } else {
+            $(".js-cache-reports").on("click", function(e) {
+                e.preventDefault();
+                $(".js-cache-reports").closest(".shadow-wrap").hide();
+                fixmystreet.offline.updateCachedReports();
+            });
+        }
     }
 
     // Catch additions and removals from the shortlist

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1009,6 +1009,12 @@ html.mobile.js-nav-open #js-menu-open-modal {
     &.chevron:after {
       background-position: flip(-16px 0, 0 0);
     }
+
+    &.offline:after {
+      background-size: 16px 16px;
+      background-position: 0 0;
+      background-image: url("/cobrands/fixmystreet/images/cloud-download.svg");
+    }
   }
 
   .sub-area-item {


### PR DESCRIPTION
Desktop users are presumably less likely to find themselves offline, so it doesn't make sense to cache all reports in the shortlist automatically. This commit adds a link to the bottom of the report list on the desktop version of the /my/planned page that allows users to kick off the caching process manually.

Behaviour on mobile is unchanged.

<img width="515" alt="image" src="https://github.com/user-attachments/assets/60d0b2e4-83b5-4e0d-9961-ecfcdce775fc">
