### PR TITLE
Added Geolocate button before 'Go' button in PostcodeForm

### DIFF
--- a/templates/web/base/around/_postcode_form_geolocation.html
+++ b/templates/web/base/around/_postcode_form_geolocation.html
@@ -1,2 +1,2 @@
-<a href="[% url | html %]" id="geolocate_link" aria-live="polite">[% INCLUDE 'around/geolocate_link_icon.html' %]
+<a href="[% url | html %]" id="geolocate_link" class="js-geolocate-link" aria-live="polite">[% INCLUDE 'around/geolocate_link_icon.html' %]
   [% loc('Use my current location') %]</a>

--- a/templates/web/base/around/_postcode_form_geolocation_screen_reader.html
+++ b/templates/web/base/around/_postcode_form_geolocation_screen_reader.html
@@ -1,0 +1,1 @@
+<a href="[% url | html %]" class="screen-reader-only js-geolocate-link btn" aria-label="[% loc('Use my current location') %]" aria-live="polite">[% INCLUDE 'around/geolocate_link_icon.html' %]</a>

--- a/templates/web/base/around/postcode_form.html
+++ b/templates/web/base/around/postcode_form.html
@@ -28,6 +28,7 @@
             <div>
                 <input type="text" name="pc" value="[% pc | html %]" id="pc" size="10" maxlength="200" required aria-describedby="pc-hint [% IF location_error_pc_lookup %]search-help pc-error[% END %]"
                 [%~ IF c.cobrand.moniker == 'oxfordshire' %] placeholder="[% tprintf(loc('e.g. ‘%s’ or ‘%s’'), c.cobrand.example_places) %]"[% END %]>
+                [% INCLUDE 'around/_postcode_form_geolocation_screen_reader.html' url=c.uri_for('/around', link_params) %]
                 [% INCLUDE 'around/_postcode_submit_button.html' %]
             </div>
 

--- a/web/js/geolocation.js
+++ b/web/js/geolocation.js
@@ -26,18 +26,22 @@ fixmystreet.geolocate = function(element, success_callback) {
     });
 };
 
-(function(){
-    var link = document.getElementById('geolocate_link');
-    if (!link) { return; }
+(function() {
+    var links = document.getElementsByClassName('js-geolocate-link');
+    if (!links.length) { return; }
     var https = window.location.protocol.toLowerCase() === 'https:';
     if ('geolocation' in navigator && https && window.addEventListener) {
-        fixmystreet.geolocate(link, function(pos) {
-            var latitude = pos.coords.latitude.toFixed(6);
-            var longitude = pos.coords.longitude.toFixed(6);
-            var coords = 'lat=' + latitude + '&lon=' + longitude;
-            location.href = link.href + (link.href.indexOf('?') > -1 ? ';' : '?') + coords;
+        Array.prototype.forEach.call(links, function(link) {
+            fixmystreet.geolocate(link, function(pos) {
+                var latitude = pos.coords.latitude.toFixed(6);
+                var longitude = pos.coords.longitude.toFixed(6);
+                var coords = 'lat=' + latitude + '&lon=' + longitude;
+                location.href = link.href + (link.href.indexOf('?') > -1 ? ';' : '?') + coords;
+            });
         });
     } else {
-        link.style.display = 'none';
+        Array.prototype.forEach.call(links, function(link) {
+            link.style.display = 'none';
+        });
     }
 })();


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4561

Currently users using assistive devices might not use the "Use my current location" button because it comes after the "Go" button. This commit includes a geolocate button visible only for screen readers, located right before the "Go" button.

Some comments:

- Because the markup is slightly different for both geolocate buttons I thought of creating a new template just for the screen-reader one. Using the Id attribute for the function in JS wouldn't be the best approach anymore so I changed them to classes instead. But let me know if you think of a better approach.
- The styling however is not ideal because when a user focus on the invisible button, this one becomes visible, but most users don't use the keyboard anyway. 

https://github.com/user-attachments/assets/7558e548-9f0d-4492-98b8-40aaf7fcdf42

- While working on this ticket I thought that a better approach would have been to put the invisible button before the postcode input, that way we avoid scenarios where a user will still add the postcode/address to later find out there is a geolocate button. But this approach would need some tweak because we currently focus straightaway on the postcode input field, so to not loose that I thought that another approach would be: We don't include the invisible button at all, instead we add an `aria-label` in the postcode input with something like -> "Add a postcode or address. Alternatively, there is a geolocate button at the end of this form." Probably not the most elegant, but I think this approach is the most UX friendly one.


Let me know if you can think of a better one or if you rather any of the above.


### Pending

- [ ] Alert page

[skip changelog]
