### PR TITLE
[Open311] Add 'staff' keyword handling

### DIFF
--- a/perllib/FixMyStreet/Test.pm
+++ b/perllib/FixMyStreet/Test.pm
@@ -69,7 +69,7 @@ BEGIN {
         my ($self, $path, $content, $code) = @_;
         my $test_res = HTTP::Response->new();
         $test_res->code($code || 200);
-        $test_res->content($content);
+        $test_res->content(encode_utf8($content));
         $injected{$path} = $test_res;
     }
 }

--- a/perllib/Open311/PopulateServiceList.pm
+++ b/perllib/Open311/PopulateServiceList.pm
@@ -336,6 +336,11 @@ sub _set_contact_from_keywords {
         push @actions, 'marked inactive';
     }
 
+    if ($contact->state ne 'staff' && $keywords{staff}) {
+        $contact->state('staff');
+        push @actions, 'marked staff';
+    }
+
     my $waste_only = $keywords{waste_only} ? 1 : 0;
     my $type = $contact->get_extra_metadata('type', '') eq 'waste';
     if ($waste_only != $type) { # If the same, nothing to do

--- a/perllib/Open311/PopulateServiceList.pm
+++ b/perllib/Open311/PopulateServiceList.pm
@@ -149,28 +149,17 @@ sub _handle_existing_contact {
 
     print $self->_current_body->id . " already has a contact for service code " . $self->_current_service->{service_code} . "\n" if $self->verbose >= 2;
 
+    my @actions;
     if ( $contact->state eq 'deleted' || $service_name ne $contact->category || $self->_current_service->{service_code} ne $contact->email ) {
-        eval {
-            $contact->update(
-                {
-                    $protected ? () : (category => $service_name),
-                    email => $self->_current_service->{service_code},
-                    state => 'confirmed',
-                    %{ $self->_action_params("undeleted") },
-                }
-            );
-        };
-
-        if ( $@ ) {
-            warn "Failed to update contact for service code " . $self->_current_service->{service_code} . " for body @{[$self->_current_body->id]}: $@\n"
-                if $self->verbose >= 1;
-            return;
-        }
+        $contact->category($service_name) unless $protected;
+        $contact->email($self->_current_service->{service_code});
+        $contact->state('confirmed');
+        push @actions, "undeleted";
     }
 
     my $metadata = $self->_current_service->{metadata} || '';
     if ( $contact and lc($metadata) eq 'true' ) {
-        $self->_add_meta_to_contact( $contact );
+        push @actions, $self->_add_meta_to_contact( $contact );
     } elsif ( $contact and $contact->extra and lc($metadata) eq 'false' ) {
         # check if there are any protected fields that we should not delete
         my @meta = (
@@ -178,13 +167,21 @@ sub _handle_existing_contact {
             @{ $contact->get_extra_fields }
         );
         $contact->set_extra_fields(@meta);
-        $contact->update;
+        push @actions, "removed extra fields" if $contact->is_column_changed('extra');
     }
 
-    $self->_set_contact_group($contact) unless $protected;
-    $self->_set_contact_non_public($contact);
-    $self->_set_contact_as_waste($contact);
-    $self->_set_contact_inactive($contact);
+    push @actions, $self->_set_contact_group($contact) unless $protected;
+    push @actions, $self->_set_contact_from_keywords($contact);
+
+    eval {
+        my $action = join("; ", grep { $_ } @actions);
+        $contact->update($self->_action_params($action)) if $action;
+    };
+    if ( $@ ) {
+        warn "Failed to update contact for service code " . $self->_current_service->{service_code} . " for body @{[$self->_current_body->id]}: $@\n"
+            if $self->verbose >= 1;
+        return;
+    }
 
     push @{ $self->found_contacts }, $self->_current_service->{service_code};
 }
@@ -194,39 +191,36 @@ sub _create_contact {
 
     my $service_name = $self->_normalize_service_name;
 
-    my $contact;
-    eval {
-        $contact = $self->schema->resultset('Contact')->create(
-            {
-                email => $self->_current_service->{service_code},
-                body_id => $self->_current_body->id,
-                category => $service_name,
-                state => 'confirmed',
-                %{ $self->_action_params("created") },
-            }
-        );
-    };
+    my @actions = ("created");
+    my $contact = $self->schema->resultset('Contact')->new({
+        email => $self->_current_service->{service_code},
+        body_id => $self->_current_body->id,
+        category => $service_name,
+        state => 'confirmed',
+        %{ $self->_action_params("created") },
+    });
 
+    my $metadata = $self->_current_service->{metadata} || '';
+    if ( $contact and lc($metadata) eq 'true' ) {
+        push @actions, $self->_add_meta_to_contact( $contact );
+    }
+
+    push @actions, $self->_set_contact_group($contact);
+    push @actions, $self->_set_contact_from_keywords($contact);
+
+    eval {
+        my $action = join("; ", grep { $_ } @actions);
+        $contact->note("$action automatically by script");
+        $contact->insert;
+    };
     if ( $@ ) {
         warn "Failed to create contact for service code " . $self->_current_service->{service_code} . " for body @{[$self->_current_body->id]}: $@\n"
             if $self->verbose >= 1;
         return;
     }
 
-    my $metadata = $self->_current_service->{metadata} || '';
-    if ( $contact and lc($metadata) eq 'true' ) {
-        $self->_add_meta_to_contact( $contact );
-    }
-
-    $self->_set_contact_group($contact);
-    $self->_set_contact_non_public($contact);
-    $self->_set_contact_as_waste($contact);
-    $self->_set_contact_inactive($contact);
-
-    if ( $contact ) {
-        push @{ $self->found_contacts }, $self->_current_service->{service_code};
-        print "created contact for service code " . $self->_current_service->{service_code} . " for body @{[$self->_current_body->id]}\n" if $self->verbose >= 2;
-    }
+    push @{ $self->found_contacts }, $self->_current_service->{service_code};
+    print "created contact for service code " . $self->_current_service->{service_code} . " for body @{[$self->_current_body->id]}\n" if $self->verbose >= 2;
 }
 
 sub _add_meta_to_contact {
@@ -283,7 +277,7 @@ sub _add_meta_to_contact {
         open311_contact_meta_override => $self->_current_service, $contact, \@meta);
 
     $contact->set_extra_fields(@meta);
-    $contact->update;
+    return "updated extra fields" if $contact->is_column_changed('extra');
 }
 
 sub _normalize_service_name {
@@ -310,60 +304,46 @@ sub _set_contact_group {
     if ($self->_groups_different($old_group, $new_group)) {
         if (@$new_group) {
             $contact->set_extra_metadata(group => @$new_group == 1 ? $new_group->[0] : $new_group);
-            $contact->update( $self->_action_params("group updated") );
+            return 'group updated';
         } else {
             $contact->unset_extra_metadata('group');
-            $contact->update( $self->_action_params("group removed") );
+            return 'group removed';
         }
     }
 }
 
-sub _set_contact_non_public {
-    my ($self, $contact) = @_;
-
-    # We never want to make a private category unprivate.
-    return if $contact->non_public;
-
-    my %keywords = map { $_ => 1 } split /,/, ( $self->_current_service->{keywords} || '' );
-    $contact->update({
-        non_public => 1,
-        %{ $self->_action_params("marked private") },
-    }) if $keywords{private};
-}
-
-sub _set_contact_inactive {
-    my ($self, $contact) = @_;
-
-    # We never want to make an inactive category active
-    return if $contact->state eq 'inactive';
-
-    my %keywords = map { $_ => 1 } split /,/, ( $self->_current_service->{keywords} || '' );
-    $contact->update({
-        state => 'inactive',
-        %{ $self->_action_params('marked inactive') },
-    }) if $keywords{inactive};
-}
-
-sub _set_contact_as_waste {
+sub _set_contact_from_keywords {
     my ($self, $contact) = @_;
 
     my %keywords = map { $_ => 1 } split /,/, ( $self->_current_service->{keywords} || '' );
+    my @actions;
+
+    # These are only one way, we don't e.g. unhide if private keyword goes
+    # missing, or mark confirmed if stops being marked inactive/staff - can be
+    # fixed manually
+    if (!$contact->non_public && $keywords{private}) {
+        $contact->non_public(1);
+        push @actions, 'marked private';
+    }
+
+    if ($contact->state ne 'inactive' && $keywords{inactive}) {
+        $contact->state('inactive');
+        push @actions, 'marked inactive';
+    }
+
     my $waste_only = $keywords{waste_only} ? 1 : 0;
     my $type = $contact->get_extra_metadata('type', '') eq 'waste';
-
-    return if $waste_only == $type; # If the same, nothing to do
-
-    if ($waste_only) { # Newly waste
-        $contact->set_extra_metadata(type => 'waste');
-        $contact->update({
-            %{ $self->_action_params("set type to 'waste'") },
-        });
-    } else { # No longer waste
-        $contact->unset_extra_metadata('type');
-        $contact->update({
-            %{ $self->_action_params("removed 'waste' type") },
-        });
+    if ($waste_only != $type) { # If the same, nothing to do
+        if ($waste_only) { # Newly waste
+            $contact->set_extra_metadata(type => 'waste');
+            push @actions, "set type to 'waste'";
+        } else { # No longer waste
+            $contact->unset_extra_metadata('type');
+            push @actions, "removed 'waste' type";
+        }
     }
+
+    return @actions;
 }
 
 sub _get_new_groups {

--- a/perllib/Open311/PopulateServiceList.pm
+++ b/perllib/Open311/PopulateServiceList.pm
@@ -150,11 +150,16 @@ sub _handle_existing_contact {
     print $self->_current_body->id . " already has a contact for service code " . $self->_current_service->{service_code} . "\n" if $self->verbose >= 2;
 
     my @actions;
-    if ( $contact->state eq 'deleted' || $service_name ne $contact->category || $self->_current_service->{service_code} ne $contact->email ) {
+    if ( $contact->state eq 'deleted' ) {
         $contact->category($service_name) unless $protected;
         $contact->email($self->_current_service->{service_code});
+        $contact->send_method(undef); # Let us assume we want to remove any devolved send method in this case
         $contact->state('confirmed');
         push @actions, "undeleted";
+    } elsif ( $service_name ne $contact->category || $self->_current_service->{service_code} ne $contact->email ) {
+        $contact->category($service_name) unless $protected;
+        $contact->email($self->_current_service->{service_code});
+        push @actions, "updated";
     }
 
     my $metadata = $self->_current_service->{metadata} || '';

--- a/t/cobrand/bristol.t
+++ b/t/cobrand/bristol.t
@@ -164,7 +164,6 @@ subtest 'check services override' => sub {
         description => 'How big is the pothole',
     } ];
 
-    $open311_contact->discard_changes;
     is_deeply $open311_contact->get_extra_fields, $extra, 'Easting has automated set';
 };
 

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -618,7 +618,6 @@ for my $test (
         };
         $processor->_current_service( { service_code => $test->{code}, service_name => 'Lamp on during day' } );
         $processor->_add_meta_to_contact( $contact );
-        $contact->discard_changes;
         my @extra_fields = $contact->get_extra_fields;
         is $extra_fields[0][2]->{code}, $test->{result}, $test->{description};
     };

--- a/t/cobrand/greenwich.t
+++ b/t/cobrand/greenwich.t
@@ -84,6 +84,7 @@ subtest 'check services override' => sub {
     };
     $processor->_current_service( { service_code => 'HOLE' } );
     $processor->_add_meta_to_contact( $contact );
+    $contact->update;
 
     my $extra = [ {
         automated => 'server_set',
@@ -102,7 +103,6 @@ subtest 'check services override' => sub {
         description => 'How big is the pothole',
     } ];
 
-    $contact->discard_changes;
     is_deeply $contact->get_extra_fields, $extra, 'Easting has automated set';
 };
 

--- a/t/cobrand/rutland.t
+++ b/t/cobrand/rutland.t
@@ -149,8 +149,6 @@ subtest 'check open311_contact_meta_override' => sub {
     $processor->_current_service( { service_code => 100, service_name => 'Traffic Lights' } );
     $processor->_add_meta_to_contact( $contact );
 
-    $contact->discard_changes;
-
     my $expected_hint = '<span>Text for Traffic Lights will go here</span>';
     my $expected_group_hint = '<span>Text for Lights, Signals and Sign will go here</span>';
 

--- a/t/cobrand/shropshire.t
+++ b/t/cobrand/shropshire.t
@@ -163,7 +163,6 @@ subtest 'check open311_contact_meta_override' => sub {
     };
     $processor->_current_service( { service_code => 100, service_name => 'Abandoned vehicle' } );
     $processor->_add_meta_to_contact( $contact );
-    $contact->discard_changes;
     my @extra_fields = $contact->get_extra_fields;
 
     is $extra_fields[0][0]->{fieldtype}, 'date', "added fieldtype 'date' to 'Abandoned since'";

--- a/t/cobrand/warwickshire.t
+++ b/t/cobrand/warwickshire.t
@@ -74,7 +74,6 @@ subtest 'check Warwickshire override' => sub {
         description => 'How big is the pothole',
     } ];
 
-    $contact->discard_changes;
     is_deeply $contact->get_extra_fields, $extra, 'No closest_address field returned for Warks';
     is $contact->get_extra_metadata('id_field'), 'external_id', 'id_field set correctly';
 };

--- a/t/open311/populate-service-list.t
+++ b/t/open311/populate-service-list.t
@@ -1118,8 +1118,6 @@ subtest 'check attribute ordering' => sub {
         },
     ];
 
-    $contact->discard_changes;
-
     is_deeply $contact->get_extra_fields, $extra, 'meta data re-ordered correctly';
 };
 
@@ -1225,8 +1223,6 @@ subtest 'check Bromley skip code' => sub {
             description => 'Right of way reference'
     } ];
 
-    $contact->discard_changes;
-
     is_deeply $contact->get_extra_fields, $extra, 'only non std bromley meta data saved';
 
     FixMyStreet::override_config {
@@ -1276,8 +1272,6 @@ subtest 'check Bromley skip code' => sub {
             description => 'Easting',
         },
     ];
-
-    $contact->discard_changes;
 
     is_deeply $contact->get_extra_fields, $extra, 'all meta data saved for non bromley';
 };
@@ -1348,7 +1342,6 @@ subtest 'check Buckinghamshire extra code' => sub {
         ],
     } ];
 
-    $contact->discard_changes;
     is_deeply $contact->get_extra_fields, $extra, 'extra Bucks field returned for flytipping';
 
     $processor->_current_service( { service_code => 100, service_name => 'Street lights' } );
@@ -1365,7 +1358,6 @@ subtest 'check Buckinghamshire extra code' => sub {
         description => 'Type of bin'
     } ];
 
-    $contact->discard_changes;
     is_deeply $contact->get_extra_fields, $extra, 'no extra Bucks field returned otherwise';
 };
 

--- a/t/open311/populate-service-list.t
+++ b/t/open311/populate-service-list.t
@@ -671,6 +671,39 @@ subtest 'check existing inactive category does not get marked active' => sub {
     is $contact->state, 'inactive', 'contact remains inactive';
 };
 
+subtest 'check existing category gets marked as staff' => sub {
+    my $contact = FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->first;
+    is $contact->state, 'inactive', 'contact marked as inactive';
+
+    my $services_xml = '<?xml version="1.0" encoding="utf-8"?>
+    <services>
+      <service>
+        <service_code>100</service_code>
+        <service_name>Cans left out 24x7</service_name>
+        <description>Garbage or recycling cans that have been left out for more than 24 hours after collection. Violators will be cited.</description>
+        <metadata>false</metadata>
+        <type>realtime</type>
+        <keywords>staff</keywords>
+        <group>sanitation</group>
+      </service>
+    </services>
+        ';
+
+    my $service_list = get_xml_simple_object( $services_xml );
+
+    my $processor = Open311::PopulateServiceList->new();
+    $processor->_current_body( $body );
+    $processor->process_services( $service_list );
+
+    my $contact_count = FixMyStreet::DB->resultset('Contact')->search( { body_id => $body->id } )->count();
+    is $contact_count, 1, 'correct number of contacts';
+
+    $contact->discard_changes;
+    is $contact->email, '100', 'email correct';
+    is $contact->category, 'Cans left out 24x7', 'category correct';
+    is $contact->state, 'staff', 'contact is staff';
+};
+
 for my $test (
     {
         desc => 'check meta data added to existing contact',


### PR DESCRIPTION
The main point of this PR is to add the ability for an Open311 endpoint to use a 'staff' keyword which will then automatically mark the category as staff only when it's created/updated. That's the last commit.

However, while implementing it it seemed good to tidy up the populate script so that it only updated the contact table once for a category (it was possible for a new Open311 category to update the DB once to create the category, once to add extra fields (with no note), once to set the group, once to set as non public or inactive or waste; updating a category would only do it for changes, but could still leave more than one). And then also I thought it good to make a difference between undeleting a category and having its name/destination change (in the former I think we can drop any devolved send method; and in the latter case keep the state rather than always switch to confirmed, which could eg potentially lose a staff status).