### PR TITLE
[P'bro][WW] Limit bulky location details to 250 characters

### DIFF
--- a/perllib/FixMyStreet/App/Form/Waste/Bulky/Shared.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky/Shared.pm
@@ -53,6 +53,11 @@ has_page location => (
             $fields->{location}{label} = 'Please tell us where you will place the items for collection (include any access codes the crew will need)';
             $fields->{location}{tags}{hint} = 'For example, ‘On the driveway’';
         }
+
+        my $maxlength
+            = $form->c->cobrand->call_hook('bulky_location_max_length');
+        $fields->{location}{maxlength} = $maxlength if $maxlength;
+
         return $fields;
     },
 );

--- a/perllib/FixMyStreet/Cobrand/Peterborough/Bulky.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough/Bulky.pm
@@ -39,6 +39,12 @@ a bulky waste collection
 
 sub max_bulky_collection_dates       {2}
 
+=item * Max length of location details text is 250 characters
+
+=cut
+
+sub bulky_location_max_length {250}
+
 =item * Bulky workpack name is of the form 'Waste-BULKY WASTE-<date>' or
 'Waste-WHITES-<date>'
 

--- a/t/app/controller/waste_kands_bulky.t
+++ b/t/app/controller/waste_kands_bulky.t
@@ -331,6 +331,9 @@ FixMyStreet::override_config {
         );
         $mech->content_contains('Items must be out for collection by 6:30am on the collection day.');
         $mech->submit_form_ok({ with_fields => { location => '' } }, 'Will error with a blank location');
+        $mech->submit_form_ok({ with_fields => { location => ( 'a' x 251 ) } });
+        $mech->content_contains('tandc', 'No max location length');
+        $mech->back;
         $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
 
         sub test_summary {

--- a/t/app/controller/waste_peterborough_bulky.t
+++ b/t/app/controller/waste_peterborough_bulky.t
@@ -1326,6 +1326,11 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { 'item_1' => 'Amplifiers', 'item_2' => 'High chairs' } });
         $mech->content_contains('a href="peterborough-bulky-waste-tandc.com"');
         $mech->content_lacks('Items must be out for collection by', 'Lacks Kingston/Sutton extra text');
+        $mech->submit_form_ok({ with_fields => { location => ( 'a' x 251 ) } });
+        $mech->content_contains(
+            'Field should not exceed 250 characters',
+            'Error for location that is too long',
+        );
         $mech->submit_form_ok({ with_fields => { location => '' } });
         $mech->content_contains('tandc', 'Can have a blank location');
         $mech->back;


### PR DESCRIPTION
Bartec has a 250 char limit on the CREW_NOTES field (the 'location' field our end); reports fail to send if this limit is exceeded.

For https://3.basecamp.com/4020879/buckets/32749602/todos/7873595742 /  fixes https://github.com/mysociety/societyworks/issues/4568 .

[skip changelog]