### PR TITLE
Added GOVUK radio buttons on National Highways report message

### DIFF
--- a/web/cobrands/highways/assets.js
+++ b/web/cobrands/highways/assets.js
@@ -150,31 +150,41 @@ function add_highways_warning(road_name) {
   var $warning = $('<div class="box-warning" id="highways"><p>It looks like you clicked on the <strong>' + road_name + '</strong> which is managed by <strong>National Highways</strong>. ' +
                    'Does your report concern something on this road, or somewhere else (e.g a road crossing it)?<p></div>');
   var $page = $('<div data-page-name="highwaysengland" class="js-reporting-page js-reporting-page--active js-reporting-page--highways"></div>');
-  var $radios = $('<p class="segmented-control segmented-control--radio"></p>');
+  var $radios = $('<fiedset class="govuk-fieldset govuk-radios"></fieldset>');
 
-    $('<input>')
-        .attr('type', 'radio')
-        .attr('name', 'highways-choice')
-        .attr('id', 'js-highways')
-        .prop('checked', true)
-        .on('click', he_selected)
+    $('<div>')
+        .addClass('govuk-radios__item')
+        .append(
+            $('<input>')
+                .attr('type', 'radio')
+                .attr('name', 'highways-choice')
+                .attr('id', 'js-highways')
+                .prop('checked', true)
+                .on('click', he_selected)
+                .addClass('govuk-radios__input'),
+            $('<label>')
+                .attr('for', 'js-highways')
+                .text('On the ' + road_name)
+                .addClass('govuk-label govuk-radios__label')
+        )
         .appendTo($radios);
-    $('<label>')
-        .attr('for', 'js-highways')
-        .text('On the ' + road_name)
-        .addClass('btn')
+
+    $('<div>')
+        .addClass('govuk-radios__item')
+        .append(
+            $('<input>')
+                .attr('type', 'radio')
+                .attr('name', 'highways-choice')
+                .attr('id', 'js-not-highways')
+                .on('click', non_he_selected)
+                .addClass('govuk-radios__input'),
+            $('<label>')
+                .attr('for', 'js-not-highways')
+                .text('Somewhere else')
+                .addClass('govuk-label govuk-radios__label')
+        )
         .appendTo($radios);
-    $('<input>')
-        .attr('type', 'radio')
-        .attr('name', 'highways-choice')
-        .attr('id', 'js-not-highways')
-        .on('click', non_he_selected)
-        .appendTo($radios);
-    $('<label>')
-        .attr('for', 'js-not-highways')
-        .text('Somewhere else')
-        .addClass('btn')
-        .appendTo($radios);
+
     $radios.appendTo($warning);
     $warning.wrap($page);
     $page = $warning.parent();


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4549

Currently we use the segmented-control(pill) component, unfortunately it does not cover cases where the address of the report is quite long. This causes horizontal overflow and UI wise both buttons look quite uneven, because one is quite long while the other one says "Somewhere else".

With this change I think is also more obvious that they are options and not buttons. For example I tried stacking both "buttons" vertically so the first button being too long is not a problem anymore, unfortunately I think in terms of UX is a bit confusing because they look just like `.btn` and `btn--primary` so it just look like styled links, where one has more emphasis than the other one, instead of what they really are: option A which is active, and then we have option B.

<img width="714" alt="Screenshot 2024-10-09 at 11 32 26" src="https://github.com/user-attachments/assets/ad22975b-9c51-49d5-aa7f-a24b62440583">

[skip changelog]
