### PR TITLE
Reduce some translation DB calls, and related

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -102,7 +102,7 @@ This admin page displays the overall configuration for the site.
 sub config_page : Path( 'config' ) : Args(0) {
     my ($self, $c) = @_;
     my $dir = FixMyStreet->path_to();
-    my $git_version = `cd $dir && git describe --tags`;
+    my $git_version = `cd $dir && git describe --tags 2>&1`;
     chomp $git_version;
     $c->stash(
         git_version => $git_version,

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -323,7 +323,7 @@ sub format_problem_for_display : Private {
     }
 
     my $first_body = (values %{$problem->bodies})[0];
-    $c->stash->{extra_name_info} = $first_body && $first_body->name =~ /Bromley/ ? 1 : 0;
+    $c->stash->{extra_name_info} = $first_body && $first_body->get_column('name') =~ /Bromley/ ? 1 : 0;
 
     $c->forward('generate_map_tags');
 

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -128,7 +128,7 @@ sub relative_url_for_report {
 sub munge_around_category_where {
     my ($self, $where) = @_;
 
-    my $iow = grep { $_->name eq 'Isle of Wight Council' } @{ $self->{c}->stash->{around_bodies} };
+    my $iow = grep { $_->get_column('name') eq 'Isle of Wight Council' } @{ $self->{c}->stash->{around_bodies} };
     if ($iow) {
         # display all the categories on Isle of Wight at the moment as there's no way to
         # do the expand bit later as we fetch it using ajax which uses a bounding box so
@@ -179,7 +179,7 @@ sub munge_reports_area_list {
 sub munge_report_new_bodies {
     my ($self, $bodies) = @_;
 
-    my %bodies = map { $_->name => 1 } values %$bodies;
+    my %bodies = map { $_->get_column('name') => 1 } values %$bodies;
     if ( $bodies{'TfL'} ) {
         # Presented categories vary if we're on/off a red route
         my $tfl = FixMyStreet::Cobrand::TfL->new({ c => $self->{c} });
@@ -192,7 +192,7 @@ sub munge_report_new_bodies {
         my $on_he_road = $c->stash->{on_he_road} = $he->report_new_is_on_he_road;
 
         if (!$on_he_road) {
-            %$bodies = map { $_->id => $_ } grep { $_->name ne 'National Highways' } values %$bodies;
+            %$bodies = map { $_->id => $_ } grep { $_->get_column('name') ne 'National Highways' } values %$bodies;
         }
     }
 
@@ -228,7 +228,7 @@ sub munge_report_new_contacts {
     # Ignore contacts with a special type (e.g. waste, noise, claim)
     @$contacts = grep { !$_->get_extra_metadata('type') } @$contacts;
 
-    my %bodies = map { $_->body->name => $_->body } @$contacts;
+    my %bodies = map { $_->body->get_column('name') => $_->body } @$contacts;
 
     if ( my $body = $bodies{'Isle of Wight Council'} ) {
         return $self->_iow_category_munge($body, $contacts);
@@ -265,7 +265,7 @@ sub munge_unmixed_category_groups {
     my ($self, $groups, $opts) = @_;
     return unless $opts->{reporting};
     my $bodies = $self->{c}->stash->{bodies};
-    my %bodies = map { $_->name => 1 } values %$bodies;
+    my %bodies = map { $_->get_column('name') => 1 } values %$bodies;
     if ($bodies{"Buckinghamshire Council"}) {
         my @category_groups = grep { $_->{name} ne 'Car park issue' } @$groups;
         my ($car_park_group) = grep { $_->{name} eq 'Car park issue' } @$groups;

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -135,13 +135,10 @@ sub munge_around_category_where {
         # can't determine the body
         $where->{send_method} = [ { '!=' => 'Triage' }, undef ];
     }
-    my $waste = grep { $_->name =~ /Bromley Council|Peterborough City Council/ } @{ $self->{c}->stash->{around_bodies} };
-    if ($waste) {
-        $where->{'-or'} = [
-            extra => undef,
-            -not => { extra => { '@>' => '{"type":"waste"}' } }
-        ];
-    }
+    $where->{'-or'} = [
+        extra => undef,
+        -not => { extra => { '@>' => '{"type":"waste"}' } }
+    ];
 }
 
 sub _iow_category_munge {

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -700,7 +700,7 @@ sub munge_surrounding_london {
 
     # Hackney doesn't have any of the council TfL categories so don't show
     # any Hackney categories on red routes
-    my %bodies = map { $_->name => $_->id } values %$bodies;
+    my %bodies = map { $_->get_column('name') => $_->id } values %$bodies;
     if ( $bodies{'Hackney Council'} && $self->report_new_is_on_tlrn ) {
         delete $bodies->{ $bodies{'Hackney Council'} };
     }
@@ -728,7 +728,7 @@ sub munge_red_route_categories {
             map { $_ => 1 } @{ $self->_tlrn_categories },
             map { $_ => 1 } @{ $self->_tfl_council_categories },
         );
-        @$contacts = grep { !( $_->body->name eq 'TfL' && $tlrn_cats{$_->category } ) } @$contacts;
+        @$contacts = grep { !( $_->body->get_column('name') eq 'TfL' && $tlrn_cats{$_->category } ) } @$contacts;
     }
 }
 

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -489,7 +489,7 @@ sub updates_disallowed {
 
     my $cfg = $self->feature('updates_allowed') || '';
 
-    my $body_user = $c->user_exists && $c->user->from_body && $c->user->from_body->name eq $self->council_name;
+    my $body_user = $c->user_exists && $c->user->from_body && $c->user->from_body->get_column('name') eq $self->council_name;
     return $self->_updates_disallowed_check($cfg, $problem, $body_user);
 }
 

--- a/perllib/FixMyStreet/Roles/DB/Moderation.pm
+++ b/perllib/FixMyStreet/Roles/DB/Moderation.pm
@@ -12,7 +12,7 @@ sub latest_moderation {
 
     return $self->moderation_original_datas->search(
         $self->moderation_filter,
-    )->order_by('-id')->first;
+    )->order_by('-id')->search(undef, { rows => 1 })->first;
 }
 
 sub latest_moderation_log_entry {

--- a/perllib/FixMyStreet/Test.pm
+++ b/perllib/FixMyStreet/Test.pm
@@ -24,6 +24,7 @@ sub import {
     warnings->import(FATAL => 'all');
     utf8->import;
     Data::Dumper::Concise::Sugar->export_to_level(1);
+    binmode Test::More->builder->output, ':utf8';
     Test::More->export_to_level(1);
     $db->txn_begin;
 }

--- a/t/app/controller/about.t
+++ b/t/app/controller/about.t
@@ -6,7 +6,6 @@ use parent 'FixMyStreet::Cobrand::Default';
 sub path_to_web_templates { [ FixMyStreet->path_to( 't', 'app', 'controller', 'templates') ] }
 
 package main;
-use utf8;
 use FixMyStreet::TestMech;
 
 ok( my $mech = FixMyStreet::TestMech->new, 'Created mech object' );

--- a/t/app/controller/admin/bodies.t
+++ b/t/app/controller/admin/bodies.t
@@ -11,7 +11,6 @@ sub anonymous_account { { email => 'anoncategory@example.org', name => 'Anonymou
 
 package main;
 
-use utf8;
 use FixMyStreet::TestMech;
 
 my $mech = FixMyStreet::TestMech->new;

--- a/t/app/controller/alert_new.t
+++ b/t/app/controller/alert_new.t
@@ -1,4 +1,3 @@
-use utf8;
 use FixMyStreet::TestMech;
 use FixMyStreet::Script::Alerts;
 

--- a/t/app/controller/claims.t
+++ b/t/app/controller/claims.t
@@ -1,4 +1,3 @@
-use utf8;
 use FixMyStreet::TestMech;
 use FixMyStreet::Script::Reports;
 use Path::Tiny;

--- a/t/app/controller/contact_enquiry.t
+++ b/t/app/controller/contact_enquiry.t
@@ -1,4 +1,3 @@
-use utf8;
 use Encode;
 use FixMyStreet::TestMech;
 use Path::Tiny;

--- a/t/app/controller/dashboard.t
+++ b/t/app/controller/dashboard.t
@@ -19,9 +19,6 @@ sub dashboard_permission {
 
 package main;
 
-use strict;
-use warnings;
-
 use FixMyStreet::TestMech;
 use File::Temp 'tempdir';
 use Path::Tiny;

--- a/t/app/controller/js.t
+++ b/t/app/controller/js.t
@@ -1,4 +1,3 @@
-use utf8;
 use JSON::MaybeXS;
 use FixMyStreet::TestMech;
 my $mech = FixMyStreet::TestMech->new;

--- a/t/app/controller/rss.t
+++ b/t/app/controller/rss.t
@@ -1,4 +1,3 @@
-use utf8;
 use open ':std', ':locale';
 use FixMyStreet::TestMech;
 use FixMyStreet::App;

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -1,4 +1,3 @@
-use utf8;
 use Test::MockModule;
 use Test::MockTime qw(:all);
 use FixMyStreet::TestMech;

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -1,4 +1,3 @@
-use utf8;
 use Test::Deep;
 use Test::MockModule;
 use Test::MockObject;

--- a/t/app/controller/waste_brent_garden.t
+++ b/t/app/controller/waste_brent_garden.t
@@ -1,4 +1,3 @@
-use utf8;
 use Test::MockModule;
 use Test::MockTime qw(:all);
 use FixMyStreet::TestMech;

--- a/t/app/controller/waste_brent_small_items.t
+++ b/t/app/controller/waste_brent_small_items.t
@@ -1,4 +1,3 @@
-use utf8;
 use Test::MockModule;
 use Test::MockTime qw(:all);
 use Test::Output;

--- a/t/app/controller/waste_bromley_bulky.t
+++ b/t/app/controller/waste_bromley_bulky.t
@@ -1,4 +1,3 @@
-use utf8;
 use Test::MockModule;
 use Test::MockTime 'set_fixed_time';
 use FixMyStreet::TestMech;

--- a/t/app/controller/waste_kands_bulky.t
+++ b/t/app/controller/waste_kands_bulky.t
@@ -1,4 +1,3 @@
-use utf8;
 use Test::MockModule;
 use Test::MockTime qw(:all);
 use FixMyStreet::TestMech;

--- a/t/app/controller/waste_kingston.t
+++ b/t/app/controller/waste_kingston.t
@@ -1,4 +1,3 @@
-use utf8;
 use File::Temp 'tempdir';
 use JSON::MaybeXS;
 use Test::MockModule;

--- a/t/app/controller/waste_kingston_r.t
+++ b/t/app/controller/waste_kingston_r.t
@@ -1,4 +1,3 @@
-use utf8;
 use JSON::MaybeXS;
 use Path::Tiny;
 use Storable qw(dclone);

--- a/t/app/controller/waste_merton.t
+++ b/t/app/controller/waste_merton.t
@@ -1,4 +1,3 @@
-use utf8;
 use JSON::MaybeXS;
 use Path::Tiny;
 use Storable qw(dclone);

--- a/t/app/controller/waste_merton_bulky.t
+++ b/t/app/controller/waste_merton_bulky.t
@@ -1,4 +1,3 @@
-use utf8;
 use Test::MockModule;
 use Test::MockTime qw(:all);
 use FixMyStreet::TestMech;

--- a/t/app/controller/waste_merton_garden.t
+++ b/t/app/controller/waste_merton_garden.t
@@ -1,4 +1,3 @@
-use utf8;
 use JSON::MaybeXS;
 use Test::MockModule;
 use Test::MockTime qw(:all);

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -1,4 +1,3 @@
-use utf8;
 use Test::MockModule;
 use Test::MockTime qw(:all);
 use FixMyStreet::TestMech;

--- a/t/app/controller/waste_peterborough_bulky.t
+++ b/t/app/controller/waste_peterborough_bulky.t
@@ -1,4 +1,3 @@
-use utf8;
 use Test::MockModule;
 use Test::MockTime qw(:all);
 use FixMyStreet::TestMech;

--- a/t/app/controller/waste_sutton_garden.t
+++ b/t/app/controller/waste_sutton_garden.t
@@ -1,4 +1,3 @@
-use utf8;
 use JSON::MaybeXS;
 use Test::MockModule;
 use Test::MockTime qw(:all);

--- a/t/app/controller/waste_sutton_r.t
+++ b/t/app/controller/waste_sutton_r.t
@@ -1,4 +1,3 @@
-use utf8;
 use JSON::MaybeXS;
 use Path::Tiny;
 use Storable qw(dclone);

--- a/t/app/model/alert_type.t
+++ b/t/app/model/alert_type.t
@@ -1,4 +1,3 @@
-use utf8;
 use FixMyStreet::TestMech;
 use FixMyStreet::Script::Alerts;
 

--- a/t/app/model/responsepriority.t
+++ b/t/app/model/responsepriority.t
@@ -1,7 +1,3 @@
-use strict;
-use warnings;
-use Test::More;
-
 use FixMyStreet::TestMech;
 use JSON::MaybeXS;
 

--- a/t/app/model/responsetemplate.t
+++ b/t/app/model/responsetemplate.t
@@ -1,4 +1,3 @@
-use utf8;
 use FixMyStreet::TestMech;
 use JSON::MaybeXS;
 

--- a/t/cobrand/bromley_waste.t
+++ b/t/cobrand/bromley_waste.t
@@ -1,4 +1,3 @@
-use utf8;
 use CGI::Simple;
 use JSON::MaybeXS;
 use Test::MockModule;

--- a/t/cobrand/fixmystreet.t
+++ b/t/cobrand/fixmystreet.t
@@ -7,7 +7,6 @@ sub council_area_id { 2514 }
 sub cut_off_date { DateTime->now->subtract(days => 30)->strftime('%Y-%m-%d') }
 
 package main;
-use utf8;
 use Test::MockModule;
 use FixMyStreet::TestMech;
 use FixMyStreet::Script::UpdateAllReports;

--- a/t/cobrand/hackney.t
+++ b/t/cobrand/hackney.t
@@ -1,4 +1,3 @@
-use utf8;
 use CGI::Simple;
 use DateTime;
 use DateTime::Format::W3CDTF;

--- a/t/cobrand/isleofwight.t
+++ b/t/cobrand/isleofwight.t
@@ -1,4 +1,3 @@
-use utf8;
 use CGI::Simple;
 use DateTime;
 use Test::MockModule;

--- a/t/cobrand/nottinghamshirepolice.t
+++ b/t/cobrand/nottinghamshirepolice.t
@@ -10,7 +10,7 @@ END { FixMyStreet::App->log->enable('info'); }
 my $notts_police = $mech->create_body_ok(2236, 'Immediate Justice', {}, { cobrand => 'nottinghamshirepolice' });
 my $contact = $mech->create_contact_ok( body_id => $notts_police->id, category => 'Graffiti', email => 'graffiti@example.org' );
 my $contact_referral = $mech->create_contact_ok( body_id => $notts_police->id, category => 'Council referral', email => 'council-referral' );
-my $staff = $mech->create_user_ok( 'staff@example.org', from_body => $notts_police->id );
+my $staff = $mech->create_user_ok( 'staff@example.org', from_body => $notts_police->id, name => 'Staff' );
 $staff->user_body_permissions->create({ body => $notts_police, permission_type => 'report_edit' });
 
 my $standard_user_1

--- a/t/cobrand/surrey.t
+++ b/t/cobrand/surrey.t
@@ -6,6 +6,10 @@ use File::Temp 'tempdir';
 
 my $mech = FixMyStreet::TestMech->new;
 
+# disable info logs for this test run
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
 use_ok 'FixMyStreet::Cobrand::Surrey';
 
 my $surrey = $mech->create_body_ok(2242, 'Surrey County Council', {}, { cobrand => 'surrey' });

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -1,7 +1,6 @@
 # TODO
 # Overdue alerts
 
-use utf8;
 use DateTime;
 use Email::MIME;
 use File::Temp;

--- a/t/forms/waste/bulky.t
+++ b/t/forms/waste/bulky.t
@@ -1,4 +1,3 @@
-use utf8;
 use FixMyStreet::App::Form::Waste::Bulky;
 use FixMyStreet::Cobrand::Peterborough;
 use FixMyStreet::TestMech;

--- a/t/integrations/evo_claim.t
+++ b/t/integrations/evo_claim.t
@@ -1,5 +1,3 @@
-use strict;
-use warnings;
 use Test::More;
 use Test::MockObject;
 use Test::MockModule;

--- a/t/open311.t
+++ b/t/open311.t
@@ -10,7 +10,6 @@ use CGI::Simple;
 use HTTP::Response;
 use DateTime;
 use DateTime::Format::W3CDTF;
-use utf8;
 use Encode;
 
 use_ok( 'Open311' );

--- a/t/open311/getupdates.t
+++ b/t/open311/getupdates.t
@@ -1,4 +1,3 @@
-use utf8;
 use FixMyStreet::Test;
 use URI::Split qw(uri_split);
 

--- a/t/open311/populate-service-list.t
+++ b/t/open311/populate-service-list.t
@@ -12,7 +12,6 @@ package main;
 use FixMyStreet::TestMech;
 use FixMyStreet::DB;
 use Test::Warn;
-use utf8;
 
 use_ok( 'Open311::PopulateServiceList' );
 use_ok( 'Open311' );


### PR DESCRIPTION
Switch name to get_column('name') in a few places, as name does auto-translation lookup and we don't need this in these places, saves 2x(num contacts)+a few body calls (all quick but still). We only look for one row in moderation so request that (don't think this actually makes any material difference).
On the other side, realised there was some hard-coded waste category hiding that wasn't applying to some councils, so add that, didn't seem worth a PR on its own.
And  I wanted the test suite to be clean again. [skip changelog]
