### PR TITLE
Added aria-label to input#pc

### DIFF
--- a/templates/web/base/alert/index.html
+++ b/templates/web/base/alert/index.html
@@ -16,7 +16,7 @@
       [% INCLUDE 'errors.html' %]
     [% END %]
     <div>
-      <input type="text" id="pc" name="pc" value="[% pc | html %]" aria-describedby="pc-hint [% IF location_error %]email-error[% END %]" required>
+      <input type="text" id="pc" name="pc" value="[% pc | html %]" aria-describedby="pc-hint [% IF location_error %]email-error[% END %]" required aria-label="Add a postcode or address. Alternatively, there is a geolocate button at the end of this form">
       [% INCLUDE 'around/_postcode_submit_button.html' %]
     </div>
   </fieldset>

--- a/templates/web/base/around/postcode_form.html
+++ b/templates/web/base/around/postcode_form.html
@@ -27,7 +27,7 @@
             [% END %]
             <div>
                 <input type="text" name="pc" value="[% pc | html %]" id="pc" size="10" maxlength="200" required aria-describedby="pc-hint [% IF location_error_pc_lookup %]search-help pc-error[% END %]"
-                [%~ IF c.cobrand.moniker == 'oxfordshire' %] placeholder="[% tprintf(loc('e.g. ‘%s’ or ‘%s’'), c.cobrand.example_places) %]"[% END %]>
+                [%~ IF c.cobrand.moniker == 'oxfordshire' %] placeholder="[% tprintf(loc('e.g. ‘%s’ or ‘%s’'), c.cobrand.example_places) %]"[% END %] aria-label="Add a postcode or address. Alternatively, there is a geolocate button at the end of this form">
                 [% INCLUDE 'around/_postcode_submit_button.html' %]
             </div>
 


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4561
Replaces: https://github.com/mysociety/fixmystreet/pull/5207

Because the Geolocate button comes after the submit button, assistive device users might not realise it even exists. So, we have added an aria-label to input#pc in the front and alert page that provides more context about the input postcode and a geolocate button at the end of the form.

[skip changelog]
