### PR TITLE
Reduce body name translation db lookups

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -329,7 +329,9 @@ sub by_category_ajax_data : Private {
 
     if ($extras or $c->stash->{unresponsive}->{$category} or $c->stash->{report_extra_fields}) {
         $body->{category_extra} = $c->render_fragment('report/new/category_extras.html');
-        $body->{category_extra_json} = $c->forward('generate_category_extra_json');
+        if ($c->stash->{native_app}) {
+            $body->{category_extra_json} = $c->forward('generate_category_extra_json');
+        }
         $body->{extra_hidden} = 1 if $c->stash->{category_extras_hidden}->{$category} && !$c->stash->{report_extra_fields};
     }
     if ( $c->cobrand->moniker eq 'zurich' ) {

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -1327,7 +1327,7 @@ sub contacts_to_bodies : Private {
     # to a road.
     if ($options->{do_not_send}) {
         my %do_not_send_check = map { $_ => 1 } @{$options->{do_not_send}};
-        my @contacts_filtered = grep { !$do_not_send_check{$_->body->name} } @contacts;
+        my @contacts_filtered = grep { !$do_not_send_check{$_->body->get_column('name')} } @contacts;
         @contacts = @contacts_filtered if scalar @contacts_filtered;
     }
 

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -767,7 +767,7 @@ sub setup_categories_and_bodies : Private {
 
     my $all_areas = $c->stash->{all_areas};
 
-    my @bodies = $c->model('DB::Body')->active->for_areas(keys %$all_areas)->all;
+    my @bodies = $c->model('DB::Body')->active->for_areas(keys %$all_areas)->translated->all;
     my %bodies = map { $_->id => $_ } @bodies;
 
     $c->cobrand->call_hook(munge_report_new_bodies => \%bodies);

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -244,6 +244,7 @@ sub report_form_ajax : Path('ajax') : Args(0) {
         next if $unresponsive->{$_->body_id};
         my $body = $_->body;
         push @{$lookups->{bodies}{$category}}, {
+            id => $body->id,
             name => $body->name,
             cobrand_name => $body->cobrand_name,
         };
@@ -355,7 +356,7 @@ sub by_category_ajax_data : Private {
         $body->{councils_text} = $c->render_fragment( 'report/new/councils_text.html');
     }
 
-    my $cobrand_overrides = $c->stash->{cobrand_field_overrides_by_body}->{$bodies->[0]->{name}} if @$bodies == 1;
+    my $cobrand_overrides = $c->stash->{cobrand_field_overrides_by_body}->{$bodies->[0]->{id}} if @$bodies == 1;
     my $category_overrides = $lookups->{overrides}{$category};
 
     my $title_label_override = $cobrand_overrides->{title_label};
@@ -889,7 +890,7 @@ sub setup_categories_and_bodies : Private {
         $overrides{title_hint} = $title_hint if $title_hint;
         $overrides{detail_label} = $detail_label if $detail_label;
         $overrides{detail_hint} = $detail_hint if $detail_hint;
-        $cobrand_field_overrides_by_body{$body->name} = \%overrides;
+        $cobrand_field_overrides_by_body{$body->id} = \%overrides;
     }
 
     $c->cobrand->call_hook(munge_report_new_category_list => \@category_options, \@contacts, \%category_extras);

--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -209,15 +209,15 @@ sub munge_overlapping_asset_bodies {
         if (!$cobrand || $cobrand eq 'Brent') {
             # ...Brent's responsibility - remove the other bodies covering the Brent area
             %$bodies = map { $_->id => $_ } grep {
-                $_->name ne 'Camden Borough Council' &&
-                $_->name ne 'Barnet Borough Council' &&
-                $_->name ne 'Harrow Borough Council'
+                $_->get_column('name') ne 'Camden Borough Council' &&
+                $_->get_column('name') ne 'Barnet Borough Council' &&
+                $_->get_column('name') ne 'Harrow Borough Council'
                 } values %$bodies;
         } else {
             # Camden wants sole responsibility of Camden agreed areas
             if ($cobrand eq 'Camden') {
                 %$bodies = map { $_->id => $_ } grep {
-                    $_->name eq 'Camden Borough Council' || $_->name eq 'TfL' || $_->name eq 'National Highways'
+                    $_->get_column('name') eq 'Camden Borough Council' || $_->get_column('name') eq 'TfL' || $_->get_column('name') eq 'National Highways'
                 } values %$bodies;
                 return;
             }
@@ -225,7 +225,7 @@ sub munge_overlapping_asset_bodies {
             my %cobrands = (Harrow => 'Harrow Borough Council', Barnet => 'Barnet Borough Council');
             my $selected = $cobrands{$cobrand};
             %$bodies = map { $_->id => $_ } grep {
-                $_->name eq $selected || $_->name eq 'Brent Council' || $_->name eq 'TfL' || $_->name eq 'National Highways'
+                $_->get_column('name') eq $selected || $_->get_column('name') eq 'Brent Council' || $_->get_column('name') eq 'TfL' || $_->get_column('name') eq 'National Highways'
             } values %$bodies;
         }
     } else {
@@ -233,13 +233,13 @@ sub munge_overlapping_asset_bodies {
         if (!$cobrand || $cobrand ne 'Brent') {
             # ...not Brent's responsibility - remove Brent
             %$bodies = map { $_->id => $_ } grep {
-                $_->name ne 'Brent Council'
+                $_->get_column('name') ne 'Brent Council'
                 } values %$bodies;
         } else {
             # If it's for Brent shared with Camden, make wholly Brent's responsibility
-            if (grep { $_->name eq 'Camden Borough Council' } values %$bodies) {
+            if (grep { $_->get_column('name') eq 'Camden Borough Council' } values %$bodies) {
                 %$bodies = map { $_->id => $_ } grep {
-                    $_->name eq 'Brent Council' || $_->name eq 'TfL' || $_->name eq 'National Highways'
+                    $_->get_column('name') eq 'Brent Council' || $_->get_column('name') eq 'TfL' || $_->get_column('name') eq 'National Highways'
                 } values %$bodies;
             }
         }
@@ -256,7 +256,7 @@ of one body, and the non-street categories of the other.
 sub munge_cobrand_asset_categories {
     my ($self, $contacts) = @_;
 
-    my %bodies = map { $_->body->name => $_->body } @$contacts;
+    my %bodies = map { $_->body->get_column('name') => $_->body } @$contacts;
     my %non_street = (
         'Barnet' => { map { $_ => 1 } @{ $self->_barnet_non_street } },
         'Harrow' => { map { $_ => 1 } @{ $self->_harrow_non_street } },

--- a/perllib/FixMyStreet/Cobrand/Bristol.pm
+++ b/perllib/FixMyStreet/Cobrand/Bristol.pm
@@ -195,11 +195,11 @@ sub munge_overlapping_asset_bodies {
     } elsif ($self->check_report_is_on_cobrand_asset) {
         # We are not in a Bristol area but the report is in a park that Bristol is responsible for,
         # so only show Bristol categories.
-        %$bodies = map { $_->id => $_ } grep { $_->name eq $self->council_name } values %$bodies;
+        %$bodies = map { $_->id => $_ } grep { $_->get_column('name') eq $self->council_name } values %$bodies;
     } else {
         # We are not in a Bristol area and the report is not in a park that Bristol is responsible for,
         # so only show other categories.
-        %$bodies = map { $_->id => $_ } grep { $_->name ne $self->council_name } values %$bodies;
+        %$bodies = map { $_->id => $_ } grep { $_->get_column('name') ne $self->council_name } values %$bodies;
     }
 }
 

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -171,8 +171,8 @@ sub munge_overlapping_asset_bodies {
     my $cobrand = $self->check_report_is_on_cobrand_asset;
     if (!$in_bromley && $cobrand) {
         my $bromley = FixMyStreet::DB->resultset('Body')->find({ name => $self->council_name });
-        %$bodies = map { $_->id => $_ } grep { $_->name ne 'Lewisham Borough Council' } values %$bodies;
-        %$bodies = map { $_->id => $_ } grep { $_->name ne 'TfL' } values %$bodies;
+        %$bodies = map { $_->id => $_ } grep { $_->get_column('name') ne 'Lewisham Borough Council' } values %$bodies;
+        %$bodies = map { $_->id => $_ } grep { $_->get_column('name') ne 'TfL' } values %$bodies;
         $$bodies{$bromley->id} = $bromley;
     }
 }

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -929,7 +929,7 @@ sub owns_problem {
     }
 
     # Want to ignore National Highways here
-    my %areas = map { %{$_->areas} } grep { $_->name !~ /National Highways/ } @bodies;
+    my %areas = map { %{$_->areas} } grep { $_->get_column('name') !~ /National Highways/ } @bodies;
 
     foreach my $area_id ($self->area_ids_for_problems) {
         return 1 if $areas{$area_id};

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -156,7 +156,7 @@ sub _iow_category_munge {
 sub munge_reports_category_list {
     my ($self, $categories) = @_;
 
-    my %bodies = map { $_->body->name => $_->body } @$categories;
+    my %bodies = map { $_->body->get_column('name') => $_->body } @$categories;
     if ( my $body = $bodies{'Isle of Wight Council'} ) {
         return $self->_iow_category_munge($body, $categories);
     }
@@ -487,7 +487,7 @@ sub suppress_reporter_alerts {
 sub must_have_2fa {
     my ($self, $user) = @_;
     return 1 if $user->is_superuser && !FixMyStreet->staging_flag('skip_must_have_2fa');
-    return 1 if $user->from_body && $user->from_body->name eq 'TfL';
+    return 1 if $user->from_body && $user->from_body->get_column('name') eq 'TfL';
     return 0;
 }
 
@@ -530,7 +530,7 @@ sub report_new_munge_after_insert {
 sub munge_contacts_to_bodies {
     my ($self, $contacts, $report) = @_;
 
-    my %bodies = map { $_->body->name => 1 } @$contacts;
+    my %bodies = map { $_->body->get_column('name') => 1 } @$contacts;
 
     if ($bodies{'Buckinghamshire Council'}) {
         # Make sure Bucks grass cutting reports are routed correctly
@@ -593,10 +593,10 @@ around 'munge_sendreport_params' => sub {
 sub reopening_disallowed {
     my ($self, $problem) = @_;
     my $c = $self->{c};
-    return 1 if $problem->to_body_named("Southwark") && $c->user_exists && (!$c->user->from_body || $c->user->from_body->name ne "Southwark Council");
-    return 1 if $problem->to_body_named("Merton") && $c->user_exists && (!$c->user->from_body || $c->user->from_body->name ne "Merton Council");
-    return 1 if $problem->to_body_named("Northumberland") && $c->user_exists && (!$c->user->from_body || $c->user->from_body->name ne "Northumberland County Council");
-    return 1 if $problem->to_body_named("Gloucestershire") && $c->user_exists && (!$c->user->from_body || $c->user->from_body->name ne "Gloucestershire County Council");
+    return 1 if $problem->to_body_named("Southwark") && $c->user_exists && (!$c->user->from_body || $c->user->from_body->get_column('name') ne "Southwark Council");
+    return 1 if $problem->to_body_named("Merton") && $c->user_exists && (!$c->user->from_body || $c->user->from_body->get_column('name') ne "Merton Council");
+    return 1 if $problem->to_body_named("Northumberland") && $c->user_exists && (!$c->user->from_body || $c->user->from_body->get_column('name') ne "Northumberland County Council");
+    return 1 if $problem->to_body_named("Gloucestershire") && $c->user_exists && (!$c->user->from_body || $c->user->from_body->get_column('name') ne "Gloucestershire County Council");
     return $self->next::method($problem);
 }
 
@@ -628,7 +628,7 @@ sub fetch_area_children {
     my $features = FixMyStreet->config('COBRAND_FEATURES') || {};
     my $bodies = $features->{categories_restriction_bodies} || {};
     $bodies = $bodies->{tfl} || [];
-    if ($body && any { $_ eq $body->name } @$bodies) {
+    if ($body && any { $_ eq $body->get_column('name') } @$bodies) {
         my $areas = FixMyStreet::MapIt::call('areas', 'LBO');
         foreach (keys %$areas) {
             $areas->{$_}->{name} =~ s/\s*(Borough|City|District|County) Council$//;

--- a/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
+++ b/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
@@ -53,7 +53,7 @@ sub admin_allow_user {
     my ( $self, $user ) = @_;
     return 1 if $user->is_superuser;
     return undef unless defined $user->from_body;
-    return $user->from_body->name eq 'National Highways';
+    return $user->from_body->get_column('name') eq 'National Highways';
 }
 
 sub report_form_extras {
@@ -197,7 +197,7 @@ sub _redact {
 sub munge_report_new_bodies {
     my ($self, $bodies) = @_;
     # On the cobrand there is only the HE body
-    %$bodies = map { $_->id => $_ } grep { $_->name eq 'National Highways' } values %$bodies;
+    %$bodies = map { $_->id => $_ } grep { $_->get_column('name') eq 'National Highways' } values %$bodies;
 }
 
 # Strip all (NH) from end of category names
@@ -235,7 +235,7 @@ sub national_highways_cleaning_groups {
     if (defined $c->stash->{he_referral}) {
         @$contacts = grep {
             my @groups = @{$_->groups};
-            $_->body->name ne 'National Highways'
+            $_->body->get_column('name') ne 'National Highways'
             && ( $cleaning_cats{$_->category_display} || grep { $cleaning_cats{$_} } @groups )
         } @$contacts;
     } else {
@@ -246,7 +246,7 @@ sub national_highways_cleaning_groups {
             if ( $cleaning_cats{$_->category_display} || grep { $cleaning_cats{$_} } @groups ) {
                 $_->set_extra_metadata(nh_council_cleaning => 1);
             }
-            $_->body->name ne 'National Highways'
+            $_->body->get_column('name') ne 'National Highways'
             || ( $_->category_display !~ /Flytipping/ && $_->groups->[0] ne 'Litter' )
         } @$contacts;
     }

--- a/perllib/FixMyStreet/Cobrand/IsleOfWight.pm
+++ b/perllib/FixMyStreet/Cobrand/IsleOfWight.pm
@@ -151,7 +151,7 @@ sub munge_reports_category_list {
     my ($self, $categories) = @_;
 
     my $user = $self->{c}->user;
-    my %bodies = map { $_->body->name => $_->body } @$categories;
+    my %bodies = map { $_->body->get_column('name') => $_->body } @$categories;
     my $b = $bodies{'Isle of Wight Council'};
 
     if ( $user && ( $user->is_superuser || $user->belongs_to_body( $b->id ) ) ) {
@@ -167,7 +167,7 @@ sub munge_report_new_contacts {
     my ($self, $contacts) = @_;
 
     my $user = $self->{c}->user;
-    my %bodies = map { $_->body->name => $_->body } @$contacts;
+    my %bodies = map { $_->body->get_column('name') => $_->body } @$contacts;
     my $b = $bodies{'Isle of Wight Council'};
 
     if ( $user && ( $user->is_superuser || $user->belongs_to_body( $b->id ) ) ) {

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -802,7 +802,7 @@ sub bin_services_for_address {
             # If on the day, but before 5pm, show a special message to call
             # (which is slightly different for staff, who are actually allowed to report)
             if ($last->ymd eq $now->ymd && $now->hour < 17) {
-                my $is_staff = $self->{c}->user_exists && $self->{c}->user->from_body && $self->{c}->user->from_body->name eq "Peterborough City Council";
+                my $is_staff = $self->{c}->user_exists && $self->{c}->user->from_body && $self->{c}->user->from_body->get_column('name') eq "Peterborough City Council";
                 $row->{report_allowed} = $is_staff ? 1 : 0;
                 $row->{report_locked_out} = [ "ON DAY PRE 5PM" ];
                 # Set a global flag to show things in the sidebar
@@ -1160,7 +1160,7 @@ sub waste_munge_problem_data {
 sub waste_munge_problem_form_fields {
     my ($self, $field_list) = @_;
 
-    my $not_staff = !($self->{c}->user_exists && $self->{c}->user->from_body && $self->{c}->user->from_body->name eq "Peterborough City Council");
+    my $not_staff = !($self->{c}->user_exists && $self->{c}->user->from_body && $self->{c}->user->from_body->get_column('name') eq "Peterborough City Council");
     my $label_497 = $not_staff
     ? 'The bin wasn’t returned to the collection point (Please phone 01733 747474 to report this issue)'
     : 'The bin wasn’t returned to the collection point';

--- a/perllib/FixMyStreet/Cobrand/Thamesmead.pm
+++ b/perllib/FixMyStreet/Cobrand/Thamesmead.pm
@@ -15,7 +15,7 @@ sub reopening_disallowed {
     my $problem = shift;
     my $c = $self->{c};
 
-    my $staff = $c->user_exists && $c->user->from_body && $c->user->from_body->name eq $self->council_name;
+    my $staff = $c->user_exists && $c->user->from_body && $c->user->from_body->get_column('name') eq $self->council_name;
     my $superuser = $c->user_exists && $c->user->is_superuser;
     my $reporter = $c->user_exists && $c->user->id == $problem->user->id;
     my $reopening_disallowed = $self->SUPER::reopening_disallowed($problem);
@@ -31,7 +31,7 @@ sub admin_allow_user {
     my ( $self, $user ) = @_;
     return 1 if $user->is_superuser;
     return undef unless defined $user->from_body;
-    return $user->from_body->name eq 'Thamesmead';
+    return $user->from_body->get_column('name') eq 'Thamesmead';
 }
 
 sub cut_off_date { '2022-04-25' }
@@ -144,10 +144,10 @@ sub munge_thamesmead_body {
 
     if ( my $category = $self->area_type_for_point ) {
         $self->{c}->stash->{'thamesmead_category'} = $category;
-        %$bodies = map { $_->id => $_ } grep { $_->name eq 'Thamesmead' } values %$bodies;
+        %$bodies = map { $_->id => $_ } grep { $_->get_column('name') eq 'Thamesmead' } values %$bodies;
     } else {
         $self->{c}->stash->{'thamesmead_category'} = '';
-        %$bodies = map { $_->id => $_ } grep { $_->name ne 'Thamesmead' } values %$bodies;
+        %$bodies = map { $_->id => $_ } grep { $_->get_column('name') ne 'Thamesmead' } values %$bodies;
     }
 }
 

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -52,7 +52,7 @@ sub process_open311_extras {
     my $extra   = shift;
     my $fields  = shift || [];
 
-    if ( $body && $body->name =~ /Bromley/ ) {
+    if ( $body && $body->get_column('name') =~ /Bromley/ ) {
         my @fields = ( 'fms_extra_title', @$fields );
         for my $field ( @fields ) {
             my $value = $ctx->get_param($field);
@@ -199,17 +199,18 @@ sub munge_body_areas_practical {
     my ($self, $body, $area_ids) = @_;
 
     my %ids = map { $_ => 1 } @$area_ids;
+    my $name = $body->get_column('name');
     if ($ids{2505}) {
-        @$area_ids = (2488) if $body->name =~ /Brent/;
-        @$area_ids = (2489) if $body->name =~ /Barnet/;
-        @$area_ids = (2505) if $body->name =~ /Camden/;
-        @$area_ids = (2512) if $body->name =~ /City of London/;
-        @$area_ids = (2509) if $body->name =~ /Haringey/;
-        @$area_ids = (2507) if $body->name =~ /Islington/;
-        @$area_ids = (2504) if $body->name =~ /Westminster/;
+        @$area_ids = (2488) if $name =~ /Brent/;
+        @$area_ids = (2489) if $name =~ /Barnet/;
+        @$area_ids = (2505) if $name =~ /Camden/;
+        @$area_ids = (2512) if $name =~ /City of London/;
+        @$area_ids = (2509) if $name =~ /Haringey/;
+        @$area_ids = (2507) if $name =~ /Islington/;
+        @$area_ids = (2504) if $name =~ /Westminster/;
     } elsif ($ids{2488}) {
-        @$area_ids = (2487) if $body->name =~ /Harrow/;
-    } elsif ($ids{2561} && $body->name =~ /Bristol/) {
+        @$area_ids = (2487) if $name =~ /Harrow/;
+    } elsif ($ids{2561} && $name =~ /Bristol/) {
         @$area_ids = (2561);
     }
 }
@@ -407,7 +408,7 @@ sub get_body_handler_for_problem {
 
     # Do not do anything for National Highways here, as we don't want it to
     # treat this as a cobrand for e.g. submit report emails made on .com
-    my @bodies = grep { $_->name !~ /National Highways/ } values %{$row->bodies};
+    my @bodies = grep { $_->get_column('name') !~ /National Highways/ } values %{$row->bodies};
 
     for my $body ( @bodies ) {
         my $cobrand = $body->get_cobrand_handler;

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -343,7 +343,7 @@ sub admin_allow_user {
     return 1 if $user->is_superuser;
     return undef unless defined $user->from_body;
     # Make sure TfL staff can't access other London cobrand admins
-    return undef if $user->from_body->name eq 'TfL';
+    return undef if $user->from_body->get_column('name') eq 'TfL';
     return $user->from_body->get_extra_metadata('cobrand', '') eq $self->moniker;
 }
 
@@ -402,7 +402,7 @@ sub munge_reports_category_list {
 sub munge_report_new_bodies {
     my ($self, $bodies) = @_;
 
-    my %bodies = map { $_->name => 1 } values %$bodies;
+    my %bodies = map { $_->get_column('name') => 1 } values %$bodies;
     if ( $bodies{'TfL'} ) {
         # Presented categories vary if we're on/off a red route
         my $tfl = FixMyStreet::Cobrand::TfL->new({ c => $self->{c} });
@@ -447,7 +447,7 @@ sub munge_report_new_contacts {
         @$contacts = grep { !$_->get_extra_metadata('type') } @$contacts;
     }
 
-    my %bodies = map { $_->body->name => $_->body } @$contacts;
+    my %bodies = map { $_->body->get_column('name') => $_->body } @$contacts;
     if ( $bodies{'TfL'} ) {
         # Presented categories vary if we're on/off a red route
         my $tfl = FixMyStreet::Cobrand->get_class_for_moniker( 'tfl' )->new({ c => $self->{c} });

--- a/perllib/FixMyStreet/Cobrand/Westminster.pm
+++ b/perllib/FixMyStreet/Cobrand/Westminster.pm
@@ -242,7 +242,7 @@ in-Westminster sense.
 sub munge_overlapping_asset_bodies {
     my ($self, $bodies) = @_;
 
-    my %bodies = map { $_->name => 1 } values %$bodies;
+    my %bodies = map { $_->get_column('name') => 1 } values %$bodies;
     if ( $bodies{'Camden Borough Council'} ) {
         my $camden = FixMyStreet::Cobrand::Camden->new({ c => $self->{c} });
         $camden->munge_overlapping_asset_bodies($bodies);

--- a/perllib/FixMyStreet/DB/ResultSet/Contact.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Contact.pm
@@ -52,17 +52,33 @@ sub for_new_reports {
         $params->{$rs->me('state')} = [ 'unconfirmed', 'confirmed' ];
     }
 
-    $rs->search($params, { prefetch => 'body' });
+    $rs = $rs->search($params, { prefetch => 'body' });
+    my $schema = $rs->result_source->schema;
+    $rs = $rs->search(undef, {
+        '+columns' => {
+            'body.msgstr' => \"COALESCE(translations.msgstr, body.name)",
+            'msgstr' => \"COALESCE(translations_2.msgstr, me.category)"
+        },
+        join => [ 'translations', 'translations' ],
+        bind => [
+            'name', $schema->lang, 'body',
+            'category', $schema->lang, 'contact',
+        ],
+    });
+    return $rs;
 }
 
 sub translated {
     my $rs = shift;
     my $schema = $rs->result_source->schema;
-    $rs->search(undef, {
-        '+columns' => { 'msgstr' => \"COALESCE(translations.msgstr, me.category)" },
-        join => 'translations',
-        bind => [ 'category', $schema->lang, 'contact' ],
-    });
+    if (!$rs->{attrs}{'+columns'}[0]{msgstr}) {
+        $rs = $rs->search(undef, {
+            '+columns' => { 'msgstr' => \"COALESCE(translations.msgstr, me.category)" },
+            join => 'translations',
+            bind => [ 'category', $schema->lang, 'contact' ],
+        });
+    }
+    return $rs;
 }
 
 sub all_sorted {


### PR DESCRIPTION
[skip changelog]
I did some in f241299b1 but seemed to have missed quite a few! We don't need to check translations for all the overlapping asset stuff etc, we want to check against the actual db name.
This should cut down on the number of translation DB lookups when e.g. fetching /report/new/ajax pages.

I also try and fetch the translations first off, so that no more DB queries are needed anyway. (That's probably a better way of doing it I thought of after, but might as well leave the others, clearer for the comparison.)