### PR TITLE
[Merton][WW] Allow transfer of ggw subscription

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -18,6 +18,7 @@ use FixMyStreet::App::Form::Waste::Garden::Modify;
 use FixMyStreet::App::Form::Waste::Garden::Cancel;
 use FixMyStreet::App::Form::Waste::Garden::Renew;
 use FixMyStreet::App::Form::Waste::Garden::Sacks::Purchase;
+use FixMyStreet::App::Form::Waste::Garden::Transfer;
 use Memcached;
 use JSON::MaybeXS;
 
@@ -846,6 +847,54 @@ sub process_request_data : Private {
     return 1;
 }
 
+sub process_garden_transfer : Private {
+    my ($self, $c, $form) = @_;
+    my $data = $form->saved_data;
+
+    # Get the current subscription for the old address
+    my $old_property_id = $data->{previous_ggw_address}->{value};
+    #$c->forward('get_original_sub', ['', $old_property_id]);
+
+    my $base = {};
+    $base->{name} = $c->get_param('name');
+    $base->{email} = $c->get_param('email');
+    $base->{phone} = $c->get_param('phone');
+
+    # Cancel the old subscription
+    my $cancel = { %$base };
+    $cancel->{category} = 'Cancel Garden Subscription';
+    $cancel->{title} = 'Garden Subscription - Cancel';
+    $cancel->{address} = $data->{previous_ggw_address}->{label};
+    my $now = DateTime->now->set_time_zone(FixMyStreet->local_time_zone);
+    my $end_date_field = $c->cobrand->call_hook(alternative_backend_field_names => 'Subscription_End_Date') || 'Subscription_End_Date';
+    $c->set_param($end_date_field, $now->ymd);
+    $c->set_param('property_id', $old_property_id);
+    $c->set_param('uprn', $data->{transfer_old_ggw_sub}{transfer_uprn});
+    $c->set_param('transferred_to', $c->stash->{property}->{uprn});
+    $c->forward('setup_garden_sub_params', [ $cancel, undef ]);
+    $c->forward('add_report', [ $cancel ]) or return;
+    $c->stash->{report}->confirm;
+    $c->stash->{report}->update;
+
+    # Create a report for it for the new address
+    my $new = { %$base };
+    $new->{category} = 'Garden Subscription';
+    $new->{title} = 'Garden Subscription - New';
+    $new->{bins_wanted} = $data->{transfer_old_ggw_sub}->{transfer_bin_number};
+    $new->{transfer_bin_type} = $data->{transfer_old_ggw_sub}->{transfer_bin_type};
+
+    my $expiry = $data->{transfer_old_ggw_sub}->{subscription_enddate};
+    $expiry = DateTime::Format::W3CDTF->parse_datetime($expiry);
+    $c->set_param($end_date_field, $expiry->ymd);
+    $c->set_param('property_id', '');
+    $c->set_param('uprn', '');
+    $c->set_param('transferred_from', $data->{transfer_old_ggw_sub}{transfer_uprn});
+    $c->forward('setup_garden_sub_params', [ $new, $c->stash->{garden_subs}->{New} ]);
+    $c->forward('add_report', [ $new ]) or return;
+    $c->stash->{report}->confirm;
+    $c->stash->{report}->update;
+}
+
 sub group_reports {
     my ($c, @reports) = @_;
     my $report = shift @reports;
@@ -1280,6 +1329,15 @@ sub garden_renew : Chained('garden_setup') : Args(0) {
     $c->forward('form');
 }
 
+sub garden_transfer : Chained('garden_setup') : Args(0) {
+    my ($self, $c) = @_;
+
+    $c->detach( '/page_error_403_access_denied', [] ) unless $c->stash->{is_staff};
+
+    $c->stash->{form_class} = 'FixMyStreet::App::Form::Waste::Garden::Transfer';
+    $c->forward('form');
+}
+
 sub process_garden_cancellation : Private {
     my ($self, $c, $form) = @_;
 
@@ -1353,6 +1411,7 @@ sub get_original_sub : Private {
     }
 
     my $r = $c->stash->{orig_sub} = $p->first;
+
     $c->cobrand->call_hook(waste_check_existing_dd => $r)
         if $r && ($r->get_extra_field_value('payment_method') || '') eq 'direct_debit';
 }
@@ -1360,7 +1419,7 @@ sub get_original_sub : Private {
 sub setup_garden_sub_params : Private {
     my ($self, $c, $data, $type) = @_;
 
-    my $address = $c->stash->{property}->{address};
+    my $address = $data->{address} || $c->stash->{property}->{address};
 
     $data->{detail} = "$data->{category}\n\n$address";
 
@@ -1610,7 +1669,7 @@ sub add_report : Private {
     $c->set_param('title', $data->{title});
     $c->set_param('detail', $data->{detail});
     $c->set_param('uprn', $c->stash->{property}{uprn}) unless $c->get_param('uprn');
-    $c->set_param('property_id', $c->stash->{property}{id});
+    $c->set_param('property_id', $c->stash->{property}{id}) unless $c->get_param('property_id');
 
     # Data may contain duplicate photo data under different keys e.g.
     # 'item_photo_1' => 'c8a965ad74acad4104341a8ea893b1a1275efa4d.jpeg',

--- a/perllib/FixMyStreet/App/Form/Waste/Garden/Transfer.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Garden/Transfer.pm
@@ -1,0 +1,162 @@
+package FixMyStreet::App::Form::Waste::Garden::Transfer;
+
+use utf8;
+use HTML::FormHandler::Moose;
+use JSON;
+extends 'FixMyStreet::App::Form::Waste';
+
+has original_subscriber => (
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my $c = $self->{c};
+
+        my $p = $c->cobrand->problems->search({
+        category => 'Garden Subscription',
+        title => ['Garden Subscription - New', 'Garden Subscription - Renew'],
+        extra => { '@>' => encode_json({ "_fields" => [ { name => "property_id", value => ($self->saved_data->{previous_ggw_address}->{value}) } ] }) },
+        state => [ FixMyStreet::DB::Result::Problem->open_states ]
+        })->order_by('-id')->to_body($c->cobrand->body)->first;
+
+        my $user;
+        ($user) = $c->model('DB::User')->find({ id => $p->user_id }) if $p;
+        return $user;
+    },
+);
+
+has_page intro => (
+    title => 'Transfer garden waste subscription - check',
+    fields => ['resident_moved', 'continue_address'],
+    next => 'old_address',
+);
+
+has_page old_address => (
+    title => 'Transfer garden waste subscription - old address',
+    fields => ['postcode', 'continue_select'],
+    next => 'select_old_address',
+);
+
+has_page select_old_address => (
+    title => 'Transfer garden waste subscription - old address',
+    fields => ['addresses', 'continue_confirm'],
+    next => 'confirm',
+);
+
+has_page confirm => (
+    intro => 'garden/transfer_confirm_addresses.html',
+    title => 'Confirm transfer',
+    fields => ['email', 'phone', 'name', 'continue_done'],
+    finished => sub {
+        return $_[0]->wizard_finished('process_garden_transfer');
+    },
+    next => 'done',
+);
+
+with 'FixMyStreet::App::Form::Waste::AboutYou';
+
+sub default_name {
+    my $self = shift;
+
+    return $self->original_subscriber ? $self->original_subscriber->name : '';
+}
+
+sub default_phone {
+    my $self = shift;
+
+    return $self->original_subscriber ? $self->original_subscriber->phone : '';
+}
+
+sub default_email {
+    my $self = shift;
+
+    return $self->original_subscriber ? $self->original_subscriber->email : '';
+}
+
+has_page done => (
+    title => 'Transferred',
+    template => 'waste/garden/transferred.html',
+);
+
+
+has_field resident_moved => (
+    type => 'Checkbox',
+    required => 1,
+    option_label => 'Confirm that resident has moved to the address above and has brought their garden bins or bags with them',
+);
+
+has_field continue_address => (
+    type => 'Submit',
+    value => 'Find old address',
+    element_attr => { class => 'govuk-button' },
+);
+
+has_field continue_select => (
+    type => 'Submit',
+    element_attr => { class => 'govuk-button' },
+    order => 999,
+);
+
+has_field continue_confirm => (
+    type => 'Submit',
+    value => 'Select',
+    element_attr => { class => 'govuk-button' },
+    order => 999,
+);
+
+has_field continue_done => (
+    type => 'Submit',
+    value => 'Transfer',
+    element_attr => { class => 'govuk-button' },
+    order => 999
+);
+
+has_field postcode => (
+    type => 'Postcode',
+    value => 'Enter postcode',
+    validate_method => sub {
+        my $self = shift;
+        my $c = $self->form->c;
+        return if $self->has_errors; # Called even if already failed
+        my $data = $c->cobrand->bin_addresses_for_postcode($self->value);
+        if (!@$data) {
+            my $error = 'Sorry, we did not find any results for that postcode';
+            $self->add_error($error);
+        }
+        $self->form->saved_data->{addresses} = $data;
+    }
+);
+
+has_field addresses => (
+    label => 'Select previous address',
+    type => 'Select',
+    options_method => sub {
+         my $field = shift;
+         return $field->form->saved_data->{addresses};
+    },
+    validate_method => sub {
+        my $self = shift;
+        my $c = $self->form->c;
+
+        my %messages = (
+            'current' => 'There is currently a garden subscription at the new address',
+            'no_previous' => 'There is no garden subscription at this address',
+            'due_soon' => 'Subscription can not be transferred as is in the renewal period or expired',
+            'duplicate' => "This should be the old address, not the new one",
+        );
+
+        if ($self->value == $c->stash->{property}{id}) {
+            $self->add_error($messages{'duplicate'});
+            return;
+        }
+        my $data = $c->cobrand->call_hook('check_ggw_transfer_applicable' => $self->value);
+        if ($data->{error}) {
+            $self->add_error($messages{ $data->{error} });
+            return;
+        };
+        $self->form->saved_data->{transfer_old_ggw_sub} = $data;
+        ($self->form->saved_data->{previous_ggw_address}) = (grep { $_->{value} == $self->value } @{$self->form->saved_data->{addresses}})[0];
+    }
+);
+
+1;

--- a/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
@@ -105,7 +105,7 @@ sub bin_addresses_for_postcode {
 sub _allow_async_echo_lookup {
     my $self = shift;
     my $action = $self->{c}->action;
-    return 0 if $action eq 'waste/pay_retry' || $action eq 'waste/direct_debit_error' || $action eq 'waste/calendar_ics';
+    return 0 if $action eq 'waste/pay_retry' || $action eq 'waste/direct_debit_error' || $action eq 'waste/calendar_ics' || $action eq 'waste/garden_transfer';
     return 1;
 }
 
@@ -498,7 +498,6 @@ sub _parse_schedules {
         my $start_date = construct_bin_date($schedule->{StartDate})->strftime("%F");
         my $end_date = construct_bin_date($schedule->{EndDate})->strftime("%F");
         $max_end_date = $end_date if !defined($max_end_date) || $max_end_date lt $end_date;
-
         next if $end_date lt $today;
 
         my $next = $schedule->{NextInstance};

--- a/perllib/FixMyStreet/Roles/Cobrand/SLWP.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/SLWP.pm
@@ -377,6 +377,7 @@ sub waste_garden_sub_params {
     my $service = $self->garden_current_subscription;
     my $choice = $data->{container_choice} || '';
     my $existing = $service ? $service->{garden_container} : undef;
+    $existing = $data->{transfer_bin_type} if $data->{transfer_bin_type};
     my $container;
     if ($choice eq 'sack') {
         $container = CONTAINER_GARDEN_SACK;

--- a/templates/web/base/waste/garden/transfer_confirm_addresses.html
+++ b/templates/web/base/waste/garden/transfer_confirm_addresses.html
@@ -1,0 +1,3 @@
+<p>Please confirm that you want to transfer the green garden waste subscription:</p>
+<p>From: [% form.saved_data.previous_ggw_address.label %]</p>
+<p>To: [% property.address %]

--- a/templates/web/base/waste/garden/transferred.html
+++ b/templates/web/base/waste/garden/transferred.html
@@ -1,0 +1,19 @@
+[% title = 'The subscription has been transferred' %]
+[% PROCESS 'waste/header.html' %]
+
+<div class="govuk-panel govuk-panel--confirmation">
+    <h1 class="govuk-panel__title">
+        [% title %]
+    </h1>
+    <div class="govuk-panel__body">
+        <p>
+          Subscription has been successfully transferred
+        </p>
+    </div>
+</div>
+
+[% TRY %][% PROCESS 'waste/_confirmation_after.html' %][% CATCH file %][% END %]
+
+[% INCLUDE 'waste/_button_show_upcoming.html' %]
+
+[% INCLUDE footer.html %]

--- a/templates/web/merton/waste/_more_services_sidebar.html
+++ b/templates/web/merton/waste/_more_services_sidebar.html
@@ -42,5 +42,13 @@
         <li><a href="[% c.uri_for_action('waste/enquiry', [ property.id ]) %]?category=Assisted+collection+add&amp;service_id=2238">Set up for assisted collection</a></li>
     [% END %]
     </ul>
+    <h3>Transfer GGW to property</h3>
+    [% IF !show_garden_subscribe %]
+    <p>There is already a garden waste subscription at this property or garden waste is not permitted</p>
+    [% ELSE %]
+    <ul>
+    <li><a href="[% c.uri_for_action('waste/garden_transfer', [ property.id ]) %]">Transfer GGW subscription</a></li>
+  </ul>
+  [% END %]
 [% END %]
 


### PR DESCRIPTION
When a Green Garden Waste subscriber in Merton moves to another address in Merton, they can transfer the remainder of their ggw subscription to the new address

1) As long as the new address does not already have a sub 
2) As long as there is a ggw on their previous property, and it is not in the renewal period
3) They have brought their bin(s) with them

This is a staff only feature.

https://github.com/mysociety/societyworks/issues/4551

[skip changelog]