### PR TITLE
[Bexley][WW] Handle container removal requests

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -722,49 +722,46 @@ sub calendar_ics : Chained('property') : PathPart('calendar.ics') : Args(0) {
 sub construct_bin_request_form {
     my $c = shift;
 
-    my $field_list = $c->cobrand->call_hook( 'construct_bin_request_form', $c )
-        // [];
+    my $field_list = [];
 
-    if ( !@$field_list ) {
-        foreach (@{$c->stash->{service_data}}) {
-            next unless $_->{next} || $_->{request_only};
-            my $service = $_;
-            my $name = $_->{service_name};
-            my $containers = $_->{request_containers};
-            my $maximum = $_->{request_max};
-            foreach my $id (@$containers) {
-                my $max = ref $maximum ? $maximum->{$id} : $maximum;
-                push @$field_list, "container-$id" => {
-                    type => 'Checkbox',
-                    label => $name,
-                    option_label => $c->stash->{containers}->{$id},
-                    tags => { toggle => "form-quantity-$id-row" },
-                    disabled => $_->{requests_open}{$id} ? 1 : 0,
+    foreach (@{$c->stash->{service_data}}) {
+        next unless $_->{next} || $_->{request_only};
+        my $service = $_;
+        my $name = $_->{service_name};
+        my $containers = $_->{request_containers};
+        my $maximum = $_->{request_max};
+        foreach my $id (@$containers) {
+            my $max = ref $maximum ? $maximum->{$id} : $maximum;
+            push @$field_list, "container-$id" => {
+                type => 'Checkbox',
+                label => $name,
+                option_label => $c->stash->{containers}->{$id},
+                tags => { toggle => "form-quantity-$id-row" },
+                disabled => $_->{requests_open}{$id} ? 1 : 0,
+            };
+            $name = ''; # Only on first container
+            if ($max == 1) {
+                push @$field_list, "quantity-$id" => {
+                    type => 'Hidden',
+                    default => '1',
+                    apply => [ { check => qr/^1$/ } ],
                 };
-                $name = ''; # Only on first container
-                if ($max == 1) {
-                    push @$field_list, "quantity-$id" => {
-                        type => 'Hidden',
-                        default => '1',
-                        apply => [ { check => qr/^1$/ } ],
-                    };
-                } else {
-                    push @$field_list, "quantity-$id" => {
-                        type => 'Select',
-                        label => 'Quantity',
-                        tags => {
-                            hint => "You can request a maximum of " . NUMWORDS($max) . " containers",
-                            initial_hidden => 1,
-                        },
-                        options => [
-                            { value => "", label => '-' },
-                            map { { value => $_, label => $_ } } (1..$max),
-                        ],
-                        required_when => { "container-$id" => 1 },
-                    };
-                }
-                $c->cobrand->call_hook("bin_request_form_extra_fields", $service, $id, $field_list);
+            } else {
+                push @$field_list, "quantity-$id" => {
+                    type => 'Select',
+                    label => 'Quantity',
+                    tags => {
+                        hint => "You can request a maximum of " . NUMWORDS($max) . " containers",
+                        initial_hidden => 1,
+                    },
+                    options => [
+                        { value => "", label => '-' },
+                        map { { value => $_, label => $_ } } (1..$max),
+                    ],
+                    required_when => { "container-$id" => 1 },
+                };
             }
+            $c->cobrand->call_hook("bin_request_form_extra_fields", $service, $id, $field_list);
         }
     }
 
@@ -775,30 +772,35 @@ sub construct_bin_request_form {
 
 sub request : Chained('property') : Args(0) {
     my ($self, $c) = @_;
-    my $field_list = construct_bin_request_form($c);
 
-    $c->stash->{first_page} = 'request';
-    my $next = $c->cobrand->call_hook('waste_request_form_first_next');
-    my $title = $c->cobrand->call_hook('waste_request_form_first_title') || 'Which containers do you need?';
+    my %form_settings
+        = $c->cobrand->call_hook( 'construct_bin_request_form', $c );
+
+    my $field_list = $form_settings{field_list}
+        || construct_bin_request_form($c);
+
+    $c->stash->{first_page} = $form_settings{first_page} || 'request';
 
     my $cls = ucfirst $c->cobrand->council_url;
     $c->stash->{form_class} = "FixMyStreet::App::Form::Waste::Request::$cls";
 
-    $c->stash->{page_list} = [
-        request => {
-            fields => [ grep { ! ref $_ } @$field_list, 'submit' ],
-            title => $title,
-            intro => 'request/intro.html',
-            check_unique_id => 0,
-            next => $next,
-            update_field_list => sub {
-                my $form = shift;
-                my $fields = $form->{c}->cobrand->call_hook(
-                    waste_request_form_update_field_list => $form ) // {};
-                return $fields;
+    if ( $form_settings{page_list} ) {
+        $c->stash->{page_list} = $form_settings{page_list};
+    } else {
+        my $next  = $c->cobrand->call_hook('waste_request_form_first_next');
+        my $title = $c->cobrand->call_hook('waste_request_form_first_title')
+            || 'Which containers do you need?';
+
+        $c->stash->{page_list} = [
+            request => {
+                fields => [ grep { ! ref $_ } @$field_list, 'submit' ],
+                title => $title,
+                intro => 'request/intro.html',
+                check_unique_id => 0,
+                next => $next,
             },
-        },
-    ];
+        ];
+    }
 
     $c->cobrand->call_hook("waste_munge_request_form_pages", $c->stash->{page_list}, $field_list);
     $c->stash->{field_list} = $field_list;

--- a/perllib/FixMyStreet/App/Form/Waste/Request/Bexley.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Request/Bexley.pm
@@ -4,6 +4,16 @@ use utf8;
 use HTML::FormHandler::Moose;
 extends 'FixMyStreet::App::Form::Waste::Request';
 
+has_field category_delivery => (
+    type => 'Hidden',
+    default => 'Request new container',
+);
+
+has_field category_removal => (
+    type => 'Hidden',
+    default => 'Request container removal',
+);
+
 # Shown as first page if property able to order Green Wheelie Bins
 has_page household_size => (
     title => 'Household size',

--- a/perllib/FixMyStreet/Cobrand/Bexley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley.pm
@@ -446,7 +446,8 @@ Missed collection reports are automatically confirmed
 sub waste_auto_confirm_report {
     my ($self, $report) = @_;
     return $report->category eq 'Report missed collection'
-        || $report->category eq 'Request new container';
+        || $report->category eq 'Request new container'
+        || $report->category eq 'Request container removal';
 }
 
 1;

--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -1253,90 +1253,213 @@ sub get_in_cab_logs_reason_prefix {
 
 # Container maintenance
 
+# TODO e.g. blue lidded wheelie bin request being created for delivery when
+# I haven't selected
+
 sub construct_bin_request_form {
+    my ( $self, $c ) = @_;
+
+    my $request_type = $c->get_param('request_type');
+
+    my $full_field_list;
+    my $page_list;
+    my $first_page;
+
+    if ( $request_type eq 'delivery' ) {
+        # Household size page needs to appear first, if applicable
+        $first_page
+            = $c->stash->{property}{household_size_check}
+            ? 'household_size'
+            : 'request';
+
+        my $delivery_field_list
+            = $self->_construct_bin_request_form_delivery($c);
+        my $removal_field_list
+            = $self->_construct_bin_request_form_removal($c);
+
+        # Not all properties have containers eligible for removal
+        my $include_removal = @$removal_field_list;
+
+        # Above-shop properties get a single default reason, so no need to send
+        # them to reason selection
+        my $include_reason
+            = $self->{c}->stash->{property}{above_shop} ? 0 : 1;
+
+        my $next
+            = $include_removal
+            ? 'request_removal'
+            : ( $include_reason ? 'request_reason' : 'about_you' );
+
+        $page_list = [
+            request => {
+                fields => [ grep { ! ref $_ } @$delivery_field_list, 'submit' ],
+                title => 'Which containers do you need?',
+                check_unique_id => 0,
+                next => $next,
+                update_field_list => sub {
+                    my $form = shift;
+                    my $fields
+                        = $self->waste_request_form_update_field_list($form);
+                    return $fields;
+                },
+            },
+        ];
+        $full_field_list = [ @$delivery_field_list ];
+
+        if ( $include_removal ) {
+            push @$page_list, (
+                request_removal => {
+                    fields => [ grep { ! ref $_ } @$removal_field_list, 'submit' ],
+                    title => 'Which containers do you need to be removed?',
+                    check_unique_id => 0,
+                    next => ( $include_reason ? 'request_reason' : 'about_you' ),
+                },
+            );
+            push @$full_field_list, @$removal_field_list;
+        }
+
+    } else {
+        $first_page = 'request_removal';
+        $full_field_list = $self->_construct_bin_request_form_removal($c);
+
+        $page_list = [
+            request_removal => {
+                fields => [ grep { ! ref $_ } @$full_field_list, 'submit' ],
+                title => 'Which containers do you need to be removed?',
+                check_unique_id => 0,
+                next => 'request_reason',
+            },
+        ];
+
+    }
+
+    return (
+        field_list => $full_field_list,
+        first_page => $first_page,
+        page_list  => $page_list,
+    );
+}
+
+sub _construct_bin_request_form_delivery {
     my ( $self, $c ) = @_;
 
     my $field_list = [];
 
-    my $request_type = $c->get_param('request_type');
     my $property = $c->stash->{property};
     my $open_reports = $property->{open_reports}{request};
 
-    if ( $request_type eq 'delivery' ) {
-        for my $container (
-            @{ $property->{containers_for_delivery} } )
-        {
-            if ( $container->{subtypes} ) {
-                my $id = $container->{name} =~ s/ /-/gr;
+    for my $container ( @{ $property->{containers_for_delivery} } )
+    {
+        if ( $container->{subtypes} ) {
+            my $id = $container->{name} =~ s/ /-/gr;
 
-                my $disabled = grep { $open_reports->{$_->{service_item_name}} } @{ $container->{subtypes} };
-                push @$field_list, "parent-$id" => {
-                    type         => 'Checkbox',
-                    label        => $container->{name},
-                    option_label => $container->{description},
-                    tags         => { toggle => "form-bin-size-$id-row" },
-                    disabled => $disabled,
-                };
+            my $disabled = grep { $open_reports->{ $_->{service_item_name} } }
+                @{ $container->{subtypes} };
 
-                push @$field_list, "bin-size-$id" => {
-                    type    => 'Select',
-                    label   => 'Bin Size',
-                    tags    => { initial_hidden => 1 },
-                    options => [
-                        map {
-                            label     => $_->{size},
-                            value     => $_->{service_item_name},
-                        },
-                        @{ $container->{subtypes} }
-                    ],
-                    required_when => { "parent-$id" => 1 },
-                };
-            } else {
-                my $id = $container->{service_item_name} =~ s/ /-/gr;
-                my $disabled = $open_reports->{$container->{service_item_name}} ? 1 : 0;
+            push @$field_list, "parent-$id" => {
+                type         => 'Checkbox',
+                label        => $container->{name},
+                option_label => $container->{description},
+                tags         => { toggle => "form-bin-size-$id-row" },
+                disabled     => $disabled,
+            };
 
-                push @$field_list, "container-$id" => {
-                    type         => 'Checkbox',
-                    label        => $container->{name},
-                    option_label => $container->{description},
-                    tags => { toggle => "form-quantity-$id-row" },
-                    disabled => $disabled,
-                };
-
-                my $max = $container->{max} || 1;
-                if ( $max > 1 ) {
-                    push @$field_list, "quantity-$id" => {
-                        type => 'Select',
-                        label => 'Quantity',
-                        tags => {
-                            hint => "You can request a maximum of " . NUMWORDS($max) . " containers",
-                            initial_hidden => 1,
-                        },
-                        options => [
-                            map { { value => $_, label => $_ } }
-                                ( 1 .. $max ),
-                        ],
-                        required_when => { "container-$id" => 1 },
-                    };
-                }
-            }
-        }
-    } else {
-        # Removal
-        for my $container (
-            @{ $c->stash->{property}{containers_for_removal} } )
-        {
-            # TODO Use size/code for service that exists on property
-
-            my $id
-                = $container->{subtypes}
-                ? $container->{subtypes}[0]{service_item_name}
-                : $container->{service_item_name};
+            push @$field_list, "bin-size-$id" => {
+                type    => 'Select',
+                label   => 'Bin Size',
+                tags    => { initial_hidden => 1 },
+                options => [
+                    map {
+                        label     => $_->{size},
+                            value => $_->{service_item_name},
+                    },
+                    @{ $container->{subtypes} }
+                ],
+                required_when => { "parent-$id" => 1 },
+            };
+        } else {
+            my $id = $container->{service_item_name} =~ s/ /-/gr;
+            my $disabled = $open_reports->{$container->{service_item_name}} ? 1 : 0;
 
             push @$field_list, "container-$id" => {
                 type         => 'Checkbox',
                 label        => $container->{name},
                 option_label => $container->{description},
+                tags         => { toggle => "form-quantity-$id-row" },
+                disabled     => $disabled,
+            };
+
+            my $max = $container->{max} || 1;
+            if ( $max > 1 ) {
+                push @$field_list,
+                    "quantity-$id" => {
+                    type  => 'Select',
+                    label => 'Quantity',
+                    tags  => {
+                        hint => "You can request a maximum of "
+                            . NUMWORDS($max)
+                            . " containers",
+                        initial_hidden => 1,
+                    },
+                    options => [
+                        map { { value => $_, label => $_ } } ( 1 .. $max ),
+                    ],
+                    required_when => { "container-$id" => 1 },
+                    };
+            }
+        }
+    }
+
+    return $field_list;
+}
+
+sub _construct_bin_request_form_removal {
+    my ( $self, $c ) = @_;
+
+    return [] unless @{ $c->stash->{property}{containers_for_removal} };
+
+    my $field_list = [];
+
+    my %service_names_to_ids
+            = map { $_->{service_name} => $_->{service_id} }
+            @{ $self->{c}->stash->{service_data} };
+
+    for my $container (
+        @{ $c->stash->{property}{containers_for_removal} } )
+    {
+        # For containers with subtypes, choose the ID ('service_item_name')
+        # that the property currently has
+        my $id
+            = $container->{subtypes}
+            ? $service_names_to_ids{ $container->{name} }
+            : $container->{service_item_name};
+
+        $id .= '-removal';
+
+        push @$field_list, "container-$id" => {
+            type         => 'Checkbox',
+            label        => $container->{name},
+            option_label => $container->{description},
+            tags => { toggle => "form-quantity-$id-row" },
+
+            # TODO
+            # disabled => $_->{requests_open}{$id} ? 1 : 0,
+        };
+
+        my $max = $container->{max} || 1;
+        if ( $max > 1 ) {
+            push @$field_list, "quantity-$id" => {
+                type => 'Select',
+                label => 'Quantity',
+                tags => {
+                    hint => "You can request removal of a maximum of " . NUMWORDS($max) . " containers",
+                    initial_hidden => 1,
+                },
+                options => [
+                    map { { value => $_, label => $_ } }
+                        ( 1 .. $max ),
+                ],
+                required_when => { "container-$id" => 1 },
             };
         }
     }
@@ -1373,26 +1496,6 @@ sub waste_request_form_update_field_list {
     return $fields;
 }
 
-sub waste_request_form_first_next {
-    my $self = shift;
-
-    # Above-shop properties get a single default reason, so no need to send
-    # them to reason selection
-    return $self->{c}->stash->{property}{above_shop}
-        ? 'about_you'
-        : 'request_reason';
-}
-
-sub waste_munge_request_form_pages {
-    my ( $self, $page_list, $field_list ) = @_;
-
-    my $c = $self->{c};
-
-    if ( $c->stash->{property}{household_size_check} ) {
-        $c->stash->{first_page} = 'household_size';
-    }
-}
-
 sub waste_munge_request_form_data {
     my ( $self, $data ) = @_;
 
@@ -1411,23 +1514,37 @@ sub waste_munge_request_data {
     my ( $self, $id, $data ) = @_;
 
     my $c  = $self->{c};
-    my $delivery_containers = $c->stash->{property}{containers_for_delivery};
+
+    my $type = 'delivery';
+    if ( $id =~ /-removal$/ ) {
+        $type = 'removal';
+    }
 
     my $service;
-    for my $dc (@$delivery_containers) {
-        $service = $dc if $id eq ( $dc->{service_item_name} // '' );
+
+    my $containers
+        = $type eq 'delivery'
+        ? $c->stash->{property}{containers_for_delivery}
+        : $c->stash->{property}{containers_for_removal};
+
+    for my $ctr (@$containers) {
+        # Removal options from form have a '-removal' suffix
+        my $original_id = $id =~ s/-removal$//r;
+
+        $service = $ctr
+            if $original_id eq ( $ctr->{service_item_name} // '' );
 
         last if $service;
 
-        if ( @{ $dc->{subtypes} // [] } ) {
+        if ( @{ $ctr->{subtypes} // [] } ) {
             # The service we are looking for may be the subtype of
             # a parent
             # (e.g. 'RES-140' under 'Green Wheelie Bin')
-            for my $subtype ( @{ $dc->{subtypes} } ) {
-                if ( $id eq $subtype->{service_item_name} ) {
+            for my $subtype ( @{ $ctr->{subtypes} } ) {
+                if ( $original_id eq $subtype->{service_item_name} ) {
                     $service = $subtype;
                     # Use parent name
-                    $service->{name} = $dc->{name};
+                    $service->{name} = $ctr->{name};
                     last;
                 }
             }
@@ -1439,16 +1556,22 @@ sub waste_munge_request_data {
         # E.g. 'Deliver Box lids 55L'.
         # We need to unhyphen string that was hyphenated in
         # construct_bin_request_form().
-        my $id_spaced = $id =~ s/-/ /gr;
+        my $id_spaced = $original_id =~ s/-/ /gr;
 
-        if ( $id_spaced eq ( $dc->{service_item_name} // '' ) ) {
-            $service = $dc;
+        if ( $id_spaced eq ( $ctr->{service_item_name} // '' ) ) {
+            $service = $ctr;
         }
 
         last if $service;
     }
 
-    $data->{title}  = "Request new $service->{name}";
+    if ( $type eq 'delivery' ) {
+        $data->{title}    = "Request new $service->{name}";
+        $data->{category} = $data->{category_delivery};
+    } else {
+        $data->{title}    = "Request removal of $service->{name}";
+        $data->{category} = $data->{category_removal};
+    }
 
     my $address = $c->stash->{property}{address};
     my $reason
@@ -1704,12 +1827,14 @@ sub _containers_for_requests {
 
         'Food Waste' => [
             {   name                => 'Brown Caddy',
+                description         => 'Food waste',
                 service_item_name   => 'FO-23',
                 service_id_delivery => '224',
                 service_id_removal  => '156',
                 max                 => 3,
             },
             {   name                => 'Kitchen Caddy',
+                description         => 'Food waste',
                 service_item_name   => 'Kitchen 5 Ltr Caddy',
                 service_id_delivery => '235',
             },

--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -1413,16 +1413,18 @@ sub _construct_bin_request_form_delivery {
 sub _construct_bin_request_form_removal {
     my ( $self, $c ) = @_;
 
-    return [] unless @{ $c->stash->{property}{containers_for_removal} };
+    my $property = $c->stash->{property};
+    return [] unless @{ $property->{containers_for_removal} };
 
     my $field_list = [];
 
+    my $open_reports = $property->{open_reports}{request};
     my %service_names_to_ids
             = map { $_->{service_name} => $_->{service_id} }
             @{ $self->{c}->stash->{service_data} };
 
     for my $container (
-        @{ $c->stash->{property}{containers_for_removal} } )
+        @{ $property->{containers_for_removal} } )
     {
         # For containers with subtypes, choose the ID ('service_item_name')
         # that the property currently has
@@ -1431,6 +1433,8 @@ sub _construct_bin_request_form_removal {
             ? $service_names_to_ids{ $container->{name} }
             : $container->{service_item_name};
 
+        my $disabled = $open_reports->{$id} ? 1 : 0;
+
         $id .= '-removal';
 
         push @$field_list, "container-$id" => {
@@ -1438,9 +1442,7 @@ sub _construct_bin_request_form_removal {
             label        => $container->{name},
             option_label => $container->{description},
             tags => { toggle => "form-quantity-$id-row" },
-
-            # TODO
-            # disabled => $_->{requests_open}{$id} ? 1 : 0,
+            disabled => $disabled,
         };
 
         my $max = $container->{max} || 1;

--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -1253,9 +1253,6 @@ sub get_in_cab_logs_reason_prefix {
 
 # Container maintenance
 
-# TODO e.g. blue lidded wheelie bin request being created for delivery when
-# I haven't selected
-
 sub construct_bin_request_form {
     my ( $self, $c ) = @_;
 
@@ -1503,7 +1500,7 @@ sub waste_munge_request_form_data {
     for ( keys %$data ) {
         my ($parent_id) = /^parent-(.*)/;
 
-        next unless $parent_id;
+        next unless $parent_id && $data->{"parent-$parent_id"};
 
         my $subtype_id = $data->{"bin-size-$parent_id"};
         $data->{"container-$subtype_id"} = 1 if $subtype_id;

--- a/t/app/controller/waste_bexley_container_requests.t
+++ b/t/app/controller/waste_bexley_container_requests.t
@@ -1020,6 +1020,11 @@ FixMyStreet::override_config {
         $mech->get_ok('/waste/10001/request?request_type=delivery');
         $mech->submit_form_ok({ with_fields => { household_size => 2 } });
         $mech->content_like(qr/name="container-PG-55"[^>]*disabled/, 'PG-55 option is disabled');
+        $mech->submit_form_ok( { with_fields => { 'container-Kitchen-5-Ltr-Caddy' => 1 } } );
+        $mech->content_like(
+            qr/name="container-PG-55-removal"[^>]*disabled/,
+            'PG-55 option is disabled for removals as well'
+        );
     };
 };
 

--- a/t/app/controller/waste_bexley_container_requests.t
+++ b/t/app/controller/waste_bexley_container_requests.t
@@ -815,7 +815,17 @@ FixMyStreet::override_config {
             $mech->content_contains( 'Please review the information',
                 'On summary page' );
 
-# TODO Container summary
+            note 'Delivery summary:';
+            $mech->content_contains('Green Wheelie Bin (Non-recyclable waste) - Small 140 litre');
+            $mech->content_contains('White Recycling Box (Plastics, cans and glass)');
+            $mech->content_contains('Recycling Box Lids');
+            $mech->content_contains('Brown Caddy (Food waste)');
+            $mech->content_like(qr/govuk-summary-list__value.*2/);
+
+            note 'Removal summary:';
+            $mech->content_contains('Green Wheelie Bin (Non-recyclable waste) - Medium 180 litre');
+            $mech->content_contains('Brown Caddy (Food waste)');
+            $mech->content_like(qr/govuk-summary-list__value.*3/);
 
             $mech->submit_form_ok(
                 { with_fields => { submit => 'Request new containers' } } );
@@ -892,6 +902,9 @@ FixMyStreet::override_config {
             $mech->content_contains( 'Please review the information',
                 'On summary page' );
 
+            note 'Delivery summary:';
+            $mech->content_contains('Clear Sack(s) (Mixed recycling)');
+
             $mech->submit_form_ok(
                 { with_fields => { submit => 'Request new containers' } } );
 
@@ -953,6 +966,11 @@ FixMyStreet::override_config {
             },
             'submit "about you" page',
         );
+
+        note 'Removal summary:';
+        $mech->content_contains('Green Wheelie Bin (Non-recyclable waste) - Medium 180 litre');
+        $mech->content_contains('Brown Caddy (Food waste)');
+        $mech->content_like(qr/govuk-summary-list__value.*2/);
 
         $mech->submit_form_ok(
             { with_fields => { submit => 'Request new containers' } } );

--- a/t/app/controller/waste_bexley_container_requests.t
+++ b/t/app/controller/waste_bexley_container_requests.t
@@ -764,9 +764,6 @@ FixMyStreet::override_config {
                         'parent-Green-Wheelie-Bin'   => 1,
                         'bin-size-Green-Wheelie-Bin' => 'RES-140',
 
-                        'parent-Blue-Lidded-Wheelie-Bin'   => 1,
-                        'bin-size-Blue-Lidded-Wheelie-Bin' => 'PC-240',
-
                         'container-PG-55' => 1,
 
                         'container-Deliver-Box-lids-55L' => 1,
@@ -827,7 +824,7 @@ FixMyStreet::override_config {
                 'Request successful' );
 
             my $rows = FixMyStreet::DB->resultset("Problem")->order_by('id');
-            is $rows->count, 8, 'correct number of reports raised';
+            is $rows->count, 7, 'correct number of reports raised';
 
             my %extra;
             while ( my $report = $rows->next ) {
@@ -844,7 +841,6 @@ FixMyStreet::override_config {
             cmp_deeply \%extra, {
                 'Request new container' => {
                     'RES-140'              => 1,
-                    'PC-240'               => 1,
                     'PG-55'                => 1,
                     'Deliver Box lids 55L' => 4,
                     'FO-23'                => 2,

--- a/templates/web/base/waste/confirmation.html
+++ b/templates/web/base/waste/confirmation.html
@@ -1,5 +1,5 @@
 [%
-IF report.category == 'Request new container';
+IF report.category == 'Request new container' || report.category == 'Request container removal';
     title = 'Your container request has been sent';
 ELSIF report.category == 'Report missed collection';
     title = 'Thank you for reporting a missed collection';

--- a/templates/web/bexley/waste/summary_request.html
+++ b/templates/web/bexley/waste/summary_request.html
@@ -1,0 +1,55 @@
+[%
+  title = 'Submit container request';
+  thing = 'container request';
+  summary_title = 'Container requests';
+  step1 = 'request';
+
+  data = form.saved_data;
+  requests = c.cobrand.requests_for_display(data);
+%]
+
+[% BLOCK answers %]
+  [% IF data.household_size %]
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key govuk-summary-list__key--sub">Household size</dt>
+      <dd class="govuk-summary-list__value">[% data.household_size %] person(s)</dd>
+    </div>
+  [% END %]
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key govuk-summary-list__key--sub">Reason</dt>
+    <dd class="govuk-summary-list__value">[% data.request_reason %]</dd>
+  </div>
+
+  [% # Deliveries %]
+  [% IF requests.0.size %]
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key govuk-summary-list__key--sub"><b>Deliver new or replacement:</b></dt>
+    </div>
+    [% FOR container IN requests.0 %]
+      [% INCLUDE container_row %]
+    [% END %]
+  [% END %]
+
+  [% # Removals %]
+  [% IF requests.1.size %]
+    <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key govuk-summary-list__key--sub"><b>Remove old:</b></dt>
+    </div>
+    [% FOR container IN requests.1 %]
+      [% INCLUDE container_row %]
+    [% END %]
+  [% END %]
+
+[% END %]
+
+[% PROCESS waste/summary.html %]
+
+[% BLOCK container_row %]
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key govuk-summary-list__key--sub">
+      [% container.name %][% IF container.description %] ([% container.description %])[% END %][% IF container.size_description %] - [% container.size_description %][% END %]
+    </dt>
+    <dd class="govuk-summary-list__value">[% container.quantity || 1 %]</dd>
+  </div>
+[% END %]


### PR DESCRIPTION
For https://github.com/mysociety/societyworks/issues/4576 and some of https://github.com/mysociety/societyworks/issues/4575.

The normal 'request new' journey also includes options for removal, if property has containers that can be removed.
There is also a separate journey that handles removals only.

[skip changelog]
