### PR TITLE
[Open311] Skip latest data identical updates.

### DIFF
--- a/perllib/Open311/UpdatesBase.pm
+++ b/perllib/Open311/UpdatesBase.pm
@@ -164,6 +164,8 @@ sub _process_update {
     my $open311 = $self->current_open311;
     my $body = $self->current_body;
 
+    $self->_handle_assigned_user($request, $p);
+
     my $state = $open311->map_state( $request->{status} );
     my $old_state = $p->state;
     my $external_status_code = $request->{external_status_code} || '';
@@ -177,6 +179,18 @@ sub _process_update {
         $email_text = $request->{email_text};
     };
 
+    if ($request->{extras} && $request->{extras}{latest_data_only} ) {
+        # Hide if the new comment is the same as the latest comment by the body user
+        my $latest = $p->comments->search({
+            state => 'confirmed',
+            user_id => $self->system_user->id,
+        }, {
+            order_by => [ { -desc => 'confirmed' }, { -desc => 'id' } ],
+            rows => 1,
+        })->first;
+        return if $latest && $text eq $latest->text && $state eq $latest->problem_state;
+    }
+
     # An update shouldn't precede an auto-internal update nor should it be earlier than when the
     # report was sent.
     my $auto_comment = $p->comments->search({ external_id => 'auto-internal' })->first;
@@ -186,36 +200,6 @@ sub _process_update {
         }
     } elsif ($p->whensent && $request->{comment_time} <= $p->whensent) {
         $request->{comment_time} = $p->whensent + DateTime::Duration->new( seconds => 1 );
-    }
-
-    # Assign admin user to report if 'assigned_user_*' fields supplied
-    if ( $request->{extras} && $request->{extras}{assigned_user_email} ) {
-        my $assigned_user_email = $request->{extras}{assigned_user_email};
-        my $assigned_user_name  = $request->{extras}{assigned_user_name};
-
-        my $assigned_user
-            = FixMyStreet::DB->resultset('User')
-            ->find( { email => $assigned_user_email } );
-
-        unless ($assigned_user) {
-            $assigned_user = FixMyStreet::DB->resultset('User')->create(
-                {   email          => $assigned_user_email,
-                    name           => $assigned_user_name,
-                    from_body      => $body->id,
-                    email_verified => 1,
-                },
-            );
-
-            # Make them an inspector
-            # TODO Other permissions required?
-            $assigned_user->user_body_permissions->create(
-                {   body_id         => $body->id,
-                    permission_type => 'report_inspect',
-                }
-            );
-        }
-
-        $assigned_user->add_to_planned_reports($p);
     }
 
     my $comment = $self->schema->resultset('Comment')->new(
@@ -331,6 +315,41 @@ sub comment_text_for_request {
 
     print STDERR "Couldn't determine update text for $request->{update_id} (report " . $problem->id . ")\n";
     return ("", undef);
+}
+
+sub _handle_assigned_user {
+    my ($self, $request, $p) = @_;
+    my $body = $self->current_body;
+
+    # Assign admin user to report if 'assigned_user_*' fields supplied
+    if ( $request->{extras} && $request->{extras}{assigned_user_email} ) {
+        my $assigned_user_email = $request->{extras}{assigned_user_email};
+        my $assigned_user_name  = $request->{extras}{assigned_user_name};
+
+        my $assigned_user
+            = FixMyStreet::DB->resultset('User')
+            ->find( { email => $assigned_user_email } );
+
+        unless ($assigned_user) {
+            $assigned_user = FixMyStreet::DB->resultset('User')->create(
+                {   email          => $assigned_user_email,
+                    name           => $assigned_user_name,
+                    from_body      => $body->id,
+                    email_verified => 1,
+                },
+            );
+
+            # Make them an inspector
+            # TODO Other permissions required?
+            $assigned_user->user_body_permissions->create(
+                {   body_id         => $body->id,
+                    permission_type => 'report_inspect',
+                }
+            );
+        }
+
+        $assigned_user->add_to_planned_reports($p);
+    }
 }
 
 1;

--- a/t/app/model/problem.t
+++ b/t/app/model/problem.t
@@ -123,6 +123,7 @@ for my $test (
     };
 }
 
+my $normal_user = FixMyStreet::DB->resultset('User')->find_or_create({ email => 'user@example.net' });
 my $user = FixMyStreet::DB->resultset('User')->find_or_create(
     {
         email => 'system_user@example.net'
@@ -254,6 +255,55 @@ for my $test (
         }
     };
 }
+
+subtest 'Test receiving latest data only' => sub {
+    $problem->comments->delete;
+    $problem->add_to_comments({
+        user => $user,
+        external_id => 'timestampA',
+        send_state => 'processed',
+        text => 'An update',
+        confirmed => $comment_time,
+        created => $comment_time,
+    });
+    $problem->add_to_comments({
+        user => $user,
+        external_id => 'timestampB',
+        send_state => 'processed',
+        problem_state => 'in progress',
+        text => 'Latest data update',
+        confirmed => $comment_time,
+        created => $comment_time,
+    });
+    $problem->add_to_comments({
+        user => $normal_user,
+        external_id => 'timestampC',
+        send_state => 'sent',
+        problem_state => 'in progress',
+        text => 'Some text from a user',
+        confirmed => $comment_time,
+        created => $comment_time,
+    });
+
+    my $request = {
+        comment_time => $comment_time,
+        status       => 'IN_PROGRESS',
+        description  => 'Latest data update',
+        extras       => {
+            latest_data_only => 1,
+        },
+    };
+
+    my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
+    my $updates = Open311::GetUpdates->new(
+        current_open311 => $o,
+        current_body => $body,
+        system_user => $user,
+    );
+
+    my $update = $updates->process_update($request, $problem);
+    is $update, undef;
+};
 
 for my $test (
     {


### PR DESCRIPTION
If we're told the update is only the latest data, so we can't trust the timestamp, compare it against the last system user comment, and skip if it matches the same text and problem state. Move the assigned user code earlier so that it will be run.

[FMS end corresponding with https://github.com/mysociety/open311-adapter/pull/371 ]

I did wonder about changing the update_id at the open311 end to be a hash of state+text (which it looks like we do do in another backend or two), so it would match once and then not again, but I thought comparing against the last system update received was better if something moved into the same state twice (and perhaps those other backends could be switched to do this as well - unless I've missed something about checking the last update!)

For https://github.com/mysociety/societyworks/issues/3710