### PR TITLE
[Bromley] Reset category override once sent.

### DIFF
--- a/perllib/FixMyStreet/SendReport/Open311.pm
+++ b/perllib/FixMyStreet/SendReport/Open311.pm
@@ -88,6 +88,7 @@ sub send {
     $row->discard_changes;
 
     if ( $skip || $resp ) {
+        $row->unset_extra_metadata('open311_category_override'); # If we were overridden, we don't want to keep that for future
         $row->update({ external_id => $resp });
         $self->success( 1 );
     } else {


### PR DESCRIPTION
Otherwise, a later resending will still use the override category.
[skip changelog]