### PR TITLE
[Merton] Bin not being returned correctly and waste spillage

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1098,6 +1098,9 @@ sub enquiry : Chained('property') : Args(0) {
         } elsif ($datatype eq 'multivaluelist') {
             my @options = map { { label => $_->{name}, value => $_->{key} } } @{$_->{values}};
             %config = (type => 'Multiple', widget => 'CheckboxGroup', options => \@options);
+        } elsif ($datatype eq 'singlevaluelist') {
+            my @options = map { { label => $_->{name}, value => $_->{key} } } @{$_->{values}};
+            %config = (type => 'Select', widget => 'RadioGroup', options => \@options);
         }
 
         my $required = $_->{required} eq 'true' ? 1 : 0;

--- a/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
@@ -370,8 +370,15 @@ sub waste_munge_enquiry_data {
     $data->{title} = $data->{category};
 
     my $detail;
-    foreach (sort grep { /^extra_/ } keys %$data) {
-        $detail .= "$data->{$_}\n\n";
+    if ($data->{category} eq 'Bin not returned') {
+        $detail .= ($data->{'extra_Report_Type'} eq '1' ? 'Bin position' : 'Lid not closed') . "\n\n";
+        $detail .= ($data->{'extra_Crew_Required_to_Return?'} eq '1' ? 'Request bin collectors return'
+            : 'No request for bin collectors return') ."\n\n";
+        $detail .= ($data->{'extra_Notes'} ? $data->{'extra_Notes'} : '') . "\n\n";
+    } else {
+        foreach (sort grep { /^extra_/ } keys %$data) {
+            $detail .= "$data->{$_}\n\n";
+        }
     }
     $detail .= $address;
     $data->{detail} = $detail;

--- a/t/app/controller/waste_merton.t
+++ b/t/app/controller/waste_merton.t
@@ -66,6 +66,23 @@ create_contact({ category => 'Request additional collection', email => 'addition
     { code => 'service_id', required => 1, automated => 'hidden_field' },
     { code => 'fixmystreet_id', required => 1, automated => 'hidden_field' },
 );
+create_contact({ category => 'Bin not returned', email => '1570' }, 'Waste',
+    { code => 'Report_Type', required => 1, datatype => 'singlevaluelist',
+    values => [
+        { 'name' => 'Bin Position', 'key' => '1'},
+        { 'name' => 'Lid Not Closed', 'key' => '2'}
+    ] },
+    { code => 'Crew_Required_to_Return?', required => 1, datatype => 'singlevaluelist',
+        values => [
+        { 'name' => 'Yes', 'key' => '1'},
+        { 'name' => 'No', 'key' => '0'}
+    ] },
+    { code => 'Notes', description => 'Details', required => 0, datatype => 'text' },
+);
+create_contact({ category => 'Waste spillage', email => '1545' }, 'Waste',
+    { code => 'Notes', description => 'Details', required => 0, datatype => 'text' },
+);
+
 my $no_echo_contact = $mech->create_contact_ok(
     body => $merton,
     category => 'No Echo',
@@ -550,6 +567,65 @@ FixMyStreet::override_config {
         is $report->user->email, 'anne@example.org';
         is $report->name, 'Anne Assist';
         $e->mock('GetEventsForObject', sub { [] }); # reset
+    };
+
+    subtest 'test report a problem' => sub {
+        FixMyStreet::Script::Reports::send();
+        $mech->clear_emails_ok;
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('Report a problem with a non-recyclable waste collection', 'Can report a problem with non-recyclable waste');
+        $mech->content_contains('Report a problem with a food waste collection', 'Can report a problem with food waste');
+        my $root = HTML::TreeBuilder->new_from_content($mech->content());
+        my $panel = $root->look_down(id => 'panel-2240');
+        is $panel->as_text =~ /.*Please note that missed collections can only be reported.*/, 1, "Paper and card past reporting deadline";
+        $mech->content_lacks('Report a problem with a paper and card collection', 'Can not report a problem with paper and card as past reporting deadline');
+        $mech->content_lacks('Report a problem with a textiles and shoes collection', 'Can not report a problem with a textiles collection as orange bags');
+        $mech->content_lacks('Report a problem with a batteries collection', 'Can not report a problem with a batteries collection as orange bagss');
+        $mech->follow_link_ok({ text => 'Report a problem with a non-recyclable waste collection' });
+        $mech->submit_form_ok( { with_fields => { category => 'Bin not returned' } });
+        $mech->submit_form_ok( { with_fields => { extra_Report_Type => '1', 'extra_Crew_Required_to_Return?' => '0' } });
+        $mech->submit_form_ok( { with_fields => { name => 'Joe Schmoe', email => 'schmoe@example.org' } });
+        $mech->submit_form_ok( { with_fields => { submit => '1' } });
+        $mech->content_contains('Your enquiry has been submitted');
+        $mech->content_contains('Show upcoming bin days');
+        $mech->content_contains('/waste/12345"');
+        my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+        is $report->get_extra_field_value('Notes'), '', "Blank notes field is empty string";
+        is $report->detail, "Bin position\n\nNo request for bin collectors return\n\n2 Example Street, Merton, KT1 1AA", "Details of report contain information about problem";
+        is $report->user->email, 'schmoe@example.org', 'User details added to report';
+        is $report->name, 'Joe Schmoe', 'User details added to report';
+        is $report->category, 'Bin not returned', "Correct category";
+        FixMyStreet::Script::Reports::send();
+        my $email = $mech->get_email;
+        is $mech->get_text_body_from_email($email) =~ /Your report over the problem with your bin collection has been made to the council/, 1, 'Other problem text included in email';
+        my $req = Open311->test_req_used;
+        my $cgi = CGI::Simple->new($req->content);
+        is $cgi->param('api_key'), 'KEY';
+        is $cgi->param('attribute[Report_Type]'), '1', "Report_Type added to open311 data for Echo";
+        is $cgi->param('attribute[Crew_Required_to_Return?]'), '0', "Crew_Required_to_Return? added to open311 data for Echo";
+        $mech->get_ok('/waste/12345');
+        $mech->follow_link_ok({ text => 'Report a problem with a non-recyclable waste collection' });
+        $mech->submit_form_ok( { with_fields => { category => 'Waste spillage' } });
+        $mech->submit_form_ok( { with_fields => { extra_Notes => 'Rubbish left on driveway' } });
+        $mech->submit_form_ok( { with_fields => { name => 'Joe Schmoe', email => 'schmoe@example.org' } });
+        $mech->submit_form_ok( { with_fields => { submit => '1' } });
+        $mech->content_contains('Your enquiry has been submitted');
+        $mech->content_contains('Show upcoming bin days');
+        $mech->content_contains('/waste/12345"');
+        $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+        is $report->category, 'Waste spillage', "Correct category";
+        is $report->get_extra_field_value('Notes'), 'Rubbish left on driveway', "Notes filled in";
+        is $report->detail, "Rubbish left on driveway\n\n2 Example Street, Merton, KT1 1AA", "Details of report contain information about problem";
+        is $report->user->email, 'schmoe@example.org', 'User details added to report';
+        is $report->name, 'Joe Schmoe', 'User details added to report';
+        $mech->clear_emails_ok;
+        FixMyStreet::Script::Reports::send();
+        $email = $mech->get_email;
+        is $mech->get_text_body_from_email($email) =~ /Your report over the problem with your bin collection has been made to the council/, 1, 'Other problem text included in email';
+        $req = Open311->test_req_used;
+        $cgi = CGI::Simple->new($req->content);
+        is $cgi->param('api_key'), 'KEY';
+        is $cgi->param('attribute[Notes]'), 'Rubbish left on driveway', "Notes added to open311 data for Echo";
     };
 
     subtest 'test staff-only additional collection' => sub {

--- a/templates/email/default/waste/other-reported.html
+++ b/templates/email/default/waste/other-reported.html
@@ -60,6 +60,11 @@ INCLUDE '_email_top.html';
     <strong>Use track your request link to check for your scheduled delivery date.</strong>
   </p>
 
+[% ELSIF cobrand.moniker == 'merton' AND (report.category == 'Waste spillage' OR report.category == 'Bin not returned') %]
+  <p style="[% p_style %]">
+  Your report over the problem with your bin collection has been made to the council.
+  </p>
+
 [% ELSE %]
 
     [% IF report.category == 'Report missed collection' %]

--- a/templates/email/default/waste/other-reported.txt
+++ b/templates/email/default/waste/other-reported.txt
@@ -43,6 +43,9 @@ On delivery day - You do not need to be home for our crew to deliver the bin.
 Collecting your old bin - If you've requested a collection of your old bin, we'll schedule a specific date for our
 crew to remove it. We aim for this to be the same day as we deliver your new bin, but it could be a different day.
 
+[% ELSIF cobrand.moniker == 'merton' AND (report.category == 'Waste spillage' OR report.category == 'Bin not returned') %]
+  Your report over the problem with your bin collection has been made to the council.
+
 [% ELSE %]
 
 [% IF report.category == 'Report missed collection' %]

--- a/templates/web/base/waste/services.html
+++ b/templates/web/base/waste/services.html
@@ -6,7 +6,7 @@
     A [% unit.service_name FILTER lower %] container request has been made
   </span>
 
-    [% IF c.cobrand.moniker == 'merton' %]
+  [% IF c.cobrand.moniker == 'merton' %]
         [% IF NOT (property_time_banded AND unit.service_id == 2242) %]
             <a href="[% c.uri_for_action('waste/enquiry', [ property.id ]) %]?category=Failure+to+deliver&amp;service_id=[% unit.service_id %]" class="waste-service-link waste-service-descriptor">Report a failure to deliver a [% unit.service_name FILTER lower %] container</a>
         [% END %]
@@ -27,6 +27,9 @@
     [% END %]
     [% IF is_staff AND NOT unit.orange_bag %]
         <a href="[% c.uri_for_action('waste/report', [ property.id ]) %]?additional=1&amp;service-[% unit.service_id %]=1" class="waste-service-link waste-service-descriptor">Request an additional [% unit.service_name FILTER lower %] collection</a>
+    [% END %]
+    [% IF NOT unit.orange_bag AND unit.report_allowed %]
+        <a href="[% c.uri_for_action('waste/enquiry', [ property.id ]) %]?template=problem&amp;service_id=[% unit.service_id %]" class="waste-service-link waste-service-descriptor">Report a problem with a [% unit.service_name FILTER lower %] collection</a>
     [% END %]
 [% END %]
 

--- a/templates/web/merton/waste/enquiry-problem.html
+++ b/templates/web/merton/waste/enquiry-problem.html
@@ -1,0 +1,7 @@
+[% PROCESS waste/enquiry.html
+    title = 'Report a problem'
+    field_options = [
+        { value = 'Bin not returned', label = 'Bin not returned correctly' },
+        { value = 'Waste spillage', label = 'Waste spillage' },
+    ]
+%]


### PR DESCRIPTION
Part 1 of MRT167 Set up remaining processes in WW

Allow residents to select specified bin types to report a problem that bins haven't been returned correctly to the correct  location or have been left open.

These reports allow a request for the bin collectors to return and rectify the issue along with a notes field

Waste spillage can be reported just with a notes field.

To make live: Check category details on servers with same branch name are live and merge this

https://github.com/mysociety/societyworks/issues/4593

[skip changelog]