### PR TITLE
[Merton] Use stored item names rather than ID map.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Merton.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton.pm
@@ -113,10 +113,8 @@ sub open311_extra_data_include {
     if ($h->{sending_to_crimson}) {
         # Want to send bulky item names rather than IDs
         if ($row->category eq 'Bulky collection') {
-            my @items_list = @{ $self->bulky_items_master_list };
-            my %items = map { $_->{bartec_id} => $_->{name} } @items_list;
-            my @ids = split /::/, $row->get_extra_field_value('Bulky_Collection_Bulky_Items'), -1;
-            @ids = map { $items{$_} } @ids;
+            my @fields = sort grep { /^item_\d/ } keys %{$row->get_extra_metadata};
+            my @ids = map { $row->get_extra_metadata($_) } @fields;
             my $ids = join('::', @ids);
             $row->update_extra_field({ name => 'Bulky_Collection_Bulky_Items', value => $ids });
             push @$open311_only, { name => 'Current_Item_Count', value => scalar @ids };

--- a/t/app/controller/waste_merton_bulky.t
+++ b/t/app/controller/waste_merton_bulky.t
@@ -1056,6 +1056,7 @@ FixMyStreet::override_config {
             dt => $dt,
         });
         $report->update_extra_field({ name => 'Bulky_Collection_Bulky_Items', value => '3::83::3' });
+        $report->set_extra_metadata( item_1 => 'BBQ', item_2 => 'Bath', item_3 => 'BBQ' );
         $report->update;
 
         $send->send_reports;


### PR DESCRIPTION
Multiple items are using the same ID. [skip changelog] Fixes FD-4790.
