### PR TITLE
[Surrey] Add text under happy-or-not section

### DIFF
--- a/templates/web/surrey/footer_extra.html
+++ b/templates/web/surrey/footer_extra.html
@@ -1,5 +1,10 @@
 <section id="happy-or-not-smiley-section">
     <div id="happy-or-not-smiley-digital-embed"></div>
+  [% IF c.action == 'tokens/confirm_problem' OR c.action == 'report/confirmation' %]
+    <div class="container hidden-nojs" id="happy-or-not-feedback-statement">
+        <p>This feedback relates to how easy it was to report and will not be included as part of your report.</p>
+    </div>
+  [% END %]
 </section>
 
 <section class="scc-subscribe">

--- a/web/cobrands/surrey/base.scss
+++ b/web/cobrands/surrey/base.scss
@@ -184,6 +184,11 @@ a#geolocate_link,
   background: #f3f6f9;
 }
 
+#happy-or-not-feedback-statement {
+  padding: 1em 0;
+  text-align: center;
+}
+
 .scc-subscribe {
   background-color: #e0e7cf;
   padding: 0.9375rem 0;


### PR DESCRIPTION
For FD-4776

<img width="1444" alt="image" src="https://github.com/user-attachments/assets/65e2619c-9dd8-48f0-a069-e59a0e7e4518">


<!-- [skip changelog] -->