### PR TITLE
[Docker] Changes needed for systemd to work.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   nginx:
     image: nginx:1.15.3
@@ -21,8 +19,19 @@ services:
         condition: service_healthy
       memcached:
         condition: service_started
+    cgroup: host
+    stop_signal: SIGRTMIN+3
     volumes:
       - ./conf/general.yml-docker:/var/www/fixmystreet/fixmystreet/conf/general.yml
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - type: tmpfs
+        target: /run
+        tmpfs:
+          size: "104857600"
+      - type: tmpfs
+        target: /run/lock
+        tmpfs:
+          size: "104857600"
     environment:
       POSTGRES_PASSWORD: 'password'
       FMS_DB_HOST: 'postgres.svc'

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   setup:
     build:


### PR DESCRIPTION
See https://github.com/jgoerzen/docker-debian-base-standard?tab=readme-ov-file#container-invocation-systemd-containers-busterbullseyesid (with options changed to be in the docker compose file).
[skip changelog]

Without these lines you get lots of failures about operation not permitted, or read only file system, or process manager cannot be allocated, etc etc