### PR TITLE
cpanfile: Use url instead mirror for Geography::NationalGrid

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -89,7 +89,7 @@ requires 'File::Find';
 requires 'File::Path';
 requires 'Geo::OLC';
 requires 'Geography::NationalGrid',
-    mirror => 'https://cpan.metacpan.org/';
+    url => 'https://cpan.metacpan.org/authors/id/P/PK/PKENT/Geography-NationalGrid-1.6.tar.gz';
 requires 'Getopt::Long', '2.52';
 requires 'Getopt::Long::Descriptive', '0.105';
 requires 'HTML::Entities';


### PR DESCRIPTION
## Description
`mirror =>` is failing (for `carton install`, not sure about `carton install --deployment`) with recent `carton`/`cpanm` and I doubt it works with old vendored carton neither.

I propose to replace per `url =>` which is [documented](https://metacpan.org/pod/Carton#Specifying-a-CPAN-distribution) (`mirror` is documented but only with usage of `dist` along).  

What do you think?

Please check the following:

- [ ] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]

