### PR TITLE
[Oxfordshire] Send additional email on category

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Oxfordshire.pm
@@ -265,6 +265,21 @@ sub report_inspect_update_extra {
     }
 }
 
+sub open311_post_send {
+    my ($self, $row, $h, $sender) = @_;
+
+    if ($row->category eq 'Trees obstructing traffic light' && !$row->get_extra_metadata('extra_email_sent')) {
+        my $emails = $self->feature('open311_email');
+        if (my $dest = $emails->{$row->category}) {
+            my $sender = FixMyStreet::SendReport::Email->new( to => [ $dest ]);
+            $sender->send($row, $h);
+            if ($sender->success) {
+                $row->update_extra_metadata(extra_email_sent => 1);
+            }
+        }
+    }
+}
+
 sub on_map_default_status { return 'open'; }
 
 sub around_nearby_filter {


### PR DESCRIPTION
Oxfordshire would like the category 'Trees obscuring street lights' to send an additional email as well as being sent over open311.

https://mysocietysupport.freshdesk.com/a/tickets/4741

[skip changelog]
