### PR TITLE
[Peterborough] Link to report waste service only in on place

### DIFF
--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -104,6 +104,9 @@ FixMyStreet::override_config {
         $mech->content_contains('Every two weeks');
         $mech->content_contains('Thursday, 5th August 2021');
         $mech->content_contains('Report a recycling bin collection as missed');
+        my $root = HTML::TreeBuilder->new_from_content($mech->content());
+        my $more_services = $root->look_down(id => 'more-services');
+        is !($more_services->as_text =~ /.*Report a missed.*/), 1, "Report missed only under individual services, not more_services";
         set_fixed_time('2021-08-06T14:00:00Z');
         $mech->get_ok('/waste/PE1%203NA:100090215480');
         $mech->content_contains('Report a recycling bin collection as missed');

--- a/templates/web/peterborough/waste/_more_services_sidebar.html
+++ b/templates/web/peterborough/waste/_more_services_sidebar.html
@@ -2,9 +2,6 @@
 [% SET pboro_staff_request = ( NOT waste_features.request_disabled ) AND c.user_exists AND (c.user.is_superuser OR (c.user.from_body AND c.user.from_body.name == "Peterborough City Council")) %]
 <h3>More services</h3>
 <ul>
-  [% IF any_report_allowed AND NOT on_day_pre_5pm %]
-    <li><a href="[% c.uri_for_action('waste/report', [ property.id ]) %]">Report a missed collection</a></li>
-  [% END %]
   [% IF pboro_staff_request AND NOT open_service_requests.425 %]
     <li><a href="[% c.uri_for_action('waste/request', [ property.id ]) %]?skip_bags=1">Request a new bin</a></li>
   [% END %]


### PR DESCRIPTION
Link should only be under individual containers and not in the more_services block

https://mysocietysupport.freshdesk.com/a/tickets/4774

[skip changelog]