### PR TITLE
[Surrey] [Hart] Continue button should not be visible when disabled

### DIFF
--- a/.cypress/cypress/integration/surrey.js
+++ b/.cypress/cypress/integration/surrey.js
@@ -15,11 +15,13 @@ describe('Reporting not on a road', function() {
         cy.pickCategory('Abandoned vehicles');
         cy.contains('You cannot send Surrey County Council a report');
         cy.get('#map_sidebar').scrollTo('bottom');
-        cy.get('.js-reporting-page--next:visible').should('be.disabled');
+        cy.get('.js-reporting-page--next').should('be.disabled');
+        cy.get('.js-reporting-page--next').should('not.be.visible');
         cy.pickCategory('Flooding inside a building');
         cy.contains('You cannot send Surrey County Council a report').should('not.be.visible');
         cy.get('#map_sidebar').scrollTo('bottom');
         cy.get('.js-reporting-page--next:visible').should('not.be.disabled');
+        cy.get('.js-reporting-page--next').should('be.visible');
     });
 });
 

--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -1556,7 +1556,7 @@ fixmystreet.message_controller = (function() {
     }
 
     function hide_continue_button() {
-        var cobrands_to_hide = ['hart'];
+        var cobrands_to_hide = ['hart', 'surrey'];
         if (cobrands_to_hide.indexOf(fixmystreet.cobrand) !== -1) {
             return 1;
         }


### PR DESCRIPTION
Reported that users think the button is broken and don't read the message above for an explanation of why they can't proceed

https://mysocietysupport.freshdesk.com/a/tickets/4768
https://mysocietysupport.freshdesk.com/a/tickets/4818

[skip changelog]