### PR TITLE
Better logging of page_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Releases
 
+* Unreleased
+    - Development improvements
+        - More logging when page_error is called, to aid troubleshooting. #5279
+
 * v6.0 (14th November 2024)
     - Front end improvements:
         - Include requirements for redeeming the link in the email change confirmation mail. #4422

--- a/perllib/FixMyStreet/App/Controller/Form.pm
+++ b/perllib/FixMyStreet/App/Controller/Form.pm
@@ -46,6 +46,7 @@ sub load_form {
     );
 
     if (!$form->has_current_page) {
+        $c->stash->{internal_error} = "Form doesn't have current page";
         $c->detach('/page_error_400_bad_request', [ 'Bad request' ]);
     }
 
@@ -114,6 +115,7 @@ sub get_page : Private {
     my $process = $c->get_param('process') || '';
     $goto = $self->first_page($c) unless $goto || $process;
     if ($goto && $process) {
+        $c->stash->{internal_error} = "Both goto and process parameters set";
         $c->detach('/page_error_400_bad_request', [ 'Bad request' ]);
     }
 

--- a/perllib/FixMyStreet/App/Controller/Questionnaire.pm
+++ b/perllib/FixMyStreet/App/Controller/Questionnaire.pm
@@ -38,6 +38,7 @@ sub check_questionnaire : Private {
         my $problem_url = $c->cobrand->base_url_for_report( $problem ) . $problem->url;
         my $contact_url = $c->uri_for( "/contact" );
         my $message = sprintf(_("You have already answered this questionnaire. If you have a question, please <a href='%s'>get in touch</a>, or <a href='%s'>view your problem</a>.\n"), $contact_url, $problem_url);
+        $c->stash->{internal_message} = "Questionnaire ID " . $questionnaire->id;
         $c->detach('/page_error_400_bad_request', [ $message ]);
     }
 

--- a/t/app/controller/admin.t
+++ b/t/app/controller/admin.t
@@ -9,6 +9,9 @@ package main;
 
 use FixMyStreet::TestMech;
 
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
 my $mech = FixMyStreet::TestMech->new;
 
 my $user = $mech->create_user_ok('test@example.com', name => 'Test User');

--- a/t/app/controller/admin/triage.t
+++ b/t/app/controller/admin/triage.t
@@ -1,6 +1,9 @@
 use FixMyStreet::TestMech;
 use FixMyStreet::Script::Alerts;
 
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
 my $mech = FixMyStreet::TestMech->new;
 
 my $user = $mech->create_user_ok('test@example.com', name => 'Test User');

--- a/t/app/controller/auth_profile.t
+++ b/t/app/controller/auth_profile.t
@@ -10,6 +10,10 @@ package main;
 
 use Test::MockModule;
 use FixMyStreet::TestMech;
+
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
 my $mech = FixMyStreet::TestMech->new;
 
 my $resolver = Test::MockModule->new('Email::Valid');

--- a/t/app/controller/index.t
+++ b/t/app/controller/index.t
@@ -2,6 +2,9 @@ use FixMyStreet::TestMech;
 use DateTime;
 use Web::Scraper;
 
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
 my $mech = FixMyStreet::TestMech->new;
 
 use t::Mock::Nominatim;

--- a/t/app/controller/my.t
+++ b/t/app/controller/my.t
@@ -1,4 +1,8 @@
 use FixMyStreet::TestMech;
+
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
 my $mech = FixMyStreet::TestMech->new;
 
 $mech->get_ok('/my');

--- a/t/app/controller/my_planned.t
+++ b/t/app/controller/my_planned.t
@@ -1,4 +1,8 @@
 use FixMyStreet::TestMech;
+
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
 my $mech = FixMyStreet::TestMech->new;
 
 $mech->get_ok('/my/planned');

--- a/t/app/controller/questionnaire.t
+++ b/t/app/controller/questionnaire.t
@@ -2,6 +2,9 @@ use DateTime;
 
 use FixMyStreet::TestMech;
 
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
 ok( my $mech = FixMyStreet::TestMech->new, 'Created mech object' );
 
 my $user = $mech->create_user_ok('test@example.com', name => 'Test User');

--- a/t/app/controller/report_updates.t
+++ b/t/app/controller/report_updates.t
@@ -17,6 +17,9 @@ use Web::Scraper;
 use Path::Class;
 use DateTime;
 
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
 my $mech = FixMyStreet::TestMech->new;
 
 my $user = $mech->create_user_ok('test@example.com', name => 'Test User');

--- a/t/app/controller/waste_echo.t
+++ b/t/app/controller/waste_echo.t
@@ -2,6 +2,9 @@ use Test::MockTime qw(set_fixed_time);
 use FixMyStreet::TestMech;
 use FixMyStreet::Cobrand::Merton;
 
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
 my $mech = FixMyStreet::TestMech->new;
 
 $mech->create_body_ok(2500, 'Merton Council', { cobrand => 'merton' });

--- a/templates/web/base/errors/generic.html
+++ b/templates/web/base/errors/generic.html
@@ -9,6 +9,9 @@
 <div class="confirmation-header confirmation-header--[% header_class %]">
     <h1>[% title %]</h1>
     <p>[% message | safe %]</p>
+    [% IF error_id %]
+        <small>[% tprintf(loc('Code: %s'), error_id) %]</small>
+    [% END %]
 </div>
 
 [% INCLUDE 'footer.html' %]

--- a/templates/web/brent/errors/generic.html
+++ b/templates/web/brent/errors/generic.html
@@ -36,6 +36,9 @@ END %]
     <div class="confirmation-header confirmation-header--[% header_class %]">
         <h1>[% title %]</h1>
         <p>[% message | safe %]</p>
+        [% IF error_id %]
+            <small>[% tprintf(loc('Code: %s'), error_id) %]</small>
+        [% END %]
     </div>
 [% END %]
 

--- a/templates/web/highwaysengland/errors/generic.html
+++ b/templates/web/highwaysengland/errors/generic.html
@@ -35,6 +35,9 @@ END %]
     <div class="confirmation-header confirmation-header--failure">
         <h1>[% title %]</h1>
         <p>[% message | safe %]</p>
+        [% IF error_id %]
+            <small>[% tprintf(loc('Code: %s'), error_id) %]</small>
+        [% END %]
     </div>
 [% END %]
 

--- a/templates/web/tfl/errors/generic.html
+++ b/templates/web/tfl/errors/generic.html
@@ -36,6 +36,9 @@ END %]
     <div class="confirmation-header confirmation-header--[% header_class %]">
         <h1>[% title %]</h1>
         <p>[% message | safe %]</p>
+        [% IF error_id %]
+            <small>[% tprintf(loc('Code: %s'), error_id) %]</small>
+        [% END %]
     </div>
 [% END %]
 

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -3074,6 +3074,10 @@ a#geolocate_link {
     word-break: break-word; // It prevents screen overflow when there is a long url, when a page has not been found.
   }
 
+  &.confirmation-header--failure small {
+    color: #888888;
+  }
+
   & > :last-child {
     margin-bottom: 0;
   }


### PR DESCRIPTION
This adds more logging to page_error, including the HTTP status code, the request IP address, an internal message to show the reason for the error, and a random string to help identify the error in the logs. This string is also shown on the error page to the user, to improve the chance of it being included in any screenshots from users.

<img width="550" alt="image" src="https://github.com/user-attachments/assets/78266749-f36b-4e96-bf59-caf741f5035a">

<img width="601" alt="image" src="https://github.com/user-attachments/assets/969ccd74-7643-423e-9760-78394d3ea832">


For https://github.com/mysociety/societyworks/issues/4628