### PR TITLE
[Sutton] Change url for waste calendar

### DIFF
--- a/templates/web/base/waste/bin_days_sidebar.html
+++ b/templates/web/base/waste/bin_days_sidebar.html
@@ -5,8 +5,8 @@
            <li><a href="[% c.uri_for_action('waste/calendar', [ property.id ]) %]">Add to your calendar</a></li>
         [% IF c.cobrand.moniker == 'kingston' %]
             <li><a href="https://kingston-self.achieveservice.com/service/In_my_Area_Results?displaymode=collections&amp;altVal=&amp;uprn=[% property.uprn %]">Download PDF waste calendar</a></li>
-        [% ELSIF c.cobrand.moniker == 'sutton' AND NOT slwp_garden_sacks %]
-            <li><a href="https://sutton-self.achieveservice.com/service/In_My_Area_Results?altval=LBS&amp;displaymode=collections&amp;uprn=[% property.uprn %]">Download PDF waste calendar</a></li>
+        [% ELSIF c.cobrand.moniker == 'sutton' %]
+            <li><a href="https://sutton-self.achieveservice.com/service/In_my_Area_Results__Sutton_?displaymode=collections&amp;altVal=LBS&amp;uprn=[% property.uprn %]">Download PDF waste calendar</a></li>
         [% ELSIF calendar_link OR ggw_calendar_link %]
             [%- FOR link IN calendar_link -%]
               <li><a [% external_new_tab | safe %] href="[% link.href OR link %]">[% link.text OR 'Download PDF waste calendar' %]</a></li>


### PR DESCRIPTION
Flats change is reversing what was done in e8189b702b8dcd49a1e313b7d75fefcc7fa93257

https://mysocietysupport.freshdesk.com/a/tickets/4822

[skip changelog]