### PR TITLE
[Bexley] Fix for assisted collections flag

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -1127,10 +1127,7 @@ sub waste_munge_report_data {
     $c->set_param('service_id', $id);
     $c->set_param('location_of_containers', $data->{bin_location}) if $data->{bin_location};
     $c->set_param('service_item_name', $service_id);
-
-    # Check if this property has assisted collections
-    my $contracts = $self->whitespace->GetSiteContracts($property->{uprn});
-    $c->set_param('assisted_yn', (grep { $_->{ContractID} == 7 } @$contracts) ? 'Yes' : 'No');
+    $c->set_param('assisted_yn', $property->{has_assisted} ? 'Yes' : 'No');
 }
 
 sub waste_munge_report_form_fields {

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -305,19 +305,6 @@ FixMyStreet::override_config {
         );
     };
 
-    $whitespace_mock->mock( 'GetSiteContracts', sub {
-        my ( $self, $uprn ) = @_;
-        return [
-            {   ContractID => 1,
-                ContractName => 'Contract 1',
-                ContractType => 'Type 1',
-                ContractStartDate => '2024-03-31T00:00:00',
-                ContractEndDate => '2024-03-31T00:00:00',
-                ContractStatus => 'Active',
-            },
-        ];
-    });
-
     subtest 'Correct services are shown for address' => sub {
         $mech->submit_form_ok( { with_fields => { address => 10001 } } );
 
@@ -763,7 +750,7 @@ FixMyStreet::override_config {
             ok $report->confirmed;
             is $report->state, 'confirmed';
             is $report->get_extra_field_value('uprn'), '10001', 'UPRN is correct';
-            is $report->get_extra_field_value('assisted_yn'), 'No', 'Assisted collection is correct';
+            is $report->get_extra_field_value('assisted_yn'), 'Yes', 'Assisted collection is correct';
             is $report->get_extra_field_value('location_of_containers'), 'Front boundary of property', 'Location of containers is correct';
             push @service_item_names, $report->get_extra_field_value('service_item_name');
         }


### PR DESCRIPTION
This was being set incorrectly as Whitespace returns inaccurate information from its GetSiteContracts endpoint. So instead set it from $property->{has_assisted} as we do elsewhere.

For FD-4777

<!-- [skip changelog] -->
