### PR TITLE
[Merton] Send different email on bulky amending.

### DIFF
--- a/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
@@ -831,6 +831,11 @@ sub waste_check_last_update {
             return;
         }
     }
+    if ($report->cobrand eq 'merton' && $status eq 'cancelled'
+        && $report->category eq 'Bulky collection' && $report->state eq 'cancelled') {
+        print "  Cancelled update received on already cancelled report\n" if $cfg->{verbose};
+        return;
+    }
     return 1;
 }
 

--- a/t/app/controller/waste_merton_bulky.t
+++ b/t/app/controller/waste_merton_bulky.t
@@ -632,11 +632,15 @@ FixMyStreet::override_config {
             $mech->submit_form_ok({ with_fields => { tandc => 1 } });
 
             is $report->comments->count, 2; # Confirmation and then cancellation
-            FixMyStreet::Script::Alerts::send_updates();
-            $mech->email_count_is(1); # Cancellation update on original
+            $new_report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+
+            my $email = $mech->get_email;
+            is $email->header('Subject'), 'Bulky waste collection service - reference ' . $new_report->id;
             $mech->clear_emails_ok;
 
-            $new_report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+            FixMyStreet::Script::Alerts::send_updates();
+            $mech->email_count_is(0); # No cancellation update on original
+
             is $new_report->category, 'Bulky collection', 'correct category on report';
             is $new_report->title, 'Bulky goods collection', 'correct title on report';
             is $new_report->get_extra_field_value('payment_method'), 'credit_card', 'correct payment method on report';
@@ -767,6 +771,8 @@ FixMyStreet::override_config {
             $mech->get_ok("/waste/pay_complete/$report_id/$token");
             is $sent_params->{reference}, 12345, 'correct scpReference sent';
             FixMyStreet::Script::Reports::send();
+            my $email = $mech->get_email;
+            is $email->header('Subject'), 'Bulky waste collection service - reference ' . $new_report->id;
             $mech->clear_emails_ok;
             $new_report->discard_changes;
             is $new_report->get_extra_metadata('payment_reference'), '54321', 'correct payment reference on report';
@@ -776,7 +782,7 @@ FixMyStreet::override_config {
             is $update->state, 'confirmed';
             is $update->text, 'Payment confirmed, reference 54321, amount £23.75';
             FixMyStreet::Script::Alerts::send_updates();
-            $mech->email_count_is(1); # Cancellation update should come through now
+            $mech->email_count_is(0); # No cancellation update
             $mech->clear_emails_ok;
 
             $mech->content_contains('Bulky collection booking confirmed');
@@ -915,6 +921,10 @@ FixMyStreet::override_config {
             $mech->content_lacks("You can cancel this booking till");
             $mech->content_lacks('Cancel this booking');
         };
+
+        FixMyStreet::Script::Alerts::send_updates();
+        like $mech->get_text_body_from_email, qr/Booking cancelled by customer/;
+        $mech->clear_emails_ok;
     };
 
     subtest 'Missed collections' => sub {

--- a/t/cobrand/merton.t
+++ b/t/cobrand/merton.t
@@ -2,6 +2,7 @@ use Test::MockModule;
 use FixMyStreet::TestMech;
 use HTML::Selector::Element qw(find);
 use FixMyStreet::Script::Reports;
+use FixMyStreet::Script::Alerts;
 
 FixMyStreet::App->log->disable('info');
 END { FixMyStreet::App->log->enable('info'); }
@@ -11,11 +12,13 @@ my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Merton');
 
 $cobrand->mock('area_types', sub { [ 'LBO' ] });
 
+my $superuser = $mech->create_user_ok('superuser@example.com', name => 'Super User', is_superuser => 1);
 my $merton = $mech->create_body_ok(2500, 'Merton Council', {
     api_key => 'aaa',
     jurisdiction => 'merton',
     endpoint => 'http://endpoint.example.org',
     send_method => 'Open311',
+    comment_user => $superuser,
     cobrand => 'merton'
 });
 my @cats = ('Litter', 'Other', 'Potholes', 'Traffic lights');
@@ -29,7 +32,6 @@ for my $contact ( @cats ) {
     $mech->create_contact_ok(body_id => $hackney->id, category => $contact, email => "\L$contact\@hackney.example.org");
 }
 
-my $superuser = $mech->create_user_ok('superuser@example.com', name => 'Super User', is_superuser => 1);
 my $counciluser = $mech->create_user_ok('counciluser@example.com', name => 'Council User', from_body => $merton);
 my $normaluser = $mech->create_user_ok('normaluser@example.com', name => 'Normal User');
 my $hackneyuser = $mech->create_user_ok('hackneyuser@example.com', name => 'Hackney User', from_body => $hackney);
@@ -310,6 +312,92 @@ subtest "hides duplicate updates from endpoint" => sub {
 
     $p->discard_changes;
     is $p->comments->search({ state => 'confirmed' })->count, 1;
+};
+
+package SOAP::Result;
+sub result { return $_[0]->{result}; }
+sub new { my $c = shift; bless { @_ }, $c; }
+
+package main;
+
+subtest 'updating of waste reports' => sub {
+    my $date = DateTime->now->subtract(days => 1)->strftime('%Y-%m-%dT%H:%M:%SZ');
+    my $integ = Test::MockModule->new('SOAP::Lite');
+    $integ->mock(call => sub {
+        my ($cls, @args) = @_;
+        my $method = $args[0]->name;
+        if ($method eq 'GetEvent') {
+            my ($key, $type, $value) = ${$args[3]->value}->value;
+            my $external_id = ${$value->value}->value->value;
+            my ($waste, $event_state_id, $resolution_code) = split /-/, $external_id;
+            my $data = [];
+            return SOAP::Result->new(result => {
+                Guid => $external_id,
+                EventStateId => $event_state_id,
+                EventTypeId => '1636',
+                LastUpdatedDate => { OffsetMinutes => 60, DateTime => $date },
+                ResolutionCodeId => $resolution_code,
+                Data => { ExtensibleDatum => $data },
+            });
+        } elsif ($method eq 'GetEventType') {
+            return SOAP::Result->new(result => {
+                Workflow => { States => { State => [
+                    { CoreState => 'New', Name => 'New', Id => 12396 },
+                    { CoreState => 'Pending', Name => 'Allocated to Crew', Id => 12398 },
+                    { CoreState => 'Closed', Name => 'Partially Completed', Id => 12399 },
+                    { CoreState => 'Closed', Name => 'Completed', Id => 12400 },
+                    { CoreState => 'Closed', Name => 'Not Completed', Id => 12401 },
+                    { CoreState => 'Cancelled', Name => 'Cancelled', Id => 12402 },
+                ] } },
+            });
+        } else {
+            is $method, 'UNKNOWN';
+        }
+    });
+
+    my ($report) = $mech->create_problems_for_body(1, $merton->id, 'Bulky collection', {
+        confirmed => \'current_timestamp',
+        user => $normaluser,
+        category => 'Bulky collection',
+        cobrand_data => 'waste',
+        non_public => 1,
+        extra => { payment_reference => 'reference' },
+    });
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'merton',
+        COBRAND_FEATURES => {
+            echo => { merton => {
+                url => 'https://www.example.org/',
+                receive_action => 'action',
+                receive_username => 'un',
+                receive_password => 'password',
+            } },
+            waste => { merton => 1 }
+        },
+    }, sub {
+        $mech->clear_emails_ok;
+        $normaluser->create_alert($report->id, { cobrand => 'merton', whensubscribed => $date });
+        my $in = $mech->echo_notify_xml('waste-12402-', 1636, 12402, '', 'FMS-' . $report->id);
+        my $mech2 = $mech->clone;
+        $mech2->host('merton.example.org');
+
+        $mech2->post('/waste/echo', Content_Type => 'text/xml', Content => $in);
+        is $report->comments->count, 1, 'A new update';
+        $report->discard_changes;
+        is $report->state, 'cancelled', 'A state change';
+        FixMyStreet::Script::Alerts::send_updates();
+        my $email = $mech->get_text_body_from_email;
+        like $email, qr/Cancelled/;
+
+        $report->update({ state => 'cancelled' });
+
+        $mech2->post('/waste/echo', Content_Type => 'text/xml', Content => $in);
+        is $report->comments->count, 1, 'No new update';
+        $report->discard_changes;
+        is $report->state, 'cancelled', 'No state change';
+        FixMyStreet::Script::Alerts::send_updates();
+        $mech->email_count_is(0);
+    };
 };
 
 done_testing;


### PR DESCRIPTION
Rather than a cancellation update on the original and no logged on the new (if no payment), send the reverse - a logged email on the new, and no cancellation update.
[skip changelog]
Fixes FD-4484