### PR TITLE
[Bromley] Any streetlight on a Bromley asset should be 'in Bromley'

### DIFF
--- a/.cypress/cypress/integration/bromley.js
+++ b/.cypress/cypress/integration/bromley.js
@@ -45,6 +45,24 @@ describe('Bromley cobrand', function() {
     cy.get('.mobile-map-banner').should('be.visible');
   });
 
+  it('sets extra cobrand owner field when streetlight asset selected', function() {
+    cy.pickCategory('Street Lighting and Road Signs');
+    cy.nextPageReporting();
+    cy.pickSubcategory('Street Lighting and Road Signs', 'Lamp Column Damaged');
+    cy.wait('@lights');
+    cy.nextPageReporting();
+    cy.get('.mobile-map-banner').should('be.visible');
+    cy.get('#form_fms_layer_owner').should('have.value', '');
+    cy.visit('http://bromley.localhost:3001/report/new?longitude=0.022775&latitude=51.398387');
+    cy.wait('@report-ajax');
+    cy.get('#mob_ok').click();
+    cy.pickCategory('Street Lighting and Road Signs');
+    cy.nextPageReporting();
+    cy.pickSubcategory('Street Lighting and Road Signs', 'Lamp Column Damaged');
+    cy.wait('@lights');
+    cy.get('#form_fms_layer_owner').should('have.value', 'bromley');
+  });
+
   it('adds stopper for Crystal Palace Park', function() {
     cy.visit('http://bromley.localhost:3001/report/new?longitude=-0.064555&latitude=51.422382');
     cy.contains('transferred to the Crystal Palace Park Trust');

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -361,7 +361,16 @@ if ($opt->test_fixtures) {
         variable => 'true',
         required => 'false',
         automated => 'hidden_field',
-    });
+    },
+    {
+        code => 'fms_layer_owner',
+        datatype => 'string',
+        order => 1,
+        variable => 'true',
+        required => 'false',
+        automated => 'hidden_field',
+    }
+    );
     $child_cat->update;
 
     $child_cat = FixMyStreet::DB->resultset("Contact")->find({

--- a/data/test-asset-layers.yml
+++ b/data/test-asset-layers.yml
@@ -140,6 +140,10 @@ bromley:
       feature_id: 'FEATURE_ID'
     asset_category: ["Lamp Column Damaged", "Light Not Working", "Light On All Day", "Light blocked by vegetation"]
     asset_item: 'street light'
+    select_action: true
+    actions:
+      asset_found: fixmystreet.assets.bromley.set_asset_owner
+      asset_not_found: fixmystreet.assets.bromley.unset_asset_owner
   - wfs_feature: "PROW"
     stylemap: 'fixmystreet.assets.bromley.prow_stylemap'
     always_visible: true

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -154,7 +154,7 @@ sub title_list {
 sub check_report_is_on_cobrand_asset {
     my $self = shift;
 
-    if ($self->{c}->get_param('feature_id') && $self->{c}->get_param('feature_id') =~ /A-48-24|A-48-26|A-48-27/) {
+    if ($self->{c}->get_param('fms_layer_owner') && $self->{c}->get_param('fms_layer_owner') eq 'bromley') {
         return 1;
     } else {
         return 0;
@@ -284,7 +284,7 @@ sub open311_extra_data_include {
 }
 
 sub open311_extra_data_exclude {
-    [ 'feature_id', 'prow_reference' ]
+    [ 'feature_id', 'prow_reference', 'fms_layer_owner' ]
 }
 
 sub open311_config_updates {

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -52,6 +52,8 @@ my @PLACES = (
     [ '?', 51.422382, -0.064555, 2482, 'Bromley Council', 'LBO' ],
     # National Sports Centre in Crystal Palace Park
     [ '?', 51.419275, -0.071410, 2482, 'Bromley Council', 'LBO' ],
+    # On a light asset
+    [ '?', 51.398387, 0.022775, 2482, 'Bromley Council', 'LBO' ],
     [ 'KT1 1AA', 51.408688, -0.304465, 2480, 'Kingston upon Thames Council', 'LBO' ],
     [ 'SM2 5HF', 51.354679, -0.183895, 2498, 'Sutton Borough Council', 'LBO' ],
     [ '?', 51.466707, 0.181108, 2494, 'London Borough of Bexley', 'LBO' ],

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -54,7 +54,7 @@ my $streetlights = $mech->create_contact_ok(
     email => 'LIGHT',
 );
 $streetlights->set_extra_fields(
-    { code => 'feature_id', datatype => 'string', automated => 'hidden_field' },
+    { code => 'fms_layer_owner', datatype => 'string', automated => 'hidden_field' },
 );
 $streetlights->update;
 
@@ -635,7 +635,7 @@ subtest 'Can select asset that is in Lewisham area on Bromley Cobrand' => sub {
         $mech->submit_form_ok( { with_fields => {
                 title => 'Lamp issue in Lewisham on Bromley',
                 detail => 'Lamp issue over the border',
-                feature_id => 'A-48-24',
+                fms_layer_owner => 'bromley',
                 longitude => 0.005357,
                 latitude => 51.418776,
                 fms_extra_title => 'Mr'
@@ -658,7 +658,7 @@ subtest 'Can select asset that is in Lewisham area on FMS' => sub {
         $mech->submit_form_ok( { with_fields => {
                 title => 'Lamp issue in Lewisham on FMS',
                 detail => 'Lamp issue over the border',
-                feature_id => 'A-48-26',
+                fms_layer_owner => 'bromley',
                 longitude => 0.005357,
                 latitude => 51.418776,
                 fms_extra_title => 'Mr'

--- a/web/cobrands/fixmystreet-uk-councils/assets.js
+++ b/web/cobrands/fixmystreet-uk-councils/assets.js
@@ -296,6 +296,15 @@ fixmystreet.assets.bromley.not_found = function(layer) {
     fixmystreet.message_controller.road_found(layer);
 };
 
+fixmystreet.assets.bromley.set_asset_owner = function() {
+    $('#form_fms_layer_owner').val('bromley');
+};
+
+fixmystreet.assets.bromley.unset_asset_owner = function() {
+    $('#form_fms_layer_owner').val('');
+};
+
+
 /* Buckinghamshire */
 
 fixmystreet.assets.buckinghamshire = {};


### PR DESCRIPTION
Set a hidden field when the asset is selected and the report is made so that we can recognise it was on an streetlight belonging to Bromley regardless of the id

- [x] To deploy, add 'fms_layer_owner' field to "Lamp Column Damaged", "Light blocked by vegetation", "Light Not Working", and "Light On All Day"
- [x] Also make assets/bromley.yml changes for actions, live
- [ ] Merge deploy branch

https://mysocietysupport.freshdesk.com/a/tickets/4815

[skip changelog]