### PR TITLE
[Bexley] Spot logs with more text in their round.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -431,7 +431,7 @@ sub bin_services_for_address {
         $filtered_service->{report_locked_out_reason} = '';
         my $log_reason_prefix = $self->get_in_cab_logs_reason_prefix($filtered_service->{service_id});
         if ($log_reason_prefix) {
-            my @relevant_logs = grep { $_->{reason} =~ /^$log_reason_prefix/ && $_->{round} eq $filtered_service->{round} } @$property_logs;
+            my @relevant_logs = grep { $_->{reason} =~ /^$log_reason_prefix/ && $_->{round} =~ /\Q$filtered_service->{round}\E/ } @$property_logs;
             if (@relevant_logs) {
                 $filtered_service->{report_locked_out} = 1;
                 $filtered_service->{report_locked_out_reason} = $relevant_logs[0]->{reason};

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -636,6 +636,30 @@ FixMyStreet::override_config {
         $mech->content_lacks('Reported as collected today');
         $mech->content_contains('Could not be collected today because it was red-tagged. See reason below.');
 
+        note 'Property has collection but also manual red tag';
+        $whitespace_mock->mock( 'GetInCabLogsByUsrn', sub {
+            return [
+                {
+                    LogID => 1,
+                    Reason => 'N/A',
+                    RoundCode => 'RND-8-9',
+                    LogDate => '2024-04-01T12:00:00.417',
+                    Uprn => '',
+                    Usrn => '321',
+                },
+                {
+                    LogID => 2,
+                    Reason => 'Paper & Card - Bin has gone feral',
+                    RoundCode => '(Mon) RND-8-9',
+                    LogDate => '2024-04-01T12:00:00.417',
+                    Uprn => '10001',
+                    Usrn => '321',
+                },
+            ];
+        });
+        $mech->get_ok('/waste/10001');
+        $mech->content_contains('Could not be collected today because it was red-tagged. See reason below.');
+
         note 'Red tag on other property on same street';
         $whitespace_mock->mock( 'GetInCabLogsByUsrn', sub {
             return [


### PR DESCRIPTION
Manual exceptions have round codes like "(Mon) GDN-R1" rather than just GDN-R1.
Should fix FD-4764.