### PR TITLE
Prevent Open311 updates from being sent out of order

### DIFF
--- a/perllib/Open311/PostServiceRequestUpdates.pm
+++ b/perllib/Open311/PostServiceRequestUpdates.pm
@@ -182,6 +182,30 @@ sub process_update {
         return;
     }
 
+    # Comments are ordered randomly.
+    # Some cobrands/APIs do not handle ordering by age their end (e.g.
+    # Northumberland + Alloy) so we skip comment for now if an older unsent
+    # one exists for the problem. Otherwise an older update may overwrite a
+    # newer one in Alloy etc.
+    my $formatter = FixMyStreet::DB->schema->storage->datetime_parser;
+    my $unsent_comment_for_problem
+        = $problem->comments->search(
+            {
+                state => 'confirmed',
+                send_state => 'unprocessed',
+                confirmed => { '<' =>
+                        $formatter->format_datetime( $comment->confirmed ) },
+                id => { '!=' => $comment->id },
+            },
+            { rows => 1 },
+        )->single;
+
+    if ($unsent_comment_for_problem) {
+        $self->log( $comment,
+            'Skipping for now because of older unprocessed update' );
+        return;
+    }
+
     # Some cobrands (e.g. Buckinghamshire) don't want to receive updates
     # from anyone except the original problem reporter.
     if (my $skip = $cobrand->call_hook(should_skip_sending_update => $comment)) {


### PR DESCRIPTION
Updates are selected in random order but some cobrands/APIs (e.g. Northumberland/Alloy) do not know how to handle updates in order their end, so an earlier update may overwrite a later one.

This change checks that an update is not sent until earlier updates for that problem are sent.

Fixes https://github.com/mysociety/societyworks/issues/4640.

[skip changelog]