### PR TITLE
Add waste_property_id function.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
@@ -186,7 +186,7 @@ sub view : Private {
     my $p = $c->stash->{problem};
 
     $c->stash->{property} = {
-        id => $p->get_extra_field_value('property_id'),
+        id => $p->waste_property_id,
         address => $p->get_extra_metadata('property_address'),
     };
 

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -1519,6 +1519,26 @@ sub create_related_things {
 
 =head2 Waste related activity
 
+=head3 waste_property_id
+
+Return the property ID used in the URL of a bin day page. This is usually
+property_id on the report, but could be the UPRN (e.g. Bexley).
+
+=cut
+
+sub waste_property_id {
+    my $self = shift;
+    return $self->get_extra_field_value('uprn') if $self->cobrand eq 'bexley';
+    return $self->get_extra_field_value('property_id');
+}
+
+=head3 waste_confirm_payment
+
+This is called when a payment has been confirmed in order to record the
+payment, perhaps send an email, add a payment confirmation update for
+already-sent bulky collections, cancel a previous collection if an amendment,
+and so on.
+
 =cut
 
 sub waste_confirm_payment {

--- a/perllib/FixMyStreet/Roles/Cobrand/DDProcessor.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/DDProcessor.pm
@@ -147,7 +147,7 @@ sub waste_reconcile_direct_debits {
                 $p = $cur;
             }
             if ( $p ) {
-                my $service = $self->waste_get_current_garden_sub( $p->get_extra_field_value('property_id') );
+                my $service = $self->waste_get_current_garden_sub( $p->waste_property_id );
                 my $quantity;
                 if ($service) {
                     $quantity = $self->waste_get_sub_quantity($service);
@@ -244,7 +244,7 @@ sub waste_reconcile_direct_debits {
 
         if ( $r ) {
             $self->log("processing matched report " . $r->id);
-            my $service = $self->waste_get_current_garden_sub( $r->get_extra_field_value('property_id') );
+            my $service = $self->waste_get_current_garden_sub( $r->waste_property_id );
             # if there's not a service then it's fine as it's already been cancelled
             if ( $service ) {
                 $r->set_extra_metadata('dd_date', $payment->date);
@@ -301,7 +301,7 @@ sub _duplicate_waste_report {
         payment_method => 'direct_debit',
         $self->garden_subscription_container_field => $report->get_extra_field_value($self->garden_subscription_container_field),
         service_id => $report->get_extra_field_value('service_id'),
-        property_id => $report->get_extra_field_value('property_id'),
+        property_id => $report->waste_property_id,
     };
 
 

--- a/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
@@ -1062,7 +1062,7 @@ sub clear_cached_lookups_bulky_slots {
 sub bulky_refetch_slots {
     my ($self, $row, $verbose) = @_;
 
-    my $property_id = $row->get_extra_field_value('property_id');
+    my $property_id = $row->waste_property_id;
     my $date = $self->collection_date($row);
     my $guid = $row->get_extra_field_value('GUID');
     my $window = $self->_bulky_collection_window();

--- a/templates/email/bromley/_council_reference_alert_update.html
+++ b/templates/email/bromley/_council_reference_alert_update.html
@@ -1,4 +1,4 @@
 [% IF problem.cobrand_data == 'waste' %]
-    [% SET property_id = problem.get_extra_field_value('property_id') %]
+    [% SET property_id = problem.waste_property_id %]
 <a href="https://recyclingservices.bromley.gov.uk/waste[% IF property_id %]/[% property_id %][% END %]">Check your bin collections day</a>
 [% END %]

--- a/templates/email/bromley/_council_reference_alert_update.txt
+++ b/templates/email/bromley/_council_reference_alert_update.txt
@@ -1,4 +1,4 @@
 [% IF problem.cobrand_data == 'waste' %]
-    [% SET property_id = problem.get_extra_field_value('property_id') %]
+    [% SET property_id = problem.waste_property_id %]
 Check your bin collections day: https://recyclingservices.bromley.gov.uk/waste[% IF property_id %]/[% property_id %][% END %]
 [% END %]

--- a/templates/email/default/waste/bulky-reminder.html
+++ b/templates/email/default/waste/bulky-reminder.html
@@ -8,7 +8,7 @@ email_columns = 2;
 PROCESS '_email_settings.html';
 INCLUDE '_email_top.html';
 
-property_id_uri = report.get_extra_field_value('property_id') | uri;
+property_id_uri = report.waste_property_id | uri;
 cancel_url = cobrand.base_url _ '/waste/' _ property_id_uri _ '/' _ bulky_cancel_url _ '/' _ report.id;
 %]
 

--- a/templates/email/default/waste/bulky-reminder.txt
+++ b/templates/email/default/waste/bulky-reminder.txt
@@ -42,7 +42,7 @@ If you wish to cancel your booking, please call 01733 74 74 74.
 
 If you wish to cancel your booking, please visit:
 
-    [% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') | uri %]/[% bulky_cancel_url %]/[% report.id %]
+    [% cobrand.base_url %]/waste/[% report.waste_property_id | uri %]/[% bulky_cancel_url %]/[% report.id %]
 
 [% IF days == 1 %]
 You may still be able to cancel your booking.

--- a/templates/email/default/waste/other-reported-bulky.html
+++ b/templates/email/default/waste/other-reported-bulky.html
@@ -8,7 +8,7 @@ email_columns = 2;
 PROCESS '_email_settings.html';
 INCLUDE '_email_top.html';
 
-property_id_uri = report.get_extra_field_value('property_id') | uri;
+property_id_uri = report.waste_property_id | uri;
 cancel_url = cobrand.base_url _ '/waste/' _ property_id_uri _ '/' _ bulky_cancel_url _ '/' _ report.id;
 %]
 

--- a/templates/email/default/waste/other-reported-bulky.txt
+++ b/templates/email/default/waste/other-reported-bulky.txt
@@ -47,7 +47,7 @@ If you wish to cancel your booking, please call 01733 74 74 74.
 
 If you wish to cancel your booking, please visit:
 
-    [% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') | uri %]/[% bulky_cancel_url %]/[% report.id %]
+    [% cobrand.base_url %]/waste/[% report.waste_property_id | uri %]/[% bulky_cancel_url %]/[% report.id %]
 
 [% END ~%]
 

--- a/templates/email/kingston/_council_reference_alert_update.html
+++ b/templates/email/kingston/_council_reference_alert_update.html
@@ -1,4 +1,4 @@
 [% IF problem.cobrand_data == 'waste' %]
-    [% SET property_id = problem.get_extra_field_value('property_id') %]
+    [% SET property_id = problem.waste_property_id %]
 <a href="https://waste-services.kingston.gov.uk/waste[% IF property_id %]/[% property_id %][% END %]">Check your bin collections day</a>
 [% END %]

--- a/templates/email/kingston/_council_reference_alert_update.txt
+++ b/templates/email/kingston/_council_reference_alert_update.txt
@@ -1,4 +1,4 @@
 [% IF problem.cobrand_data == 'waste' %]
-    [% SET property_id = problem.get_extra_field_value('property_id') %]
+    [% SET property_id = problem.waste_property_id %]
 Check your bin collections day: https://waste-services.kingston.gov.uk/waste[% IF property_id %]/[% property_id %][% END %]
 [% END %]

--- a/templates/email/kingston/waste/bulky-reminder.html
+++ b/templates/email/kingston/waste/bulky-reminder.html
@@ -7,7 +7,7 @@ email_columns = 2;
 PROCESS '_email_settings.html';
 INCLUDE '_email_top.html';
 
-property_id_uri = report.get_extra_field_value('property_id') | uri;
+property_id_uri = report.waste_property_id | uri;
 cancel_url = cobrand.base_url _ '/waste/' _ property_id_uri _ '/' _ bulky_cancel_url _ '/' _ report.id;
 %]
 

--- a/templates/email/kingston/waste/bulky-reminder.txt
+++ b/templates/email/kingston/waste/bulky-reminder.txt
@@ -9,7 +9,7 @@ END;
 
 [% PROCESS 'waste/_bulky_data.html';
 
-property_id_uri = report.get_extra_field_value('property_id') | uri;
+property_id_uri = report.waste_property_id | uri;
 cancel_url = cobrand.base_url _ '/waste/' _ property_id_uri _ '/' _ bulky_cancel_url _ '/' _ report.id;
 
 ~%]

--- a/templates/email/merton/_council_reference_alert_update.html
+++ b/templates/email/merton/_council_reference_alert_update.html
@@ -1,4 +1,4 @@
 [% IF problem.cobrand_data == 'waste' %]
-    [% SET property_id = problem.get_extra_field_value('property_id') %]
+    [% SET property_id = problem.waste_property_id %]
 <a href="https://recycling-services.merton.gov.uk/waste[% IF property_id %]/[% property_id %][% END %]">Check your bin collections day</a>
 [% END %]

--- a/templates/email/merton/_council_reference_alert_update.txt
+++ b/templates/email/merton/_council_reference_alert_update.txt
@@ -1,4 +1,4 @@
 [% IF problem.cobrand_data == 'waste' %]
-    [% SET property_id = problem.get_extra_field_value('property_id') %]
+    [% SET property_id = problem.waste_property_id %]
 Check your bin collections day: https://recycling-services.merton.gov.uk/waste[% IF property_id %]/[% property_id %][% END %]
 [% END %]

--- a/templates/email/sutton/_council_reference_alert_update.html
+++ b/templates/email/sutton/_council_reference_alert_update.html
@@ -1,4 +1,4 @@
 [% IF problem.cobrand_data == 'waste' %]
-    [% SET property_id = problem.get_extra_field_value('property_id') %]
+    [% SET property_id = problem.waste_property_id %]
 <a href="https://waste-services.sutton.gov.uk/waste[% IF property_id %]/[% property_id %][% END %]">Check your bin collections day</a>
 [% END %]

--- a/templates/email/sutton/_council_reference_alert_update.txt
+++ b/templates/email/sutton/_council_reference_alert_update.txt
@@ -1,4 +1,4 @@
 [% IF problem.cobrand_data == 'waste' %]
-    [% SET property_id = problem.get_extra_field_value('property_id') %]
+    [% SET property_id = problem.waste_property_id %]
 Check your bin collections day: https://waste-services.sutton.gov.uk/waste[% IF property_id %]/[% property_id %][% END %]
 [% END %]

--- a/templates/web/base/admin/reports/_edit_waste.html
+++ b/templates/web/base/admin/reports/_edit_waste.html
@@ -85,8 +85,8 @@
   [% IF problem.get_extra_field_value('uprn') %]
     <li>UPRN: [% problem.get_extra_field_value('uprn') %]
   [% END %]
-  [% IF problem.get_extra_field_value('property_id') %]
-    <li>Property ID: <a href="/waste/[% problem.get_extra_field_value('property_id') %]">[% problem.get_extra_field_value('property_id') %]</a>
+  [% IF problem.waste_property_id %]
+    <li>Property ID: <a href="/waste/[% problem.waste_property_id %]">[% problem.waste_property_id %]</a>
   [% END %]
   [% IF problem.get_extra_field_value('service_id') %]
     <li>Service ID: [% problem.get_extra_field_value('service_id') %]

--- a/templates/web/base/waste/_button_show_upcoming.html
+++ b/templates/web/base/waste/_button_show_upcoming.html
@@ -6,6 +6,6 @@
 
 <p>
   [% # sometimes we have the property on the stash, sometimes it's just the report (e.g. token confirmation)
-     property_id = property.id OR report.get_extra_field_value('property_id') %]
+     property_id = property.id OR report.waste_property_id %]
   <a href="[% c.uri_for_action('waste/bin_days', [ property_id ]) %]" class="govuk-button">[% button_text %]</a>
 </p>

--- a/templates/web/fixmystreet-uk-councils/report/_updates_disallowed_message.html
+++ b/templates/web/fixmystreet-uk-councils/report/_updates_disallowed_message.html
@@ -1,5 +1,5 @@
 [% IF disallowed == 'waste';
-    SET property_id = problem.get_extra_field_value('property_id');
+    SET property_id = problem.waste_property_id;
 %]
 <p>
    <a href="/waste[% IF property_id %]/[% property_id %][% END %]">See your bin collections</a>.

--- a/templates/web/peterborough/waste/bulky/confirmation.html
+++ b/templates/web/peterborough/waste/bulky/confirmation.html
@@ -28,7 +28,7 @@
         <p class="govuk-!-margin-bottom-2">We have sent you an email confirming this booking.</p>
         <p>Can’t find our email? <strong>Check your spam folder.</strong></p>
       [% END %]
-        <a href="[% c.uri_for_action('waste/bin_days', [ report.get_extra_field_value('property_id') ]) %]" class="btn btn--primary">Go back home</a>
+        <a href="[% c.uri_for_action('waste/bin_days', [ report.waste_property_id ]) %]" class="btn btn--primary">Go back home</a>
     </div>
 </div>
 

--- a/templates/web/peterborough/waste/confirmation.html
+++ b/templates/web/peterborough/waste/confirmation.html
@@ -82,7 +82,7 @@ END ~%]
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     [% # sometimes we have the property on the stash, sometimes it's just the report (e.g. token confirmation)
-       property_id = property.id OR report.get_extra_field_value('property_id') %]
+       property_id = property.id OR report.waste_property_id %]
     <a href="[% c.uri_for_action('waste/bin_days', [ property_id ]) %]" class="govuk-button">Show upcoming bin days</a>
   </div>
 </div>


### PR DESCRIPTION
Bexley uses the UPRN, not the property ID, so use this so that some things that add links to bin day pages can work more automatically. [skip changelog]

There's one use left of property_id directly, I think, which is in the get_original_sub call, so that will need looking at as part of Bexley GGW.