### PR TITLE
[FMS] Make sure /reports link for Kingston work

### DIFF
--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -127,6 +127,12 @@ sub short_name {
     return $name;
 }
 
+sub is_london_or_royal {
+    my ( $self, $short_name ) = @_;
+
+    return $short_name =~ /bexley|greenwich|kingston/i;
+}
+
 sub find_closest {
     my ($self, $data) = @_;
 
@@ -149,9 +155,8 @@ sub find_closest {
 
 sub reports_body_check {
     my ( $self, $c, $code ) = @_;
-
-    # Deal with Bexley and Greenwich name not starting with short name
-    if ($code =~ /bexley|greenwich/i) {
+    # Some full names do not start with short name
+    if ( $self->is_london_or_royal($code) ) {
         my $body = $c->model('DB::Body')->search( { name => { -like => "%$code%" } } )->single;
         $c->stash->{body} = $body;
         return $body;

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -251,9 +251,8 @@ sub all_reports_single_body {
 
 sub reports_body_check {
     my ( $self, $c, $code ) = @_;
-
-    # Deal with Bexley/Greenwich name not starting with short name
-    if ($code =~ /bexley|greenwich/i) {
+    # Some full names do not start with short name
+    if ( $self->is_london_or_royal($code) ) {
         my $body = $c->model('DB::Body')->search( { name => { -like => "%$code%" } } )->single;
         $c->stash->{body} = $body;
         return $body;


### PR DESCRIPTION
Rather than directing back to the dashboard page.

We already had checks for Bexley & Greenwich, whose full names start with 'London|Royal Borough of'; we needed a check for Kingston upon Thames as well.

This is a minimal fix; I feel there's improvements to be made elsewhere or other bugs that may crop up (e.g. should perllib/FixMyStreet/Cobrand/Kingston.pm have its council_name updated to be 'Royal Borough of...'?) But I do not know how much behaviour that would affect down the line.

Fixes https://github.com/mysociety/societyworks/issues/4609.

[skip changelog]
