### PR TITLE
[Sutton] Add garden waste sack image

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Sutton.pm
+++ b/perllib/FixMyStreet/Cobrand/Sutton.pm
@@ -70,6 +70,7 @@ sub image_for_unit {
     my $base = '/i/waste-containers';
     if (my $container = $unit->{garden_container}) {
         return svg_container_bin("wheelie", '#41B28A', '#8B5E3D') if $container == 26 || $container == 27;
+        return svg_container_sack('normal', '#F5F5DC') if $container == 28; # Garden waste sack
         return "";
     }
     if (my $container = $unit->{request_containers}[0]) {

--- a/t/app/controller/waste_sutton_garden.t
+++ b/t/app/controller/waste_sutton_garden.t
@@ -228,6 +228,34 @@ subtest "check signature generation" => sub {
     is $sha, "06BB8BCD34670AE7BDBC054D23B84B30DFDEBABA", "correct signature generated";
 };
 
+subtest "check garden waste container images" => sub {
+    my $cobrand = FixMyStreet::Cobrand::Sutton->new;
+
+    # Test garden waste bin image
+    my $bin_unit = {
+        garden_container => 26,  # Garden waste bin
+    };
+    my $bin_image = $cobrand->image_for_unit($bin_unit);
+    is_deeply $bin_image, {
+        type => 'svg',
+        data => $bin_image->{data},  # SVG data will vary
+        colour => '#41B28A',
+        lid_colour => '#8B5E3D',
+        recycling_logo => undef,
+    }, "garden waste bin shows as green bin with brown lid";
+
+    # Test garden waste sack image
+    my $sack_unit = {
+        garden_container => 28,  # Garden waste sack
+    };
+    my $sack_image = $cobrand->image_for_unit($sack_unit);
+    is_deeply $sack_image, {
+        type => 'svg',
+        data => $sack_image->{data},  # SVG data will vary
+        colour => '#F5F5DC',
+    }, "garden waste sack shows as cream colored sack";
+};
+
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => 'sutton',
     MAPIT_URL => 'http://mapit.uk/',


### PR DESCRIPTION
Adds a cream-coloured Garden Waste Sack Image, requested by the client in FD-4929.

<img width="1177" alt="Screenshot 2024-12-20 at 9 55 37 am" src="https://github.com/user-attachments/assets/9fc52bb7-d755-4d20-b49e-6baee371cd24" />

<!-- [skip changelog] -->