### PR TITLE
[FixaMinGata] Hide app badges when using PWABuilder

### DIFF
--- a/templates/web/fixamingata/footer_extra.html
+++ b/templates/web/fixamingata/footer_extra.html
@@ -21,7 +21,7 @@
                     <p>Rapportera eller visa lokala problem. Var som helst i Sverige.</p>
                 </div>
 
-                <div class="fms-app-badges">
+                <div class="fms-app-badges" style="display: none;">
                     <a class="js-lazyload fms-app-badge fms-app-badge--ios" href="http://appstore.com/fixamingata">
                         FixaMinGata på App Store
                     </a>

--- a/web/cobrands/fixamingata/js.js
+++ b/web/cobrands/fixamingata/js.js
@@ -25,3 +25,13 @@ if (window.$) {
         fixmystreet.fixChromeAutocomplete
     );
 }
+
+// Show the app badges if the app is not a PWABuilder progressive web app from
+// the iOS App Store.
+if (document.cookie.indexOf("app-platform=iOS App Store") === -1) {
+    var fmsAppBadges = document.getElementsByClassName("fms-app-badges")[0];
+
+    if (fmsAppBadges) {
+        fmsAppBadges.style.display = "block";
+    }
+}


### PR DESCRIPTION
Please check the following:

- [ ] Has the code POD documentation been added or updated?
- [ ] Whether this PR should include changes to any public documentation, or the FAQ;
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [ ] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Will cobrand-specific changes require additional work to ensure consistent behaviour on www.fixmystreet.com? 
- [ ] Are the changes tested for accessibility?
- [ ] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

The `app-platform` cookie comes from the PWABuilder code:

```
$ grep -Inr app-platform
./src/FixaMinGata/Settings.swift:22:let platformCookie = Cookie(name: "app-platform", value: "iOS App Store")
```

It has worked okay for us. The app icons are visible outside of the iOS app but hidden inside the iOS app.

Apple rejected the app until we made that change.

Related to #4153.