### PR TITLE
[FixaMinGata] Avoid displaying the installation banner

### DIFF
--- a/web/cobrands/fixamingata/js.js
+++ b/web/cobrands/fixamingata/js.js
@@ -35,3 +35,14 @@ if (document.cookie.indexOf("app-platform=iOS App Store") === -1) {
         fmsAppBadges.style.display = "block";
     }
 }
+
+// Hide the default PWA installation banner since it covers important UI
+// elements (https://github.com/mysociety/fixmystreet/issues/4153).
+// deferredPrompt could be used to provide an in-app installation flow.
+var deferredPrompt;
+
+addEventListener("beforeinstallprompt", function (event) {
+    event.preventDefault();
+
+    deferredPrompt = event;
+});


### PR DESCRIPTION
Please check the following:

- [ ] Has the code POD documentation been added or updated?
- [ ] Whether this PR should include changes to any public documentation, or the FAQ;
- [x] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [ ] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [x] Will cobrand-specific changes require additional work to ensure consistent behaviour on www.fixmystreet.com? 
- [ ] Are the changes tested for accessibility?
- [ ] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

We disabled the installation banner two years ago and no one has complained.

Related to #4153.