### PR TITLE
[Bexley] Ignore duplicate log entries from Whitespace

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -628,6 +628,7 @@ sub _in_cab_logs {
     my @property_logs;
     my @street_logs;
     my %completed_or_attempted_collections;
+    my %seen_logs;
 
     return ( \@property_logs, \@street_logs, \%completed_or_attempted_collections )
         unless $cab_logs;
@@ -646,6 +647,13 @@ sub _in_cab_logs {
         # Gather property-level and street-level exceptions
         if ( $_->{Reason} && $_->{Reason} ne 'N/A' ) {
             if ( $_->{Uprn} && $_->{Uprn} eq $property->{uprn} ) {
+                # Create a unique key for this log entry based on the actual event details
+                # using just the date portion of LogDate since multiple logs for the same
+                # event might have different timestamps on the same day
+                my $date_only = $logdate->ymd;
+                my $log_key = join(':', $_->{Reason}, $_->{RoundCode}, $date_only);
+                next if $seen_logs{$log_key}++;
+
                 push @property_logs, {
                     uprn   => $_->{Uprn},
                     round  => $_->{RoundCode},


### PR DESCRIPTION
Sometimes Whitespace will return identical logs which only differ by a few seconds, but have different IDs. We want to ignore these as they don't give us any extra information and look confusing when displayed to the user.

For FD-4974

<!-- [skip changelog] -->