### PR TITLE
[Street Manager] Only activate asset layer when starting report

### DIFF
--- a/web/cobrands/fixmystreet-uk-councils/roadworks.js
+++ b/web/cobrands/fixmystreet-uk-councils/roadworks.js
@@ -15,9 +15,11 @@ var roadworks_defaults = {
     format_class: OpenLayers.Format.GeoJSON,
     stylemap: fixmystreet.assets.stylemap_invisible,
     non_interactive: true,
-    always_visible: true,
+    asset_category: [],
+    always_visible: false,
     nearest_radius: 100,
     road: true,
+    name: "Street Manager",
     actions: {
         found: function(layer, feature) {
             if (fixmystreet.roadworks.filter(feature)) {
@@ -92,6 +94,18 @@ fixmystreet.roadworks.filter = function(feature) {
     return !categories.length || OpenLayers.Util.indexOf(categories, category) != -1;
 };
 
-fixmystreet.assets.add(roadworks_defaults);
+var roadworks_layer = fixmystreet.assets.add(roadworks_defaults);
+
+// Don't want to activate it until they start to make a report
+fixmystreet.roadworks.activate = function(){
+    roadworks_layer.fixmystreet.always_visible = true;
+    roadworks_layer.setVisibility(true);
+};
+
+$(function(){
+    if (fixmystreet.page === 'new') {
+        fixmystreet.roadworks.activate();
+    }
+});
 
 })();

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -200,6 +200,12 @@ $.extend(fixmystreet.utils, {
             drag.activate();
         }
 
+        // Only now do we want to activate the Street Manager layer, if it's
+        // present, as we haven't needed it until now.
+        if (fixmystreet.roadworks) {
+            fixmystreet.roadworks.activate();
+        }
+
         fixmystreet.maps.hide_keyboard_instructions();
 
         // check to see if markers are visible. We click the


### PR DESCRIPTION
Previously all map pans on /around were hitting the Street Manager API unnecessarily.

WIP - /report/new is broken at the very least, probably others.

[skip changelog]

For https://github.com/mysociety/societyworks/issues/4728