### PR TITLE
[Bexley] Communal/FAS take precedence for staff.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -1177,12 +1177,11 @@ sub _bin_location_field {
     my $c        = $self->{c};
     my $property = $c->stash->{property};
 
-    my $type
-        = $c->stash->{is_staff}
-        || $property->{has_assisted} ? 'staff_or_assisted'
-        : $property->{is_communal}   ? 'communal'
-        : $property->{above_shop}    ? 'above_shop'
-        :                              '';
+    my $type =
+          $property->{is_communal} ? 'communal'
+        : $property->{above_shop} ? 'above_shop'
+        : $c->stash->{is_staff} || $property->{has_assisted} ? 'staff_or_assisted'
+        : '';
 
     my $options = _bin_location_options()->{$type};
 

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -727,6 +727,14 @@ FixMyStreet::override_config {
             for
             @{ FixMyStreet::Cobrand::Bexley::Waste::_bin_location_options()
                 ->{staff_or_assisted} };
+
+        $mech->get_ok('/waste/10002/report');
+        $mech->content_contains('Bin location');
+        $mech->content_contains('name="bin_location"');
+        $mech->content_contains($_)
+            for
+            @{ FixMyStreet::Cobrand::Bexley::Waste::_bin_location_options()
+                ->{communal} };
     };
 
     subtest 'Correct labels used when reporting missed collection' => sub {


### PR DESCRIPTION
Communal/flat above shop properties should always show their location lists, for staff as well as public.
Fixes https://mysocietysupport.freshdesk.com/a/tickets/5046
[skip changelog]