### PR TITLE
[Bexley] Add payment fallback script

### DIFF
--- a/bin/fixmystreet.com/waste-check-payments
+++ b/bin/fixmystreet.com/waste-check-payments
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+#
+# This script checks for successful payments where the
+# user may not have reached the confirmation page.
+
+use v5.14;
+use warnings;
+
+BEGIN {    # set all the paths to the perl code
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use Getopt::Long::Descriptive;
+use FixMyStreet::Cobrand;
+use FixMyStreet::Script::Waste::CheckPayments;
+
+my ($opts, $usage) = describe_options(
+    '%c %o',
+    ['cobrand=s@', 'which cobrands to check'],
+    ['help|h', "print usage message and exit" ],
+);
+$usage->die if $opts->help;
+$usage->die unless $opts->cobrand;
+
+foreach (@{$opts->cobrand}) {
+    my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker($_)->new;
+    my $check = FixMyStreet::Script::Waste::CheckPayments->new(cobrand => $cobrand);
+    $check->check_payments;
+}

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -284,7 +284,7 @@ sub pay_complete : Path('pay_complete') : Args(2) {
     $c->forward('check_payment_redirect_id', [ $id, $token ]);
     my $p = $c->stash->{report};
 
-    my $ref = $c->cobrand->garden_cc_check_payment_status($c, $p);
+    my $ref = $c->cobrand->waste_cc_check_payment_status($c, $p);
 
     if ( $ref ) {
         $c->stash->{title} = 'Payment successful';

--- a/perllib/FixMyStreet/Roles/Cobrand/Adelante.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Adelante.pm
@@ -117,7 +117,7 @@ sub cc_check_payment_and_update {
     return ($error, undef);
 }
 
-sub garden_cc_check_payment_status {
+sub waste_cc_check_payment_status {
     my ($self, $c, $p) = @_;
 
     # need to get some ID Things which I guess we stored in pay

--- a/perllib/FixMyStreet/Roles/Cobrand/Paye.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Paye.pm
@@ -117,7 +117,7 @@ around waste_cc_get_redirect_url => sub {
     return $self->$orig($c, $back);
 };
 
-around garden_cc_check_payment_status => sub {
+around waste_cc_check_payment_status => sub {
     my ($orig, $self, $c, $p) = @_;
 
     if (my $apn = $p->get_extra_metadata('apnReference')) {

--- a/perllib/FixMyStreet/Script/Waste/CheckPayments.pm
+++ b/perllib/FixMyStreet/Script/Waste/CheckPayments.pm
@@ -19,8 +19,12 @@ sub check_payments {
     });
     while (my $row = $problems->next) {
         $cobrand->set_lang_and_domain($row->lang, 1);
-        my $query_id = $row->get_extra_metadata('scpReference') or next; # Problem fetching unique ID from payment provider
-        my ($error, $reference) = $cobrand->cc_check_payment_and_update($query_id, $row);
+        my ($error, $reference);
+        if (my $scp = $row->get_extra_metadata('scpReference')) {
+            ($error, $reference) = $cobrand->cc_check_payment_and_update($scp, $row);
+        } elsif (my $apn = $row->get_extra_metadata('apnReference')) {
+            ($error, $reference) = $cobrand->paye_check_payment_and_update($apn, $row);
+        }
         if ($reference) {
             $row->waste_confirm_payment($reference);
         }

--- a/perllib/FixMyStreet/Script/Waste/CheckPayments.pm
+++ b/perllib/FixMyStreet/Script/Waste/CheckPayments.pm
@@ -1,0 +1,30 @@
+package FixMyStreet::Script::Waste::CheckPayments;
+
+use Moo;
+use FixMyStreet::DB;
+
+has cobrand => ( is => 'ro' );
+
+sub check_payments {
+    my $self = shift;
+    my $cobrand = $self->cobrand;
+    FixMyStreet::Map::set_map_class($cobrand);
+    my $problems = FixMyStreet::DB->resultset('Problem')->to_body($cobrand->body->id)->search({
+        -or => [
+            { state => 'unconfirmed', category => 'Garden Subscription' },
+            { state => 'confirmed', category => 'Bulky collection' },
+        ],
+        -not => { extra => { '\?' => 'payment_reference' } },
+        created => [ -and => { '<', \"current_timestamp - '15 minutes'::interval" }, { '>=', \"current_timestamp - '1 hour'::interval" } ],
+    });
+    while (my $row = $problems->next) {
+        $cobrand->set_lang_and_domain($row->lang, 1);
+        my $query_id = $row->get_extra_metadata('scpReference') or next; # Problem fetching unique ID from payment provider
+        my ($error, $reference) = $cobrand->cc_check_payment_and_update($query_id, $row);
+        if ($reference) {
+            $row->waste_confirm_payment($reference);
+        }
+    }
+}
+
+1;

--- a/t/app/controller/waste_bromley_bulky.t
+++ b/t/app/controller/waste_bromley_bulky.t
@@ -1,3 +1,4 @@
+use utf8;
 use Test::MockModule;
 use Test::MockTime 'set_fixed_time';
 use FixMyStreet::TestMech;
@@ -705,7 +706,11 @@ FixMyStreet::override_config {
             created => "2023-10-01T08:00:00Z",
             cobrand => "bromley",
         });
-        $p->set_extra_fields({ name => 'uprn', value => 'UPRN' });
+        $p->set_extra_fields(
+            { name => 'uprn', value => 'UPRN' },
+            { name => 'payment_method', value => 'credit_card' },
+            { name => 'payment', value => '3000' },
+        );
         $p->set_extra_metadata('payment_reference', 'test');
         $p->set_extra_metadata('scpReference', 'unpaid');
         $p->update;
@@ -741,9 +746,9 @@ FixMyStreet::override_config {
         is $p->get_extra_metadata('continuousAuditNumber'), 123;
         is $p->get_extra_metadata('authCode'), 112233;
         is $p->get_extra_metadata('payment_reference'), 54321;
-        is $p->get_extra_field_value('LastPayMethod'), $cobrand->bin_payment_types->{'csc'};
+        is $p->get_extra_field_value('LastPayMethod'), $cobrand->bin_payment_types->{'credit_card'};
         is $p->get_extra_field_value('PaymentCode'), 54321;
-        is $p->comments->first->text, "Payment confirmed, reference 54321";
+        is $p->comments->first->text, "Payment confirmed, reference 54321, amount £30.00";
         is $p->get_extra_field_value('uprn'), 'UPRN';
 
         # No payment non-staff and check confirms unpaid - cancelled.


### PR DESCRIPTION
For https://github.com/mysociety/societyworks/issues/4681 [skip changelog]

Doesn't actually include any Bexley specific tests/stuff, that should be added when payments are added in some other work. This is being used by Merton (and can be used by any SCP usage, which Bexley is).