### PR TITLE
[Bristol] Add layers for allowed reports

### DIFF
--- a/templates/web/bristol/report/new/roads_message.html
+++ b/templates/web/bristol/report/new/roads_message.html
@@ -1,0 +1,8 @@
+<div id="bristol-not-owned" class="hidden js-responsibility-message js-roads-bristol">
+    <strong>
+        The area selected is not maintained by Bristol City Council
+    </strong>
+    <p>
+        To enable you to find out who owns/maintains this area please contact HM Land Registry at https://www.gov.uk/search-property-information-land-registry.
+    </p>
+</div>

--- a/templates/web/fixmystreet.com/report/new/roads_message.html
+++ b/templates/web/fixmystreet.com/report/new/roads_message.html
@@ -71,6 +71,14 @@
             </a> who own and manage it.
         </p>
     </div>
+    <div id="bristol-not-owned" class="hidden js-responsibility-message js-roads-bristol">
+        <strong>
+            The area selected is not maintained by Bristol City Council
+        </strong>
+        <p>
+            To enable you to find out who owns/maintains this area please contact HM Land Registry at https://www.gov.uk/search-property-information-land-registry.
+        </p>
+    </div>
 </div>
 <div id="js-environment-message" class="hidden">
     <p>

--- a/web/cobrands/fixmystreet-uk-councils/assets.js
+++ b/web/cobrands/fixmystreet-uk-councils/assets.js
@@ -268,19 +268,36 @@ fixmystreet.assets.bristol.park_stylemap = new OpenLayers.StyleMap({
 });
 
 
-var bristol_owned_asset = false;
+var bristol_owned_assets = {
+    road: false,
+    property: false
+};
 
 fixmystreet.assets.bristol.road_found = function(layer) {
-    bristol_owned_asset = true;
+    bristol_owned_assets.road = true;
+    fixmystreet.message_controller.road_found(layer);
+};
+
+fixmystreet.assets.bristol.property_found = function(layer) {
+    bristol_owned_assets.property = true;
     fixmystreet.message_controller.road_found(layer);
 };
 
 fixmystreet.assets.bristol.road_not_found = function(layer) {
-    if (bristol_owned_asset) {
-        bristol_owned_asset = false;
-        return;
-    } else {
+    bristol_owned_assets.road = false;
+    if (!bristol_owned_assets.road && !bristol_owned_assets.property && !fixmystreet.staff_set_up) {
         fixmystreet.message_controller.road_not_found(layer, function() {return true;});
+    } else {
+        fixmystreet.message_controller.road_found(layer);
+    }
+};
+
+fixmystreet.assets.bristol.property_not_found = function(layer) {
+    bristol_owned_assets.property = false;
+    if (!bristol_owned_assets.road && !bristol_owned_assets.property && !fixmystreet.staff_set_up) {
+        fixmystreet.message_controller.road_not_found(layer, function() {return true;});
+    } else {
+        fixmystreet.message_controller.road_found(layer);
     }
 };
 

--- a/web/cobrands/fixmystreet-uk-councils/assets.js
+++ b/web/cobrands/fixmystreet-uk-councils/assets.js
@@ -267,6 +267,23 @@ fixmystreet.assets.bristol.park_stylemap = new OpenLayers.StyleMap({
     })
 });
 
+
+var bristol_owned_asset = false;
+
+fixmystreet.assets.bristol.road_found = function(layer) {
+    bristol_owned_asset = true;
+    fixmystreet.message_controller.road_found(layer);
+};
+
+fixmystreet.assets.bristol.road_not_found = function(layer) {
+    if (bristol_owned_asset) {
+        bristol_owned_asset = false;
+        return;
+    } else {
+        fixmystreet.message_controller.road_not_found(layer, function() {return true;});
+    }
+};
+
 /* Bromley */
 
 fixmystreet.assets.bromley = {};


### PR DESCRIPTION
Setup for two asset layers to have either selected to allow reports in Bristol on relevant categories.

https://github.com/mysociety/societyworks/issues/4692

Configuration in same branch on the servers

[skip changelog]