### PR TITLE
[Bromley] Include flytip information in report description

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -347,6 +347,16 @@ sub open311_pre_send {
             $row->detail($text);
         }
     }
+
+    # Any special extra questions to include
+    my $extra = $row->get_extra_fields;
+    foreach (@$extra) {
+        if ($_->{name} =~ /_Q$/ && $_->{value}) {
+            (my $name = ucfirst lc $_->{name}) =~ s/_q//;
+            my $text = "$name information: " . $_->{value} . "\n\n" . $row->detail;
+            $row->detail($text);
+        }
+    }
 }
 
 sub _include_user_title_in_extra {

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -288,6 +288,27 @@ subtest 'Private comments on updates are added to open311 description' => sub {
     };
 };
 
+subtest 'ensure flytip information is added to open311 description' => sub {
+    $report->set_extra_fields({ name => 'FLYTIP_Q', value => 'Large sofa and household waste' });
+    $report->send_state('unprocessed');
+    $report->update;
+
+    FixMyStreet::override_config {
+        STAGING_FLAGS => { send_reports => 1 },
+        ALLOWED_COBRANDS => [ 'fixmystreet', 'bromley' ],
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        FixMyStreet::Script::Reports::send();
+    };
+
+    $report->discard_changes;
+    is $report->send_state, 'sent', 'Report marked as sent';
+
+    my $req = Open311->test_req_used;
+    my $c = CGI::Simple->new($req->content);
+    like $c->param('description'), qr/Flytip information: Large sofa and household waste/, 'flytip information included in description';
+};
+
 for my $test (
     {
         cobrand => 'bromley',


### PR DESCRIPTION
If a category has a `FLYT_NOT` extra field then include that in the report description.

For FD-5053

<!-- [skip changelog] -->
