### PR TITLE
[Lincolnshire] Add staff user and role to dashboard CSV export

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
@@ -243,4 +243,30 @@ sub open311_get_user {
     return $user;
 }
 
+sub dashboard_export_problems_add_columns {
+    my ($self, $csv) = @_;
+
+    $csv->add_csv_columns(
+        staff_role => 'Staff Role',
+    );
+
+    return if $csv->dbi; # All covered already
+
+    my $user_lookup = $self->csv_staff_users;
+    my $userroles = $self->csv_staff_roles($user_lookup);
+
+    $csv->csv_extra_data(sub {
+        my $report = shift;
+
+        my $by = $report->get_extra_metadata('contributed_by');
+        my $staff_role = '';
+        if ($by) {
+            $staff_role = join(',', @{$userroles->{$by} || []});
+        }
+        return {
+            staff_role => $staff_role,
+        };
+    });
+}
+
 1;

--- a/perllib/FixMyStreet/Script/CSVExport.pm
+++ b/perllib/FixMyStreet/Script/CSVExport.pm
@@ -55,7 +55,7 @@ my $EXTRAS = {
     reassigned => { tfl => 1 },
     assigned_to => { northumberland => 1, tfl => 1 },
     staff_user => { bathnes => 1, bromley => 1, buckinghamshire => 1, northumberland => 1, peterborough => 1 },
-    staff_roles => { brent => 1, bromley => 1, northumberland => 1, oxfordshire => 1 },
+    staff_roles => { brent => 1, bromley => 1, lincolnshire => 1, northumberland => 1, oxfordshire => 1 },
     user_details => { bathnes => 1, bexley => 1, brent => 1, camden => 1, cyclinguk => 1, highwaysengland => 1, kingston => 1, southwark => 1, sutton => 1 },
     comment_content => { highwaysengland => 1 },
     db_state => { peterborough => 1 },


### PR DESCRIPTION
Extends the dashboard CSV export to include additional columns for staff users and their roles when a report is contributed by a staff member.

For FD-5038

<!-- [skip changelog] -->
