### PR TITLE
Fix HTML in site messages

### DIFF
--- a/perllib/FixMyStreet/Template.pm
+++ b/perllib/FixMyStreet/Template.pm
@@ -156,6 +156,21 @@ sub html_paragraph_email_factory : FilterFactory('html_para_email') {
     }
 }
 
+=head2 html_paragraph_conditional
+
+Calls html_paragraph, but only if the text doesn't include
+a <p>, <ol>, or <ul>.
+
+=cut
+
+sub html_paragraph_conditional : Filter('html_para_conditional') {
+    my $text = shift;
+    if ($text !~ /<(p|ol|ul)[^>]*>/) {
+        $text = html_paragraph($text);
+    }
+    return $text;
+}
+
 sub sanitize {
     my ($text, $admin) = @_;
 

--- a/templates/web/base/front/site-message.html
+++ b/templates/web/base/front/site-message.html
@@ -1,7 +1,7 @@
 [% site_message = c.cobrand.site_message %]
 [% IF site_message && !rendered_site_message %]
 <div class="site-message">
-  [% site_message | html_para %]
+  [% site_message | html_para_conditional %]
 </div>
 [% END %]
 [% rendered_site_message = 1 %]

--- a/templates/web/base/report/new/form_after_heading.html
+++ b/templates/web/base/report/new/form_after_heading.html
@@ -1,7 +1,7 @@
 [% site_message = c.cobrand.site_message('reporting') %]
 [% IF site_message %]
 <div class="site-message__reporting">
-    [% site_message | safe | html_para %]
+    [% site_message | html_para_conditional %]
 </div>
 [% END %]
 

--- a/templates/web/base/waste/header.html
+++ b/templates/web/base/waste/header.html
@@ -20,7 +20,7 @@ END;
 [% site_message = c.cobrand.site_message('waste') %]
 [% IF site_message %]
 <div class="site-message">
-  [% site_message | html_para %]
+  [% site_message | html_para_conditional %]
 </div>
 [% END %]
 [% IF site_message_upcoming_downtime %]

--- a/templates/web/bathnes/around/_postcode_form_post.html
+++ b/templates/web/bathnes/around/_postcode_form_post.html
@@ -1,6 +1,6 @@
 [% site_message = c.cobrand.site_message %]
 [% IF site_message %]
 <div class="front-main-other-issues-wrapper">
-  [% site_message | html_para %]
+  [% site_message | html_para_conditional %]
 </div>
 [% END %]

--- a/templates/web/peterborough/waste/header.html
+++ b/templates/web/peterborough/waste/header.html
@@ -17,6 +17,6 @@ END;
 [% site_message = c.cobrand.site_message('waste') %]
 [% IF site_message %]
 <div class="site-message">
-  [% site_message | html_para %]
+  [% site_message | html_para_conditional %]
 </div>
 [% END %]


### PR DESCRIPTION
If we detect that a site message contains HTML then don't use the html_para filter to avoid adding extra <br> elements which mess up spacing.

For FD-5103

## Before

<img width="1056" alt="image" src="https://github.com/user-attachments/assets/c7373290-dcde-4f1e-a8db-db20e283e43f" />

## After

<img width="1092" alt="image" src="https://github.com/user-attachments/assets/a3df941e-11ed-4314-a867-95392a4bc4ce" />


<!-- [skip changelog] -->
