### PR TITLE
[Bristol][Alloy] Adds putting usrn into Alloy reports

### DIFF
--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -580,7 +580,7 @@ sub _fetch_features_url {
         SERVICE => "WFS",
         SRSNAME => $cfg->{srsname},
         TYPENAME => $cfg->{typename},
-        VERSION => "1.1.0",
+        VERSION => $cfg->{version} || "1.1.0",
         outputformat => $cfg->{outputformat} || "geojson",
         $cfg->{filter} ? ( Filter => $cfg->{filter} ) : ( BBOX => $cfg->{bbox} ),
     );


### PR DESCRIPTION
Where an Alloy report is sending to Bristol over Open311 it must have a usrn present to identify the street it is on so the report can be parented to the correct road and given the correct locality.

https://github.com/mysociety/societyworks/issues/4743

[skip changelog]