### PR TITLE
[Hounslow] Rename body to "Hounslow Highways"

### DIFF
--- a/.cypress/cypress/integration/hounslow.js
+++ b/.cypress/cypress/integration/hounslow.js
@@ -27,9 +27,9 @@ describe('private categories', function() {
     cy.get('#map_box').click(290, 307);
     cy.wait('@report-ajax');
     cy.pickCategory('Potholes');
-    cy.contains('sent to Hounslow Borough Council and also published online');
+    cy.contains('sent to Hounslow Highways and also published online');
     cy.pickCategory('Other');
-    cy.contains('sent to Hounslow Borough Council but not published online');
+    cy.contains('sent to Hounslow Highways but not published online');
   });
 
 });

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -156,7 +156,7 @@ if ($opt->test_fixtures) {
         { area_id => 164186, categories => [ 'Graffiti' ], name => 'West Northamptonshire Council' },
         { area_id => 2483, categories => [
                 'Potholes', { category => 'Other', non_public => 1 },
-            ], name => 'Hounslow Borough Council', cobrand => 'hounslow' },
+            ], name => 'Hounslow Highways', cobrand => 'hounslow' },
         { area_id => 2508, categories => [ 'Potholes', 'Other' ], name => 'Hackney Council', cobrand => 'hackney' },
         { area_id => 2636, categories => [
                 { category => 'Potholes', send_method => 'Triage' },

--- a/perllib/FixMyStreet/Cobrand/Hounslow.pm
+++ b/perllib/FixMyStreet/Cobrand/Hounslow.pm
@@ -81,11 +81,6 @@ sub report_sent_confirmation_email { 'external_id' }
 # Used to change the "Sent to" line on report pages
 sub link_to_council_cobrand { "Hounslow Highways" }
 
-# The "all reports" link will default to using council_name, which
-# in our case doesn't correspond to a body and so causes an infinite redirect.
-# Instead, force the borough council name to be used.
-sub all_reports_single_body { { name => "Hounslow Borough Council" } }
-
 sub open311_post_send {
     my ($self, $row, $h) = @_;
 

--- a/perllib/FixMyStreet/DB/Result/Comment.pm
+++ b/perllib/FixMyStreet/DB/Result/Comment.pm
@@ -304,8 +304,6 @@ sub meta_line {
                 $body = "$body <img src='/cobrands/bromley/favicon.png' alt=''>";
             } elsif ($body eq 'Royal Borough of Greenwich') {
                 $body = "$body <img src='/cobrands/greenwich/favicon.png' alt=''>";
-            } elsif ($body eq 'Hounslow Borough Council') {
-                $body = 'Hounslow Highways';
             } elsif ($body eq 'Isle of Wight Council') {
                 $body = 'Island Roads';
             } elsif ($body eq 'Thamesmead') {

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -72,9 +72,9 @@ my @PLACES = (
     [ 'E8 1DY', 51.552267, -0.063316, 2508, 'Hackney Borough Council', 'LBO' ],
     [ 'E8 2DY', 51.552287, -0.063326, 2508, 'Hackney Council', 'LBO' ],
     [' E6 1AX', 51.524448, -0.077625, 2508, 'Hackney Council', 'LBO', 144379, 'Hoxton East & Shoreditch', 'LBW' ],
-    [ 'TW7 5JN', 51.482286, -0.328163, 2483, 'Hounslow Borough Council', 'LBO' ],
-    [ '?', 51.48111, -0.327219, 2483, 'Hounslow Borough Council', 'LBO' ],
-    [ '?', 51.482045, -0.327219, 2483, 'Hounslow Borough Council', 'LBO' ],
+    [ 'TW7 5JN', 51.482286, -0.328163, 2483, 'Hounslow Highways', 'LBO' ],
+    [ '?', 51.48111, -0.327219, 2483, 'Hounslow Highways', 'LBO' ],
+    [ '?', 51.482045, -0.327219, 2483, 'Hounslow Highways', 'LBO' ],
     [ '?', 51.345714, -0.227959, 2457, 'Epsom and Ewell Borough Council', 'DIS' ],
     [ 'CW11 1HZ', 53.145324, -2.370437, 21069, 'Cheshire East Council', 'UTA', 135301, 'Sandbach Town', 'UTW' ],
     [ '?', 50.78301, -0.646929 ],
@@ -191,7 +191,7 @@ sub dispatch_request {
         } elsif ($areas eq 'LBO' || $areas eq 'LBO,UTA,DIS') {
             $self->output({
                 2482 => {parent_area => undef, id => 2482, name => "Bromley Borough Council", type => "LBO"},
-                2483 => {parent_area => undef, id => 2483, name => "Hounslow Borough Council", type => "LBO"},
+                2483 => {parent_area => undef, id => 2483, name => "Hounslow Highways", type => "LBO"},
             });
         } elsif ($areas eq 60705) {
             $self->output({60705 => {parent_area => 2245, id => 60705, name => "Trowbridge", type => "CPC"}});

--- a/t/app/controller/contact_enquiry.t
+++ b/t/app/controller/contact_enquiry.t
@@ -11,7 +11,7 @@ END { FixMyStreet::App->log->enable('info'); }
 
 my $mech = FixMyStreet::TestMech->new;
 
-my $body = $mech->create_body_ok( 2483, 'Hounslow Borough Council', {
+my $body = $mech->create_body_ok( 2483, 'Hounslow Highways', {
     send_method => 'Open311',
     endpoint => 'endpoint',
     api_key => 'key',

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -40,6 +40,7 @@ for my $body (
     { area_id => 2333, name => 'Hart Council', cobrand => 'hart' },
     { area_id => 2535, name => 'Sandwell Borough Council' },
     { area_id => 1000, name => 'National Highways', cobrand => 'highwaysengland' },
+    # Different name to test the display name mapping below
     { area_id => 2483, name => 'Hounslow Borough Council', cobrand => 'hounslow' },
 ) {
     my $extra = { cobrand => $body->{cobrand} } if $body->{cobrand};
@@ -868,6 +869,7 @@ subtest "check map click ajax response" => sub {
     }, sub {
         $extra_details = $mech->get_ok_json( '/report/new/ajax?latitude=51.482286&longitude=-0.328163' );
     };
+
     is_deeply $extra_details->{display_names}, { 'Hounslow Borough Council' => 'Hounslow Highways' }, 'council display name mapping correct';
 
     FixMyStreet::override_config {

--- a/t/cobrand/hounslow.t
+++ b/t/cobrand/hounslow.t
@@ -2,7 +2,7 @@ use FixMyStreet::TestMech;
 
 ok( my $mech = FixMyStreet::TestMech->new, 'Created mech object' );
 
-my $hounslow_id = $mech->create_body_ok(2483, 'Hounslow Borough Council', { cobrand => 'hounslow' })->id;
+my $hounslow_id = $mech->create_body_ok(2483, 'Hounslow Highways', { cobrand => 'hounslow' })->id;
 $mech->create_contact_ok(
     body_id => $hounslow_id,
     category => 'Potholes',

--- a/t/sendreport/open311_send.t
+++ b/t/sendreport/open311_send.t
@@ -181,7 +181,7 @@ subtest 'test handles bad category', sub {
     like $bad_category_report->send_fail_reason, qr/Category Flytipping does not exist for body/, 'failure message set';
 };
 
-my $hounslow = $mech->create_body_ok( 2483, 'Hounslow Borough Council', { cobrand => 'hounslow' });
+my $hounslow = $mech->create_body_ok( 2483, 'Hounslow Highways', { cobrand => 'hounslow' });
 my $contact2 = $mech->create_contact_ok( body_id => $hounslow->id, category => 'Graffiti', email => 'GRAF' );
 $contact2->set_extra_fields(
     { code => 'easting', datatype => 'number' },

--- a/web/cobrands/fixmystreet-uk-councils/council_validation_rules.js
+++ b/web/cobrands/fixmystreet-uk-councils/council_validation_rules.js
@@ -34,7 +34,7 @@ body_validation_rules = {
           maxlength: 256
         }
     },
-    'Hounslow Borough Council': confirm_validation_rules,
+    'Hounslow Highways': confirm_validation_rules,
     'Isle of Wight Council': confirm_validation_rules,
     'Island Roads': confirm_validation_rules,
     'Lincolnshire County Council': confirm_validation_rules,

--- a/web/cobrands/hounslow/js.js
+++ b/web/cobrands/hounslow/js.js
@@ -4,19 +4,4 @@ if (!fixmystreet.maps) {
     return;
 }
 
-if (fixmystreet.cobrand == 'hounslow') {
-    // We want the cobranded site to always display "Hounslow Highways"
-    // as the destination for reports in the "Public details" section.
-    // This is OK because the cobranded site only shows categories which
-    // Hounslow Highways actually handle.
-    // To achieve this we ignore the passed list of bodies and always
-    // use "Hounslow Highways" when calling the original function.
-    // NB calling the original function is required so that private categories
-    // cause the correct text to be shown in the UI.
-    var original_update_public_councils_text = fixmystreet.update_public_councils_text;
-    fixmystreet.update_public_councils_text = function(text, bodies) {
-        original_update_public_councils_text.call(this, text, ['Hounslow Highways']);
-    };
-}
-
 })();


### PR DESCRIPTION
Rename the **Hounslow Borough Council** body to **Hounslow Highways**, seeing as that's what it's publicly called.

This should also fix an issue where a report could go to multiple bodies but it wasn't previously listing all those bodies to the user.

For FD-5117

## Note to deployer

The following need to be done when deploying this change

- [ ] Update body name in the admin from `Hounslow Borough Council` to `Hounslow Highways`
  - [x] On staging
  - [ ] On live
- [ ] In the servers repo change `Hounslow Borough Council` to `Hounslow Highways` in `vhosts/fixmystreet/assets/hounslow.yml.include` and redeploy (will need to be done with a conditional on staging first)
  - [x] On staging
  - [ ] On live

<!-- [skip changelog] -->
