### PR TITLE
[Peterborough] Fix closed flytipping message.

### DIFF
--- a/t/cobrand/peterborough.t
+++ b/t/cobrand/peterborough.t
@@ -371,7 +371,7 @@ subtest "flytipping on non PCC land is emailed" => sub {
         is $p->get_extra_metadata('sent_to')->[0], 'flytipping@example.org', 'sent_to extra metadata set';
         is $p->state, 'closed', 'report closed having sent email';
         is $p->comments->count, 1, 'comment added';
-        like $p->comments->first->text, qr/You can report cases/, 'correct comment text';
+        like $p->comments->first->text, qr/You can report cases.*?clear the waste\.\n\n/, 'correct comment text';
         ok !Open311->test_req_used, 'no open311 sent';
 
         $mech->email_count_is(1);

--- a/templates/web/fixmystreet.com/report/new/flytipping_text.html
+++ b/templates/web/fixmystreet.com/report/new/flytipping_text.html
@@ -1,5 +1,8 @@
-You can report cases of fly-tipping on private land to Peterborough City Council, although it is the landowner’s responsibility to clear the waste.<br>
+You can report cases of fly-tipping on private land to Peterborough City Council, although it is the landowner’s responsibility to clear the waste.
+
 The council's Environmental Enforcement Team can only investigate if there is enough evidence available, e.g. witness statement, CCTV footage, evidence in the waste, etc.
-When you report, please state if you’re able to provide any evidence to support the investigation.<br>
-If there is enough evidence, once the case is referred to the Environmental Enforcement Team for investigation, the council will mark the report as closed on the system.<br>
+When you report, please state if you’re able to provide any evidence to support the investigation.
+
+If there is enough evidence, once the case is referred to the Environmental Enforcement Team for investigation, the council will mark the report as closed on the system.
+
 If there is no evidence of the fly-tipping being committed, or who the waste originally belonged to, the council are unable to investigate and proceed with your report.

--- a/templates/web/fixmystreet.com/report/new/roads_message.html
+++ b/templates/web/fixmystreet.com/report/new/roads_message.html
@@ -73,9 +73,7 @@
     </div>
 </div>
 <div id="js-environment-message" class="hidden">
-    <p>
-    [% INCLUDE 'report/new/flytipping_text.html' %]
-    </p>
+    [% fly_text = INCLUDE 'report/new/flytipping_text.html' %][% fly_text | html_para %]
 </div>
 <div id="js-graffiti-message" class="hidden">
     <p>

--- a/templates/web/peterborough/report/new/flytipping_text.html
+++ b/templates/web/peterborough/report/new/flytipping_text.html
@@ -1,5 +1,8 @@
-You can report cases of fly-tipping on private land to us, although it is the landowner’s responsibility to clear the waste.<br>
+You can report cases of fly-tipping on private land to us, although it is the landowner’s responsibility to clear the waste.
+
 Our Environmental Enforcement Team can only investigate if there is enough evidence available, e.g. witness statement, CCTV footage, evidence in the waste, etc.
-When you report, please state if you’re able to provide any evidence to support our investigation.<br>
-If there is enough evidence, once the case is referred to the Environmental Enforcement Team for investigation, we will mark the report as closed on the system.<br>
+When you report, please state if you’re able to provide any evidence to support our investigation.
+
+If there is enough evidence, once the case is referred to the Environmental Enforcement Team for investigation, we will mark the report as closed on the system.
+
 If there is no evidence of the fly-tipping being committed, or who the waste originally belonged to, we are unable to investigate and proceed with your report.

--- a/templates/web/peterborough/report/new/roads_message.html
+++ b/templates/web/peterborough/report/new/roads_message.html
@@ -3,9 +3,7 @@
     </div>
 </div>
 <div id="js-environment-message" class="hidden box-warning">
-    <p>
-    [% INCLUDE 'report/new/flytipping_text.html' %]
-    </p>
+    [% fly_text = INCLUDE 'report/new/flytipping_text.html' %][% fly_text | html_para %]
 </div>
 <div id="js-graffiti-message" class="hidden box-warning">
     <p>


### PR DESCRIPTION
Remove `<br>`s that were appearing in the update.
[skip changelog]
Fixes https://github.com/mysociety/societyworks/issues/4730
For FD-4998