### PR TITLE
Accessibility improvements to hint_style for emails

### DIFF
--- a/templates/email/bathnes/_email_top.html
+++ b/templates/email/bathnes/_email_top.html
@@ -66,11 +66,7 @@
 [% END %]
   <table [% wrapper_table | safe %] style="[% wrapper_style %]">
     <tr>
-      <th class="spacer-cell"></th>
-      <th width="[% wrapper_max_width %]" style="[% td_style %][% hint_style %]" class="hint">
-        [% email_summary %]
-      </th>
-      <th class="spacer-cell"></th>
+      <td height="24">&nbsp;</td>
     </tr>
   </table>
   <table [% wrapper_table | safe %] style="[% wrapper_style %]">

--- a/templates/email/bathnes/archive.html
+++ b/templates/email/bathnes/archive.html
@@ -1,7 +1,5 @@
 [%
 
-email_summary = "Your reports on " _ site_name;
-
 PROCESS '_email_settings.html';
 
 INCLUDE '_email_top.html';

--- a/templates/email/bexley/alert-update.html
+++ b/templates/email/bexley/alert-update.html
@@ -3,12 +3,6 @@
 PROCESS 'waste/_email_data.html';
 
 title = report.title | html;
-email_summary
-  = is_missed_collection
-  ? "New updates on your missed collection report"
-  : is_container_request
-  ? 'New updates on your replacement bin request'
-  : "New updates on “" _ title _ "”";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/bexley/waste/other-reported.html
+++ b/templates/email/bexley/waste/other-reported.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Your reference number is " _ report.id;
 email_columns = 2;
 
 PROCESS 'waste/_email_data.html';

--- a/templates/email/bexley/waste/submit.html
+++ b/templates/email/bexley/waste/submit.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "New " _ report.category _ " submitted by a " _ site_name _ " user.";
 email_footer = "";
 email_columns = 2;
 

--- a/templates/email/buckinghamshire/alert-update.html
+++ b/templates/email/buckinghamshire/alert-update.html
@@ -2,7 +2,6 @@
 
 title = report.title | html;
 category = report.category | html;
-email_summary = "New updates on " _ category _ " report";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/buckinghamshire/other-reported-claim.html
+++ b/templates/email/buckinghamshire/other-reported-claim.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Thanks for logging your report";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/buckinghamshire/other-reported.html
+++ b/templates/email/buckinghamshire/other-reported.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Thanks for logging your report";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/buckinghamshire/submit.html
+++ b/templates/email/buckinghamshire/submit.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "A new problem in your area has been reported by a " _ site_name _ " user.";
 email_footer = "";
 email_columns = 2;
 

--- a/templates/email/default/_email_bottom.html
+++ b/templates/email/default/_email_bottom.html
@@ -7,6 +7,11 @@
   <table [% wrapper_table | safe %] style="[% wrapper_style %]">
     <tr>
       <th class="spacer-cell"></th>
+      <td height="24">&nbsp;</td>
+      <th class="spacer-cell"></th>
+    </tr>
+    <tr>
+      <th class="spacer-cell"></th>
       <th width="[% wrapper_max_width %]" style="[% td_style %][% hint_style %]" class="hint">
         [%~ IF email_footer.defined %]
           [% email_footer | safe %]

--- a/templates/email/default/_email_settings.html
+++ b/templates/email/default/_email_settings.html
@@ -89,7 +89,7 @@ wrapper_min_width = 520 # in pixels without "px" suffix
 hint_min_width = wrapper_min_width - (column_padding * 2)
 hint_style = "min-width: ${ hint_min_width }px; padding: ${ column_padding }px; color: $body_text_color; font-size: 12px; line-height: 18px;"
 
-warning_style = "min-width: ${ hint_min_width }x; padding: ${ column_padding }px; background-color: $color_red_dark; color: $color_white;"
+warning_style = "min-width: ${ hint_min_width }x; padding: ${ column_padding }px; background-color: $color_red_dark; color: $color_white; box-sizing: border-box;"
 
 header_style = "padding: $header_padding; background: $header_background_color; color: $header_text_color;"
 

--- a/templates/email/default/_email_settings.html
+++ b/templates/email/default/_email_settings.html
@@ -87,7 +87,7 @@ wrapper_max_width = 620 # in pixels without "px" suffix
 wrapper_min_width = 520 # in pixels without "px" suffix
 
 hint_min_width = wrapper_min_width - (column_padding * 2)
-hint_style = "min-width: ${ hint_min_width }px; padding: ${ column_padding }px; color: $body_text_color; font-size: 12px; line-height: 18px;"
+hint_style = "min-width: ${ hint_min_width }px; padding: ${ column_padding }px; color: $body_text_color; background: $color_white; box-sizing:border-box; font-size: 12px; line-height: 18px;"
 
 warning_style = "min-width: ${ hint_min_width }x; padding: ${ column_padding }px; background-color: $color_red_dark; color: $color_white; box-sizing: border-box;"
 

--- a/templates/email/default/_email_top.html
+++ b/templates/email/default/_email_top.html
@@ -62,11 +62,7 @@
 [% END %]
   <table [% wrapper_table | safe %] style="[% wrapper_style %]">
     <tr>
-      <th class="spacer-cell"></th>
-      <th width="[% wrapper_max_width %]" style="[% td_style %][% hint_style %]" class="hint">
-        [% email_summary %]
-      </th>
-      <th class="spacer-cell"></th>
+      <td height="24">&nbsp;</td>
     </tr>
   </table>
   <table [% wrapper_table | safe %] style="[% wrapper_style %]">

--- a/templates/email/default/alert-confirm.html
+++ b/templates/email/default/alert-confirm.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "You need to confirm your " _ site_name _ " alert settings before we can send you alerts.";
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/alert-problem-area.html
+++ b/templates/email/default/alert-problem-area.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "New reports in " _ area_name;
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/alert-problem-council.html
+++ b/templates/email/default/alert-problem-council.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "New reports to ${ area_name }";
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/alert-problem-nearby.html
+++ b/templates/email/default/alert-problem-nearby.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "New reports within your area";
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/alert-problem-ward.html
+++ b/templates/email/default/alert-problem-ward.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "New reports to " _ area_name _ " within " _ ward_name;
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/alert-problem.html
+++ b/templates/email/default/alert-problem.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "New reports on " _ site_name;
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/alert-subscribed.html
+++ b/templates/email/default/alert-subscribed.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Subscribed to " _ site_name _ " alerts";
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/alert-update.html
+++ b/templates/email/default/alert-update.html
@@ -2,7 +2,6 @@
 [%
 
 title = report.title | html;
-email_summary = "New updates on “" _ title _ "”";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/archive-old-enquiries.html
+++ b/templates/email/default/archive-old-enquiries.html
@@ -1,7 +1,5 @@
 [%
 
-email_summary = "Your reports on " _ site_name;
-
 PROCESS '_email_settings.html';
 
 INCLUDE '_email_top.html';

--- a/templates/email/default/change_email.html
+++ b/templates/email/default/change_email.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Click this link to change your " _ site_name _ " email address";
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/contact.html
+++ b/templates/email/default/contact.html
@@ -2,7 +2,6 @@
 
 subject_html = subject | html;
 name = form_name | html;
-email_summary = "“" _ subject_html _ "” – Message from " _ name _ " on " _ host;
 email_footer = "Sent via " _ host _ ", IP " _ ip;
 email_columns = 1;
 

--- a/templates/email/default/cy/alert-confirm.html
+++ b/templates/email/default/cy/alert-confirm.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "You need to confirm your " _ site_name _ " alert settings before we can send you alerts.";
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/cy/alert-problem-area.html
+++ b/templates/email/default/cy/alert-problem-area.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Adroddiadau newydd " _ area_name;
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/cy/alert-problem-council.html
+++ b/templates/email/default/cy/alert-problem-council.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Adroddiadau newydd ${ area_name }";
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/cy/alert-problem-nearby.html
+++ b/templates/email/default/cy/alert-problem-nearby.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Adroddiadau newydd o fewn eich ardal";
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/cy/alert-problem-ward.html
+++ b/templates/email/default/cy/alert-problem-ward.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Adroddiadau newydd i " _ area_name _ " o fewn " _ ward_name;
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/cy/alert-problem.html
+++ b/templates/email/default/cy/alert-problem.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Adroddiadau newydd ar " _ site_name;
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/cy/alert-subscribed.html
+++ b/templates/email/default/cy/alert-subscribed.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Wedi tanysgrifio i hysbysiadau " _ site_name _ " ";
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/cy/alert-update.html
+++ b/templates/email/default/cy/alert-update.html
@@ -1,7 +1,6 @@
 [%
 
 title = report.title | html;
-email_summary = "Diweddariadau newydd “" _ title _ "”";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/cy/archive-old-enquiries.html
+++ b/templates/email/default/cy/archive-old-enquiries.html
@@ -1,7 +1,5 @@
 [%
 
-email_summary = "Eich adroddiadau ar " _ site_name;
-
 PROCESS '_email_settings.html';
 
 INCLUDE '_email_top.html';

--- a/templates/email/default/cy/change_email.html
+++ b/templates/email/default/cy/change_email.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Cliciwch ar y ddolen isod i newid eich cyfeiriad e-bost " _ site_name _ " ";
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/cy/contact.html
+++ b/templates/email/default/cy/contact.html
@@ -2,7 +2,6 @@
 
 subject_html = subject | html;
 name = form_name | html;
-email_summary = "“" _ subject_html _ "” – Neges gan " _ name _ " on " _ host;
 email_footer = "Sent via " _ host _ ", IP " _ ip;
 email_columns = 1;
 

--- a/templates/email/default/cy/inactive-account.html
+++ b/templates/email/default/cy/inactive-account.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Eich cyfrif anweithredol ar " _ site_name;
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/cy/login.html
+++ b/templates/email/default/cy/login.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Cliciwch y ddolen isod i gadarnhau eich cyfeiriad e-bost a mewngofnodi i " _ site_name;
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/cy/other-reported.html
+++ b/templates/email/default/cy/other-reported.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Diolch am gofnodi eich adroddiad";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/cy/other-updated.html
+++ b/templates/email/default/cy/other-updated.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Diolch am gofnodi eich diweddariad";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/cy/partial.html
+++ b/templates/email/default/cy/partial.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Cadarnhewch eich adroddiad ar " _ site_name;
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/cy/problem-confirm-not-sending.html
+++ b/templates/email/default/cy/problem-confirm-not-sending.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Rydych chi angen cadarnhau eich adroddiad i " _ site_name _ " cyn y gellir ei gyhoeddi.";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/cy/problem-confirm.html
+++ b/templates/email/default/cy/problem-confirm.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Rydych chi angen cadarnhau eich adroddiad " _ site_name _ " cyn y gall cael ei anfon at ${ report.body }.";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/cy/questionnaire.html
+++ b/templates/email/default/cy/questionnaire.html
@@ -1,7 +1,6 @@
 [%
 
 title = report.title | html;
-email_summary = "Oes gennych chi ddwy funud? Rhowh wybod beth ddigwyddodd i'ch adroddiad " _ site_name _ " am ${ title }.";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/cy/submit.html
+++ b/templates/email/default/cy/submit.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Mae problem newydd yn eich ardal wedi'i hadrodd gan ddefnyddiwr " _ site_name _ " .";
 email_footer = "Os oes cyfeiriad e-bost mwy priodol ar gyfer negeseuon am " _ category_footer _ ", rhowch wybod i ni. Bydd hyn yn helpu i wella'r gwasanaeth i bobl leol. Rydym hefyd yn croesawu unrhyw sylwadau eraill.";
 email_columns = 2;
 

--- a/templates/email/default/cy/templated_email_alert-update.html
+++ b/templates/email/default/cy/templated_email_alert-update.html
@@ -1,7 +1,6 @@
 [%
 
 title = report.title | html;
-email_summary = "Diweddariad cyngor ar “" _ title _ "”";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/cy/update-confirm.html
+++ b/templates/email/default/cy/update-confirm.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Cadarnhewch eich diweddariad " _ site_name;
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/inactive-account.html
+++ b/templates/email/default/inactive-account.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Your inactive account on " _ site_name;
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/login.html
+++ b/templates/email/default/login.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Click the link below to confirm your email address and log into " _ site_name;
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/other-reported.html
+++ b/templates/email/default/other-reported.html
@@ -7,7 +7,6 @@
 [% ELSE ~%]
 [%
 
-email_summary = "Thanks for logging your report";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/other-updated.html
+++ b/templates/email/default/other-updated.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Thanks for logging your update";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/partial.html
+++ b/templates/email/default/partial.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Confirm your report on " _ site_name;
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/problem-confirm-not-sending.html
+++ b/templates/email/default/problem-confirm-not-sending.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "You need to confirm your " _ site_name _ " report before it can be made public.";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/problem-confirm.html
+++ b/templates/email/default/problem-confirm.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "You need to confirm your " _ site_name _ " report before it can be sent to ${ report.body }.";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/problem-moderated.html
+++ b/templates/email/default/problem-moderated.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Your report on " _ site_name _ " has been moderated.";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/questionnaire.html
+++ b/templates/email/default/questionnaire.html
@@ -1,7 +1,6 @@
 [%
 
 title = report.title | html;
-email_summary = "Got a minute spare? Let us know what happened to your " _ site_name _ " report about ${ title }.";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/submit.html
+++ b/templates/email/default/submit.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "A new problem in your area has been reported by a " _ site_name _ " user.";
 email_footer = "If there is a more appropriate email address for messages about " _ category_footer _ ", please let us know. This will help improve the service for local people. We also welcome any other feedback you may have.";
 email_columns = 2;
 

--- a/templates/email/default/update-confirm.html
+++ b/templates/email/default/update-confirm.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Confirm your update on " _ site_name;
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/waste/csc_payment_failed.html
+++ b/templates/email/default/waste/csc_payment_failed.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "There was a problem with your payment";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/waste/direct_debit_in_progress.html
+++ b/templates/email/default/waste/direct_debit_in_progress.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Thanks for logging your request";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/default/waste/other-reported.html
+++ b/templates/email/default/waste/other-reported.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Thanks for logging your report";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/fixamingata/alert-confirm.html
+++ b/templates/email/fixamingata/alert-confirm.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Bekräfta din bevakning på FixaMinGata";
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/fixamingata/alert-problem-area.html
+++ b/templates/email/fixamingata/alert-problem-area.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Nya rapporter i " _ area_name _ " på FixaMinGata";
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/fixamingata/alert-problem-council.html
+++ b/templates/email/fixamingata/alert-problem-council.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Nya rapporter i ${ area_name } på FixaMinGata";
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/fixamingata/alert-problem-nearby.html
+++ b/templates/email/fixamingata/alert-problem-nearby.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Nya rapporter på FixaMinGata";
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/fixamingata/alert-problem-ward.html
+++ b/templates/email/fixamingata/alert-problem-ward.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Nya rapporter i " _ area_name _ " på FixaMinGata"
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/fixamingata/alert-problem.html
+++ b/templates/email/fixamingata/alert-problem.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Nya rapporter på FixaMinGata";
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/fixamingata/alert-update.html
+++ b/templates/email/fixamingata/alert-update.html
@@ -1,7 +1,6 @@
 [%
 
 title = title | html;
-email_summary = "Ny uppdatering - " _ title;
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/fixamingata/change_email.html
+++ b/templates/email/fixamingata/change_email.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Klicka på den här länken för att ändra din FixaMinGata-epostadress";
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/fixamingata/contact.html
+++ b/templates/email/fixamingata/contact.html
@@ -2,7 +2,6 @@
 
 subject_html = subject | html;
 name = form_name | html;
-email_summary = "“" _ subject_html _ "” – Meddelande från " _ name _ " hos " _ host;
 email_footer = "Skickat via " _ host _ " och IP-adressen " _ ip;
 email_columns = 1;
 

--- a/templates/email/fixamingata/inactive-account.html
+++ b/templates/email/fixamingata/inactive-account.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Ditt inaktiva konto på " _ site_name;
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/fixamingata/login.html
+++ b/templates/email/fixamingata/login.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Klicka på knappen för att bekräfta din e-postadress och logga in på FixaMinGata";
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/fixamingata/other-reported.html
+++ b/templates/email/fixamingata/other-reported.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Tack för att du loggade din rapport";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/fixamingata/other-updated.html
+++ b/templates/email/fixamingata/other-updated.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Tack för att du loggade din uppdatering";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/fixamingata/problem-confirm-not-sending.html
+++ b/templates/email/fixamingata/problem-confirm-not-sending.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Du måste bekräfta din FixaMinGata-rapport innan den kan visas på sajten";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/fixamingata/problem-confirm.html
+++ b/templates/email/fixamingata/problem-confirm.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Du måste bekräfta din FixaMinGata-rapport innan den kan skickas till ${ report.body }";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/fixamingata/problem-moderated.html
+++ b/templates/email/fixamingata/problem-moderated.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Din rapport på " _ site_name _ " har blivit modererad.";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/fixamingata/questionnaire.html
+++ b/templates/email/fixamingata/questionnaire.html
@@ -1,7 +1,6 @@
 [%
 
 title = report.title | html;
-email_summary = "Har du en minut över? Informera oss om vad som hände med din FixaMinGata-rapport om ${ title }.";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/fixamingata/submit.html
+++ b/templates/email/fixamingata/submit.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Det här meddelandet rör en rapport om ett problem i gatumiljön som en medborgare lämnat via tjänsten FixaMinGata";
 email_footer = "Föreningen Sambruk som driver tjänsten ansvarar för en användargrupp som det går bra att gå med i för att få tillgång till ytterligare FixaMinGata-relaterade tjänster och support. Bland annat kan varje kategori ha sin egen e-postadress, och FixaMinGata kan även kopplas mot system som Open311";
 email_columns = 2;
 

--- a/templates/email/fixamingata/update-confirm.html
+++ b/templates/email/fixamingata/update-confirm.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Bekräfta din uppdatering på " _ site_name;
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/fixmystreet.com/cy/submit.html
+++ b/templates/email/fixmystreet.com/cy/submit.html
@@ -2,7 +2,6 @@
 
 PROCESS '_email_settings.html';
 
-email_summary = "Mae problem newydd yn eich ardal chi wedi cael ei hadrodd gan ddefnyddiwr " _ site_name _ ".";
 email_footer = PROCESS '_submit_footer.html';
 email_columns = 2;
 

--- a/templates/email/fixmystreet.com/submit.html
+++ b/templates/email/fixmystreet.com/submit.html
@@ -5,7 +5,6 @@
 
 PROCESS '_email_settings.html';
 
-email_summary = "A new problem in your area has been reported by a " _ site_name _ " user.";
 email_footer = PROCESS '_submit_footer.html';
 email_columns = 2;
 

--- a/templates/email/gloucestershire/archive-old-enquiries.html
+++ b/templates/email/gloucestershire/archive-old-enquiries.html
@@ -1,7 +1,5 @@
 [%
 
-email_summary = "Your reports on " _ site_name;
-
 PROCESS '_email_settings.html';
 
 INCLUDE '_email_top.html';

--- a/templates/email/highwaysengland/submit.html
+++ b/templates/email/highwaysengland/submit.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "A new problem in your area has been reported by a " _ site_name _ " user.";
 email_footer = "Sent via FixMyStreet";
 email_columns = 2;
 

--- a/templates/email/hounslow/archive.html
+++ b/templates/email/hounslow/archive.html
@@ -1,7 +1,5 @@
 [%
 
-email_summary = "Your reports on " _ site_name;
-
 PROCESS '_email_settings.html';
 
 INCLUDE '_email_top.html';

--- a/templates/email/hounslow/other-reported.html
+++ b/templates/email/hounslow/other-reported.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Thanks for logging your report";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/hounslow/problem-confirm.html
+++ b/templates/email/hounslow/problem-confirm.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "You need to confirm your " _ site_name _ " report before it can be sent to Hounslow Highways.";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/hounslow/submit.html
+++ b/templates/email/hounslow/submit.html
@@ -2,7 +2,6 @@
 
 PROCESS '_email_settings.html';
 
-email_summary = "A new problem in your area has been reported by a " _ site_name _ " user.";
 email_footer = "";
 email_columns = 2;
 

--- a/templates/email/isleofwight/archive.html
+++ b/templates/email/isleofwight/archive.html
@@ -1,7 +1,5 @@
 [%
 
-email_summary = "Your reports on FixMyStreet";
-
 PROCESS '_email_settings.html';
 
 INCLUDE '_email_top.html';

--- a/templates/email/isleofwight/confirm_report_sent.html
+++ b/templates/email/isleofwight/confirm_report_sent.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Thanks for logging your report";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/isleofwight/problem-confirm.html
+++ b/templates/email/isleofwight/problem-confirm.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "You need to confirm your " _ site_name _ " report before it can be sent to Island Roads.";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/kingston/alert-update.html
+++ b/templates/email/kingston/alert-update.html
@@ -1,7 +1,6 @@
 [%
 
 title = report.title | html;
-email_summary = "New updates on “" _ title _ "”, reference " _ report.id;
 email_columns = 2;
 
 PROCESS '_email_settings.html';
@@ -12,7 +11,7 @@ INCLUDE '_email_top.html';
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
   [% start_padded_box | safe %]
-  <h1 style="[% h1_style %]">New updates</h1>
+  <h1 style="[% h1_style %]">New updates, reference RBK-[% report.id %]</h1>
   [%~ INCLUDE '_email_comment_list.html' %]
   [% TRY %][% INCLUDE '_alert_update_after_updates.html' %][% CATCH file %][% END %]
  [% IF unsubscribe_url %]

--- a/templates/email/kingston/login.html
+++ b/templates/email/kingston/login.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Click the link below to confirm your email address for " _ site_name;
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/kingston/waste/bulky-reminder.html
+++ b/templates/email/kingston/waste/bulky-reminder.html
@@ -16,6 +16,8 @@ cancel_url = cobrand.base_url _ '/waste/' _ property_id_uri _ '/' _ bulky_cancel
 
   <p style="[% p_style %]">Dear [% report.name %],</p>
 
+  <p style="[% p_style %]">[% email_summary %]</p>
+
   <p style="[% p_style %]">
     [% IF days == 3 %]
     Your bulky waste is due to be collected

--- a/templates/email/lincolnshire/contact.html
+++ b/templates/email/lincolnshire/contact.html
@@ -2,7 +2,6 @@
 
 subject_html = subject | html;
 name = form_name | html;
-email_summary = "“" _ subject_html _ "” – Message from " _ name _ " on " _ host;
 email_footer = "Sent via " _ host _ ", IP " _ ip;
 email_columns = 1;
 

--- a/templates/email/nottinghamshirepolice/submit.html
+++ b/templates/email/nottinghamshirepolice/submit.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "A new problem in your area has been reported by a " _ site_name _ " user.";
 email_footer = "";
 email_columns = 2;
 

--- a/templates/email/oxfordshire/archive.html
+++ b/templates/email/oxfordshire/archive.html
@@ -1,7 +1,5 @@
 [%
 
-email_summary = "Your reports on " _ site_name;
-
 PROCESS '_email_settings.html';
 
 INCLUDE '_email_top.html';

--- a/templates/email/peterborough/other-reported.html
+++ b/templates/email/peterborough/other-reported.html
@@ -5,7 +5,6 @@
 [% ELSE ~%]
 [%
 
-email_summary = "Thanks for logging your report";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/rutland/archive.html
+++ b/templates/email/rutland/archive.html
@@ -1,7 +1,5 @@
 [%
 
-email_summary = "Your reports on " _ site_name;
-
 PROCESS '_email_settings.html';
 
 INCLUDE '_email_top.html';

--- a/templates/email/sutton/alert-update.html
+++ b/templates/email/sutton/alert-update.html
@@ -1,7 +1,6 @@
 [%
 
 title = report.title | html;
-email_summary = "New updates on “" _ title _ "”, reference " _ report.id;
 email_columns = 2;
 
 PROCESS '_email_settings.html';
@@ -12,7 +11,7 @@ INCLUDE '_email_top.html';
 
 <th style="[% td_style %][% primary_column_style %]" id="primary_column">
   [% start_padded_box | safe %]
-  <h1 style="[% h1_style %]">New updates</h1>
+  <h1 style="[% h1_style %]">New updates, reference LBS-[% report.id %]</h1>
   [%~ INCLUDE '_email_comment_list.html' %]
   [% TRY %][% INCLUDE '_alert_update_after_updates.html' %][% CATCH file %][% END %]
  [% IF unsubscribe_url %]

--- a/templates/email/sutton/login.html
+++ b/templates/email/sutton/login.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Click the link below to confirm your email address for " _ site_name;
 email_columns = 1;
 
 PROCESS '_email_settings.html';

--- a/templates/email/tfl/other-reported.html
+++ b/templates/email/tfl/other-reported.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "Thanks for logging your report";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/tfl/problem-confirm.html
+++ b/templates/email/tfl/problem-confirm.html
@@ -1,6 +1,5 @@
 [%
 
-email_summary = "You need to confirm your " _ site_name _ " report before it can be sent to Transport for London.";
 email_columns = 2;
 
 PROCESS '_email_settings.html';

--- a/templates/email/tfl/submit.html
+++ b/templates/email/tfl/submit.html
@@ -2,7 +2,6 @@
 
 PROCESS '_email_settings.html';
 
-email_summary = "A new problem in your area has been reported by a " _ site_name _ " user.";
 email_footer = "";
 email_columns = 2;
 

--- a/templates/email/westminster/archive.html
+++ b/templates/email/westminster/archive.html
@@ -1,7 +1,5 @@
 [%
 
-email_summary = "Your reports on " _ site_name;
-
 PROCESS '_email_settings.html';
 
 INCLUDE '_email_top.html';


### PR DESCRIPTION
Fixes: https://github.com/mysociety/fixmystreet/issues/5348

Currently, the email's top(email_summary) and bottom(email_footer) parts don't necessarily pass the contrast test. The text colour uses body_text_color, and the background colour for the top and bottom sections is not set, so the hint text is above whatever the body_background_color is. Looking at some cobrands, I can see that the problem is not only with FMS. The solution on this commit gives hint_style a background that uses color_white as a variable, and because the text is using the body_text_color, it is less likely the contrast test will fail. The scenario where this could happen is when body_text_color is using a light colour, which, so far, I haven't seen a cobrand doing this.


https://github.com/user-attachments/assets/565bfa12-72b8-49cd-ab54-fe040785e8a8

### Important:

- [ ] If the solution above is accepted then we need to update the `email_top` and `email_bottom` templates for: Hackney, Bathnes and Fixamingata
- [ ] Regarding getting rid of `email_summary` it does seem like it could be done. However looking at the `email_summary` content across cobrands it seems like it doesn't mimic the main title of the email 100% of the time. Reason why I didn't remove it.

I added an extra commit that corrects the extra space use by "This email was sent from a staging site."
#### Before
<img width="1155" alt="Screenshot 2025-02-17 at 14 30 46" src="https://github.com/user-attachments/assets/8f637dcd-c756-4e53-87c9-6fc76bd177b4" />

#### After
<img width="1155" alt="Screenshot 2025-02-17 at 14 30 05" src="https://github.com/user-attachments/assets/21a01504-e837-4022-be36-eccf55775b03" />


[skip changelog]
