### PR TITLE
[Bexley][WW] Garden cancellation textbox fix

### DIFF
--- a/perllib/FixMyStreet/App/Form/Waste/Garden/Cancel/Bexley.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Garden/Cancel/Bexley.pm
@@ -25,7 +25,6 @@ sub options_reason {
 }
 
 has_field reason_further_details => (
-    required => 1,
     type => 'Text',
     widget => 'Textarea',
     label =>

--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -725,8 +725,7 @@ FixMyStreet::override_config {
 
             $mech->submit_form_ok(
                 {   with_fields => {
-                        reason  => 'Other',
-                        reason_further_details => 'Burnt all my leaves',
+                        reason  => 'Price',
                         confirm => 1,
                     },
                 }
@@ -743,7 +742,7 @@ FixMyStreet::override_config {
             is $report->get_extra_field_value('due_date'),
                 $tomorrow;
             is $report->get_extra_field_value('reason'),
-                'Other: Burnt all my leaves';
+                'Price';
 
             $mech->clear_emails_ok;
             FixMyStreet::Script::Reports::send();


### PR DESCRIPTION
For https://3.basecamp.com/4020879/buckets/40373795/todos/8328047893.

'Further details' text box should only be required when reason is 'Other'.

[skip changelog]
