### PR TITLE
[Bexley][WW] Validate DD bank details before submitting them

### DIFF
--- a/perllib/FixMyStreet/App/Form/Waste/AccessPaySuiteBankDetails.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/AccessPaySuiteBankDetails.pm
@@ -116,6 +116,8 @@ has_field account_number => (
     validate_method => sub {
         my $self = shift;
         return unless $self->value;
+        # NB the given value is also validated, along with the sort code,
+        # against the Access PaySuite bankchecker API.
         # Remove any non-numerical characters
         my $value = $self->value;
         $value =~ s/[^0-9]//g;
@@ -134,6 +136,8 @@ has_field sort_code => (
     validate_method => sub {
         my $self = shift;
         return unless $self->value;
+        # NB the given value is also validated, along with the account number,
+        # against the Access PaySuite bankchecker API.
         my $sort_code = $self->value;
         $sort_code =~ s/[^0-9]//g;
         $self->value($sort_code);

--- a/perllib/FixMyStreet/App/Form/Waste/Garden/Bexley.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Garden/Bexley.pm
@@ -1,6 +1,12 @@
 package FixMyStreet::App::Form::Waste::Garden::Bexley;
 
 use utf8;
+use LWP::UserAgent;
+use JSON::MaybeXS;
+use URI;
+use Try::Tiny;
+use Data::Dumper;
+
 use HTML::FormHandler::Moose;
 extends 'FixMyStreet::App::Form::Waste::Garden';
 
@@ -13,5 +19,106 @@ has_page bank_details => (
     fields => ['name_title', 'first_name', 'surname', 'address1', 'address2', 'address3', 'address4', 'post_code', 'account_holder', 'account_number', 'sort_code', 'submit_bank_details'],
     next => 'summary',
 );
+
+sub validate {
+    my $self = shift;
+
+    if ( $self->page_name eq 'bank_details' ) {
+        my $sort_code = $self->field('sort_code');
+        my $account_number = $self->field('account_number');
+        return 1 unless $sort_code && $account_number;
+        return 1 if $self->_validate_bank_details($sort_code, $account_number);
+    }
+
+    $self->next::method();
+}
+
+=head2 * _validate_bank_details
+
+Takes sort code/account number fields and validates values against the Access
+PaySuite bankchecker API which performs 'modulus checks' on them.
+
+Returns 0 if valid, 1 if invalid. If invalid, sets form errors accordingly.
+
+=cut
+
+
+sub _validate_bank_details {
+    my ($self, $sort_code, $account_number ) = @_;
+
+    # don't bother calling the API if we don't have both values
+    return 1 unless $sort_code->value && $account_number->value;
+
+    my $cfg = $self->{c}->cobrand->feature('payment_gateway');
+
+    # fail validation if not configured - we don't want to set up invalid DDs.
+    unless ( $cfg && $cfg->{validator_url} ) {
+        $self->add_form_error("There was a problem verifying your bank details; please try again");
+        return 1;
+    }
+
+    my $url = $cfg->{validator_url};
+
+    my $ua = LWP::UserAgent->new(
+        timeout => 20,
+        agent => 'WasteWorks by SocietyWorks (swtech@societyworks.org)',
+    );
+
+    my $uri = URI->new('');
+    $uri->query_form({
+        client => $cfg->{validator_client},
+        apikey => $cfg->{validator_apikey},
+        sortCode => $sort_code->value,
+        accountNumber => $account_number->value,
+    });
+    $url .= "?" . $uri->query;
+
+    $self->{c}->log->debug("PaySuite bankcheck API call: $url");
+    my $result;
+    try {
+        my $j = JSON->new->utf8->allow_nonref;
+        my $response = $ua->get($url);
+        $result = $j->decode($response->content);
+    } catch {
+        my $e = $_ || '';
+        $self->{c}->log->error("PaySuite bankcheck API error: $e");
+    };
+
+    # didn't get valid JSON back, or request failed.
+    unless ( $result ) {
+        $self->{c}->log->error("PaySuite bankcheck API call failed.");
+        $self->add_form_error("There was a problem verifying your bank details; please try again");
+        return 1;
+    }
+
+    # API call succeeded but a problem with the params
+    if ( $result->{error} ) {
+        $self->{c}->log->error("PaySuite bankcheck API call returned error: " . $result->{error});
+        $self->add_form_error("There was a problem verifying your bank details; please try again");
+        return 1;
+    } elsif ( $result->{success} ) {
+        # API call succeeded, parameters were OK, now check the content to
+        # verify the sort code/account no were actually valid.
+
+        my $ret = 0;
+        # We only fail account number validation if 'status' value is false
+        if ( !$result->{success}->{account}->{status} ) {
+            $account_number->add_error("Account number is invalid.");
+            $ret = 1;
+        }
+        if ( $result->{success}->{sortcode} eq 'invalid') {
+            $sort_code->add_error("Sort code is invalid.");
+            $ret = 1;
+        }
+        return $ret;
+    }
+
+    # Unknown response from API; fail validation just to be safe.
+    $self->{c}->log->error("PaySuite bankcheck validation failure:");
+    $self->{c}->log->error(Dumper($result));
+    $self->add_form_error("There was a problem verifying your bank details; please try again");
+    return 1;
+}
+
 
 1;

--- a/t/Mock/AccessPaySuiteBankChecker.pm
+++ b/t/Mock/AccessPaySuiteBankChecker.pm
@@ -1,0 +1,87 @@
+package t::Mock::AccessPaySuiteBankChecker;
+
+use JSON::MaybeXS;
+use Web::Simple;
+use LWP::Protocol::PSGI;
+
+has json => (
+    is => 'lazy',
+    default => sub {
+        JSON->new->pretty->allow_blessed->convert_blessed;
+    },
+);
+
+sub output {
+    my ($self, $response) = @_;
+    my $json = $self->json->encode($response);
+    return [ 200, [ 'Content-Type' => 'application/json' ], [ $json ] ];
+}
+
+sub dispatch_request {
+    my $self = shift;
+
+    sub (GET + ?*) {
+        my ($self, $query) = @_;
+        if (my $code = $query->{sortCode}) {
+            my $codes = {
+                # valid everything
+                123456 => {
+                    success => {
+                        account => {
+                            status => JSON->true,
+                            cautious => JSON->false,
+                        },
+                        sortcode => {
+                            Bank => 'Test Bank',
+                            Branch => 'Test Branch',
+                        },
+                    },
+                },
+
+                # invalid account number
+                110012 => {
+                    success => {
+                        account => {
+                            status => JSON->false,
+                        },
+                        sortcode => {
+                            Bank => 'Test Bank',
+                            Branch => 'Test Branch',
+                        },
+                    },
+                },
+
+                # invalid sort code
+                110013 => {
+                    success => {
+                        account => {
+                            status => JSON->true,
+                            cautious => JSON->false,
+                        },
+                        sortcode => "invalid",
+                    },
+                },
+
+                # invalid api key
+                110014 => { error => "Either the client code or the API key is incorrect."},
+
+                # invalid client param
+                110015 => { error => "Either the client code or the API key is incorrect, or there is more than one client with the same code in the database"},
+
+                # another weird error
+                110016 => { error => "Account number includes non-numeric characters"},
+
+            };
+            my $default = { error => "Invalid parameters." };
+
+            if ( $code eq '000000' ) {
+                return [ 200, [ 'Content-Type' => 'text/plain' ], [ "this is just a plain text string" ] ];
+            } else {
+                return $self->output($codes->{$code} || $default);
+            }
+        }
+    },
+
+}
+
+__PACKAGE__->run_if_script;


### PR DESCRIPTION
The Access PaySuite DD API does not validate bank details when creating new contracts, so we first pass them to a totally separate Access PaySuite 'bankchecker' API to make sure they're good.

For https://github.com/mysociety/societyworks/issues/4823