### PR TITLE
[Zurich][FMS] Add Script for anonymising reports by date

### DIFF
--- a/bin/process-inactive-reports
+++ b/bin/process-inactive-reports
@@ -21,6 +21,7 @@ GetOptions(\%h,
     'delete=s' => \&time_check,
     'category=s',
     'state=s',
+    'created',
     'cobrand=s', 'verbose|v', 'help|h', 'dry-run|n') or exit 1;
 pod2usage(0) if $h{help};
 pod2usage(1) unless $h{anonymize} || $h{close} || $h{delete};
@@ -42,7 +43,7 @@ process-inactive-reports - deal with anonymizing inactive non-open reports
 =head1 SYNOPSIS
 
 process-inactive-reports [--anonymize N] [--close N] [--delete N] [--cobrand COBRAND]
-  [--category CATEGORY] [--state STATE]
+  [--category CATEGORY] [--state STATE] [--created]
 
  Options:
    --anonymize   Anonymize non-open reports (and related) inactive longer than this time
@@ -50,8 +51,9 @@ process-inactive-reports [--anonymize N] [--close N] [--delete N] [--cobrand COB
    --delete      Delete non-open reports inactive longer than this time
    --cobrand     Only act upon reports made on this cobrand
    --category    Only act upon reports made in this category
-   --state       Only act upon reports in this state
+   --state       Only act upon reports in this state, or 'all' for any state (including open)
    --dry-run     Don't actually anonymize anything or send any emails
+   --created     Operate based upon created timestamp, not lastupdate
    --verbose     Output as to which reports are being affected
    --help        This help message
 


### PR DESCRIPTION
Add a script to anonymise reports that are before n years ago.

Includes testing in Zurich as they have requested the feature and a script for calling the anonymisation script for use in a cron job.

https://mysocietysupport.freshdesk.com/a/tickets/5143

[skip changelog]