### PR TITLE
Added viewport meta tag to email templates

### DIFF
--- a/templates/email/bathnes/_email_top.html
+++ b/templates/email/bathnes/_email_top.html
@@ -14,6 +14,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <title>[% rss_title | safe %]</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <style type="text/css">
   [%~ # Styles here will be applied by everything except Gmail.com %]

--- a/templates/email/default/_email_top.html
+++ b/templates/email/default/_email_top.html
@@ -14,6 +14,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <title>[% rss_title | safe %]</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="color-scheme" content="only" />
   <meta name="supported-color-schemes" content="only" />


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4122

Temporary comment: I thought this added `<meta>` tag was solving the [issue 4122](https://github.com/mysociety/societyworks/issues/4122), but the issue seems to have been solved already. However this  tag would allow us to use the `Toggle Device toolbar` when using the Dev tools, so we could have a better preview of the email when using it on mobile, not as good as Litmus, but free.


# Tested on Litmus

## Gmail (Android 11)

<img width="469" alt="Screenshot 2025-03-04 at 12 46 52" src="https://github.com/user-attachments/assets/bba29429-0bb4-48c5-aa74-e3dbfea97e95" />

## Gmail (iOS 14.2)

<img width="469" alt="Screenshot 2025-03-04 at 12 47 48" src="https://github.com/user-attachments/assets/655b9d9e-c5b4-4f70-bbdb-a7689f4c1d32" />


## iOS 15
https://github.com/user-attachments/assets/39dbb593-a563-47d6-8bc2-49e3f150fd17


