### PR TITLE
[SLWP] Deal with multiple slot lists.

### DIFF
--- a/perllib/Integrations/Echo.pm
+++ b/perllib/Integrations/Echo.pm
@@ -469,9 +469,32 @@ sub ReserveAvailableSlotsForEvent {
     $from = $parser->parse_datetime($from);
     $to = $parser->parse_datetime($to);
 
+    my @data;
+    if ($event_type == 3130) {
+        push @data, Data => [
+            # Non-pop bookcase
+            { ExtensibleDatum => ixhash(
+                ChildData => { ExtensibleDatum => [ ixhash(
+                    DatatypeId => 57230,
+                    Value => 1842,
+                ) ] },
+                DatatypeId => 57229,
+            ) },
+            # Armchair - POP
+            { ExtensibleDatum => ixhash(
+                ChildData => { ExtensibleDatum => [ ixhash(
+                    DatatypeId => 57230,
+                    Value => 1839,
+                ) ] },
+                DatatypeId => 57229,
+            ) }
+        ];
+    }
+
     my @req = ('ReserveAvailableSlotsForEvent',
         event => ixhash(
             Guid => $guid,
+            @data,
             EventObjects => { EventObject => ixhash(
                 EventObjectType => 'Source',
                 ObjectRef => _id_ref($property, 'PointAddress'),
@@ -489,7 +512,26 @@ sub ReserveAvailableSlotsForEvent {
     return [] unless ref $res eq 'HASH';
 
     $self->log($res);
-    return force_arrayref($res->{ReservedTaskInfo}{ReservedSlots}, 'ReservedSlot');
+    my $tasks = force_arrayref($res, 'ReservedTaskInfo');
+    my %data;
+    foreach (@$tasks) {
+        my ($task_id) = $_->{Description} =~ /TaskType_(.*)/;
+        my $slots = Integrations::Echo::force_arrayref($_->{ReservedSlots}, 'ReservedSlot');
+        foreach (@$slots) {
+            my $datetime = $_->{StartDate}{DateTime};
+            push @{$data{$datetime}}, $_;
+        }
+    }
+
+    my @combined;
+    foreach (sort keys %data) {
+        my $slots = $data{$_};
+        if (@$slots == @$tasks) { # All matching dates
+            $slots->[0]{Reference} = join('::', map { $_->{Reference} } @$slots);
+            push @combined, $slots->[0];
+        }
+    }
+    return \@combined;
 }
 
 sub CancelReservedSlotsForEvent {

--- a/t/app/controller/waste_kands_bulky.t
+++ b/t/app/controller/waste_kands_bulky.t
@@ -90,29 +90,68 @@ FixMyStreet::override_config {
             ]
         }
     );
-    $echo->mock('ReserveAvailableSlotsForEvent', sub {
-        my ($self, $service, $event_type, $property, $guid, $start, $end) = @_;
-        is $service, 986;
-        is $event_type, 3130;
-        is $property, 12345;
-        return [
-        {
-            StartDate => { DateTime => '2023-07-01T00:00:00Z' },
-            EndDate => { DateTime => '2023-07-02T00:00:00Z' },
-            Expiry => { DateTime => '2023-06-25T10:10:00Z' },
-            Reference => 'reserve1==',
-        }, {
-            StartDate => { DateTime => '2023-07-08T00:00:00Z' },
-            EndDate => { DateTime => '2023-07-09T00:00:00Z' },
-            Expiry => { DateTime => '2023-06-25T10:10:00Z' },
-            Reference => 'reserve2==',
-        }, {
-            StartDate => { DateTime => '2023-07-15T00:00:00Z' },
-            EndDate => { DateTime => '2023-07-16T00:00:00Z' },
-            Expiry => { DateTime => '2023-06-25T10:10:00Z' },
-            Reference => 'reserve3==',
-        },
-    ] });
+
+    # Redefine call for this one as we want to test the rest of the
+    # ReserveAvailableSlotsForEvent function
+    $echo->redefine( call => sub {
+        is $_[1], 'ReserveAvailableSlotsForEvent';
+        is $_[2], 'event';
+        is $_[3]->{EventTypeId}, 3130;
+        is $_[3]->{ServiceId}, 986;
+        is $_[3]->{Data}[0]{ExtensibleDatum}{ChildData}{ExtensibleDatum}[0]{Value}, 1842;
+        # Dig down to the property ID
+        is $_[3]->{EventObjects}{EventObject}{ObjectRef}{Value}[0]{'msArray:anyType'}->value, 12345;
+        return {
+            ReservedTaskInfo => [
+                {
+                    Description => 'TaskType_1234',
+                    ReservedSlots => {
+                        ReservedSlot => [
+                            {
+                                StartDate => { DateTime => '2023-07-01T00:00:00Z' },
+                                EndDate => { DateTime => '2023-07-02T00:00:00Z' },
+                                Expiry => { DateTime => '2023-06-25T10:10:00Z' },
+                                Reference => 'reserve1==',
+                            }, {
+                                StartDate => { DateTime => '2023-07-08T00:00:00Z' },
+                                EndDate => { DateTime => '2023-07-09T00:00:00Z' },
+                                Expiry => { DateTime => '2023-06-25T10:10:00Z' },
+                                Reference => 'reserve2==',
+                            }, {
+                                StartDate => { DateTime => '2023-07-15T00:00:00Z' },
+                                EndDate => { DateTime => '2023-07-16T00:00:00Z' },
+                                Expiry => { DateTime => '2023-06-25T10:10:00Z' },
+                                Reference => 'reserve3==',
+                            },
+                        ]
+                    }
+                },
+                {
+                    Description => 'TaskType_5678',
+                    ReservedSlots => {
+                        ReservedSlot => [
+                            {
+                                StartDate => { DateTime => '2023-07-01T00:00:00Z' },
+                                EndDate => { DateTime => '2023-07-02T00:00:00Z' },
+                                Expiry => { DateTime => '2023-06-25T10:10:00Z' },
+                                Reference => 'reserve4==',
+                            }, {
+                                StartDate => { DateTime => '2023-07-08T00:00:00Z' },
+                                EndDate => { DateTime => '2023-07-09T00:00:00Z' },
+                                Expiry => { DateTime => '2023-06-25T10:10:00Z' },
+                                Reference => 'reserve5==',
+                            }, {
+                                StartDate => { DateTime => '2023-07-22T00:00:00Z' },
+                                EndDate => { DateTime => '2023-07-16T00:00:00Z' },
+                                Expiry => { DateTime => '2023-06-25T10:10:00Z' },
+                                Reference => 'reserve6==',
+                            },
+                        ]
+                    }
+                }
+            ]
+        };
+    });
 
     subtest 'Ineligible property' => sub {
         $echo->mock(
@@ -275,8 +314,9 @@ FixMyStreet::override_config {
         $mech->content_contains('placed outside before 6:30am on the collection day.');
         $mech->content_contains('1 July');
         $mech->content_contains('8 July');
+        $mech->content_contains('2023-07-01T00:00:00;reserve1==::reserve4==;2023-06-25T10:10:00');
         $mech->submit_form_ok(
-            { with_fields => { chosen_date => '2023-07-01T00:00:00;reserve1==;2023-06-25T10:10:00' } }
+            { with_fields => { chosen_date => '2023-07-01T00:00:00;reserve1==::reserve4==;2023-06-25T10:10:00' } }
         );
         $mech->content_contains('Select the items that you need us to collect using the');
         $mech->content_contains('You can book the collection of up to eight items');
@@ -788,34 +828,71 @@ FixMyStreet::override_config {
         my (undef, $guid) = @_;
         ok $guid, 'non-nil GUID passed to CancelReservedSlotsForEvent';
     } );
-    $echo->mock('ReserveAvailableSlotsForEvent', sub {
-        my ($self, $service, $event_type, $property, $guid, $start, $end) = @_;
-        is $service, 960;
-        is $event_type, 3130;
+    $echo->redefine( call => sub {
+        is $_[1], 'ReserveAvailableSlotsForEvent';
+        is $_[2], 'event';
+        is $_[3]->{EventTypeId}, 3130;
+        is $_[3]->{ServiceId}, 960;
+        is $_[3]->{Data}[0]{ExtensibleDatum}{ChildData}{ExtensibleDatum}[0]{Value}, 1842;
+        # Dig down to the property ID
+        my $property = $_[3]->{EventObjects}{EventObject}{ObjectRef}{Value}[0]{'msArray:anyType'}->value;
         like $property, qr/1234[56]/;
         if ($property == 12345) {
-            is $start, '2023-07-07';
+            is $_[5]{From}{'dataContract:DateTime'}, '2023-07-07T00:00:00Z';
         } elsif ($property == 12346) {
-            is $start, '2023-07-08';
+            is $_[5]{From}{'dataContract:DateTime'}, '2023-07-08T00:00:00Z';
         }
-        return [
-        {
-            StartDate => { DateTime => '2023-07-01T00:00:00Z' },
-            EndDate => { DateTime => '2023-07-02T00:00:00Z' },
-            Expiry => { DateTime => '2023-06-25T10:10:00Z' },
-            Reference => 'reserve1==',
-        }, {
-            StartDate => { DateTime => '2023-07-08T00:00:00Z' },
-            EndDate => { DateTime => '2023-07-09T00:00:00Z' },
-            Expiry => { DateTime => '2023-06-25T10:10:00Z' },
-            Reference => 'reserve2==',
-        }, {
-            StartDate => { DateTime => '2023-07-15T00:00:00Z' },
-            EndDate => { DateTime => '2023-07-16T00:00:00Z' },
-            Expiry => { DateTime => '2023-06-25T10:10:00Z' },
-            Reference => 'reserve3==',
-        },
-    ] });
+        return {
+            ReservedTaskInfo => [
+                {
+                    Description => 'TaskType_1234',
+                    ReservedSlots => {
+                        ReservedSlot => [
+                            {
+                                StartDate => { DateTime => '2023-07-01T00:00:00Z' },
+                                EndDate => { DateTime => '2023-07-02T00:00:00Z' },
+                                Expiry => { DateTime => '2023-06-25T10:10:00Z' },
+                                Reference => 'reserve1==',
+                            }, {
+                                StartDate => { DateTime => '2023-07-08T00:00:00Z' },
+                                EndDate => { DateTime => '2023-07-09T00:00:00Z' },
+                                Expiry => { DateTime => '2023-06-25T10:10:00Z' },
+                                Reference => 'reserve2==',
+                            }, {
+                                StartDate => { DateTime => '2023-07-15T00:00:00Z' },
+                                EndDate => { DateTime => '2023-07-16T00:00:00Z' },
+                                Expiry => { DateTime => '2023-06-25T10:10:00Z' },
+                                Reference => 'reserve3==',
+                            },
+                        ]
+                    }
+                },
+                {
+                    Description => 'TaskType_5678',
+                    ReservedSlots => {
+                        ReservedSlot => [
+                            {
+                                StartDate => { DateTime => '2023-07-01T00:00:00Z' },
+                                EndDate => { DateTime => '2023-07-02T00:00:00Z' },
+                                Expiry => { DateTime => '2023-06-25T10:10:00Z' },
+                                Reference => 'reserve4==',
+                            }, {
+                                StartDate => { DateTime => '2023-07-08T00:00:00Z' },
+                                EndDate => { DateTime => '2023-07-09T00:00:00Z' },
+                                Expiry => { DateTime => '2023-06-25T10:10:00Z' },
+                                Reference => 'reserve5==',
+                            }, {
+                                StartDate => { DateTime => '2023-07-22T00:00:00Z' },
+                                EndDate => { DateTime => '2023-07-16T00:00:00Z' },
+                                Expiry => { DateTime => '2023-06-25T10:10:00Z' },
+                                Reference => 'reserve6==',
+                            },
+                        ]
+                    }
+                }
+            ]
+        };
+    });
 
     $echo->mock('GetPointAddress', sub {
         my ($self, $id) = @_;
@@ -866,8 +943,9 @@ FixMyStreet::override_config {
         $mech->get_ok('/waste/12345/bulky');
         $mech->submit_form_ok;
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
+        $mech->content_contains('2023-07-08T00:00:00;reserve2==::reserve5==;2023-06-25T10:10:00');
         $mech->submit_form_ok(
-            { with_fields => { chosen_date => '2023-07-08T00:00:00;reserve4==;2023-06-25T10:20:00' } }
+            { with_fields => { chosen_date => '2023-07-08T00:00:00;reserve2==::reserve5==;2023-06-25T10:10:00' } }
         );
         $mech->submit_form_ok(
             {   with_fields => {
@@ -882,6 +960,7 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { tandc => 1 } });
         my $report = FixMyStreet::DB->resultset("Problem")->order_by('-id')->first;
         is $report->get_extra_field_value('payment_method'), 'csc';
+        is $report->get_extra_field_value('reservation'), 'reserve2==::reserve5==';
         $mech->submit_form_ok({ with_fields => { payenet_code => '54321' } });
         my $email = $mech->get_email;
         like $email->header('Subject'), qr/Your bulky waste collection - reference LBS/, "Confirmation booking email sent after staff payment process";


### PR DESCRIPTION
[skip changelog] For https://github.com/mysociety/societyworks/issues/4828 (everything except getting the two slots into Echo at the open311 end) - nothing within front end etc should change, this is about sending items through in order to get two slot lists, dealing with two slot lists in the hidden reservation IDs.