### PR TITLE
[Bexley] For pending reports, look for confirmed.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -187,7 +187,7 @@ sub get_pending_subscription : Private {
 
     my $uprn = $c->stash->{property}{uprn};
     my $state = 'unconfirmed';
-    $state = ['unconfirmed', 'confirmed'] if $c->cobrand->moniker eq 'bexley';
+    $state = 'confirmed' if $c->cobrand->moniker eq 'bexley';
     my $subs = $c->model('DB::Problem')->search({
         state => $state,
         created => { '>=' => \"current_timestamp-'20 days'::interval" },


### PR DESCRIPTION
Just had this thought this morning; DD reports are confirmed immediately, so we don't need to check for unconfirmed reports, which might confuse with unpaid credit card reports. [skip changelog]

Wasn't entirely sure if should only do this for cancelled, the known issue, not new/renew, but I thought this was slightly better in case there's a problem sending to Agile so we don't have the RENEWALDUE from there.