### PR TITLE
[Waste] Use report category to check for codes.

### DIFF
--- a/perllib/FixMyStreet/Roles/Cobrand/Adelante.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Adelante.pm
@@ -10,7 +10,7 @@ requires 'waste_cc_payment_reference';
 sub waste_cc_has_redirect { 1 }
 
 sub waste_cc_get_redirect_url {
-    my ($self, $c, $type) = @_;
+    my ($self, $c, $back) = @_;
 
     my $payment = Integrations::Adelante->new({
         config => $self->feature('payment_gateway')->{adelante}
@@ -31,10 +31,10 @@ sub waste_cc_get_redirect_url {
     my $fund_code = $payment->config->{fund_code};
     my $cost_code = $payment->config->{cost_code};
 
-    if ($type eq 'bulky') {
+    if ($p->category eq 'Bulky collection') {
         $fund_code = $payment->config->{bulky_fund_code} || $fund_code;
         $cost_code = $payment->config->{bulky_cost_code} || $cost_code;
-    } elsif ($type eq 'request') {
+    } elsif ($p->category eq 'Request new container') {
         $cost_code = $payment->config->{request_cost_code} || $cost_code;
     }
 

--- a/perllib/FixMyStreet/Roles/Cobrand/SCP.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/SCP.pm
@@ -33,7 +33,7 @@ sub waste_cc_get_redirect_url {
     my $customer_ref = $payment->config->{customer_ref};
 
     my $backUrl;
-    if ($back eq 'bulky') {
+    if ($p->category eq 'Bulky collection') {
         # Need to pass through property ID as not sure how to work it out once we're back
         my $id = URI::Escape::uri_escape_utf8($c->stash->{property}{id});
         $backUrl = $c->uri_for_action('/waste/pay_cancel', [ $p->id, $redirect_id ] ) . '?property_id=' . $id;
@@ -43,7 +43,7 @@ sub waste_cc_get_redirect_url {
         if (my $bulky_customer_ref = $payment->config->{bulky_customer_ref}) {
             $customer_ref = $bulky_customer_ref;
         }
-    } elsif ($back eq 'request') {
+    } elsif ($p->category eq 'Request new container') {
         if (my $request_customer_ref = $payment->config->{request_customer_ref}) {
             $customer_ref = $request_customer_ref;
         }


### PR DESCRIPTION
Back is only for use in generating a back URL, and might not correspond to the type of report (e.g. if you're retrying a failed payment). [skip changelog]
From FD-5197