### PR TITLE
[FMS][BANES] Create Script to send all Confirm reports to Passthrough endpoint

### DIFF
--- a/bin/banes/send_confirm_to_passthrough
+++ b/bin/banes/send_confirm_to_passthrough
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+#
+# This script sends waste reports additionally to BANES's
+# Open311 endpoint. They have already been sent to Confirm.
+
+use v5.14;
+use warnings;
+
+BEGIN {    # set all the paths to the perl code
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use FixMyStreet::Script::BANES::PassthroughConfirm;
+
+my $send = FixMyStreet::Script::BANES::PassthroughConfirm->new;
+
+
+$send->send_reports;
+$send->send_comments;

--- a/perllib/FixMyStreet/Cobrand/BathNES.pm
+++ b/perllib/FixMyStreet/Cobrand/BathNES.pm
@@ -13,6 +13,9 @@ use strict;
 use warnings;
 use utf8;
 
+use Moo;
+with 'FixMyStreet::Roles::Open311Multi';
+
 =head2 Defaults
 
 =over 4
@@ -292,6 +295,15 @@ sub categories_restriction {
         'me.send_method' => 'Email::BathNES', # Street Light Fault
         'me.send_method' => 'Blackhole', # Parks categories
     ] } );
+}
+
+=head2 open311_munge_update_params
+
+Stub needs to exist for FixMyStreet::Roles::Open311Multi
+
+=cut
+
+sub open311_munge_update_params {
 }
 
 =head2 dashboard_export_updates_add_columns

--- a/perllib/FixMyStreet/Script/BANES/PassthroughConfirm.pm
+++ b/perllib/FixMyStreet/Script/BANES/PassthroughConfirm.pm
@@ -1,0 +1,114 @@
+package FixMyStreet::Script::BANES::PassthroughConfirm;
+
+use Moo;
+use FixMyStreet::DB;
+use FixMyStreet::Queue::Item::Report;
+use FixMyStreet::SendReport::Open311;
+use Open311;
+
+has body => (
+    is => 'ro',
+    default => sub { FixMyStreet::DB->resultset('Body')->find( { name => 'Bath and North East Somerset Council' } ) or die $! }
+);
+
+sub send_reports {
+    my ($self) = @_;
+
+    my $problems = $self->_problems;
+
+    while (my $row = $problems->next) {
+        my $item = FixMyStreet::Queue::Item::Report->new( report => $row );
+        FixMyStreet::DB->schema->cobrand($item->cobrand);
+        my $confirm_id = $row->external_id;
+        $item->cobrand->set_lang_and_domain($row->lang, 1);
+        $item->_create_vars;
+        $item->h->{sending_to_banes_passthrough} = 1;
+        my $sender_info = {
+            method => 'Open311',
+            config => $self->body,
+        };
+        my $reporter = FixMyStreet::SendReport::Open311->new;
+        $reporter->add_body( $self->body, $sender_info->{config} );
+        $item->_set_reporters([$reporter]);
+        my $service_code = 'Passthrough-' . $row->contact->email;
+        $item->h->{alternative_service_code} = $service_code;
+        $item->_send;
+        if ($reporter->success) {
+            $row->discard_changes;
+            $row->set_extra_metadata('sent_to_banes_passthrough' => 1);
+            $row->set_extra_metadata('passthrough_id' => $row->external_id);
+            $row->external_id($confirm_id);
+            $row->update;
+        } else {
+            STDERR->print("Failed to post over Open311\n\n" . $reporter->error . "\n");
+        }
+    }
+};
+
+sub send_comments {
+    my ($self) = @_;
+    my $comments = $self->_comments;
+    while (my $row = $comments->next) {
+        my $problem = $row->problem;
+        my $confirm_id = $row->external_id;
+        my $cobrand = $problem->get_cobrand_logged;
+        FixMyStreet::DB->schema->cobrand($cobrand);
+        $cobrand->set_lang_and_domain($problem->lang, 1);
+        my $service_code = 'Passthrough-' . $row->problem->contact->email;
+        my %o311_cfg = (
+            jurisdiction => 'banes',
+            endpoint => $self->body->endpoint,
+            api_key => $self->body->api_key,
+            extended_statuses => $self->body->send_extended_statuses,
+            fixmystreet_body => $self->body,
+            use_customer_reference => 1,
+            service_code => $service_code,
+        );
+        my $o = Open311->new(%o311_cfg);
+        $problem->set_extra_metadata( customer_reference => $problem->get_extra_metadata('passthrough_id') );
+        my $id = $o->post_service_request_update( $row );
+        if ( $id ) {
+            $row->external_id($confirm_id);
+            $row->set_extra_metadata( sent_to_banes_passthrough => 1 );
+            $row->set_extra_metadata( passthrough_id => $id );
+            $row->update;
+        } else {
+            STDERR->print("Failed to post over Open311\n\n" . $o->error . "\n");
+        }
+    }
+}
+
+sub _problems {
+    my $self = shift;
+    FixMyStreet::DB->resultset('Problem')->to_body($self->body->id)->search({
+        'me.state' => { -not_in => [ FixMyStreet::DB::Result::Problem::hidden_states ] },
+        external_id => { '!=' => undef },
+        bodies_str => $self->body->id,
+        'contact.email' => { -not_like => '%@%' },
+        -or => [
+            'me.extra' => undef,
+            -not => { 'me.extra' => { '\?' => 'sent_to_banes_passthrough' } },
+        ],
+    }, {
+        prefetch => 'contact',
+    }
+
+    );
+};
+
+sub _comments {
+    my $self = shift;
+    FixMyStreet::DB->resultset('Comment')->to_body($self->body->id)->search({
+         'problem.bodies_str' => $self->body->id,
+         'problem.extra' => { '\?' => 'sent_to_banes_passthrough' },
+         'me.external_id' => \'is not null',
+        -or => [
+            'me.extra' => undef,
+            -not => { 'me.extra' => { '\?' => 'sent_to_banes_passthrough' } },
+        ],
+    }, {
+        prefetch => 'problem',
+    });
+}
+
+1;

--- a/perllib/Open311.pm
+++ b/perllib/Open311.pm
@@ -37,6 +37,7 @@ has always_upload_photos => ( is => 'ro', isa => Bool, default => 0 );
 has use_customer_reference => ( is => 'ro', isa => Bool, default => 0 );
 has mark_reopen => ( is => 'ro', isa => Bool, default => 0 );
 has fixmystreet_body => ( is => 'ro', isa => InstanceOf['FixMyStreet::DB::Result::Body'] );
+has service_code => ( is => 'ro', 'isa' => Str, default => '' );
 
 before [
     qw/get_service_list get_service_meta_info get_service_requests get_service_request_updates
@@ -87,7 +88,7 @@ sub send_service_request {
     my $self = shift;
     my $problem = shift;
     my $extra = shift;
-    my $service_code = shift;
+    my $service_code = $extra->{alternative_service_code} || shift;
 
     my $params = $self->_populate_service_request_params(
         $problem, $extra, $service_code
@@ -504,6 +505,7 @@ sub _populate_service_request_update_params {
 
     my $cobrand = $self->fixmystreet_body->get_cobrand_handler || $comment->get_cobrand_logged;
     $cobrand->call_hook(open311_munge_update_params => $params, $comment, $self->fixmystreet_body);
+    $params->{service_code} = $self->service_code if $self->service_code;
 
     if ( $comment->photo ) {
         my $cobrand = $comment->get_cobrand_logged;

--- a/t/script/banes/sendtopassthrough.t
+++ b/t/script/banes/sendtopassthrough.t
@@ -1,0 +1,63 @@
+use FixMyStreet::TestMech;
+use DateTime;
+use Test::Output;
+use Test::MockModule;
+use CGI::Simple;
+
+use_ok 'FixMyStreet::Script::BANES::PassthroughConfirm';
+
+my $bathnes = Test::MockModule->new('FixMyStreet::Cobrand::BathNES');
+$bathnes->mock('lookup_site_code', sub { '102345' } );
+
+my $mech = FixMyStreet::TestMech->new;
+my $area_id = 2551;
+my $body = $mech->create_body_ok($area_id, 'Bath and North East Somerset Council', {
+    endpoint => '',
+    api_key => 'key',
+    jurisdiction => 'BANES',
+    send_method => 'open311',
+    cobrand => 'bathnes',
+});
+
+my $email_category = $mech->create_contact_ok(category => 'Potholes', body_id => $body->id, email => 'Passthrough-potholes@example.com');
+my $confirm_category = $mech->create_contact_ok(category => 'Graffiti', body_id => $body->id, email => 'confirm_graffiti');
+
+FixMyStreet::override_config {
+          ALLOWED_COBRANDS => [ 'bathnes' ],
+          MAPIT_URL => 'http://mapit.uk/',
+}, sub {
+    my ($pothole_report) = $mech->create_problems_for_body( 1, $body->id, 'Potholes in the road', { category => $email_category->category, cobrand => 'bathnes', external_id => 'pass1' });
+    my ($graffiti_report) = $mech->create_problems_for_body( 1, $body->id, 'Graffiti on the wall', { category => $confirm_category->category, cobrand => 'bathnes', external_id => 'ext1' });
+
+    my $script = FixMyStreet::Script::BANES::PassthroughConfirm->new();
+    $script->send_reports;
+    $graffiti_report->discard_changes;
+
+    my $req = Open311->test_req_used;
+    my $c = CGI::Simple->new($req->content);
+    is $c->{service_code}[0], 'Passthrough-confirm_graffiti', "service_code has Passthrough- prefix";
+    is $c->{"attribute[title]"}[0] =~ /Graffiti on the wall/, 1, "Confirm report selected";
+    is $graffiti_report->external_id, 'ext1', "external_id restored to Confirm id";
+    is $graffiti_report->get_extra_metadata('passthrough_id'), '248', "Passthrough id stored on report";
+    is $graffiti_report->get_extra_metadata('sent_to_banes_passthrough'), '1', "Report registered as sent";
+
+    my $comment = $mech->create_comment_for_problem($graffiti_report, $graffiti_report->user, 'Name', 'Update', 0, 'confirmed', 'confirmed');
+    $comment->external_id('update1');
+    $comment->update;
+
+    Open311->_inject_response('servicerequestupdates.xml', '<?xml version="1.0" encoding="utf-8"?><service_request_updates><request_update><update_id>pass_update1</update_id></request_update></service_request_updates>');
+    $script->send_comments;
+    $req = Open311->test_req_used;
+    $c = CGI::Simple->new($req->content);
+
+    is $c->{service_request_id}[0], '248', "Passthrough service_request_id is set as the report's passthrough id";
+    is $c->{service_code}[0], 'Passthrough-confirm_graffiti', "service_code has Passthrough- prefix";
+    $comment->discard_changes;
+    $comment->problem->discard_changes;
+    is $comment->external_id, 'update1', "Confirm external_id restored";
+    is $comment->get_extra_metadata('sent_to_banes_passthrough'), '1', "Comment registered as sent to passthrough";
+    is $comment->get_extra_metadata('passthrough_id'), 'pass_update1', "Passthrough id stored on comment";
+    is $comment->problem->get_extra_metadata('customer_reference'), undef, "Problem customer_reference not stored";
+};
+
+done_testing;


### PR DESCRIPTION
After reports or comments have been sent to Confirm through the standard send-reports script, we want to then send them on to the Passthrough endpoint.

Reports and comments should keep their Confirm identifications as they will continue to receive updates from Confirm.

https://github.com/mysociety/societyworks/issues/4831

[skip changelog]
