### PR TITLE
[Bexley] Don’t pass NOACTIVE as ACTIVE.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
@@ -61,7 +61,7 @@ sub lookup_subscription_for_uprn {
         next unless $contracts;
         $customer = $_;
         for ( @$contracts ) {
-            next unless $_->{ServiceContractStatus} =~ /(ACTIVE|PRECONTRACT|RENEWALDUE)/; # Options seem to be ACTIVE/NOACTIVE/PRECONTRACT/RENEWALDUE
+            next unless $_->{ServiceContractStatus} =~ /^(ACTIVE|PRECONTRACT|RENEWALDUE)$/; # Options seem to be ACTIVE/NOACTIVE/PRECONTRACT/RENEWALDUE
             $contract = $_;
             # use the first matching customer/contract
             last OUTER if $customer && $contract;

--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -697,7 +697,7 @@ FixMyStreet::override_config {
                                     EndDate => '31/01/2024 12:00',
                                     Reference => $contract_id,
                                     WasteContainerQuantity => 2,
-                                    ServiceContractStatus => 'NOACTIVE',
+                                    ServiceContractStatus => 'ACTIVE',
                                     Payments => [ { PaymentStatus => 'Paid', Amount => '100' } ]
                                 },
                             ],
@@ -1117,6 +1117,17 @@ FixMyStreet::override_config {
                             CustomerExternalReference => 'CUSTOMER_123',
                             CustomertStatus => 'ACTIVATED',
                             ServiceContracts => [
+                                {
+                                    EndDate => '12/12/2024 12:21',
+                                    ServiceContractStatus => 'NOACTIVE',
+                                    Payments => [
+                                        {
+                                            PaymentStatus => "Paid",
+                                            PaymentMethod => "Direct debit",
+                                            Amount => 55
+                                        }
+                                    ]
+                                },
                                 {
                                     EndDate => '12/12/2025 12:21',
                                     ServiceContractStatus => 'ACTIVE',


### PR DESCRIPTION
[skip changelog]