### PR TITLE
Improved accessibility for links

### DIFF
--- a/web/cobrands/fixmystreet.com/base.scss
+++ b/web/cobrands/fixmystreet.com/base.scss
@@ -369,6 +369,15 @@ html.lazyload .js-lazyload {
     background: none;
     margin: 0;
   }
+
+  // Applies text-decoration underline only to links that are in areas where there is a lot of text, so they could be easily missed by someone with visual impairments.
+  a {
+    text-decoration: underline;
+
+    &:hover, &:focus {
+      text-decoration: none;
+    }
+  }
 }
 
 .footer-marketing {

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -6,8 +6,8 @@ $heading-font: "Museo300-display", MuseoSans, Helmet, Freesans, sans-serif !defa
 $menu-image: "menu-white" !default;
 $close-menu-image: "close-#{$menu-image}" !default;
 
-$link-color: #005ea5 !default;
-$link-hover-color: #2b8cc4 !default;
+$link-color: #005A9E !default;
+$link-hover-color: #1573b9 !default;
 $link-visited-color: $link-color !default;
 $link-text-decoration: none !default;
 $link-hover-text-decoration: underline !default;
@@ -262,6 +262,12 @@ a,
   &:active {
     text-decoration: $link-hover-text-decoration;
     color: $link-hover-color;
+  }
+
+  &:focus-visible {
+    box-shadow: 0px 0px 0px 5px #000;
+    outline: 3px solid $primary;
+    outline-offset: 2px;
   }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4538

- Increased colour contrast for link's default state(AA -> AAA)
- Increased colour contrast for link's hover state(Failed -> AA)
- Added text-decoration underline, so it's more noticeable for users with visual impairments that there is a link.
- Improved focus state by adding box-shadow and outline.

**Note:** We could have used the existing variables to change the underline `$link-text-decoration` and `$link-hover-text-decoration` behaviour. The problem with this alternative is that by adding an underline to the default state, we are also adding an underline to the links in the footer, navbar, sticky sidebar and links nested inside `item-list__item`. But it looks a bit jarring. It's probably why we got rid of the underline by default in the first place. I thought of two alternatives:

Option 1: We could have created new variables to control each of the underline property for those links. This would also help tidy up(not massively, though) cobrands by getting rid of the overrides in them.
Option 2: We make `$link-text-decoration` and `$link-hover-text-decoration` apply only to links nested inside `.container--sidebar .content`(this would also affect the admin page), considering this underline is more relevant when the link is surrounded by a lot of text, making it easy to miss, especially if you struggle with colour blindness. Alternative instead of `.container--sidebar .content` we could add a new class like `content-text` that represents a bit better the context.

Overall, if we wanted to move ahead with any of the alternatives above, I would also suggest creating variables for the link's `outline`, `outline-offset` and `box-shadow` properties, which is becoming more common when styling cobrands.

Let me know what you think, the initial approach on this PR was probably the most straight forward to implement without messing with the cobrands.

[Skip changelog]