### PR TITLE
Remove any use of my $x if $foo.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -356,7 +356,7 @@ sub by_category_ajax_data : Private {
         $body->{councils_text} = $c->render_fragment( 'report/new/councils_text.html');
     }
 
-    my $cobrand_overrides = $c->stash->{cobrand_field_overrides_by_body}->{$bodies->[0]->{id}} if @$bodies == 1;
+    my $cobrand_overrides = @$bodies == 1 ? $c->stash->{cobrand_field_overrides_by_body}->{$bodies->[0]->{id}} : undef;
     my $category_overrides = $lookups->{overrides}{$category};
 
     my $title_label_override = $cobrand_overrides->{title_label};
@@ -1137,7 +1137,7 @@ sub process_report : Private {
     # create a session here if it doesn't already exist (which accessing
     # $c->session does) as that can cause CSRF failures for e.g. visitors coming
     # directly to /report/new (as tested in camden.t)
-    my $service = $c->session->{app_platform} if $c->sessionid;
+    my $service = $c->sessionid ? $c->session->{app_platform} : undef;
     # The old app sends the platform as a query parameter when POSTing reports.
     $service ||= $c->get_param('service');
 

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1684,7 +1684,10 @@ sub add_report : Private {
     };
 
     # Don’t let staff inadvertently change their name when making reports
-    my $original_name = $c->user->name if $c->user_exists && $c->user->from_body && $c->user->email eq ($data->{email} || '');
+    my $original_name;
+    if ($c->user_exists && $c->user->from_body && $c->user->email eq ($data->{email} || '')) {
+        $original_name = $c->user->name;
+    }
 
     # We want to take what has been entered in the form, even if someone is logged in
     $c->stash->{ignore_logged_in_user} = 1;

--- a/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Buckinghamshire.pm
@@ -260,7 +260,7 @@ sub _add_claim_auto_response {
 
     # Attach auto-response template if present
     my $template = $row->response_templates->search({ 'me.state' => $row->state })->first;
-    my $description = $template->text if $template;
+    my $description = $template ? $template->text : undef;
     if ( $description ) {
         my $updates = Open311::GetServiceRequestUpdates->new(
             system_user => $user,
@@ -833,7 +833,8 @@ sub munge_contacts_to_bodies {
     if (!$greater_than_30) {
         # Look up the report's location on the speed limit WFS server
         my $speed_limit_xml = $self->speed_limit_wfs_query($report);
-        my $speed_limit = $1 if $speed_limit_xml =~ /<OS_Highways_Speed:speed>([\.\d]+)<\/OS_Highways_Speed:speed>/;
+        my $speed_limit;
+        $speed_limit = $1 if $speed_limit_xml =~ /<OS_Highways_Speed:speed>([\.\d]+)<\/OS_Highways_Speed:speed>/;
 
         if ($speed_limit) {
             $greater_than_30 = $speed_limit > 30 ? 'yes' : 'no';

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -770,8 +770,8 @@ sub bin_services_for_address {
             $property->{has_black_bin} = 1;
         }
 
-        my $last_obj = { date => $last, ordinal => ordinal($last->day) } if $last;
-        my $next_obj = { date => $next, ordinal => ordinal($next->day) } if $next;
+        my $last_obj = $last ? { date => $last, ordinal => ordinal($last->day) } : undef;
+        my $next_obj = $next ? { date => $next, ordinal => ordinal($next->day) } : undef;
         my $row = {
             id => $_->{JobID},
             last => $last_obj,

--- a/perllib/Open311/UpdatesBase.pm
+++ b/perllib/Open311/UpdatesBase.pm
@@ -303,7 +303,7 @@ sub _process_update {
 sub comment_text_for_request {
     my ($self, $template, $request, $problem) = @_;
 
-    my $template_email_text = $template->email_text if $template;
+    my $template_email_text = $template ? $template->email_text : undef;
     $template = $template->text if $template;
 
     my $desc = $request->{description} || '';


### PR DESCRIPTION
As perlsyn says, "NOTE: The behaviour of a `my`, `state`, or `our` modified with a statement modifier conditional or loop construct (for example, `my $x if ...`) is undefined. The value of the `my` variable may be `undef`, any previously assigned value, or possibly anything else."

Repeat of #2377 [skip changelog]