### PR TITLE
[Bexley] Add Content-Length header to DD requests

### DIFF
--- a/perllib/Integrations/AccessPaySuite.pm
+++ b/perllib/Integrations/AccessPaySuite.pm
@@ -93,7 +93,6 @@ sub headers {
 
     return {
         'Accept' => 'application/json',
-        'Content-Type' => 'application/x-www-form-urlencoded',
         'User-Agent' => 'WasteWorks by SocietyWorks (swtech@societyworks.org)',
         'ApiKey' => $self->config->{api_key},
     };
@@ -128,12 +127,12 @@ sub build_request_url {
 
 sub create_request {
     my ($self, $method, $url, $data) = @_;
-    my $content = ($method eq 'POST' || $method eq 'PUT') ? $self->build_form_data($data) : '';
 
-    return HTTP::Request->new(
-        $method => $url,
-        HTTP::Headers->new(%{ $self->headers }),
-        $content
+    my $headers = $self->headers();
+
+    return HTTP::Request::Common->can($method)->($url,
+        $method eq 'POST' || $method eq 'PUT' ? $data : (),
+        %$headers
     );
 }
 

--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -1868,6 +1868,21 @@ FixMyStreet::override_config {
             };
         };
     };
+
+    subtest 'Test AccessPaySuite create_request' => sub {
+        my $aps = Integrations::AccessPaySuite->new(config => { api_key => 'test-api-key', endpoint => 'http://example.com' });
+
+        my $req = $aps->create_request('POST', 'http://example.com/test', { param1 => 'value1', param2 => 'value2' });
+        is $req->header('Content-Length'), length($req->content), 'Content-Length matches content length';
+        is $req->header('Content-Type'), 'application/x-www-form-urlencoded', 'Content-Type is set correctly';
+        like $req->content, qr/param1=value1/, 'param1 is correct';
+        like $req->content, qr/param2=value2/, 'param2 is correct';
+        is $req->method, 'POST', 'Method is correct';
+        is $req->uri, 'http://example.com/test', 'URI is correct';
+        like $req->header('User-Agent'), qr/WasteWorks by SocietyWorks/, 'User-Agent is correct';
+        is $req->header('ApiKey'), 'test-api-key', 'ApiKey is correct';
+        is $req->header('Accept'), 'application/json', 'Accept is correct';
+    };
 };
 
 sub get_report_from_redirect {


### PR DESCRIPTION
This ensures that HTTP requests made to the Access PaySuite API have the correct Content-Length header set, which it seems to require, for POST requests at least.

Spotted this when trying to archive contracts manually from the CLI.

<!-- [skip changelog] -->