### PR TITLE
[Bexley][WW] Send UPRN in additionalReference field for DDs

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
@@ -268,6 +268,7 @@ sub waste_setup_direct_debit {
     my $email = $report->user->email;
 
     my $data = $c->stash->{form_data};
+    my $uprn = $report->get_extra_field_value('uprn');
 
     my $i = $self->get_dd_integration;
 
@@ -297,7 +298,7 @@ sub waste_setup_direct_debit {
         paymentMonthInYear => $c->stash->{payment_date}->month,
         paymentDayInMonth => 28, # Always the 28th for Bexley
         amount => $c->stash->{amount},
-        additionalReference => $c->stash->{reference},
+        additionalReference => $uprn,
     };
 
     if ($customer->{error}) {

--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -986,7 +986,7 @@ FixMyStreet::override_config {
             paymentMonthInYear => 1,
             amount => '70.00',
             start => '2024-01-28T17:00:00.000',
-            additionalReference => "BEX-$id-10001",
+            additionalReference => "10001",
         }, 'Contract parameters are correct';
 
         $mech->content_contains('Your Direct Debit has been set up successfully');
@@ -1546,7 +1546,7 @@ FixMyStreet::override_config {
         ok $report, "Found the report";
 
         # Check a couple of contract params
-        is $contract_params->{additionalReference}, 'BEX-' . $report->id . '-10001', 'Correct additional reference';
+        is $contract_params->{additionalReference}, '10001', 'Correct additional reference';
         is $contract_params->{amount}, '125.00', 'Correct amount';
 
         is $report->title, "Garden Subscription - Renew", "Correct title";


### PR DESCRIPTION
When creating a Direct Debit in Access PaySuite Bexley want the property UPRN to go in the additionalReference field to make it easier for them to match things up.

For [Additional reference field in DDCMS](https://3.basecamp.com/4020879/buckets/40373795/todos/8415278536)

<!-- [skip changelog] -->