### PR TITLE
[FMS] Test receiving stopper categories from open311

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -405,7 +405,7 @@ sub disable_form_message : Private {
         } elsif (($_->{variable} || '') eq 'true' && @{$_->{values} || []}) {
             my %category;
             foreach my $opt (@{$_->{values}}) {
-                if ($opt->{disable}) {
+                if ($opt->{disable} || $opt->{disable_message}) {
                     my $message = $opt->{disable_message} || $_->{datatype_description};
                     $category{$message} ||= {};
                     $category{$message}->{message} = $message;
@@ -2066,7 +2066,7 @@ sub generate_category_extra_json : Private {
         # Mobile app still looks in datatype_description
         if (($_->{variable} || '') eq 'true' && @{$_->{values} || []}) {
             foreach my $opt (@{$_->{values}}) {
-                if ($opt->{disable}) {
+                if ($opt->{disable} || $opt->{disable_message}) {
                     $opt->{disable} = "1";
                     my $message = $opt->{disable_message} || $_->{datatype_description};
                     $data{datatype_description} = $message;

--- a/t/app/controller/report_new_open311.t
+++ b/t/app/controller/report_new_open311.t
@@ -398,9 +398,9 @@ subtest "Category extras includes form disabling string" => sub {
         });
         $contact4->push_extra_fields({ datatype_description => 'Please ring different numbers', description => 'What sort of dangerous?', code => 'danger_type',
             variable => 'true', order => '0', values => [
-                { name => 'slightly', key => 'slightly', disable => 1, disable_message => 'Ring the slightly number'  },
-                { name => 'very', key => 'very', disable => 1, disable_message => 'Ring the very number'  },
-                { name => 'extremely', key => 'extremely', disable => 1, disable_message => 'Ring the very number'  },
+                { name => 'slightly', key => 'slightly', disable_message => 'Ring the slightly number'  },
+                { name => 'very', key => 'very', disable_message => 'Ring the very number'  },
+                { name => 'extremely', key => 'extremely', disable_message => 'Ring the very number'  },
                 { name => 'No', key => 'no' }
             ]
         });

--- a/t/open311/populate-service-list.t
+++ b/t/open311/populate-service-list.t
@@ -988,6 +988,58 @@ for my $test (
     </service_definition>
         ',
     },
+    {
+        desc => 'check disable on select value set from meta',
+        has_meta => 1,
+        end_meta => [
+            {
+                variable => 'true',
+                code => 'bin_owner',
+                datatype => 'singlevaluelist',
+                datatype_description => 'Whose bin',
+                order => 1,
+                description => 'Is this your bin or another bin',
+                values => [
+                    {
+                        'name' => 'My bin',
+                        'key' => 'mine'
+                    },
+                    {
+                        'name' => 'Someone else\'s bin',
+                        'key' => 'else',
+                        'disable_message' => 'You can only report on your own bin',
+                    }
+                    ],
+            },
+        ],
+        orig_meta => [],
+        meta_xml => '<?xml version="1.0" encoding="utf-8"?>
+    <service_definition>
+        <service_code>100</service_code>
+        <attributes>
+            <attribute>
+            <code>bin_owner</code>
+            <datatype>singlevaluelist</datatype>
+            <datatype_description>Whose bin</datatype_description>
+            <description>Is this your bin or another bin</description>
+            <order>1</order>
+            <values>
+                <value>
+                <name>My bin</name>
+                <key>mine</key>
+                </value>
+                <value>
+                <name>Someone else\'s bin</name>
+                <key>else</key>
+                <disable_message>You can only report on your own bin</disable_message>
+                </value>
+            </values>
+            <variable>true</variable>
+            </attribute>
+        </attributes>
+    </service_definition>
+        ',
+    },
 ) {
     subtest $test->{desc} => sub {
         my $processor = Open311::PopulateServiceList->new();


### PR DESCRIPTION
Check that stopper categories in the metadata are added to options.

https://github.com/mysociety/societyworks/issues/4757

[skip changelog]