### PR TITLE
[Bexley] Don't show form on double submission

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Form.pm
+++ b/perllib/FixMyStreet/App/Controller/Form.pm
@@ -87,10 +87,15 @@ sub form : Private {
 
     $form->process unless $form->processed;
 
-    # If we have sent a confirmation email, that function will have
-    # set a template that we need to show
-    $c->stash->{template} = $c->stash->{override_template} || $form->template || $self->index_template
-        unless $c->stash->{sent_confirmation_message};
+    # If the form has the already_submitted_error flag set, show the already_submitted template
+    if ($form->already_submitted_error) {
+        $c->stash->{template} = 'waste/already_submitted.html';
+    } else {
+        # If we have sent a confirmation email, that function will have
+        # set a template that we need to show
+        $c->stash->{template} = $c->stash->{override_template} || $form->template || $self->index_template
+            unless $c->stash->{sent_confirmation_message};
+    }
     $c->stash->{form} = $form;
 }
 

--- a/perllib/FixMyStreet/App/Form/Wizard.pm
+++ b/perllib/FixMyStreet/App/Form/Wizard.pm
@@ -26,6 +26,8 @@ has saved_data => ( is => 'rw', lazy => 1, isa => 'HashRef', default => sub {
 has previous_form => ( is => 'ro', isa => 'Maybe[HTML::FormHandler]', weak_ref => 1 );
 has csrf_token => ( is => 'ro', isa => 'Str' );
 
+has already_submitted_error => ( is => 'rw', isa => 'Bool', default => 0 );
+
 has_field saved_data => ( type => 'JSON' );
 has_field token => ( type => 'Hidden', required => 1 );
 has_field process => ( type => 'Hidden', required => 1 );
@@ -122,6 +124,7 @@ after 'validate_form' => sub {
         # Mismatch of unique ID, resubmission?
         if ($self->unique_id_session && $page->check_unique_id && $self->unique_id_session ne ($self->unique_id_form || '')) {
             $self->add_form_error('You have already submitted this form.');
+            $self->already_submitted_error(1);
             return;
         }
 

--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -966,6 +966,9 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { tandc => 1 } });
         $mech->content_lacks('Your Direct Debit has been set up successfully');
         $mech->content_contains('You have already submitted this form');
+        $mech->content_contains('To avoid duplicate submissions, this form cannot be resubmitted.');
+        $mech->content_lacks('Change answers');
+        $mech->content_lacks('Please review the information you’ve provided before you submit your garden subscription');
 
         is $report->get_extra_metadata('direct_debit_customer_id'), 'CUSTOMER123', 'Correct customer ID';
         is $report->get_extra_metadata('direct_debit_contract_id'), 'CONTRACT123', 'Correct contract ID';

--- a/templates/web/base/waste/already_submitted.html
+++ b/templates/web/base/waste/already_submitted.html
@@ -1,0 +1,19 @@
+[% SET title = 'Form Already Submitted' %]
+[% PROCESS 'waste/header.html' %]
+
+<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Important
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">
+      You have already submitted this form.
+    </p>
+    <p class="govuk-body">To avoid duplicate submissions, this form cannot be resubmitted. If you need to make changes or have questions about your submission, please contact us.</p>
+    <a href="/waste" class="govuk-button">Return to homepage</a>
+  </div>
+</div>
+
+[% INCLUDE footer.html %]


### PR DESCRIPTION
If a user refreshes the page after submitting the form we detect this and show them an error.

I also tried adding a check for an existing sub in Agile before creating the Direct Debit, but this doesn't work in the case of a renewal where a user is switching from Credit/Debit Card to Direct Debit, in which case there will already be a sub in Agile. Might be possible to do something there, but was a bit fiddly, and we're already checking for an existing sub in the main flow, so this is a bit of an edge case.

[Related Slack thread](https://mysociety.slack.com/archives/C07H1MFDNRG/p1742908679431989)

<img width="1177" alt="image" src="https://github.com/user-attachments/assets/e5e29eaa-bb98-4b00-8096-b203a32ca2fa" />

<!-- [skip changelog] -->
