### PR TITLE
[Bexley] Default email address for Direct Debit when not provided

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
@@ -285,7 +285,7 @@ sub waste_setup_direct_debit {
     my $c = $self->{c};
 
     my $report = $c->stash->{report};
-    my $email = $report->user->email;
+    my $email = $report->user->email || 'gardenwaste@' . $self->admin_user_domain;
 
     my $data = $c->stash->{form_data};
     my $uprn = $report->get_extra_field_value('uprn');


### PR DESCRIPTION
Staff aren't required to enter an email address, so set a default in that case as the email is required by Access PaySuite for setting up the Direct Debit.

For [this Basecamp todo](https://3.basecamp.com/4020879/buckets/40373795/todos/8471147856).

<!-- [skip changelog] -->
