### PR TITLE
[Bexley] Removes warnings from test output

### DIFF
--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -5,8 +5,8 @@ use FixMyStreet::TestMech;
 use FixMyStreet::Script::Reports;
 use List::MoreUtils qw(firstidx);
 
-FixMyStreet::App->log->disable('info');
-END { FixMyStreet::App->log->enable('info'); }
+FixMyStreet::App->log->disable('info', 'error');
+END { FixMyStreet::App->log->enable('info', 'error'); }
 
 my $addr_mock = Test::MockModule->new('BexleyAddresses');
 # We don't actually read from the file, so just put anything that is a valid path
@@ -1122,6 +1122,7 @@ FixMyStreet::override_config {
                         {
                             EndDate => '12/12/2025 12:21',
                             ServiceContractStatus => 'ACTIVE',
+                            WasteContainerQuantity => 2,
                             Payments => [ { PaymentStatus => 'Paid', Amount => '100', PaymentMethod => 'Credit/Debit Card' } ]
                         },
                     ],
@@ -1385,6 +1386,7 @@ FixMyStreet::override_config {
                                 ServiceContractStatus => 'ACTIVE',
                                 Reference => $contract_id,
                                 WasteContainerQuantity => 2,
+                                Payments => [ { PaymentStatus => 'Paid', Amount => '100', PaymentMethod => 'Credit/Debit Card' } ],
                             },
                         ],
                     },
@@ -1484,6 +1486,7 @@ FixMyStreet::override_config {
                             Reference => $contract_id,
                             WasteContainerQuantity => 2,
                             ServiceContractStatus => 'ACTIVE',
+                            Payments => [ { PaymentStatus => 'Paid', Amount => '100', PaymentMethod => 'Credit/Debit Card' } ],
                         },
                     ],
                 },


### PR DESCRIPTION
Hide api errors for duration of tests and add in data to remove uninitialised variable warnings.

https://github.com/mysociety/societyworks/issues/4880

