### PR TITLE
[Waste] When checking update, add parameter to URL

### DIFF
--- a/web/cobrands/fixmystreet-uk-councils/refresh.js
+++ b/web/cobrands/fixmystreet-uk-councils/refresh.js
@@ -4,7 +4,9 @@ const us = document.getElementById('page-refresh');
 const every = us.dataset.every || 2;
 
 function update() {
-    fetch(window.location.href, { headers: { 'x-requested-with': 'fetch' } })
+    const url = new URL(window.location.href);
+    url.searchParams.append('page_loading', 1);
+    fetch(url, { headers: { 'x-requested-with': 'fetch' } })
         .then(resp => resp.text())
         .then(html => {
             const parser = new DOMParser();


### PR DESCRIPTION
Chrome sometimes caches the ajax response (without header or footer) and can show that when clicking Back/Forward. [skip changelog] FD-5311