### PR TITLE
[Bexley] Handle Bexley addresses that are not on Bexley streets

### DIFF
--- a/perllib/BexleyAddresses.pm
+++ b/perllib/BexleyAddresses.pm
@@ -82,7 +82,7 @@ sub addresses_for_postcode {
           $address_fields
      FROM lpi
      JOIN blpu ON lpi.uprn = blpu.uprn
-     JOIN street_descriptors sd ON sd.usrn = lpi.usrn
+     LEFT JOIN street_descriptors sd ON sd.usrn = lpi.usrn
     WHERE postcode = ?
       AND class != 'P' AND class != 'PP'
 SQL
@@ -125,7 +125,7 @@ sub address_for_uprn {
           $address_fields
      FROM lpi
      JOIN blpu ON lpi.uprn = blpu.uprn
-     JOIN street_descriptors sd ON sd.usrn = lpi.usrn
+     LEFT JOIN street_descriptors sd ON sd.usrn = lpi.usrn
     WHERE lpi.uprn = ?
 SQL
         undef,


### PR DESCRIPTION
Bexley have a unique record in their systems where the property is in Bexley, but the street isn't. This means we need to relax the requirement for a matching street record when doing postcode and uprn lookups.

For FD-5333

---

The only slight issue with this is that because there's no associated street record it's displayed as just the property number, but I think that's ok for this unique situation.

<img width="1024" alt="image" src="https://github.com/user-attachments/assets/e7bda6d5-c71b-45fe-94f9-657c8e1f6c89" />

<!-- [skip changelog] -->
