### PR TITLE
[Bristol] Send Dott reports to a different email address

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bristol.pm
+++ b/perllib/FixMyStreet/Cobrand/Bristol.pm
@@ -384,6 +384,16 @@ sub munge_sendreport_params {
 
         $params->{To} = $to;
     }
+
+    # Check if this is a Dott report made within Bristol
+    # and change the destination email address if so.
+    my @areas = split(",", $row->areas);
+    my %ids = map { $_ => 1 } @areas;
+    if ($row->category eq 'Abandoned Dott bike or scooter' && $ids{2561}) {
+        if (my $email = $self->feature("dott_email")) {
+            $params->{To}->[0]->[0] = $email;
+        }
+    }
 }
 
 1;

--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -575,6 +575,17 @@ sub get_body_handler_for_problem {
 around 'munge_sendreport_params' => sub {
     my ($orig, $self, $row, $h, $params) = @_;
 
+    # Check if this is a Dott report made within Bristol
+    # and change the destination email address if so.
+    my @areas = split(",", $row->areas);
+    my %ids = map { $_ => 1 } @areas;
+    if ($row->category eq 'Abandoned Dott bike or scooter' && $ids{2561}) {
+        my $cobrand = FixMyStreet::Cobrand::Bristol->new;
+        if (my $email = $cobrand->feature("dott_email")) {
+            $params->{To}->[0]->[0] = $email;
+        }
+    }
+
     my $to = $params->{To}->[0]->[0];
     if ($to !~ /(cumbria|northamptonshire|nyorks|somerset)$/) {
         return $self->$orig($row, $h, $params);


### PR DESCRIPTION
For FD-4905

To test locally you will need:

```yaml
COBRAND_FEATURES:
  dott_email:
    bristol: foo@bar.example.org
```

[skip changelog]