### PR TITLE
[UK] Add reporter-open/staff updates_allowed option

### DIFF
--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -487,6 +487,8 @@ sub _updates_disallowed_check {
         return $cfg unless $reporter && $open;
     } elsif ($cfg eq 'reporter/staff') {
         return $cfg unless $reporter || $staff;
+    } elsif ($cfg eq 'reporter-open/staff') {
+        return $cfg unless ( $reporter && $open )|| $staff;
     } elsif ($cfg eq 'reporter/staff-open') {
         return $cfg unless ($reporter || $staff) && $open;
     } elsif ($cfg eq 'notopen311') {

--- a/t/cobrand/councils.t
+++ b/t/cobrand/councils.t
@@ -59,6 +59,8 @@ subtest "Test update shown/not shown appropriately" => sub {
             { type => 'reporter-open', state => 'closed', update => [0,0,0] },
             { type => 'reporter-open', state => 'in progress', update => [0,1,0] },
             { type => 'reporter/staff', update => [0,1,1] },
+            { type => 'reporter-open/staff', update => [0,1,1] },
+            { type => 'reporter-open/staff', state => 'closed', update => [0,0,1] },
             { type => 'reporter/staff-open', state => 'closed', update => [0,0,0] },
             { type => 'reporter/staff-open', state => 'in progress', update => [0,1,1] },
             { type => 'open', state => 'closed', update => [0,0,0] },


### PR DESCRIPTION
The permutation requested in https://github.com/mysociety/societyworks/issues/4792 didn't exist, but now it does.

[skip changelog]