### PR TITLE
[Sutton] Update Time-banded info-box group name check

### DIFF
--- a/perllib/FixMyStreet/Roles/Cobrand/SLWP.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/SLWP.pm
@@ -207,14 +207,6 @@ sub waste_extra_service_info {
             $property->{domestic_refuse_bin} = 1;
         }
         $self->{c}->stash->{communal_property} = 1 if $service_id == $TASK_IDS{communal_refuse} || $service_id == $TASK_IDS{communal_food} || $service_id == $TASK_IDS{communal_paper} || $service_id == $TASK_IDS{communal_mixed};
-
-        # Check for time-banded property
-        my $schedules = $_->{Schedules};
-        if ($self->moniker eq 'sutton' && $schedules->{next}{schedule}) {
-            my $round_group_name = $schedules->{next}{schedule}{Allocation}{RoundGroupName} || '';
-            $self->{c}->stash->{property_time_banded} = 1 if $round_group_name eq "SF Night Time Economy";
-        }
-
     }
 }
 

--- a/perllib/FixMyStreet/Roles/Cobrand/SLWP2.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/SLWP2.pm
@@ -206,15 +206,10 @@ sub waste_extra_service_info {
             $property->{domestic_refuse_bin} = 1;
         }
         $self->{c}->stash->{communal_property} = 1 if $service_id == $service_ids->{communal_refuse} || $service_id == $service_ids->{communal_food} || $service_id == $service_ids->{communal_paper} || $service_id == $service_ids->{communal_mixed};
-        $self->{c}->stash->{fas_property} = 1 if $service_id == $service_ids->{fas_refuse} || $service_id == $service_ids->{fas_mixed};
 
-        # Check for time-banded property
-        my $schedules = $_->{Schedules};
-        if ($self->moniker eq 'sutton' && $schedules->{next}{schedule}) {
-            my $round_group_name = $schedules->{next}{schedule}{Allocation}{RoundGroupName} || '';
-            $self->{c}->stash->{property_time_banded} = 1 if $round_group_name eq "SF Night Time Economy";
+        if ($service_id == $service_ids->{fas_refuse} || $service_id == $service_ids->{fas_mixed}) {
+            $self->{c}->stash->{fas_property} = 1 if $service_id == $service_ids->{fas_refuse} || $service_id == $service_ids->{fas_mixed};
         }
-
     }
 }
 

--- a/t/app/controller/waste_sutton_r.t
+++ b/t/app/controller/waste_sutton_r.t
@@ -456,9 +456,7 @@ FixMyStreet::override_config {
     };
 
     subtest 'Time banded property display' => sub {
-        my $dupe = dclone($bin_data);
-        $dupe->[0]{ServiceTasks}{ServiceTask}[0]{ServiceTaskSchedules}{ServiceTaskSchedule}{Allocation}{RoundGroupName} = 'SF Night Time Economy';
-        $e->mock('GetServiceUnitsForObject', sub { $dupe });
+        $e->mock('GetServiceUnitsForObject', sub { $above_shop_data });
         $mech->get_ok('/waste/12345');
         $mech->content_contains('Put your bags out between 6pm and 8pm');
         $e->mock('GetServiceUnitsForObject', sub { $bin_data });

--- a/templates/web/sutton/waste/_announcement.html
+++ b/templates/web/sutton/waste/_announcement.html
@@ -1,4 +1,4 @@
-[% IF property_time_banded %]
+[% IF fas_property %]
 <p class="govuk-warning-text error">
     <strong class="govuk-warning-text__text">
     Put your bags out between 6pm and 8pm. Find out more about time-banded collections on our web page


### PR DESCRIPTION
Following on the from the recent change to a new Echo system this RoundGroupName that's used to check whether the time-banded info box should be shown has been renamed, so this updates the code to use the new name.

<!-- [skip changelog] -->

For FD-5402