### PR TITLE
[Bexley] GGW amend DD amount

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1308,6 +1308,7 @@ sub garden_modify : Chained('garden_setup') : Args(0) {
         };
 
         $c->stash->{form_class} = 'FixMyStreet::App::Form::Waste::Garden::Modify';
+        $c->stash->{current_payment_method} = $payment_method;
     }
 
     $c->stash->{first_page} = 'intro';

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -485,7 +485,6 @@ sub direct_debit_modify : Private {
 
     my $ref = $c->stash->{orig_sub}->get_extra_metadata('payerReference');
     $p->set_extra_metadata(payerReference => $ref);
-    $p->confirm if $c->cobrand->moniker eq 'bexley';
     $p->update;
     $c->cobrand->call_hook('waste_report_extra_dd_data');
 
@@ -517,6 +516,11 @@ sub direct_debit_modify : Private {
         amount => sprintf('%.2f', $total / 100),
         orig_sub => $c->stash->{orig_sub},
     } );
+
+    if ( $c->cobrand->moniker eq 'bexley' ) {
+        $p->confirm;
+        $p->update;
+    }
 }
 
 sub direct_debit_cancel_sub : Private {
@@ -525,8 +529,6 @@ sub direct_debit_cancel_sub : Private {
     my $p = $c->stash->{report};
     my $ref = $c->stash->{orig_sub}->get_extra_metadata('payerReference');
     $p->set_extra_metadata(payerReference => $ref);
-    # Bexley can have immediate cancellation
-    $p->confirm if $c->cobrand->moniker eq 'bexley';
     $p->update;
     $c->cobrand->call_hook('waste_report_extra_dd_data');
 
@@ -537,6 +539,12 @@ sub direct_debit_cancel_sub : Private {
         payer_reference => $ref,
         report => $p,
     } );
+
+    # Bexley can have immediate cancellation
+    if ( $c->cobrand->moniker eq 'bexley' ) {
+        $p->confirm;
+        $p->update;
+    }
 }
 
 sub csc_code : Private {

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -497,6 +497,8 @@ sub direct_debit_modify : Private {
 
     my $i = $c->cobrand->get_dd_integration;
 
+    # TODO Display error messages to user
+
     # if reducing bin count then there won't be an ad-hoc payment
     if ( $ad_hoc ) {
         my $one_off_ref = $i->one_off_payment( {

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1511,7 +1511,15 @@ sub process_garden_modification : Private {
     my $payment_method;
     # Needs to check current subscription too
     my $service = $c->cobrand->garden_current_subscription;
-    my $costs = WasteWorks::Costs->new({ cobrand => $c->cobrand, discount => $data->{apply_discount} });
+    my $costs = WasteWorks::Costs->new(
+        {   cobrand            => $c->cobrand,
+            discount           => $data->{apply_discount},
+            first_bin_discount => $c->cobrand->call_hook(
+                garden_waste_first_bin_discount_applies => $data
+            ) || 0,
+        }
+    );
+
     if ($c->stash->{slwp_garden_sacks} && $service->{garden_container} == $GARDEN_IDS{$c->cobrand->moniker}{sack}) { # SLWP Sack
         # This must be Kingston
         $data->{bins_wanted} = 1;

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -485,6 +485,7 @@ sub direct_debit_modify : Private {
 
     my $ref = $c->stash->{orig_sub}->get_extra_metadata('payerReference');
     $p->set_extra_metadata(payerReference => $ref);
+    $p->confirm if $c->cobrand->moniker eq 'bexley';
     $p->update;
     $c->cobrand->call_hook('waste_report_extra_dd_data');
 

--- a/perllib/FixMyStreet/App/Form/Waste/Garden/Modify.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Garden/Modify.pm
@@ -79,6 +79,11 @@ has_page summary => (
         my $current_bins = $data->{current_bins};
         my $bin_count = $data->{bins_wanted};
         my $new_bins = $bin_count - $current_bins;
+
+        # We need to make sure we have payment_method before we call
+        # garden_waste_first_bin_discount_applies
+        $data->{payment_method}
+            = $c->stash->{garden_form_data}->{payment_method};
         my $costs = WasteWorks::Costs->new({
             cobrand => $c->cobrand,
             discount => $data->{apply_discount},
@@ -90,7 +95,6 @@ has_page summary => (
         my $total = $cost_pa;
         $pro_rata += $cost_now_admin;
 
-        $data->{payment_method} = $c->stash->{garden_form_data}->{payment_method};
         $data->{cost_now_admin} = $cost_now_admin / 100;
         $data->{display_pro_rata} = $pro_rata < 0 ? 0 : $pro_rata / 100;
         $data->{display_total} = $total / 100;

--- a/perllib/FixMyStreet/App/Form/Waste/Garden/Modify.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Garden/Modify.pm
@@ -37,7 +37,11 @@ has_page alter => (
         my $new_bins = $bins_wanted - $current_bins;
 
         my $edit_current_allowed = $c->cobrand->call_hook('waste_allow_current_bins_edit');
-        my $costs = WasteWorks::Costs->new({ cobrand => $c->cobrand, discount => $form->saved_data->{apply_discount} });
+        my $costs = WasteWorks::Costs->new({
+            cobrand => $c->cobrand,
+            discount => $form->saved_data->{apply_discount},
+            first_bin_discount => $c->cobrand->call_hook(garden_waste_first_bin_discount_applies => $data) || 0,
+        });
         my $cost_pa = $costs->bins($bins_wanted);
         my $cost_now_admin = $costs->new_bin_admin_fee($new_bins);
         $c->stash->{cost_pa} = $cost_pa / 100;
@@ -75,7 +79,11 @@ has_page summary => (
         my $current_bins = $data->{current_bins};
         my $bin_count = $data->{bins_wanted};
         my $new_bins = $bin_count - $current_bins;
-        my $costs = WasteWorks::Costs->new({ cobrand => $c->cobrand, discount => $data->{apply_discount} });
+        my $costs = WasteWorks::Costs->new({
+            cobrand => $c->cobrand,
+            discount => $data->{apply_discount},
+            first_bin_discount => $c->cobrand->call_hook(garden_waste_first_bin_discount_applies => $data) || 0,
+        });
         my $pro_rata = $costs->pro_rata_cost($new_bins);
         my $cost_pa = $costs->bins($bin_count);
         my $cost_now_admin = $costs->new_bin_admin_fee($new_bins);

--- a/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
@@ -71,15 +71,17 @@ sub lookup_subscription_for_uprn {
     return unless $customer && $contract;
 
     # XXX should maybe sort by CreatedDate rather than assuming first is OK
-    $sub->{cost} = try {
-        my ($payment) = grep { $_->{PaymentStatus} =~ /(Paid|Pending)/ } @{ $contract->{Payments} };
-        if ($payment && $payment->{PaymentMethod} eq 'Direct debit') {
-            # Got an active contract with a DD payment method, nothing due to renew
-            $self->{c}->stash->{direct_debit_status} = 'active';
-            $sub->{has_been_renewed} = 1;
-        }
-        return $payment->{Amount} // 0;
-    };
+    my ($payment) = grep { $_->{PaymentStatus} =~ /(Paid|Pending)/ } @{ $contract->{Payments} };
+    my $payment_method
+        = $payment && $payment->{PaymentMethod} eq 'Direct debit'
+        ? 'direct_debit'
+        : 'credit_card';
+
+    if ($payment_method eq 'direct_debit') {
+        # Got an active contract with a DD payment method, nothing due to renew
+        $self->{c}->stash->{direct_debit_status} = 'active';
+        $sub->{has_been_renewed} = 1;
+    }
 
     my $parser = DateTime::Format::Strptime->new( pattern => '%d/%m/%Y %H:%M' );
     $sub->{end_date} = $parser->parse_datetime( $contract->{EndDate} );
@@ -90,6 +92,17 @@ sub lookup_subscription_for_uprn {
     $sub->{customer_external_ref} = $customer->{CustomerExternalReference};
 
     $sub->{bins_count} = $contract->{WasteContainerQuantity};
+
+    # Agile does not necessarily return the correct cost, so calculate instead
+    my $costs = WasteWorks::Costs->new(
+        {   cobrand => $self,
+            first_bin_discount =>
+                $self->garden_waste_first_bin_discount_applies(
+                    { payment_method => $payment_method }
+                ),
+        },
+    );
+    $sub->{cost} = $costs->bins( $sub->{bins_count} ) / 100;
 
     return $sub;
 }

--- a/perllib/FixMyStreet/Roles/Cobrand/AccessPaySuite.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/AccessPaySuite.pm
@@ -21,6 +21,7 @@ sub get_dd_integration {
             api_key => $config->{dd_api_key},
             client_code => $config->{dd_client_code},
             log_ident => $config->{log_ident},
+            adhoc_schedule_id => $config->{dd_adhoc_schedule_id},
         },
     });
 }

--- a/perllib/Integrations/AccessPaySuite.pm
+++ b/perllib/Integrations/AccessPaySuite.pm
@@ -342,8 +342,8 @@ sub one_off_payment {
         # Assuming a successful response might return some data, but 1 indicates success
         return 1;
     } elsif (ref $resp eq 'HASH' && !keys %$resp) {
-         # Handle cases where success might be an empty hash {}
-         return 1;
+        # Handle cases where success might be an empty hash {}
+        return 1;
     } else {
         # Handle unexpected response format or potential success cases not returning a hash
         # Log or handle as appropriate, returning 1 for presumed success if no error indicated

--- a/perllib/Integrations/AccessPaySuite.pm
+++ b/perllib/Integrations/AccessPaySuite.pm
@@ -118,7 +118,7 @@ sub build_request_url {
     my ($self, $method, $path, $data) = @_;
     my $url = $self->endpoint . $self->build_path($path);
 
-    if ($data && ($method eq 'GET' || $method eq 'DELETE')) {
+    if ($data && ($method eq 'GET' || $method eq 'DELETE' || $method eq 'PATCH')) {
         my $query = $self->build_form_data($data);
         $url .= '?' . $query if $query;
     }

--- a/perllib/Integrations/AccessPaySuite.pm
+++ b/perllib/Integrations/AccessPaySuite.pm
@@ -249,4 +249,37 @@ sub cancel_plan {
     }
 }
 
+=item * amend_plan
+
+Amends the payment amount for an existing direct debit plan.
+
+Takes a hashref of parameters:
+- orig_sub - The original subscription report object containing the contract_id in metadata
+- amount - The new amount to be taken (decimal number with max 2 decimal places)
+
+Returns 1 on success or a hashref with an error key on failure.
+
+=cut
+
+sub amend_plan {
+    my ($self, $args) = @_;
+
+    my $contract_id = $args->{orig_sub}->get_extra_metadata('direct_debit_contract_id');
+    unless ($contract_id) {
+        die "No direct debit contract ID found in original subscription report metadata";
+    }
+
+    my $path = "contract/" . $contract_id . "/amount";
+    my $data = {
+        amount => $args->{amount},
+        comment => "WasteWorks: Plan amount amended for " . $args->{orig_sub}->id,
+    };
+
+    my $resp = $self->call('PATCH', $path, $data);
+
+    if (ref $resp eq 'HASH' && $resp->{error}) {
+        die "Error amending plan: " . $resp->{error};
+    }
+}
+
 1;

--- a/perllib/Integrations/AccessPaySuite.pm
+++ b/perllib/Integrations/AccessPaySuite.pm
@@ -350,7 +350,7 @@ sub one_off_payment {
     } else {
         # Handle unexpected response format or potential success cases not returning a hash
         # Log or handle as appropriate, returning 1 for presumed success if no error indicated
-        warn "Unexpected response format from AccessPaySuite adhoc payment: " . Dumper($resp);
+        $self->log('Unexpected response format from AccessPaySuite adhoc payment: ' . Dumper($resp) );
         return 1; # Assuming success if no error hash
     }
 }

--- a/perllib/Integrations/AccessPaySuite.pm
+++ b/perllib/Integrations/AccessPaySuite.pm
@@ -44,6 +44,7 @@ use HTTP::Request::Common;
 use JSON::MaybeXS;
 use URI::Escape;
 use URI;
+use Data::Dumper;
 
 has log_ident => (
     is => 'lazy',
@@ -279,6 +280,75 @@ sub amend_plan {
 
     if (ref $resp eq 'HASH' && $resp->{error}) {
         die "Error amending plan: " . $resp->{error};
+    }
+}
+
+=item * create_payment
+
+Creates a payment for a specified contract.
+
+=cut
+sub create_payment {
+    my ($self, $contract_id, $data) = @_;
+    return $self->call('POST', "contract/$contract_id/payment", $data);
+}
+
+=item * one_off_payment
+
+Adds an AdHoc payment to be taken for a specified contract.
+=cut
+
+sub one_off_payment {
+    my ($self, $args) = @_;
+
+    my $orig_sub = $args->{orig_sub};
+    my $adhoc_contract_id = $orig_sub->get_extra_metadata('direct_debit_adhoc_contract_id');
+
+    unless ($adhoc_contract_id) {
+        # Adhoc contract ID not found, create a new one
+        my $customer_id = $orig_sub->get_extra_metadata('direct_debit_customer_id');
+        unless ($customer_id) {
+            die "No direct debit customer ID found in original subscription report metadata";
+        }
+
+        # Create a new contract for the adhoc payment
+        my $contract_data = {
+            scheduleId => $self->config->{adhoc_schedule_id},
+            start => $args->{date}->strftime('%Y-%m-%dT%H:%M:%S.000'),
+            isGiftAid => 0,
+            terminationType => "Until further notice",
+            atTheEnd => "Switch to further notice",
+        };
+        my $resp = $self->create_contract($customer_id, $contract_data);
+
+        # TODO: Check $resp for errors before proceeding
+
+        $adhoc_contract_id = $resp->{Id};
+        # Store the new adhoc contract ID back in metadata for future use
+        $orig_sub->set_extra_metadata('direct_debit_adhoc_contract_id', $adhoc_contract_id);
+        $orig_sub->update;
+    }
+
+    # Create the adhoc payment using the determined contract ID
+    my $resp = $self->create_payment($adhoc_contract_id, {
+        amount => $args->{amount},
+        date => $args->{date}->strftime('%Y-%m-%dT%H:%M:%S.000'),
+        comment => "WasteWorks: AdHoc payment for " . $orig_sub->id,
+    });
+
+    if (ref $resp eq 'HASH' && $resp->{error}) {
+        return $resp; # Return the error hash
+    } elsif (ref $resp eq 'HASH' && keys %$resp) {
+        # Assuming a successful response might return some data, but 1 indicates success
+        return 1;
+    } elsif (ref $resp eq 'HASH' && !keys %$resp) {
+         # Handle cases where success might be an empty hash {}
+         return 1;
+    } else {
+        # Handle unexpected response format or potential success cases not returning a hash
+        # Log or handle as appropriate, returning 1 for presumed success if no error indicated
+        warn "Unexpected response format from AccessPaySuite adhoc payment: " . Dumper($resp);
+        return 1; # Assuming success if no error hash
     }
 }
 

--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -2088,8 +2088,8 @@ FixMyStreet::override_config {
                     qr/Frequency.*Pending/,
                     'garden waste shown with pending Whitespace values';
                 like $mech->text,
-                    qr/100\.00 per year \(1 bin\)/,
-                    'garden waste shown with Agile values';
+                    qr/75\.00 per year \(1 bin\)/,
+                    'garden waste shown with calculated cost';
                 like $mech->text,
                     qr/Manage garden waste bins/,
                     'management link shown';
@@ -2161,8 +2161,8 @@ FixMyStreet::override_config {
                     qr/Frequency.*Weekly/,
                     'garden waste shown with Whitespace values';
                 like $mech->text,
-                    qr/100\.00 per year \(1 bin\)/,
-                    'garden waste shown with Agile values';
+                    qr/75\.00 per year \(1 bin\)/,
+                    'garden waste shown with calculated cost';
                 unlike $mech->text,
                     qr/Your subscription is soon due for renewal/,
                     'renewal warning not shown';

--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -660,6 +660,13 @@ FixMyStreet::override_config {
                 $mech->log_in_ok( $user->email );
                 $mech->get_ok("/waste/$uprn/garden_modify");
                 like $mech->content, qr/current_bins.*value="2"/s, 'correct number of current bins prefilled';
+                my $old_annual_cost_pence
+                    = $ggw_cost_first - $ggw_first_bin_discount + $ggw_cost;
+                my $old_annual_cost_human
+                    = sprintf( '%.2f', $old_annual_cost_pence / 100 );
+                like $mech->text,
+                    qr/Total per year.*£$old_annual_cost_human/,
+                    'correct original cost displayed';
 
                 $mech->submit_form_ok(
                     {   with_fields => {
@@ -670,18 +677,22 @@ FixMyStreet::override_config {
                     "Modify"
                 );
 
-                # like $mech->text, qr/Garden waste collection3 bins/, 'correct bin total in summary';
-                my $new_annual_cost_pence = ($ggw_cost_first - $ggw_first_bin_discount) + (2 * $ggw_cost);
+                my $new_annual_cost_pence = $old_annual_cost_pence + $ggw_cost;
                 my $new_annual_cost_human = sprintf('%.2f', $new_annual_cost_pence / 100);
-                # like $mech->text, qr/Total£$new_annual_cost_human/, 'correct new annual payment total in summary';
-                # like $mech->text, qr/Total to pay today.0\.00/, 'correct today-payment in summary (zero for DD amend)';
-                # like $mech->text, qr/Your nameDD Modifier/, 'correct name in summary';
+
+                like $mech->text, qr/Garden waste collection3 bins/,
+                    'correct bin total in summary';
+                like $mech->text, qr/Total£$new_annual_cost_human/,
+                    'correct new annual payment total in summary';
+# TODO
+# like $mech->text, qr/Total to pay today.0\.00/,
+    # 'correct today-payment in summary (zero for DD amend)';
+                like $mech->text, qr/Your nameDD Modifier/,
+                    'correct name in summary';
                 my $email = $user->email;
-                # like $mech->text, qr/$email/, 'correct email in summary';
+                like $mech->text, qr/$email/, 'correct email in summary';
 
                 $mech->submit_form_ok( { with_fields => { tandc => 1 } }, "Confirm" );
-
-                diag $mech->content;
 
                 ok $amend_plan_args, 'Integrations::AccessPaySuite->amend_plan was called';
                 isa_ok $amend_plan_args->{orig_sub}, 'FixMyStreet::DB::Result::Problem', 'amend_plan received report object for original sub';

--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -684,9 +684,8 @@ FixMyStreet::override_config {
                     'correct bin total in summary';
                 like $mech->text, qr/Total£$new_annual_cost_human/,
                     'correct new annual payment total in summary';
-# TODO
-# like $mech->text, qr/Total to pay today.0\.00/,
-    # 'correct today-payment in summary (zero for DD amend)';
+                like $mech->text, qr/Total to pay today.55\.00/,
+                    'correct today-payment in summary';
                 like $mech->text, qr/Your nameDD Modifier/,
                     'correct name in summary';
                 my $email = $user->email;
@@ -712,7 +711,8 @@ FixMyStreet::override_config {
                 is $modify_report->get_extra_field_value('total_containers'), 3, 'Amend report: correct total_containers';
                 is $modify_report->get_extra_field_value('type'), 'amend', 'Amend report: correct type';
                 is $modify_report->get_extra_field_value('customer_external_ref'), 'CUSTOMER_123', 'Amend report: correct customer_external_ref';
-                is $modify_report->state, 'confirmed', 'Amend report: state correct (confirmed for DD amend)';
+                is $modify_report->state, 'confirmed',
+                    'Amend report: state correct (confirmed for DD amend)';
 
                 $access_mock->unmock_all;
             };

--- a/templates/web/base/waste/garden/modify.html
+++ b/templates/web/base/waste/garden/modify.html
@@ -12,6 +12,8 @@
     [% INCLUDE waste/garden/_bin_quantities.html form_page='modify' %]
   <hr class="fieldset-hr">
   <div class="cost-pa__total js-bin-costs"
+    data-payment_method="[% current_payment_method %]"
+    data-first_bin_discount="[% garden_costs.first_bin_discount_absolute_amount %]"
     data-per_bin_cost="[% garden_costs.per_bin %]"
     data-per_bin_first_cost="[% garden_costs.per_bin_first %]"
     data-per_new_bin_first_cost="[% garden_costs.per_new_bin_first %]"

--- a/web/cobrands/bexley/waste.js
+++ b/web/cobrands/bexley/waste.js
@@ -1,5 +1,8 @@
 window.garden_waste_first_bin_discount_applies = function() {
-    return $('input[name="payment_method"]:checked').val() === 'direct_debit';
+    var costs = $('.js-bin-costs'),
+        payment_method = costs.data('payment_method');
+
+    return payment_method === 'direct_debit' || $('input[name="payment_method"]:checked').val() === 'direct_debit';
 };
 
 $(function() {

--- a/web/js/waste.js
+++ b/web/js/waste.js
@@ -58,8 +58,9 @@ $(function() {
       var total_bins = parseInt($('#bins_wanted').val() || 0);
       var existing_bins = parseInt($('#current_bins').val() || 0);
       var new_bins = total_bins - existing_bins;
+      var calculated_first_cost = calculate_first_cost();
       var pro_rata_cost = 0;
-      var total_per_year = (total_bins-1) * cost + first_cost;
+      var total_per_year = (total_bins-1) * cost + calculated_first_cost;
       var admin_fee = 0;
       var new_bin_text = new_bins == 1 ? 'bin' : 'bins';
       $('#new_bin_text').text(new_bin_text);


### PR DESCRIPTION
Adds code for taking a one-off payment to cover any in-year difference in cost, as well as code for changing the amount of the original contract for future payments.

For https://github.com/mysociety/societyworks/issues/4796

Part of https://github.com/mysociety/fixmystreet/pull/5374

## Notes/Todo

The live API doesn't have the "No Frequency - AD-HOC Payments" schedule, it's only in test, which you can see with the following calls:

```
$ curl -L -g -X GET 'https://playpen.accesspaysuite.com/api/v3/client/APIRTM/schedules' -H "apiKey: $APS_TEST_API_KEY"
$ curl -L -g -X GET 'https://ddcms.accesspaysuite.com/api/v3/client/LBBEX/schedules' -H "apiKey: $APS_LIVE_API_KEY"
```

You can also get the schedule ID you need for the `dd_adhoc_schedule_id` config setting from that playpen call.

- [x] Fix tests (there seems to be an issue with the DD discount not being applied currently)
- [x] Test things are working with an existing contract in the APS test API
- [x] Add error checking after creating the adhoc contract in `one_off_payment`

(Added 08/07/25:)

- [ ] Cost displayed on bin days page needs to be internally calculated, not fetched from Agile as the latter is likely to be incorrect

<!-- [skip changelog] -->