### PR TITLE
[Merton][Echo] Amend Bulky collection on same date

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1745,17 +1745,7 @@ sub add_report : Private {
     $c->set_param('uprn', $c->stash->{property}{uprn}) unless $c->get_param('uprn');
     $c->set_param('property_id', $c->stash->{property}{id}) unless $c->get_param('property_id');
 
-    # Data may contain duplicate photo data under different keys e.g.
-    # 'item_photo_1' => 'c8a965ad74acad4104341a8ea893b1a1275efa4d.jpeg',
-    # 'item_photo_1_fileid' => 'c8a965ad74acad4104341a8ea893b1a1275efa4d.jpeg'.
-    # So ignore keys that end with 'fileid'.
-    # XXX Should fix this so there isn't duplicate data across different keys.
-    my @bulky_photo_data;
-    push @bulky_photo_data, $data->{location_photo} if $data->{location_photo};
-    for (grep { /^item_photo_\d+$/ } sort keys %$data) {
-        push @bulky_photo_data, $data->{$_} if $data->{$_};
-    }
-    $c->stash->{bulky_photo_data} = \@bulky_photo_data;
+    $c->forward('add_bulky_photo_data', [$data]);
 
     $c->forward('setup_categories_and_bodies') unless $c->stash->{contacts};
     $c->forward('/report/new/non_map_creation', [['/waste/remove_name_errors']]) or return;
@@ -1802,6 +1792,21 @@ sub add_report : Private {
     );
 
     return 1;
+}
+
+sub add_bulky_photo_data: Private {
+    my ($self, $c, $data) = @_;
+    # Data may contain duplicate photo data under different keys e.g.
+    # 'item_photo_1' => 'c8a965ad74acad4104341a8ea893b1a1275efa4d.jpeg',
+    # 'item_photo_1_fileid' => 'c8a965ad74acad4104341a8ea893b1a1275efa4d.jpeg'.
+    # So ignore keys that end with 'fileid'.
+    # XXX Should fix this so there isn't duplicate data across different keys.
+    my @bulky_photo_data;
+    push @bulky_photo_data, $data->{location_photo} if $data->{location_photo};
+    for (grep { /^item_photo_\d+$/ } sort keys %$data) {
+        push @bulky_photo_data, $data->{$_} if $data->{$_};
+    }
+    $c->stash->{bulky_photo_data} = \@bulky_photo_data;
 }
 
 sub remove_name_errors : Private {

--- a/perllib/Open311.pm
+++ b/perllib/Open311.pm
@@ -504,7 +504,7 @@ sub _populate_service_request_update_params {
 
     my $cobrand = $self->fixmystreet_body->get_cobrand_handler || $comment->get_cobrand_logged;
     $cobrand->call_hook(open311_munge_update_params => $params, $comment, $self->fixmystreet_body);
-
+    $cobrand->call_hook(open_311_bulky_update_same_date => $params, $comment);
     if ( $comment->photo ) {
         my $cobrand = $comment->get_cobrand_logged;
         my $email_base_url = $cobrand->base_url($comment->cobrand_data);


### PR DESCRIPTION
When amending a bulky booking but keeping the same collection date, don't cancel the report.

Use an update on the report to send the data to Open311 and do the update to same booking.

https://github.com/mysociety/societyworks/issues/4732

