### PR TITLE
[Sutton] Different no-service message for some address types.

### DIFF
--- a/t/app/controller/waste_sutton_r.t
+++ b/t/app/controller/waste_sutton_r.t
@@ -13,6 +13,14 @@ END { FixMyStreet::App->log->enable('info'); }
 my $mech = FixMyStreet::TestMech->new;
 my $sample_file = path(__FILE__)->parent->child("sample.jpg");
 
+my $address_data = {
+    Id => 12345,
+    SharedRef => { Value => { anyType => '1000000002' } },
+    PointType => 'PointAddress',
+    PointAddressType => { Name => 'House', Id => 284 },
+    Coordinates => { GeoPoint => { Latitude => 51.359723, Longitude => -0.193146 } },
+    Description => '2 Example Street, Sutton, SM1 1AA',
+};
 my $bin_data = decode_json(path(__FILE__)->sibling('waste_sutton_4443082.json')->slurp_utf8);
 my $bin_140_data = decode_json(path(__FILE__)->sibling('waste_sutton_4443082_140.json')->slurp_utf8);
 my $kerbside_bag_data = decode_json(path(__FILE__)->sibling('waste_sutton_4471550.json')->slurp_utf8);
@@ -87,6 +95,7 @@ FixMyStreet::override_config {
             url => 'http://example.org/',
         } },
         waste => { sutton => 1 },
+        waste_features => { sutton => { no_service_residential_address_types => [ 283, 284, 285 ] } },
         echo => { sutton => { bulky_service_id => 960 }},
         payment_gateway => { sutton => {
             cc_url => 'http://example.com',
@@ -392,10 +401,15 @@ FixMyStreet::override_config {
         $e->mock('GetServiceUnitsForObject', sub { $bin_data });
     };
 
-    subtest 'Fetching property without services give Sutton specific error' => sub {
+    subtest 'Fetching property without services give Sutton specific errors' => sub {
         $e->mock('GetServiceUnitsForObject', sub { [] });
         $mech->get_ok('/waste/12345/');
         $mech->content_contains('Oh no! Something has gone wrong');
+        my $non_residential = { %$address_data, PointAddressType => { Id => 123 } };
+        $e->mock('GetPointAddress', sub { $non_residential });
+        $mech->get_ok('/waste/12345/');
+        $mech->content_contains('No schedule found for this property');
+        $e->mock('GetPointAddress', sub { $address_data });
         $e->mock('GetServiceUnitsForObject', sub { $bin_data });
     };
 
@@ -629,16 +643,7 @@ sub get_report_from_redirect {
 
 sub shared_echo_mocks {
     my $e = Test::MockModule->new('Integrations::Echo');
-    $e->mock('GetPointAddress', sub {
-        return {
-            Id => 12345,
-            SharedRef => { Value => { anyType => '1000000002' } },
-            PointType => 'PointAddress',
-            PointAddressType => { Name => 'House' },
-            Coordinates => { GeoPoint => { Latitude => 51.359723, Longitude => -0.193146 } },
-            Description => '2 Example Street, Sutton, SM1 1AA',
-        };
-    });
+    $e->mock('GetPointAddress', sub { $address_data });
     $e->mock('GetServiceUnitsForObject', sub { $bin_data });
     $e->mock('GetEventsForObject', sub { [] });
     $e->mock('GetTasks', sub { [] });

--- a/templates/web/sutton/waste/_bin_days_no_collections.html
+++ b/templates/web/sutton/waste/_bin_days_no_collections.html
@@ -1,15 +1,25 @@
 [% IF waste_features.garden_disabled %]
 
-<h3 class="govuk-heading-m waste-service-name">Oh no! Something has gone wrong</h3>
-<p>
-    We are unable to find a waste collection schedule for this property. This may be because the property is a new build and has not completed the registration process correctly.
-</p>
-<p>
-    If you believe that your address is eligible for waste and recycling services, please call our customer services team on 020 8770 5000 (Monday to Friday from 9:00-17:00) or alternatively email us at <a href="mailto:neighbourhoodservices@sutton.gov.uk">neighbourhoodservices@sutton.gov.uk</a> and we'll look to put this right.
-</p>
-<p>
-    Please be aware that we do not provide collections to some property types such as commercial businesses, places of worship and schools.
-</p>
+  [% IF waste_features.no_service_residential_address_types.grep(property.type_id).size %]
+    <h3 class="govuk-heading-m waste-service-name">Oh no! Something has gone wrong.</h3>
+    <p>
+        We are unable to find a waste collection schedule for this property. This may be because the property is a new build and has not completed the registration process correctly.
+    </p>
+    <p>
+        Please be aware that we do not provide collections to some property types such as commercial businesses, places of worship and schools.
+    </p>
+    <p>
+        If you believe that your address is eligible for waste and recycling services, please call our customer services team on 020 8770 5000 (Monday to Friday from 9:00-17:00) or alternatively email us at <a href="mailto:neighbourhoodservices@sutton.gov.uk">neighbourhoodservices@sutton.gov.uk</a> and we'll look to put this right.
+    </p>
+  [% ELSE %]
+    <h3 class="govuk-heading-m waste-service-name">No schedule found for this property.</h3>
+    <p>
+        Please be aware that we do not provide collections to some property types such as commercial businesses, places of worship and schools.
+    </p>
+    <p>
+        You will need to contact your service provider directly to resolve any issues you may have.
+    </p>
+  [% END %]
 
 [% ELSE %]
 


### PR DESCRIPTION
[skip changelog] Config for this would be `no_service_residential_address_types: [ 102, 279, 105, 281, 284, 285, 288, 290, 352, 351, 350, 296, 289 ]` from https://3.basecamp.com/4020879/buckets/40355775/todos/8526030249#__recording_8541184649