### PR TITLE
Add script to send stuck report summary emails.

### DIFF
--- a/bin/fixmystreet.com/send-stuck-reports-summary
+++ b/bin/fixmystreet.com/send-stuck-reports-summary
@@ -1,0 +1,50 @@
+#!/usr/bin/env perl
+#
+# This script sends a summary of stuck reports to
+# a given email for the given categories and body
+
+use v5.14;
+use warnings;
+
+BEGIN {    # set all the paths to the perl code
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use CronFns;
+use Getopt::Long::Descriptive;
+use FixMyStreet::DB;
+use FixMyStreet::Cobrand;
+use FixMyStreet::Script::SendStuckReportsSummary;
+
+my ($opts, $usage) = describe_options(
+    '%c %o',
+    ['body=s', 'body to filter by'],
+    ['category=s@', 'categories to filter by'],
+    ['email=s', 'email to send the summary to'],
+    ['unconfirmed|u', 'include unconfirmed reports'],
+    ['commit|c', 'actually send the email'],
+    ['help|h', "print usage message and exit" ],
+);
+$usage->die if $opts->help;
+$usage->die unless $opts->email && $opts->category && $opts->body;
+
+my $body = FixMyStreet::DB->resultset('Body')->find({ name => $opts->body });
+die "Couldn't find body " . $opts->body unless $body;
+
+my $site = CronFns::site(FixMyStreet->config('BASE_URL'));
+CronFns::language($site);
+
+unless ($opts->{commit}) {
+    print "Running in dry mode. Email will not be sent but printed instead.";
+}
+
+FixMyStreet::Script::SendStuckReportsSummary::run({
+    body => $body,
+    categories => $opts->category,
+    email => $opts->email,
+    unconfirmed => $opts->unconfirmed,
+    commit => $opts->commit,
+});

--- a/perllib/FixMyStreet/Script/SendStuckReportsSummary.pm
+++ b/perllib/FixMyStreet/Script/SendStuckReportsSummary.pm
@@ -1,0 +1,77 @@
+package FixMyStreet::Script::SendStuckReportsSummary;
+
+use v5.14;
+use warnings;
+
+use FixMyStreet::DB;
+use FixMyStreet::Email;
+use Lingua::EN::Inflect qw(PL_N PL_V WORDLIST);
+
+sub run {
+    my $params = shift;
+    my $cobrand = $params->{body}->get_cobrand_handler;
+
+    my @stuck_reports = FixMyStreet::DB->resultset('Problem')->to_body($params->{body}->id)->search({
+        category => $params->{categories},
+        send_state => 'unprocessed',
+        state => [ FixMyStreet::DB::Result::Problem::open_states() ],
+        send_fail_count => { '>', 0 },
+    })->order_by('-confirmed')->all;
+    my $stuck_reports_count = scalar @stuck_reports;
+    my $category_count = scalar @{$params->{categories}};
+
+    foreach (@stuck_reports) {
+        my $reason = $_->send_fail_reason;
+        $reason =~ s/^.*?error: 500: //s;
+        $reason =~ s/"MessageDetails".*/.../s;
+        $reason =~ s/ at \/data\/vhost.*//s;
+        $_->send_fail_reason($reason);
+    }
+
+    my @unconfirmed_reports;
+    my $unconfirmed_reports_count;
+    if ($params->{unconfirmed}) {
+        @unconfirmed_reports = FixMyStreet::DB->resultset('Problem')->to_body($params->{body}->id)->search({
+            category => $params->{categories},
+            state => 'unconfirmed',
+            -or => [
+                extra => undef,
+                -not => { extra => { '\?' => 'stuck_email_sent' } }
+            ],
+        })->order_by('-created')->all;
+        $unconfirmed_reports_count = scalar @unconfirmed_reports;
+    }
+
+    my $overview = "There " . PL_V("is", $stuck_reports_count) . " $stuck_reports_count stuck " . PL_N("report", $stuck_reports_count);
+    if ($params->{unconfirmed}) {
+        $overview .= " and $unconfirmed_reports_count unconfirmed " . PL_N("report", $unconfirmed_reports_count);
+    }
+    $overview .= " for " . PL_N('category', $category_count) . " " . WORDLIST(map { "'$_'" } @{$params->{categories}});
+
+
+    FixMyStreet::Email::send_cron(
+        FixMyStreet::DB->schema,
+        'stuck-reports-summary.txt',
+        {
+            body => $params->{body},
+            cobrand => $cobrand,
+            overview => $overview,
+            stuck_reports => \@stuck_reports,
+            unconfirmed_reports => \@unconfirmed_reports,
+        },
+        { To => $params->{email} },
+        undef,    # env_from
+        $params->{commit} ? 0 : 1,    # nomail
+        $cobrand,
+        "en-gb",
+    );
+
+    if ($params->{commit}) {
+        foreach (@unconfirmed_reports) {
+            $_->set_extra_metadata( stuck_email_sent => 1 );
+            $_->update;
+        }
+    }
+}
+
+1;

--- a/t/script/send-stuck-reports-summary.t
+++ b/t/script/send-stuck-reports-summary.t
@@ -1,0 +1,152 @@
+use FixMyStreet;
+BEGIN { FixMyStreet->test_mode(1); }
+
+package FixMyStreet::Cobrand::Test;
+use parent 'FixMyStreet::Cobrand::Default';
+sub base_url { 'base-url' }
+sub do_not_reply_email { 'do-not-reply@testcobrand' }
+sub contact_name { 'Test' }
+
+package main;
+
+use Test::LongString;
+use FixMyStreet::TestMech;
+use FixMyStreet::Script::SendStuckReportsSummary;
+
+my $mech = FixMyStreet::TestMech->new();
+$mech->clear_emails_ok;
+
+my $body = $mech->create_body_ok(2237, 'Body', { cobrand => 'test' });
+my $graffiti = $mech->create_contact_ok(body_id => $body->id, category => 'Graffiti', email => "GRAF");
+my $potholes = $mech->create_contact_ok(body_id => $body->id, category => 'Potholes', email => "POTH");
+my $bins = $mech->create_contact_ok(body_id => $body->id, category => 'Bins', email => "BINS");
+
+
+subtest 'No reports to send' => sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'test' ],
+    }, sub {
+        FixMyStreet::Script::SendStuckReportsSummary::run({
+            body => $body,
+            categories => ['Graffiti', 'Potholes'],
+            email => 'out-address@test',
+            unconfirmed => 1,
+            commit => 1,
+        });
+        my @emails = $mech->get_email;
+        $mech->email_count_is(1);
+        my $email = $emails[0];
+
+        is $email->header('Subject'), "Summary of stuck reports for Body", 'correct subject';
+        is $email->header('To'), 'out-address@test', 'correct destination';
+        is $email->header('From'), 'Test <do-not-reply@testcobrand>', 'correct sender';
+
+        my $email_body = $mech->get_text_body_from_email($email);
+        like $email_body, qr/There are 0 stuck reports and 0 unconfirmed reports for categories 'Graffiti' and 'Potholes'/, 'correct overview';
+    };
+};
+
+subtest 'Reports to send' => sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'test' ],
+    }, sub {
+        my ($stuck_graffiti_report) = $mech->create_problems_for_body(1, $body->id, 'TITLE', {
+            category => $graffiti->category,
+            send_state => 'unprocessed',
+            state => 'confirmed',
+            send_fail_count => 2,
+            send_fail_timestamp => '2025-04-24T13:00:00Z',
+            send_fail_reason => "Failed to send over Open311\n\nrequest failed: 500 Internal Server Error\nerror: 500: UPRN 12345 does not have a subscription to be renewed, or is invalid at /data/vhost/open311-adapter.mysociety.org/open311-adapter-2025-04-25T10-56-30/",
+        });
+        my $graffiti_id = $stuck_graffiti_report->id;
+        my ($stuck_potholes_report) = $mech->create_problems_for_body(1, $body->id, 'TITLE', {
+            category => $potholes->category,
+            send_state => 'unprocessed',
+            state => 'confirmed',
+            send_fail_count => 3,
+            send_fail_timestamp => '2025-04-24T14:00:00Z',
+            send_fail_reason => "Failed to send over Open311\n\nrequest failed: 500 Internal Server Error\nerror: 500: [{\"Code\":40,\"Message\":\"There is not an active contract for this address linked to the customer\",\"MessageDetails\":\"   at Contender.BusinessLogic.External.ExternalBL.HandleMicroservice",
+        });
+        my $pothole_id = $stuck_potholes_report->id;
+        my ($stuck_bins_report) = $mech->create_problems_for_body(1, $body->id, ',ITLE', {
+            category => $bins->category,
+            send_state => 'unprocessed',
+            state => 'confirmed',
+            send_fail_count => 0,
+            send_fail_timestamp => '2025-04-24T13:00:00Z',
+            send_fail_reason => 'something went wrong',
+        });
+        my ($unconfirmed_graffiti_report) = $mech->create_problems_for_body(1, $body->id, 'TITLE', {
+            category => $graffiti->category,
+            state => 'unconfirmed',
+            created => '2025-04-24T11:00:00Z'
+        });
+        my $graffiti_unconfirmed_id = $unconfirmed_graffiti_report->id;
+
+        $mech->clear_emails_ok;
+        FixMyStreet::Script::SendStuckReportsSummary::run({
+            body => $body,
+            categories => ['Graffiti', 'Potholes'],
+            email => 'out-address@test',
+            unconfirmed => 1,
+            commit => 1,
+        });
+        my $email = $mech->get_email;
+
+        my $stuck_expected = <<EOF;
+Graffiti report base-url/report/$graffiti_id has failed to send 2 times.
+
+The last failure was at 2025-04-24T13:00:00 with error:
+
+UPRN 12345 does not have a subscription to be renewed, or is invalid
+
+------------------------------------------------------------
+
+Potholes report base-url/report/$pothole_id has failed to send 3 times.
+
+The last failure was at 2025-04-24T14:00:00 with error:
+
+[{"Code":40,"Message":"There is not an active contract for this address linked to the customer",...
+
+------------------------------------------------------------
+EOF
+
+        my $email_body = $mech->get_text_body_from_email($email);
+        is_string_nows $email_body, <<EOF;
+There are 2 stuck reports and 1 unconfirmed report for categories 'Graffiti' and 'Potholes'
+
+------------------------------------------------------------
+
+$stuck_expected
+
+Graffiti report base-url/report/$graffiti_unconfirmed_id is unconfirmed.
+
+It was created at 2025-04-24T11:00:00.
+
+------------------------------------------------------------
+EOF
+        unlike $email_body, qr/Bins/s, 'does not contain the stuck bins report';
+
+        $mech->clear_emails_ok;
+        FixMyStreet::Script::SendStuckReportsSummary::run({
+            body => $body,
+            categories => ['Graffiti', 'Potholes'],
+            email => 'out-address@test',
+            unconfirmed => 1,
+            commit => 1,
+        });
+        $email = $mech->get_email;
+
+        $email_body = $mech->get_text_body_from_email($email);
+        is_string_nows $email_body, <<EOF;
+There are 2 stuck reports and 0 unconfirmed reports for categories 'Graffiti' and 'Potholes'
+
+------------------------------------------------------------
+
+$stuck_expected
+EOF
+        unlike $email_body, qr/Bins/s, 'does not contain the stuck bins report';
+    };
+};
+
+done_testing();

--- a/templates/email/default/stuck-reports-summary.txt
+++ b/templates/email/default/stuck-reports-summary.txt
@@ -1,0 +1,29 @@
+Subject: Summary of stuck reports for [% body.name %]
+
+[% overview %]
+
+[% IF stuck_reports.size > 0 OR unconfirmed_reports.size > 0 %]
+------------------------------------------------------------
+[% END %]
+
+[% FOR report IN stuck_reports %]
+[% SET url = cobrand.base_url _ "/report/" _ report.id %]
+[% report.category %] report [% url %] has failed to send [% report.send_fail_count %] times.
+
+The last failure was at [% report.send_fail_timestamp %] with error:
+
+[% report.send_fail_reason %]
+
+------------------------------------------------------------
+[% END %]
+
+[% FOR report IN unconfirmed_reports %]
+[% SET url = cobrand.base_url _ "/report/" _ report.id %]
+[% report.category %] report [% url %] is unconfirmed.
+
+It was created at [% report.created %].
+
+------------------------------------------------------------
+[% END %]
+
+


### PR DESCRIPTION
Similar to the send-failure-summary one used internally but can be filtered to reports for a specific body and specific categories, and uses the cobrand URL, so better suited for flagging stuck reports externally.

Also supports sending details of unconfirmed reports.

For https://github.com/mysociety/societyworks/issues/4879.

`bexley-ggw-stuck-reports-cron` branch in servers repo has the changes to set-up the cron for Bexley. Verified with test script runs on staging site.

[skip changelog]