### PR TITLE
Allow users to skip map when reporting on mobile

### DIFF
--- a/templates/web/base/maps/openlayers.html
+++ b/templates/web/base/maps/openlayers.html
@@ -42,7 +42,8 @@
 <div id="map_box">
     [% pre_map %]
     <div id="map">
-      <a href="#map_sidebar" class="skiplink">[% loc('Skip map') %]</a>
+      [% tprintf(loc('<a id="skip-map-mobile" class="skiplink" href="%s" aria-label="%s" rel="nofollow">Skip this step</a>'), url_skip, loc('Can\'t use the map to start a report? tap 3 consecutive times to skip it')) %]
+      <a href="#map_sidebar" class="skiplink">[% loc('Skip map controls') %]</a>
       [% IF noscript_map_template == 'maps/noscript_map_base_wmx.html' %]
           [% INCLUDE 'maps/noscript_map_base_wmx.html' js = 1 %]
       [% ELSE %]

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1374,6 +1374,28 @@ $.extend(fixmystreet.set_up, {
         if (fixmystreet.page !== 'around' && fixmystreet.page !== 'new' && !$('#toggle-fullscreen').length) {
             $('#sub_map_links').append('<a href="#" id="toggle-fullscreen" data-expand-text="'+ translation_strings.expand_map +'" data-compress-text="'+ translation_strings.collapse_map +'" >'+ translation_strings.expand_map +'</span>');
         }
+
+        // Implement triple tap for skipping the map
+        if ($('#skip-map-mobile').length) {
+            var skipUrl = $('#skip-map-mobile').attr('href');
+            var tapCount = 0;
+            var tapTimer;
+            var tapDelay = 500; //miliseconds
+
+            $(document).on('touchend', function(e) {
+                tapCount++;
+
+                clearTimeout(tapTimer);
+
+
+                tapTimer = setTimeout(function() {
+                    if (tapCount === 3) {
+                    window.location.href = skipUrl;
+                    }
+                    tapCount = 0;
+                }, tapDelay);
+            });
+        }
     }
 
     // Show/hide depending on whether it has any children to show

--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -421,6 +421,11 @@ body.mappage.admin {
   }
 }
 
+#skip-map-mobile {
+  // It's not needed on dektop because of .map-alternatives
+  display: none;
+}
+
 // Only want to capture footers that are inside .content
 // (like the one in base)
 .content {


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/4873

I ended up adding a new button that allows users to do a 3 consecutive tap so they can skip the map and do a report. Unlike the existing 'Skip map' with skip the map controls, this button will take the user to the next page so they can start a report.

I tried other solutions like 2 finger swipe up, unfortunately makes the map move a little before skipping it.


[skip changelog]