### PR TITLE
Add open/staff config to updates_disallowed_check

### DIFF
--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -464,6 +464,15 @@ sub updates_disallowed {
     return $self->_updates_disallowed_check($cfg, $problem, $body_user);
 }
 
+=head2 _updates_disallowed_check
+
+NOTE: If you add a new check/configuration string to this method,
+you may also need to update the following files:
+F<templates/web/fixmystreet-uk-councils/about/faq-en-gb.html> and
+F<templates/web/fixmystreet-uk-councils/admin/bodies/_updates_disallowed_hint.html>.
+
+=cut
+
 sub _updates_disallowed_check {
     my ($self, $cfg, $problem, $body_user) = @_;
 
@@ -481,6 +490,9 @@ sub _updates_disallowed_check {
         return $cfg unless $staff;
     } elsif ($cfg eq 'open') {
         return $cfg unless $open;
+    } elsif ($cfg eq 'open/staff') {
+        # Allow anyone on open reports, only staff on closed/fixed reports
+        return $cfg unless $open || $staff;
     } elsif ($cfg eq 'reporter') {
         return $cfg unless $reporter;
     } elsif ($cfg eq 'reporter-open') {

--- a/t/cobrand/councils.t
+++ b/t/cobrand/councils.t
@@ -63,6 +63,8 @@ subtest "Test update shown/not shown appropriately" => sub {
             { type => 'reporter/staff-open', state => 'in progress', update => [0,1,1] },
             { type => 'open', state => 'closed', update => [0,0,0] },
             { type => 'open', state => 'in progress', update => [1,1,1] },
+            { type => 'open/staff', state => 'closed', update => [0,0,1] },
+            { type => 'open/staff', state => 'in progress', update => [1,1,1] },
         ) {
             FixMyStreet::override_config {
                 ALLOWED_COBRANDS => $cobrand,

--- a/templates/web/fixmystreet-uk-councils/about/faq-en-gb.html
+++ b/templates/web/fixmystreet-uk-councils/about/faq-en-gb.html
@@ -228,7 +228,7 @@ cleaning</strong> or <strong>clearing</strong>.
         Yes, you can leave updates on open reports, by visiting a report page and
         filling in the update form.
     </p>
-[% ELSIF c.cobrand.feature('updates_allowed') == 'reporter-open' OR c.cobrand.feature('updates_allowed') == 'reporter/staff-open' %]
+[% ELSIF c.cobrand.feature('updates_allowed') == 'reporter-open' OR c.cobrand.feature('updates_allowed') == 'reporter/staff-open' OR c.cobrand.feature('updates_allowed') == 'open/staff' %]
     <dt>Can I make updates to my report?</dt>
     <p>
         Yes, you can leave updates on open reports you have made, by visiting a

--- a/templates/web/fixmystreet-uk-councils/admin/bodies/_updates_disallowed_hint.html
+++ b/templates/web/fixmystreet-uk-councils/admin/bodies/_updates_disallowed_hint.html
@@ -9,6 +9,7 @@
   [%~ ELSIF cfg == 'reporter/staff-open' %] the problem reporter or staff will be able to leave updates.
   [%~ ELSIF cfg == 'open' %] open reports can have updates left on them.
   [%~ ELSIF cfg == 'reporter-not-open/staff-open' %] staff can leave updates on an open report, and only the problem reporter can leave updates on a closed or fixed report.
+  [%~ ELSIF cfg == 'open/staff' %] staff can leave updates on a closed or fixed report, and anyone can leave updates on an open report.
   [%~ END %]
 </span>
 [% END %]


### PR DESCRIPTION
This allows anyone to update an open report, but only staff can update a closed report.

Part of https://github.com/mysociety/societyworks/issues/4668 for Gloucester City.

<!-- [skip changelog] -->
