### PR TITLE
[Open311] Check photo has changed in new update.

### DIFF
--- a/perllib/Open311/UpdatesBase.pm
+++ b/perllib/Open311/UpdatesBase.pm
@@ -271,8 +271,8 @@ sub _process_update {
 
     # If nothing to show (no text change, photo, or state change), don't show this update
     $comment->state('hidden') unless
-        $comment->text && (!$latest || $latest->text ne $comment->text)
-        || $comment->photo
+        ($comment->text && (!$latest || $latest->text ne $comment->text))
+        || ($comment->photo && (!$latest || $latest->photo ne $comment->photo))
         || ($comment->problem_state && $state ne $old_state);
 
     my $cobrand = $body->get_cobrand_handler;


### PR DESCRIPTION
We can be in the situation where we get multiple fixed updates from a backend, each with the same photo and no text or state change, and we don’t want to show this update just because it has a photo.
Fixes https://github.com/mysociety/societyworks/issues/4810