### PR TITLE
[Bristol] Protect manually added categories.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/BathNES.pm
+++ b/perllib/FixMyStreet/Cobrand/BathNES.pm
@@ -411,7 +411,7 @@ sub dashboard_export_problems_add_columns {
     });
 }
 
-=head2
+=head2 open311_filter_contacts_for_deletion
 
 We protect all BANES categories that are open311 protected from being removed.
 

--- a/perllib/FixMyStreet/Cobrand/Bristol.pm
+++ b/perllib/FixMyStreet/Cobrand/Bristol.pm
@@ -181,6 +181,25 @@ sub open311_config_updates {
     $params->{multi_photos} = 1;
 }
 
+=head2 open311_filter_contacts_for_deletion
+
+The default Open311 protection is to allow the category name/group to be
+changed without being overwritten by the category name of its existing service
+code. We protect all categories that are Open311 protected, which will have
+been manually added, from being removed by the Open311 populate service list
+script.
+
+=cut
+
+sub open311_filter_contacts_for_deletion {
+    my ($self, $contacts) = @_;
+
+    # Don't delete open311 protected contacts when importing
+    return $contacts->search({
+        -not => { extra => { '@>' => '{"open311_protect":1}' } }
+    });
+}
+
 =head2 open311_update_missing_data
 
 All reports sent to Alloy should have a USRN set so the street parent


### PR DESCRIPTION
Normally, these would be removed, but Bristol want to maintain them. We can't use the normal devolved send method workaround, because those do not appear on the Bristol cobrand. Fixes FD-5462 [skip changelog]