### PR TITLE
[Gloucester] Add display_name to admin contact

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Gloucester.pm
+++ b/perllib/FixMyStreet/Cobrand/Gloucester.pm
@@ -70,6 +70,12 @@ sub enter_postcode_text {
     return 'Enter a Gloucester postcode or street name';
 }
 
+=item * Add display_name as an extra contact field
+
+=cut
+
+sub contact_extra_fields { [ 'display_name' ] }
+
 =item * TODO: Don't show reports before the go-live date
 
 =cut


### PR DESCRIPTION
Gloucester have a category with the same name under two different parents with two different destinations, so we'll need to use the display name so we can have them display correctly.

Fixes https://github.com/mysociety/societyworks/issues/4957

<!-- [skip changelog] -->