### PR TITLE
[Bristol] Only use message controller on one layer.

### DIFF
--- a/web/cobrands/fixmystreet-uk-councils/assets.js
+++ b/web/cobrands/fixmystreet-uk-councils/assets.js
@@ -265,37 +265,16 @@ fixmystreet.assets.bristol.park_stylemap = new OpenLayers.StyleMap({
     })
 });
 
-
-var bristol_owned_assets = {
-    road: false,
-    property: false
+fixmystreet.assets.bristol.road_property_found = function(layer) {
+    var roads = fixmystreet.map.getLayersByName('bristol_roads')[0];
+    fixmystreet.message_controller.road_found(roads);
 };
 
-fixmystreet.assets.bristol.road_found = function(layer) {
-    bristol_owned_assets.road = true;
-    fixmystreet.message_controller.road_found(layer);
-};
-
-fixmystreet.assets.bristol.property_found = function(layer) {
-    bristol_owned_assets.property = true;
-    fixmystreet.message_controller.road_found(layer);
-};
-
-fixmystreet.assets.bristol.road_not_found = function(layer) {
-    bristol_owned_assets.road = false;
-    if (!bristol_owned_assets.road && !bristol_owned_assets.property && !fixmystreet.staff_set_up) {
-        fixmystreet.message_controller.road_not_found(layer, function() {return true;});
-    } else {
-        fixmystreet.message_controller.road_found(layer);
-    }
-};
-
-fixmystreet.assets.bristol.property_not_found = function(layer) {
-    bristol_owned_assets.property = false;
-    if (!bristol_owned_assets.road && !bristol_owned_assets.property && !fixmystreet.staff_set_up) {
-        fixmystreet.message_controller.road_not_found(layer, function() {return true;});
-    } else {
-        fixmystreet.message_controller.road_found(layer);
+fixmystreet.assets.bristol.road_property_not_found = function(layer) {
+    var roads = fixmystreet.map.getLayersByName('bristol_roads')[0];
+    var property = fixmystreet.map.getLayersByName('bristol_property')[0];
+    if (!roads.selected_feature && !property.selected_feature && !fixmystreet.staff_set_up) {
+        fixmystreet.message_controller.road_not_found(roads, function() {return true;});
     }
 };
 


### PR DESCRIPTION
Similar to Gloucester layer recently discussed with Nik. We have road and property layers, with messaging only to show if not in either, so only want the message attached to one of the layers. Currently, it would sometimes briefly show two messages, and not work depending on the order layers were returned.

Server diff would be:

```diff
diff --git a/vhosts/fixmystreet/assets/bristol.yml.include b/vhosts/fixmystreet/assets/bristol.yml.include
index 402afdd915..d18f796168 100644
--- a/vhosts/fixmystreet/assets/bristol.yml.include
+++ b/vhosts/fixmystreet/assets/bristol.yml.include
@@ -53,7 +53,8 @@ my $tilma_host = "https://" . ($staging ? "tilma.staging.mysociety.org" : "tilma
   http_options:
     params:
       layer: designs_wasteContainers
-- filter_key: ''
+- name: 'bristol_property'
+  filter_key: ''
   wfs_feature: "COD_COUNCIL_PROPERTY_OWNERSHIP"
   asset_type: 'area'
   asset_group: ['Flytipping', 'Flyposting', 'Graffiti', 'Street cleansing']
@@ -62,9 +63,10 @@ my $tilma_host = "https://" . ($staging ? "tilma.staging.mysociety.org" : "tilma
   road: true
   no_asset_msg_id: '#bristol-not-owned'
   actions:
-    found: fixmystreet.assets.bristol.property_found
-    not_found: fixmystreet.assets.bristol.property_not_found
-- filter_key: ''
+    found: fixmystreet.assets.bristol.road_property_found
+    not_found: fixmystreet.assets.bristol.road_property_not_found
+- name: 'bristol_roads'
+  filter_key: ''
   wfs_feature: "COD_LSG"
   propertyNames: [ 'USRN', 'SHAPE' ]
   asset_type: 'area'
@@ -76,8 +78,8 @@ my $tilma_host = "https://" . ($staging ? "tilma.staging.mysociety.org" : "tilma
   stylemap: fixmystreet.assets.stylemap_invisible
   road: true
   actions:
-    found: fixmystreet.assets.bristol.road_found
-    not_found: fixmystreet.assets.bristol.road_not_found
+    found: fixmystreet.assets.bristol.road_property_found
+    not_found: fixmystreet.assets.bristol.road_property_not_found
 - filter_key: ''
   wfs_feature: "COD_PRIVATE_STREETS"
   asset_type: 'line'
```