### PR TITLE
Update FAQ answer on closed reports.html

### DIFF
--- a/templates/web/fixmystreet.com/about/faq-en-gb.html
+++ b/templates/web/fixmystreet.com/about/faq-en-gb.html
@@ -278,7 +278,13 @@ or inappropriate content or wish to appeal a decision we have made, you can
 
 <dt>Someone has marked my problem was fixed, but it isn’t</dt>
 <dd>
-<p>As the owner of your report on FixMyStreet, you can change its status back to ‘not fixed’ at any time. Go to your report’s web page and check the box under ‘update’.
+<p>Depending on how the authority that received your report interacts with FixMyStreet, you may be able to change your report’s status back to ‘not fixed’. You can do this by going to your report’s web page and checking the box under ‘update’.
+<p>Some authorities do not allow report statuses to be changed by report-makers once submitted. There could be many reasons for this, but the main ones are:
+  <ol>
+    <li>The authority has internal processes that mean a report is marked as closed or fixed when it has been assgined to a third party or contractor to deal with, so from the authority’s perspective it’s all in hand and changing its status could delay the resolution process.</li>
+    <li>An integration is in place between FixMyStreet and the system used by the authority to manage its reports, and that system does not allow for reports to be reopened by report-makers. </li>
+  </ol>
+<p>If you believe your report’s status has been changed incorrectly and you cannot update it yourself, please check for an update with the authority directly.</p>
 </dd>
 
 <dt>My report is old and my problem has been fixed. Can I now delete it?</dt>


### PR DESCRIPTION
Update to the answer to the question about reports being marked as closed or fixed when they are not. This follows a request from Georgia who has been dealing with support requests pointing out that in some areas it is not possible for report-makers to update the status of their reports. The FAQ should now better reflect the reality of the situation.

Fixes https://github.com/mysociety/societyworks/issues/4959 [skip changelog]