### PR TITLE
[Gloucester] Hide some county categories

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Gloucester.pm
+++ b/perllib/FixMyStreet/Cobrand/Gloucester.pm
@@ -76,6 +76,28 @@ sub contact_extra_fields { [ 'display_name' ] }
 
 sub default_map_zoom { 5 }
 
+=item * Ignores some categories that are not relevant to Gloucester
+
+=cut
+
+sub categories_restriction {
+    my ($self, $rs) = @_;
+
+    return $rs->search({
+        'me.category' => {
+            -not_in => [
+                # Hide all categories with parent 'Noxious weeds'
+                'Giant Hogweed',
+                'Himalayan Balsam',
+                'Japanese Knotweed',
+                'Nettles, brambles, dandelions etc.',
+                'Ragwort',
+            ],
+            -not_like => 'Ash Tree located on%',
+        },
+    });
+}
+
 =item * TODO: Don't show reports before the go-live date
 
 =cut


### PR DESCRIPTION
Gloucester have asked for some of the county categories to be hidden on their cobrand.

This hides any category that starts with "Ash Tree located on" (as there are two county categories on the live site like that), as well as all of the "Noxious weeds" categories.

I couldn't see an easy way to hide based on the parent, so if more Noxious weeds categories are added in the future, they'll need to be added to this list.

For [this Basecamp todo](https://3.basecamp.com/4020879/buckets/38208405/todos/8663336750).

<!-- [skip changelog] -->