### PR TITLE
[Aberdeenshire] Text and pin changes

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Aberdeenshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Aberdeenshire.pm
@@ -160,4 +160,25 @@ sub disambiguate_location {
     };
 }
 
+=head2 pin_colour
+
+Green for anything completed or closed, red for confirmed,
+orange for other open, blue for pulled in reports.
+
+=cut
+
+sub is_defect {
+    my ($self, $p) = @_;
+    #return $p->external_id && $p->external_id =~ /^JOB_/;
+    return $p->user_id == $self->body->comment_user_id;
+}
+
+sub pin_colour {
+    my ( $self, $p ) = @_;
+    return 'blue' if $self->is_defect($p);
+    return 'green' if $p->is_fixed || $p->is_closed;
+    return 'red' if $p->state eq 'confirmed';
+    return 'orange-work';
+}
+
 1;

--- a/templates/web/aberdeenshire/report/new/after_photo.html
+++ b/templates/web/aberdeenshire/report/new/after_photo.html
@@ -1,0 +1,13 @@
+<div class="description_tips" id="js-photo-tips" aria-label="[% loc('Tips for perfect photos') %]">
+    <ul class="do">
+        <li class="js-photo-tips-default-do">[% loc('To help us locate the problem, include both a close-up and a wide shot') %]</li>
+    </ul>
+    <ul class="dont">
+        <li id="js-photo-tips-avoid-personal-info">[% loc('Avoid personal information and vehicle number plates') %]</li>
+    </ul>
+</div>
+<div class="description_tips hidden" id="js-photo-tips-bucks-vehicle-littering" aria-label="[% loc('Tips for perfect photos') %]">
+    <ul class="do">
+        To help us resolve this problem please upload two images (screen shots from video); one of the vehicle index and one of the litter being thrown from the vehicle
+    </ul>
+</div>

--- a/templates/web/aberdeenshire/report/new/inline-tips.html
+++ b/templates/web/aberdeenshire/report/new/inline-tips.html
@@ -1,0 +1,10 @@
+<div id="js-description-tips" class="description_tips" aria-label="Tips for successful reports">
+    <ul class="do">
+        <li>Be polite</li>
+        <li>Use exact locations</li>
+    </ul>
+    <ul class="dont">
+        <li>Don’t identify or accuse other&nbsp;people</li>
+        <li>Don’t include private contact details in the&nbsp;description</li>
+    </ul>
+</div>


### PR DESCRIPTION
For https://3.basecamp.com/4020879/buckets/39821225/card_tables/cards/8715868327 and https://3.basecamp.com/4020879/buckets/39821225/card_tables/cards/8753207454 - as mentioned on Slack, went with all pulled in reports for blue, and any non-Open open state for orange; easy to change. [skip changelog]