### PR TITLE
[Gloucester] Lookup Alloy code before sending over Open311

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Gloucester.pm
+++ b/perllib/FixMyStreet/Cobrand/Gloucester.pm
@@ -166,4 +166,123 @@ sub open311_post_send {
     }
 }
 
+=head2 _asset_layer_mapping
+
+Gloucester's Alloy integration has assets separated into different layers.
+When looking up a parent asset for a report that doesn't have one, we need
+to know which layer(s) to check. This method provides a mapping from the
+report category to the relevant asset layer(s). The asset layer names
+correspond to asset layers configured in the Tilma proxy service.
+
+=cut
+
+sub _asset_layer_mapping {
+    my $self = shift;
+    my $layers = $self->feature("asset_layers") or return;
+    my $out;
+    foreach my $layer (@$layers) {
+        next unless ref $layer eq 'HASH' && $layer->{http_options};
+        if ($layer->{asset_category}) {
+            my $cat = ref $layer->{asset_category} ? $layer->{asset_category} : [ $layer->{asset_category} ];
+            foreach (@$cat) {
+                push @{$out->{category}{$_}}, $layer->{http_options}{params}{layer};
+            }
+        }
+        if ($layer->{asset_group}) {
+            my $g = $layer->{asset_group};
+            push @{$out->{group}{$g}}, $layer->{http_options}{params}{layer};
+        }
+    }
+    return $out;
+}
+
+=head2 open311_update_missing_data
+
+This is a hook called before sending a report to Open311. For the Gloucester
+Alloy integration, all reports must be associated with a parent asset. If the
+user hasn't selected one during reporting (e.g. on the app or with JavaScript
+disabled), this method calls C<lookup_site_code> to find the nearest suitable
+asset and attach it to the report.
+
+=cut
+
+sub open311_update_missing_data {
+    my ($self, $row, $h, $contact) = @_;
+
+    # If the report doesn't already have an asset, associate it with the
+    # closest feature from the Alloy asset layers.
+    if (!$row->get_extra_field_value('asset_resource_id')) {
+        if (my $item_id = $self->lookup_site_codes($row, $contact)) {
+            $row->update_extra_field({ name => 'asset_resource_id', value => $item_id });
+        }
+    }
+}
+
+=head2 lookup_site_codes
+
+The Alloy layer code uses lat/lon rather than easting/northing, and
+can have multiple layers depending upon the report's category.
+
+=cut
+
+sub lookup_site_codes {
+    my ($self, $row, $contact) = @_;
+
+    my $mapping = $self->_asset_layer_mapping or return;
+    my @groups = map { [ 'group', $_ ] } @{$contact->groups};
+    my $category = [ 'category', $contact->category ];
+    foreach (@groups, $category) {
+        my ($type, $name) = @$_;
+        my $layers = $mapping->{$type}{$name};
+        next unless $layers && @$layers;
+        for my $layer (@$layers) {
+            my $item_id = $self->lookup_site_code($row, $layer);
+            return $item_id if $item_id;
+        }
+    }
+}
+
+sub _fetch_features_url {
+    my ($self, $cfg) = @_;
+
+    # Convert bbox from EN to lat/lon
+    my ($w, $s, $e, $n) = split(/,/, $cfg->{bbox});
+    ($s, $w) = Utils::convert_en_to_latlon($w, $s);
+    ($n, $e) = Utils::convert_en_to_latlon($e, $n);
+    my $bbox = "$w,$s,$e,$n";
+
+    my $uri = URI->new($cfg->{proxy_url});
+    $uri->query_form(
+        layer => $cfg->{layer},
+        url => $cfg->{url},
+        bbox => $bbox,
+    );
+
+    return $uri;
+}
+
+=head2 lookup_site_code_config
+
+This method generates the configuration required by C<lookup_site_code> to
+query a specific asset layer in Gloucester's Alloy system. Unlike other cobrands
+that might have a single, static configuration, this one is parameterised by
+the asset C<$layer> to allow for checking multiple different layers for a single report.
+
+=cut
+
+sub lookup_site_code_config {
+    my ($self, $layer) = @_;
+
+    my $host = FixMyStreet->config('STAGING_SITE') ? "tilma.staging.mysociety.org" : "tilma.mysociety.org";
+    return {
+        buffer => 200, # metres
+        _nearest_uses_latlon => 1,
+        proxy_url => "https://$host/alloy/layer.php",
+        layer => $layer,
+        url => "https://gloucester.assets",
+        property => "itemId",
+        accept_feature => sub { 1 },
+    };
+}
+
 1;

--- a/t/cobrand/gloucester.t
+++ b/t/cobrand/gloucester.t
@@ -2,13 +2,30 @@ use FixMyStreet::Cobrand::Gloucester;
 use FixMyStreet::Script::Reports;
 use FixMyStreet::TestMech;
 use Test::Deep;
+use Test::MockModule;
 
 FixMyStreet::App->log->disable('info');
 END { FixMyStreet::App->log->enable('info'); }
 
 my $mech    = FixMyStreet::TestMech->new;
-my $cobrand = FixMyStreet::Cobrand::Gloucester->new;
-my $body    = $mech->create_body_ok(
+my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::UKCouncils');
+$cobrand->mock(
+    '_fetch_features',
+    sub {
+        return [
+            {   properties => { itemId => 'an_asset_id' },
+                geometry   => {
+                    type        => 'LineString',
+                    coordinates =>
+                        [ [ -2.24586, 51.86506 ], [ -2.24586, 51.86506 ], ],
+                }
+            }
+        ];
+    },
+);
+
+
+my $body = $mech->create_body_ok(
     2325,
     'Gloucester City Council',
     {   send_method  => 'Open311',
@@ -32,7 +49,7 @@ my $graffiti = $mech->create_contact_ok(
 my $flytipping = $mech->create_contact_ok(
     body_id  => $body->id,
     category => 'Flytipping',
-    email    => 'Flytipping',
+    email    => 'Regular_fly-tipping_(not_witnessed_and_no_evidence_likely)',
 );
 
 # Open311 but sends email too if certain answer provided
@@ -64,6 +81,12 @@ FixMyStreet::override_config {
                 'Dog fouling' => 'enviro-crime@gloucester.dev'
             }
         },
+        asset_layers => { gloucester => [
+            {
+                http_options => { params => { layer => 'plots' } },
+                asset_category => ['Flytipping'],
+            }
+        ] },
     },
 }, sub {
     ok $mech->host('gloucester'), 'change host to gloucester';
@@ -134,12 +157,15 @@ FixMyStreet::override_config {
             FixMyStreet::Script::Reports::send();
             $report->discard_changes;
 
+
             is $report->send_state,  'sent', 'sent successfully';
             is $report->external_id, '248', 'has external ID';
             is $report->get_extra_field_value('did_you_witness'), undef,
                 'no witness question';
             is $report->get_extra_metadata('extra_email_sent'), undef,
                 'no extra_email_sent';
+            is $report->get_extra_field_value('asset_resource_id'), 'an_asset_id',
+                'asset_resource_id set';
 
             $mech->email_count_is(0), 'no email sent';
         };


### PR DESCRIPTION
Use the lookup site code functionality to get the relevant Alloy ID for the nearest feature if it wasn't selected during report creation.

For https://3.basecamp.com/4020879/buckets/38208405/todos/8726231700

<!-- [skip changelog] -->