### PR TITLE
[Bristol] [Southwark] Remove override map type.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bristol.pm
+++ b/perllib/FixMyStreet/Cobrand/Bristol.pm
@@ -39,12 +39,6 @@ sub council_url { return 'bristol'; }
 
 use constant ROADWORKS_CATEGORY => 'Inactive roadworks';
 
-=item * Bristol use the OS Maps API at all zoom levels.
-
-=cut
-
-sub map_type { 'OS::API' }
-
 =item * Users with a bristol.gov.uk email can always be found in the admin.
 
 =cut

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -74,7 +74,7 @@ sub feature {
     my $features = FixMyStreet->config('COBRAND_FEATURES');
     return unless $features && ref $features eq 'HASH';
     return unless $features->{$feature} && ref $features->{$feature} eq 'HASH';
-    return $features->{$feature}->{$self->moniker} || $features->{$feature}->{_fallback};
+    return $features->{$feature}->{$self->moniker} // $features->{$feature}->{_fallback};
 }
 
 sub csp_config {

--- a/perllib/FixMyStreet/Cobrand/Southwark.pm
+++ b/perllib/FixMyStreet/Cobrand/Southwark.pm
@@ -33,12 +33,6 @@ sub council_area { 'Southwark' }
 sub council_name { 'Southwark Council' }
 sub council_url { 'southwark' }
 
-=item * Southwark use the OS Maps API at all zoom levels.
-
-=cut
-
-sub map_type { 'OS::API' }
-
 =item * Don't show reports before the go-live date, 22nd March 2023
 
 =cut


### PR DESCRIPTION
OS::API can be handled by the default FMS map type, as long as `os_maps_leisure` is not set.

We'd update the config to have:
```
os_maps_leisure:
  _fallback: 1
  bristol: 0
  southwark: 0
```
