### PR TITLE
[Peterborough] Use private land layer for Abandoned vehicles category

### DIFF
--- a/.cypress/cypress/integration/peterborough.js
+++ b/.cypress/cypress/integration/peterborough.js
@@ -53,6 +53,10 @@ describe('new report form', function() {
     cy.wait('@report-ajax');
     cy.pickCategory('Non offensive graffiti');
     cy.get('.pre-button-messaging:visible').should('not.exist');
+    cy.visit('http://peterborough.localhost:3001/report/new?longitude=-0.242007&latitude=52.571903');
+    cy.wait('@report-ajax');
+    cy.pickCategory('Abandoned vehicles');
+    cy.get('.pre-button-messaging:visible').should('not.exist');
     cy.visit('http://peterborough.localhost:3001/report/new?longitude=-0.241841&latitude=52.570792');
     cy.wait('@report-ajax');
     cy.pickCategory('General fly tipping');
@@ -61,6 +65,10 @@ describe('new report form', function() {
     cy.wait('@report-ajax');
     cy.pickCategory('Non offensive graffiti');
     cy.get('.pre-button-messaging:visible').should('contain', 'For graffiti on private land this would be deemed');
+    cy.visit('http://peterborough.localhost:3001/report/new?longitude=-0.241841&latitude=52.570792');
+    cy.wait('@report-ajax');
+    cy.pickCategory('Abandoned vehicles');
+    cy.get('.pre-button-messaging:visible').should('contain', 'Unfortunately, as this car is on private land');
   });
 
   it('correctly changes the asset select message', function() {

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -180,7 +180,8 @@ if ($opt->test_fixtures) {
                 { group => 'Trees', category => 'Damaged Tree' },
                 { group => 'Street lighting', category => 'Light Out' },
                 { group => 'Street lighting', category => 'Light Dim' },
-                'General fly tipping', 'Fallen branch', 'Pothole', 'Non offensive graffiti'
+                'General fly tipping', 'Fallen branch', 'Pothole', 'Non offensive graffiti',
+                'Abandoned vehicles'
             ], name => 'Peterborough City Council', cobrand => 'peterborough' },
         { area_id => 2498, categories => [
                 { group => 'Bus Stops and Shelters', category => 'Incorrect timetable' },

--- a/data/test-asset-layers.yml
+++ b/data/test-asset-layers.yml
@@ -370,36 +370,45 @@ peterborough:
       asset_id_field: 'UNITID'
       asset_type: 'spot'
       asset_item: 'light'
-    - name: 'flytipping'
+
+    - name: 'pcc_property'
       template: 'arcgis'
-      http_options:
-        params:
-          inSR: '3857'
-          outSR: '3857'
-          f: 'geojson'
-          outFields: ''
+      # this prevents issues when public and non public land are right next to each other
       nearest_radius: 0.01
       stylemap: fixmystreet.assets.stylemap_invisible
-      asset_category: ['General fly tipping', 'Hazardous fly tipping']
       non_interactive: true
       road: true
       asset_item: 'road'
       asset_type: 'road'
-    - name: 'graffiti'
-      template: 'arcgis'
+
+    # PCC Property Combined
+    - name: 'pcc_property_combined'
+      template: 'pcc_property'
       http_options:
+        url: 'https://tilma.mysociety.org/resource-proxy/proxy.php?https://peterborough.assets/4/query?'
         params:
           inSR: '3857'
           outSR: '3857'
-          f: 'geojson'
+          f: 'json'
           outFields: ''
-      nearest_radius: 0.01
-      stylemap: fixmystreet.assets.stylemap_invisible
-      asset_category: ['Offensive graffiti', 'Non offensive graffiti', 'Offensive graffiti - STAFF ONLY']
-      non_interactive: true
-      road: true
-      asset_item: 'road'
-      asset_type: 'road'
+      actions:
+        found: fixmystreet.assets.peterborough.pcc_found
+        not_found: fixmystreet.assets.peterborough.pcc_not_found
+
+    # PCC Property Leased Out NOT Responsible
+    - name: 'pcc_property_leased_out'
+      template: 'pcc_property'
+      http_options:
+        url: 'https://tilma.mysociety.org/resource-proxy/proxy.php?https://peterborough.assets/3/query?'
+        params:
+          inSR: '3857'
+          outSR: '3857'
+          f: 'json'
+          outFields: ''
+      actions:
+        found: fixmystreet.assets.peterborough.leased_found
+        not_found: fixmystreet.assets.peterborough.leased_not_found
+
   - template: 'trees'
     wfs_feature: "tree_points"
     asset_type: 'spot'
@@ -416,36 +425,28 @@ peterborough:
     actions:
       asset_found: fixmystreet.assets.peterborough.lighting_asset_found
       asset_not_found: fixmystreet.assets.peterborough.lighting_asset_not_found
-  # PCC Property Combined
-  - template: 'flytipping'
+
+  - asset_category: ['General fly tipping', 'Hazardous fly tipping' ]
+    template: 'pcc_property_combined'
     message_template: '#js-environment-message'
-    http_options:
-      url: 'https://tilma.staging.mysociety.org/resource-proxy/proxy.php?https://peterborough.assets/4/query?'
-    actions:
-      found: fixmystreet.assets.peterborough.pcc_found
-      not_found: fixmystreet.assets.peterborough.pcc_not_found
-  - template: 'graffiti'
-    message_template: '#js-graffiti-message'
-    http_options:
-      url: 'https://tilma.staging.mysociety.org/resource-proxy/proxy.php?https://peterborough.assets/4/query?'
-    actions:
-      found: fixmystreet.assets.peterborough.pcc_found
-      not_found: fixmystreet.assets.peterborough.pcc_not_found
-  # PCC Property Leased Out NOT Responsible
-  - template: 'flytipping'
+  - asset_category: ['General fly tipping', 'Hazardous fly tipping' ]
+    template: 'pcc_property_leased_out'
     message_template: '#js-environment-message'
-    http_options:
-      url: 'https://tilma.staging.mysociety.org/resource-proxy/proxy.php?https://peterborough.assets/3/query?'
-    actions:
-      found: fixmystreet.assets.peterborough.leased_found
-      not_found: fixmystreet.assets.peterborough.leased_not_found
-  - template: 'graffiti'
+
+  - asset_category: ['Offensive graffiti', 'Non offensive graffiti', 'Offensive graffiti - STAFF ONLY' ]
+    template: 'pcc_property_combined'
     message_template: '#js-graffiti-message'
-    http_options:
-      url: 'https://tilma.staging.mysociety.org/resource-proxy/proxy.php?https://peterborough.assets/3/query?'
-    actions:
-      found: fixmystreet.assets.peterborough.leased_found
-      not_found: fixmystreet.assets.peterborough.leased_not_found
+  - asset_category: ['Offensive graffiti', 'Non offensive graffiti', 'Offensive graffiti - STAFF ONLY' ]
+    template: 'pcc_property_leased_out'
+    message_template: '#js-graffiti-message'
+
+  - asset_category: ['Abandoned vehicles']
+    template: 'pcc_property_combined'
+    message_template: '#js-abandoned-vehicles-message'
+  - asset_category: ['Abandoned vehicles']
+    template: 'pcc_property_leased_out'
+    message_template: '#js-abandoned-vehicles-message'
+
 shropshire:
   - http_wfs_url: "https://tilma.mysociety.org/mapserver/shropshire"
     asset_type: 'spot'

--- a/templates/web/fixmystreet.com/report/new/abandoned_vehicles_text.html
+++ b/templates/web/fixmystreet.com/report/new/abandoned_vehicles_text.html
@@ -1,0 +1,7 @@
+Unfortunately, as this car is on private land, it is not the responsibility of the Council to remove an abandoned vehicle on this occasion.
+
+If you wish to report this incident to the landowner, we advise seeking confirmation of ownership via the Land Registry through the following link: https://www.gov.uk/government/organisations/land-registry. Additionally, details of some private roads with developers can be found here: https://www.peterborough.gov.uk/council/planning-and-development/highway-control.
+
+If the vehicle is causing an obstruction of the road or pavement, blocking a driveway, or posing a danger, the police may investigate and enforce. They can be contacted on 101, or you can complete their ASB form online to report the obstruction: https://www.cambs.police.uk/ro/report/asb/asb/report-antisocial-behaviour/.
+
+Note: If you are the landowner and seek support to remove the vehicle, please email us at environmentalenforcementteam@peterborough.gov.uk.

--- a/templates/web/fixmystreet.com/report/new/roads_message.html
+++ b/templates/web/fixmystreet.com/report/new/roads_message.html
@@ -87,4 +87,7 @@
     <p>
     [% graffiti_text = INCLUDE 'report/new/graffiti_text.html' %][% graffiti_text | add_links | html_para %]
     </p>
+</div>
+<div id="js-abandoned-vehicles-message" class="hidden">
+    [% abandoned_vehicles_text = INCLUDE 'report/new/abandoned_vehicles_text.html' %][% abandoned_vehicles_text | add_links | html_para %]
 

--- a/templates/web/peterborough/report/new/abandoned_vehicles_text.html
+++ b/templates/web/peterborough/report/new/abandoned_vehicles_text.html
@@ -1,0 +1,7 @@
+Unfortunately, as this car is on private land, it is not the responsibility of the Council to remove an abandoned vehicle on this occasion.
+
+If you wish to report this incident to the landowner, we advise seeking confirmation of ownership via the Land Registry through the following link: https://www.gov.uk/government/organisations/land-registry. Additionally, details of some private roads with developers can be found here: https://www.peterborough.gov.uk/council/planning-and-development/highway-control.
+
+If the vehicle is causing an obstruction of the road or pavement, blocking a driveway, or posing a danger, the police may investigate and enforce. They can be contacted on 101, or you can complete their ASB form online to report the obstruction: https://www.cambs.police.uk/ro/report/asb/asb/report-antisocial-behaviour/.
+
+Note: If you are the landowner and seek support to remove the vehicle, please email us at environmentalenforcementteam@peterborough.gov.uk.

--- a/templates/web/peterborough/report/new/roads_message.html
+++ b/templates/web/peterborough/report/new/roads_message.html
@@ -5,7 +5,8 @@
 <div id="js-environment-message" class="hidden box-warning">
     [% INCLUDE 'report/new/flytipping_text.html' %]
 </div>
+<div id="js-abandoned-vehicles-message" class="hidden box-warning">
+    [% abandoned_vehicles_text = INCLUDE 'report/new/abandoned_vehicles_text.html' %][% abandoned_vehicles_text | add_links | html_para %]
+</div>
 <div id="js-graffiti-message" class="hidden box-warning">
-    <p>
     [% graffiti_text = INCLUDE 'report/new/graffiti_text.html' %][% graffiti_text | add_links | html_para %]
-    </p>


### PR DESCRIPTION
This will be shown when people try and make a report on land that Peterborough aren't responsible for.

I've refactored the asset layers so that there are templates for the PCC land and PCC leased land, then there's two layers each for Flytipping/Graffiti/Abandoned vehicles, one for owned and one for leased.

See also commit `d769fca1d7d3359eff4e9e7209515e815c82eb68` on the `FD-5595-peterborough-abandoned-vehicles-private-land-check` branch in /data/servers, which updates the asset layer config.

For FD-5595

<img width="618" alt="image" src="https://github.com/user-attachments/assets/99f7a84b-3d6c-426d-bb9f-c405a8551f9b" />


Also tidied up the HTML for the graffiti category. HTML isn't supported in these templates because they're piped though `add_links | html_para`, so I've removed the tel:111 links and made the .com graffiti template match the Peterborough one.

Which should fix this issue:


<img width="525" alt="Screenshot 2025-06-27 at 12 00 14 pm" src="https://github.com/user-attachments/assets/0c9746d4-d490-484b-8605-716f016d73ad" />


<!-- [skip changelog] -->
