### PR TITLE
[TfL] Add photo column to CSV export

### DIFF
--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -412,6 +412,7 @@ sub dashboard_export_problems_add_columns {
         closure_email_at => "Closure email at",
         reassigned_at => "Reassigned at",
         reassigned_by => "Reassigned by",
+        photo => "Photo",
     );
     $csv->splice_csv_column('fixed', action_scheduled => 'Action scheduled');
 
@@ -447,6 +448,7 @@ sub dashboard_export_problems_add_columns {
                 delivered_to => join(',', @$delivered_to),
                 closure_email_at => $closure_email_at,
                 bike_number => $bike_number,
+                photo => $report->{photo} ? 1 : 0,
             };
             foreach (@{$csv->_extra_field($report)}) {
                 next if $_->{name} eq 'safety_critical';
@@ -494,6 +496,7 @@ sub dashboard_export_problems_add_columns {
             reassigned_at => $reassigned_at,
             reassigned_by => $reassigned_by,
             bike_number => $bike_number,
+            photo => $report->photo ? 1 : 0,
         };
         foreach (@{$csv->_extra_field($report)}) {
             next if $_->{name} eq 'safety_critical';

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -415,6 +415,7 @@ sub dashboard_export_problems_add_columns {
         closure_email_at => "Closure email at",
         reassigned_at => "Reassigned at",
         reassigned_by => "Reassigned by",
+        photo => "Photo",
     );
     $csv->splice_csv_column('fixed', action_scheduled => 'Action scheduled');
 
@@ -450,6 +451,7 @@ sub dashboard_export_problems_add_columns {
                 delivered_to => join(',', @$delivered_to),
                 closure_email_at => $closure_email_at,
                 bike_number => $bike_number,
+                photo => $report->{photo} ? 1 : 0,
             };
             foreach (@{$csv->_extra_field($report)}) {
                 next if $_->{name} eq 'safety_critical';
@@ -497,6 +499,7 @@ sub dashboard_export_problems_add_columns {
             reassigned_at => $reassigned_at,
             reassigned_by => $reassigned_by,
             bike_number => $bike_number,
+            photo => $report->photo ? 1 : 0,
         };
         foreach (@{$csv->_extra_field($report)}) {
             next if $_->{name} eq 'safety_critical';

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -640,10 +640,15 @@ subtest 'Dashboard CSV extra columns' => sub {
     $mech->content_contains('Category,Subcategory');
     $mech->content_contains('Query,Borough');
     $mech->content_contains(',Acknowledged,"Action scheduled",Fixed');
-    $mech->content_contains(',"Safety critical","Delivered to","Closure email at","Reassigned at","Reassigned by","Is the pole leaning?"');
+    $mech->content_contains(',"Safety critical","Delivered to","Closure email at","Reassigned at","Reassigned by",Photo,"Is the pole leaning?"');
     $mech->content_contains('"Bus things","Bus stops"');
     $mech->content_contains('"BR1 3UH",Bromley,');
-    $mech->content_contains(',,,no,busstops@example.com,,,,Yes');
+    $mech->content_contains(',,,no,busstops@example.com,,,,0,Yes');
+
+    $report->update({ photo => 't/fixtures/blank.jpeg' });
+    $mech->get_ok('/dashboard?export=1&category=Bus+stops');
+    $mech->content_contains(',,,no,busstops@example.com,,,,1,Yes', "Photo column is 1 for report with photo");
+    $report->update({ photo => undef });
 
     $report->set_extra_fields({ name => 'safety_critical', value => 'yes' });
     $report->anonymous(1);
@@ -665,19 +670,19 @@ subtest 'Dashboard CSV extra columns' => sub {
     $mech->get_ok('/dashboard?export=1');
     $mech->content_contains('Query,Borough');
     $mech->content_contains(',Acknowledged,"Action scheduled",Fixed');
-    $mech->content_contains(',"Safety critical","Delivered to","Closure email at","Reassigned at","Reassigned by"');
+    $mech->content_contains(',"Safety critical","Delivered to","Closure email at","Reassigned at","Reassigned by",Photo');
     $mech->content_contains('(anonymous ' . $report->id . ')');
     $mech->content_contains($dt . ',,,confirmed,51.4021');
-    $mech->content_contains(',,,yes,busstops@example.com,,' . $dt . ',"Council User"');
+    $mech->content_contains(',,,yes,busstops@example.com,,' . $dt . ',"Council User",0');
 
     $report->set_extra_fields({ name => 'stop_code', value => '98756' }, { name => 'Question', value => '12345' });
     $report->update;
 
     $mech->get_ok('/dashboard?export=1');
     $mech->content_contains(',12345,,no,busstops@example.com,,', "Bike number added to csv");
-    $mech->content_contains('"Council User",,,98756', "Stop code added to csv for all categories report");
+    $mech->content_contains('"Council User",0,,,98756', "Stop code added to csv for all categories report");
     $mech->get_ok('/dashboard?export=1&category=Bus+stops');
-    $mech->content_contains('"Council User",,,98756', "Stop code added to csv for bus stop category report");
+    $mech->content_contains('"Council User",0,,,98756', "Stop code added to csv for bus stop category report");
 
     $report->set_extra_fields({ name => 'leaning', value => 'Yes' }, { name => 'safety_critical', value => 'yes' },
         { name => 'stop_code', value => '98756' }, { name => 'Question', value => '12345' });
@@ -699,10 +704,10 @@ subtest 'Dashboard CSV extra columns' => sub {
     $mech->content_contains('Category,Subcategory');
     $mech->content_contains('Query,Borough');
     $mech->content_contains(',Acknowledged,"Action scheduled",Fixed');
-    $mech->content_contains(',"Safety critical","Delivered to","Closure email at","Reassigned at","Reassigned by","Is the pole leaning?"');
+    $mech->content_contains(',"Safety critical","Delivered to","Closure email at","Reassigned at","Reassigned by",Photo,"Is the pole leaning?"');
     $mech->content_contains('"Bus things","Bus stops"');
     $mech->content_contains('"BR1 3UH",Bromley,');
-    $mech->content_contains(',12345,,yes,busstops@example.com,,' . $dt . ',"Council User",Yes,,98756');
+    $mech->content_contains(',12345,,yes,busstops@example.com,,' . $dt . ',"Council User",0,Yes,,98756');
     my $c = () = $mech->encoded_content =~ /^$y_id/mg;
     is $c, 1, 'Only one report from yesterday';
 
@@ -710,10 +715,10 @@ subtest 'Dashboard CSV extra columns' => sub {
     $mech->content_contains('Category,Subcategory');
     $mech->content_contains('Query,Borough');
     $mech->content_contains(',Acknowledged,"Action scheduled",Fixed');
-    $mech->content_contains(',"Safety critical","Delivered to","Closure email at","Reassigned at","Reassigned by","Is the pole leaning?"');
+    $mech->content_contains(',"Safety critical","Delivered to","Closure email at","Reassigned at","Reassigned by",Photo,"Is the pole leaning?"');
     $mech->content_contains('(anonymous ' . $report->id . ')');
     $mech->content_contains($dt . ',,,confirmed,51.4021');
-    $mech->content_contains(',12345,,yes,busstops@example.com,,' . $dt . ',"Council User",Yes,,98756');
+    $mech->content_contains(',12345,,yes,busstops@example.com,,' . $dt . ',"Council User",0,Yes,,98756');
 
     $mech->get_ok('/dashboard?export=1&category=Trees+(brown)');
     $mech->content_contains('Trees (brown)');

--- a/t/cobrand/tfl.t
+++ b/t/cobrand/tfl.t
@@ -639,10 +639,15 @@ subtest 'Dashboard CSV extra columns' => sub {
     $mech->content_contains('Category,Subcategory');
     $mech->content_contains('Query,Borough');
     $mech->content_contains(',Acknowledged,"Action scheduled",Fixed');
-    $mech->content_contains(',"Safety critical","Delivered to","Closure email at","Reassigned at","Reassigned by","Is the pole leaning?"');
+    $mech->content_contains(',"Safety critical","Delivered to","Closure email at","Reassigned at","Reassigned by",Photo,"Is the pole leaning?"');
     $mech->content_contains('"Bus things","Bus stops"');
     $mech->content_contains('"BR1 3UH",Bromley,');
-    $mech->content_contains(',,,no,busstops@example.com,,,,Yes');
+    $mech->content_contains(',,,no,busstops@example.com,,,,0,Yes');
+
+    $report->update({ photo => 't/fixtures/blank.jpeg' });
+    $mech->get_ok('/dashboard?export=1&category=Bus+stops');
+    $mech->content_contains(',,,no,busstops@example.com,,,,1,Yes', "Photo column is 1 for report with photo");
+    $report->update({ photo => undef });
 
     $report->set_extra_fields({ name => 'safety_critical', value => 'yes' });
     $report->anonymous(1);
@@ -664,19 +669,19 @@ subtest 'Dashboard CSV extra columns' => sub {
     $mech->get_ok('/dashboard?export=1');
     $mech->content_contains('Query,Borough');
     $mech->content_contains(',Acknowledged,"Action scheduled",Fixed');
-    $mech->content_contains(',"Safety critical","Delivered to","Closure email at","Reassigned at","Reassigned by"');
+    $mech->content_contains(',"Safety critical","Delivered to","Closure email at","Reassigned at","Reassigned by",Photo');
     $mech->content_contains('(anonymous ' . $report->id . ')');
     $mech->content_contains($dt . ',,,confirmed,51.4021');
-    $mech->content_contains(',,,yes,busstops@example.com,,' . $dt . ',"Council User"');
+    $mech->content_contains(',,,yes,busstops@example.com,,' . $dt . ',"Council User",0');
 
     $report->set_extra_fields({ name => 'stop_code', value => '98756' }, { name => 'Question', value => '12345' });
     $report->update;
 
     $mech->get_ok('/dashboard?export=1');
     $mech->content_contains(',12345,,no,busstops@example.com,,', "Bike number added to csv");
-    $mech->content_contains('"Council User",,,98756', "Stop code added to csv for all categories report");
+    $mech->content_contains('"Council User",0,,,98756', "Stop code added to csv for all categories report");
     $mech->get_ok('/dashboard?export=1&category=Bus+stops');
-    $mech->content_contains('"Council User",,,98756', "Stop code added to csv for bus stop category report");
+    $mech->content_contains('"Council User",0,,,98756', "Stop code added to csv for bus stop category report");
 
     $report->set_extra_fields({ name => 'leaning', value => 'Yes' }, { name => 'safety_critical', value => 'yes' },
         { name => 'stop_code', value => '98756' }, { name => 'Question', value => '12345' });
@@ -698,10 +703,10 @@ subtest 'Dashboard CSV extra columns' => sub {
     $mech->content_contains('Category,Subcategory');
     $mech->content_contains('Query,Borough');
     $mech->content_contains(',Acknowledged,"Action scheduled",Fixed');
-    $mech->content_contains(',"Safety critical","Delivered to","Closure email at","Reassigned at","Reassigned by","Is the pole leaning?"');
+    $mech->content_contains(',"Safety critical","Delivered to","Closure email at","Reassigned at","Reassigned by",Photo,"Is the pole leaning?"');
     $mech->content_contains('"Bus things","Bus stops"');
     $mech->content_contains('"BR1 3UH",Bromley,');
-    $mech->content_contains(',12345,,yes,busstops@example.com,,' . $dt . ',"Council User",Yes,,98756');
+    $mech->content_contains(',12345,,yes,busstops@example.com,,' . $dt . ',"Council User",0,Yes,,98756');
     my $c = () = $mech->encoded_content =~ /^$y_id/mg;
     is $c, 1, 'Only one report from yesterday';
 
@@ -709,10 +714,10 @@ subtest 'Dashboard CSV extra columns' => sub {
     $mech->content_contains('Category,Subcategory');
     $mech->content_contains('Query,Borough');
     $mech->content_contains(',Acknowledged,"Action scheduled",Fixed');
-    $mech->content_contains(',"Safety critical","Delivered to","Closure email at","Reassigned at","Reassigned by","Is the pole leaning?"');
+    $mech->content_contains(',"Safety critical","Delivered to","Closure email at","Reassigned at","Reassigned by",Photo,"Is the pole leaning?"');
     $mech->content_contains('(anonymous ' . $report->id . ')');
     $mech->content_contains($dt . ',,,confirmed,51.4021');
-    $mech->content_contains(',12345,,yes,busstops@example.com,,' . $dt . ',"Council User",Yes,,98756');
+    $mech->content_contains(',12345,,yes,busstops@example.com,,' . $dt . ',"Council User",0,Yes,,98756');
 
     $mech->get_ok('/dashboard?export=1&category=Trees+(brown)');
     $mech->content_contains('Trees (brown)');


### PR DESCRIPTION
Adds a photo column to the CSV export that contains either 1 or 0 to indicate whether a report has a photo.

I'm not 100% sure I've done this correctly, I still haven't fully grokked the CSV pre-generation, so there may be more to do on this.

Fixes FD-5606

<!-- [skip changelog] -->
