### PR TITLE
[Glos City] Add archive email templates

### DIFF
--- a/templates/email/gloucester/archive.html
+++ b/templates/email/gloucester/archive.html
@@ -1,0 +1,53 @@
+[%
+
+PROCESS '_email_settings.html';
+
+INCLUDE '_email_top.html';
+
+%]
+
+<th style="[% td_style %][% only_column_style %]">
+  <h1 style="[% h1_style %]">Your reports on [% site_name %]</h1>
+  <p style="[% p_style %]">
+    Hello [% user.name %],
+  </p>
+  <p style="[% p_style %]">
+    FixMyStreet is being updated in Gloucester City Council to
+    improve how problems get reported.
+  </p>
+  <p style="[% p_style %]">
+    As part of this process we are closing all reports
+    made before the update.
+  </p>
+  <p style="[% p_style %]">
+    We noticed that you have [% report_count %] old [% nget('report', 'reports', report_count) %] on the system,
+    which we've listed below.
+  </p>
+  <p style="[% p_style %]">
+    All of your reports will have been received and reviewed by Gloucester City Council, so if your report is no longer an issue, you don't need to do
+    anything.
+  </p>
+  <p style="[% p_style %]">
+    If you believe that the issue has not been resolved you can <a href="https://report.gloucester.gov.uk">report it again here.</a>
+  </p>
+
+  [% FOR report IN reports %]
+  <div style="[% list_item_style %]">
+  [% IF report.photo %]
+    <a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
+      <img style="[% list_item_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="">
+    </a>
+  [% END %]
+    <h2 style="[% list_item_h2_style %]"><a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
+      [%~ report.title | html ~%]
+    </a></h2>
+    <p style="[% list_item_p_style %]">[% report.detail | html %]</p>
+    <p style="[% list_item_date_style %]">
+      Reported [% report.time_ago %] ago.
+    </p>
+  </div>
+  [% END %]
+
+</th>
+
+[% INCLUDE '_email_bottom.html' %]

--- a/templates/email/gloucester/archive.txt
+++ b/templates/email/gloucester/archive.txt
@@ -1,0 +1,27 @@
+Subject: Your reports on [% site_name %]
+
+Hello [% user.name %],
+
+FixMyStreet is being updated in Gloucester City Council to improve how problems get reported.
+
+As part of this process we are closing all reports made before the update.
+
+We noticed that you have [% report_count %] old [% nget('report', 'reports', report_count) %] on the system, which we've listed below.
+
+All of your reports will have been received and reviewed by Gloucester City Council, so if your report is no longer an issue, you don't need to do anything.
+
+If you believe that the issue has not been resolved you can report it again here: https://report.gloucester.gov.uk
+
+[% FOR report IN reports %]
+
+[% report.title %]
+
+Reported [% report.time_ago %] ago.
+
+View report: [% cobrand.base_url_for_report( report ) %]/report/[% report.id %]
+
+----
+
+[% END %]
+
+The FixMyStreet team and Gloucester City Council


### PR DESCRIPTION
For https://github.com/mysociety/societyworks/issues/5040.

As tried locally: 
```
bin/archive-old-enquiries --body 22 --user 1 --cobrand gloucester --email-cutoff="2025-07-02 09:00:00" --closure-cutoff="0001-01-01 00:00:00"
```
Needs dry-run on live *then* run with `--commit`; need to change: `--body 2325` & `--user 2178596`.

[skip changelog]
