### PR TITLE
[Bexley] Check for cancellations in Agile

### DIFF
--- a/bin/bexley/cancel-garden-waste-from-agile
+++ b/bin/bexley/cancel-garden-waste-from-agile
@@ -1,0 +1,40 @@
+#!/usr/bin/env perl
+
+use v5.14;
+use warnings;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use Getopt::Long::Descriptive;
+use FixMyStreet::Cobrand;
+use FixMyStreet::Script::Bexley::CancelGardenWaste;
+
+my ($opts, $usage) = describe_options(
+    '%c %o',
+    ['days=i', 'How many days to check for cancellations (max 7)', { default => 7 } ],
+    ['uprn=s', 'A specific UPRN to cancel'],
+    ['verbose|v', 'Print verbose output'],
+    ['help|h', "print usage message and exit" ],
+);
+
+$usage->die if $opts->help;
+if ($opts->days > 7) {
+    $usage->die("Days must be 7 or less");
+}
+
+my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker('bexley')->new;
+my $canceller = FixMyStreet::Script::Bexley::CancelGardenWaste->new(
+    cobrand => $cobrand,
+    verbose => $opts->verbose,
+);
+
+if ($opts->uprn) {
+    $canceller->cancel_by_uprn($opts->uprn);
+} else {
+    $canceller->cancel_from_api($opts->days);
+}

--- a/perllib/FixMyStreet/Script/Bexley/CancelGardenWaste.pm
+++ b/perllib/FixMyStreet/Script/Bexley/CancelGardenWaste.pm
@@ -1,0 +1,110 @@
+=head1 NAME
+
+FixMyStreet::Script::Bexley::CancelGardenWaste - cancel garden waste subscriptions from Agile
+
+=cut
+
+package FixMyStreet::Script::Bexley::CancelGardenWaste;
+
+use v5.14;
+use warnings;
+use Moo;
+use Integrations::Agile;
+use DateTime;
+use FixMyStreet;
+use JSON::MaybeXS qw(encode_json);
+
+has 'cobrand' => ( is => 'ro', required => 1 );
+has 'verbose' => ( is => 'ro', default => 0 );
+has 'agile' => (
+    is => 'lazy',
+    default => sub {
+        my $self = shift;
+        my $config = $self->cobrand->feature('agile');
+        return Integrations::Agile->new(%$config);
+    },
+);
+
+sub cancel_from_api {
+    my ($self, $days) = @_;
+
+    my $contracts = $self->agile->LastCancelled($days);
+    if (ref $contracts eq 'HASH' && $contracts->{error}) {
+        warn "Error fetching cancellations: $contracts->{error}\n";
+        return;
+    }
+
+    unless ($contracts && @$contracts) {
+        $self->_vprint("No cancellations found in the last $days days");
+        return;
+    }
+    $self->_vprint("Found " . scalar(@$contracts) . " cancellations");
+
+    foreach my $contract (@$contracts) {
+        $self->cancel_by_uprn($contract->{UPRN});
+    }
+}
+
+sub cancel_by_uprn {
+    my ($self, $uprn) = @_;
+
+    $self->_vprint("Attempting to cancel subscription for UPRN $uprn");
+
+    # Find active garden subscription report for this UPRN
+    my $report = $self->cobrand->problems->search({
+        category => 'Garden Subscription',
+        extra => { '@>' => encode_json({ "_fields" => [ { name => "uprn", value => $uprn } ] }) },
+        state => [ FixMyStreet::DB::Result::Problem->open_states ],
+    })->order_by('-id')->first;
+
+    unless ($report) {
+        $self->_vprint("  No active garden subscription found for UPRN $uprn");
+        return;
+    }
+
+    $self->_vprint("  Found active report " . $report->id);
+
+    # TODO: Create a cancellation report (but mark as sent, as it doesn't need to go to Agile)
+    # TODO: Check for an existing cancellation for this report before cancelling DD.
+
+    my $payment_method = $report->get_extra_field_value('payment_method') || 'credit_card';
+    if ($payment_method eq 'direct_debit') {
+        $self->_cancel_direct_debit($report);
+    } else {
+        # Nothing to do for credit card
+    }
+}
+
+sub _cancel_direct_debit {
+    my ($self, $original_report) = @_;
+
+    my $i = $self->cobrand->get_dd_integration;
+    unless ($i) {
+        $self->_vprint("  WARNING: Could not get Direct Debit integration object. Unable to cancel at source.");
+        return;
+    }
+
+    my $payer_ref = $original_report->get_extra_metadata('direct_debit_contract_id');
+    if (!$payer_ref) {
+        $self->_vprint("  WARNING: Direct debit cancellation failed: direct_debit_contract_id not found on original report " . $original_report->id);
+        return;
+    }
+
+    $self->_vprint("  Cancelling Direct Debit plan with payer reference $payer_ref");
+    my $update_ref = $i->cancel_plan({
+        report => $original_report,
+    });
+
+    if ($update_ref) {
+        $self->_vprint("  Successfully sent cancellation request to Direct Debit provider.");
+    } else {
+        $self->_vprint("  Failed to send cancellation request to Direct Debit provider.");
+    }
+}
+
+sub _vprint {
+    my ($self, $message) = @_;
+    print "$message\n" if $self->verbose;
+}
+
+1;

--- a/perllib/Integrations/Agile.pm
+++ b/perllib/Integrations/Agile.pm
@@ -75,4 +75,31 @@ sub CustomerSearch {
     );
 }
 
+sub LastCancelled {
+    my ( $self, $days ) = @_;
+
+    my $response = $self->call(
+        action     => 'lastCancelled',
+        controller => 'servicecontract',
+        data       => { NumberOfDays => $days },
+    );
+
+    if (ref $response eq 'HASH' && exists $response->{error}) {
+        return $response;
+    }
+
+    # TODO: Confirm which format is correct, the documentation suggests a hash
+    # with a ServiceContracts key but the actual response is an array. This
+    # is a workaround to handle both formats.
+    if (ref $response eq 'HASH' && exists $response->{ServiceContracts}) {
+        return $response->{ServiceContracts};
+    }
+    if (ref $response eq 'ARRAY') {
+        return $response;
+    }
+
+    warn "Unexpected response format from Agile LastCancelled\n";
+    return { error => "Unexpected response format from Agile LastCancelled" };
+}
+
 1;

--- a/t/script/bexley/cancel-garden-waste.t
+++ b/t/script/bexley/cancel-garden-waste.t
@@ -1,0 +1,148 @@
+use FixMyStreet::TestMech;
+use DateTime;
+use Test::Output;
+use Test::MockModule;
+use JSON::MaybeXS;
+
+use_ok 'FixMyStreet::Script::Bexley::CancelGardenWaste';
+
+my $mech = FixMyStreet::TestMech->new;
+my $area_id = 2494;
+my $body = $mech->create_body_ok($area_id, 'Bexley Council', {
+    cobrand => 'bexley',
+});
+
+# Create test contacts
+my $garden_contact = $mech->create_contact_ok(
+    category => 'Garden Subscription',
+    body_id => $body->id,
+    email => 'garden@example.com'
+);
+
+my $cancel_contact = $mech->create_contact_ok(
+    category => 'Cancel Garden Subscription',
+    body_id => $body->id,
+    email => 'cancel@example.com'
+);
+
+# Create test user
+my $user = $mech->create_user_ok('test@example.com', name => 'Test User');
+
+# Mock the Agile integration
+my $agile_mock = Test::MockModule->new('Integrations::Agile');
+my $agile_response;
+$agile_mock->mock('LastCancelled', sub { return $agile_response });
+
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => ['bexley'],
+    MAPIT_URL => 'http://mapit.uk/',
+    COBRAND_FEATURES => {
+        agile => {
+            bexley => {
+                url => 'http://example.com/agile',
+            },
+        },
+    },
+}, sub {
+    my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker('bexley')->new;
+
+    subtest 'cancel_from_api tests' => sub {
+        my $canceller = FixMyStreet::Script::Bexley::CancelGardenWaste->new(
+            cobrand => $cobrand,
+            verbose => 0,
+        );
+
+        subtest 'handles API error' => sub {
+            $agile_response = { error => 'API Error' };
+
+            my $result;
+            stderr_is { $result = $canceller->cancel_from_api(7) }
+                "Error fetching cancellations: API Error\n",
+                "API error is reported";
+
+            is $result, undef, "Returns undef on API error";
+        };
+
+        subtest 'handles empty response' => sub {
+            $agile_response = [];
+
+            my $canceller_verbose = FixMyStreet::Script::Bexley::CancelGardenWaste->new(
+                cobrand => $cobrand,
+                verbose => 1,
+            );
+
+            stdout_is { $canceller_verbose->cancel_from_api(7) }
+                "No cancellations found in the last 7 days\n",
+                "Empty response handled correctly";
+        };
+
+        subtest 'processes cancellations' => sub {
+            $agile_response = [
+                { UPRN => '123456789' },
+                { UPRN => '987654321' },
+            ];
+
+            my $cancel_calls = [];
+            my $canceller_test = FixMyStreet::Script::Bexley::CancelGardenWaste->new(
+                cobrand => $cobrand,
+                verbose => 1,
+            );
+
+            # Mock cancel_by_uprn to track calls
+            my $cancel_mock = Test::MockModule->new('FixMyStreet::Script::Bexley::CancelGardenWaste');
+            $cancel_mock->mock('cancel_by_uprn', sub {
+                my ($self, $uprn) = @_;
+                push @$cancel_calls, $uprn;
+            });
+
+            stdout_is { $canceller_test->cancel_from_api(7) }
+                "Found 2 cancellations\n",
+                "Correct number of cancellations found";
+
+            is_deeply $cancel_calls, ['123456789', '987654321'],
+                "cancel_by_uprn called for each UPRN";
+        };
+    };
+
+    subtest 'cancel_by_uprn tests' => sub {
+        my $canceller = FixMyStreet::Script::Bexley::CancelGardenWaste->new(
+            cobrand => $cobrand,
+            verbose => 1,
+        );
+
+        my $uprn = '123456789';
+
+        subtest 'no active subscription found' => sub {
+            stdout_is { $canceller->cancel_by_uprn($uprn) }
+                "Attempting to cancel subscription for UPRN $uprn\n" .
+                "  No active garden subscription found for UPRN $uprn\n",
+                "Handles no active subscription correctly";
+        };
+
+        subtest 'handles direct debit cancellation' => sub {
+            my $uprn = '111222333';
+
+            # Create an active garden subscription with direct debit
+            my ($garden_report) = $mech->create_problems_for_body(1, $body->id, 'Garden Subscription - New', {
+                category => 'Garden Subscription',
+            });
+            $garden_report->set_extra_metadata('uprn', $uprn);
+            $garden_report->set_extra_metadata('payment_method', 'direct_debit');
+            $garden_report->set_extra_metadata('direct_debit_contract_id', 'PAYER123');
+            $garden_report->update;
+
+            my $dd_integration_mock_obj = Test::MockModule->new('Integrations::Agile');
+            $dd_integration_mock_obj->mock('cancel_plan', sub {
+                my ($self, $args) = @_;
+                is $args->{report}->id, $garden_report->id, 'Correct report passed';
+                return 1;
+            });
+
+            stdout_like { $canceller->cancel_by_uprn($uprn) }
+                qr/Attempting to cancel subscription for UPRN $uprn.*Found active report.*Cancelling Direct Debit.*Successfully sent cancellation request/s,
+                "Successfully handles direct debit cancellation";
+        };
+    };
+};
+
+done_testing;


### PR DESCRIPTION
Add a script to check Agile's LastCancelled API for recent cancellations and cancel the related Direct Debit in Access PaySuite.

## TODO

- [ ] Create a cancellation report in the database to cancellations that have already been processed (see TODO comments in code)
- [ ] Fix broken tests (for some reason I can't figure out the report isn't being found in the database via its UPRN)
- [ ] Test with real data once Bexley have done some test cancellations in Agile

Fixes https://github.com/mysociety/societyworks/issues/4799

<!-- [skip changelog] -->