### PR TITLE
Increased z-index of .mobile-filters-active

### DIFF
--- a/web/cobrands/sass/_report_list.scss
+++ b/web/cobrands/sass/_report_list.scss
@@ -9,7 +9,7 @@ $govuk-input-focus-box-shadow: #fd0 !default;
 
   .mobile-filters-active & {
     position: fixed;
-    z-index: 1;
+    z-index: 999;
     bottom: 0;
     left: 0;
     right: 0;


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/5077

Because the z-index number was quite low, the element didn't have the right order compared with the other elements on the page. This was causing the drawer to be opened, but its contents were behind the map.

[skip changelog]