### PR TITLE
[Northumberland] Add aerial mapping layer.

### DIFF
--- a/.cypress/cypress/integration/northumberland.js
+++ b/.cypress/cypress/integration/northumberland.js
@@ -1,0 +1,13 @@
+it('loads the right front page', function() {
+    cy.visit('http://northumberland.localhost:3001/');
+    cy.contains('Northumberland');
+});
+
+it('toggles the aerial map', function() {
+    cy.get('[name=pc]').type(Cypress.env('postcode'));
+    cy.get('[name=pc]').parents('form').submit();
+    cy.get('.map-layer-toggle').click();
+    cy.get('.map-layer-toggle').should('have.class', 'roads');
+    cy.get('.map-layer-toggle').click();
+    cy.get('.map-layer-toggle').should('have.class', 'aerial');
+});

--- a/.cypress/cypress/integration/simple_spec.js
+++ b/.cypress/cypress/integration/simple_spec.js
@@ -32,11 +32,6 @@ describe('Clicking the map', function() {
     });
 
     it('map pins toggle okay', function() {
-        cy.get('.map-layer-toggle').click();
-        cy.get('.map-layer-toggle').should('have.class', 'roads');
-        cy.get('.map-layer-toggle').click();
-        cy.get('.map-layer-toggle').should('have.class', 'aerial');
-
         cy.get('.map-pins-toggle').click();
         cy.get('.map-pins-toggle').should('contain', 'Show pins');
         cy.get('.map-pins-toggle').click();

--- a/bin/browser-tests
+++ b/bin/browser-tests
@@ -26,6 +26,7 @@ BEGIN {
         lincolnshire
         merton
         northamptonshire
+        northumberland
         oxfordshire
         peterborough
         shropshire

--- a/perllib/FixMyStreet/Cobrand/Northumberland.pm
+++ b/perllib/FixMyStreet/Cobrand/Northumberland.pm
@@ -76,6 +76,8 @@ sub pin_colour {
     return 'orange'; # all the other `open_states` like "in progress"
 }
 
+sub has_aerial_maps { 'tilma.mysociety.org/mapcache/gmaps/northumberlandaerial@osmaps' }
+
 =item * Hovering over a pin includes the state as well as the title
 
 =cut

--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -74,6 +74,8 @@ sub pin_colour {
     return 'yellow';
 }
 
+sub has_aerial_maps { 1 }
+
 # This isn't used
 sub find_closest {
     my ( $self, $problem ) = @_;

--- a/perllib/FixMyStreet/Map/Base.pm
+++ b/perllib/FixMyStreet/Map/Base.pm
@@ -34,7 +34,7 @@ sub display_map {
         if defined $c->get_param('lon');
     $params{zoomToBounds} = $params{any_zoom} && !defined $c->get_param('zoom');
 
-    $params{aerial} = $c->get_param("aerial") && FixMyStreet->config('BING_MAPS_API_KEY') ? 1 : 0;
+    $params{aerial} = $c->get_param("aerial") && $c->cobrand->call_hook('has_aerial_maps') ? 1 : 0;
 
     my $map = $cls->new({
         # Co-ordinates are in case the layer needs to decide things

--- a/t/map/fms.t
+++ b/t/map/fms.t
@@ -4,56 +4,35 @@ use FixMyStreet::Cobrand;
 
 my $cobrand = FixMyStreet::Cobrand::FixMyStreet->new;
 
-#   Z   NI  Aerial
+#   Z   NI
 my $expected = {
     10 => {
-        0 => {
-            0 => 'zxy/Road_3857/10/32420/21504',
-            1 => 'ch/1010100100.*?A,G,L',
-        },
-        1 => {
-            0 => '10/32420/21504.png',
-            1 => 'ch/1010100100.*?A,G,L',
-       },
+        0 => 'zxy/Road_3857/10/32420/21504',
+        1 => '10/32420/21504.png',
     },
     13 => {
-        0 => {
-            0 => 'zxy/Road_3857/13/32420/21504',
-            1 => 'ch/3131010100100.*?A,G,L',
-        },
-        1 => {
-            0 => '13/32420/21504.png',
-            1 => 'ch/3131010100100.*?A,G,L',
-        },
+        0 => 'zxy/Road_3857/13/32420/21504',
+        1 => '13/32420/21504.png',
     },
     16 => {
-        0 => {
-            0 => 'zxy/Road_3857/16/32420/21504',
-            1 => 'ch/0313131010100100.*?A,G,L',
-        },
-        1 => {
-            0 => '16/32420/21504.png',
-            1 => 'ch/0313131010100100.*?A,G,L',
-        },
+        0 => 'zxy/Road_3857/16/32420/21504',
+        1 => '16/32420/21504.png',
     },
 };
 
 subtest "Correct tiles with various parameters" => sub {
-    for my $aerial (0, 1) {
-        for my $ni (0, 1) {
-            my $map = FixMyStreet::Map::FMS->new(
-                cobrand => $cobrand,
-                latitude => $ni ? 55 : 51,
-                longitude => $ni ? -6 : -2,
+    for my $ni (0, 1) {
+        my $map = FixMyStreet::Map::FMS->new(
+            cobrand => $cobrand,
+            latitude => $ni ? 55 : 51,
+            longitude => $ni ? -6 : -2,
+        );
+        for my $zoom (qw(10 13 16)) {
+            my $tiles = $map->map_tiles(
+                x_tile => 32421, y_tile => 21505, zoom_act => $zoom,
             );
-            for my $zoom (qw(10 13 16)) {
-                my $tiles = $map->map_tiles(
-                    x_tile => 32421, y_tile => 21505, zoom_act => $zoom,
-                    aerial => $aerial,
-                );
-                my $wanted = $expected->{$zoom}{$ni}{$aerial};
-                like $tiles->[0], qr/$wanted/, "with zoom $zoom, NI $ni, aerial $aerial";
-            }
+            my $wanted = $expected->{$zoom}{$ni};
+            like $tiles->[0], qr/$wanted/, "with zoom $zoom, NI $ni";
         }
     }
 };

--- a/templates/web/base/maps/fms.html
+++ b/templates/web/base/maps/fms.html
@@ -1,1 +1,1 @@
-[% map_html = INCLUDE maps/openlayers.html include_key = 1 map_type_toggle = 1 %]
+[% map_html = INCLUDE maps/openlayers.html %]

--- a/templates/web/base/maps/google-ol.html
+++ b/templates/web/base/maps/google-ol.html
@@ -1,1 +1,1 @@
-[% map_html = INCLUDE maps/openlayers.html map_type_toggle = 1 %]
+[% map_html = INCLUDE maps/openlayers.html %]

--- a/templates/web/base/maps/openlayers.html
+++ b/templates/web/base/maps/openlayers.html
@@ -25,10 +25,8 @@
     data-numZoomLevels=[% map.numZoomLevels %]
     data-zoomOffset=[% map.zoomOffset %]
     data-map_type="[% map.map_type %]"
-[% IF include_key -%]
-    data-bing_key='[% c.config.BING_MAPS_API_KEY %]'
-[% END -%]
 [% IF map.os_maps -%]
+    data-aerial_url='[% map.aerial_url %]'
     data-os_key='[% map.os_maps.key %]'
     data-os_layer='[% map.os_maps.layer %]'
     data-os_url='[% map.os_maps.url %]'
@@ -57,8 +55,7 @@
     <img id="loading-indicator" class="hidden" aria-hidden="true" src="/i/loading.svg" alt="Loading...">
 
 <div class="map-links">
-  [% IF map_type_toggle %]
-    [% IF c.config.BING_MAPS_API_KEY OR c.cobrand.moniker == 'zurich' %]
+    [% IF c.cobrand.has_aerial_maps %]
       [% aerial = c.req.params.aerial %]
       [% SET aerial = 1 IF c.cobrand.moniker == 'zurich' AND NOT c.req.params.aerial.defined %]
       [% IF aerial %]
@@ -67,7 +64,6 @@
         <a class="map-layer-toggle aerial" rel="nofollow" href="[% c.uri_with( { aerial => 1 } ) %]"><span class="map-link-label">[% loc('Aerial map') %]</span></a>
       [% END %]
     [% END %]
-  [% END %]
 
   [% IF page == "around" %]
     [% IF c.req.params.no_pins %]

--- a/templates/web/base/maps/osm.html
+++ b/templates/web/base/maps/osm.html
@@ -1,4 +1,4 @@
 [%
 map.copyright = ''; # This is handled with OpenLayers.Control.Attribution
-map_html = INCLUDE maps/openlayers.html map_type_toggle = 1
+map_html = INCLUDE maps/openlayers.html
 %]

--- a/templates/web/zurich/maps/zurich.html
+++ b/templates/web/zurich/maps/zurich.html
@@ -1,4 +1,4 @@
 [% map_html = BLOCK %]
-[% INCLUDE maps/openlayers.html map_type_toggle = 1 %]
+[% INCLUDE maps/openlayers.html %]
 [% INCLUDE maps/wmts_config.html %]
 [% END %]

--- a/web/cobrands/fixmystreet/map.js
+++ b/web/cobrands/fixmystreet/map.js
@@ -3,7 +3,7 @@ var fixmystreet = fixmystreet || {};
 (function(){
 
     var map_data = document.getElementById('js-map-data'),
-        map_keys = [ 'area', 'latitude', 'longitude', 'zoomToBounds', 'zoom', 'pin_prefix', 'pin_new_report_colour', 'numZoomLevels', 'zoomOffset', 'map_type', 'bing_key', 'bodies', 'staging', 'os_licence', 'os_key', 'os_layer', 'os_url', 'os_oml_zoom_switch', 'os_premium' ],
+        map_keys = [ 'area', 'latitude', 'longitude', 'zoomToBounds', 'zoom', 'pin_prefix', 'pin_new_report_colour', 'numZoomLevels', 'zoomOffset', 'map_type', 'aerial_url', 'bodies', 'staging', 'os_licence', 'os_key', 'os_layer', 'os_url', 'os_oml_zoom_switch', 'os_premium' ],
         numeric = { zoom: 1, numZoomLevels: 1, zoomOffset: 1, id: 1, os_oml_zoom_switch: 1, os_premium: 1 },
         bool = { draggable: 1 },
         pin_keys = [ 'lat', 'lon', 'colour', 'id', 'title', 'type', 'draggable' ];

--- a/web/js/map-os-bng.js
+++ b/web/js/map-os-bng.js
@@ -4,7 +4,22 @@ fixmystreet.maps.config = function() {
 
 fixmystreet.maps.tile_base = 'https://{S}tilma.mysociety.org/mapcache/gmaps/oml@osmaps';
 
-OpenLayers.Layer.OSMapsBNG = OpenLayers.Class(OpenLayers.Layer.XYZ, {
+OpenLayers.Layer.BNG = OpenLayers.Class(OpenLayers.Layer.XYZ, {
+    initialize: function(name, url, options) {
+        options = OpenLayers.Util.extend({
+            units: "m",
+            projection: new OpenLayers.Projection("EPSG:27700"),
+            tileOrigin: new OpenLayers.LonLat(-238375, 1376256),
+            maxExtent: new OpenLayers.Bounds(-3276800, -3276800, 3276800, 3276800),
+            resolutions: [896, 448, 224, 112, 56, 28, 14, 7, 7/2, 7/4, 7/8, 7/16, 7/32, 7/64].slice(fixmystreet.zoomOffset || 0).slice(0, fixmystreet.numZoomLevels),
+        }, options);
+        OpenLayers.Layer.XYZ.prototype.initialize.call(this, name, url, options);
+    },
+
+    CLASS_NAME: "OpenLayers.Layer.BNG"
+});
+
+OpenLayers.Layer.OSMapsBNG = OpenLayers.Class(OpenLayers.Layer.BNG, {
     initialize: function(name, options) {
         var url = fixmystreet.os_url.replace('%s', fixmystreet.os_layer) + "/${z}/${x}/${y}.png";
         if (fixmystreet.os_key) {
@@ -20,14 +35,7 @@ OpenLayers.Layer.OSMapsBNG = OpenLayers.Class(OpenLayers.Layer.XYZ, {
         attribution += '</div>';
         this.attribution = logo + attribution;
 
-        options = OpenLayers.Util.extend({
-            units: "m",
-            projection: new OpenLayers.Projection("EPSG:27700"),
-            tileOrigin: new OpenLayers.LonLat(-238375, 1376256),
-            maxExtent: new OpenLayers.Bounds(-3276800, -3276800, 3276800, 3276800),
-            resolutions: [896, 448, 224, 112, 56, 28, 14, 7, 7/2, 7/4, 7/8, 7/16, 7/32, 7/64].slice(fixmystreet.zoomOffset || 0).slice(0, fixmystreet.numZoomLevels),
-        }, options);
-        OpenLayers.Layer.XYZ.prototype.initialize.call(this, name, url, options);
+        OpenLayers.Layer.BNG.prototype.initialize.call(this, name, url, options);
     },
 
     tile_prefix: [ '', 'a-', 'b-', 'c-' ],
@@ -65,3 +73,37 @@ OpenLayers.Layer.OSLeisure = OpenLayers.Class(OpenLayers.Layer.OSMapsBNG, {
 
 fixmystreet.maps.zoom_for_normal_size = 8;
 fixmystreet.maps.zoom_for_small_size = 6;
+
+OpenLayers.Layer.Aerial = OpenLayers.Class(OpenLayers.Layer.BNG, {
+    initialize: function(name, options) {
+        var url = fixmystreet.aerial_url + "/${z}/${x}/${y}.png";
+        var attribution = '<div class="os-api-branding copyright">&copy; Bluesky International Ltd and Getmapping Ltd 1999-2020<br>&copy; Bluesky International Limited 2021 and onwards</div>';
+        this.attribution = attribution;
+        OpenLayers.Layer.BNG.prototype.initialize.call(this, name, url, options);
+    },
+    getURL: function (bounds) {
+        var xyz = this.getXYZ(bounds);
+        return OpenLayers.String.format(this.url, xyz);
+    },
+    CLASS_NAME: "OpenLayers.Layer.Aerial"
+});
+
+$(function(){
+    $('.map-layer-toggle').on('click', fixmystreet.maps.toggle_base);
+    // If page loaded with Aerial as starting, rather than default road
+    if ($('.map-layer-toggle').text() == translation_strings.map_roads) {
+        fixmystreet.map.setBaseLayer(fixmystreet.map.layers[1]);
+    }
+});
+
+(function() {
+    // We haven't yet got the data out of js-map-data (as map.js needs all the layer types defined), so get it from the DOM directly.
+    var map_data = document.getElementById('js-map-data');
+    var aerial_url = map_data.getAttribute('data-aerial_url');
+    if (aerial_url) {
+        fixmystreet.layer_options = [
+            {},
+            { map_type: OpenLayers.Layer.Aerial }
+        ];
+    }
+})();


### PR DESCRIPTION
Tidying up a little now Bing aerial has gone, but hopefully then only changing Northumberland and nothing else.
The tilma set up is already there, added to the mapcache config in servers (this relies on two files existing in /data/vhost/tilma.../layers/northumberland/ called watermark.png and aerial.xml which contains the actual endpoint and metadata etc).
The aerial.xml file was generated following the instructions at https://mapserver.org/de/mapcache/sources.html#wmts-sources
The watermark was generated by me personally.
[skip changelog] 
