### PR TITLE
[Zurich] Admin interface for managing hierarchical attributes

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -1449,4 +1449,21 @@ sub munge_around_filter_category_list {
     $c->stash->{prefill_description} = $c->get_param('prefill_description') if $c->get_param('prefill_description');
 }
 
+sub get_default_hierarchical_attributes {
+    my $self = shift;
+    return {
+        "Geschäftsbereich" => {
+            "entries" => {}
+        },
+        "Objekt" => {
+            "parent" => "Geschäftsbereich",
+            "entries" => {}
+        },
+        "Kategorie" => {
+            "parent" => "Geschäftsbereich",
+            "entries" => {}
+        }
+    };
+}
+
 1;

--- a/t/cobrand/zurich.t
+++ b/t/cobrand/zurich.t
@@ -1118,9 +1118,12 @@ subtest "test stats" => sub {
 
     $mech->content_contains('Innerhalb eines Arbeitstages moderiert: 3');
     $mech->content_contains('Innerhalb von fünf Arbeitstagen abgeschlossen: 3');
-    # my @data = $mech->content =~ /(?:moderiert|abgeschlossen): \d+/g;
-    # diag Dumper(\@data); use Data::Dumper;
 
+    $report->set_extra_metadata(hierarchical_attributes => {
+        Geschäftsbereich => 1,
+        Objekt => 2,
+        Kategorie => 3,
+    });
     $report->update({ non_public => 1 });
 
     my $export_count = get_export_rows_count($mech);
@@ -1129,6 +1132,8 @@ subtest "test stats" => sub {
         $mech->content_contains('fixed - council');
     }
 
+    $mech->content_contains('Geschäftsbereich,Objekt,Kategorie');
+    $mech->content_like(qr/,G1,O2,K3$/m);
     $mech->content_contains('Hydranten-Nr.,"Interne meldung"');
     $mech->content_contains('"This is the public response to your report. Freundliche Gruesse.",,,,,1', "Internal report is marked as such");
     $report->update({ non_public => 0 });

--- a/t/cobrand/zurich_attributes.t
+++ b/t/cobrand/zurich_attributes.t
@@ -1,0 +1,219 @@
+use FixMyStreet::TestMech;
+
+my $mech = FixMyStreet::TestMech->new;
+
+use_ok 'FixMyStreet::App', 'FixMyStreet::Cobrand::Zurich';
+
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => 'zurich',
+    MAPIT_URL => 'http://mapit.uk/',
+}, sub {
+    my $zurich = $mech->create_body_ok(1, 'Zurich');
+    my $division = $mech->create_body_ok( 423017, 'Division 1', {
+        parent => $zurich->id, send_method => 'Zurich', endpoint => 'division@example.org' } );
+    my $division_id = $division->id;
+
+    # In Zurich, users from the parent body are superusers
+    my $superuser = $mech->create_user_ok('super@example.com', name => 'Super User', from_body => $zurich->id);
+    my $division_user = $mech->create_user_ok('division@example.com', name => 'Division User', from_body => $division->id);
+    $division_user->user_body_permissions->create({ body => $division, permission_type => 'category_edit' });
+
+    subtest 'Default hierarchical attributes structure' => sub {
+        $mech->log_in_ok($superuser->email);
+        $mech->get_ok("/admin/body/$division_id/attributes");
+
+        $mech->content_contains('Geschäftsbereich');
+        $mech->content_contains('Objekt');
+        $mech->content_contains('Kategorie');
+
+        $mech->content_contains('new_Objekt_parent');
+        $mech->content_contains('new_Kategorie_parent');
+    };
+
+    subtest 'Adding new hierarchical attributes' => sub {
+        $mech->log_in_ok($superuser->email);
+
+        $mech->get_ok("/admin/body/$division_id/attributes");
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Geschäftsbereich_name' => 'Test Business Area',
+            }
+        });
+        $mech->content_contains('Hierarchical attributes updated');
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Geschäftsbereich_name' => 'Second Business Area',
+            }
+        });
+
+        $mech->get_ok("/admin/body/$division_id/attributes");
+        $mech->content_contains('Test Business Area');
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Objekt_name' => 'Test Object',
+                'new_Objekt_parent' => '1', # First entry has ID 1
+            }
+        });
+        $mech->content_contains('Hierarchical attributes updated');
+
+        $mech->get_ok("/admin/body/$division_id/attributes");
+        $mech->content_contains('Test Object');
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Kategorie_name' => 'Test Category',
+                'new_Kategorie_parent' => '1',
+            }
+        });
+        $mech->content_contains('Hierarchical attributes updated');
+
+        $mech->get_ok("/admin/body/$division_id/attributes");
+        $mech->content_contains('Test Category');
+    };
+
+    subtest 'Validation errors' => sub {
+        $mech->log_in_ok($superuser->email);
+
+        $mech->get_ok("/admin/body/$division_id/attributes");
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Geschäftsbereich_name' => '',
+            }
+        });
+        $mech->content_lacks('Hierarchical attributes updated');
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Objekt_name' => 'Test Object Without Parent',
+                'new_Objekt_parent' => '',
+            }
+        });
+        $mech->content_contains('Parent is required');
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Geschäftsbereich_name' => 'Test Business Area', # Already exists
+            }
+        });
+        $mech->content_contains('An entry with this name already exists');
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Objekt_name' => 'Test Object',
+                'new_Objekt_parent' => '1', # First entry has ID 1
+            }
+        });
+        $mech->content_contains('An entry with this name already exists');
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Objekt_name' => 'Test Object',
+                'new_Objekt_parent' => '2',
+            }
+        });
+        $mech->content_contains('Hierarchical attributes updated');
+    };
+
+    subtest 'Editing existing entry names' => sub {
+        $mech->log_in_ok($superuser->email);
+
+        $mech->get_ok("/admin/body/$division_id/attributes");
+        $mech->content_contains('Test Business Area');
+        $mech->submit_form_ok({
+            with_fields => {
+                'Geschäftsbereich_1_name' => 'Updated Name',
+            }
+        });
+        $mech->content_contains('Hierarchical attributes updated');
+
+        $mech->get_ok("/admin/body/$division_id/attributes");
+        $mech->content_contains('Updated Name');
+        $mech->content_lacks('Test Business Area');
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'Geschäftsbereich_1_name' => '',
+            }
+        });
+        $mech->content_contains('Name cannot be empty');
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Geschäftsbereich_name' => 'Another Area',
+            }
+        });
+        $mech->submit_form_ok({
+            with_fields => {
+                'Geschäftsbereich_1_name' => 'Another Area',
+            }
+        });
+        $mech->content_contains('An entry with this name already exists');
+    };
+
+    subtest 'Invalid parent validation' => sub {
+        $mech->log_in_ok($superuser->email);
+        $mech->get_ok("/admin/body/$division_id/attributes");
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Objekt_name' => 'Test Object Invalid Parent',
+                'new_Objekt_parent' => '999',
+            }
+        });
+        $mech->content_contains('Invalid parent selected');
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Geschäftsbereich_name' => 'Parent to Delete',
+            }
+        });
+
+        $mech->get_ok("/admin/body/$division_id/attributes");
+        $mech->submit_form_ok({
+            with_fields => {
+                'Geschäftsbereich_3_deleted' => 1,
+            }
+        });
+        $mech->content_contains('Hierarchical attributes updated');
+
+        # Deleted parent should be invalid
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Objekt_name' => 'Test Object Invalid Parent',
+                'new_Objekt_parent' => '3',
+            }
+        });
+        $mech->content_contains('Invalid parent selected');
+    };
+
+    subtest 'Deleting attributes with child validation' => sub {
+        $mech->log_in_ok($superuser->email);
+        $mech->get_ok("/admin/body/$division_id/attributes");
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'Geschäftsbereich_1_deleted' => 1,
+            }
+        });
+        $mech->content_contains('Cannot delete entry that has active child entries');
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'Objekt_1_deleted' => 1,
+                'Kategorie_1_deleted' => 1,
+            }
+        });
+        $mech->content_contains('Hierarchical attributes updated');
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'Geschäftsbereich_1_deleted' => 1,
+            }
+        });
+        $mech->content_contains('Hierarchical attributes updated');
+    };
+
+};
+
+done_testing();

--- a/t/cobrand/zurich_attributes.t
+++ b/t/cobrand/zurich_attributes.t
@@ -1,4 +1,6 @@
+use utf8;
 use FixMyStreet::TestMech;
+use t::Mock::MapItZurich;
 
 my $mech = FixMyStreet::TestMech->new;
 
@@ -6,7 +8,10 @@ use_ok 'FixMyStreet::App', 'FixMyStreet::Cobrand::Zurich';
 
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => 'zurich',
-    MAPIT_URL => 'http://mapit.uk/',
+    MAPIT_URL => 'http://mapit.zurich/',
+    MAPIT_TYPES => [ 'O08' ],
+    MAPIT_ID_WHITELIST => [ 423017 ],
+    MAP_TYPE => 'Zurich,OSM',
 }, sub {
     my $zurich = $mech->create_body_ok(1, 'Zurich');
     my $division = $mech->create_body_ok( 423017, 'Division 1', {
@@ -17,6 +22,11 @@ FixMyStreet::override_config {
     my $superuser = $mech->create_user_ok('super@example.com', name => 'Super User', from_body => $zurich->id);
     my $division_user = $mech->create_user_ok('division@example.com', name => 'Division User', from_body => $division->id);
     $division_user->user_body_permissions->create({ body => $division, permission_type => 'category_edit' });
+
+    # Create a subdivision for SDM testing
+    my $subdivision = $mech->create_body_ok( 423018, 'Subdivision A', {
+        parent => $division->id, send_method => 'Zurich', endpoint => 'subdivision@example.org' } );
+    my $sdm_user = $mech->create_user_ok('sdm@example.com', name => 'SDM User', from_body => $subdivision->id);
 
     subtest 'Default hierarchical attributes structure' => sub {
         $mech->log_in_ok($superuser->email);
@@ -212,6 +222,123 @@ FixMyStreet::override_config {
             }
         });
         $mech->content_contains('Hierarchical attributes updated');
+    };
+
+    subtest 'Report hierarchical attributes functionality' => sub {
+        $mech->log_in_ok($superuser->email);
+        $mech->get_ok("/admin/body/$division_id/attributes");
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Geschäftsbereich_name' => 'Test Geschäftsbereich',
+            }
+        });
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Objekt_name' => 'Test Objekt',
+                'new_Objekt_parent' => '2',
+            }
+        });
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Kategorie_name' => 'Test Kategorie',
+                'new_Kategorie_parent' => '2',
+            }
+        });
+
+        my ($problem) = $mech->create_problems_for_body(1, $division->id, 'Test Problem');
+        $problem->update({ state => 'confirmed' });
+
+        $mech->get_ok("/admin/report_edit/" . $problem->id);
+        $mech->content_contains('Hierarchical Attributes');
+        $mech->content_contains('hierarchical_Geschäftsbereich');
+        $mech->content_contains('hierarchical_Objekt');
+        $mech->content_contains('hierarchical_Kategorie');
+        $mech->content_contains('Test Geschäftsbereich');
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'submit' => '1',
+                'new_internal_note' => 'Test note without attributes',
+            }
+        });
+        $mech->content_contains('Please select all hierarchical attributes before saving');
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'submit' => '1',
+                'hierarchical_Geschäftsbereich' => '1',
+                'hierarchical_Objekt' => '1',
+                'hierarchical_Kategorie' => '1',
+                'new_internal_note' => 'Test note with attributes',
+            }
+        });
+        $mech->content_like(qr/Updated|message-updated/);
+
+        $problem->discard_changes;
+        my $saved_attributes = $problem->get_extra_metadata('hierarchical_attributes');
+        ok($saved_attributes, 'Hierarchical attributes were saved');
+        is($saved_attributes->{Geschäftsbereich}, '1', 'Geschäftsbereich saved correctly');
+        is($saved_attributes->{Objekt}, '1', 'Objekt saved correctly');
+        is($saved_attributes->{Kategorie}, '1', 'Kategorie saved correctly');
+
+        my $external_body = $mech->create_body_ok(999, 'External Body');
+        my $external_contact = $mech->create_contact_ok(
+            body_id => $external_body->id,
+            category => 'External Category',
+            email => 'external@example.com',
+        );
+
+        $mech->get_ok("/admin/report_edit/" . $problem->id);
+        $mech->submit_form_ok({
+            with_fields => {
+                'submit' => '1',
+                'state' => 'confirmed',
+                'category' => 'External Category',
+                'hierarchical_Geschäftsbereich' => '1',
+                'hierarchical_Objekt' => '1',
+                'hierarchical_Kategorie' => '1',
+            }
+        });
+
+        $problem->discard_changes;
+        my $cleared_attributes = $problem->get_extra_metadata('hierarchical_attributes');
+        ok(!$cleared_attributes, 'Hierarchical attributes cleared on body reassignment');
+    };
+
+    subtest 'SDM view of hierarchical attributes' => sub {
+        $mech->log_in_ok($sdm_user->email);
+
+        # Create a problem with hierarchical attributes for the division (parent body)
+        my ($problem) = $mech->create_problems_for_body(1, $division->id, 'SDM Test Problem');
+        $problem->update({ state => 'in progress' });
+        $problem->set_extra_metadata('hierarchical_attributes', {
+            Geschäftsbereich => '1',
+            Objekt => '1',
+            Kategorie => '1',
+        });
+        $problem->update;
+
+        # SDM should see attributes but not be able to edit them
+        $mech->get_ok("/admin/report_edit/" . $problem->id);
+        $mech->content_contains('Hierarchical Attributes');
+        $mech->content_contains('Updated Name');  # Name was changed in earlier test
+        $mech->content_contains('Test Object');
+        $mech->content_contains('Test Category');
+
+        # Should not contain editable dropdowns
+        $mech->content_lacks('hierarchical_Geschäftsbereich');
+        $mech->content_lacks('Select Geschäftsbereich');
+
+        $problem->update({ bodies_str => $subdivision->id });
+
+        $mech->get_ok("/admin/report_edit/" . $problem->id);
+        $mech->content_contains('Hierarchical Attributes');
+        $mech->content_contains('Updated Name');
+        $mech->content_contains('Test Object');
+        $mech->content_contains('Test Category');
     };
 
 };

--- a/templates/web/zurich/admin/bodies/attributes.html
+++ b/templates/web/zurich/admin/bodies/attributes.html
@@ -1,0 +1,130 @@
+[% body_name = body.name | html;
+   INCLUDE 'admin/header.html' title=tprintf(loc('Hierarchical attributes for %s'), body_name) -%]
+
+[% IF updated %]
+  <p>
+    <em>[% updated %]</em>
+  </p>
+[% END %]
+
+[% IF errors.size %]
+    <ul>
+        [% FOREACH error IN errors %]
+            <li class="error">[% error.value %]</li>
+        [% END %]
+    </ul>
+[% END %]
+
+<p>
+    <a href="[% c.uri_for_action('/admin/bodies/edit', [ body.id ]) %]">&larr; [% loc('Back to body') %]</a>
+</p>
+
+<h2>[% loc('Hierarchical attributes') %]</h2>
+
+<form method="post">
+    <input type="hidden" name="token" value="[% csrf_token %]">
+
+    [% FOREACH level_name IN ['Geschäftsbereich', 'Objekt', 'Kategorie'] %]
+        [% level = hierarchical_attributes.$level_name %]
+        [% SET level_entries = level.entries || {} %]
+
+        <div class="admin-box">
+            <h3>[% level_name %]</h3>
+
+                <table class="admin-table" cellspacing="0" cellpadding="2" border="1">
+                    <thead>
+                        <tr>
+                            <th>[% loc('ID') %]</th>
+                            <th>[% loc('Name') %]</th>
+                            [% IF level.parent %]
+                                <th>[% level.parent %]</th>
+                            [% END %]
+                            <th>[% loc('Deleted') %]</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        [% IF level_entries.keys.size > 0 %]
+                            [% FOREACH id IN level_entries.keys.sort %]
+                                [% entry = level_entries.$id %]
+                                <tr [% IF entry.deleted %]class="is-deleted"[% END %]>
+                                    <td>[% id %]</td>
+                                    <td>
+                                        <input type="text" name="[% level_name %]_[% id %]_name"
+                                               value="[% entry.name | html %]" size="30" class="form-control"
+                                               [% IF errors.item("${level_name}_${id}_name") %]style="border-color: red;"[% END %]>
+                                        [% IF errors.item("${level_name}_${id}_name") %]
+                                            <div class="error-msg">[% errors.item("${level_name}_${id}_name") %]</div>
+                                        [% END %]
+                                    </td>
+                                    [% IF level.parent %]
+                                        <td>
+                                            <select name="[% level_name %]_[% id %]_parent" class="form-control">
+                                                <option value="">-- [% loc('Select parent') %] --</option>
+                                                [% parent_level = hierarchical_attributes.${level.parent} %]
+                                                [% FOREACH parent_id IN parent_level.entries.keys.sort %]
+                                                    [% parent_entry = parent_level.entries.$parent_id %]
+                                                    [% NEXT IF parent_entry.deleted AND entry.parent_id != parent_id %]
+                                                    <option value="[% parent_id %]"
+                                                        [% ' selected' IF entry.parent_id == parent_id %]>
+                                                        [% parent_entry.name | html %]
+                                                    </option>
+                                                [% END %]
+                                            </select>
+                                        </td>
+                                    [% END %]
+                                    <td>
+                                        <label class="inline">
+                                            <input type="checkbox" name="[% level_name %]_[% id %]_deleted" value="1"
+                                                [% ' checked' IF entry.deleted %]>
+                                            [% loc('Deleted') %]
+                                        </label>
+                                    </td>
+                                </tr>
+                            [% END %]
+                        [% END %]
+
+                        <!-- Add new entry row -->
+                        <tr class="add-new-row">
+                            <td><em>[% loc('New') %]:</em></td>
+                            <td>
+                                <input type="text" id="new_[% level_name %]_name" name="new_[% level_name %]_name"
+                                       size="30" class="form-control" placeholder="[% loc('Enter name') %]"
+                                       [% IF errors.item("new_${level_name}_name") %]style="border-color: red;"[% END %]>
+                                [% IF errors.item("new_${level_name}_name") %]
+                                    <div class="error-msg">[% errors.item("new_${level_name}_name") %]</div>
+                                [% END %]
+                            </td>
+                            [% IF level.parent %]
+                                <td>
+                                    <select id="new_[% level_name %]_parent" name="new_[% level_name %]_parent" class="form-control"
+                                            [% IF errors.item("new_${level_name}_parent") %]style="border-color: red;"[% END %]>
+                                        <option value="">-- [% loc('Select parent') %] --</option>
+                                        [% parent_level = hierarchical_attributes.${level.parent} %]
+                                        [% FOREACH parent_id IN parent_level.entries.keys.sort %]
+                                            [% parent_entry = parent_level.entries.$parent_id %]
+                                            [% NEXT IF parent_entry.deleted %]
+                                            <option value="[% parent_id %]">[% parent_entry.name | html %]</option>
+                                        [% END %]
+                                    </select>
+                                    [% IF errors.item("new_${level_name}_parent") %]
+                                        <div class="error-msg">[% errors.item("new_${level_name}_parent") %]</div>
+                                    [% END %]
+                                </td>
+                            [% END %]
+                            <td><!-- Empty cell for deleted column --></td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                [% IF level_entries.keys.size == 0 %]
+                    <p class="no-entries-message"><em>[% loc('No entries yet. Use the form above to add the first entry.') %]</em></p>
+                [% END %]
+
+                <div class="form-actions">
+                    <input type="submit" value="[% loc('Update attributes') %]" class="btn btn-primary">
+                </div>
+        </div>
+    [% END %]
+</form>
+
+[% INCLUDE 'admin/footer.html' %]

--- a/templates/web/zurich/admin/bodies/body.html
+++ b/templates/web/zurich/admin/bodies/body.html
@@ -37,6 +37,11 @@
     <a class="btn" href="[% c.uri_for_action('/admin/bodies/add_category', [ body.id ]) %]">[% loc('Add new category') %]</a>
   [% END %]
 
+    <div class="admin-box">
+      <h2>[% loc('Hierarchical attributes') %]</h2>
+      <p>[% loc('Manage Geschäftsbereich, Objekt, and Kategorie attributes for this body.') %]</p>
+      <a class="btn" href="[% c.uri_for_action('/admin/bodies/attributes', [ body.id ]) %]">[% loc('Manage attributes') %]</a>
+    </div>
 [% END %]
 
 <h2>[% loc('Edit body details') %]</h2>

--- a/templates/web/zurich/admin/report_edit-sdm.html
+++ b/templates/web/zurich/admin/report_edit-sdm.html
@@ -79,6 +79,18 @@
      </dd>
   [% END %]
 
+    [% IF problem.state != 'submitted' AND hierarchical_attributes AND selected_hierarchical_attributes %]
+        [% SET selected = selected_hierarchical_attributes %]
+            <dt><span class="mock-label">[% loc('Hierarchical Attributes:') %]</span></dt>
+            <dd>
+                [% FOR field IN ['Geschäftsbereich', 'Objekt', 'Kategorie'] %]
+                    [% IF selected.$field AND hierarchical_attributes.$field.entries.${selected.$field} %]
+                        <strong>[% field %]</strong> [% hierarchical_attributes.$field.entries.${selected.$field}.name %]<br>
+                    [% END %]
+                [% END %]
+            </dd>
+    [% END %]
+
 </dl>
 
 </div>

--- a/templates/web/zurich/admin/reports/edit.html
+++ b/templates/web/zurich/admin/reports/edit.html
@@ -152,6 +152,36 @@
         </select>
     </dd>
 
+    [% IF problem.state != 'submitted' AND hierarchical_attributes %]
+        <dt class="screen-only">
+            <span class="mock-label">[% loc('Hierarchical Attributes:') %]</span>
+        </dt>
+        <dd class="screen-only hierarchical-attributes">
+            [% SET selected = selected_hierarchical_attributes || {} %]
+
+            [% FOR field IN [ 'Geschäftsbereich', 'Objekt', 'Kategorie' ] %]
+            <div class="hierarchical-field">
+                <label for="hierarchical_[% field %]">[% field %]:</label>
+                <select class="form-control" name="hierarchical_[% field %]" id="hierarchical_[% field %]"
+                        [% IF hierarchical_errors.$field %]style="border-color: red;"[% END %]>
+                    <option value="">--</option>
+                    [% FOREACH id IN hierarchical_attributes.$field.sorted_entries %]
+                        [% entry = hierarchical_attributes.$field.entries.$id %]
+                        [% NEXT IF entry.deleted %]
+                        [% parent_id = entry.parent_id || 0 %]
+                        <option value="[% id %]" data-parent="[% parent_id %]" [% ' selected' IF selected.$field == id %]>
+                            [% entry.name %]
+                        </option>
+                    [% END %]
+                </select>
+                [% IF hierarchical_errors.$field %]
+                    <div class="error-msg">[% hierarchical_errors.$field %]</div>
+                [% END %]
+            </div>
+            [% END %]
+        </dd>
+    [% END %]
+
 </dl>
 
 <ul class="no-bullets screen-only">

--- a/web/cobrands/zurich/js.js
+++ b/web/cobrands/zurich/js.js
@@ -16,7 +16,7 @@ $(function() {
         $(this).toggleClass("active");
     }).on('click', function(){
         window.location = this.getElementsByTagName('a')[0];
-    }).find('td').last().hide();
+    }).find('td:last-child').hide();
 
     $('th.edit').hide();
 

--- a/web/cobrands/zurich/js.js
+++ b/web/cobrands/zurich/js.js
@@ -125,4 +125,77 @@ $(function() {
     $("form#report_edit").find("input, select, textarea").on('change', function() {
         form_fields_changed = true;
     });
+
+    /*
+     * Hierarchical Attributes functionality
+     */
+
+    var $geschaftsbereichSelect = $('#hierarchical_Geschäftsbereich');
+    var $objektSelect = $('#hierarchical_Objekt');
+    var $kategorieSelect = $('#hierarchical_Kategorie');
+
+    if ($geschaftsbereichSelect.length && $objektSelect.length && $kategorieSelect.length) {
+
+        // Initially disable the second and third dropdowns
+        $objektSelect.prop('disabled', true);
+        $kategorieSelect.prop('disabled', true);
+
+        // Filter options by parent ID
+        var filterOptions = function($selectElement, parentId) {
+            var $options = $selectElement.find('option[data-parent]');
+            var hasVisibleOptions = false;
+
+            $options.each(function() {
+                var $option = $(this);
+                var optionParentId = $option.data('parent').toString();
+
+                if (parentId === '' || optionParentId === parentId) {
+                    $option.show();
+                    hasVisibleOptions = true;
+                } else {
+                    $option.hide();
+                    if ($option.prop('selected')) {
+                        $option.prop('selected', false);
+                    }
+                }
+            });
+
+            return hasVisibleOptions;
+        };
+
+        // Reset and disable dependent dropdowns when Geschäftsbereich changes
+        var resetDependentDropdowns = function($selectElement) {
+            $selectElement.val('').prop('disabled', true);
+            $selectElement.find('option[data-parent]').hide();
+        };
+
+        // Handle Geschäftsbereich selection
+        $geschaftsbereichSelect.on('change', function() {
+            var selectedId = $(this).val();
+
+            resetDependentDropdowns($objektSelect);
+            resetDependentDropdowns($kategorieSelect);
+
+            if (selectedId) {
+                if (filterOptions($objektSelect, selectedId)) {
+                    $objektSelect.prop('disabled', false);
+                }
+
+                if (filterOptions($kategorieSelect, selectedId)) {
+                    $kategorieSelect.prop('disabled', false);
+                }
+            }
+        });
+
+        // Initialize dropdowns based on current selections
+        var selectedGeschaftsbereich = $geschaftsbereichSelect.val();
+        if (selectedGeschaftsbereich) {
+            if (filterOptions($objektSelect, selectedGeschaftsbereich)) {
+                $objektSelect.prop('disabled', false);
+            }
+            if (filterOptions($kategorieSelect, selectedGeschaftsbereich)) {
+                $kategorieSelect.prop('disabled', false);
+            }
+        }
+    }
 });


### PR DESCRIPTION
[edit: This PR now also incorporates #5631 and #5635]

Interface allows creation, editing and deletion of attributes associated with a division. These attributes will then be added to the admin report screen to allow admins to update these attributes before the reports is reassigned to a subdivision.

Fixes https://github.com/mysociety/societyworks/issues/4973
Fixes https://github.com/mysociety/societyworks/issues/4974
Fixes https://github.com/mysociety/societyworks/issues/4975

## Screenshot

<img width="1070" height="965" alt="image" src="https://github.com/user-attachments/assets/37a32739-ed46-43a4-b29a-4e1daec888a4" />

<!-- [skip changelog] -->
