### PR TITLE
[Sutton][Small Items] Add email notifications for booking

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Sutton.pm
+++ b/perllib/FixMyStreet/Cobrand/Sutton.pm
@@ -790,4 +790,6 @@ sub waste_munge_small_items_data {
     $self->waste_munge_bulky_data($data);
 }
 
+sub small_items_free_collection_available { 1 };
+
 1;

--- a/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
@@ -50,6 +50,8 @@ sub small_items_enabled {
     return $cfg->{small_items_enabled};
 }
 
+sub small_items_free_collection_available { 0 };
+
 sub bulky_items_master_list { $_[0]->wasteworks_config->{item_list} || [] }
 sub small_items_master_list { $_[0]->wasteworks_config->{small_item_list} || [] }
 sub bulky_per_item_costs { $_[0]->wasteworks_config->{per_item_costs} }
@@ -203,7 +205,10 @@ sub bulky_total_cost {
     my ($self, $data) = @_;
     my $c = $self->{c};
 
-    if ($self->bulky_free_collection_available) {
+    if (
+        (!$c->stash->{small_items} && $self->bulky_free_collection_available)
+        || ($c->stash->{small_items} && $self->small_items_free_collection_available)
+    ) {
         $data->{extra_CHARGEABLE} = 'FREE';
         $c->stash->{payment} = 0;
     } else {
@@ -604,9 +609,13 @@ sub bulky_reminders {
     });
 
     # If we haven't had payment, we don't want to send a reminder
+    # But if a service identifies as free we're not waiting for payment
     if ($self->bulky_send_before_payment) {
         $collections = $collections->search({
-            extra => { '\?' => [ 'payment_reference', 'chequeReference' ] },
+             -or => [
+                extra => { '\?' => [ 'payment_reference', 'chequeReference' ] },
+                extra => { '@>' => '{"_fields":[{"name":"CHARGEABLE","value":"FREE"}]}' }
+            ]
         });
     }
 

--- a/t/app/controller/waste_sutton_small_items.t
+++ b/t/app/controller/waste_sutton_small_items.t
@@ -2,6 +2,7 @@ use Test::MockModule;
 use Test::MockTime qw(:all);
 use FixMyStreet::TestMech;
 use Path::Tiny;
+use FixMyStreet::Script::Reports;
 
 FixMyStreet::App->log->disable('info');
 END { FixMyStreet::App->log->enable('info'); }
@@ -40,6 +41,7 @@ create_contact(
     { code => 'Exact_Location' },
     { code => 'GUID' },
     { code => 'reservation' },
+    { code => 'CHARGEABLE' },
 );
 
 my $user = $mech->create_user_ok('maryk@example.org', name => 'Test User');
@@ -305,6 +307,11 @@ FixMyStreet::override_config {
             'value' => 'reserve7a==',
             'description' => undef,
             'name' => 'reservation'
+          },
+          {
+            'value' => 'FREE',
+            'description' => undef,
+            'name' => 'CHARGEABLE'
           }
         ];
         is_deeply $report->get_extra_fields, $test_extra, "Data added to report";
@@ -339,8 +346,64 @@ FixMyStreet::override_config {
         'Friday 15 August', 'Saturday 16 August', 'Sunday 17 August') {
             $mech->content_contains($date, 'Date 2-9 included');
         };
-    }
+    };
 
+    my $id = $report->id;
+    my $sutton_id = 'LBS-' . $id;
+    subtest 'Confirmation email' => sub {
+        ok $report->confirmed, "Report has been automatically confirmed";
+        $report->confirmed('2025-08-01T10:00:00');
+        $report->update;
+        FixMyStreet::Script::Reports::send();
+        my @emails = $mech->get_email;
+        my $confirmation_email_txt = $mech->get_text_body_from_email($emails[1]);
+        my $confirmation_email_html = $mech->get_html_body_from_email($emails[1]);
+        like $emails[1]->header('Subject'), qr/Your small items collection - reference $sutton_id/, 'Small items in email subject';
+        for my $email ($confirmation_email_txt, $confirmation_email_html) {
+            like $email, qr/Date booking made: Friday 01 August 2025/, 'Includes booking date';
+            like $email, qr/Reference: (<strong>)?$sutton_id/, 'Includes reference number';
+            like $email, qr/Items to be collected:/, 'Includes header for items';
+            like $email, qr/Batteries \(A bag of batteries\)/, 'Includes item 1 with notes';
+            like $email, qr/Small WEEE \(A toaster\)/, 'Includes item 2 with notes';
+            unlike $email, qr/Total cost/, 'There is no total cost';
+            like $email, qr/Address: 2 Example Street, Sutton, SM2 5HF/, 'Includes collection address';
+            like $email, qr/Collection date: Friday 08 August/, 'Includes collection date';
+            like $email, qr#http://sutton.example.org/waste/12345/small_items/cancel/$id#, 'Includes cancellation link';
+            like $email, qr/tandc_link/, 'Terms and conditions link included';
+        }
+    };
+
+    subtest 'Reminder emails' => sub {
+        $mech->clear_emails_ok;
+        my $cobrand = $sutton->get_cobrand_handler;
+        for my $test (
+            {
+                text => 'in 3 days',
+                date => '2025-08-05T10:00:00Z'
+            },
+            {
+                text => 'tomorrow',
+                date => '2025-08-07T10:00:00Z'
+            },
+        ) {
+            $mech->clear_emails_ok;
+            set_fixed_time($test->{date});
+            my $text = $test->{text};
+            $cobrand->bulky_reminders;
+            my $email = $mech->get_email;
+            like $email->header('Subject'), qr/Your small items collection is $text - $sutton_id/, "Reminder email for correct service and due $text";
+            my $reminder_email_txt = $mech->get_text_body_from_email($email);
+            my $reminder_email_html = $mech->get_html_body_from_email($email);
+            for my $email ($reminder_email_txt, $reminder_email_html) {
+                like $email, qr/Address: 2 Example Street, Sutton, SM2 5HF/, 'Includes collection address';
+                like $email, qr/on Friday 08 August/, 'Includes collection date';
+                like $email, qr/Items to be collected/, 'Includes Items to be collected section';
+                like $email, qr/Batteries \(A bag of batteries\)/, 'Includes item 1 with notes';
+                like $email, qr/Small WEEE \(A toaster\)/, 'Includes item 2 with notes';
+                like $email, qr#http://sutton.example.org/waste/12345/small_items/cancel/$id#, 'Includes cancellation link';
+            };
+        }
+    }
 };
 
 done_testing;

--- a/templates/email/default/other-reported.html
+++ b/templates/email/default/other-reported.html
@@ -1,6 +1,6 @@
 [% IF report.category == 'Garden Subscription' OR report.category == 'Cancel Garden Subscription' OR report.category == 'Amend Garden Subscription' ~%]
 [% PROCESS 'waste/other-reported-garden.html' ~%]
-[% ELSIF report.category == 'Bulky collection' ~%]
+[% ELSIF report.category == 'Bulky collection' OR report.category == 'Small items collection' ~%]
 [% PROCESS 'waste/other-reported-bulky.html' ~%]
 [% ELSIF report.cobrand_data == 'waste' ~%]
 [% PROCESS 'waste/other-reported.html' ~%]

--- a/templates/email/default/other-reported.txt
+++ b/templates/email/default/other-reported.txt
@@ -1,6 +1,6 @@
 [% IF report.category == 'Garden Subscription' OR report.category == 'Cancel Garden Subscription' OR report.category == 'Amend Garden Subscription' ~%]
 [% PROCESS 'waste/other-reported-garden.txt' ~%]
-[% ELSIF report.category == 'Bulky collection' ~%]
+[% ELSIF report.category == 'Bulky collection' OR report.category == 'Small items collection' ~%]
 [% PROCESS 'waste/other-reported-bulky.txt' ~%]
 [% ELSIF report.cobrand_data == 'waste' ~%]
 [% PROCESS 'waste/other-reported.txt' ~%]

--- a/templates/email/default/waste/other-reported-bulky.html
+++ b/templates/email/default/waste/other-reported-bulky.html
@@ -21,7 +21,7 @@ cancel_url = cobrand.base_url _ '/waste/' _ property_id_uri _ '/' _ bulky_cancel
 
     [% INCLUDE '_council_reference.html' problem=report %]
 
-  [% IF cobrand.moniker != 'sutton' && cobrand.moniker != 'kingston' %]
+  [% IF (cobrand.moniker != 'sutton' && cobrand.moniker != 'kingston') || report.category == 'Small items collection' %]
     <p style="[% p_style %]">
           Date booking made: [% report_date %]
     </p>
@@ -63,7 +63,7 @@ cancel_url = cobrand.base_url _ '/waste/' _ property_id_uri _ '/' _ bulky_cancel
   [% INCLUDE 'waste/_bulky_extra_text.html' %]
 [% END %]
 
-[% IF cobrand.moniker == 'sutton' || cobrand.moniker == 'kingston' %]
+[% IF (cobrand.moniker == 'sutton' || cobrand.moniker == 'kingston') && report.category != 'Small items collection' %]
   <p style="[% p_style %]">Check you’ve read the <a href="[% cobrand.feature('waste_features').bulky_tandc_link %]">terms and conditions</a>.</p>
 [% ELSIF report.category == 'Small items collection' AND cobrand.feature('waste_features').small_items_tandc_link %]
   <p style="[% p_style %]">Please check you have read the <a href="[% cobrand.feature('waste_features').small_items_tandc_link %]">terms and conditions</a></p>

--- a/templates/email/default/waste/other-reported-bulky.txt
+++ b/templates/email/default/waste/other-reported-bulky.txt
@@ -1,8 +1,10 @@
 Subject: [%
-IF report.category == 'Small items collection';
+IF report.category == 'Small items collection' && cobrand.moniker != 'sutton';
     " Small items collection service - reference " _ report.id;
 ELSIF cobrand.moniker == 'kingston';
     "Your bulky waste collection - reference RBK-" _ report.id;
+ELSIF cobrand.moniker == 'sutton' && report.category == 'Small items collection';
+    "Your small items collection - reference LBS-" _ report.id;
 ELSIF cobrand.moniker == 'sutton';
     "Your bulky waste collection - reference LBS-" _ report.id;
 ELSE;
@@ -22,7 +24,7 @@ Dear [% report.name %],
 
 [% report.detail %]
 
-[% IF cobrand.moniker != 'sutton' && cobrand.moniker != 'kingston' ~%]
+[% IF (cobrand.moniker != 'sutton' && cobrand.moniker != 'kingston') || report.category == 'Small items collection' ~%]
 Date booking made: [% report_date %]
 
 [% END ~%]

--- a/templates/email/kingston/waste/bulky-reminder.html
+++ b/templates/email/kingston/waste/bulky-reminder.html
@@ -28,6 +28,13 @@ cancel_url = cobrand.base_url _ '/waste/' _ property_id_uri _ '/' _ bulky_cancel
     [% END %]
   </p>
 
+  [% IF cobrand.moniker == 'sutton' AND report.title == 'Small items collection' %]
+  <p style="[% p_style %]">
+    Items to be collected:
+    [% INCLUDE 'waste/_bulky_list.txt' %]
+  </p>
+  [% END %]
+
   [% INCLUDE 'waste/_bulky_extra_text.html' %]
 
   <p style="[% p_style %]">

--- a/templates/email/kingston/waste/bulky-reminder.txt
+++ b/templates/email/kingston/waste/bulky-reminder.txt
@@ -1,4 +1,6 @@
-Subject: Your bulky waste collection is [%
+Subject: Your [%
+    report.title.lower
+%] is [%
 IF cobrand.moniker == 'kingston'; SET ref_prefix = 'RBK-';
 ELSE; SET ref_prefix = 'LBS-';
 END;
@@ -23,6 +25,11 @@ Your bulky waste is due to be collected tomorrow on [% collection_date %].
 [% END %]
 
 [% report.detail %]
+
+[% IF cobrand.moniker == 'sutton' AND report.title == 'Small items collection' %]
+Items to be collected:
+[% INCLUDE 'waste/_bulky_list.txt' %]
+[% END %]
 
 [% INCLUDE 'waste/_bulky_extra_text.txt' %]
 


### PR DESCRIPTION
Handles checking for small items/bulky in category for correct text in Sutton templates.

Creates new attribute for free small items collection, defaulting to non-free.

When sending reminders for booking, if skipping reminders until payment is received, then also check if the report itself is marked as free so reminder can be sent.

https://github.com/mysociety/societyworks/issues/4921

[skip changelog]
