### PR TITLE
[Bexley] Don't show garden waste signup if no Agile data

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
@@ -121,6 +121,7 @@ sub garden_current_subscription {
         for my $garden_id ( @{ $self->garden_service_ids } ) {
             @$services = grep { $_->{service_id} ne $garden_id } @$services;
         }
+        $property->{no_garden_subscription_data} = 1;
         return undef;
     }
 

--- a/templates/web/bexley/waste/services_extra.html
+++ b/templates/web/bexley/waste/services_extra.html
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row" id="in-cab-logs">
-  [% IF property.garden_signup_eligible %]
+  [% IF property.garden_signup_eligible && !property.no_garden_subscription_data %]
   <h3 class="govuk-heading-m waste-service-name">
     Brown Wheelie Bin
   </h3>


### PR DESCRIPTION
This change prevents showing the sign up for garden waste button when we get an error from Agile.

<!-- [skip changelog] -->

