### PR TITLE
[Bexley] Improve Agile API error handling for garden waste

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
@@ -48,9 +48,13 @@ sub lookup_subscription_for_uprn {
     my ( $customer, $contract );
 
     my $results = $self->agile->CustomerSearch($uprn);
-    # 'error' will usually be 404, maybe 400; we can't guarantee there aren't
-    # other possible values
-    return if $results->{error};
+    if ($results->{error}) {
+        # Unexpected error - API problem
+        return {
+            error => $results->{error},
+            error_message => $results->{error_message},
+        };
+    }
 
     # find the first 'ACTIVATED' Customer with an 'ACTIVE'/'PRECONTRACT' contract
     my $customers = $results->{Customers} || [];
@@ -68,7 +72,7 @@ sub lookup_subscription_for_uprn {
         }
     }
 
-    return unless $customer && $contract;
+    return { subscription => undef } unless $customer && $contract;
 
     # XXX should maybe sort by CreatedDate rather than assuming first is OK
     $sub->{cost} = try {
@@ -91,7 +95,14 @@ sub lookup_subscription_for_uprn {
 
     $sub->{bins_count} = $contract->{WasteContainerQuantity};
 
-    return $sub;
+    return { subscription => $sub };
+}
+
+sub _remove_garden_services {
+    my ($self, $services) = @_;
+    for my $garden_id ( @{ $self->garden_service_ids } ) {
+        @$services = grep { $_->{service_id} ne $garden_id } @$services;
+    }
 }
 
 =head2 garden_current_subscription
@@ -115,12 +126,20 @@ sub garden_current_subscription {
     my $uprn = $property->{uprn};
     return undef unless $uprn;
 
-    my $sub = $self->lookup_subscription_for_uprn($uprn);
+    my $lookup_result = $self->lookup_subscription_for_uprn($uprn);
+
+    if ($lookup_result->{error}) {
+        $property->{garden_api_error} = 1;
+        $property->{garden_api_error_code} = $lookup_result->{error};
+        $property->{garden_api_error_message} = $lookup_result->{error_message} || $lookup_result->{error};
+        $self->_remove_garden_services($services);
+        return undef;
+    }
+
+    my $sub = $lookup_result->{subscription};
     unless ($sub) {
         # No Agile data, so remove Whitespace service
-        for my $garden_id ( @{ $self->garden_service_ids } ) {
-            @$services = grep { $_->{service_id} ne $garden_id } @$services;
-        }
+        $self->_remove_garden_services($services);
         return undef;
     }
 

--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -518,9 +518,11 @@ sub bin_services_for_address {
     # unless it's got a parent property AND no services of its own (communal),
     # or it already has a subscription in Agile
     # or it has sacks
+    # or there's an API error
     if (   $property->{is_communal}
         || $property->{has_garden_subscription}
         || !$whitespace_paper_bin
+        || $property->{garden_api_error}
     ) {
         $property->{garden_signup_eligible} = 0;
     }

--- a/perllib/Integrations/Agile.pm
+++ b/perllib/Integrations/Agile.pm
@@ -51,7 +51,10 @@ sub call {
     if ( $res->is_success ) {
         return decode_json( $res->content );
     } else {
-        return { error => $res->code };
+        return {
+            error => $res->code,
+            error_message => $res->content
+        };
     }
 }
 

--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -226,6 +226,32 @@ FixMyStreet::override_config {
         $mech->content_contains('Subscribe to garden waste collection service', 'Subscribe link present if expired');
     };
 
+    subtest 'check Agile API error handling' => sub {
+        # Test that various API error responses show the same error handling behavior
+        my %error_codes = (
+            '503' => 'Service Unavailable',
+            '404' => 'Not Found',
+            '400' => 'Bad Request'
+        );
+
+        foreach my $error_code (keys %error_codes) {
+            subtest "Error code $error_code" => sub {
+                $agile_mock->mock( 'CustomerSearch', sub { {
+                    error => $error_code,
+                    error_message => $error_codes{$error_code}
+                } } );
+
+                $mech->get_ok('/waste/10001');
+                $mech->content_lacks('Sign up for a garden waste collection', "Sign-up button not shown for $error_code");
+                $mech->content_lacks('Subscribe to garden waste collection service', "Subscribe link not shown for $error_code");
+                $mech->content_contains("We're currently unable to check your garden waste subscription status", "API error message shown for $error_code");
+                $mech->content_contains('Please try again later. If the problem persists, contact us directly', "API error help text shown for $error_code");
+            };
+        }
+
+        default_mocks();
+    };
+
     subtest 'check new sub bin limits' => sub {
         $mech->get_ok('/waste/10001/garden');
         $mech->submit_form_ok({ form_number => 1 });

--- a/templates/web/bexley/waste/services_extra.html
+++ b/templates/web/bexley/waste/services_extra.html
@@ -19,6 +19,24 @@
       </div>
     </div>
   </div>
+  [% ELSIF property.garden_api_error %]
+  <h3 class="govuk-heading-m waste-service-name">
+    Brown Wheelie Bin
+  </h3>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-quarter text-centered">
+      <img src="/i/waste-containers/bexley/garden-waste-brown-bin.png" alt="" class="waste-service-image">
+    </div>
+    <div class="govuk-grid-column-three-quarters">
+      <div class="waste-services-launch-panel" id="panel-GA-240">
+        <p><strong>Status:</strong> We're currently unable to check your garden waste subscription status.
+        </p>
+        <p>
+          Please try again later. If the problem persists, contact us directly.
+        </p>
+      </div>
+    </div>
+  </div>
   [% END %]
 
   [%# Allow superusers to see red tags and service updates for debugging purposes %]
@@ -35,6 +53,18 @@
       [% END %]
       <dt>USRN</dt>
       <dd>[% property.usrn %]</dd>
+      <dt>Garden signup eligible</dt>
+      <dd>[% property.garden_signup_eligible ? 'Yes' : 'No' %]</dd>
+      <dt>Garden API error</dt>
+      <dd>[% property.garden_api_error ? 'Yes' : 'No' %]</dd>
+      [% IF property.garden_api_error_code %]
+      <dt>Garden API error code</dt>
+      <dd>[% property.garden_api_error_code %]</dd>
+      [% END %]
+      [% IF property.garden_api_error_message %]
+      <dt>Garden API error message</dt>
+      <dd>[% property.garden_api_error_message %]</dd>
+      [% END %]
     </dl>
     <h2>Services</h2>
     [% FOREACH service IN service_data %]


### PR DESCRIPTION
Differentiate between 400/404 error, which are expected when there's no subscription for a property, and other errors which indicate an unexpected problem.

When an unexpected problem occurs show the user a helpful message and remove garden bins from the listing page, as they won't have the correct data available.

Also adds some debugging info to the superuser debugging panel.

<!-- [skip changelog] -->

Related to FD-5877.