### PR TITLE
"Add items for collection": layout and styling improvements

### DIFF
--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -118,7 +118,7 @@ END; END %]
   [% IF c.cobrand.bulky_pricing_strategy.strategy == 'banded' %]
   <p id="band-pricing-info"></p>
   [% END %]
-  <button type="submit" id="add-new-item" class="btn-secondary govuk-!-margin-bottom-3" aria-label="Add item" name="goto-same-page" value="1">
+  <button type="submit" id="add-new-item" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-3" aria-label="Add item" name="goto-same-page" value="1">
     [% IF c.cobrand.moniker == 'kingston' OR c.cobrand.moniker == 'sutton' ~%]
       Add another item
     [%~ ELSE ~%]
@@ -153,7 +153,7 @@ END; END %]
     [% photo_fileid = photo _ '_fileid' %]
     [% PROCESS form override_fields = [ photo, photo_fileid ] %]
   [% END %]
-    <button type="button" class="delete-item btn-secondary govuk-!-margin-bottom-3">Delete item</button>
+    <button type="button" class="delete-item govuk-button govuk-button--warning govuk-!-margin-bottom-3">Delete item</button>
     <hr>
   </div>
 [% END %]

--- a/web/cobrands/sass/_waste.scss
+++ b/web/cobrands/sass/_waste.scss
@@ -579,13 +579,16 @@ html.js {
 
     .bulky-item-wrapper {
         .delete-item {
-          margin-top: 1em;
           display: inline-block;
         }
 
         .dropzone {
           max-width: 380px;
         }
+    }
+
+    hr {
+      margin: 1.2em 0;
     }
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/5079

This PR adds:

- `govuk-button--secondary` to "add item" button
- `govuk-button--warning` to "Delete item"
- Deleted `margin-top` for "Delete item". `govuk-form-group` which is the previous element already has `margin-bottom`
- Added extra vertical margin to `hr` elements to improve distance between the items to collect. 

### Desktop
https://github.com/user-attachments/assets/33f7cb57-7653-4ab5-a0dc-5304a7852aea

### Mobile
https://github.com/user-attachments/assets/237da0bf-cbfa-4969-b184-781c3d13e8cf


[skip changelog]