### PR TITLE
[Waste] PWA installation improvements

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Offline.pm
+++ b/perllib/FixMyStreet/App/Controller/Offline.pm
@@ -67,7 +67,9 @@ sub send_manifest: Private {
     my $short_name = $theme->{short_name};
 
     if ($app eq 'ww') {
-        $start_url = '/waste?pwa';
+        my $p = $c->get_param('p') || '';
+        $p =~ s/[^A-Za-z0-9\:]//g; # sanitise property ID
+        $start_url = $p ? "/waste/$p?pwa" : '/waste?pwa';
         $name = $theme->{wasteworks_name} if $theme->{wasteworks_name};
         $short_name = $theme->{wasteworks_short_name} if $theme->{wasteworks_short_name};
     }

--- a/templates/web/base/common_header_tags.html
+++ b/templates/web/base/common_header_tags.html
@@ -18,7 +18,7 @@
 [% INCLUDE 'header/css.html' %]
 
 [% IF c.req.uri.path.match('^/waste') %]
-    <link rel="manifest" href="/.well-known/manifest-waste.webmanifest">
+    <link rel="manifest" href="/.well-known/manifest-waste.webmanifest[% IF property_id %]?p=[% property_id %][% END %]">
 [% ELSE %]
     <link rel="manifest" href="/.well-known/manifest-fms.webmanifest">
 [% END %]

--- a/templates/web/base/common_header_tags.html
+++ b/templates/web/base/common_header_tags.html
@@ -17,7 +17,7 @@
 [% INCLUDE 'header/title.html' %]
 [% INCLUDE 'header/css.html' %]
 
-[% IF c.req.uri.path.match('^/waste') %]
+[% IF c.req.uri.path.match('^/waste') OR c.req.uri.path == '/about/waste-web-app' %]
     <link rel="manifest" href="/.well-known/manifest-waste.webmanifest[% IF property_id %]?p=[% property_id %][% END %]">
 [% ELSE %]
     <link rel="manifest" href="/.well-known/manifest-fms.webmanifest">

--- a/templates/web/base/waste/bin_days_sidebar.html
+++ b/templates/web/base/waste/bin_days_sidebar.html
@@ -3,6 +3,7 @@
          <h3>Download your collection schedule</h3>
          <ul>
            <li><a href="[% c.uri_for_action('waste/calendar', [ property.id ]) %]">Add to your calendar</a></li>
+           <li><a href="/about/waste-web-app?p=[% property.id %]">Add to your home screen</a></li>
         [% IF c.cobrand.moniker == 'kingston' %]
             <!-- <li><a href="https://kingston-self.achieveservice.com/service/In_my_Area_Results?displaymode=collections&amp;altVal=&amp;uprn=[% property.uprn %]">Download PDF waste calendar</a></li> -->
         [% ELSIF c.cobrand.moniker == 'sutton' %]

--- a/templates/web/fixmystreet-uk-councils/about/waste-web-app.html
+++ b/templates/web/fixmystreet-uk-councils/about/waste-web-app.html
@@ -1,0 +1,1 @@
+[% INCLUDE 'about/web-app.html', wasteworks = 1 %]

--- a/templates/web/fixmystreet-uk-councils/about/waste-web-app.html
+++ b/templates/web/fixmystreet-uk-councils/about/waste-web-app.html
@@ -1,1 +1,2 @@
-[% INCLUDE 'about/web-app.html', wasteworks = 1 %]
+[% property_id = c.get_param('p').replace("[^A-Za-z0-9\:]", "");
+INCLUDE 'about/web-app.html', wasteworks = 1 %]

--- a/templates/web/fixmystreet-uk-councils/about/web-app.html
+++ b/templates/web/fixmystreet-uk-councils/about/web-app.html
@@ -2,9 +2,9 @@
 
 <h1>[% c.cobrand.council_name %] reporting app</h1>
 
-<p>The [% c.cobrand.council_name %] reporting service is powered by FixMyStreet Pro, which is a progressive web app (PWA). This means that you can save this website to your mobile’s home screen and use it just like an app. See below for instructions on how to do this on both iOS and Android devices.</p>
+<p>The [% c.cobrand.council_name %] reporting service is powered by [% IF wasteworks %]WasteWorks[% ELSE %]FixMyStreet Pro[% END %], which is a progressive web app (PWA). This means that you can save this website to your mobile’s home screen and use it just like an app. See below for instructions on how to do this on both iOS and Android devices.</p>
 
-<p>We chose to develop a PWA instead of a dedicated app because it gives you the choice to use this service on whatever device you want, and ensures that you always benefit from the same user experience, including having access to offline reporting functionality. It also means that we can introduce new features and updates more quickly, while also keeping maintenance costs low due to only having to support one codebase.</p>
+<p>We chose to develop a PWA instead of a dedicated app because it gives you the choice to use this service on whatever device you want, and ensures that you always benefit from the same user experience[% UNLESS wasteworks %], including having access to offline reporting functionality[% END %]. It also means that we can introduce new features and updates more quickly, while also keeping maintenance costs low due to only having to support one codebase.</p>
 
 <h2>How to install [% site_name %] as an app</h2>
 
@@ -31,7 +31,7 @@
 <h3>iOS (Apple iPhones/iPads)</h3>
 <img alt="" class="web-app-install__scrshot" srcset="/cobrands/fixmystreet-uk-councils/web-app/small/iphone-[% c.cobrand.moniker %]_framed.png, /cobrands/fixmystreet-uk-councils/web-app/large/iphone-[% c.cobrand.moniker %]_framed.png 2x" src="/cobrands/fixmystreet-uk-councils/web-app/large/iphone-[% c.cobrand.moniker %]_framed.png">
 <ol>
-    <li>Load [% c.uri_for('/') %] on your mobile browser (if you have iOS version 16.3 or less, the installation will only work via Safari)</li>
+    <li>Load [% IF wasteworks %]your property's bin days page[% ELSE %][% c.uri_for('/') %][% END %] on your mobile browser</li>
     <li>
         Hit the save/share button
         <img alt="" class="web-app-install__step" src="/cobrands/fixmystreet-uk-councils/web-app/iphone-share.jpeg">

--- a/templates/web/fixmystreet-uk-councils/about/web-app.html
+++ b/templates/web/fixmystreet-uk-councils/about/web-app.html
@@ -31,9 +31,11 @@
 <h3>iOS (Apple iPhones/iPads)</h3>
 <img alt="" class="web-app-install__scrshot" srcset="/cobrands/fixmystreet-uk-councils/web-app/small/iphone-[% c.cobrand.moniker %]_framed.png, /cobrands/fixmystreet-uk-councils/web-app/large/iphone-[% c.cobrand.moniker %]_framed.png 2x" src="/cobrands/fixmystreet-uk-councils/web-app/large/iphone-[% c.cobrand.moniker %]_framed.png">
 <ol>
-    <li>Load [% IF wasteworks %]your property's bin days page[% ELSE %][% c.uri_for('/') %][% END %] on your mobile browser</li>
+    [% UNLESS wasteworks AND property_id %]
+        <li>Load [% IF wasteworks %]your property’s bin days page[% ELSE %][% c.uri_for('/') %][% END %] on your mobile browser</li>
+    [% END %]
     <li>
-        Hit the save/share button
+        Hit the save/share button[% IF wasteworks AND property_id %] on this page or your property’s bin days page[% END %]
         <img alt="" class="web-app-install__step" src="/cobrands/fixmystreet-uk-councils/web-app/iphone-share.jpeg">
     </li>
     <li>Select ‘add to home screen’
@@ -50,8 +52,10 @@
 <h3>Android</h3>
 <img alt="" class="web-app-install__scrshot" srcset="/cobrands/fixmystreet-uk-councils/web-app/small/android-[% c.cobrand.moniker %]_framed.png, /cobrands/fixmystreet-uk-councils/web-app/large/android-[% c.cobrand.moniker %]_framed.png 2x" src="/cobrands/fixmystreet-uk-councils/web-app/large/android-[% c.cobrand.moniker %]_framed.png">
 <ol>
-    <li>Load [% c.uri_for('/') %] on your mobile browser</li>
-    <li>Press the ‘three dots’ icon to open the browser menu
+    [% UNLESS wasteworks AND property_id %]
+        <li>Load [% IF wasteworks %]your property’s bin days page[% ELSE %][% c.uri_for('/') %][% END %] on your mobile browser</li>
+    [% END %]
+    <li>Press the ‘three dots’ icon to open the browser menu[% IF wasteworks AND property_id %] on this page or your property’s bin days page[% END %]
         <img alt="" class="web-app-install__step" src="/cobrands/fixmystreet-uk-councils/web-app/android-dots.jpeg">
     </li>
     <li>Select ‘Install app’ or similar


### PR DESCRIPTION
 - Adds new `/about/waste-web-app` page with WW-tailored instructions
 - Updates web manifest used on property pages to set `start_url` to the property page
 - Adds link to new help page from property page and allows PWA installation for that property from there

For https://github.com/mysociety/societyworks/issues/4962
For https://github.com/mysociety/societyworks/issues/3993