### PR TITLE
[Waste] Bulky/small items missed collection skips selection page

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Waste.pm
@@ -80,6 +80,7 @@ sub edit : Chained('body') : PathPart('') : Args(0) {
                 base_price => 'int',
                 daily_slots => 'int',
                 items_per_collection_max => 'int',
+                small_items_per_collection_max => 'int',
                 band1_price => 'int',
                 band1_max => 'int',
                 free_mode => 'bool',
@@ -94,7 +95,7 @@ sub edit : Chained('body') : PathPart('') : Args(0) {
                 } elsif ($keys{$_} eq 'int') {
                     if ($val && $val ne $val+0) {
                         $c->stash->{errors}->{site_wide} = "Not an integer";
-                    } elsif ($_ eq 'items_per_collection_max' && $val > 200) {
+                    } elsif ($_ =~ /items_per_collection_max/ && $val && $val > 200) {
                         $c->stash->{errors}->{site_wide} = "Maximum items per collection cannot be more than 200";
                     }
                     $new_cfg->{$_} = $val;
@@ -220,7 +221,7 @@ sub stash_body_config_json : Private {
     } else {
         $c->stash->{body_config_json} = JSON->new->utf8(1)->pretty->canonical->encode($cfg);
     }
-    foreach (qw(free_mode per_item_costs per_item_min_collection_price base_price daily_slots items_per_collection_max food_bags_disabled show_location_page band1_price band1_max show_individual_notes)) {
+    foreach (qw(free_mode per_item_costs per_item_min_collection_price base_price daily_slots small_items_per_collection_max items_per_collection_max food_bags_disabled show_location_page band1_price band1_max show_individual_notes)) {
         $c->stash->{$_} = $c->get_param($_) || $cfg->{$_};
     }
 }

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -844,7 +844,7 @@ sub construct_bin_report_form {
     # Plus side, gets the report missed stuff built in; minus side it
     # doesn't have any next/last collection stuff which is assumed
     my $allow_report_bulky = 0;
-    foreach (values %{ $c->stash->{bulky_missed} || {} }) {
+    foreach (values %{ $c->stash->{booked_missed} || {} }) {
         $allow_report_bulky = $_ if $_->{report_allowed} && !$_->{report_open};
     }
     if ($allow_report_bulky) {

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -501,18 +501,11 @@ sub property : Chained('property_id') : PathPart('') : CaptureArgs(0) {
         $c->detach( '/page_error_404_not_found', [] );
     }
 
-    if ($c->cobrand->can('bulky_enabled')) {
-        my @pending = $c->cobrand->find_pending_bulky_collections($property->{uprn});
-        $c->stash->{pending_bulky_collections} = @pending ? \@pending : undef;
-
-        my @recent = $c->cobrand->find_recent_bulky_collections($property->{uprn});
-        $c->stash->{recent_bulky_collections} = @recent ? \@recent : undef;
-
+    if ($c->cobrand->can('find_booked_collections')) {
         my $cfg = $c->cobrand->feature('waste_features');
-        if ($cfg->{bulky_retry_bookings} && $c->stash->{is_staff}) {
-            my @unconfirmed = $c->cobrand->find_unconfirmed_bulky_collections($property->{uprn})->all;
-            $c->stash->{unconfirmed_bulky_collections} = @unconfirmed ? \@unconfirmed : undef;
-        }
+        my $retry = $cfg->{bulky_retry_bookings} && $c->stash->{is_staff};
+        my $collections = $c->cobrand->find_booked_collections($property->{uprn}, 'recent', $retry);
+        $c->stash->{collections} = $collections;
     }
 
     $c->stash->{latitude} = Utils::truncate_coordinate( $property->{latitude} );

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -881,14 +881,15 @@ sub report : Chained('property') : Args(0) {
     my $field_list = construct_bin_report_form($c);
 
     if ( $c->stash->{original_booking_report} ) {
-        $c->stash->{first_page} = 'notes';
+        $c->stash->{first_page}
+            = $c->cobrand->call_hook('waste_report_form_first_bulky')
+            || 'about_you';
         $c->stash->{field_list} = $field_list;
 
     } else {
         $c->stash->{first_page} = 'report';
         my $next = 'about_you';
 
-        $c->stash->{form_class} ||= 'FixMyStreet::App::Form::Waste::Report';
         $c->stash->{page_list} = [
             report => {
                 fields => [ grep { ! ref $_ } @$field_list, 'submit' ],
@@ -901,6 +902,7 @@ sub report : Chained('property') : Args(0) {
 
     }
 
+    $c->stash->{form_class} ||= 'FixMyStreet::App::Form::Waste::Report';
     $c->forward('form');
 }
 

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1161,7 +1161,11 @@ sub add_report : Private {
 
     $c->cobrand->call_hook(
         clear_cached_lookups_property => $c->stash->{property}{id},
-        'skip_echo', # We do not want to remove/cancel anything in Echo just before payment
+    );
+    $c->cobrand->call_hook(
+        clear_cached_lookups_bulky_slots => $c->stash->{property}{id},
+        skip_echo => 1, # We do not want to remove/cancel anything in Echo just before payment
+        delete_guid => 1, # We don't need the cached GUID any more
     );
 
     return 1;

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -840,21 +840,30 @@ sub construct_bin_report_form {
         };
     }
 
-    # XXX Should we refactor bulky into the general service data (above)?
+    # XXX Should we refactor bulky & small items into the general service
+    # data (above)?
     # Plus side, gets the report missed stuff built in; minus side it
-    # doesn't have any next/last collection stuff which is assumed
+    # doesn't have any next/last collection stuff which is assumed.
     my $allow_report_bulky = 0;
-    foreach (values %{ $c->stash->{booked_missed} || {} }) {
-        $allow_report_bulky = $_ if $_->{report_allowed} && !$_->{report_open};
+    my $allow_report_small_items = 0;
+
+    foreach ( values %{ $c->stash->{booked_missed} || {} } ) {
+        if ( $_->{report_allowed} && !$_->{report_open} ) {
+            $_->{service_name} eq 'Small items'
+                ? $allow_report_small_items = $_
+                : $allow_report_bulky = $_;
+        }
     }
-    if ($allow_report_bulky) {
-        my $service_id = $allow_report_bulky->{service_id};
-        my $service_name = $allow_report_bulky->{service_name};
-        push @$field_list, "service-$service_id" => {
-            type => 'Checkbox',
-            label => "$service_name collection",
-            option_label => "$service_name collection",
-        };
+    for ( $allow_report_bulky, $allow_report_small_items ) {
+        if ($_) {
+            my $service_id = $_->{service_id};
+            my $service_name = $_->{service_name};
+            push @$field_list, "service-$service_id" => {
+                type => 'Checkbox',
+                label => "$service_name collection",
+                option_label => "$service_name collection",
+            };
+        }
     }
 
     $c->cobrand->call_hook("waste_munge_report_form_fields", $field_list);
@@ -864,6 +873,11 @@ sub construct_bin_report_form {
 
 sub report : Chained('property') : Args(0) {
     my ($self, $c) = @_;
+
+    $c->stash->{original_booking_report}
+        = FixMyStreet::DB->resultset("Problem")
+        ->find( { id => $c->get_param('original_booking_id') } )
+        if $c->get_param('original_booking_id');
 
     my $field_list = construct_bin_report_form($c);
 

--- a/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
@@ -49,6 +49,7 @@ sub setup_small : Chained('/waste/property') : PathPart('small_items') : Capture
         $c->detach('/waste/property_redirect');
     }
 
+    $c->stash->{small_items} = 1;
     $c->stash->{booking_maximum} = $c->cobrand->wasteworks_config->{small_items_per_collection_max} || 5;
 }
 
@@ -234,8 +235,10 @@ sub view : Private {
     };
 
     if ($p->category eq 'Small items collection') {
+        $c->stash->{small_items} = 1;
         $c->stash->{booking_maximum} = $c->cobrand->wasteworks_config->{small_items_per_collection_max} || 5;
     } else {
+        $c->stash->{small_items} = 0;
         $c->stash->{booking_maximum} = $c->cobrand->wasteworks_config->{items_per_collection_max} || 5;
     }
 

--- a/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
@@ -254,12 +254,15 @@ sub view : Private {
         address => $p->get_extra_metadata('property_address'),
     };
 
+    my $items_extra;
     if ($p->category eq 'Small items collection') {
         $c->stash->{small_items} = 1;
         $c->stash->{booking_maximum} = $c->cobrand->wasteworks_config->{small_items_per_collection_max} || 5;
+        $items_extra = $c->cobrand->call_hook('small_items_extra');
     } else {
         $c->stash->{small_items} = 0;
         $c->stash->{booking_maximum} = $c->cobrand->wasteworks_config->{items_per_collection_max} || 5;
+        $items_extra = $c->cobrand->call_hook('bulky_items_extra', exclude_pricing => 1);
     }
 
     $c->stash->{template} = 'waste/bulky/summary.html';
@@ -268,7 +271,7 @@ sub view : Private {
 
     my $saved_data = $c->cobrand->waste_reconstruct_bulky_data($p);
     $c->stash->{form} = {
-        items_extra => $c->cobrand->call_hook('bulky_items_extra', exclude_pricing => 1),
+        items_extra => $items_extra,
         saved_data  => $saved_data,
     };
 }

--- a/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
@@ -39,6 +39,11 @@ sub setup : Chained('/waste/property') : PathPart('bulky') : CaptureArgs(0) {
     }
 
     $c->stash->{booking_maximum} = $c->cobrand->wasteworks_config->{items_per_collection_max} || 5;
+    $c->stash->{booking_class} = $c->cobrand->booking_class->new(
+        cobrand => $c->cobrand,
+        property => $c->stash->{property},
+        type => 'bulky',
+    );
 }
 
 sub setup_small : Chained('/waste/property') : PathPart('small_items') : CaptureArgs(0) {
@@ -51,6 +56,11 @@ sub setup_small : Chained('/waste/property') : PathPart('small_items') : Capture
 
     $c->stash->{small_items} = 1;
     $c->stash->{booking_maximum} = $c->cobrand->wasteworks_config->{small_items_per_collection_max} || 5;
+    $c->stash->{booking_class} = Integrations::Echo::Booking->new(
+        cobrand => $c->cobrand,
+        property => $c->stash->{property},
+        type => 'small_items',
+    );
 }
 
 sub bulky_item_options_method {
@@ -184,7 +194,9 @@ sub index : PathPart('') : Chained('setup') : Args(0) {
 
     if ( $c->stash->{form}->current_page->name eq 'intro' ) {
         $c->cobrand->call_hook(
-            clear_cached_lookups_bulky_slots => $c->stash->{property}{id} );
+            clear_cached_lookups_bulky_slots => $c->stash->{property}{id},
+            delete_guid => 1,
+        );
     }
 }
 
@@ -218,7 +230,9 @@ sub amend : Chained('setup') : Args(1) {
 
     if ( $c->stash->{form}->current_page->name eq 'intro' ) {
         $c->cobrand->call_hook(
-            clear_cached_lookups_bulky_slots => $c->stash->{property}{id} );
+            clear_cached_lookups_bulky_slots => $c->stash->{property}{id},
+            delete_guid => 1,
+        );
     }
 }
 

--- a/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
@@ -32,8 +32,6 @@ sub pre_form : Private {
 
 sub setup : Chained('/waste/property') : PathPart('bulky') : CaptureArgs(0) {
     my ($self, $c) = @_;
-
-    $c->detach('/waste/property_redirect') if $c->cobrand->moniker eq 'brent';
     if ( !$c->stash->{property}{show_bulky_waste} ) {
         $c->detach('/waste/property_redirect');
     }
@@ -48,9 +46,7 @@ sub setup : Chained('/waste/property') : PathPart('bulky') : CaptureArgs(0) {
 
 sub setup_small : Chained('/waste/property') : PathPart('small_items') : CaptureArgs(0) {
     my ($self, $c) = @_;
-
-    $c->detach('/waste/property_redirect') if $c->cobrand->moniker ne 'brent';
-    if ( !$c->stash->{property}{show_bulky_waste} ) {
+    if ( !$c->stash->{property}{show_small_items} ) {
         $c->detach('/waste/property_redirect');
     }
 

--- a/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
@@ -190,7 +190,7 @@ sub index_small : PathPart('') : Chained('setup_small') : Args(0) {
     $c->stash->{form_class} = 'FixMyStreet::App::Form::Waste::SmallItems';
 
     my $cfg = $c->cobrand->feature('waste_features');
-    if ($c->stash->{collections}{small_items}{pending} && !$cfg->{bulky_multiple_bookings}) {
+    if ($c->stash->{collections}{small_items}{pending} && !$cfg->{small_items_multiple_bookings}) {
         $c->detach('/waste/property_redirect');
     }
     $c->detach('index_booking');
@@ -359,6 +359,22 @@ sub process_bulky_data : Private {
     } else {
         $c->forward('/waste/add_report', [ $data ]) or return;
     }
+    return 1;
+}
+
+sub process_small_items_data : Private {
+    my ($self, $c, $form) = @_;
+    my $data = $form->saved_data;
+
+    $c->cobrand->call_hook("waste_munge_small_items_data", $data);
+
+    # Read extra details in loop
+    foreach (grep { /^extra_/ } keys %$data) {
+        my ($id) = /^extra_(.*)/;
+        $c->set_param($id, $data->{$_});
+    }
+
+    $c->forward('/waste/add_report', [ $data ]) or return;
     return 1;
 }
 

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky/Shared.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky/Shared.pm
@@ -14,6 +14,8 @@ use HTML::FormHandler::Moose;
 extends 'FixMyStreet::App::Form::Waste';
 use FixMyStreet::Template::SafeString;
 
+has small_items => ( is => 'ro', default => 0 );
+
 has_page choose_date_earlier => (
     fields => [ 'continue', 'chosen_date', 'show_later_dates' ],
     title => 'Choose date for collection',
@@ -125,6 +127,9 @@ has_page summary => (
         return 0;
     },
     finished => sub {
+        if ($_[0]->small_items) {
+            return $_[0]->wizard_finished('process_small_items_data');
+        }
         if ($_[0]->c->stash->{amending_booking}) {
             return $_[0]->wizard_finished('process_bulky_amend');
         } else {

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky/Shared.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky/Shared.pm
@@ -82,7 +82,7 @@ has_page summary => (
         if ($cobrand ne 'sutton' && $cobrand ne 'kingston' && $cobrand ne 'merton') {
             return ['payment_method', 'payment_explanation', 'cheque_reference'];
         }
-        if (!$c->stash->{is_staff}) {
+        if (!$c->stash->{is_staff} || $c->stash->{small_items}) {
             return ['payment_method', 'payment_explanation', 'cheque_reference'];
         }
         if ($cobrand eq 'merton') {

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky/Shared.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky/Shared.pm
@@ -93,7 +93,7 @@ has_page summary => (
     update_field_list => sub {
         my ($form) = @_;
         my $data = $form->saved_data;
-        my $new = _renumber_items($data, $form->c->cobrand->bulky_items_maximum);
+        my $new = _renumber_items($data, $form->c->stash->{booking_maximum});
         %$data = %$new;
         return {};
     },
@@ -345,7 +345,7 @@ sub validate {
 
     my $cobrand = $self->c->cobrand;
     if ($self->current_page->name eq 'add_items') {
-        my $max_items = $cobrand->bulky_items_maximum;
+        my $max_items = $self->c->stash->{booking_maximum};
         my %given;
 
         my $points = 0;
@@ -402,7 +402,7 @@ sub validate {
     if ($self->current_page->name eq 'summary' && $self->c->stash->{amending_booking}) {
         my $old = $cobrand->waste_reconstruct_bulky_data($self->c->stash->{amending_booking});
         my $new = $self->saved_data;
-        my $max_items = $cobrand->bulky_items_maximum;
+        my $max_items = $self->c->stash->{booking_maximum};
         my $same = 1;
         my @fields = qw(chosen_date location location_photo);
         push @fields, map { ("item_$_", "item_photo_$_") } 1 .. $max_items;

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky/Shared.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky/Shared.pm
@@ -176,7 +176,7 @@ sub _get_dates {
     my ( $c, $last_earlier_date ) = @_;
 
     my %dates_booked;
-    foreach (@{$c->stash->{pending_bulky_collections} || []}) {
+    foreach (@{$c->stash->{collections}{bulky}{pending} || []}) {
         my $date = $c->cobrand->collection_date($_);
         $dates_booked{$date} = 1;
     }

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky/Shared.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky/Shared.pm
@@ -272,7 +272,8 @@ has_field tandc => (
     build_option_label_method => sub {
         my $form = $_[0]->form;
         my $c = $form->c;
-        my $link = $c->cobrand->call_hook('bulky_tandc_link');
+        my $link = $c->stash->{small_items} ? 'small_items_tandc_link' : 'bulky_tandc_link';
+        $link = $c->cobrand->call_hook($link);
         my $label;
         if ($c->cobrand->moniker eq 'sutton') {
             $label = 'I have read the <a href="' . $link . '" target="_blank">terms and conditions</a> of the service on the council’s website and agree to them.';

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky/Shared.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky/Shared.pm
@@ -109,9 +109,9 @@ has_page summary => (
         }
 
         # Some cobrands may set a new chosen_date on the form
-        my $slot_still_available = $c->cobrand->call_hook(
-            check_bulky_slot_available => $form->saved_data->{chosen_date},
-            form                       => $form,
+        my $slot_still_available = $c->stash->{booking_class}->check_slot_available(
+            $form->saved_data->{chosen_date},
+            form => $form,
         );
 
         return 1 if $slot_still_available;
@@ -208,12 +208,7 @@ sub _get_dates {
             selected => $existing_date && $existing_date eq $_->{date},
             }
             : undef
-        } @{
-        $c->cobrand->call_hook(
-            'find_available_bulky_slots', $c->stash->{property},
-            $last_earlier_date,
-        )
-        };
+        } @{ $c->stash->{booking_class}->find_available_slots($last_earlier_date) };
 
     return @dates;
 }

--- a/perllib/FixMyStreet/App/Form/Waste/SmallItems.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/SmallItems.pm
@@ -34,7 +34,11 @@ We sort the items by ID so that we can manually set the ordering in the admin.
 
 sub _build_items_master_list {
     [ sort { $a->{bartec_id} <=> $b->{bartec_id} }
-            @{ $_[0]->c->cobrand->call_hook('bulky_items_master_list') } ];
+            @{ $_[0]->c->cobrand->call_hook('small_items_master_list') } ];
+}
+
+sub _build_items_extra {
+    shift->c->cobrand->small_items_extra;
 }
 
 1;

--- a/perllib/FixMyStreet/App/Form/Waste/SmallItems.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/SmallItems.pm
@@ -4,6 +4,8 @@ use utf8;
 use HTML::FormHandler::Moose;
 extends 'FixMyStreet::App::Form::Waste::Bulky::Shared';
 
+has small_items => ( is => 'ro', default => 1 );
+
 has_page intro => (
     title => 'Book small items collection',
     intro => 'small_items/intro.html',

--- a/perllib/FixMyStreet/App/Form/Waste/SmallItems.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/SmallItems.pm
@@ -6,7 +6,7 @@ extends 'FixMyStreet::App::Form::Waste::Bulky::Shared';
 
 has_page intro => (
     title => 'Book small items collection',
-    intro => 'bulky/intro.html',
+    intro => 'small_items/intro.html',
     fields => ['continue'],
     next => 'about_you',
 );

--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1191,11 +1191,8 @@ sub waste_munge_report_data {
     $data->{title} = "Report missed $service";
     $data->{detail} = "$data->{title}\n\n$address";
 
-    if ($c->get_param('original_booking_id')) {
-        if (my $booking_report = FixMyStreet::DB->resultset("Problem")->find({ id => $c->get_param('original_booking_id') })) {
-            $c->set_param('Original_Event_ID', $booking_report->external_id);
-        }
-    }
+    $c->set_param('Original_Event_ID', $c->stash->{original_booking_report}->external_id )
+        if $c->stash->{original_booking_report};
 
     $c->set_param('service_id', $id);
 }

--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1536,7 +1536,7 @@ sub waste_munge_bulky_data {
     $data->{extra_Exact_Location} = $data->{location};
 
     my (%types);
-    my $max = $self->bulky_items_maximum;
+    my $max = $c->stash->{booking_maximum};
     my $other_item = 'Small electricals: Other item under 30x30x30 cm';
     for (1..$max) {
         if (my $item = $data->{"item_$_"}) {

--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1613,7 +1613,7 @@ sub bulky_location_text_prompt {
 
 sub bulky_location_photo_prompt {
     my $self = shift;
-    return 'Please check the <a href="' . $self->bulky_tandc_link . '" target="_blank">Terms & Conditions</a> for information about when and where to leave your items for collection.' . "\n\n\n"
+    return 'Please check the <a href="' . $self->small_items_tandc_link . '" target="_blank">Terms & Conditions</a> for information about when and where to leave your items for collection.' . "\n\n\n"
         . 'Help us by attaching a photo of where the items will be left for collection (optional).';
 }
 

--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1160,7 +1160,7 @@ sub image_for_unit {
         $SERVICE_IDS{fas_refuse} => svg_container_sack("normal", '#333333'),
         $SERVICE_IDS{fas_mixed} => svg_container_sack("normal", '#d8d8d8'),
         $SERVICE_IDS{domestic_paper} => "$base/bag-blue",
-        bulky => "$base/electricals-batteries-textiles",
+        small_items => "$base/electricals-batteries-textiles",
     };
     return $images->{$service_id};
 }
@@ -1509,9 +1509,9 @@ sub bulky_free_collection_available { 0 }
 sub bulky_hide_later_dates { 1 }
 sub bulky_disabled_item_photos { 1 }
 
-sub bulky_allowed_property {
+sub small_items_allowed_property {
     my ( $self, $property ) = @_;
-    return $self->bulky_enabled;
+    return $self->small_items_enabled;
 }
 
 sub collection_date {

--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1134,16 +1134,6 @@ sub missed_event_types { return {
     $EVENT_TYPE_IDS{bulky} => 'bulky',
 } }
 
-around bulky_check_missed_collection => sub {
-    my ($orig, $self) = (shift, shift);
-    $orig->($self, @_);
-    if ($self->{c}->stash->{bulky_missed}) {
-        foreach (values %{$self->{c}->stash->{bulky_missed}}) {
-            $_->{service_name} = 'Small items';
-        }
-    }
-};
-
 sub image_for_unit {
     my ($self, $unit) = @_;
     my $service_id = $unit->{service_id};
@@ -1193,7 +1183,7 @@ sub waste_munge_report_data {
     my $service = $c->stash->{services}{$id}{service_name};
 
     my $cfg = $self->feature('echo');
-    my $service_id_missed = $cfg->{bulky_service_id_missed};
+    my $service_id_missed = $cfg->{small_items_service_id_missed};
     if (!$service && $id == $service_id_missed) {
         $service = 'small items / clinical';
     }
@@ -1519,7 +1509,7 @@ sub collection_date {
     return $self->_bulky_date_to_dt($p->get_extra_field_value('Collection_Date'));
 }
 
-sub waste_munge_bulky_data {
+sub waste_munge_small_items_data {
     my ($self, $data) = @_;
 
     my $c = $self->{c};

--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1525,7 +1525,7 @@ sub waste_munge_bulky_data {
     my $c = $self->{c};
     my ($date, $ref, $expiry) = split(";", $data->{chosen_date});
 
-    my $guid_key = $self->council_url . ":echo:bulky_event_guid:" . $c->stash->{property}->{id};
+    my $guid_key = $c->stash->{booking_class}->guid_key;
     $data->{extra_GUID} = $self->{c}->waste_cache_get($guid_key);
     $data->{extra_reservation} = $ref;
 

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -1158,7 +1158,7 @@ sub waste_munge_bulky_data {
     my $cfg = $self->feature('waste_features');
     my $quantity_1_code = $cfg->{bulky_quantity_1_code};
 
-    my $max = $self->bulky_items_maximum;
+    my $max = $c->stash->{booking_maximum};
     for (1..$max) {
         if (my $item = $data->{"item_$_"}) {
             push @item_names, $item;

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -1132,7 +1132,7 @@ sub waste_munge_bulky_data {
     my $c = $self->{c};
     my ($date, $ref, $expiry) = split(";", $data->{chosen_date});
 
-    my $guid_key = $self->council_url . ":echo:bulky_event_guid:" . $c->stash->{property}->{id};
+    my $guid_key = $c->stash->{booking_class}->guid_key;
     $data->{extra_GUID} = $self->{c}->waste_cache_get($guid_key);
     $data->{extra_reservation} = $ref;
 

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -278,7 +278,7 @@ sub open311_pre_send {
         my $title = "Crew notes: " . ( $row->get_extra_field_value("CREW NOTES") || "" );
         $title .= "\n\nItems:\n";
 
-        my $max = $self->bulky_items_maximum;
+        my $max = $row->get_cobrand_logged->wasteworks_config->{items_per_collection_max} || 5;
         for (1..$max) {
             my $two = sprintf("%02d", $_);
             if (my $item = $row->get_extra_field_value("ITEM_$two")) {

--- a/perllib/FixMyStreet/Cobrand/Peterborough/Bulky.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough/Bulky.pm
@@ -21,6 +21,9 @@ use FixMyStreet;
 use Integrations::Bartec;
 use JSON::MaybeXS;
 use FixMyStreet::Email;
+use Integrations::Bartec::Booking;
+
+sub booking_class { 'Integrations::Bartec::Booking' }
 
 =head3 Defaults & constants for bulky waste
 
@@ -32,27 +35,11 @@ use FixMyStreet::Email;
 
 sub bulky_collection_window_days     {56}
 
-=item * We return a maximum of 2 date options to users when they are booking
-a bulky waste collection
-
-=cut
-
-sub max_bulky_collection_dates       {2}
-
 =item * Max length of location details text is 250 characters
 
 =cut
 
 sub bulky_location_max_length {250}
-
-=item * Bulky workpack name is of the form 'Waste-BULKY WASTE-<date>' or
-'Waste-WHITES-<date>'
-
-=cut
-
-sub bulky_workpack_name {
-    qr/Waste-(BULKY WASTE|WHITES)-(?<date_suffix>\d{6})/;
-}
 
 =item * User can amend/refund/cancel up to 14:00 the working day before the bulky collection
 
@@ -70,103 +57,6 @@ sub bulky_collection_time { { hours => 6, minutes => 45 } }
 
 sub bulky_daily_slots { $_[0]->wasteworks_config->{daily_slots} || 40 }
 
-# XXX
-# Error handling
-# Holidays, bank holidays?
-# Monday limit, Tuesday limit etc.?
-# Check which bulky collections are pending, open
-sub find_available_bulky_slots {
-    my ( $self, $property, $last_earlier_date_str ) = @_;
-    my $c = $self->{c};
-
-    my $key
-        = 'peterborough:bartec:available_bulky_slots:'
-        . ( $last_earlier_date_str ? 'later' : 'earlier' ) . ':'
-        . $property->{uprn};
-    my $data = $c->waste_cache_get($key);
-    return $data if $data;
-
-    my $bartec = $self->feature('bartec');
-    $bartec = Integrations::Bartec->new(%$bartec);
-
-    my $window = $self->_bulky_collection_window($last_earlier_date_str);
-    if ( $window->{error} ) {
-        # XXX Handle error gracefully
-        die $window->{error};
-    }
-    my $workpacks = $bartec->Premises_FutureWorkpacks_Get(
-        date_from => $window->{date_from},
-        date_to   => $window->{date_to},
-        uprn      => $property->{uprn},
-    );
-
-    my @available_slots;
-    my %seen_dates;
-
-    my $last_workpack_date;
-    for my $workpack (@$workpacks) {
-        # Depending on the Collective API version (R1531 or R1611),
-        # $workpack->{Actions} can be an arrayref or a hashref.
-        # If a hashref, it may be an action structure of the form
-        # { 'ActionName' => ... },
-        # or it may have the key {Action}.
-        # $workpack->{Actions}{Action} can also be an arrayref or hashref.
-        # From this variety of structures, we want to get an arrayref of
-        # action hashrefs of the form [ { 'ActionName' => ... }, {...} ].
-        my $action_data = $workpack->{Actions};
-        if ( ref $action_data eq 'HASH' ) {
-            if ( exists $action_data->{Action} ) {
-                $action_data = $action_data->{Action};
-                $action_data = [$action_data] if ref $action_data eq 'HASH';
-            } else {
-                $action_data = [$action_data];
-            }
-        }
-
-        my %action_hash = map {
-            my $action_name = $_->{ActionName} // '';
-            $action_name = $self->service_name_override()->{$action_name}
-                // $action_name;
-
-            $action_name => $_;
-        } @$action_data;
-
-        # We only want dates that coincide with black bin collections
-        next if !exists $action_hash{'Black Bin'};
-
-        # This case shouldn't occur, but in case there are multiple black bin
-        # workpacks for the same date, we only take the first into account
-        next if $workpack->{WorkPackDate} eq ( $last_workpack_date // '' );
-
-        # Only include if max jobs not already reached
-        if ($self->check_bulky_slot_available($workpack->{WorkPackDate}, bartec => $bartec)) {
-            push @available_slots, {
-                workpack_id => $workpack->{id},
-                date        => $workpack->{WorkPackDate},
-            };
-            $seen_dates{$workpack->{WorkPackDate}} = 1;
-        }
-
-        $last_workpack_date = $workpack->{WorkPackDate};
-
-        # Provision of $last_earlier_date_str implies we want to fetch all
-        # remaining available slots in the given window, so we ignore the
-        # limit
-        last
-            if !$last_earlier_date_str
-            && @available_slots == max_bulky_collection_dates();
-    }
-
-    if (my $amend = $c->stash->{amending_booking}) {
-        my $date = $amend->get_extra_field_value('DATE');
-        if (!$seen_dates{$date}) {
-            unshift @available_slots, { date => $date };
-        }
-    }
-
-    return $c->waste_cache_set($key, \@available_slots);
-}
-
 sub collection_date {
     my ($self, $p) = @_;
     return $self->_bulky_date_to_dt($p->get_extra_field_value('DATE'));
@@ -177,60 +67,6 @@ sub _bulky_date_to_dt {
     my $parser = DateTime::Format::Strptime->new( pattern => '%FT%T', time_zone => FixMyStreet->local_time_zone);
     my $dt = $parser->parse_datetime($date);
     return $dt ? $dt->truncate( to => 'day' ) : undef;
-}
-
-# Checks if there is a slot available for a given date
-sub check_bulky_slot_available {
-    my ( $self, $date, %args ) = @_;
-
-    my $bartec = $args{bartec};
-
-    unless ($bartec) {
-        $bartec = $self->feature('bartec');
-        $bartec = Integrations::Bartec->new(%$bartec);
-    }
-
-    my $suffix_date_parser = DateTime::Format::Strptime->new( pattern => '%d%m%y' );
-    my $workpack_dt = $self->_bulky_date_to_dt($date);
-    next unless $workpack_dt;
-
-    my $now = DateTime->now( time_zone => FixMyStreet->local_time_zone );
-    my $cutoff = $self->_bulky_cancellation_cutoff_date($workpack_dt);
-    return 0 if $now > $cutoff;
-
-    my $date_from = $workpack_dt->clone->strftime('%FT%T');
-    my $date_to = $workpack_dt->clone->set(
-        hour   => 23,
-        minute => 59,
-        second => 59,
-    )->strftime('%FT%T');
-    my $workpacks_for_day = $bartec->WorkPacks_Get(
-        date_from => $date_from,
-        date_to   => $date_to,
-    );
-
-    my %jobs_per_uprn;
-    for my $wpfd (@$workpacks_for_day) {
-        next if $wpfd->{Name} !~ bulky_workpack_name();
-
-        # Ignore workpacks with names with faulty date suffixes
-        my $suffix_dt = $suffix_date_parser->parse_datetime( $+{date_suffix} );
-
-        next
-            if !$suffix_dt
-            || $workpack_dt->date ne $suffix_dt->date;
-
-        my $jobs = $bartec->Jobs_Get_for_workpack( $wpfd->{ID} ) || [];
-
-        # Group jobs by UPRN. For a bulky workpack, a UPRN/premises may
-        # have multiple jobs (equivalent to item slots); these all count
-        # as a single bulky collection slot.
-        $jobs_per_uprn{ $_->{Job}{UPRN} }++ for @$jobs;
-    }
-
-    my $total_collection_slots = keys %jobs_per_uprn;
-
-    return $total_collection_slots < $self->bulky_daily_slots;
 }
 
 sub bulky_cancellation_report {

--- a/perllib/FixMyStreet/Cobrand/Peterborough/Bulky.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough/Bulky.pm
@@ -300,7 +300,7 @@ sub waste_munge_bulky_data {
     $data->{category} = "Bulky collection";
     $data->{extra_DATE} = $data->{chosen_date};
 
-    my $max = $self->bulky_items_maximum;
+    my $max = $c->stash->{booking_maximum};
     for (1..$max) {
         my $two = sprintf("%02d", $_);
         $data->{"extra_ITEM_$two"} = $data->{"item_$_"};
@@ -339,7 +339,7 @@ sub waste_munge_bulky_amend {
     $p->update_extra_field({ name => 'DATE', value => $data->{chosen_date} });
     $p->update_extra_field({ name => 'CREW NOTES', value => $data->{location} });
 
-    my $max = $self->{c}->cobrand->bulky_items_maximum;
+    my $max = $self->{c}->stash->{booking_maximum};
     for (1..$max) {
         my $two = sprintf("%02d", $_);
         $p->update_extra_field({ name => "ITEM_$two", value => $data->{"item_$_"} || '' });

--- a/perllib/FixMyStreet/Cobrand/Peterborough/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough/Waste.pm
@@ -123,8 +123,6 @@ sub clear_cached_lookups_property {
     foreach ( qw/bin_services_for_address/ ) {
         $self->{c}->waste_cache_delete("peterborough:bartec:$_:$uprn");
     }
-
-    $self->clear_cached_lookups_bulky_slots($uprn);
 }
 
 sub clear_cached_lookups_bulky_slots {
@@ -134,7 +132,7 @@ sub clear_cached_lookups_bulky_slots {
     $uprn =~ s/^.+\://g;
 
     for (qw/earlier later/) {
-        $self->{c}->waste_cache_delete("peterborough:bartec:available_bulky_slots:$_:$uprn");
+        $self->{c}->waste_cache_delete("peterborough:bartec:available_slots:$_:$uprn");
     }
 }
 

--- a/perllib/FixMyStreet/Cobrand/Sutton.pm
+++ b/perllib/FixMyStreet/Cobrand/Sutton.pm
@@ -763,8 +763,15 @@ sub bulky_location_text_prompt {
     "Please tell us where you will place the items for collection (the " . $text . " collection crews are different to the normal round collection crews and will not know any access codes to your property, so please include access codes here if appropriate)";
 }
 
-sub bulky_item_notes_field_mandatory { 1 }
-sub bulky_show_individual_notes { 1 } # As mandatory, must be shown
+# Mandatory for bulky, not possible for small items
+sub bulky_item_notes_field_mandatory {
+    my $self = shift;
+    return $self->{c}->stash->{small_items} ? 0 : 1;
+}
+sub bulky_show_individual_notes {
+    my $self = shift;
+    return $self->{c}->stash->{small_items} ? 0 : 1;
+}
 
 =head2 filter_booking_dates
 

--- a/perllib/FixMyStreet/Cobrand/Sutton.pm
+++ b/perllib/FixMyStreet/Cobrand/Sutton.pm
@@ -139,18 +139,18 @@ sub waste_munge_bin_services_open_requests {
     }
 }
 
-around bulky_check_missed_collection => sub {
-    my ($orig, $self, $events, $blocked_codes) = @_;
+around booked_check_missed_collection => sub {
+    my ($orig, $self, $type, $events, $blocked_codes) = @_;
 
-    $self->$orig($events, $blocked_codes);
+    $self->$orig($type, $events, $blocked_codes);
 
     # Now check for any old open missed collections that can be escalated
 
     my $cfg = $self->feature('echo');
-    my $service_id = $cfg->{bulky_service_id};
-    my $escalations = $events->filter({ event_type => 3134, service => $service_id });
+    my $service_id = $cfg->{$type . '_service_id'} or return;
 
-    my $missed = $self->{c}->stash->{bulky_missed};
+    my $escalations = $events->filter({ event_type => 3134, service => $service_id });
+    my $missed = $self->{c}->stash->{booked_missed};
     foreach my $guid (keys %$missed) {
         my $missed_event = $missed->{$guid}{report_open};
         next unless $missed_event;

--- a/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
@@ -51,6 +51,7 @@ sub small_items_enabled {
 }
 
 sub bulky_items_master_list { $_[0]->wasteworks_config->{item_list} || [] }
+sub small_items_master_list { $_[0]->wasteworks_config->{small_item_list} || [] }
 sub bulky_per_item_costs { $_[0]->wasteworks_config->{per_item_costs} }
 
 sub bulky_tandc_link {
@@ -134,6 +135,18 @@ sub bulky_is_cancelled {
     }
 }
 
+sub small_items_extra {
+    my ($self) = @_;
+
+    my $json = JSON::MaybeXS->new;
+    my %hash;
+    for my $item ( @{ $self->small_items_master_list } ) {
+        $hash{ $item->{name} }{message} = $item->{message} if $item->{message};
+        $hash{ $item->{name} }{max} = $item->{max} if $item->{max};
+        $hash{ $item->{name} }{json} = $json->encode($hash{$item->{name}}) if $hash{$item->{name}};
+    }
+    return \%hash;
+}
 sub bulky_items_extra {
     my ($self, %args) = @_;
 

--- a/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
@@ -46,11 +46,18 @@ sub bulky_enabled_staff_only {
 
 sub bulky_items_master_list { $_[0]->wasteworks_config->{item_list} || [] }
 sub bulky_per_item_costs { $_[0]->wasteworks_config->{per_item_costs} }
+
 sub bulky_tandc_link {
     my $self = shift;
     my $cfg = $self->feature('waste_features') || {};
     return FixMyStreet::Template::SafeString->new($cfg->{bulky_tandc_link});
 }
+sub small_items_tandc_link {
+    my $self = shift;
+    my $cfg = $self->feature('waste_features') || {};
+    return FixMyStreet::Template::SafeString->new($cfg->{small_items_tandc_link});
+}
+
 sub bulky_show_location_page {
     my ($self) = @_;
 

--- a/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
@@ -44,6 +44,12 @@ sub bulky_enabled_staff_only {
     return $cfg->{bulky_enabled} && $cfg->{bulky_enabled} eq 'staff';
 }
 
+sub small_items_enabled {
+    my $self = shift;
+    my $cfg = $self->feature('waste_features') || {};
+    return $cfg->{small_items_enabled};
+}
+
 sub bulky_items_master_list { $_[0]->wasteworks_config->{item_list} || [] }
 sub bulky_per_item_costs { $_[0]->wasteworks_config->{per_item_costs} }
 
@@ -110,7 +116,6 @@ Users of this role must supply the following:
 
 =cut
 
-requires 'bulky_allowed_property';
 requires 'bulky_cancellation_cutoff_time';
 requires 'bulky_collection_time';
 requires 'bulky_collection_window_days';

--- a/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
@@ -45,7 +45,6 @@ sub bulky_enabled_staff_only {
 }
 
 sub bulky_items_master_list { $_[0]->wasteworks_config->{item_list} || [] }
-sub bulky_items_maximum { $_[0]->wasteworks_config->{items_per_collection_max} || 5 }
 sub bulky_per_item_costs { $_[0]->wasteworks_config->{per_item_costs} }
 sub bulky_tandc_link {
     my $self = shift;
@@ -85,7 +84,7 @@ sub bulky_pricing_strategy {
         my $min_collection_price = $self->wasteworks_config->{per_item_min_collection_price} || 0;
         return encode_json({ strategy => 'per_item', min => $min_collection_price });
     } elsif (my $band1_price = $self->wasteworks_config->{band1_price}) {
-        my $max = $self->bulky_items_maximum;
+        my $max = $self->{c}->stash->{booking_maximum};
         return encode_json({ strategy => 'banded', bands => [ { max => $band1_max, price => $band1_price }, { max => $max, price => $base_price } ] });
     } else {
         return encode_json({ strategy => 'single' });
@@ -199,7 +198,7 @@ sub bulky_total_cost {
             my $price_key = $self->bulky_per_item_price_key;
             my %prices = map { $_->{name} => $_->{$price_key} } @{ $self->bulky_items_master_list };
             my $total = 0;
-            my $max = $self->bulky_items_maximum;
+            my $max = $c->stash->{booking_maximum};
             for (1..$max) {
                 my $item = $data->{"item_$_"} or next;
                 $total += $prices{$item};
@@ -212,7 +211,7 @@ sub bulky_total_cost {
             }
         } elsif ($cfg->{band1_price}) {
             my $count = 0;
-            my $max = $self->bulky_items_maximum;
+            my $max = $c->stash->{booking_maximum};
             for (1..$max) {
                 my $item = $data->{"item_$_"} or next;
                 $count++;

--- a/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
@@ -203,8 +203,11 @@ sub bin_services_for_address {
         'bin_services_for_address:' . $property->{id},
         $background, @to_fetch);
 
-    if ($self->can('bulky_enabled')) {
+    if ($self->can('bulky_allowed_property')) {
         $property->{show_bulky_waste} = $self->bulky_allowed_property($property);
+    }
+    if ($self->can('small_items_allowed_property')) {
+        $property->{show_small_items} = $self->small_items_allowed_property($property);
     }
 
     my @out;

--- a/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
@@ -13,7 +13,10 @@ use FixMyStreet::DateRange;
 use FixMyStreet::DB;
 use FixMyStreet::WorkingDays;
 use Open311::GetServiceRequestUpdates;
+use Integrations::Echo::Booking;
 use Integrations::Echo::Events;
+
+sub booking_class { 'Integrations::Echo::Booking' }
 
 with 'FixMyStreet::Roles::EnforcePhotoSizeOpen311PreSend';
 
@@ -863,38 +866,42 @@ sub garden_current_service_from_service_units {
 }
 
 sub clear_cached_lookups_property {
-    my ( $self, $id, $skip_echo ) = @_;
-
-    # Need to call this before clearing GUID
-    $self->clear_cached_lookups_bulky_slots( $id, $skip_echo );
+    my ( $self, $id ) = @_;
 
     foreach my $key (
         $self->council_url . ":echo:look_up_property:$id",
         $self->council_url . ":echo:bin_services_for_address:$id",
-        $self->council_url . ":echo:bulky_event_guid:$id",
     ) {
         $self->{c}->waste_cache_delete($key);
     }
 }
 
 sub clear_cached_lookups_bulky_slots {
-    my ( $self, $id, $skip_echo ) = @_;
+    my ( $self, $id, %actions ) = @_;
 
+    my $booking = $self->{c}->stash->{booking_class};
+    return unless $booking; # Not in the bulky/small items flow
+
+    my $service_id = $booking->service_id;
     for (qw/earlier later/) {
-        $self->{c}->waste_cache_delete($self->council_url . ":echo:available_bulky_slots:$_:$id");
+        $self->{c}->waste_cache_delete($self->council_url . ":echo:available_slots:$_:$service_id:$id");
     }
 
-    return if $skip_echo;
+    my $guid_key = $booking->guid_key;
+    if (!$actions{skip_echo}) {
+        # We also need to cancel the reserved slots in Echo
+        my $guid = $self->{c}->waste_cache_get($guid_key);
+        return unless $guid;
 
-    # We also need to cancel the reserved slots in Echo
-    my $guid_key = $self->council_url . ":echo:bulky_event_guid:$id";
-    my $guid = $self->{c}->waste_cache_get($guid_key);
+        my $cfg = $self->feature('echo');
+        my $echo = Integrations::Echo->new(%$cfg);
+        $echo->CancelReservedSlotsForEvent($guid);
+    }
 
-    return unless $guid;
-
-    my $cfg = $self->feature('echo');
-    my $echo = Integrations::Echo->new(%$cfg);
-    $echo->CancelReservedSlotsForEvent($guid);
+    # We don't want to do this when we're mid flow but need to fetch new slots, for example
+    if ($actions{delete_guid}) {
+        $self->{c}->waste_cache_delete($guid_key);
+    }
 }
 
 sub bulky_refetch_slots {
@@ -991,93 +998,6 @@ sub bulky_check_missed_collection {
         }
 
         $self->{c}->stash->{bulky_missed}{$guid} = $row;
-    }
-}
-
-sub find_available_bulky_slots {
-    my ( $self, $property, $last_earlier_date_str, $no_cache ) = @_;
-
-    my $key
-        = $self->council_url . ":echo:available_bulky_slots:"
-        . ( $last_earlier_date_str ? 'later' : 'earlier' ) . ':'
-        . $property->{id};
-    if (!$no_cache) {
-        my $data = $self->{c}->waste_cache_get($key);
-        return $data if $data;
-    }
-
-    my $cfg = $self->feature('echo');
-    my $echo = Integrations::Echo->new(%$cfg);
-
-    my $service_id = $cfg->{bulky_service_id};
-    my $event_type_id = $cfg->{bulky_event_type_id};
-
-    my $guid_key = $self->council_url . ":echo:bulky_event_guid:" . $property->{id};
-    my $guid = $self->{c}->waste_cache_get($guid_key);
-    unless ($guid) {
-        require UUID::Tiny;
-        $guid = UUID::Tiny::create_uuid_as_string();
-        $self->{c}->waste_cache_set($guid_key, $guid);
-    }
-
-    my $window = $self->_bulky_collection_window($last_earlier_date_str);
-    my @available_slots;
-    my $slots = $echo->ReserveAvailableSlotsForEvent($service_id, $event_type_id, $property->{id}, $guid, $window->{date_from}, $window->{date_to});
-    $self->{c}->session->{first_date_returned} = undef;
-    foreach (@$slots) {
-        my $date = construct_bin_date($_->{StartDate})->datetime;
-        push @available_slots, {
-            date => $date,
-            reference => $_->{Reference},
-            expiry => construct_bin_date($_->{Expiry})->datetime,
-        };
-        $self->{c}->session->{first_date_returned} //= $date;
-    }
-
-    $self->{c}->waste_cache_set($key, \@available_slots) if !$no_cache;
-
-    return \@available_slots;
-}
-
-sub check_bulky_slot_available {
-    my ( $self, $chosen_date_string, %args ) = @_;
-
-    my $form = $args{form};
-
-    # chosen_date_string is of the form
-    # '2023-08-29T00:00:00;AS3aUwCS7NwGCTIzMDMtMTEwMTyNVqC8SCJe+A==;2023-08-25T15:49:38'
-    my ( $collection_date, undef, $slot_expiry_date )
-        = $chosen_date_string =~ /[^;]+/g;
-
-    my $parser = DateTime::Format::Strptime->new( pattern => '%FT%T' );
-    my $slot_expiry_dt = $parser->parse_datetime($slot_expiry_date);
-
-    my $now_dt = DateTime->now;
-
-    # Note: Both $slot_expiry_dt and $now_dt are UTC
-    if ( $slot_expiry_dt <= $now_dt ) {
-        # Cancel the expired slots and call ReserveAvailableSlots again, try to
-        # get the same collection date
-        my $property = $self->{c}->stash->{property};
-        $self->clear_cached_lookups_bulky_slots($property->{id});
-
-        my $available_slots = $self->find_available_bulky_slots(
-            $property, undef, 'no_cache' );
-
-        my ($slot) = grep { $_->{date} eq $collection_date } @$available_slots;
-
-        if ($slot) {
-            $form->saved_data->{chosen_date}
-                = $slot->{date} . ";"
-                . $slot->{reference} . ";"
-                . $slot->{expiry};
-
-            return 1;
-        } else {
-            return 0;
-        }
-    } else {
-        return 1;
     }
 }
 

--- a/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
@@ -1029,7 +1029,7 @@ sub bulky_nice_item_list {
             push @fields, { item => $value, display => $display };
         }
     }
-    my $items_extra = $self->bulky_items_extra(exclude_pricing => 1);
+    my $items_extra = $report->category eq 'Small items collection' ? $self->small_items_extra() : $self->bulky_items_extra(exclude_pricing => 1);
 
     return [
         map {

--- a/perllib/FixMyStreet/Roles/Cobrand/KingstonSutton.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/KingstonSutton.pm
@@ -116,6 +116,17 @@ sub waste_munge_report_form_fields {
     $self->{c}->stash->{form_class} = 'FixMyStreet::App::Form::Waste::Report::SLWP';
 }
 
+=head2 waste_report_form_first_bulky
+
+When reporting a missed bulky or small items collection, the first page is
+'notes' (additional information).
+
+=cut
+
+sub waste_report_form_first_bulky {
+    return 'notes';
+}
+
 =head2 waste_cc_payment_line_item_ref
 
 This is used by the SCP role (all Kingston, Sutton requests) to provide the

--- a/perllib/FixMyStreet/Roles/Cobrand/KingstonSutton.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/KingstonSutton.pm
@@ -116,28 +116,6 @@ sub waste_munge_report_form_fields {
     $self->{c}->stash->{form_class} = 'FixMyStreet::App::Form::Waste::Report::SLWP';
 }
 
-=head2 waste_report_form_first_next
-
-After picking a service, we jump straight to the about you page unless it's
-bulky or small items, where we ask for more information.
-
-=cut
-
-sub waste_report_form_first_next {
-    my $self = shift;
-    my $cfg = $self->feature('echo');
-    my $bulky_service_id       = $cfg->{bulky_service_id};
-    my $small_items_service_id = $cfg->{small_items_service_id};
-    return sub {
-        my $data = shift;
-        return 'notes'
-            if ( $bulky_service_id && $data->{"service-$bulky_service_id"} )
-            || ( $small_items_service_id && $data->{"service-$small_items_service_id"} );
-        return 'about_you';
-    };
-}
-
-
 =head2 waste_cc_payment_line_item_ref
 
 This is used by the SCP role (all Kingston, Sutton requests) to provide the

--- a/perllib/FixMyStreet/Roles/Cobrand/KingstonSutton.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/KingstonSutton.pm
@@ -119,20 +119,24 @@ sub waste_munge_report_form_fields {
 =head2 waste_report_form_first_next
 
 After picking a service, we jump straight to the about you page unless it's
-bulky, where we ask for more information.
+bulky or small items, where we ask for more information.
 
 =cut
 
 sub waste_report_form_first_next {
     my $self = shift;
     my $cfg = $self->feature('echo');
-    my $bulky_service_id = $cfg->{bulky_service_id};
+    my $bulky_service_id       = $cfg->{bulky_service_id};
+    my $small_items_service_id = $cfg->{small_items_service_id};
     return sub {
         my $data = shift;
-        return 'notes' if $data->{"service-$bulky_service_id"};
+        return 'notes'
+            if ( $bulky_service_id && $data->{"service-$bulky_service_id"} )
+            || ( $small_items_service_id && $data->{"service-$small_items_service_id"} );
         return 'about_you';
     };
 }
+
 
 =head2 waste_cc_payment_line_item_ref
 

--- a/perllib/FixMyStreet/Roles/Cobrand/SLWP.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/SLWP.pm
@@ -615,7 +615,7 @@ sub waste_munge_bulky_data {
     my $c = $self->{c};
     my ($date, $ref, $expiry) = split(";", $data->{chosen_date});
 
-    my $guid_key = $self->council_url . ":echo:bulky_event_guid:" . $c->stash->{property}->{id};
+    my $guid_key = $c->stash->{booking_class}->guid_key;
     $data->{extra_GUID} = $self->{c}->waste_cache_get($guid_key);
     $data->{extra_reservation} = $ref;
 

--- a/perllib/FixMyStreet/Roles/Cobrand/SLWP.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/SLWP.pm
@@ -638,7 +638,7 @@ sub waste_munge_bulky_data {
     my @ids;
     my @photos;
 
-    my $max = $self->bulky_items_maximum;
+    my $max = $c->stash->{booking_maximum};
     for (1..$max) {
         if (my $item = $data->{"item_$_"}) {
             push @notes, $data->{"item_notes_$_"} || '';

--- a/perllib/FixMyStreet/Roles/Cobrand/SLWP2.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/SLWP2.pm
@@ -667,7 +667,7 @@ sub waste_munge_bulky_data {
     my @ids;
     my @photos;
 
-    my $max = $self->bulky_items_maximum;
+    my $max = $c->stash->{booking_maximum};
     for (1..$max) {
         if (my $item = $data->{"item_$_"}) {
             push @notes, $data->{"item_notes_$_"} || '';

--- a/perllib/FixMyStreet/Roles/Cobrand/SLWP2.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/SLWP2.pm
@@ -653,8 +653,8 @@ sub waste_munge_bulky_data {
         title => 'Small items collection',
         category => 'Small items collection',
         date_field => 'extra_Collection_Date_-_Bulky_Items', # Only used on FMS side so left as is
-        description_field => 'extra_TEM_-_Small_Item_Collection_Description',
-        ids_field => 'extra_TEM_-_Small_Item_Recycling_Item',
+        description_field => '',
+        ids_field => 'extra_Small_Item_Type',
       }
       :
       {
@@ -697,7 +697,7 @@ sub waste_munge_bulky_data {
             push @photos, $data->{"item_photos_$_"} || '';
         };
     }
-    $data->{ $fields->{description_field} } = join("::", @notes);
+    $data->{ $fields->{description_field} } = join("::", @notes) if $fields->{description_field};
     $data->{ $fields->{ids_field} } = join("::", @ids);
     $data->{extra_Image} = join("::", @photos);
     $self->bulky_total_cost($data);
@@ -715,11 +715,10 @@ sub waste_reconstruct_bulky_data {
     my @fields = split /::/,
         $p->get_extra_field_value('TEM_-_Bulky_Collection_Item')
         || $p->get_extra_field_value('Bulky_Collection_Bulky_Items')
-        || $p->get_extra_field_value('TEM_-_Small_Item_Recycling_Item');
+        || $p->get_extra_field_value('Small_Item_Type');
     my @notes = split /::/,
         $p->get_extra_field_value('TEM_-_Bulky_Collection_Description')
-        || $p->get_extra_field_value('Bulky_Collection_Notes')
-        || $p->get_extra_field_value('TEM_-_Small_Item_Collection_Description');
+        || $p->get_extra_field_value('Bulky_Collection_Notes');
 
     for my $id (1..@fields) {
         $saved_data->{"item_$id"} = $p->get_extra_metadata("item_$id");

--- a/perllib/FixMyStreet/Roles/Cobrand/SLWP2.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/SLWP2.pm
@@ -190,6 +190,10 @@ sub waste_extra_service_info_all_results {
         $property->{has_bulky_service} = 1;
     }
 
+    if (@$result && grep { $_->{ServiceId} == $service_ids->{domestic_refuse} } @$result) {
+        $property->{has_small_items_service} = 1;
+    }
+
     $property->{has_no_services} = scalar @$result == 0;
     $self->{c}->stash->{assisted_collection} = _is_assisted($result, $service_ids);
 }
@@ -643,16 +647,34 @@ sub waste_munge_bulky_data {
     my ($self, $data) = @_;
 
     my $c = $self->{c};
+
+    my $fields = $c->stash->{small_items} ?
+      {
+        title => 'Small items collection',
+        category => 'Small items collection',
+        date_field => 'extra_Collection_Date_-_Bulky_Items', # Only used on FMS side so left as is
+        description_field => 'extra_TEM_-_Small_Item_Collection_Description',
+        ids_field => 'extra_TEM_-_Small_Item_Recycling_Item',
+      }
+      :
+      {
+        title => 'Bulky goods collection',
+        category => 'Bulky collection',
+        date_field => 'extra_Collection_Date_-_Bulky_Items',
+        description_field => 'extra_TEM_-_Bulky_Collection_Description',
+        ids_field => 'extra_TEM_-_Bulky_Collection_Item',
+      };
+
     my ($date, $ref, $expiry) = split(";", $data->{chosen_date});
 
     my $guid_key = $c->stash->{booking_class}->guid_key;
     $data->{extra_GUID} = $self->{c}->waste_cache_get($guid_key);
     $data->{extra_reservation} = $ref;
 
-    $data->{title} = "Bulky goods collection";
+    $data->{title} = $fields->{title};
     $data->{detail} = "Address: " . $c->stash->{property}->{address};
-    $data->{category} = "Bulky collection";
-    $data->{'extra_Collection_Date_-_Bulky_Items'} = $date;
+    $data->{category} = $fields->{category};
+    $data->{ $fields->{date_field} } = $date;
     $data->{extra_Exact_Location} = $data->{location};
 
     my $first_date = $self->{c}->session->{first_date_returned};
@@ -660,7 +682,7 @@ sub waste_munge_bulky_data {
     my $dt = DateTime::Format::W3CDTF->parse_datetime($date);
     $data->{'extra_First_Date_Offered_-_Bulky'} = $first_date->strftime("%d/%m/%Y");
 
-    my @items_list = @{ $self->bulky_items_master_list };
+    my @items_list = $c->stash->{small_items} ? @{ $self->small_items_master_list } : @{ $self->bulky_items_master_list };
     my %items = map { $_->{name} => $_->{bartec_id} } @items_list;
 
     my @notes;
@@ -675,8 +697,8 @@ sub waste_munge_bulky_data {
             push @photos, $data->{"item_photos_$_"} || '';
         };
     }
-    $data->{'extra_TEM_-_Bulky_Collection_Description'} = join("::", @notes);
-    $data->{'extra_TEM_-_Bulky_Collection_Item'} = join("::", @ids);
+    $data->{ $fields->{description_field} } = join("::", @notes);
+    $data->{ $fields->{ids_field} } = join("::", @ids);
     $data->{extra_Image} = join("::", @photos);
     $self->bulky_total_cost($data);
 }
@@ -690,8 +712,15 @@ sub waste_reconstruct_bulky_data {
         "location_photo" => $p->get_extra_metadata("location_photo"),
     };
 
-    my @fields = split /::/, $p->get_extra_field_value('TEM_-_Bulky_Collection_Item') || $p->get_extra_field_value('Bulky_Collection_Bulky_Items');
-    my @notes = split /::/, $p->get_extra_field_value('TEM_-_Bulky_Collection_Description') || $p->get_extra_field_value('Bulky_Collection_Notes');
+    my @fields = split /::/,
+        $p->get_extra_field_value('TEM_-_Bulky_Collection_Item')
+        || $p->get_extra_field_value('Bulky_Collection_Bulky_Items')
+        || $p->get_extra_field_value('TEM_-_Small_Item_Recycling_Item');
+    my @notes = split /::/,
+        $p->get_extra_field_value('TEM_-_Bulky_Collection_Description')
+        || $p->get_extra_field_value('Bulky_Collection_Notes')
+        || $p->get_extra_field_value('TEM_-_Small_Item_Collection_Description');
+
     for my $id (1..@fields) {
         $saved_data->{"item_$id"} = $p->get_extra_metadata("item_$id");
         $saved_data->{"item_notes_$id"} = $notes[$id-1];

--- a/perllib/FixMyStreet/Roles/Cobrand/SLWP2.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/SLWP2.pm
@@ -645,7 +645,7 @@ sub waste_munge_bulky_data {
     my $c = $self->{c};
     my ($date, $ref, $expiry) = split(";", $data->{chosen_date});
 
-    my $guid_key = $self->council_url . ":echo:bulky_event_guid:" . $c->stash->{property}->{id};
+    my $guid_key = $c->stash->{booking_class}->guid_key;
     $data->{extra_GUID} = $self->{c}->waste_cache_get($guid_key);
     $data->{extra_reservation} = $ref;
 

--- a/perllib/FixMyStreet/Roles/Cobrand/SLWP2.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/SLWP2.pm
@@ -91,6 +91,7 @@ my %EVENT_TYPE_IDS = (
     garden_add => 3159,
     garden_amend => 3163,
     bulky => 3130,
+    small_items => 3144,
 );
 lock_hash(%EVENT_TYPE_IDS);
 
@@ -303,6 +304,7 @@ sub missed_event_types { return {
     $EVENT_TYPE_IDS{missed} => 'missed',
     $EVENT_TYPE_IDS{missed_assisted} => 'missed',
     $EVENT_TYPE_IDS{bulky} => 'bulky',
+    $EVENT_TYPE_IDS{small_items} => 'small_items',
 } }
 
 sub waste_munge_report_data {
@@ -310,15 +312,18 @@ sub waste_munge_report_data {
 
     my $c = $self->{c};
 
-    my $booking_report;
-    if ($c->get_param('original_booking_id')) {
-        $booking_report = FixMyStreet::DB->resultset("Problem")->find({ id => $c->get_param('original_booking_id') });
-    };
     my $address = $c->stash->{property}->{address};
     my $cfg = $self->feature('echo');
     my $service = $c->stash->{services}{$id}{service_name};
-    if ($id == $cfg->{bulky_service_id}) {
+    if (   $cfg->{bulky_service_id}
+        && $id == $cfg->{bulky_service_id} )
+    {
         $service = 'bulky collection';
+    }
+    if (   $cfg->{small_items_service_id}
+        && $id == $cfg->{small_items_service_id} )
+    {
+        $service = 'small items collection';
     }
     if ($c->get_param('additional') && $c->stash->{is_staff}) {
         $data->{category} = 'Request additional collection';
@@ -336,7 +341,7 @@ sub waste_munge_report_data {
         $data->{title} = "Report missed $service";
     }
     $data->{detail} = "$data->{title}\n\n$address";
-    if ($booking_report) {
+    if ( my $booking_report = $c->stash->{original_booking_report} ) {
         $c->set_param('Exact_Location', $booking_report->get_extra_field_value('Exact_Location'));
         $c->set_param('Original_Event_ID', $booking_report->external_id);
     }
@@ -718,7 +723,8 @@ sub waste_reconstruct_bulky_data {
         || $p->get_extra_field_value('Small_Item_Type');
     my @notes = split /::/,
         $p->get_extra_field_value('TEM_-_Bulky_Collection_Description')
-        || $p->get_extra_field_value('Bulky_Collection_Notes');
+        || $p->get_extra_field_value('Bulky_Collection_Notes')
+        || '';
 
     for my $id (1..@fields) {
         $saved_data->{"item_$id"} = $p->get_extra_metadata("item_$id");

--- a/perllib/Integrations/Bartec/Booking.pm
+++ b/perllib/Integrations/Bartec/Booking.pm
@@ -1,0 +1,193 @@
+=head1 NAME
+
+Integrations::Bartec::Booking - Bartec specific code for booking slots
+
+=head1 SYNOPSIS
+
+This handles checking slots are available in the Bartec backend for bulky
+collections.
+
+=head1 DESCRIPTION
+
+=cut
+
+package Integrations::Bartec::Booking;
+
+use Moo;
+
+has cobrand => ( is => 'ro' );
+has service_id => ( is => 'ro' );
+has event_type_id => ( is => 'ro' );
+has property => ( is => 'ro' );
+
+=item * We return a maximum of 2 date options to users when they are booking
+a bulky waste collection
+
+=cut
+
+sub max_bulky_collection_dates       {2}
+
+=item * Bulky workpack name is of the form 'Waste-BULKY WASTE-<date>' or
+'Waste-WHITES-<date>'
+
+=cut
+
+sub bulky_workpack_name {
+    qr/Waste-(BULKY WASTE|WHITES)-(?<date_suffix>\d{6})/;
+}
+
+# XXX
+# Error handling
+# Holidays, bank holidays?
+# Monday limit, Tuesday limit etc.?
+# Check which bulky collections are pending, open
+sub find_available_slots {
+    my ( $cls, $last_earlier_date_str ) = @_;
+    my $property = $cls->property;
+    my $self = $cls->cobrand;
+    my $c = $self->{c};
+
+    my $key
+        = 'peterborough:bartec:available_slots:'
+        . ( $last_earlier_date_str ? 'later' : 'earlier' ) . ':'
+        . $property->{uprn};
+    my $data = $c->waste_cache_get($key);
+    return $data if $data;
+
+    my $bartec = $self->feature('bartec');
+    $bartec = Integrations::Bartec->new(%$bartec);
+
+    my $window = $self->_bulky_collection_window($last_earlier_date_str);
+    if ( $window->{error} ) {
+        # XXX Handle error gracefully
+        die $window->{error};
+    }
+    my $workpacks = $bartec->Premises_FutureWorkpacks_Get(
+        date_from => $window->{date_from},
+        date_to   => $window->{date_to},
+        uprn      => $property->{uprn},
+    );
+
+    my @available_slots;
+    my %seen_dates;
+
+    my $last_workpack_date;
+    for my $workpack (@$workpacks) {
+        # Depending on the Collective API version (R1531 or R1611),
+        # $workpack->{Actions} can be an arrayref or a hashref.
+        # If a hashref, it may be an action structure of the form
+        # { 'ActionName' => ... },
+        # or it may have the key {Action}.
+        # $workpack->{Actions}{Action} can also be an arrayref or hashref.
+        # From this variety of structures, we want to get an arrayref of
+        # action hashrefs of the form [ { 'ActionName' => ... }, {...} ].
+        my $action_data = $workpack->{Actions};
+        if ( ref $action_data eq 'HASH' ) {
+            if ( exists $action_data->{Action} ) {
+                $action_data = $action_data->{Action};
+                $action_data = [$action_data] if ref $action_data eq 'HASH';
+            } else {
+                $action_data = [$action_data];
+            }
+        }
+
+        my %action_hash = map {
+            my $action_name = $_->{ActionName} // '';
+            $action_name = $self->service_name_override()->{$action_name}
+                // $action_name;
+
+            $action_name => $_;
+        } @$action_data;
+
+        # We only want dates that coincide with black bin collections
+        next if !exists $action_hash{'Black Bin'};
+
+        # This case shouldn't occur, but in case there are multiple black bin
+        # workpacks for the same date, we only take the first into account
+        next if $workpack->{WorkPackDate} eq ( $last_workpack_date // '' );
+
+        # Only include if max jobs not already reached
+        if ($cls->check_slot_available($workpack->{WorkPackDate}, bartec => $bartec)) {
+            push @available_slots, {
+                workpack_id => $workpack->{id},
+                date        => $workpack->{WorkPackDate},
+            };
+            $seen_dates{$workpack->{WorkPackDate}} = 1;
+        }
+
+        $last_workpack_date = $workpack->{WorkPackDate};
+
+        # Provision of $last_earlier_date_str implies we want to fetch all
+        # remaining available slots in the given window, so we ignore the
+        # limit
+        last
+            if !$last_earlier_date_str
+            && @available_slots == max_bulky_collection_dates();
+    }
+
+    if (my $amend = $c->stash->{amending_booking}) {
+        my $date = $amend->get_extra_field_value('DATE');
+        if (!$seen_dates{$date}) {
+            unshift @available_slots, { date => $date };
+        }
+    }
+
+    return $c->waste_cache_set($key, \@available_slots);
+}
+
+# Checks if there is a slot available for a given date
+sub check_slot_available {
+    my ( $cls, $date, %args ) = @_;
+    my $self = $cls->cobrand;
+
+    my $bartec = $args{bartec};
+
+    unless ($bartec) {
+        $bartec = $self->feature('bartec');
+        $bartec = Integrations::Bartec->new(%$bartec);
+    }
+
+    my $suffix_date_parser = DateTime::Format::Strptime->new( pattern => '%d%m%y' );
+    my $workpack_dt = $self->_bulky_date_to_dt($date);
+    next unless $workpack_dt;
+
+    my $now = DateTime->now( time_zone => FixMyStreet->local_time_zone );
+    my $cutoff = $self->_bulky_cancellation_cutoff_date($workpack_dt);
+    return 0 if $now > $cutoff;
+
+    my $date_from = $workpack_dt->clone->strftime('%FT%T');
+    my $date_to = $workpack_dt->clone->set(
+        hour   => 23,
+        minute => 59,
+        second => 59,
+    )->strftime('%FT%T');
+    my $workpacks_for_day = $bartec->WorkPacks_Get(
+        date_from => $date_from,
+        date_to   => $date_to,
+    );
+
+    my %jobs_per_uprn;
+    for my $wpfd (@$workpacks_for_day) {
+        next if $wpfd->{Name} !~ bulky_workpack_name();
+
+        # Ignore workpacks with names with faulty date suffixes
+        my $suffix_dt = $suffix_date_parser->parse_datetime( $+{date_suffix} );
+
+        next
+            if !$suffix_dt
+            || $workpack_dt->date ne $suffix_dt->date;
+
+        my $jobs = $bartec->Jobs_Get_for_workpack( $wpfd->{ID} ) || [];
+
+        # Group jobs by UPRN. For a bulky workpack, a UPRN/premises may
+        # have multiple jobs (equivalent to item slots); these all count
+        # as a single bulky collection slot.
+        $jobs_per_uprn{ $_->{Job}{UPRN} }++ for @$jobs;
+    }
+
+    my $total_collection_slots = keys %jobs_per_uprn;
+
+    return $total_collection_slots < $self->bulky_daily_slots;
+}
+
+1;

--- a/perllib/Integrations/Echo/Booking.pm
+++ b/perllib/Integrations/Echo/Booking.pm
@@ -72,6 +72,7 @@ sub find_available_slots {
         $c->session->{first_date_returned} //= $date;
     }
 
+    $c->cobrand->call_hook('filter_booking_dates', \@available_slots);
     $c->waste_cache_set($key, \@available_slots) if !$no_cache;
 
     return \@available_slots;

--- a/perllib/Integrations/Echo/Booking.pm
+++ b/perllib/Integrations/Echo/Booking.pm
@@ -23,8 +23,8 @@ has type => ( is => 'ro', isa => Enum['bulky', 'small_items'] );
 has config => ( is => 'lazy', default => sub { $_[0]->cobrand->feature('echo') });
 has echo => ( is => 'lazy', default => sub { Integrations::Echo->new(%{$_[0]->config}) });
 
-has service_id_key => ( is => 'lazy', default => sub { 'bulky_service_id' });
-has event_type_id_key => ( is => 'lazy', default => sub { 'bulky_event_type_id' });
+has service_id_key => ( is => 'lazy', default => sub { $_[0]->type . '_service_id' });
+has event_type_id_key => ( is => 'lazy', default => sub { $_[0]->type . '_event_type_id' });
 has service_id => ( is => 'lazy', default => sub { $_[0]->config->{$_[0]->service_id_key} });
 has event_type_id => ( is => 'lazy', default => sub { $_[0]->config->{$_[0]->event_type_id_key} });
 

--- a/perllib/Integrations/Echo/Booking.pm
+++ b/perllib/Integrations/Echo/Booking.pm
@@ -1,0 +1,121 @@
+=head1 NAME
+
+Integrations::Echo::Booking - Echo specific code for booking slots
+
+=head1 SYNOPSIS
+
+This handles reserving and checking slots are still available in the Echo
+backend, for both bulky and small items collections.
+
+=head1 DESCRIPTION
+
+=cut
+
+package Integrations::Echo::Booking;
+
+use Moo;
+use Types::Standard qw(Enum);
+
+has cobrand => ( is => 'ro' );
+has property => ( is => 'ro' );
+has type => ( is => 'ro', isa => Enum['bulky', 'small_items'] );
+
+has config => ( is => 'lazy', default => sub { $_[0]->cobrand->feature('echo') });
+has echo => ( is => 'lazy', default => sub { Integrations::Echo->new(%{$_[0]->config}) });
+
+has service_id_key => ( is => 'lazy', default => sub { 'bulky_service_id' });
+has event_type_id_key => ( is => 'lazy', default => sub { 'bulky_event_type_id' });
+has service_id => ( is => 'lazy', default => sub { $_[0]->config->{$_[0]->service_id_key} });
+has event_type_id => ( is => 'lazy', default => sub { $_[0]->config->{$_[0]->event_type_id_key} });
+
+has guid_key => ( is => 'lazy', default => sub {
+    my $self = shift;
+    my $council_url = $self->cobrand->council_url;
+    my $guid_key = $council_url . ":echo:event_guid:" . $self->service_id . ':' . $self->property->{id};
+    return $guid_key;
+});
+
+sub find_available_slots {
+    my ( $self, $last_earlier_date_str, $no_cache ) = @_;
+    my $c = $self->cobrand->{c};
+    my $council_url = $self->cobrand->council_url;
+
+    my $key
+        = $council_url . ":echo:available_slots:"
+        . ( $last_earlier_date_str ? 'later' : 'earlier' ) . ':'
+        . $self->service_id . ':'
+        . $self->property->{id};
+    if (!$no_cache) {
+        my $data = $c->waste_cache_get($key);
+        return $data if $data;
+    }
+
+    my $guid = $c->waste_cache_get($self->guid_key);
+    unless ($guid) {
+        require UUID::Tiny;
+        $guid = UUID::Tiny::create_uuid_as_string();
+        $c->waste_cache_set($self->guid_key, $guid);
+    }
+
+    my $window = $self->cobrand->_bulky_collection_window($last_earlier_date_str);
+    my @available_slots;
+    my $slots = $self->echo->ReserveAvailableSlotsForEvent($self->service_id, $self->event_type_id, $self->property->{id}, $guid, $window->{date_from}, $window->{date_to});
+    $c->session->{first_date_returned} = undef;
+    my $construct = $self->cobrand->can('construct_bin_date');
+    foreach (@$slots) {
+        my $date = $construct->($_->{StartDate})->datetime;
+        push @available_slots, {
+            date => $date,
+            reference => $_->{Reference},
+            expiry => $construct->($_->{Expiry})->datetime,
+        };
+        $c->session->{first_date_returned} //= $date;
+    }
+
+    $c->waste_cache_set($key, \@available_slots) if !$no_cache;
+
+    return \@available_slots;
+}
+
+sub check_slot_available {
+    my ( $self, $chosen_date_string, %args ) = @_;
+
+    my $form = $args{form};
+
+    # chosen_date_string is of the form
+    # '2023-08-29T00:00:00;AS3aUwCS7NwGCTIzMDMtMTEwMTyNVqC8SCJe+A==;2023-08-25T15:49:38'
+    my ( $collection_date, undef, $slot_expiry_date )
+        = $chosen_date_string =~ /[^;]+/g;
+
+    my $parser = DateTime::Format::Strptime->new( pattern => '%FT%T' );
+    my $slot_expiry_dt = $parser->parse_datetime($slot_expiry_date);
+
+    my $now_dt = DateTime->now;
+
+    # Note: Both $slot_expiry_dt and $now_dt are UTC
+    if ( $slot_expiry_dt <= $now_dt ) {
+        # Cancel the expired slots and call ReserveAvailableSlots again, try to
+        # get the same collection date
+        my $property = $self->cobrand->{c}->stash->{property};
+        $self->cobrand->clear_cached_lookups_bulky_slots($property->{id});
+
+        my $available_slots = $self->find_available_slots(undef, 'no_cache');
+
+        my ($slot) = grep { $_->{date} eq $collection_date } @$available_slots;
+
+        if ($slot) {
+            $form->saved_data->{chosen_date}
+                = $slot->{date} . ";"
+                . $slot->{reference} . ";"
+                . $slot->{expiry};
+
+            return 1;
+        } else {
+            return 0;
+        }
+    } else {
+        return 1;
+    }
+}
+
+1;

--- a/perllib/Integrations/Echo/Events.pm
+++ b/perllib/Integrations/Echo/Events.pm
@@ -68,7 +68,7 @@ sub parse {
             }
         } elsif ($type eq 'missed') {
             $self->cobrand->call_hook('parse_event_missed', $_, $event, $events);
-        } elsif ($type eq 'bulky') {
+        } elsif ($type eq 'bulky' || $type eq 'small_items') {
             if ($report) {
                 $event->{resolution} = $_->{ResolutionCodeId};
                 if ($closed) {

--- a/perllib/Integrations/Whitespace/Booking.pm
+++ b/perllib/Integrations/Whitespace/Booking.pm
@@ -1,0 +1,73 @@
+=head1 NAME
+
+Integrations::Whitespace::Booking - Echo specific code for booking slots
+
+=head1 SYNOPSIS
+
+This handles reserving and checking slots are still available in the Whitespace
+backend, for both bulky and small items collections.
+
+=head1 DESCRIPTION
+
+=cut
+
+package Integrations::Whitespace::Booking;
+
+use Moo;
+use Types::Standard qw(Enum);
+
+has cobrand => ( is => 'ro' );
+has property => ( is => 'ro' );
+has type => ( is => 'ro', isa => Enum['bulky', 'small_items'] );
+
+has config => ( is => 'lazy', default => sub { $_[0]->cobrand->feature('whitespace') });
+has ws => ( is => 'lazy', default => sub { Integrations::Whitespace->new(%{$_[0]->config}) });
+
+sub find_available_slots {
+    my ( $self, $last_earlier_date_str, $no_cache ) = @_;
+
+    my $c = $self->cobrand->{c};
+    my $key = $self->cobrand->council_url . ":whitespace:available_bulky_slots:" . $self->property->{id};
+
+    if (!$no_cache) {
+        my $data = $c->waste_cache_get($key);
+        return $data if $data;
+    }
+
+    my $window = $self->cobrand->_bulky_collection_window($last_earlier_date_str);
+    my @available_slots;
+    my $slots = $self->ws->GetCollectionSlots($self->property->{uprn}, $window->{date_from}, $window->{date_to});
+    foreach (@$slots) {
+        (my $date = $_->{AdHocRoundInstanceDate}) =~ s/T00:00:00//;
+        $date = $self->cobrand->_bulky_date_to_dt($date);
+        next if FixMyStreet::Cobrand::UK::is_public_holiday(date => $date);
+        next if $_->{SlotsFree} <= 0;
+        push @available_slots, {
+            date => $date->date,
+            reference => $_->{AdHocRoundInstanceID},
+            expiry => '',
+        };
+    }
+
+    $c->waste_cache_set($key, \@available_slots) if !$no_cache;
+
+    return \@available_slots;
+}
+
+sub check_slot_available {
+    my ( $self, $chosen_date_string, %args ) = @_;
+
+    my $c = $self->cobrand->{c};
+    # chosen_date_string is of the form
+    # '2023-08-29;12345;'
+    my ( $collection_date) = $chosen_date_string =~ /[^;]+/g;
+
+    my $property = $c->stash->{property};
+    my $available_slots = $self->find_available_slots(
+        $property, undef, 'no_cache' );
+
+    my ($slot) = grep { $_->{date} eq $collection_date } @$available_slots;
+    return $slot ? 1 : 0;
+}
+
+1;

--- a/t/app/controller/waste_brent_small_items.t
+++ b/t/app/controller/waste_brent_small_items.t
@@ -502,10 +502,15 @@ FixMyStreet::override_config {
         $mech->get_ok('/waste/12345');
         $mech->content_contains('Report a small items collection as missed', 'In time, normal completion');
         $mech->submit_form_ok({ with_fields => { 'service-787' => 1 } });
-        $mech->content_contains('Small items collection');
-        $mech->submit_form_ok({ with_fields => { 'service-787' => 1 } });
+        $mech->content_contains('About you');
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
-        $mech->submit_form_ok({ with_fields => { process => 'summary' } });
+        $mech->content_contains('Submit missed small items collection');
+
+        $mech->submit_form_ok( { form_number => 1 }, 'Go back to first page' );
+        $mech->content_contains('About you');
+        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
+
+        $mech->submit_form_ok( { form_number => 3 }, 'Submit summary' );
         $mech->content_contains('Thank you for reporting a missed collection');
         my $report = FixMyStreet::DB->resultset("Problem")->order_by('-id')->first;
         is $report->category, 'Report missed collection';

--- a/t/app/controller/waste_brent_small_items.t
+++ b/t/app/controller/waste_brent_small_items.t
@@ -75,7 +75,7 @@ FixMyStreet::override_config {
                 bulky_enabled => 1,
                 bulky_missed => 1,
                 bulky_multiple_bookings => 1,
-                bulky_tandc_link => 'tandc_link',
+                small_items_tandc_link => 'tandc_link',
             },
         },
         echo => {

--- a/t/app/controller/waste_brent_small_items.t
+++ b/t/app/controller/waste_brent_small_items.t
@@ -510,7 +510,7 @@ FixMyStreet::override_config {
         $mech->content_contains('About you');
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email }});
 
-        $mech->submit_form_ok( { form_number => 3 }, 'Submit summary' );
+        $mech->submit_form_ok( { form_number => 2 }, 'Submit summary' );
         $mech->content_contains('Thank you for reporting a missed collection');
         my $report = FixMyStreet::DB->resultset("Problem")->order_by('-id')->first;
         is $report->category, 'Report missed collection';

--- a/t/app/controller/waste_brent_small_items.t
+++ b/t/app/controller/waste_brent_small_items.t
@@ -73,16 +73,16 @@ FixMyStreet::override_config {
         waste_features => {
             brent => {
                 small_items_enabled => 1,
-                bulky_missed => 1,
-                bulky_multiple_bookings => 1,
+                small_items_missed => 1,
+                small_items_multiple_bookings => 1,
                 small_items_tandc_link => 'tandc_link',
             },
         },
         echo => {
             brent => {
-                bulky_service_id => 274,
-                bulky_service_id_missed => 787,
-                bulky_event_type_id => 2964,
+                small_items_service_id => 274,
+                small_items_service_id_missed => 787,
+                small_items_event_type_id => 2964,
                 url => 'http://example.org',
             },
         },

--- a/t/app/controller/waste_brent_small_items.t
+++ b/t/app/controller/waste_brent_small_items.t
@@ -17,7 +17,7 @@ my $user_phone = $mech->create_user_ok('0123456789');
 my $body = $mech->create_body_ok(2488, 'Brent Council', { cobrand => 'brent' });
 $body->set_extra_metadata(
     wasteworks_config => {
-        items_per_collection_max => 11,
+        small_items_per_collection_max => 11,
         base_price => 0,
         show_location_page => 'users',
         show_individual_notes => 1,

--- a/t/app/controller/waste_brent_small_items.t
+++ b/t/app/controller/waste_brent_small_items.t
@@ -21,7 +21,7 @@ $body->set_extra_metadata(
         base_price => 0,
         show_location_page => 'users',
         show_individual_notes => 1,
-        item_list => [
+        small_item_list => [
             { bartec_id => '1', name => 'Tied bag of domestic batteries (min 10 - max 100)', max => '1' },
             { bartec_id => '2', name => 'Podback Bag' },
             { bartec_id => '3', name => 'Paint, 1 can, up to 5 litres' },

--- a/t/app/controller/waste_brent_small_items.t
+++ b/t/app/controller/waste_brent_small_items.t
@@ -72,7 +72,7 @@ FixMyStreet::override_config {
         waste => { brent => 1 },
         waste_features => {
             brent => {
-                bulky_enabled => 1,
+                small_items_enabled => 1,
                 bulky_missed => 1,
                 bulky_multiple_bookings => 1,
                 small_items_tandc_link => 'tandc_link',

--- a/t/app/controller/waste_kands_bulky.t
+++ b/t/app/controller/waste_kands_bulky.t
@@ -380,6 +380,7 @@ FixMyStreet::override_config {
             $mech->content_contains('£40.00');
             $mech->content_contains("<dd>Saturday 01 July 2023</dd>");
             $mech->content_contains("on or before Saturday 01 July 2023");
+            $mech->content_contains('Bookings are not refundable');
             $mech->content_contains('Bob Marge', 'name shown');
             $mech->content_contains('44 07 111 111 111', 'phone shown');
         }

--- a/t/app/controller/waste_kands_bulky.t
+++ b/t/app/controller/waste_kands_bulky.t
@@ -774,8 +774,6 @@ FixMyStreet::override_config {
         $mech->get_ok('/waste/12345');
         $mech->content_contains('Report a bulky waste collection as missed', 'In time, normal completion');
         $mech->submit_form_ok({ form_number => 1 }, "Follow link for reporting a missed bulky collection");
-        $mech->content_contains('Bulky waste collection');
-        $mech->submit_form_ok({ form_number => 1 });
         $mech->submit_form_ok({ with_fields => { extra_detail => "They left the mattress" } });
         $mech->submit_form_ok({ form_number => 1 });
         $mech->content_contains('Submit missed bulky collection');

--- a/t/app/controller/waste_merton_bulky.t
+++ b/t/app/controller/waste_merton_bulky.t
@@ -988,7 +988,7 @@ FixMyStreet::override_config {
         $mech->submit_form_ok( { form_number => 1 }, 'Go back to first page' );
         $mech->content_contains('About you');
         $mech->submit_form_ok({ form_number => 1 });
-        $mech->submit_form_ok( { form_number => 3 }, 'Submit summary' );
+        $mech->submit_form_ok( { form_number => 2 }, 'Submit summary' );
 
 
         my $missed = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;

--- a/t/app/controller/waste_merton_bulky.t
+++ b/t/app/controller/waste_merton_bulky.t
@@ -977,12 +977,19 @@ FixMyStreet::override_config {
         } ] } );
         $mech->get_ok('/waste/12345');
         $mech->content_contains('Report a missed bulky waste collection', 'In time, normal completion');
-        $mech->submit_form_ok({ form_number => 1 }, "Follow link for reporting a missed bulky collection");
-        $mech->content_contains('Bulky waste collection');
+        $mech->submit_form_ok(
+            { with_fields => { 'service-413' => 1 } },
+            "Follow link for reporting a missed bulky collection"
+        );
+        $mech->content_contains('About you');
         $mech->submit_form_ok({ form_number => 1 });
+        $mech->content_contains('Submit missed bin report');
         #$mech->submit_form_ok({ with_fields => { extra_detail => "They left the mattress" } });
+        $mech->submit_form_ok( { form_number => 1 }, 'Go back to first page' );
+        $mech->content_contains('About you');
         $mech->submit_form_ok({ form_number => 1 });
-        $mech->submit_form_ok({ form_number => 3 });
+        $mech->submit_form_ok( { form_number => 3 }, 'Submit summary' );
+
 
         my $missed = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
         is $missed->get_extra_field_value('Exact_Location'), 'in the middle of the drive';

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -726,6 +726,7 @@ FixMyStreet::override_config {
         waste_features => {
             peterborough => {
                 admin_config_enabled => 1,
+                bulky_enabled => 1,
             }
         }
     },
@@ -816,7 +817,12 @@ FixMyStreet::override_config {
                 daily_slots => 50,
                 free_mode => 0, # not checked
                 food_bags_disabled => '', # not checked
-                base_price => 1234, per_item_costs => 1, per_item_min_collection_price => '', items_per_collection_max => 7 };
+                base_price => 1234,
+                per_item_costs => 1,
+                per_item_min_collection_price => '',
+                items_per_collection_max => 7,
+                small_items_per_collection_max => undef,
+            };
         };
     };
 };

--- a/t/app/controller/waste_sutton_small_items.t
+++ b/t/app/controller/waste_sutton_small_items.t
@@ -35,8 +35,7 @@ sub create_contact {
 create_contact(
     { category => 'Small items collection', email => '2964@test.com' },
     { code => 'Collection_Date_-_Bulky_Items', required => 0, automated => 'hidden_field' },
-    { code => 'TEM_-_Small_Item_Collection_Description', required => 0, automated => 'hidden_field' },
-    { code => 'TEM_-_Small_Item_Recycling_Item', required => 0, automated => 'hidden_field' },
+    { code => 'Small_Item_Type', required => 0, automated => 'hidden_field' },
     { code => 'Exact_Location' },
     { code => 'GUID' },
     { code => 'reservation' },
@@ -216,9 +215,8 @@ FixMyStreet::override_config {
         $mech->content_contains('option value="Batteries"', "Batteries option");
         $mech->content_contains('option value="Small WEEE"', "Small WEEE option");
         $mech->submit_form_ok( { fields => { 'item_1' => 'Batteries', 'item_2' => 'Batteries' } });
-        $mech->content_contains( 'Item note field is required');
         $mech->content_contains( 'Too many of item: Batteries');
-        $mech->submit_form_ok( { fields => { 'item_1' => 'Batteries', 'item_notes_1' => 'A bag of batteries', 'item_2' => 'Small WEEE', 'item_notes_2' => 'A toaster', 'item_photo_2' => [ $sample_file, undef, Content_Type => 'image/jpeg' ], } });
+        $mech->submit_form_ok( { fields => { 'item_1' => 'Batteries', 'item_2' => 'Small WEEE', 'item_photo_2' => [ $sample_file, undef, Content_Type => 'image/jpeg' ], } });
     };
 
     subtest 'Location page' => sub {
@@ -236,9 +234,7 @@ FixMyStreet::override_config {
         $mech->content_contains('2 Example Street, Sutton, SM2 5HF', "Shows correct address");
         $mech->content_contains('2 items requested for collection', "2 items for collection");
         $mech->content_contains('Batteries', "Batteries added");
-        $mech->content_contains('A bag of batteries', "Batteries note added");
         $mech->content_contains('Small WEEE', "Small WEEE added");
-        $mech->content_contains('A toaster', "Small WEEE note added");
         $mech->content_contains('In the alley', "Location information added");
         $mech->content_contains('<a href="tandc_link" target="_blank">terms and conditions</a>', 'T&C link addeed');
         $mech->submit_form_ok({form_number => 5});
@@ -283,13 +279,8 @@ FixMyStreet::override_config {
             'name' => 'Collection_Date_-_Bulky_Items'
           },
           {
-            'value' => 'A bag of batteries::A toaster',
-            'description' => undef,
-            'name' => 'TEM_-_Small_Item_Collection_Description'
-          },
-          {
             'value' => '1::2',
-            'name' => 'TEM_-_Small_Item_Recycling_Item',
+            'name' => 'Small_Item_Type',
             'description' => undef
           },
           {
@@ -324,9 +315,7 @@ FixMyStreet::override_config {
         $mech->content_contains('Friday 08 August 2025', 'Collection date correct');
         $mech->content_contains('2 items requested for collection', 'Correct number of items');
         $mech->content_contains('Batteries', 'item 1 added');
-        $mech->content_contains('A bag of batteries', 'item 1 notes added');
         $mech->content_contains('Small WEEE', 'item 2 added');
-        $mech->content_contains('A toaster', 'item 2 notes added');
         $mech->content_contains('Preview image successfully attached', 'Preview image added');
         $mech->content_contains('In the alley', 'Location details present');
     };

--- a/t/app/controller/waste_sutton_small_items.t
+++ b/t/app/controller/waste_sutton_small_items.t
@@ -377,10 +377,8 @@ FixMyStreet::override_config {
 
         $mech->get_ok('/waste/12345');
         $mech->content_contains('Report a small items collection as missed');
-        $mech->submit_form_ok( { form_number => 1 },
+        $mech->submit_form_ok( { with_fields => { 'service-952' => 1 } },
             "Follow link for reporting a missed collection" );
-        $mech->content_contains('Select your missed collection');
-        $mech->submit_form_ok( { with_fields => { 'service-952' => 1 } } );
         $mech->content_contains('Please supply any additional information');
         $mech->submit_form_ok(
             { with_fields => { extra_detail => 'You left a sock' } } );

--- a/t/app/controller/waste_sutton_small_items.t
+++ b/t/app/controller/waste_sutton_small_items.t
@@ -1,0 +1,347 @@
+use Test::MockModule;
+use Test::MockTime qw(:all);
+use FixMyStreet::TestMech;
+use Path::Tiny;
+
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
+my $guid = Test::MockModule->new('UUID::Tiny');
+$guid->mock('create_uuid_as_string', sub { '4ea70923-7151-11f0-aeea-cd51f3977c8c' });
+
+my $mech = FixMyStreet::TestMech->new;
+my $sample_file = path(__FILE__)->parent->child("sample.jpg");
+
+my $sutton = $mech->create_body_ok( 2498, 'Sutton Borough Council', { cobrand => 'sutton' } );
+$sutton->set_extra_metadata(wasteworks_config => {
+    small_items_per_collection_max => '6',
+    small_item_list => [{bartec_id => 1, max => 1, message => '', name => 'Batteries', price => ''}, {bartec_id => 2, max => 6, message => '', name => 'Small WEEE', price => ''}],
+    show_location_page => "users",
+   });
+$sutton->update;
+
+sub create_contact {
+    my ($params, @extra) = @_;
+    my $contact = $mech->create_contact_ok(body => $sutton, %$params, group => ['Waste'], extra => { type => 'waste' }, email => 'test@test.com');
+    $contact->set_extra_fields(
+        { code => 'uprn', required => 1, automated => 'hidden_field' },
+        { code => 'property_id', required => 1, automated => 'hidden_field' },
+        { code => 'service_id', required => 0, automated => 'hidden_field' },
+        @extra,
+    );
+    $contact->update;
+}
+
+create_contact(
+    { category => 'Small items collection', email => '2964@test.com' },
+    { code => 'Collection_Date_-_Bulky_Items', required => 0, automated => 'hidden_field' },
+    { code => 'TEM_-_Small_Item_Collection_Description', required => 0, automated => 'hidden_field' },
+    { code => 'TEM_-_Small_Item_Recycling_Item', required => 0, automated => 'hidden_field' },
+    { code => 'Exact_Location' },
+    { code => 'GUID' },
+    { code => 'reservation' },
+);
+
+my $user = $mech->create_user_ok('maryk@example.org', name => 'Test User');
+
+FixMyStreet::override_config {
+    MAPIT_URL => 'http://mapit.uk/',
+    ALLOWED_COBRANDS => 'sutton',
+    COBRAND_FEATURES => {
+        waste => { sutton => 1 },
+        waste_features => {
+            sutton => {
+                small_items_enabled => 1,
+                small_items_tandc_link => 'tandc_link',
+                small_items_multiple_bookings => 1,
+            },
+        },
+        echo => {
+            sutton => {
+                small_items_service_id => 274,
+                small_items_event_type_id => 2964,
+                bulky_address_types => [ 1, 7 ],
+                url => 'http://example.org',
+            },
+        },
+    }
+}, sub {
+    my $echo = Test::MockModule->new('Integrations::Echo');
+    $echo->mock('call', sub { die; });
+    $echo->mock( 'GetEventsForObject',       sub { [] } );
+    $echo->mock( 'ReserveAvailableSlotsForEvent', sub { return [
+            {
+                StartDate => { DateTime => '2025-08-08T00:00:00Z' },
+                EndDate => { DateTime => '2025-08-09T00:00:00Z' },
+                Expiry => { DateTime => '2025-08-25T10:20:00Z' },
+                Reference => 'reserve7a==',
+            },
+            {
+                StartDate => { DateTime => '2025-08-10T00:00:00Z' },
+                EndDate => { DateTime => '2025-08-11T00:00:00Z' },
+                Expiry => { DateTime => '2025-08-25T10:20:00Z' },
+                Reference => 'reserve7b==',
+            },
+            {
+                StartDate => { DateTime => '2025-08-11T00:00:00Z' },
+                EndDate => { DateTime => '2025-08-12T00:00:00Z' },
+                Expiry => { DateTime => '2025-08-25T10:20:00Z' },
+                Reference => 'reserve7c==',
+            },
+            {
+                StartDate => { DateTime => '2025-08-12T00:00:00Z' },
+                EndDate => { DateTime => '2025-08-13T00:00:00Z' },
+                Expiry => { DateTime => '2025-08-25T10:20:00Z' },
+                Reference => 'reserve7d==',
+            },
+            {
+                StartDate => { DateTime => '2025-08-13T00:00:00Z' },
+                EndDate => { DateTime => '2025-08-14T00:00:00Z' },
+                Expiry => { DateTime => '2025-08-25T10:20:00Z' },
+                Reference => 'reserve7e==',
+            },
+            {
+                StartDate => { DateTime => '2025-08-14T00:00:00Z' },
+                EndDate => { DateTime => '2025-08-15T00:00:00Z' },
+                Expiry => { DateTime => '2025-08-25T10:20:00Z' },
+                Reference => 'reserve7f==',
+            },
+            {
+                StartDate => { DateTime => '2025-08-15T00:00:00Z' },
+                EndDate => { DateTime => '2025-08-16T00:00:00Z' },
+                Expiry => { DateTime => '2025-08-25T10:20:00Z' },
+                Reference => 'reserve7g==',
+            },
+            {
+                StartDate => { DateTime => '2025-08-16T00:00:00Z' },
+                EndDate => { DateTime => '2025-08-17T00:00:00Z' },
+                Expiry => { DateTime => '2025-08-25T10:20:00Z' },
+                Reference => 'reserve7h==',
+            },
+            {
+                StartDate => { DateTime => '2025-08-17T00:00:00Z' },
+                EndDate => { DateTime => '2025-08-18T00:00:00Z' },
+                Expiry => { DateTime => '2025-08-25T10:20:00Z' },
+                Reference => 'reserve7i==',
+            },
+    ] });
+    $echo->mock(
+        'FindPoints',
+        sub {
+            [   {   Description => '2 Example Street, Sutton, SM2 5HF',
+                    Id          => '12345',
+                    SharedRef   => { Value => { anyType => 1000000002 } }
+                },
+            ]
+        }
+    );
+    $echo->mock(
+        'GetPointAddress',
+        sub {
+            return {
+                PointAddressType => {
+                    Id   => 1,
+                    Name => 'Detached',
+                },
+
+                Id        => '12345',
+                SharedRef => { Value => { anyType => '1000000002' } },
+                PointType => 'PointAddress',
+                Coordinates => {
+                    GeoPoint =>
+                        { Latitude => 51.354679, Longitude => -0.183895 }
+                },
+                Description => '2 Example Street, Sutton, SM2 5HF',
+            };
+        }
+    );
+
+    set_fixed_time('2025-08-18T12:00:00Z');
+
+    subtest 'Eligible property' => sub {
+        $echo->mock( 'GetServiceUnitsForObject', sub { [{'ServiceId' => 943 }] } );
+        $mech->get_ok('/waste');
+        $mech->submit_form_ok( { with_fields => { postcode => 'SM2 5HF' } } );
+        $mech->submit_form_ok( { with_fields => { address => '12345' } } );
+        $mech->content_lacks('/waste/12345/small_items', "Small bookings link not available with only communal waste");
+        $echo->mock( 'GetServiceUnitsForObject', sub { [{'ServiceId' => 940 }] } );
+        $mech->get_ok('/waste');
+        $mech->submit_form_ok( { with_fields => { postcode => 'SM2 5HF' } } );
+        $mech->submit_form_ok( { with_fields => { address => '12345' } } );
+        $mech->content_contains('/waste/12345/small_items', "Small bookings link available for property with domestic waste");
+        $mech->content_contains('Book a collection', "Small bookings link available for property with domestic waste");
+        $mech->content_lacks('View existing bookings', "No previous bookings");
+    };
+
+    subtest 'Introduction page' => sub {
+        $mech->get_ok('/waste/12345/small_items');
+
+        $mech->content_contains('Before you start your booking', "On booking introduction page");
+        $mech->content_contains('2 Example Street, Sutton, SM2 5HF', "Shows correct address");
+        $mech->content_contains('a href="tandc_link"', "Link picked up from config");
+        $mech->content_contains('There is a maximum of 6 items for a collection', "Max items picked up from config");
+    };
+
+    subtest 'About you' => sub {
+        $mech->submit_form_ok();
+        $mech->content_contains('About you', "On booking 'About you' page");
+        $mech->content_contains('2 Example Street, Sutton, SM2 5HF', "Shows correct address");
+        $mech->submit_form_ok();
+        $mech->content_contains('Error:</span> Your name is required', "Name is required");
+        $mech->content_contains('Error:</span> Please provide an email address', "Email address required");
+        $mech->submit_form_ok( { with_fields => { name => 'Mary Kay', email => $user->email } });
+    };
+
+    subtest 'Select dates' => sub {
+        $mech->content_contains('Choose date for collection', "On 'Available dates' page");
+        $mech->content_contains('2 Example Street, Sutton, SM2 5HF', "Shows correct address");
+        $mech->content_contains('Friday  8 August', "Readable date correct");
+        $mech->content_contains('2025-08-08T00:00:00;reserve7a==;2025-08-25T10:20:00', "Date value correct");
+        $mech->content_contains('Sunday 10 August', "Readable date correct");
+        $mech->content_contains('2025-08-10T00:00:00;reserve7b==;2025-08-25T10:20:00', "Date value correct");
+        for my $date ('Monday 11 August', 'Tuesday 12 August', 'Wednesday 13 August', 'Thursday 14 August'
+        , 'Friday 15 August', 'Saturday 16 August') {
+            $mech->content_contains($date, 'Date 3-8 included as well');
+        };
+        $mech->content_lacks('Sunday 17 August', 'Ninth date not included as only eight required');
+        $mech->submit_form_ok();
+        $mech->content_contains('Error:</span> Available dates field is required', "Choosing a date is required");
+        $mech->submit_form_ok( { with_fields => { chosen_date => '2025-08-08T00:00:00;reserve7a==;2025-08-25T10:20:00'}});
+    };
+
+    subtest 'List items' => sub {
+        $mech->content_contains('Add items for collection', "On items page");
+        # Why not?
+        #$mech->content_contains('2 Example Street, Sutton, SM2 5HF', "Shows correct address");
+        $mech->content_contains('option value="Batteries"', "Batteries option");
+        $mech->content_contains('option value="Small WEEE"', "Small WEEE option");
+        $mech->submit_form_ok( { fields => { 'item_1' => 'Batteries', 'item_2' => 'Batteries' } });
+        $mech->content_contains( 'Item note field is required');
+        $mech->content_contains( 'Too many of item: Batteries');
+        $mech->submit_form_ok( { fields => { 'item_1' => 'Batteries', 'item_notes_1' => 'A bag of batteries', 'item_2' => 'Small WEEE', 'item_notes_2' => 'A toaster', 'item_photo_2' => [ $sample_file, undef, Content_Type => 'image/jpeg' ], } });
+    };
+
+    subtest 'Location page' => sub {
+        $mech->content_contains('Location details', "Location page included");
+        $mech->content_contains('2 Example Street, Sutton, SM2 5HF', "Shows correct address");
+        $mech->content_contains('Please tell us where you will place the items for collection (the small items collection crews', 'Small items collection specified');
+        $mech->submit_form_ok({ form_number => 2 });
+        $mech->content_contains('There is a problem', "Location details are mandatory");
+        $mech->submit_form_ok( { with_fields => { 'location' => 'In the alley' } } );
+    };
+
+    subtest 'Booking summary' => sub {
+        $mech->content_contains('Booking Summary', "On booking confirmation page");
+        $mech->content_lacks('Bookings are not refundable', "Small items service is free so no mention of refunds");
+        $mech->content_contains('2 Example Street, Sutton, SM2 5HF', "Shows correct address");
+        $mech->content_contains('2 items requested for collection', "2 items for collection");
+        $mech->content_contains('Batteries', "Batteries added");
+        $mech->content_contains('A bag of batteries', "Batteries note added");
+        $mech->content_contains('Small WEEE', "Small WEEE added");
+        $mech->content_contains('A toaster', "Small WEEE note added");
+        $mech->content_contains('In the alley', "Location information added");
+        $mech->content_contains('<a href="tandc_link" target="_blank">terms and conditions</a>', 'T&C link addeed');
+        $mech->submit_form_ok({form_number => 5});
+        $mech->content_contains('Terms and conditions field is required', "Can't continue without accepting T&Cs");
+        $mech->submit_form_ok({form_number => 5, with_fields => { tandc => 1} });
+    };
+
+    my $report = FixMyStreet::DB->resultset("Problem")->find({ title => 'Small items collection'});
+    subtest 'Booking confirmed' => sub {
+        $mech->content_contains('Small items collection booking confirmed', "Booking confirmed ok");
+        $mech->content_contains('Our contractor will collect the items you have requested on Friday 08 August 2025', "Date included on confirmation page");
+        $mech->content_contains('Item collection starts from 6am', "Collection time included");
+        $mech->content_contains('We have emailed confirmation of your booking to ' . $user->email, "Email address included");
+        $mech->content_contains('If you need to contact us about your booking please use the reference:&nbsp;LBS-' . $report->id, "Reference included");
+    };
+
+    subtest 'Report made'  => sub {
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('View existing bookings', "Small items booking registered");
+        # Why not?
+        #is $report->user->name, 'Mary Kay', "Report made by user";
+        is $report->user->email, $user->email, "Report made by user";
+        my $test_extra = [
+          {
+            'value' => '1000000002',
+            'description' => undef,
+            'name' => 'uprn'
+          },
+          {
+            'name' => 'property_id',
+            'description' => undef,
+            'value' => '12345'
+          },
+          {
+            'name' => 'service_id',
+            'description' => undef,
+            'value' => ''
+          },
+          {
+            'description' => undef,
+            'value' => '2025-08-08T00:00:00',
+            'name' => 'Collection_Date_-_Bulky_Items'
+          },
+          {
+            'value' => 'A bag of batteries::A toaster',
+            'description' => undef,
+            'name' => 'TEM_-_Small_Item_Collection_Description'
+          },
+          {
+            'value' => '1::2',
+            'name' => 'TEM_-_Small_Item_Recycling_Item',
+            'description' => undef
+          },
+          {
+            'value' => 'In the alley',
+            'description' => undef,
+            'name' => 'Exact_Location'
+          },
+          {
+            'name' => 'GUID',
+            'description' => undef,
+            'value' => '4ea70923-7151-11f0-aeea-cd51f3977c8c'
+          },
+          {
+            'value' => 'reserve7a==',
+            'description' => undef,
+            'name' => 'reservation'
+          }
+        ];
+        is_deeply $report->get_extra_fields, $test_extra, "Data added to report";
+    };
+
+    subtest 'Viewing existing booking' => sub {
+        $mech->log_in_ok($report->user->email);
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('report/' . $report->id .'">Check collection details', 'Link to view collection');
+        $mech->get_ok('/report/' . $report->id);
+        $mech->content_contains('Your small items collection', 'Correct collection type');
+        $mech->content_contains('Booking Summary', 'On summary page');
+        $mech->content_contains('Mary Kay', 'Name from booking form');
+        $mech->content_contains($user->email, 'Correct email address');
+        $mech->content_contains('Example Street, Sutton, SM2 5HF', 'Correct property address');
+        $mech->content_contains('Friday 08 August 2025', 'Collection date correct');
+        $mech->content_contains('2 items requested for collection', 'Correct number of items');
+        $mech->content_contains('Batteries', 'item 1 added');
+        $mech->content_contains('A bag of batteries', 'item 1 notes added');
+        $mech->content_contains('Small WEEE', 'item 2 added');
+        $mech->content_contains('A toaster', 'item 2 notes added');
+        $mech->content_contains('Preview image successfully attached', 'Preview image added');
+        $mech->content_contains('In the alley', 'Location details present');
+    };
+
+    subtest 'Can not make another booking for the same day' => sub {
+        $mech->get_ok('/waste/12345/small_items');
+        $mech->submit_form_ok();
+        $mech->submit_form_ok( { with_fields => { name => 'Mary Kay', email => 'maryk@example.org'} });
+        $mech->content_unlike(qr/Friday\s+8 August/, 'No date offered where current booking');
+        for my $date ('Sunday 10 August', 'Monday 11 August', 'Tuesday 12 August', 'Wednesday 13 August', 'Thursday 14 August',
+        'Friday 15 August', 'Saturday 16 August', 'Sunday 17 August') {
+            $mech->content_contains($date, 'Date 2-9 included');
+        };
+    }
+
+};
+
+done_testing;

--- a/templates/email/default/waste/other-reported-bulky.html
+++ b/templates/email/default/waste/other-reported-bulky.html
@@ -65,6 +65,8 @@ cancel_url = cobrand.base_url _ '/waste/' _ property_id_uri _ '/' _ bulky_cancel
 
 [% IF cobrand.moniker == 'sutton' || cobrand.moniker == 'kingston' %]
   <p style="[% p_style %]">Check you’ve read the <a href="[% cobrand.feature('waste_features').bulky_tandc_link %]">terms and conditions</a>.</p>
+[% ELSIF report.category == 'Small items collection' AND cobrand.feature('waste_features').small_items_tandc_link %]
+  <p style="[% p_style %]">Please check you have read the <a href="[% cobrand.feature('waste_features').small_items_tandc_link %]">terms and conditions</a></p>
 [% ELSIF cobrand.feature('waste_features').bulky_tandc_link AND cobrand.moniker != 'peterborough' %]
   <p style="[% p_style %]">Please check you have read the <a href="[% cobrand.feature('waste_features').bulky_tandc_link %]">terms and conditions</a></p>
 [% END %]

--- a/templates/email/default/waste/other-reported-bulky.txt
+++ b/templates/email/default/waste/other-reported-bulky.txt
@@ -61,7 +61,9 @@ If you wish to cancel your booking, please visit:
 
 [% END %]
 
-[% IF cobrand.feature('waste_features').bulky_tandc_link AND cobrand.moniker != 'peterborough' %]
+[% IF report.category == 'Small items collection' AND cobrand.feature('waste_features').small_items_tandc_link %]
+Please check you have read the terms and conditions [% cobrand.feature('waste_features').small_items_tandc_link %]
+[% ELSIF cobrand.feature('waste_features').bulky_tandc_link AND cobrand.moniker != 'peterborough' %]
 Please check you have read the terms and conditions [% cobrand.feature('waste_features').bulky_tandc_link %]
 [% END %]
 

--- a/templates/web/base/admin/waste/bulky_items.html
+++ b/templates/web/base/admin/waste/bulky_items.html
@@ -1,4 +1,7 @@
-[% INCLUDE 'admin/header.html' title=loc('Bulky items list') bodyclass="bulky-items" -%]
+[%
+title = item_list_key == 'small_item_list' ? 'Small items list' : 'Bulky items list';
+INCLUDE 'admin/header.html' bodyclass="bulky-items";
+-%]
 [% PROCESS 'admin/report_blocks.html' %]
 
 [% INCLUDE status_message %]

--- a/templates/web/base/admin/waste/edit.html
+++ b/templates/web/base/admin/waste/edit.html
@@ -68,6 +68,7 @@
     <hr>
   [% END %]
 
+  [% IF body.get_cobrand_handler.small_items_enabled %]
     <h3>Small Items Collections</h3>
 
     <div>
@@ -77,6 +78,7 @@
     </div>
 
     <hr>
+  [% END %]
 
     <p>
     <label for="show_location_page">[% loc('Show location information page') %]</label>

--- a/templates/web/base/admin/waste/edit.html
+++ b/templates/web/base/admin/waste/edit.html
@@ -71,6 +71,10 @@
   [% IF body.get_cobrand_handler.small_items_enabled %]
     <h3>Small Items Collections</h3>
 
+    <ul>
+        <li><a href="[% c.uri_for_action('admin/waste/small_items', [ body.id ]) %]">Small items list</a></li>
+    </ul>
+
     <div>
     <label for="waste_small_items_per_collection_max">Maximum items per collection (1-200)</label>
     <input class="form-control" type=text max=200 min=1 name="small_items_per_collection_max" id="waste_small_items_per_collection_max"

--- a/templates/web/base/admin/waste/edit.html
+++ b/templates/web/base/admin/waste/edit.html
@@ -3,24 +3,25 @@
 
 [% INCLUDE status_message %]
 
-<ul>
-    <li><a href="[% c.uri_for_action('admin/waste/bulky_items', [ body.id ]) %]">[% loc("Bulky items list") %]</a></li>
-</ul>
+[% IF errors %]
+    <p class="error">[% loc('Please correct the errors below') %]</p>
+[% END %]
 
 <h2>Site wide configuration</h2>
 
-<h3>Bulky Collections</h3>
-
-[% IF errors %]
-    <p class="error">[% loc('Please correct the errors below') %]</p>
+[% IF errors.site_wide %]
+    <div class="form-error">[% errors.site_wide %]</div>
 [% END %]
 
 <form method="post">
     <input type="hidden" name="token" value="[% csrf_token %]" >
 
-    [% IF errors.site_wide %]
-        <div class="form-error">[% errors.site_wide %]</div>
-    [% END %]
+  [% IF body.get_cobrand_handler.bulky_enabled %]
+    <h3>Bulky Collections</h3>
+
+    <ul>
+        <li><a href="[% c.uri_for_action('admin/waste/bulky_items', [ body.id ]) %]">[% loc("Bulky items list") %]</a></li>
+    </ul>
 
 [% IF cobrand.bulky_points_per_item_pricing %]
     <input type=hidden name="per_item_costs" value=1>
@@ -63,6 +64,19 @@
     <input class="form-control" type=text name="per_item_min_collection_price" id="waste_per_item_min_collection_price"
         value="[% per_item_min_collection_price %]">
     </div>
+
+    <hr>
+  [% END %]
+
+    <h3>Small Items Collections</h3>
+
+    <div>
+    <label for="waste_small_items_per_collection_max">Maximum items per collection (1-200)</label>
+    <input class="form-control" type=text max=200 min=1 name="small_items_per_collection_max" id="waste_small_items_per_collection_max"
+        value="[% small_items_per_collection_max %]">
+    </div>
+
+    <hr>
 
     <p>
     <label for="show_location_page">[% loc('Show location information page') %]</label>

--- a/templates/web/base/waste/bin_days.html
+++ b/templates/web/base/waste/bin_days.html
@@ -211,7 +211,7 @@
 %]
   [% IF c.cobrand.moniker != 'peterborough' %]
   <h3 id="bulky-waste" class="govuk-heading-m waste-service-name">[%
-      IF c.cobrand.moniker == 'brent' %]Small items[% ELSIF c.cobrand.moniker == 'sutton' %]Bulky Waste[% ELSE %]Bulky waste[% END
+      IF c.cobrand.moniker == 'sutton' %]Bulky Waste[% ELSE %]Bulky waste[% END
   %]</h3>
     [% IF c.cobrand.moniker == 'kingston' || c.cobrand.moniker == 'sutton' %]
         <p>
@@ -235,8 +235,22 @@
       [% IF property.commercial_property %]
         [% PROCESS waste/_bulky_waste_message.html %]
       [% ELSE %]
-        [% PROCESS 'waste/bulky/_bin_days_list.html' %]
+        [% PROCESS 'waste/bulky/_bin_days_list.html' type='bulky' %]
       [% END %]
+    </div>
+  </div>
+[% END %]
+
+[% IF property.show_small_items;
+    SET image = c.cobrand.image_for_unit({ service_id => 'small_items' });
+%]
+  <h3 id="bulky-waste" class="govuk-heading-m waste-service-name">Small items</h3>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-quarter text-centered">
+      <img src="[% image %].png" srcset="[% image %].png 1x, [% image %]@2x.png 2x" alt="" class="waste-service-image">
+    </div>
+    <div class="govuk-grid-column-three-quarters">
+      [% PROCESS 'waste/bulky/_bin_days_list.html' type='small_items' %]
     </div>
   </div>
 [% END %]

--- a/templates/web/base/waste/bulky/_bin_days_list.html
+++ b/templates/web/base/waste/bulky/_bin_days_list.html
@@ -35,7 +35,7 @@
             <a class="btn btn--primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky/cancel_small', [ property.id, booking.id ]) %]">Cancel booking</a>
           [% END %]
         [% END %]
-        [% PROCESS 'waste/_service_missed.html' unit=bulky_missed.$booking_guid original_booking=booking.id no_default=1 %]
+        [% PROCESS 'waste/_service_missed.html' unit=booked_missed.$booking_guid original_booking=booking.id no_default=1 %]
     </div>
   [% END %]
 
@@ -70,9 +70,9 @@
     </dl>
     <div class="waste-services-launch-panel">
         <a class="btn btn--primary govuk-!-margin-bottom-2" href="/report/[% booking.id %]">Check collection details</a>
-        [% PROCESS 'waste/_service_missed.html' unit=bulky_missed.$booking_guid original_booking=booking.id no_default=1 %]
+        [% PROCESS 'waste/_service_missed.html' unit=booked_missed.$booking_guid original_booking=booking.id no_default=1 %]
         [% IF c.cobrand.moniker == 'sutton' %]
-        [% IF bulky_missed.$booking_guid.escalations.missed_open %]
+        [% IF booked_missed.$booking_guid.escalations.missed_open %]
             <span class="waste-service-descriptor">Thank you for reporting an issue with this collection; we are investigating.</span>
         [% END %]
         [% END %]
@@ -136,7 +136,7 @@
     <a class="btn btn--primary govuk-!-margin-bottom-2" href="/auth?r=waste/[% property.id %]">View existing bookings</a>
     <!-- END #07 -->
   [% END %]
-  [% IF waste_features.bulky_multiple_bookings OR NOT collections.$type.pending %]
+  [% IF (type == 'bulky' AND waste_features.bulky_multiple_bookings) OR (type == 'small_items' AND waste_features.small_items_multiple_bookings) OR NOT collections.$type.pending %]
     [% IF type == 'bulky' %]
     <form method="post" action="[% c.uri_for_action('waste/bulky/index', [ property.id ]) %]">
     [% ELSE %]

--- a/templates/web/base/waste/bulky/_bin_days_list.html
+++ b/templates/web/base/waste/bulky/_bin_days_list.html
@@ -1,8 +1,8 @@
-[% IF pending_bulky_collections AND NOT c.user_exists %]
+[% IF collections.$type.pending AND NOT c.user_exists %]
     [% PROCESS waste/_bulky_not_signed_user.html %]
 [% END %]
 
-[% FOR booking IN pending_bulky_collections; booking_guid = booking.external_id %]
+[% FOR booking IN collections.$type.pending; booking_guid = booking.external_id %]
     [% NEXT UNLESS c.cobrand.bulky_can_view_collection(booking) %]
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
@@ -50,7 +50,7 @@
     <!-- END #04 -->
   [% END %]
 
-  [% FOR booking IN recent_bulky_collections; booking_guid = booking.external_id; %]
+  [% FOR booking IN collections.$type.recent; booking_guid = booking.external_id; %]
     [% NEXT UNLESS c.cobrand.bulky_can_view_collection(booking) %]
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
@@ -79,10 +79,10 @@
     </div>
   [% END %]
 
-  [% IF unconfirmed_bulky_collections %]
+  [% IF collections.$type.unconfirmed %]
     <hr>
     <h2>Unconfirmed&nbsp;bookings</h2>
-    [% FOR booking IN unconfirmed_bulky_collections %]
+    [% FOR booking IN collections.$type.unconfirmed %]
       <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Collection date</dt>
@@ -131,12 +131,12 @@
 [% END %]
 
 <div class="waste-services-launch-panel">
-  [% IF NOT c.user_exists AND (pending_bulky_collections OR recent_bulky_collections) %]
+  [% IF NOT c.user_exists AND (collections.$type.pending OR collections.$type.recent) %]
     <!-- #07 Should be displayed when: user HASN'T signed in -->
     <a class="btn btn--primary govuk-!-margin-bottom-2" href="/auth?r=waste/[% property.id %]">View existing bookings</a>
     <!-- END #07 -->
   [% END %]
-  [% IF waste_features.bulky_multiple_bookings OR NOT pending_bulky_collections %]
+  [% IF waste_features.bulky_multiple_bookings OR NOT collections.$type.pending %]
     [% IF type == 'bulky' %]
     <form method="post" action="[% c.uri_for_action('waste/bulky/index', [ property.id ]) %]">
     [% ELSE %]

--- a/templates/web/base/waste/bulky/_bin_days_list.html
+++ b/templates/web/base/waste/bulky/_bin_days_list.html
@@ -29,7 +29,7 @@
           <p>If you would like to make any changes to your booking, call us on 020 8274 4902 at least 2 working days before your collection day.</p>
         [% END %]
         [% IF c.cobrand.bulky_can_cancel_collection(booking) %]
-          [% IF c.cobrand.moniker != 'brent' %]
+          [% IF type == 'bulky' %]
             <a class="btn btn--primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky/cancel', [ property.id, booking.id ]) %]">Cancel booking</a>
           [% ELSE %]
             <a class="btn btn--primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky/cancel_small', [ property.id, booking.id ]) %]">Cancel booking</a>
@@ -105,7 +105,7 @@
     [% END %]
   [% END %]
 
-[% IF c.cobrand.moniker != 'brent' %]
+[% IF type == 'bulky' %]
 <dl class="govuk-summary-list govuk-!-margin-bottom-3 govuk-!-padding-bottom-0">
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Cost</dt>
@@ -137,7 +137,7 @@
     <!-- END #07 -->
   [% END %]
   [% IF waste_features.bulky_multiple_bookings OR NOT pending_bulky_collections %]
-    [% IF c.cobrand.moniker != 'brent' %]
+    [% IF type == 'bulky' %]
     <form method="post" action="[% c.uri_for_action('waste/bulky/index', [ property.id ]) %]">
     [% ELSE %]
     <form method="post" action="[% c.uri_for_action('waste/bulky/index_small', [ property.id ]) %]">

--- a/templates/web/base/waste/bulky/_form_action.html
+++ b/templates/web/base/waste/bulky/_form_action.html
@@ -2,7 +2,7 @@
 IF c.action == 'waste/bulky/amend';
     c.uri_for_action('waste/bulky/amend', [ property.id, amending_booking.id ]);
 ELSE;
-    IF c.cobrand.moniker == 'brent';
+    IF small_items;
         c.uri_for_action('waste/bulky/index_small', [ property.id ]);
     ELSE;
         c.uri_for_action('waste/bulky/index', [ property.id ]);

--- a/templates/web/base/waste/bulky/intro.html
+++ b/templates/web/base/waste/bulky/intro.html
@@ -40,7 +40,7 @@ END %]
     <li>Requesting a [% service_name %] collection usually takes around <strong>10 minutes</strong></li>
   [% END %]
   [% IF c.cobrand.moniker != 'brent' AND c.cobrand.moniker != 'bromley' %]
-    <li>You can request up to <strong>[% c.cobrand.bulky_items_maximum | numwords %] items per collection</strong></li>
+    <li>You can request up to <strong>[% c.stash.booking_maximum | numwords %] items per collection</strong></li>
   [% END %]
   [% IF cfg.band1_price %]
     [%

--- a/templates/web/base/waste/bulky/intro.html
+++ b/templates/web/base/waste/bulky/intro.html
@@ -1,6 +1,4 @@
-[% IF c.cobrand.moniker == 'brent' ~%]
-    [% service_name = "small items" ~%]
-[% ELSIF c.cobrand.moniker == 'merton' || c.cobrand.moniker == 'bexley' ~%]
+[% IF c.cobrand.moniker == 'merton' || c.cobrand.moniker == 'bexley' ~%]
     [% service_name = "bulky waste" ~%]
 [% ELSE ~%]
     [% service_name = "bulky goods" ~%]
@@ -36,10 +34,8 @@ END %]
 
   [% ELSE %]
 
-  [% IF c.cobrand.moniker != 'brent' %]
     <li>Requesting a [% service_name %] collection usually takes around <strong>10 minutes</strong></li>
-  [% END %]
-  [% IF c.cobrand.moniker != 'brent' AND c.cobrand.moniker != 'bromley' %]
+  [% IF c.cobrand.moniker != 'bromley' %]
     <li>You can request up to <strong>[% c.stash.booking_maximum | numwords %] items per collection</strong></li>
   [% END %]
   [% IF cfg.band1_price %]
@@ -63,18 +59,11 @@ END %]
   [% IF c.cobrand.moniker != 'bromley' %]
     <li>Please make sure you have read the <strong><a href="[% c.cobrand.call_hook('bulky_tandc_link') %]" target="_blank">[% service_name %] collection</a></strong> page on the council’s website</li>
   [% END %]
-  [% IF c.cobrand.moniker == 'brent' %]
-    <li>You can arrange to have any of the following small items collected from outside your home for free: textiles, small electricals, household batteries, and paint tins.
-    <li>Householders will be able to book up to <strong>three</strong> categories per collection. For example, a collection could include 10 AA batteries, two x 5 litre paint tins, one black sack of textiles.
-    <li>To see your options for coffee pod recycling please visit
-        <a href="https://www.podback.org/recycle-checker" target="_blank">https://www.podback.org/recycle-checker</a>
-  [% ELSE %]
     <li>In order to help us with your collection, you may wish to add pictures of the items to be collected
       [% IF c.cobrand.moniker != 'bromley' %]
         and the location
       [% END %]
     </li>
-  [% END %]
     <li>Before confirming your booking, you need to check all the information provided is correct</li>
     [% IF cobrand.moniker == 'kingston' || cobrand.moniker == 'sutton' || cobrand.moniker == 'merton' %]
     <li>Bookings are final and non refundable</li>

--- a/templates/web/base/waste/bulky/intro_amend.html
+++ b/templates/web/base/waste/bulky/intro_amend.html
@@ -1,7 +1,7 @@
 <h3>Before you amend your booking</h3>
 <ol>
     <li>Requesting a bulky waste collection usually takes approximately <strong>10 minutes</strong></li>
-    <li>You can request up to <strong>[% c.cobrand.bulky_items_maximum | numwords %] items per collection</strong></li>
+    <li>You can request up to <strong>[% c.stash.booking_maximum | numwords %] items per collection</strong></li>
     <li>Please make sure you have read the <strong><a href="[% c.cobrand.call_hook('bulky_tandc_link') %]" target="_blank">bulky waste collection</a></strong> page on the council’s website</li>
     <li>In order to help us with your collection, you may wish to add pictures of the items to be collected and the location</li>
     <li>Before confirming your booking, you need to check all the information provided is correct</li>

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -102,9 +102,9 @@ END; END %]
 [% END %]
 
 <form id="item-selection-form" class="waste" method="post" enctype="multipart/form-data"
-    data-maximum="[% c.cobrand.bulky_items_maximum %]"
+    data-maximum="[% c.stash.booking_maximum %]"
     >
-  [% FOR num IN [ 1 .. c.cobrand.bulky_items_maximum ] %]
+  [% FOR num IN [ 1 .. c.stash.booking_maximum ] %]
     [% IF NOT first_empty OR form.field('item_' _ num).value %]
       [% INCLUDE item_fields %]
       [% IF NOT form.field('item_' _ num).value %][% SET first_empty = 1 %][% END %]

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -126,7 +126,7 @@ END; END %]
     [%~ END ~%]
   </button>
 
-    [% IF c.cobrand.moniker != 'brent' %]
+    [% IF NOT small_items %]
     <p>
         Total cost: £<span data-pricing="[% c.cobrand.bulky_pricing_strategy %]" id="js-bulky-total">[% pounds(total) %]</span>
     </p>

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -118,7 +118,9 @@ SET data = form.saved_data;
               [% ELSIF c.cobrand.moniker == 'sutton' || c.cobrand.moniker == 'kingston' %]
                   <p class="govuk-!-margin-bottom-3">You can cancel this booking any time before the collection
                      takes place on or before [% cobrand.bulky_nice_collection_date(data.chosen_date) %].
+                     [% IF NOT small_items %]
                      Bookings are not refundable.</p>
+                     [% END %]
               [% ELSIF c.cobrand.moniker == 'peterborough' %]
                   <p class="govuk-!-margin-bottom-3">You can cancel and receive a refund up to
                     [% cobrand.bulky_nice_cancellation_cutoff_date(data.chosen_date) %].</p>

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -143,7 +143,7 @@ SET data = form.saved_data;
         [% PROCESS change_answers_button goto='add_items' %]
       </div>
       [% items = [] %]
-      [% FOR num IN [ 1 .. cobrand.bulky_items_maximum ];
+      [% FOR num IN [ 1 .. c.stash.booking_maximum ];
         item_key = 'item_' _ num;
         photo_key = 'item_photo_' _ num;
         item = data.$item_key;
@@ -171,7 +171,7 @@ SET data = form.saved_data;
       <div class="govuk-!-margin-bottom-4">
         <p class="govuk-!-margin-bottom-0">[% tprintf(nget('%d item requested for collection.', '%d items requested for collection.', items.size), items.size) %]</p>
         [% IF c.cobrand.moniker == 'peterborough' %]
-            [% remaining = cobrand.bulky_items_maximum - items.size %]
+            [% remaining = c.stash.booking_maximum - items.size %]
             <small>([% tprintf(nget('you can add up to %d more item', 'you can add up to %d more items', remaining), remaining) %])</small>
         [% END %]
       </div>

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -26,7 +26,7 @@ SET data = form.saved_data;
 
 
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-9">
-  [% IF cobrand.moniker == 'brent' %]
+  [% IF small_items %]
     Your small items collection
   [% ELSE %]
     [% IF problem %]
@@ -151,7 +151,7 @@ SET data = form.saved_data;
         NEXT UNLESS item;
         items.push({ item => item, photo => data.$photo_key, notes => data.$notes_key });
       END %]
-      [% IF c.cobrand.moniker != 'brent' %]
+      [% IF NOT small_items %]
       <dl>
         <dt>Price</dt>
         [% IF problem;

--- a/templates/web/base/waste/small_items/intro.html
+++ b/templates/web/base/waste/small_items/intro.html
@@ -1,0 +1,10 @@
+<h3>Before you start your booking</h3>
+
+<ol>
+    <li>Please make sure you have read the <strong><a href="[% c.cobrand.call_hook('small_items_tandc_link') %]" target="_blank">small items collection</a></strong> page on the council’s website</li>
+    <li>You can arrange to have any of the following small items collected from outside your home for free: textiles, small electricals, household batteries, and paint tins.
+    <li>Householders will be able to book up to <strong>three</strong> categories per collection. For example, a collection could include 10 AA batteries, two x 5 litre paint tins, one black sack of textiles.
+    <li>To see your options for coffee pod recycling please visit
+        <a href="https://www.podback.org/recycle-checker" target="_blank">https://www.podback.org/recycle-checker</a>
+    <li>Before confirming your booking, you need to check all the information provided is correct</li>
+</ol>

--- a/templates/web/base/waste/summary.html
+++ b/templates/web/base/waste/summary.html
@@ -17,12 +17,14 @@
     <dd class="govuk-summary-list__value">
     </dd>
     <dd class="govuk-summary-list__actions">
-      [% TRY %][% INCLUDE 'waste/_change_answers_top.html' %][% CATCH file %]
-        <form method="post">
-          <input type="hidden" name="saved_data" value="[% form.fif.saved_data %]">
-          <input type="hidden" name="goto" value="[% step1 %]">
-          <input type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" value="Change answers">
-        </form>
+      [% IF step1 != 'about_you' %]
+        [% TRY %][% INCLUDE 'waste/_change_answers_top.html' %][% CATCH file %]
+          <form method="post">
+            <input type="hidden" name="saved_data" value="[% form.fif.saved_data %]">
+            <input type="hidden" name="goto" value="[% step1 %]">
+            <input type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" value="Change answers">
+          </form>
+        [% END %]
       [% END %]
     </dd>
   </div>

--- a/templates/web/base/waste/summary_report.html
+++ b/templates/web/base/waste/summary_report.html
@@ -1,5 +1,9 @@
 [%
-title = c.req.params.original_booking_id ? 'Submit missed bulky collection' : 'Submit missed bin report';
+title = original_booking_report.category == 'Bulky collection'
+  ? 'Submit missed bulky collection'
+  : original_booking_report.category == 'Small items collection'
+  ? 'Submit missed small items collection'
+  : 'Submit missed bin report';
 thing = 'missed collection';
 summary_title = 'Missed collection';
 step1 = 'report';

--- a/templates/web/base/waste/summary_report.html
+++ b/templates/web/base/waste/summary_report.html
@@ -6,7 +6,7 @@ title = original_booking_report.category == 'Bulky collection'
   : 'Submit missed bin report';
 thing = 'missed collection';
 summary_title = 'Missed collection';
-step1 = 'report';
+step1 = first_page;
 %]
 
 [% BLOCK answers %]

--- a/templates/web/brent/waste/_more_services_sidebar.html
+++ b/templates/web/brent/waste/_more_services_sidebar.html
@@ -15,7 +15,7 @@
        <li><a href="[% c.uri_for_action('waste/enquiry', [ property.id ]) %]?category=Assisted+collection+add&amp;service_id=262">Set up for assisted collection</a></li>
      -->
      [% END %]
-     [% IF property.show_small_items AND NOT pending_bulky_collections %]
+     [% IF property.show_small_items AND NOT collections.small_items.pending %]
       <li>
           <a href="[% c.uri_for_action('waste/bulky/index_small', [ property.id ]) %]">Book small items collection</a>
       </li>

--- a/templates/web/brent/waste/_more_services_sidebar.html
+++ b/templates/web/brent/waste/_more_services_sidebar.html
@@ -15,7 +15,7 @@
        <li><a href="[% c.uri_for_action('waste/enquiry', [ property.id ]) %]?category=Assisted+collection+add&amp;service_id=262">Set up for assisted collection</a></li>
      -->
      [% END %]
-     [% IF property.show_bulky_waste AND NOT pending_bulky_collections %]
+     [% IF property.show_small_items AND NOT pending_bulky_collections %]
       <li>
           <a href="[% c.uri_for_action('waste/bulky/index_small', [ property.id ]) %]">Book small items collection</a>
       </li>

--- a/templates/web/merton/waste/summary_report.html
+++ b/templates/web/merton/waste/summary_report.html
@@ -7,7 +7,7 @@ IF c.get_param('additional');
     thing = 'additional collection request';
     summary_title = 'Additional collection';
 END;
-step1 = 'report';
+step1 = first_page;
 %]
 
 [% BLOCK answers %]

--- a/templates/web/peterborough/waste/bulky/intro.html
+++ b/templates/web/peterborough/waste/bulky/intro.html
@@ -1,7 +1,7 @@
 <h3>Before you start your booking</h3>
 <ol>
     <li>Requesting a bulky waste collection usually takes around <strong>10 minutes</strong></li>
-    <li>You can request up to <strong>[% c.cobrand.bulky_items_maximum | numwords %] items per collection</strong></li>
+    <li>You can request up to <strong>[% c.stash.booking_maximum | numwords %] items per collection</strong></li>
     <li>In order to help us with your collection, you may wish to add pictures of the items to be collected</li>
 </ol>
 

--- a/templates/web/peterborough/waste/bulky/intro_amend.html
+++ b/templates/web/peterborough/waste/bulky/intro_amend.html
@@ -1,7 +1,7 @@
 <h3>Before you amend your booking</h3>
 <ol>
     <li>Requesting a bulky waste collection usually takes around <strong>10 minutes</strong></li>
-    <li>You can request up to <strong>[% c.cobrand.bulky_items_maximum | numwords %] items per collection</strong></li>
+    <li>You can request up to <strong>[% c.stash.booking_maximum | numwords %] items per collection</strong></li>
     <li>In order to help us with your collection, you may wish to add pictures of the items to be collected</li>
 </ol>
 

--- a/templates/web/sutton/waste/small_items/intro.html
+++ b/templates/web/sutton/waste/small_items/intro.html
@@ -1,0 +1,9 @@
+[% SET cfg = c.cobrand.wasteworks_config %]
+<h3>Before you start your booking</h3>
+
+<ol>
+    <li>Please make sure you have read the <strong><a href="[% c.cobrand.call_hook('small_items_tandc_link') %]" target="_blank">small items collection</a></strong> page on the council’s website</li>
+    <li>You can arrange to have any of the following small items collected from outside your home for free: Batteries, Coffee pods, Small WEEE, Textiles
+    <li>There is a maximum of [% cfg.small_items_per_collection_max %] items for a collection and you can only have one collection in a day
+    <li>You can only have one tied bag of domestic batteries in the collection
+</ol>


### PR DESCRIPTION
Reporting a bulky or small items collection as missed relies on having an 'original_booking_id' parameter. Normally, the missed collection form starts with a list of checkboxes so multiple container types/collections can be selected, but this does not make much sense for bulky/small, as the 'original_booking_id' implies that the flow is only dealing with one collection.

Closes https://github.com/mysociety/societyworks/issues/5116 .

[skip changelog]
