### PR TITLE
[Zurich] Add additional attributes to admin report edit form

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Zurich.pm
+++ b/perllib/FixMyStreet/Cobrand/Zurich.pm
@@ -611,6 +611,19 @@ sub admin_report_edit {
 
     }
 
+    # Fetch hierarchical attributes for the current body (for all user types)
+    my $current_body = $c->model('DB::Body')->find($problem->bodies_str);
+    if ($current_body) {
+        my $hierarchical_attributes = $current_body->get_extra_metadata('hierarchical_attributes') || {};
+        if (!keys %$hierarchical_attributes) {
+            $hierarchical_attributes = $c->cobrand->get_default_hierarchical_attributes();
+        }
+        $c->stash->{hierarchical_attributes} = $hierarchical_attributes;
+
+        my $selected_attributes = $problem->get_extra_metadata('hierarchical_attributes') || {};
+        $c->stash->{selected_hierarchical_attributes} = $selected_attributes;
+    }
+
     # If super or dm check that the token is correct before proceeding
     if ( ($type eq 'super' || $type eq 'dm') && $c->get_param('submit') ) {
         $c->forward('/auth/check_csrf_token');
@@ -638,6 +651,36 @@ sub admin_report_edit {
 
     # Problem updates upon submission
     if ( ($type eq 'super' || $type eq 'dm') && $c->get_param('submit') ) {
+
+        # Validate hierarchical attributes if problem state is not 'submitted'
+        my %hierarchical_errors;
+        if ($problem->state ne 'submitted') {
+            my $geschaftsbereich = $c->get_param('hierarchical_geschaftsbereich');
+            my $objekt = $c->get_param('hierarchical_objekt');
+            my $kategorie = $c->get_param('hierarchical_kategorie');
+
+            if (!$geschaftsbereich) {
+                $hierarchical_errors{hierarchical_geschaftsbereich} = _('Please select a Geschäftsbereich');
+            }
+            if (!$objekt) {
+                $hierarchical_errors{hierarchical_objekt} = _('Please select an Objekt');
+            }
+            if (!$kategorie) {
+                $hierarchical_errors{hierarchical_kategorie} = _('Please select a Kategorie');
+            }
+
+            if (%hierarchical_errors) {
+                $c->stash->{hierarchical_errors} = \%hierarchical_errors;
+                $c->stash->{status_message} = '<p class="message-error">' . _('Please select all hierarchical attributes before saving') . '</p>';
+                return $self->admin_report_edit_done;
+            }
+
+            $problem->set_extra_metadata('hierarchical_attributes', {
+                geschaftsbereich => $geschaftsbereich,
+                objekt => $objekt,
+                kategorie => $kategorie,
+            });
+        }
 
         my @keys = grep { /^publish_photo/ } keys %{ $c->req->params };
         my %publish_photo;
@@ -702,6 +745,12 @@ sub admin_report_edit {
             $problem->bodies_str( $cat->body_id );
             $problem->resend;
             $problem->set_extra_metadata(changed_category => 1);
+
+            # Clear hierarchical attributes if reassigned to different body
+            if ($cat->body_id ne $body->id) {
+                $problem->unset_extra_metadata('hierarchical_attributes');
+            }
+
             $internal_note_text = "Weitergeleitet von $old_cat an $new_cat";
             $self->update_admin_log($c, $problem, "Changed category from $old_cat to $new_cat");
             $redirect = 1 if $cat->body_id ne $body->id;
@@ -726,6 +775,12 @@ sub admin_report_edit {
             $self->set_problem_state($c, $problem, 'in progress');
             $problem->external_body( undef );
             $problem->bodies_str( $subdiv );
+
+            # Clear hierarchical attributes if reassigned to different body
+            if ($subdiv ne $body->id) {
+                $problem->unset_extra_metadata('hierarchical_attributes');
+            }
+
             $problem->resend;
             $redirect = 1;
         } else {
@@ -853,6 +908,10 @@ sub admin_report_edit {
         # do not display correctly (reloads problem from database, including
         # fields modified by the database when saving)
         $problem->discard_changes;
+
+        # Update stash with the newly saved hierarchical attributes so they display correctly
+        my $updated_selected_attributes = $problem->get_extra_metadata('hierarchical_attributes') || {};
+        $c->stash->{selected_hierarchical_attributes} = $updated_selected_attributes;
 
         # Create an internal note if required
         if ($internal_note_text) {

--- a/t/cobrand/zurich_attributes.t
+++ b/t/cobrand/zurich_attributes.t
@@ -18,6 +18,11 @@ FixMyStreet::override_config {
     my $division_user = $mech->create_user_ok('division@example.com', name => 'Division User', from_body => $division->id);
     $division_user->user_body_permissions->create({ body => $division, permission_type => 'category_edit' });
 
+    # Create a subdivision for SDM testing
+    my $subdivision = $mech->create_body_ok( 423018, 'Subdivision A', {
+        parent => $division->id, send_method => 'Zurich', endpoint => 'subdivision@example.org' } );
+    my $sdm_user = $mech->create_user_ok('sdm@example.com', name => 'SDM User', from_body => $subdivision->id);
+
     subtest 'Default hierarchical attributes structure' => sub {
         $mech->log_in_ok($superuser->email);
         $mech->get_ok("/admin/body/$division_id/attributes");
@@ -191,6 +196,115 @@ FixMyStreet::override_config {
             }
         });
         $mech->content_contains('Hierarchical attributes updated');
+    };
+
+    subtest 'Report hierarchical attributes functionality' => sub {
+        $mech->log_in_ok($superuser->email);
+        $mech->get_ok("/admin/body/$division_id/attributes");
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Geschäftsbereich_name' => 'Test Geschäftsbereich',
+            }
+        });
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Objekt_name' => 'Test Objekt',
+                'new_Objekt_parent' => '1',
+            }
+        });
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'new_Kategorie_name' => 'Test Kategorie',
+                'new_Kategorie_parent' => '1',
+            }
+        });
+
+        my ($problem) = $mech->create_problems_for_body(1, $division->id, 'Test Problem');
+        $problem->update({ state => 'confirmed' });
+
+        $mech->get_ok("/admin/report_edit/" . $problem->id);
+        $mech->content_contains('Hierarchical Attributes');
+        $mech->content_contains('hierarchical_geschaftsbereich');
+        $mech->content_contains('hierarchical_objekt');
+        $mech->content_contains('hierarchical_kategorie');
+        $mech->content_contains('Test Geschäftsbereich');
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'submit' => '1',
+                'new_internal_note' => 'Test note without attributes',
+            }
+        });
+        $mech->content_contains('Please select all hierarchical attributes before saving');
+
+        $mech->submit_form_ok({
+            with_fields => {
+                'submit' => '1',
+                'hierarchical_geschaftsbereich' => '1',
+                'hierarchical_objekt' => '1',
+                'hierarchical_kategorie' => '1',
+                'new_internal_note' => 'Test note with attributes',
+            }
+        });
+        $mech->content_like(qr/Updated|message-updated/);
+
+        $problem->discard_changes;
+        my $saved_attributes = $problem->get_extra_metadata('hierarchical_attributes');
+        ok($saved_attributes, 'Hierarchical attributes were saved');
+        is($saved_attributes->{geschaftsbereich}, '1', 'Geschäftsbereich saved correctly');
+        is($saved_attributes->{objekt}, '1', 'Objekt saved correctly');
+        is($saved_attributes->{kategorie}, '1', 'Kategorie saved correctly');
+
+        my $external_body = $mech->create_body_ok(999, 'External Body');
+        my $external_contact = $mech->create_contact_ok(
+            body_id => $external_body->id,
+            category => 'External Category',
+            email => 'external@example.com',
+        );
+
+        $mech->get_ok("/admin/report_edit/" . $problem->id);
+        $mech->submit_form_ok({
+            with_fields => {
+                'submit' => '1',
+                'state' => 'confirmed',
+                'category' => 'External Category',
+                'hierarchical_geschaftsbereich' => '1',
+                'hierarchical_objekt' => '1',
+                'hierarchical_kategorie' => '1',
+            }
+        });
+
+        $problem->discard_changes;
+        my $cleared_attributes = $problem->get_extra_metadata('hierarchical_attributes');
+        ok(!$cleared_attributes, 'Hierarchical attributes cleared on body reassignment');
+    };
+
+    subtest 'SDM view of hierarchical attributes' => sub {
+        $mech->log_in_ok($sdm_user->email);
+
+        # Create a problem with hierarchical attributes for the division (parent body)
+        my ($problem) = $mech->create_problems_for_body(1, $division->id, 'SDM Test Problem');
+        $problem->update({ state => 'in progress' });
+        $problem->set_extra_metadata('hierarchical_attributes', {
+            geschaftsbereich => '1',
+            objekt => '1',
+            kategorie => '1',
+        });
+        $problem->update;
+
+        # SDM should see attributes but not be able to edit them
+        $mech->get_ok("/admin/report_edit/" . $problem->id);
+        $mech->content_contains('Hierarchical Attributes');
+        $mech->content_contains('Updated Name');  # Name was changed in earlier test
+        $mech->content_contains('Test Object');
+        $mech->content_contains('Test Category');
+
+        # Should not contain editable dropdowns
+        $mech->content_lacks('hierarchical_geschaftsbereich');
+        $mech->content_lacks('Select Geschäftsbereich');
     };
 
 };

--- a/templates/web/zurich/admin/report_edit-sdm.html
+++ b/templates/web/zurich/admin/report_edit-sdm.html
@@ -79,6 +79,24 @@
      </dd>
   [% END %]
 
+    [% IF problem.state != 'submitted' AND hierarchical_attributes AND selected_hierarchical_attributes %]
+        [% SET selected = selected_hierarchical_attributes %]
+        [% IF selected.geschaftsbereich OR selected.objekt OR selected.kategorie %]
+            <dt><span class="mock-label">[% loc('Hierarchical Attributes:') %]</span></dt>
+            <dd>
+                [% IF selected.geschaftsbereich AND hierarchical_attributes.Geschäftsbereich.entries.${selected.geschaftsbereich} %]
+                    <strong>[% loc('Geschäftsbereich:') %]</strong> [% hierarchical_attributes.Geschäftsbereich.entries.${selected.geschaftsbereich}.name | html %]<br>
+                [% END %]
+                [% IF selected.objekt AND hierarchical_attributes.Objekt.entries.${selected.objekt} %]
+                    <strong>[% loc('Objekt:') %]</strong> [% hierarchical_attributes.Objekt.entries.${selected.objekt}.name | html %]<br>
+                [% END %]
+                [% IF selected.kategorie AND hierarchical_attributes.Kategorie.entries.${selected.kategorie} %]
+                    <strong>[% loc('Kategorie:') %]</strong> [% hierarchical_attributes.Kategorie.entries.${selected.kategorie}.name | html %]<br>
+                [% END %]
+            </dd>
+        [% END %]
+    [% END %]
+
 </dl>
 
 </div>

--- a/templates/web/zurich/admin/reports/edit.html
+++ b/templates/web/zurich/admin/reports/edit.html
@@ -152,6 +152,71 @@
         </select>
     </dd>
 
+    [% IF problem.state != 'submitted' AND hierarchical_attributes %]
+        <dt class="screen-only">
+            <span class="mock-label">[% loc('Hierarchical Attributes:') %]</span>
+        </dt>
+        <dd class="screen-only hierarchical-attributes">
+            [% SET selected = selected_hierarchical_attributes || {} %]
+
+            <div class="hierarchical-field">
+                <label for="hierarchical_geschaftsbereich">[% loc('Geschäftsbereich:') %]</label>
+                <select class="form-control" name="hierarchical_geschaftsbereich" id="hierarchical_geschaftsbereich"
+                        [% IF hierarchical_errors.hierarchical_geschaftsbereich %]style="border-color: red;"[% END %]>
+                    <option value="">-- [% loc('Select Geschäftsbereich') %] --</option>
+                    [% FOREACH id IN hierarchical_attributes.Geschäftsbereich.entries.keys.sort %]
+                        [% entry = hierarchical_attributes.Geschäftsbereich.entries.$id %]
+                        [% NEXT IF entry.deleted %]
+                        <option value="[% id %]" [% ' selected' IF selected.geschaftsbereich == id %]>
+                            [% entry.name | html %]
+                        </option>
+                    [% END %]
+                </select>
+                [% IF hierarchical_errors.hierarchical_geschaftsbereich %]
+                    <div class="error-msg">[% hierarchical_errors.hierarchical_geschaftsbereich %]</div>
+                [% END %]
+            </div>
+
+            <div class="hierarchical-field">
+                <label for="hierarchical_objekt">[% loc('Objekt:') %]</label>
+                <select class="form-control" name="hierarchical_objekt" id="hierarchical_objekt"
+                        [% IF hierarchical_errors.hierarchical_objekt %]style="border-color: red;"[% END %]>
+                    <option value="">-- [% loc('Select Objekt') %] --</option>
+                    [% FOREACH id IN hierarchical_attributes.Objekt.entries.keys.sort %]
+                        [% entry = hierarchical_attributes.Objekt.entries.$id %]
+                        [% NEXT IF entry.deleted %]
+                        [% parent_id = entry.parent_id || 0 %]
+                        <option value="[% id %]" data-parent="[% parent_id %]" [% ' selected' IF selected.objekt == id %]>
+                            [% entry.name | html %]
+                        </option>
+                    [% END %]
+                </select>
+                [% IF hierarchical_errors.hierarchical_objekt %]
+                    <div class="error-msg">[% hierarchical_errors.hierarchical_objekt %]</div>
+                [% END %]
+            </div>
+
+            <div class="hierarchical-field">
+                <label for="hierarchical_kategorie">[% loc('Kategorie:') %]</label>
+                <select class="form-control" name="hierarchical_kategorie" id="hierarchical_kategorie"
+                        [% IF hierarchical_errors.hierarchical_kategorie %]style="border-color: red;"[% END %]>
+                    <option value="">-- [% loc('Select Kategorie') %] --</option>
+                    [% FOREACH id IN hierarchical_attributes.Kategorie.entries.keys.sort %]
+                        [% entry = hierarchical_attributes.Kategorie.entries.$id %]
+                        [% NEXT IF entry.deleted %]
+                        [% parent_id = entry.parent_id || 0 %]
+                        <option value="[% id %]" data-parent="[% parent_id %]" [% ' selected' IF selected.kategorie == id %]>
+                            [% entry.name | html %]
+                        </option>
+                    [% END %]
+                </select>
+                [% IF hierarchical_errors.hierarchical_kategorie %]
+                    <div class="error-msg">[% hierarchical_errors.hierarchical_kategorie %]</div>
+                [% END %]
+            </div>
+        </dd>
+    [% END %]
+
 </dl>
 
 <ul class="no-bullets screen-only">

--- a/web/cobrands/zurich/js.js
+++ b/web/cobrands/zurich/js.js
@@ -94,11 +94,54 @@ $(function() {
 
     }).trigger('change');
 
+    /*
+     * Hierarchical Attributes functionality
+     */
+
+    var $geschaftsbereichSelect = $('#hierarchical_geschaftsbereich');
+    var $objektSelect = $('#hierarchical_objekt');
+    var $kategorieSelect = $('#hierarchical_kategorie');
+
+    // Form validation for hierarchical attributes
+    function validateHierarchicalAttributes() {
+        var isValid = true;
+        var errorMessages = [];
+
+        if (!$geschaftsbereichSelect.val()) {
+            errorMessages.push('Please select a Geschäftsbereich');
+            isValid = false;
+        }
+
+        if (!$objektSelect.val()) {
+            errorMessages.push('Please select an Objekt');
+            isValid = false;
+        }
+
+        if (!$kategorieSelect.val()) {
+            errorMessages.push('Please select a Kategorie');
+            isValid = false;
+        }
+
+        if (!isValid) {
+            alert(errorMessages.join('\n'));
+        }
+
+        return isValid;
+    }
+
     $("form#report_edit input[type=submit]").on('click', function() {
         $("form#report_edit").data("clicked_button", $(this).attr("name"));
     });
 
-    $("form#report_edit").on('submit', function() {
+    $("form#report_edit").on('submit', function(e) {
+        // Validate hierarchical attributes when visible
+        if ($geschaftsbereichSelect && $geschaftsbereichSelect.length && $geschaftsbereichSelect.is(':visible')) {
+            if (!validateHierarchicalAttributes()) {
+                e.preventDefault();
+                return false;
+            }
+        }
+
         // Make sure the external body field has a value if it's visible
         // and the form is submitted as a 'save' action (i.e. not a rotate
         // photo).
@@ -125,4 +168,69 @@ $(function() {
     $("form#report_edit").find("input, select, textarea").on('change', function() {
         form_fields_changed = true;
     });
+
+    if ($geschaftsbereichSelect.length && $objektSelect.length && $kategorieSelect.length) {
+
+        // Initially disable the second and third dropdowns
+        $objektSelect.prop('disabled', true);
+        $kategorieSelect.prop('disabled', true);
+
+        // Filter options by parent ID
+        var filterOptions = function($selectElement, parentId) {
+            var $options = $selectElement.find('option[data-parent]');
+            var hasVisibleOptions = false;
+
+            $options.each(function() {
+                var $option = $(this);
+                var optionParentId = $option.data('parent').toString();
+
+                if (parentId === '' || optionParentId === parentId) {
+                    $option.show();
+                    hasVisibleOptions = true;
+                } else {
+                    $option.hide();
+                    if ($option.prop('selected')) {
+                        $option.prop('selected', false);
+                    }
+                }
+            });
+
+            return hasVisibleOptions;
+        };
+
+        // Reset and disable dependent dropdowns when Geschäftsbereich changes
+        var resetDependentDropdowns = function($selectElement) {
+            $selectElement.val('').prop('disabled', true);
+            $selectElement.find('option[data-parent]').hide();
+        };
+
+        // Handle Geschäftsbereich selection
+        $geschaftsbereichSelect.on('change', function() {
+            var selectedId = $(this).val();
+
+            resetDependentDropdowns($objektSelect);
+            resetDependentDropdowns($kategorieSelect);
+
+            if (selectedId) {
+                if (filterOptions($objektSelect, selectedId)) {
+                    $objektSelect.prop('disabled', false);
+                }
+
+                if (filterOptions($kategorieSelect, selectedId)) {
+                    $kategorieSelect.prop('disabled', false);
+                }
+            }
+        });
+
+        // Initialize dropdowns based on current selections
+        var selectedGeschaftsbereich = $geschaftsbereichSelect.val();
+        if (selectedGeschaftsbereich) {
+            if (filterOptions($objektSelect, selectedGeschaftsbereich)) {
+                $objektSelect.prop('disabled', false);
+            }
+            if (filterOptions($kategorieSelect, selectedGeschaftsbereich)) {
+                $kategorieSelect.prop('disabled', false);
+            }
+        }
+    }
 });


### PR DESCRIPTION
Adds a hierarchical attributes section to the admin report edit page for selecting the required attributes for a report based on the division.

Attributes are validated on the client and server side, and are required to be set for any report that's not in a submitted (Erfasst) state.

<img width="325" height="602" alt="image" src="https://github.com/user-attachments/assets/da651456-74f9-476a-bf47-09e7ac939f54" />

Initially, the second and third drop-downs are disabled until something has been selected from the first drop-down.

<img width="271" height="250" alt="image" src="https://github.com/user-attachments/assets/fdafc429-d39b-41a9-9880-883881b4f2ca" />

Also add a read-only view of the attributes to the subdivision manager's report edit view:

<img width="439" height="333" alt="image" src="https://github.com/user-attachments/assets/c7f89e01-2ab1-48a9-8d73-13009725f5ba" />


Fixes https://github.com/mysociety/societyworks/issues/4974

<!-- [skip changelog] -->