### PR TITLE
[Merton] Adding a cash option (and tidying up payment references)

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -726,7 +726,7 @@ sub process_request_data : Private {
     if ($payment) {
         if ( FixMyStreet->staging_flag('skip_waste_payment') ) {
             $c->forward('/waste/pay_skip', []);
-        } elsif ($payment_method eq 'waived') {
+        } elsif ($payment_method eq 'waived' || $payment_method eq 'cash') {
             $c->forward('/waste/pay_skip', [ undef, $data->{payment_explanation} ]);
         } else {
             if ( $c->stash->{staff_payments_allowed} eq 'paye' ) {

--- a/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
@@ -371,7 +371,7 @@ sub process_bulky_data : Private {
             $c->forward('/waste/pay_skip', []);
         } elsif ($payment_method eq 'cheque') {
             $c->forward('/waste/pay_skip', [ $data->{cheque_reference}, undef ]);
-        } elsif ($payment_method eq 'waived') {
+        } elsif ($payment_method eq 'waived' || $payment_method eq 'cash') {
             $c->forward('/waste/pay_skip', [ undef, $data->{payment_explanation} ]);
         } else {
             if ( $c->stash->{staff_payments_allowed} eq 'paye' ) {

--- a/perllib/FixMyStreet/App/Controller/Waste/Garden.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste/Garden.pm
@@ -403,7 +403,7 @@ sub process_garden_new_or_renew : Private {
         $c->forward('/waste/pay_skip', []);
     } elsif ($c->cobrand->waste_cheque_payments && $payment_method eq 'cheque') {
         $c->forward('/waste/pay_skip', [ $data->{cheque_reference}, undef ]);
-    } elsif ($payment_method eq 'waived') {
+    } elsif ($payment_method eq 'waived' || $payment_method eq 'cash') {
         $c->forward('/waste/pay_skip', [ undef, $data->{payment_explanation} ]);
     } else {
         if ($dd_flow) {

--- a/perllib/FixMyStreet/App/Form/Waste/Billing.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Billing.pm
@@ -40,6 +40,7 @@ sub options_payment_method {
         push @options, { label => 'Cheque payment', value => 'cheque', data_show => '#form-cheque_reference-row', data_hide => '#form-payment_explanation-row' };
     }
     if ($cobrand eq 'merton') {
+        push @options, { label => 'Cash payment', value => 'cash', data_show => '#form-payment_explanation-row', data_hide => '#form-cheque_reference-row' };
         push @options, { label => 'No payment to be taken', value => 'waived', data_show => '#form-payment_explanation-row', data_hide => '#form-cheque_reference-row' };
     }
 
@@ -55,7 +56,7 @@ has_field cheque_reference => (
 has_field payment_explanation => (
     label => 'Explanation',
     type => 'Text',
-    required_when => { payment_method => 'waived' },
+    required_when => { payment_method => ['waived', 'cash'] },
 );
 
 1;

--- a/perllib/FixMyStreet/Roles/Cobrand/Waste.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Waste.pm
@@ -16,6 +16,7 @@ sub bin_payment_types {
         'direct_debit' => 3,
         'cheque' => 4,
         'waived' => 5,
+        'cash' => 6,
     };
 }
 

--- a/templates/web/base/waste/garden/_payment_method.html
+++ b/templates/web/base/waste/garden/_payment_method.html
@@ -4,5 +4,7 @@
     [% IF data.cheque_reference %](reference [% data.cheque_reference %])[% END %]
 [%~ ELSIF payment_method == 'waived' %]Waived
     [% IF data.payment_explanation %]([% data.payment_explanation %])[% END %]
+[%~ ELSIF payment_method == 'cash' %]Cash
+    [% IF data.payment_explanation %]([% data.payment_explanation %])[% END %]
 [%~ ELSIF payment_method == 'csc' %]CSC
 [%~ END %]


### PR DESCRIPTION
This adds a 'cash' payment option for Merton at their request (fixes https://github.com/mysociety/societyworks/issues/5099), and takes the opportunity to fix some historical cruft to do with payment references (fixes https://github.com/mysociety/societyworks/issues/4023 - see comment there for details as to what's changed).

It also stops payment options being shown during a bulky amendment if there's no payment to be taken, and removes a duplicate payment method display in the admin. [skip changelog]