### PR TITLE
Add superuser category editing for display name cobrands

### DIFF
--- a/templates/web/base/admin/bodies/_category_field.html
+++ b/templates/web/base/admin/bodies/_category_field.html
@@ -1,8 +1,20 @@
 [% IF cobrand.contact_extra_fields.0 == 'display_name' %]
 
     [% IF contact.in_storage %]
+        [% IF c.user.is_superuser %]
+        <label for="category">[% loc('Category') %]</label>
+        <p class="form-hint" id="category-hint">
+            This cobrand uses display names. The display name is shown to users and the category name is used internally and in URLs.
+        </p>
+        <input type="text" class="form-control" id="category" name="category"
+          aria-describedby="category-hint"
+          size="30" value="[% contact.category %]"
+          [% contact.category_uneditable ? 'readonly' : 'required' %]>
+        <input type="hidden" name="current_category" value="[% current_contact.category | html %]" >
+        [% ELSE %]
         <h1>[% contact.category | html %]</h1>
         <input type="hidden" name="category" value="[% contact.category | html %]" >
+        [% END %]
 
         <label for="display_name">Display name</label>
         <p class="form-hint" id="display_name-hint">


### PR DESCRIPTION
When a cobrand is setup to use a display name its sometimes still useful to have a way to change the category name.

This change adds a form field for superusers to allow them to update the category name as well as the display name on these cobrands.

Should make tickets like FD-5943 possible to fix from the admin rather than having to use the DB console.

<img width="992" height="489" alt="image" src="https://github.com/user-attachments/assets/ac132e21-b89a-4483-abd9-d8b06324ec76" />


<!-- [skip changelog] -->
