### PR TITLE
[Bulky] Added some spacing fixes to the item selection list

### DIFF
--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -118,7 +118,7 @@ END; END %]
   [% IF c.cobrand.bulky_pricing_strategy.strategy == 'banded' %]
   <p id="band-pricing-info"></p>
   [% END %]
-  <button type="submit" id="add-new-item" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-3" aria-label="Add item" name="goto-same-page" value="1">
+  <button type="submit" id="add-new-item" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-7" aria-label="Add item" name="goto-same-page" value="1">
     [% IF c.cobrand.moniker == 'kingston' OR c.cobrand.moniker == 'sutton' ~%]
       Add another item
     [%~ ELSE ~%]
@@ -153,7 +153,7 @@ END; END %]
     [% photo_fileid = photo _ '_fileid' %]
     [% PROCESS form override_fields = [ photo, photo_fileid ] %]
   [% END %]
-    <button type="button" class="delete-item govuk-button govuk-button--warning govuk-!-margin-bottom-3">Delete item</button>
+    <button type="button" class="delete-item govuk-button govuk-button--warning govuk-!-margin-bottom-3 govuk-!-margin-top-3">Delete item</button>
     <hr>
   </div>
 [% END %]

--- a/web/cobrands/sass/_waste.scss
+++ b/web/cobrands/sass/_waste.scss
@@ -588,7 +588,7 @@ html.js {
     }
 
     hr {
-      margin: 1.2em 0;
+      margin: 2.5em 0;
     }
   }
 }


### PR DESCRIPTION
Fixes: https://3.basecamp.com/4020879/buckets/42017522/card_tables/cards/8954297985#__recording_9012502051

Here is the feedback from the client:
> The margin between the Item select and the Delete item button still feels quite cramped, especially on mobile.

> Also, the Add item button ([other TO DO](https://3.basecamp.com/4020879/buckets/42017522/card_tables/cards/8954299226#__recording_9005692823)) needs a top-margin to add extra spacing.

> Could we increase the margin/padding and add a top margin to the Add item button please? The below would be ideal:

What this PR does:

- Increased spacing between items
- Increased bottom spacing for "Add item"

### Preview Desktop

<img width="1162" height="768" alt="Screenshot 2025-09-09 at 10 24 49" src="https://github.com/user-attachments/assets/ce63851d-e81a-49e4-bda7-ed1ffb4016fd" />

### Preview Mobile

<img width="375" height="732" alt="Screenshot 2025-09-09 at 10 25 23" src="https://github.com/user-attachments/assets/7566ea31-c270-419b-877f-4eec20740b57" />


[skip changelog]