### PR TITLE
Fix floating button width at higher breakpoints.

### DIFF
--- a/web/cobrands/sass/_layout.scss
+++ b/web/cobrands/sass/_layout.scss
@@ -874,7 +874,16 @@ body.authpage {
 }
 
 .floating-button-wrapper {
-    width: $mappage-sidebar-width;
+  width: $mappage-sidebar-width;
+  @media (min-width: $screen-size--medium) {
+    width: $mappage-sidebar-width--medium;
+  }
+  @media (min-width: $screen-size--large) {
+    width: $mappage-sidebar-width--large;
+  }
+  @media (min-width: $screen-size--xlarge) {
+    width: $mappage-sidebar-width--xlarge;
+  }
 }
 
 #loading-indicator {


### PR DESCRIPTION
This was missed, I think as it was introduced after the breakpoints were first looked at.
[skip changelog]

Fixes floating button during reporting not being full width at larger browser widths.