### PR TITLE
[Brent] Extend filter for TfL River categories

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -362,7 +362,7 @@ never been used to report anything.
 sub categories_restriction {
     my ($self, $rs) = @_;
 
-    return $rs->search( { 'me.category' => [ '-and' => { '-not_like' => 'River Piers%' }, { '-not_like' => 'Bus Station%' }, { '-not_like' => '%(Response Desk Buses to Action)' } ] } );
+    return $rs->search( { 'me.category' => [ '-and' => { '-not_like' => 'River %' }, { '-not_like' => 'Bus Station%' }, { '-not_like' => '%(Response Desk Buses to Action)' } ] } );
 }
 
 =head2 social_auth_enabled, user_from_oidc, and oidc_config


### PR DESCRIPTION
Open up filter to anything beginning 'River '

https://mysocietysupport.freshdesk.com/a/tickets/5968

[skip changelog]
