### PR TITLE
[WW] Increased margin-top for `.delete-item` element

### DIFF
--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -153,7 +153,7 @@ END; END %]
     [% photo_fileid = photo _ '_fileid' %]
     [% PROCESS form override_fields = [ photo, photo_fileid ] %]
   [% END %]
-    <button type="button" class="delete-item govuk-button govuk-button--warning govuk-!-margin-bottom-3 govuk-!-margin-top-3">Delete item</button>
+    <button type="button" class="delete-item govuk-button govuk-button--warning govuk-!-margin-bottom-3 govuk-!-static-margin-top-7">Delete item</button>
     <hr>
   </div>
 [% END %]


### PR DESCRIPTION
Fixes: https://3.basecamp.com/4020879/buckets/42017522/card_tables/cards/8954297985#__recording_9061255050

**Live site**
<img width="530" height="520" alt="Screenshot 2025-09-11 at 16 39 02" src="https://github.com/user-attachments/assets/7ceda976-ff08-40fb-b820-c7b31a346822" />

**Proposed**
<img width="530" height="520" alt="Screenshot 2025-09-11 at 16 38 16" src="https://github.com/user-attachments/assets/d866821b-8ad8-4911-8d7c-b8c81a48aa2d" />

I created a new PR because on the live site for bulky WW Bexley the `margin-top` is not as big as we have agreed with the client. Unfortunately on my local the original spacing `govuk-!-margin-bottom-3` was working and stacking with the bottom margin of the previous element(`.govuk-form-group`), after investigating why this was not happening on the live site I noticed that my local was using the following CSS rule:

```
html.js #item-selection-form .bulky-item-wrapper .delete-item { display: inline-block;}
```

While the live site is overriding the previous rule with:
```
element.style {
    display: block;
}
```

Causing the margins to collapse instead of stack like it would happen with `inline-block` elements.

I have an error on my console from the `waste.js` that might be causing my local to not get the `display:block`

Preview:

Desktop
<img width="1099" height="228" alt="Screenshot 2025-09-11 at 16 59 19" src="https://github.com/user-attachments/assets/84ede0c4-ef10-4a05-b704-e188ae19c3f2" />

Mobile
<img width="437" height="198" alt="Screenshot 2025-09-11 at 16 59 41" src="https://github.com/user-attachments/assets/62bb8133-5ea5-446e-b829-fe4ba0865598" />


Note: please if approved feel free to merge.
[skip changelog]