### PR TITLE
Persist send_method_used immediately during report sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
         - Process update sending in order. #5298
         - Only update lastupdate timestamp if update timestamp is newer. #5350
         - Add ability to process extra question disable messages from endpoint. #5431
+        - Persist send_method_used immediately during report sending to prevent loss when senders call discard_changes(). #5671
 
 * v6.0 (14th November 2024)
     - Front end improvements:

--- a/perllib/FixMyStreet/Queue/Item/Report.pm
+++ b/perllib/FixMyStreet/Queue/Item/Report.pm
@@ -268,6 +268,9 @@ sub _send {
         my @body_ids = map { $_->id } @{ $sender->bodies };
         if ($sender->success) {
             $report->add_send_method($sender_name);
+            # Persist send_method_used immediately so later discard_changes() calls
+            # within other sender implementations cannot wipe previous values.
+            $report->update;
             push @remove_send_fail_body_ids, @body_ids;
         } else {
             push @add_send_fail_body_ids, @body_ids;


### PR DESCRIPTION
Some senders call `discard_changes()` within their `send()` method, which results in the `send_method_used` change being overwritten rather than appended to. The end result of this is that in some cases updates aren't being sent via Open311 because the `send_method_used` ends up as `Email`.

This change ensures that `send_method_used` is persisted between sender calls, so in cases with multiple senders it correctly ends up as `Email,Open311` or similar.

Fixes https://github.com/mysociety/societyworks/issues/5146

Relates to FD-5945