### PR TITLE
[Brent] Added fix to `my-account-buttons a`

### DIFF
--- a/web/cobrands/brent/base.scss
+++ b/web/cobrands/brent/base.scss
@@ -32,7 +32,6 @@ a {
 }
 
 .my-account-buttons a {
-  background: transparent;
   @include brent-link;
 }
 


### PR DESCRIPTION
This fix makes `my-account-buttons a` to have Brent blue background instead of `transparent` that was creating accessibility issues with the buttons white text.

**Before**
<img width="1282" height="754" alt="Screenshot 2025-10-09 at 16 26 17" src="https://github.com/user-attachments/assets/bac5b66a-4bf1-4541-940d-6f7fb32206e9" />

**After**
<img width="1282" height="754" alt="Screenshot 2025-10-09 at 16 25 49" src="https://github.com/user-attachments/assets/b1dc4d9b-12f6-4168-baf9-94e2af87ce35" />

Please feel free to merge if it gets approved and I'm not here

[skip changelog]