### PR TITLE
[Bexley][GGW] Fix payment method display when amending subscription

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
@@ -534,4 +534,15 @@ sub waste_staff_choose_payment_method { 1 }
 
 sub waste_show_garden_modify { 1 }
 
+sub waste_display_payment_method {
+    my ($self, $method) = @_;
+
+    my $display = {
+        direct_debit => _('Direct Debit'),
+        credit_card => _('Credit Card'),
+    };
+
+    return $display->{$method};
+}
+
 1;


### PR DESCRIPTION
Fix payment method display when amending a subscription.

This method was only defined for Echo, so the payment method display was silently failing.

I based this branch on top of https://github.com/mysociety/fixmystreet/pull/5698, so they can hopefully be rebased together.

<!-- [skip changelog] -->
