### PR TITLE
[Echo] Work out frequency ourselves.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1105,7 +1105,7 @@ sub waste_extra_service_info {
         $schedules->{description} =~ s/other\s*// if $_->{ServiceId} == $SERVICE_IDS{domestic_food} || $_->{ServiceId} == $SERVICE_IDS{communal_refuse};
 
         # Check calendar allocation
-        if (($_->{ServiceId} == $SERVICE_IDS{domestic_refuse} || $_->{ServiceId} == $SERVICE_IDS{garden} || $_->{ServiceId} == $SERVICE_IDS{domestic_paper}) && ($schedules->{description} =~ /every other/ || $schedules->{description} =~ /every \d+(th|st|nd|rd) week/) && $schedules->{next}{schedule}) {
+        if (($_->{ServiceId} == $SERVICE_IDS{domestic_refuse} || $_->{ServiceId} == $SERVICE_IDS{garden} || $_->{ServiceId} == $SERVICE_IDS{domestic_paper}) && ($schedules->{description} =~ /every other/i || $schedules->{description} =~ /every \d+ week/i) && $schedules->{next}{schedule}) {
             my $allocation = $schedules->{next}{schedule}{Allocation};
             my $day = lc $allocation->{RoundName};
             $day =~ s/\s+//g;

--- a/perllib/FixMyStreet/Cobrand/Sutton.pm
+++ b/perllib/FixMyStreet/Cobrand/Sutton.pm
@@ -225,7 +225,7 @@ sub _setup_missed_collection_escalations_for_service {
         my $wd = FixMyStreet::WorkingDays->new();
         my $start = $wd->add_days($missed_event->{date}, 2)->set_hour(18);
         # And window is one day (weekly) two WDs (fortnightly)
-        my $window = $row->{schedule} =~ /fortnight|every other/i ? 2 : 1;
+        my $window = $row->{schedule} =~ /every other/i ? 2 : 1;
         my $end = $wd->add_days($start, $window);
         if ($now >= $start && $now < $end) {
             $row->{escalations}{missed} = $missed_event;
@@ -296,7 +296,7 @@ sub image_for_unit {
         return "$base/electricals-batteries-textiles";
     }
 
-    if ($service_id == $SERVICE_IDS{communal_refuse} && $unit->{schedule} =~ /fortnight|every other/i) {
+    if ($service_id == $SERVICE_IDS{communal_refuse} && $unit->{schedule} =~ /every other/i) {
         # Communal fortnightly is a wheelie bin, not a large bin
         return svg_container_bin('wheelie', '#8B5E3D');
     }

--- a/perllib/FixMyStreet/Roles/Cobrand/SLWP2.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/SLWP2.pm
@@ -177,15 +177,8 @@ sub waste_relevant_serviceunits {
             ServiceId => $_->{ServiceId},
             ServiceTask => $servicetask,
             Service => $_,
-            Schedules => _parse_schedules($servicetask, 'task'),
+            Schedules => _parse_schedules($servicetask),
         };
-
-        # FD-5992 override
-        if ($self->moniker eq 'sutton' && $rows[-1]{Schedules}{description}) {
-            $rows[-1]{Schedules}{description} =~ s/^Every [^ ]*$/Weekly/;
-            $rows[-1]{Schedules}{description} =~ s/^Every [^ ]* fortnightly/Fortnightly/i;
-        }
-
     }
 
     # Merton have asked for a specific ordering
@@ -308,7 +301,7 @@ sub waste_service_containers {
 
             if ($waste_containers_no_request->{$container}) {
                 $request_max->{$container} = 0; # Cannot request these
-            } elsif ($container == $CONTAINERS{recycling_blue_bag} && $schedules->{description} !~ /fortnight|every other/i) {
+            } elsif ($container == $CONTAINERS{recycling_blue_bag} && $schedules->{description} !~ /every other/i) {
                 # Blue stripe bag on a weekly collection
                 $request_max->{$container} = 0; # Cannot request these
             } elsif ($self->moniker eq 'kingston') {

--- a/perllib/Integrations/Echo.pm
+++ b/perllib/Integrations/Echo.pm
@@ -221,7 +221,6 @@ sub GetServiceUnitsForObject {
         ServiceTasks => { ServiceTask => {
             Id => '401',
             ServiceTaskSchedules => { ServiceTaskSchedule => {
-                ScheduleDescription => 'every Wednesday',
                 StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                 EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                 NextInstance => {
@@ -242,7 +241,6 @@ sub GetServiceUnitsForObject {
         ServiceTasks => { ServiceTask => {
             Id => '402',
             ServiceTaskSchedules => { ServiceTaskSchedule => {
-                ScheduleDescription => 'every other Wednesday',
                 StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                 EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                 NextInstance => {
@@ -263,7 +261,6 @@ sub GetServiceUnitsForObject {
         ServiceTasks => { ServiceTask => {
             Id => '403',
             ServiceTaskSchedules => { ServiceTaskSchedule => {
-                ScheduleDescription => 'every other Wednesday',
                 StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                 EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                 NextInstance => {
@@ -284,7 +281,6 @@ sub GetServiceUnitsForObject {
         ServiceTasks => { ServiceTask => {
             Id => '404',
             ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                ScheduleDescription => 'every other Monday',
                 StartDate => { DateTime => '2019-01-01T00:00:00Z' },
                 EndDate => { DateTime => '2020-01-01T00:00:00Z' },
                 LastInstance => {
@@ -292,7 +288,6 @@ sub GetServiceUnitsForObject {
                     CurrentScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
                 },
             }, {
-                ScheduleDescription => 'every other Monday',
                 StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                 EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                 NextInstance => {
@@ -306,7 +301,6 @@ sub GetServiceUnitsForObject {
                 },
             }, {
                 # Some bad data, future schedule, with past last instance
-                ScheduleDescription => 'every other Tuesday',
                 StartDate => { DateTime => '2050-01-01T00:00:00Z' },
                 EndDate => { DateTime => '2051-01-01T00:00:00Z' },
                 LastInstance => {
@@ -340,7 +334,6 @@ sub GetServiceUnitsForObject {
                     CurrentScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
                 },
             }, {
-                ScheduleDescription => 'every other Monday',
                 StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                 EndDate => { DateTime => '2021-03-30T00:00:00Z' },
                 NextInstance => {

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -454,7 +454,6 @@ FixMyStreet::override_config {
                     ServiceTasks => { ServiceTask => {
                         Id => 403,
                         ServiceTaskSchedules => { ServiceTaskSchedule => {
-                            ScheduleDescription => 'every other Wednesday',
                             StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                             EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                             NextInstance => {
@@ -475,7 +474,6 @@ FixMyStreet::override_config {
                     ServiceTasks => { ServiceTask => {
                         Id => 404,
                         ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                            ScheduleDescription => 'every other Monday',
                             StartDate => { DateTime => '2019-01-01T00:00:00Z' },
                             EndDate => { DateTime => '2020-01-01T00:00:00Z' },
                             LastInstance => {
@@ -483,7 +481,6 @@ FixMyStreet::override_config {
                                 CurrentScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
                             },
                         }, {
-                            ScheduleDescription => 'every other Monday',
                             StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                             EndDate => { DateTime => '2020-05-01T00:00:00Z' },
                             NextInstance => {
@@ -521,7 +518,6 @@ FixMyStreet::override_config {
                                 CurrentScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
                             },
                         }, {
-                            ScheduleDescription => 'every other Monday',
                             StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                             EndDate => { DateTime => '2020-05-21T00:00:00Z' },
                             NextInstance => {
@@ -559,7 +555,6 @@ FixMyStreet::override_config {
                     ServiceTasks => { ServiceTask => {
                         Id => 403,
                         ServiceTaskSchedules => { ServiceTaskSchedule => {
-                            ScheduleDescription => 'every other Wednesday',
                             StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                             EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                             NextInstance => {
@@ -580,7 +575,6 @@ FixMyStreet::override_config {
                     ServiceTasks => { ServiceTask => {
                         Id => 404,
                         ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                            ScheduleDescription => 'every other Monday',
                             StartDate => { DateTime => '2019-01-01T00:00:00Z' },
                             EndDate => { DateTime => '2020-01-01T00:00:00Z' },
                             LastInstance => {
@@ -588,7 +582,6 @@ FixMyStreet::override_config {
                                 CurrentScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
                             },
                         }, {
-                            ScheduleDescription => 'every other Monday',
                             StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                             EndDate => { DateTime => '2020-05-01T00:00:00Z' },
                             NextInstance => {
@@ -619,7 +612,6 @@ FixMyStreet::override_config {
                             } ] },
                         } ] },
                         ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                            ScheduleDescription => 'every other Monday',
                             StartDate => { DateTime => '2021-06-14T23:00:00Z' },
                             EndDate => { DateTime => '2021-07-14T23:00:00Z' },
                             NextInstance => {
@@ -692,7 +684,6 @@ my $REFUSE_SERVICE = {
     ServiceName => 'Refuse collection',
     ServiceTasks => { ServiceTask => {
         Id => 401,
-        ScheduleDescription => 'every Wednesday',
         ServiceTaskSchedules => { ServiceTaskSchedule => {
             StartDate => { DateTime => '2020-01-01T00:00:00Z' },
             EndDate => { DateTime => '2050-01-01T00:00:00Z' },
@@ -717,7 +708,6 @@ sub garden_waste_no_bins {
         ServiceTasks => { ServiceTask => {
             Id => 404,
             ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                ScheduleDescription => 'every other Monday',
                 StartDate => { DateTime => '2019-01-01T00:00:00Z' },
                 EndDate => { DateTime => '2020-01-01T00:00:00Z' },
                 LastInstance => {
@@ -725,7 +715,6 @@ sub garden_waste_no_bins {
                     CurrentScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
                 },
             }, {
-                ScheduleDescription => 'every other Monday',
                 StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                 EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                 NextInstance => {
@@ -777,7 +766,6 @@ sub _garden_waste_service_units {
                     CurrentScheduledDate => { DateTime => '2019-12-31T00:00:00Z' },
                 },
             }, {
-                ScheduleDescription => 'every other Monday',
                 StartDate => { DateTime => '2020-03-30T00:00:00Z' },
                 EndDate => { DateTime => '2021-03-30T00:00:00Z' },
                 NextInstance => {
@@ -877,7 +865,6 @@ FixMyStreet::override_config {
                 ServiceName => 'Garden waste collection',
                 ServiceTasks => { ServiceTask => [ {
                     Id => 405,
-                    ScheduleDescription => 'every other Monday',
                     Data => { ExtensibleDatum => [ {
                         DatatypeName => 'LBB - GW Container',
                         ChildData => { ExtensibleDatum => {
@@ -908,7 +895,6 @@ FixMyStreet::override_config {
                 },
                 {
                     Id => 405,
-                    ScheduleDescription => 'every other Monday',
                     Data => { ExtensibleDatum => [ {
                         DatatypeName => 'LBB - GW Container',
                         ChildData => { ExtensibleDatum => {
@@ -967,7 +953,6 @@ FixMyStreet::override_config {
                 ServiceTasks => { ServiceTask => {
                     Id => 402,
                     ServiceTaskSchedules => { ServiceTaskSchedule => {
-                        ScheduleDescription => 'every other Wednesday',
                         StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                         EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                         NextInstance => {

--- a/t/app/controller/waste_brent_garden.t
+++ b/t/app/controller/waste_brent_garden.t
@@ -81,7 +81,6 @@ sub food_waste_collection {
             Id => 400,
             TaskTypeId => 1688,
             ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                ScheduleDescription => 'every other Monday',
                 Allocation => {
                     RoundName => 'Monday ',
                     RoundGroupName => 'Delta 04 Week 2',
@@ -156,7 +155,6 @@ sub _garden_waste_service_units {
                 Value => $bin_type_id,
             } ] },
             ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                ScheduleDescription => 'every other Monday',
                 Allocation => {
                     RoundName => 'Monday ',
                     RoundGroupName => 'Delta 04 Week 2',

--- a/t/app/controller/waste_brent_small_items.t
+++ b/t/app/controller/waste_brent_small_items.t
@@ -97,7 +97,6 @@ FixMyStreet::override_config {
         ServiceTasks => { ServiceTask => {
             Id => 402,
             ServiceTaskSchedules => { ServiceTaskSchedule => {
-                ScheduleDescription => 'every other Wednesday',
                 Allocation => {
                     RoundName => 'Friday ',
                     RoundGroupName => 'Delta 04 Week 2',

--- a/t/app/controller/waste_bromley_bulky.t
+++ b/t/app/controller/waste_bromley_bulky.t
@@ -76,7 +76,6 @@ sub domestic_waste_service_units {
         ServiceTasks => { ServiceTask => {
             Id => '401',
             ServiceTaskSchedules => { ServiceTaskSchedule => {
-                ScheduleDescription => 'every Wednesday',
                 StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                 EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                 NextInstance => {

--- a/t/app/controller/waste_kingston.t
+++ b/t/app/controller/waste_kingston.t
@@ -82,7 +82,6 @@ sub garden_waste_no_bins {
             Id => 400,
             TaskTypeId => 4389,
             ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                ScheduleDescription => 'every other Monday',
                 StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                 EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                 NextInstance => {
@@ -114,7 +113,6 @@ sub garden_waste_only_refuse_sacks {
             Id => 400,
             TaskTypeId => 4395,
             ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                ScheduleDescription => 'every other Monday',
                 StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                 EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                 NextInstance => {
@@ -183,7 +181,6 @@ sub _garden_waste_service_units {
                 EndDate => { DateTime => '2021-03-30T00:00:00Z' },
             } ] },
             ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                ScheduleDescription => 'every other Monday',
                 StartDate => { DateTime => '2020-03-30T00:00:00Z' },
                 EndDate => { DateTime => '2021-03-30T00:00:00Z' },
                 NextInstance => {

--- a/t/app/controller/waste_kingston_4443082.json
+++ b/t/app/controller/waste_kingston_4443082.json
@@ -20,8 +20,8 @@
               "ServiceTaskSchedule": {
                 "ScheduleDescription": "Friday every other week",
                 "NextInstance": {
-                  "CurrentScheduledDate": { "DateTime": "2022-09-15T23:00:00Z" },
-                  "OriginalScheduledDate": { "DateTime": "2022-09-15T23:00:00Z" }
+                  "CurrentScheduledDate": { "DateTime": "2022-09-15T23:00:00Z", "OffsetMinutes": 60 },
+                  "OriginalScheduledDate": { "DateTime": "2022-09-15T23:00:00Z", "OffsetMinutes": 60 }
                 },
                 "LastInstance": {
                   "CurrentScheduledDate": { "DateTime": "2022-09-02T05:00:00Z" },

--- a/t/app/controller/waste_kingston_r.t
+++ b/t/app/controller/waste_kingston_r.t
@@ -101,7 +101,7 @@ FixMyStreet::override_config {
         set_fixed_time('2022-09-10T12:00:00Z');
         $mech->get_ok('/waste/12345');
         $mech->content_contains('2 Example Street, Kingston');
-        $mech->content_contains('Every Friday fortnightly');
+        $mech->content_contains('Every other Friday');
         $mech->content_contains('Friday, 2nd September');
         $mech->content_contains('Report a mixed recycling collection as missed');
     };

--- a/t/app/controller/waste_merton_4443082.json
+++ b/t/app/controller/waste_merton_4443082.json
@@ -121,8 +121,8 @@
               "ServiceTaskSchedule": {
                 "ScheduleDescription": "Friday every other week",
                 "NextInstance": {
-                  "CurrentScheduledDate": { "DateTime": "2022-09-22T23:00:00Z" },
-                  "OriginalScheduledDate": { "DateTime": "2022-09-22T23:00:00Z" }
+                  "CurrentScheduledDate": { "DateTime": "2022-09-22T23:00:00Z", "OffsetMinutes": 60 },
+                  "OriginalScheduledDate": { "DateTime": "2022-09-22T23:00:00Z", "OffsetMinutes": 60 }
                 },
                 "StartDate": { "DateTime": "2017-01-01T00:00:00Z" },
                 "LastInstance": {

--- a/t/app/controller/waste_merton_garden.t
+++ b/t/app/controller/waste_merton_garden.t
@@ -98,7 +98,6 @@ sub garden_waste_no_bins {
                 } ] },
             } ] },
             ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                ScheduleDescription => 'every other Monday',
                 StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                 EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                 NextInstance => {
@@ -152,7 +151,6 @@ sub garden_waste_only_refuse_sacks {
                 } ] },
             } ] },
             ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                ScheduleDescription => 'every other Monday',
                 StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                 EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                 NextInstance => {
@@ -210,7 +208,6 @@ sub _garden_waste_service_units {
                 EndDate => { DateTime => '2021-03-30T00:00:00Z' },
             } ] },
             ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                ScheduleDescription => 'every other Monday',
                 StartDate => { DateTime => '2020-03-30T00:00:00Z' },
                 EndDate => { DateTime => '2021-03-30T00:00:00Z' },
                 NextInstance => {

--- a/t/app/controller/waste_sutton_garden.t
+++ b/t/app/controller/waste_sutton_garden.t
@@ -95,7 +95,6 @@ sub garden_waste_no_bins {
             Id => 400,
             TaskTypeId => 4389,
             ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                ScheduleDescription => 'every other Monday',
                 StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                 EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                 NextInstance => {
@@ -149,7 +148,6 @@ sub garden_waste_only_refuse_sacks {
             Id => 400,
             TaskTypeId => 4395,
             ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                ScheduleDescription => 'every other Monday',
                 StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                 EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                 NextInstance => {
@@ -207,7 +205,6 @@ sub _garden_waste_service_units {
                 EndDate => { DateTime => '2021-03-30T00:00:00Z' },
             } ] },
             ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                ScheduleDescription => 'every other Monday',
                 StartDate => { DateTime => '2020-03-30T00:00:00Z' },
                 EndDate => { DateTime => '2021-03-30T00:00:00Z' },
                 NextInstance => {

--- a/t/app/controller/waste_sutton_r.t
+++ b/t/app/controller/waste_sutton_r.t
@@ -394,6 +394,7 @@ FixMyStreet::override_config {
 
 
     $e->mock('GetServiceUnitsForObject', sub { $kerbside_bag_data });
+    set_fixed_time('2022-10-12T19:00:00Z');
     subtest 'No requesting a red stripe bag' => sub {
         $mech->get_ok('/waste/12345');
         $mech->content_contains('#E83651');
@@ -454,6 +455,7 @@ FixMyStreet::override_config {
         $e->mock('GetServiceUnitsForObject', sub { $bin_data });
     };
 
+    set_fixed_time('2022-09-09T19:00:00Z');
     subtest 'Assisted collection display for staff' => sub {
         $mech->log_in_ok($staff->email);
         $mech->get_ok('/waste/12345');

--- a/t/cobrand/brent.t
+++ b/t/cobrand/brent.t
@@ -1103,7 +1103,6 @@ FixMyStreet::override_config {
             ServiceTasks => { ServiceTask => {
                 Id => 401,
                 ServiceTaskSchedules => { ServiceTaskSchedule => {
-                    ScheduleDescription => 'every other Wednesday',
                     StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                     EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                     NextInstance => {
@@ -1124,7 +1123,6 @@ FixMyStreet::override_config {
             ServiceTasks => { ServiceTask => {
                 Id => 36384495,
                 ServiceTaskSchedules => { ServiceTaskSchedule => {
-                    ScheduleDescription => 'Wednesday every other week',
                     Allocation => {
                         RoundName => 'Wednesday',
                         RoundGroupName => 'Delta 12 Week 2',
@@ -1148,9 +1146,7 @@ FixMyStreet::override_config {
             ServiceName => 'Domestic Food Waste Collection',
             ServiceTasks => { ServiceTask => {
                 Id => 403,
-                ScheduleDescription => 'every Thursday fortnightly',
                 ServiceTaskSchedules => { ServiceTaskSchedule => {
-                    ScheduleDescription => 'every other Thursday',
                     StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                     EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                     NextInstance => {
@@ -1177,7 +1173,6 @@ FixMyStreet::override_config {
                 TaskTypeId => 4317,
                 Data => '',
                 ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                    ScheduleDescription => 'every other Wednesday',
                     Allocation => {
                         RoundName => 'Wednesday',
                         RoundGroupName => 'PaperCard07 WKB',
@@ -1210,7 +1205,6 @@ FixMyStreet::override_config {
                     Value => 1,
                 } ] },
                 ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                    ScheduleDescription => 'every other Monday',
                     Allocation => {
                         RoundName => 'Monday ',
                         RoundGroupName => 'Delta 04 Week 2',
@@ -1279,7 +1273,7 @@ FixMyStreet::override_config {
     $mech->content_contains("(07:30&ndash;08:30)", 'shows time band');
     $mech->content_contains('https://example.org/media/16420712/wednesdayweek2', 'showing PDF calendar');
     $mech->content_contains('https://example.org/media/16420712/mondayweek2', 'showing green garden waste PDF calendar');
-    $mech->content_contains('every Thursday', 'food showing right schedule');
+    $mech->content_contains('Every Thursday', 'food showing right schedule');
 
     subtest 'test requesting a container' => sub {
         set_fixed_time('2025-01-27T12:00:00Z'); # After new general bin notice text
@@ -1538,7 +1532,6 @@ FixMyStreet::override_config {
             ServiceTasks => { ServiceTask => {
                 Id => 401,
                 ServiceTaskSchedules => { ServiceTaskSchedule => {
-                    ScheduleDescription => 'every other Wednesday',
                     StartDate => { DateTime => '2020-01-01T00:00:00Z' },
                     EndDate => { DateTime => '2050-01-01T00:00:00Z' },
                     NextInstance => {
@@ -1599,7 +1592,6 @@ FixMyStreet::override_config {
                     Value => 1,
                 } ] },
                 ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                    ScheduleDescription => 'Monday every 4th week',
                     Allocation => {
                         RoundName => 'Monday ',
                         RoundGroupName => 'Delta 04 Week 2',

--- a/t/cobrand/bromley_waste.t
+++ b/t/cobrand/bromley_waste.t
@@ -450,7 +450,6 @@ subtest 'Checking correct renewal prices' => sub {
                         } ] },
                     } ] },
                     ServiceTaskSchedules => { ServiceTaskSchedule => [ {
-                        ScheduleDescription => 'every other Monday',
                         StartDate => { DateTime => '2021-06-14T23:00:00Z' },
                         EndDate => { DateTime => '2021-07-14T23:00:00Z' },
                         NextInstance => {
@@ -889,7 +888,6 @@ subtest 'check direct debit reconcilliation' => sub {
                 ServiceName => 'Garden waste collection',
                 ServiceTasks => { ServiceTask => {
                     Id => 405,
-                    ScheduleDescription => 'every other Monday',
                     Data => { ExtensibleDatum => [ {
                         DatatypeName => 'LBB - GW Container',
                         ChildData => { ExtensibleDatum => {
@@ -925,7 +923,6 @@ subtest 'check direct debit reconcilliation' => sub {
                 ServiceName => 'Garden waste collection',
                 ServiceTasks => { ServiceTask => {
                     Id => 405,
-                    ScheduleDescription => 'every other Monday',
                     Data => { ExtensibleDatum => [ {
                         DatatypeName => 'LBB - GW Container',
                         ChildData => { ExtensibleDatum => {


### PR DESCRIPTION
Rather than rely upon a task or schedule description. [skip changelog]

For FD-6114 (date display from that is fixed, this is about the frequency display which is still wrong)

Most file changes are removing now-unused ScheduleDescriptions; some tests had to have time changes so that the last/next were actually displaying the right things (rather than relying on the description as previously); some code no longer needs to check for 'fortnightly'; the substantive change is in `Echo.pm`, to store the last/next original dates, and pick the closest weeks from them. This will display the wrong day if the next schedule's original date was a different day, but not sure there's a lot we can do then.