### PR TITLE
[Bristol] Override ignored USRNs when sending to Alloy

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bristol.pm
+++ b/perllib/FixMyStreet/Cobrand/Bristol.pm
@@ -249,9 +249,15 @@ sub lookup_site_code_config {
 sub open311_update_missing_data {
     my ($self, $row, $h, $contact) = @_;
 
-    if ($contact->email =~ /^Alloy-/ && !$row->get_extra_field_value('usrn')) {
-        if (my $usrn = $self->lookup_site_code($row)) {
-            $row->update_extra_field({ name => 'usrn', value => $usrn });
+    if ($contact->email =~ /^Alloy-/) {
+        my $stored_usrn = $row->get_extra_field_value('usrn');
+        my %ignored = map { $_ => 1 } @{ $self->_ignored_usrns };
+
+        # Look up USRN if it's empty or if it's in the ignored list
+        if (!$stored_usrn || $ignored{$stored_usrn}) {
+            if (my $usrn = $self->lookup_site_code($row)) {
+                $row->update_extra_field({ name => 'usrn', value => $usrn });
+            }
         }
     };
 }


### PR DESCRIPTION
The report may get a USRN value from the frontend which is one that should be ignored when sending to Alloy. Now we replace it with the correct code if that's the case.

I think this means we can remove the asset layer config that stores the USRN:
```
usrn:
      attribute: USRN
      field: usrn
```

but we need to leave the actual asset layer in to ensure a valid location is selected.

[skip changelog]