### PR TITLE
[Open311] Protect contacts with send_method from service list updates

### DIFF
--- a/perllib/Open311/PopulateServiceList.pm
+++ b/perllib/Open311/PopulateServiceList.pm
@@ -142,6 +142,8 @@ sub _action_params {
 sub _handle_existing_contact {
     my ( $self, $contact ) = @_;
 
+    return if $contact->send_method; # don't clobber devolved contacts
+
     my $service_name = $self->_normalize_service_name;
     my $protected = $contact->get_extra_metadata("open311_protect");
 


### PR DESCRIPTION
Treat contacts that have a send_method set the same as if open311_protect is set.

[skip changelog]