### PR TITLE
[Aberdeenshire] Interpolate into response templates more extra fields in incoming updates

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Aberdeenshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Aberdeenshire.pm
@@ -173,9 +173,10 @@ Aberdeenshire want certain defect fields shown in updates on FMS.
 
 These values, if present, are passed back from open311-adapter in the
 <extras> element. If the template being used for this update has placeholders
-like '{{targetDate}}', '{{jobStartDate}}', '{{featureSPD}}', or '{{featureCCAT}}' in its text,
-they get replaced with the value from Confirm. If there is no value then 'TBC'
-is used for targetDate and jobStartDate, or an empty string for featureSPD and featureCCAT.
+like '{{targetDate}}', '{{jobStartDate}}', or any fields configured in the
+'response_template_variables' Config entry, they get replaced with the value
+from Confirm. If there is no value then 'TBC' is used for date fields, or an
+empty string for other fields.
 
 Additionally, the incoming update might be for a defect which has superseded an
 existing one, so if that's the case we need to identify and close it.
@@ -202,8 +203,13 @@ sub open311_get_update_munging {
         }
     }
 
-    # Handle other fields as-is
-    for my $field (qw(featureSPD featureCCAT)) {
+    # Get a list of plain text variables from DB
+    my $vars = FixMyStreet::DB->resultset("Config")->get('response_template_variables');
+    my @fields = ();
+    if ($vars && $vars->{$self->moniker}) {
+        @fields = @{ $vars->{$self->moniker} };
+    }
+    for my $field (@fields) {
         if ($text =~ /\{\{$field}}/) {
             my $value = '';
             if ($request->{extras} && $request->{extras}->{$field}) {
@@ -219,7 +225,6 @@ sub open311_get_update_munging {
     return unless $supersedes && $supersedes =~ /^DEFECT_/;
 
     $self->_supersede_report($comment->problem, $supersedes);
-
 }
 
 =head2 open311_report_fetched

--- a/t/open311/getservicerequestupdates.t
+++ b/t/open311/getservicerequestupdates.t
@@ -511,6 +511,14 @@ subtest 'Check template placeholders' => sub {
 };
 
 subtest 'Check Aberdeenshire template interpolation' => sub {
+    # Set up Config for allowed template vars
+    FixMyStreet::DB->resultset("Config")->find_or_create({
+        key => 'response_template_variables',
+        value => {
+            aberdeenshire => ['featureSPD', 'featureCCAT']
+        }
+    });
+
     my $tpl = $bodies{2648}->response_templates->create({
         title => "a placeholder in progress template",
         text => "Target date: {{targetDate}}\nCategory: {{featureCCAT}}\nSpeed limit: {{featureSPD}}",


### PR DESCRIPTION
This adds `jobStartDate` to the fields that are processed and formatted as dates, and uses `FixMyStreet::DB::Result::Config` for the plain text fields rather than an ever expanding hardcoded list.

For FD-6155, and FD-6157.

[skip changelog]