### PR TITLE
[Merton] Extend filter for TfL River categories

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Merton.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton.pm
@@ -167,7 +167,7 @@ Hide TfL's River Piers categories on the Merton cobrand.
 sub categories_restriction {
     my ($self, $rs) = @_;
 
-    return $rs->search( { 'me.category' => { -not_like => 'River Piers%' } } );
+    return $rs->search( { 'me.category' => { -not_like => 'River %' } } );
 }
 
 =head2 check_report_is_on_cobrand_asset


### PR DESCRIPTION
Same as done for Brent - open up filter to anything beginning 'River '

For FD-6246

[skip changelog]