### PR TITLE
[Bromley] Chinbrook Meadows asset layer

### DIFF
--- a/web/cobrands/fixmystreet-uk-councils/assets.js
+++ b/web/cobrands/fixmystreet-uk-councils/assets.js
@@ -325,6 +325,14 @@ fixmystreet.assets.bromley.add_park_message = function(layer) {
     layer.map_messaging.asset = layer.fixmystreet.no_asset_message;
 };
 
+fixmystreet.assets.bromley.chinbrook_found = function(layer) {
+    fixmystreet.message_controller.road_not_found(layer, function() {return true;});
+};
+
+fixmystreet.assets.bromley.chinbrook_not_found = function(layer) {
+    fixmystreet.message_controller.road_found(layer);
+};
+
 /* Buckinghamshire */
 
 fixmystreet.assets.buckinghamshire = {};


### PR DESCRIPTION
This adds the JS for a new asset layer for Bromley.

You'll need to add the following under Bromley's `asset_layers:` key in general.yml:

```yaml
- wfs_feature: "Chinbrook_Meadows"
  asset_type: 'area'
  always_visible: true
  road: true
  non_interactive: true
  stylemap: fixmystreet.assets.stylemap_invisible
  no_asset_message: The location you have selected is within Chinbrook Meadows, which is not accessible for public reporting.
  actions:
    found: fixmystreet.assets.bromley.chinbrook_found
    not_found: fixmystreet.assets.bromley.chinbrook_not_found
```

See also https://github.com/mysociety/fixmystreet.com/pull/76

For FD-6165

You can find Chinbrook Meadows just south-east of Grove Park station:

<img width="557" height="621" alt="image" src="https://github.com/user-attachments/assets/967b37bc-f52c-4461-85c7-c423bde2103c" />


<!-- [skip changelog] -->
