### PR TITLE
[Bexley][GGW] Pass along customer ref for renewal-as-new-sub

### DIFF
--- a/perllib/FixMyStreet/App/Form/Waste/Garden/Verify/Bexley.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Garden/Verify/Bexley.pm
@@ -100,6 +100,10 @@ sub about_you {
 
             if ($name_verified) {
                 $form->saved_data->{name} = $first_name . ' ' . $last_name;
+
+                $form->saved_data->{customer_external_ref}
+                    = $current_subscription->{customer_external_ref};
+
                 return $args{next_page};
 
             } elsif ( $form->isa('FixMyStreet::App::Form::Waste::Garden::Renew::Bexley') ) {

--- a/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
@@ -289,8 +289,7 @@ sub waste_garden_sub_params {
     } elsif ( $data->{title} =~ /Renew/ ) {
         $c->set_param( 'type', 'renew' );
         $c->set_param( 'total_containers', $data->{bins_wanted} );
-        $c->set_param( 'customer_external_ref', $srv->{customer_external_ref} )
-            unless $data->{blank_customer_external_ref};
+        $c->set_param( 'customer_external_ref', $srv->{customer_external_ref} );
 
     } elsif ( $data->{title} =~ /Amend/ ) {
         $c->set_param( 'type', 'amend' );


### PR DESCRIPTION
Minor thing, but we were saving it on customer_reference page but not when verification passed on about_you page.

[skip changelog]