### PR TITLE
[Merton] Allow garden waste renewal with disabled bins_wanted field

### DIFF
--- a/perllib/FixMyStreet/App/Form/Waste/Garden/Renew/Shared.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Garden/Renew/Shared.pm
@@ -202,8 +202,9 @@ has_field submit => (
 sub validate {
     my $self = shift;
     my $max_bins = $self->{c}->stash->{garden_form_data}->{max_bins};
-    unless ( $self->field('bins_wanted')->is_inactive ) {
-        my $total = $self->field('bins_wanted')->value;
+    my $bins_wanted = $self->field('bins_wanted');
+    unless ( $bins_wanted->is_inactive || $bins_wanted->disabled ) {
+        my $total = $bins_wanted->value;
         $self->add_form_error('The total number of bins cannot exceed ' . $max_bins)
             if $total > $max_bins;
 


### PR DESCRIPTION
Update the garden waste renewal to skip validation of the bins wanted field if its disabled.

This handles exceptional cases where the customer has more bins than $max_bins so that they can renew. Also seems like a sensible default for other cobrands, since it doesn't make sense to validate a field that you can't change.

For FD-6281

<!-- [skip changelog] -->