### PR TITLE
[Kingston][Sutton] Remove fms emergency messaging admin

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Kingston.pm
+++ b/perllib/FixMyStreet/Cobrand/Kingston.pm
@@ -29,6 +29,16 @@ sub council_name { return 'Kingston upon Thames Council'; }
 sub council_url { return 'kingston'; }
 sub admin_user_domain { 'kingston.gov.uk' }
 
+=head2 wasteworks_only
+
+Configuration for cobrands which don't have street reporting.
+Currently in use for the ooh messages on the admin page to
+remove unnecessary fields.
+
+=cut
+
+sub wasteworks_only { 1 }
+
 my %SERVICE_IDS = (
     domestic_refuse => 966, # 4394
     communal_refuse => 969, # 4407

--- a/perllib/FixMyStreet/Cobrand/Sutton.pm
+++ b/perllib/FixMyStreet/Cobrand/Sutton.pm
@@ -28,6 +28,16 @@ sub council_name { return 'Sutton Council'; }
 sub council_url { return 'sutton'; }
 sub admin_user_domain { 'sutton.gov.uk' }
 
+=head2 wasteworks_only
+
+Configuration for cobrands which don't have street reporting.
+Currently in use for the ooh messages on the admin page to
+remove unnecessary fields.
+
+=cut
+
+sub wasteworks_only { 1 }
+
 my %SERVICE_IDS = (
     domestic_refuse => 940, # 4394
     communal_refuse => 943, # 4407

--- a/t/app/controller/admin/sitemessage.t
+++ b/t/app/controller/admin/sitemessage.t
@@ -8,7 +8,8 @@ my $bexley = $mech->create_body_ok(2494, 'Bexley Council', { cobrand => 'bexley'
 $mech->create_contact_ok(body_id => $bexley->id, category => 'Damaged road', email => "ROAD");
 my $body = $mech->create_body_ok(2237, 'Oxfordshire County Council', { cobrand => 'oxfordshire' });
 my $user = $mech->create_user_ok('user@example.com', name => 'Test User', from_body => $body);
-
+my $sutton = $mech->create_body_ok(2498, 'Sutton Borough Council', { cobrand => 'sutton' });
+my $sutton_user = $mech->create_user_ok('sutton_user@example.com', name => 'Test User', from_body => $sutton);
 $mech->log_in_ok( $user->email );
 
 my $ukc = Test::MockModule->new('FixMyStreet::Cobrand::UK');
@@ -60,6 +61,46 @@ FixMyStreet::override_config {
 };
 
 FixMyStreet::override_config {
+    ALLOWED_COBRANDS => [ 'sutton' ],
+    COBRAND_FEATURES => { waste => { sutton => 1 } },
+}, sub {
+    subtest "Sutton don't have Report or Homepage message form elements" => sub     {
+        $sutton_user->user_body_permissions->create({
+            body => $sutton,
+            permission_type => 'emergency_message_edit',
+        });
+        $mech->log_in_ok( $sutton_user->email );
+        $mech->get_ok('/admin/sitemessage');
+        $mech->content_lacks('Reporting page');
+        $mech->content_lacks('Homepage');
+        $mech->content_contains('Waste message');
+        $mech->content_contains('Out of hours periods');
+        $mech->submit_form_ok( { with_fields => &_create_full_fields });
+        $sutton->discard_changes;
+        is $sutton->get_extra_metadata->{site_message_waste}, 'Message for all bin users';
+        is $sutton->get_extra_metadata->{site_message_waste_ooh}, 'Message for all night owls';
+        is_deeply $sutton->get_extra_metadata->{ooh_times}, [['1', 15, 30]];
+    }
+};
+
+sub _create_full_fields {
+    my $fields = {
+            'site_message_waste' => 'Message for all bin users',
+            'site_message_waste_ooh' => 'Message for all night owls',
+            'ooh[0].day' => '1',
+            'ooh[0].start' => '00:15',
+            'ooh[0].end' => '00:30',
+    };
+    for my $index (1..12, 9999) {
+        $fields->{'ooh[' . $index . '].day'} = '0';
+        $fields->{'ooh[' . $index . '].start'} = '00:00';
+        $fields->{'ooh[' . $index . '].end'} = '00:00';
+    };
+
+    return $fields;
+}
+
+FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'oxfordshire' ],
     COBRAND_FEATURES => { waste => { oxfordshire => 1 } },
 }, sub {
@@ -68,7 +109,7 @@ FixMyStreet::override_config {
             body => $body,
             permission_type => 'emergency_message_edit',
         });
-
+        $mech->log_in_ok( $user->email );
         $mech->get_ok('/admin/sitemessage');
         $mech->content_contains('Waste message');
         $mech->submit_form_ok({ with_fields => { site_message_waste => 'Testing site waste message' } });

--- a/templates/web/base/admin/sitemessage/edit.html
+++ b/templates/web/base/admin/sitemessage/edit.html
@@ -11,6 +11,8 @@
 }
 </style>
 
+[% IF !body_cobrand.wasteworks_only %]
+
 <h2>Homepage</h2>
 
 <p>[% loc('This site message will be shown on the homepage.') %]</p>
@@ -32,8 +34,14 @@
         <textarea name="site_message_ooh" class="form-control" rows="10">[% site_message_ooh %]</textarea>
     </p>
     </div>
+[% END %]
 
   [% IF body_cobrand.feature('waste') %]
+    [% IF body_cobrand.wasteworks_only %]
+      <form method="post"
+      accept-charset="utf-8"
+      class="validate">
+    [% END %]
     <h2>WasteWorks</h2>
     <p>The waste message will be shown on all waste pages.</p>
     <div class="two-col">
@@ -47,6 +55,8 @@
     </p>
     </div>
   [% END %]
+
+[% IF !body_cobrand.wasteworks_only %]
 
     <h2>Reporting page</h2>
 
@@ -66,7 +76,7 @@
     </p>
     </div>
   [% END %]
-
+[% END %]
 <h2>Out of hours periods</h2>
 
 <p>


### PR DESCRIPTION
Remove the fields from the emergency/site messaging admin that don't have a use for WasteWorks only cobrands.

https://mysocietysupport.freshdesk.com/a/tickets/6263

[skip changelog]