### PR TITLE
[Brent] Adds container request form

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1339,7 +1339,7 @@ sub add_report : Private {
         $c->forward('/report/new/redirect_or_confirm_creation', [ 1 ]);
     }
 
-    $c->cobrand->call_hook('waste_post_report_creation', $report);
+    $c->cobrand->call_hook('waste_post_report_creation', $report, $data);
 
     $c->user->update({ name => $original_name }) if $original_name;
 

--- a/perllib/FixMyStreet/App/Form/Waste/Request/Brent.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Request/Brent.pm
@@ -52,11 +52,6 @@ has_page about_you => (
     next => 'summary',
 );
 
-has_page request_refuse_call_us => (
-    fields => [],
-    template => 'waste/refuse_call_us.html',
-);
-
 has_page request_extra_refusal => (
     fields => [],
     template => 'waste/refuse_extra_container.html',
@@ -70,6 +65,10 @@ has_page replacement => (
         my $choice = $data->{"container-choice"};
         my $reason = $data->{request_reason};
 
+        if ($choice == $CONTAINER_GREY_BIN && $reason eq 'extra') {
+            return 'request_extra_refusal' if $data->{refuse_outcome};
+            return 'request_refuse_container';
+        }
         return 'about_you' if $choice == $CONTAINER_CLEAR_SACK;
         return 'how_long_lived' if $reason eq 'new_build';
         return 'request_extra_refusal' if $reason eq 'extra' && $data->{ordered_previously};
@@ -146,7 +145,7 @@ sub options_request_reason {
         push @options, { value => 'damaged', label => 'My container is damaged' };
         push @options, { value => 'missing', label => 'My container is missing' };
     } else {
-        push @options, { value => 'new_build', label => 'I am a new resident without a container' };
+        push @options, { value => 'new_build', label => 'I am a new resident without a container' } unless $choice == $CONTAINER_GREY_BIN;
         push @options, { value => 'damaged', label => 'My container is damaged' };
         push @options, { value => 'missing', label => 'My container is missing' };
         push @options, { value => 'extra', label => 'I would like an extra container' };
@@ -168,6 +167,33 @@ has_field how_long_lived => (
     options => [
         { value => 'less3', label => 'Less than 3 months' },
         { value => '3more', label => '3 months or more' },
+    ],
+);
+
+has_page request_refuse_container => (
+    title => 'Household details',
+    intro => 'refuse_call_us.html',
+    fields => [ 'property_people', 'property_children', 'continue'],
+    next => 'about_you',
+);
+
+has_field property_people =>(
+    required => 1,
+    type => 'Select',
+    label => 'How many people live at your property?',
+    options => [
+        { value => '1', label => 'Up to 5' },
+        { value => '6', label => '6 or more' }
+    ],
+);
+
+has_field property_children =>(
+    required => 1,
+    type => 'Select',
+    label => 'Do any children live at the property?',
+    options => [
+        { value => 'No', label => 'No' },
+        { value => 'Yes', label => 'Yes' }
     ],
 );
 

--- a/perllib/FixMyStreet/Cobrand/Brent.pm
+++ b/perllib/FixMyStreet/Cobrand/Brent.pm
@@ -1228,6 +1228,9 @@ sub waste_munge_request_form_fields {
         next unless $key =~ /^container-(\d+)/;
         my $id = $1;
         my ($cost, $hint) = $self->request_cost($id);
+        if (!$hint) {
+            $hint = $id == $CONTAINER_IDS{rubbish_grey_bin} ? 'Chargeable - Subject to approval' : '';
+        }
         push @radio_options, {
             value => $id,
             label => $self->{c}->stash->{containers}->{$id},
@@ -1291,7 +1294,7 @@ sub waste_munge_request_data {
 
     my $c = $self->{c};
 
-    for (qw(how_long_lived contamination_reports ordered_previously)) {
+    for (qw(how_long_lived contamination_reports ordered_previously property_people property_children)) {
         $c->set_param("request_$_", $data->{$_} || '');
     }
     if (request_referral($id, $data)) {
@@ -1357,6 +1360,20 @@ sub request_referral {
     # return 1 if ($data->{contamination_reports} || 0) >= 3; # Will be present on missing only
     return 1 if ($data->{how_long_lived} || '') eq '3more'; # Will be present on new build only
     return 1 if $data->{ordered_previously};
+
+    if (
+        ( ($data->{'container-choice'} && $data->{'container-choice'} == $CONTAINER_IDS{rubbish_grey_bin})
+          || $data->{'container-' . $CONTAINER_IDS{rubbish_grey_bin}}
+        )
+    ) {
+        if ($data->{request_reason} eq 'extra') {
+            if ($data->{property_people} == 6 || $data->{property_children} eq 'Yes') {
+                return 1;
+            }
+        } else {
+          return 1;
+        }
+    }
 }
 
 sub waste_request_form_first_title { 'Which container do you need?' }
@@ -1366,7 +1383,26 @@ sub waste_request_form_first_next {
     return sub {
         my $data = shift;
         my $choice = $data->{"container-choice"};
-        return 'request_refuse_call_us' if $choice == $CONTAINER_IDS{rubbish_grey_bin};
+        if ($choice == $CONTAINER_IDS{rubbish_grey_bin}) {
+            my $date = DateTime->now()->subtract( weeks => 2 );
+            my $parser = DateTime::Format::Strptime->new( pattern => '%Y-%m-%d');
+            my $c = $self->{c};
+            $data->{refuse_outcome} = $c->cobrand->problems->search(
+                {
+                    category => 'Request new container',
+                    title => ['Request new General rubbish bin (grey bin)'],
+                    confirmed => { '>=', $parser->format_datetime($date) },
+                    uprn => $c->stash->{property}{uprn},
+                }
+            )->first;
+        };
+        if ($data->{refuse_outcome}) {
+            if ($data->{refuse_outcome}->get_extra_field_value('request_referral')) {
+                $data->{refuse_outcome} = 'referral';
+            } else {
+                $data->{refuse_outcome} = 'capacity';
+            }
+        };
         return 'replacement';
     };
 }
@@ -1492,6 +1528,26 @@ sub waste_garden_mod_params {
         $c->set_param('Container_Quantity', $data->{new_bins});
     }
 }
+
+
+sub waste_post_report_creation {
+    my ($self, $report, $data) = @_;
+
+    if (
+        $report->title =~ /Request new General rubbish bin \(grey bin\)/
+        && $data->{request_reason} eq 'extra'
+        ) {
+
+        if ($report->get_extra_field_value('request_referral')) {
+            $report->detail('Request forwarded to Brent Council by email');
+        } else {
+            $self->{c}->stash->{brent_request_automatic} = 1;
+            $report->detail('Request automatically calculated');
+            $report->state('fixed - council');
+        }
+        $report->update;
+    }
+};
 
 =item * Uses custom text for the title field for new reports.
 

--- a/templates/web/base/waste/confirmation.html
+++ b/templates/web/base/waste/confirmation.html
@@ -2,6 +2,8 @@
 IF report.category == 'Request new container' || report.category == 'Request container removal';
     IF cobrand.moniker == 'bexley';
         title = 'Your bin request has been sent';
+    ELSIF cobrand.moniker == 'brent' AND brent_request_automatic;
+        title = '';
     ELSE;
         title = 'Your container request has been sent';
     END;
@@ -14,11 +16,27 @@ ELSE;
 END ~%]
 [% PROCESS 'waste/header.html' %]
 
+[% IF report.category == 'Request new container' && c.cobrand.moniker == 'brent' && brent_request_automatic %]
+<div class="govuk-panel govuk-panel--warning">
+[% ELSE %]
 <div class="govuk-panel govuk-panel--confirmation">
+[% END %]
     <h1 class="govuk-panel__title">
         [% title %]
     </h1>
     <div class="govuk-panel__body">
+        [% IF report.category == 'Request new container' && c.cobrand.moniker == 'brent' %]
+            [% IF NOT brent_request_automatic %]
+            <p class="govuk-body">Your application has been sent to Brent Council who will
+            contact you to let you know if your request has been approved. If it has, they will need
+            to take payment before any bins can be delivered.
+            </p>
+            [% ELSE %]
+            <p class="govuk-body">
+                Your property meets current general waste bin capacity requirements.
+            </p>
+            [% END %]
+        [% ELSE %]
         <p>
             [% IF report.user.email && report.get_extra_metadata('contributed_as') != 'anonymous_user' %]
                 A copy has been sent to your email address, [% report.user.email %].
@@ -30,6 +48,7 @@ END ~%]
           [% END %]
           [% INCLUDE 'waste/_report_ids.html' %]
         </p>
+        [% END %]
     </div>
 </div>
 

--- a/templates/web/base/waste/summary_request.html
+++ b/templates/web/base/waste/summary_request.html
@@ -28,8 +28,29 @@ step1 = first_page;
             [% IF data.$removal_key %][% data.$removal_key %] to remove[% END %]
         </dd>
       [% END %]
-    </div>
-  [% END %]
+      </div>
+      [% IF c.cobrand.moniker == 'brent' AND containers.$container_id == 'General rubbish bin (grey bin)' AND data.request_reason == 'extra' %]
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Household details</dt>
+        <dd class="govuk-summary-list__value"></dd>
+        <dd class="govuk-summary-list__actions">
+          <form method="post">
+            <input type="hidden" name="saved_data" value="[% form.fif.saved_data %]">
+            <input type="hidden" name="goto" value="request_refuse_container">
+            <input type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" value="Change answers">
+          </form>
+        </dd>
+      </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-summary-list__key--sub">People at propery</dt>
+          <dd class="govuk-summary-list__value">[% label_for_field(form, 'property_people', data.property_people) %]</dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-summary-list__key--sub">Children at property</dt>
+          <dd class="govuk-summary-list__value">[% label_for_field(form, 'property_children', data.property_children) %]</dd>
+        </div>
+      [% END %]
+    [% END %]
   [% FOR removal IN data.keys.grep('^removal-') %]
     [% SET container_key = removal.replace('removal-', 'container-') %]
     [% SET container_id = removal.replace('removal-', '') %]

--- a/templates/web/brent/waste/refuse_call_us.html
+++ b/templates/web/brent/waste/refuse_call_us.html
@@ -1,11 +1,3 @@
-[% USE date(format='%Y%m%d') ~%]
-[% PROCESS 'waste/header.html' %]
-[% IF property %]
-    [% INCLUDE 'waste/_address_display.html' %]
-[% END %]
-
-<h1 class="govuk-heading-xl">Please complete this form to apply for a new/replacement refuse bin</h1>
-
 <p class="govuk-body">New and replacement rubbish bins cost:</p>
 <ul class="govuk-list govuk-list--bullet">
     <li>£65 for a 140 litre bin</li>
@@ -21,7 +13,3 @@ a general waste bin. You can find out more by reading
 <a href="https://www.legislation.gov.uk/ukpga/1990/43/section/46" target="_blank">Section 46 of the Environmental Protection Act 1990</a>.
 </p>
 
-<p class="govuk-body"><a class="btn" href="https://brent-self.achieveservice.com/en/AchieveForms/?form_uri=sandbox-publish://AF-Form-cbd6c86f-4b36-47e5-b571-c86e6fcefaef/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen&consentMessage=yes">Apply for a new/replacement refuse bin</a>
-</p>
-
-[% INCLUDE footer.html %]

--- a/templates/web/brent/waste/refuse_extra_container.html
+++ b/templates/web/brent/waste/refuse_extra_container.html
@@ -6,8 +6,12 @@
 <h1 class="govuk-heading-xl">Request new container</h1>
 
 <p class="govuk-body">
-We are unable to complete your request because our records show a similar container was recently ordered to this address.
-If you require further assistance, please email [% c.cobrand.feature('open311_email').item("Request new container") %].
+[% IF form.saved_data.refuse_outcome AND form.saved_data.refuse_outcome == 'capacity' %]
+    Your property meets current general waste bin capacity requirements.
+[% ELSE %]
+    We are unable to complete your request because our records show a similar container was recently ordered to this address.
+    If you require further assistance, please email [% c.cobrand.feature('open311_email').item("Request new container") %].
+[% END %]
 </p>
 
 [% INCLUDE footer.html %]

--- a/web/cobrands/brent/base.scss
+++ b/web/cobrands/brent/base.scss
@@ -550,6 +550,11 @@ dl dt {
   background-repeat: no-repeat;
 }
 
+.govuk-panel--warning {
+    color: #000;
+    background: #d8a166;
+}
+
 // Waste
 .waste {
   .content {


### PR DESCRIPTION
Add a form for ordering a grey refuse container to collect information about the request and send it by email to the Council.

If the household is not going to be successful in its application according to certain data collected, pre-empt the application by stopping the process.

Prohibit reapplication for a period of two weeks to prevent unnecessary reapplications.

https://github.com/mysociety/societyworks/issues/5120#issuecomment-3556888655
[skip changelog]