### PR TITLE
[Westminster] Add manually edited Open311 categories

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Westminster.pm
+++ b/perllib/FixMyStreet/Cobrand/Westminster.pm
@@ -211,6 +211,7 @@ sub categories_restriction {
             -or => [
                 'me.send_method' => undef, # Open311 categories
                 'me.send_method' => '', # Open311 categories that have been edited in the admin
+                'me.send_method' => 'Open311', # Open311 categories that have been added manually - rare
             ]
         });
 }


### PR DESCRIPTION
Request to manually add two open311 categories requires category filter for site to allow Open311 send method to be shown on the site

https://mysocietysupport.freshdesk.com/a/tickets/6335

[skip changelog]