### PR TITLE
[Admin] Fix tabs when report has no updates

### DIFF
--- a/templates/web/base/admin/reports/_edit_main.html
+++ b/templates/web/base/admin/reports/_edit_main.html
@@ -235,9 +235,12 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
       </ul>
   [% END %]
 
-    <section id="section_updates">
+    [% IF updates.size %]
+      <section id="section_updates">
         [% INCLUDE 'admin/list_updates.html' %]
-    </section>
+      </section>
+    [% END %]
+
 
  [% IF moderation_history %]
   <section id="section_moderation">


### PR DESCRIPTION
Odd behaviour and JS errors in console:

![tabs](https://github.com/user-attachments/assets/fe8a874b-df9e-49a4-b906-235871565857)

[skip changelog]