### PR TITLE
[Merton] Don't show total for current year ggw modification

### DIFF
--- a/t/app/controller/waste_merton_garden.t
+++ b/t/app/controller/waste_merton_garden.t
@@ -594,7 +594,7 @@ FixMyStreet::override_config {
         $mech->content_contains($two_cost_human);
         $mech->content_contains($delivery_human);
         $mech->submit_form_ok({ with_fields => { goto => 'alter' } });
-        $mech->content_contains('<span id="cost_per_year">' . $two_cost_human);
+        $mech->content_lacks('<span id="cost_per_year">' . $two_cost_human);
         $mech->content_contains('<span id="pro_rata_cost">' . $total_human);
         $mech->submit_form_ok({ with_fields => { current_bins => 1, bins_wanted => 2 } });
         $mech->waste_submit_check({ with_fields => { tandc => 1 } });

--- a/templates/web/base/waste/garden/modify.html
+++ b/templates/web/base/waste/garden/modify.html
@@ -20,9 +20,11 @@
     data-per_new_bin_cost="[% garden_costs.per_new_bin %]"
     data-pro_rata_bin_cost="[% garden_costs.per_pro_rata_bin %]"
   >
+  [% IF c.cobrand.moniker != 'merton' %]
     <span class="cost-pa__total-costs">
     Total per year, from [% display_end_date.strftime('%e %B %Y') %]: £<span id="cost_per_year">[% tprintf('%.2f', cost_pa) %]</span>
     </span>
+  [% END %]
   [% IF garden_costs.per_new_bin %]
     <span class="cost-pa__total-costs">
         Admin fee: £<span id="cost_now_admin">[% tprintf( '%.2f', cost_now_admin ) %]</span>


### PR DESCRIPTION
Try removing line showing total for current year for ggw when modifying a subscription to see if useful for making what the information clearer.

https://mysocietysupport.freshdesk.com/a/tickets/6331

[skip changelog]