### PR TITLE
Refactor front_stats_data to use static JSON files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
         - Only update lastupdate timestamp if update timestamp is newer. #5350
         - Add ability to process extra question disable messages from endpoint. #5431
         - Persist send_method_used immediately during report sending to prevent loss when senders call discard_changes(). #5671
+    - Performance improvements:
+        - Use on-disk cache for front page stats rather than memcache. #5763
 
 * v6.0 (14th November 2024)
     - Front end improvements:

--- a/bin/generate-front-stats
+++ b/bin/generate-front-stats
@@ -1,0 +1,64 @@
+#!/usr/bin/env perl
+
+# generate-front-stats: Generate and store front page statistics for all cobrands
+#
+# Usage:
+#
+# $ bin/generate-front-stats [--verbose]
+
+use v5.14;
+use warnings;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../setenv.pl";
+    STDOUT->autoflush(1);
+}
+
+use FixMyStreet;
+use FixMyStreet::Cobrand;
+use FixMyStreet::DB;
+use Getopt::Long;
+use JSON::MaybeXS;
+use Path::Tiny;
+
+my $verbose = 0;
+
+GetOptions(
+    'verbose' => \$verbose,
+);
+
+my @cobrands = FixMyStreet::Cobrand->available_cobrand_classes;
+my $all_stats = {};
+
+foreach my $cobrand_info (@cobrands) {
+    my $cobrand_class = $cobrand_info->{class};
+    next unless $cobrand_class;
+    my $cobrand = $cobrand_class->new;
+    my $moniker = $cobrand->moniker;
+
+    print "Generating stats for $moniker... " if $verbose;
+
+    eval {
+        my $stats = $cobrand->calculate_front_stats_data;
+        $all_stats->{$moniker} = $stats;
+        print "done.\n" if $verbose;
+    };
+    if ($@) {
+        warn "Error generating stats for $moniker: $@\n";
+    }
+}
+
+# Add generation timestamp
+$all_stats->{_generated} = time();
+
+# Write consolidated stats file
+my $dir = FixMyStreet->path_to('../data');
+path($dir)->mkpath unless -d $dir;
+
+my $file = path($dir, "front-page-stats.json");
+$file->spew_utf8(JSON::MaybeXS->new(pretty => 1, canonical => 1)->encode($all_stats));
+
+print "Stats written to $file\n" if $verbose;

--- a/perllib/FixMyStreet/DB/ResultSet/Problem.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Problem.pm
@@ -101,36 +101,26 @@ sub recent_fixed {
 
 sub _recent_in_states {
     my ($rs, $state_key, $states) = @_;
-    my $key = "recent_$state_key:$site_key";
-    return Memcached::get_or_calculate($key, _cache_timeout(), sub {
-        return $rs->search( {
-            state => $states,
-            lastupdate => { '>', \"current_timestamp-'1 month'::interval" },
-        } )->count;
-    });
+    return $rs->search( {
+        state => $states,
+        lastupdate => { '>', \"current_timestamp-'1 month'::interval" },
+    } )->count;
 }
 
 sub number_comments {
     my $rs = shift;
-    my $key = "number_comments:$site_key";
-    return Memcached::get_or_calculate($key, _cache_timeout(), sub {
-        return $rs->search(
-            { 'comments.state' => 'confirmed' },
-            { join => 'comments' }
-        )->count;
-    });
+    return $rs->search(
+        { 'comments.state' => 'confirmed' },
+        { join => 'comments' }
+    )->count;
 }
 
 sub recent_new {
     my ( $rs, $interval ) = @_;
-    (my $key = $interval) =~ s/\s+//g;
-    $key = "recent_new:$site_key:$key";
-    return Memcached::get_or_calculate($key, _cache_timeout(), sub {
-        return $rs->search( {
-            state => [ FixMyStreet::DB::Result::Problem->visible_states() ],
-            confirmed => { '>', \"current_timestamp-'$interval'::interval" },
-        } )->count;
-    });
+    return $rs->search( {
+        state => [ FixMyStreet::DB::Result::Problem->visible_states() ],
+        confirmed => { '>', \"current_timestamp-'$interval'::interval" },
+    } )->count;
 }
 
 # Front page recent lists

--- a/templates/web/base/front/stats.html
+++ b/templates/web/base/front/stats.html
@@ -3,6 +3,7 @@
 [%
     stats = c.cobrand.front_stats_data();
 
+  IF stats;
     new_text =
         stats.recency == '1 week'
         ? nget(
@@ -15,25 +16,25 @@
             "<big>%s</big> reports recently",
             stats.new
          );
-    
-  IF stats.completed.defined;
-    completed_text = nget(
-        "<big>%s</big> completed in past month",
-        "<big>%s</big> completed in past month",
-        stats.completed
-    );
-    completed_n = stats.completed | format_number;
-  END;
 
-  IF stats.fixed.defined;
-    fixed_text = nget(
-        "<big>%s</big> fixed in past month",
-        "<big>%s</big> fixed in past month",
-        stats.fixed
-    );
-    fixed_n = stats.fixed | format_number;
-  END;
-    
+    IF stats.completed.defined;
+      completed_text = nget(
+          "<big>%s</big> completed in past month",
+          "<big>%s</big> completed in past month",
+          stats.completed
+      );
+      completed_n = stats.completed | format_number;
+    END;
+
+    IF stats.fixed.defined;
+      fixed_text = nget(
+          "<big>%s</big> fixed in past month",
+          "<big>%s</big> fixed in past month",
+          stats.fixed
+      );
+      fixed_n = stats.fixed | format_number;
+    END;
+
     updates_text = nget(
         "<big>%s</big> update on reports",
         "<big>%s</big> updates on reports",
@@ -47,3 +48,6 @@
 <div id="front_stats">
     [% PROCESS 'front/_stats.html' %]
 </div>
+[%
+  END;
+%]


### PR DESCRIPTION
Splits the front_stats_data method into two:
- store_front_stats_data: calculates stats and writes to JSON file
- front_stats_data: reads stats from JSON file

Adds bin/generate-front-stats script to generate stats for all cobrands. This allows stats to be generated once (e.g. via cron) rather than on page load.
