### PR TITLE
[WasteWorks] Prevent staff from submitting successful payment if previously marked as failed

### DIFF
--- a/templates/web/base/waste/garden/csc_payment_failed.html
+++ b/templates/web/base/waste/garden/csc_payment_failed.html
@@ -10,7 +10,11 @@
           [% END %]
         </p>
 
-      [% IF report.category == 'Bulky collection' %]
+      [% IF attempted_resubmission %]
+        <p>
+          This booking was previously cancelled so cannot be resubmitted.
+        </p>
+      [% ELSIF report.category == 'Bulky collection' %]
         <p>
             No booking has been created.
           [% IF waste_features.bulky_retry_bookings %]


### PR DESCRIPTION
Closes https://github.com/mysociety/societyworks/issues/4819.

[skip changelog]
