### PR TITLE
[Bromley] [DD] Don’t warn about already processed hidden reports

### DIFF
--- a/perllib/FixMyStreet/Roles/Cobrand/DDProcessor.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/DDProcessor.pm
@@ -135,10 +135,10 @@ sub waste_reconcile_direct_debits {
                 $self->log("looking at potential match " . $cur->id . " with state " . $cur->state);
                 # only match direct debit payments
                 next unless $self->waste_is_dd_payment($cur);
-                # only confirmed records are valid.
-                next unless FixMyStreet::DB::Result::Problem->visible_states()->{$cur->state};
                 # already processed
                 next RECORD if $cur->get_extra_metadata('dd_date') && $cur->get_extra_metadata('dd_date') eq $payment->date;
+                # only confirmed records are valid.
+                next unless FixMyStreet::DB::Result::Problem->visible_states()->{$cur->state};
                 next if $p;
 
                 my $sub_type = $cur->get_extra_field_value($self->garden_subscription_type_field);

--- a/t/cobrand/bromley_waste.t
+++ b/t/cobrand/bromley_waste.t
@@ -1673,6 +1673,15 @@ subtest 'check direct debit reconcilliation' => sub {
     stdout_like {
         $c->waste_reconcile_direct_debits({ reference => $renewal_nothing_in_echo_ref, force_when_missing => 1, verbose => 1 });
     } qr/looking at payment $renewal_nothing_in_echo_ref for £10 on 16\/03\/2021.*?category: Garden Subscription \(2\).*?is a renewal.*?looking at potential match @{[$renewal_nothing_in_echo->id]}.*?is a matching new report.*?created new confirmed report.*?done looking at payment/s, "creates a renewal if forced to";
+
+    # Test that a processed renewal that is then hidden doesn't generate warnings
+    $processed_renewal->discard_changes;
+    $processed_renewal->update({ state => 'hidden' });
+
+    my $processed_renewal_ref = "GGW654324";
+    warnings_are {
+        $c->waste_reconcile_direct_debits({ reference => $processed_renewal_ref });
+    } [], "no warnings for processed renewal that was later hidden";
 };
 
 };


### PR DESCRIPTION
Prevents warnings about subscriptions which were manually marked as hidden after the DD payment was successfully processed.

[skip changelog]