### PR TITLE
[Open311] Handle base64-encoded data URIs when fetching updates/reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
         - Add ability to process extra question disable messages from endpoint. #5431
         - Persist send_method_used immediately during report sending to prevent loss when senders call discard_changes(). #5671
         - Strip EXIF metadata from photos imported via media_url. #5841
+        - Photos can be included as base64-encoded data: URIs when fetching updates/reports. #5785
     - Performance improvements:
         - Use on-disk cache for front page stats rather than memcache. #5763
 

--- a/perllib/Open311.pm
+++ b/perllib/Open311.pm
@@ -17,6 +17,7 @@ use Path::Tiny 'path';
 use FixMyStreet::App::Model::PhotoSet;
 use FixMyStreet::ImageMagick;
 use Try::Tiny;
+use MIME::Base64;
 
 has jurisdiction => ( is => 'ro', isa => Str );;
 has api_key => ( is => 'ro', isa => Str );
@@ -413,7 +414,13 @@ sub add_media {
         my $photo_blob;
         if ($_ =~ /^data:/) {
             my @parts = split ',', $_, 2;
-            $photo_blob = $parts[1];
+            if ($parts[0] =~ m{image/(jpeg|pjpeg|gif|tiff|png)}) {
+                my $data = $parts[1];
+                if ($parts[0] =~ /;base64/) {
+                    $data = decode_base64($data);
+                }
+                $photo_blob = $data;
+            }
         } else {
             my $ua = LWP::UserAgent->new;
             my $res = $ua->get($_);

--- a/t/open311.t
+++ b/t/open311.t
@@ -985,6 +985,37 @@ EOT
     is $c_description, $description, 'description correct';
 };
 
+subtest 'add_media with base64 data URIs' => sub {
+    my $o = Open311->new();
+
+    # 1x1px PNG
+    my $base64_png = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR42mP4z/AfAAQAAf8c9+lcAAAAAElFTkSuQmCC';
+    my $data_uri_base64 = "data:image/png;base64,$base64_png";
+
+    my $test_problem = FixMyStreet::DB->resultset('Problem')->new({
+        latitude => 1,
+        longitude => 1,
+        title => 'test',
+        detail => 'test',
+        user => $user,
+    });
+
+    # Test base64 data URI
+    $o->add_media($data_uri_base64, $test_problem);
+    ok $test_problem->photo, 'photo set from base64 data URI';
+
+    # Test multiple data URIs
+    $test_problem->photo(undef);
+    $o->add_media([$data_uri_base64, $data_uri_base64], $test_problem);
+    ok $test_problem->photo, 'photos set from multiple base64 data URIs';
+
+    # Test invalid MIME type is rejected
+    $test_problem->photo(undef);
+    my $invalid_data_uri = "data:text/plain;base64,bmV2ZXIgZ29ubmEgZ2l2ZSB5b3UgdXA=";
+    $o->add_media($invalid_data_uri, $test_problem);
+    ok !$test_problem->photo, 'photo not set from invalid MIME type data URI';
+};
+
 done_testing();
 
 


### PR DESCRIPTION
Add support for decoding base64-encoded data URIs when processing media URLs. The method now checks for the `;base64` marker and decodes the data appropriately.

For FD-6433
