### PR TITLE
Allow superusers to change body of failed reports

### DIFF
--- a/templates/web/base/admin/reports/_edit_main.html
+++ b/templates/web/base/admin/reports/_edit_main.html
@@ -32,13 +32,21 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
 
 <li>[% loc('Bodies') %]:
   [% IF problem.bodies_str %]
-    [% FOREACH body IN problem.bodies.values %]
-      [% SET body_printed = 1 %]
-      <a href="[% c.uri_for_action('admin/bodies/edit', [ body.id ]) %]">[% body.name | html %]</a>
-      [%- ',' IF NOT loop.last %]
-    [% END %]
-    [% IF NOT body_printed %]
-      <em>[% problem.bodies_str %]</em>
+    [% IF c.user.is_superuser AND NOT problem.whensent AND problem.send_fail_count > 0 AND problem.bodies_str_ids.size == 1 AND bodies.values.size > 1 %]
+      <select class="form-control" name="body_id" id="body_id">
+        [% FOREACH body IN bodies.values %]
+          <option value="[% body.id %]"[% IF body.id == problem.bodies_str %] selected[% END %]>[% body.name | html %]</option>
+        [% END %]
+      </select>
+    [% ELSE %]
+      [% FOREACH body IN problem.bodies.values %]
+        [% SET body_printed = 1 %]
+        <a href="[% c.uri_for_action('admin/bodies/edit', [ body.id ]) %]">[% body.name | html %]</a>
+        [%- ',' IF NOT loop.last %]
+      [% END %]
+      [% IF NOT body_printed %]
+        <em>[% problem.bodies_str %]</em>
+      [% END %]
     [% END %]
   [% ELSE %]
     <em>[% loc('None' ) %]</em>


### PR DESCRIPTION
Replaces the body name on the admin report edit page with a dropdown, allowing superusers to change the destination body for a failed report.

This is intended primarily for the situation where a report has been associated with the wrong body when created (e.g. some NH reports on FMS.com) and needs manually changing to the correct body.

Deliberately limited in scope, the dropdown only appears for reports that:

 - haven't yet been sent,
 - have failed to send at least once,
 - are for a single body, and
 - are at a location that has another body they can be asssigned to.

Any changes made are added to the admin log for the report.

![dropdown2](https://github.com/user-attachments/assets/cfcef90b-95fd-4df3-a4cc-5cc0b1f80a64)


[skip changelog]