### PR TITLE
Remove unused 'display_location_extra_params'

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -329,16 +329,12 @@ sub map_features : Private {
 
     return if $c->get_param('js'); # JS will request the same (or more) data client side
 
-    # Allow the cobrand to add in any additional query parameters
-    my $extra_params = $c->cobrand->call_hook('display_location_extra_params');
-
     my ( $on_map, $nearby, $distance ) =
       FixMyStreet::Map::map_features(
         $c, %$extra,
         categories => [ keys %{$c->stash->{filter_category}} ],
         states => $c->stash->{filter_problem_states},
         order => $c->stash->{sort_order},
-        extra => $extra_params,
       );
 
     my @pins;

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -761,7 +761,6 @@ sub _nearby_json :Private {
             my $pin_size = $c->get_param('pin_size') || '';
             $pin_size = 'small' unless $pin_size =~ /^(mini|small|normal|big)$/;
 
-            $params->{extra} = $c->cobrand->call_hook('display_location_extra_params');
             $params->{limit} = 5;
 
             my $nearby = $c->model('DB::Nearby')->nearby($c, %$params);

--- a/perllib/FixMyStreet/DB/ResultSet/Nearby.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Nearby.pm
@@ -37,9 +37,6 @@ sub nearby {
 
     FixMyStreet::DB::ResultSet::Problem->non_public_if_possible($params, $c, 'problem');
 
-    # Add in any optional extra query parameters
-    $params = { %$params, %{$args{extra}} } if $args{extra};
-
     my $attrs = {
         join => 'problem',
         bind => [ $args{latitude}, $args{longitude}, $args{distance} ],

--- a/perllib/FixMyStreet/DB/ResultSet/Problem.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Problem.pm
@@ -245,9 +245,6 @@ sub around_map {
 
     $rs->non_public_if_possible($q, $c);
 
-    # Add in any optional extra query parameters
-    $q = { %$q, %{$p{extra}} } if $p{extra};
-
     my $problems = mySociety::Locale::in_gb_locale {
         $rs->search( $q, $attr )->include_comment_counts->page($p{page});
     };

--- a/t/app/controller/around.t
+++ b/t/app/controller/around.t
@@ -330,13 +330,6 @@ subtest 'check category, status and extra filtering works on /around' => sub {
     $json = $mech->get_ok_json( '/around?ajax=1&status=fixed&filter_category=Vegetation&bbox=' . $bbox );
     $pins = $json->{pins};
     is scalar @$pins, 2, 'correct number of fixed Vegetation reports';
-
-    my $cobrand = Test::MockModule->new('FixMyStreet::Cobrand::Default');
-    $cobrand->mock('display_location_extra_params', sub { { external_body => "Pothole-confirmed" } });
-
-    $json = $mech->get_ok_json( '/around?ajax=1&bbox=' . $bbox );
-    $pins = $json->{pins};
-    is scalar @$pins, 1, 'correct number of external_body reports';
 };
 
 my $district = $mech->create_body_ok(2421, "Oxford City");


### PR DESCRIPTION
Was introduced in a 2015 commit (a344b99) but I am not sure it was ever used for anything.

[skip changelog]
