### PR TITLE
[Gloucestershire] Use per-category anonymous reporting setting

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Gloucestershire.pm
+++ b/perllib/FixMyStreet/Cobrand/Gloucestershire.pm
@@ -51,12 +51,6 @@ sub council_url { 'gloucestershire' }
 
 sub admin_user_domain { 'gloucestershire.gov.uk' }
 
-=item * Allows anonymous reporting
-
-=cut
-
-sub allow_anonymous_reports { 'button' }
-
 =item * Gloucestershire use their own privacy policy
 
 =cut

--- a/t/cobrand/gloucestershire.t
+++ b/t/cobrand/gloucestershire.t
@@ -21,6 +21,7 @@ my $graffiti = $mech->create_contact_ok(
     body_id  => $body->id,
     category => 'Graffiti',
     email    => 'GLOS_GRAFFITI',
+    extra    => { anonymous_allowed => 1 },
 );
 
 my $standard_user_1


### PR DESCRIPTION
The Gloucestershire cobrand was allowing anonymous reports for Gloucester City categories, which should not be permitted since Gloucester's cobrand does not enable anonymous reporting.

This change removes the cobrand-level anonymous reporting setting in favour of setting it on individual categories within the body.

## Notes for deployer

- [ ] Before deploying go through Gloucestershire's categories and set them as `anonymous_allowed` (or do it in the DB)

For FD-6454

[skip changelog]