### PR TITLE
Hide deleted and 'zero' categories on dashboard page

### DIFF
--- a/.cypress/cypress/integration/category_tests.js
+++ b/.cypress/cypress/integration/category_tests.js
@@ -15,6 +15,7 @@ describe('Basic categories', function() {
         'Graffiti',
         'Offensive graffiti',
         'G|Licensing',
+        'G|Parks',
         'Parks/landscapes',
         'Pavements',
         'Potholes',
@@ -25,6 +26,7 @@ describe('Basic categories', function() {
         'Street cleaning',
         'Street lighting',
         'Street nameplates',
+        'G|Streets',
         'Traffic lights',
         'Trees',
         'Other'

--- a/.cypress/cypress/integration/dashboard.js
+++ b/.cypress/cypress/integration/dashboard.js
@@ -1,0 +1,177 @@
+describe('Dashboard page', function() {
+    beforeEach(function(){
+        // Sign in as superuser
+        cy.visit('http://borsetshire.localhost:3001/auth');
+        cy.contains('Super user').click();
+    });
+
+    it('no deleted categories', function(){
+        // Make sure Graffiti is confirmed (we delete later)
+        cy.visit('http://borsetshire.localhost:3001/admin/body/1/Graffiti');
+        cy.get('#state-confirmed').click();
+        cy.get('[value="Save changes"]').click();
+
+        cy.visit('http://borsetshire.localhost:3001/dashboard');
+
+        // Check that deleted categories button is not present
+        cy.get('#toggle-deleted-contacts-btn').should('not.exist');
+
+        // Initially visible categories
+        cy.get('tr:visible').should('contain', 'Graffiti');
+        cy.get('tr:visible').should('contain', 'Other');
+        cy.get('tr:visible').should('contain', 'Potholes');
+        cy.get('tr:visible').should('contain', 'Street lighting');
+
+        // Intially hidden categories & headings (groups)
+        cy.get('tr:visible').should('not.contain', 'Abandoned vehicles');
+        cy.get('tr:visible').should('not.contain', 'Licensing');
+        cy.get('tr:visible').should('not.contain', 'Waste');
+        cy.get('tr:visible').should('not.contain', 'Multiple');
+
+        cy.get('.subtotal td').last().should('contain', 21);
+
+        // Click 'zero reports' button
+        cy.get('#toggle-zeroes-btn').click();
+        cy.get('tr:visible').should('contain', 'Abandoned vehicles');
+        cy.get('tr:visible').should('contain', 'Licensing');
+        cy.get('tr:visible').should('contain', 'Waste');
+        cy.get('tr:visible').should('contain', 'Multiple');
+
+        // Check we can re-hide
+        cy.get('#toggle-zeroes-btn').click();
+        cy.get('tr:visible').should('not.contain', 'Abandoned vehicles');
+        cy.get('tr:visible').should('not.contain', 'Licensing');
+        cy.get('tr:visible').should('not.contain', 'Waste');
+        cy.get('tr:visible').should('not.contain', 'Multiple');
+    });
+
+    it('has deleted category', function(){
+        // Set Graffiti to deleted
+        cy.visit('http://borsetshire.localhost:3001/admin/body/1/Graffiti');
+        cy.get('#state-deleted').click();
+        cy.get('[value="Save changes"]').click();
+
+        // Check button visible on dashboard
+        cy.visit('http://borsetshire.localhost:3001/dashboard');
+        cy.get('#toggle-deleted-contacts-btn').should('exist');
+
+        // Initially visible categories
+        cy.get('tr:visible').should('contain', 'Other');
+        cy.get('tr:visible').should('contain', 'Potholes');
+        cy.get('tr:visible').should('contain', 'Street lighting');
+
+        // Intially hidden categories & headings (groups)
+        cy.get('tr:visible').should('not.contain', 'Graffiti');
+        cy.get('tr:visible').should('not.contain', 'Abandoned vehicles');
+        cy.get('tr:visible').should('not.contain', 'Licensing');
+        cy.get('tr:visible').should('not.contain', 'Waste');
+        cy.get('tr:visible').should('not.contain', 'Multiple');
+
+        // Check total is still the same even though deleted not visible
+        cy.get('.subtotal td').last().should('contain', 21);
+
+        // Click deleted categories button
+        cy.get('#toggle-deleted-contacts-btn').click();
+
+        // Deleted 'Graffiti' should show, but not other hidden ones
+        cy.get('tr:visible').should('contain', 'Graffiti');
+        cy.get('tr:visible').should('not.contain', 'Abandoned vehicles');
+        cy.get('tr:visible').should('not.contain', 'Licensing');
+        cy.get('tr:visible').should('not.contain', 'Waste');
+        cy.get('tr:visible').should('not.contain', 'Multiple');
+
+        // Click 'category' tab
+        cy.get('[title="Group by Category"]').click();
+
+        // Everything back to hidden
+        cy.get('tr:visible').should('not.contain', 'Graffiti');
+        cy.get('tr:visible').should('not.contain', 'Abandoned vehicles');
+        cy.get('tr:visible').should('not.contain', 'Licensing');
+        cy.get('tr:visible').should('not.contain', 'Waste');
+        cy.get('tr:visible').should('not.contain', 'Multiple');
+
+        // Click both buttons
+        cy.get('#toggle-zeroes-btn').click();
+        cy.get('#toggle-deleted-contacts-btn').click();
+
+        cy.get('tr:visible').should('contain', 'Graffiti');
+        cy.get('tr:visible').should('contain', 'Abandoned vehicles');
+        cy.get('tr:visible').should('contain', 'Licensing');
+        cy.get('tr:visible').should('contain', 'Waste');
+        cy.get('tr:visible').should('contain', 'Multiple');
+
+        // Check other tabs do not have buttons
+        cy.get('[title="Group by State"]').click();
+        cy.get('#toggle-zeroes-btn').should('not.exist');
+        cy.get('#toggle-deleted-contacts-btn').should('not.exist');
+
+        // Search by particular categories:
+        // - has reports
+        cy.visit('http://borsetshire.localhost:3001/dashboard');
+        cy.get('.multi-select-button').eq(1).click();
+        cy.get('input[value=Potholes]').click();
+        cy.get('[value="Look up"]').click();
+        cy.get('tr:visible').should('contain', 'Potholes');
+        cy.get('tr:visible').should('not.contain', 'Graffiti');
+        cy.get('tr:visible').should('not.contain', 'Other');
+        cy.get('tr:visible').should('not.contain', 'Street lighting');
+        cy.get('tr:visible').should('not.contain', 'Abandoned vehicles');
+        cy.get('tr:visible').should('not.contain', 'Licensing');
+        cy.get('tr:visible').should('not.contain', 'Waste');
+        cy.get('tr:visible').should('not.contain', 'Multiple');
+        cy.get('.subtotal td').last().should('contain', 6);
+
+        // - has no reports
+        cy.visit('http://borsetshire.localhost:3001/dashboard');
+        cy.get('.multi-select-button').eq(1).click();
+        cy.get('input[value="group-Licensing"]').click();
+        cy.get('[value="Look up"]').click();
+        cy.get('tr:visible').should('contain', 'Licensing');
+        cy.get('tr:visible').should('contain', 'Dropped Kerbs');
+        cy.get('tr:visible').should('contain', 'Skips');
+        cy.get('tr:visible').should('not.contain', 'Graffiti');
+        cy.get('tr:visible').should('not.contain', 'Other');
+        cy.get('tr:visible').should('not.contain', 'Potholes');
+        cy.get('tr:visible').should('not.contain', 'Street lighting');
+        cy.get('tr:visible').should('not.contain', 'Abandoned vehicles');
+        cy.get('tr:visible').should('not.contain', 'Waste');
+        cy.get('tr:visible').should('not.contain', 'Multiple');
+        cy.get('.subtotal td').last().should('contain', 0);
+
+        cy.visit('http://borsetshire.localhost:3001/dashboard');
+        cy.get('.multi-select-button').eq(1).click();
+        cy.get('input[value="Skips"]').click();
+        cy.get('[value="Look up"]').click();
+        cy.get('tr:visible').should('contain', 'Licensing');
+        cy.get('tr:visible').should('not.contain', 'Dropped Kerbs');
+        cy.get('tr:visible').should('contain', 'Skips');
+        cy.get('tr:visible').should('not.contain', 'Graffiti');
+        cy.get('tr:visible').should('not.contain', 'Other');
+        cy.get('tr:visible').should('not.contain', 'Potholes');
+        cy.get('tr:visible').should('not.contain', 'Street lighting');
+        cy.get('tr:visible').should('not.contain', 'Abandoned vehicles');
+        cy.get('tr:visible').should('not.contain', 'Waste');
+        cy.get('tr:visible').should('not.contain', 'Multiple');
+        cy.get('.subtotal td').last().should('contain', 0);
+
+        // - deleted
+        cy.visit('http://borsetshire.localhost:3001/dashboard');
+        cy.get('.multi-select-button').eq(1).click();
+        cy.get('input[value="Graffiti"]').click();
+        cy.get('[value="Look up"]').click();
+        cy.get('tr:visible').should('contain', 'Graffiti');
+        cy.get('tr:visible').should('not.contain', 'Potholes');
+        cy.get('tr:visible').should('not.contain', 'Other');
+        cy.get('tr:visible').should('not.contain', 'Street lighting');
+        cy.get('tr:visible').should('not.contain', 'Abandoned vehicles');
+        cy.get('tr:visible').should('not.contain', 'Licensing');
+        cy.get('tr:visible').should('not.contain', 'Waste');
+        cy.get('tr:visible').should('not.contain', 'Multiple');
+        cy.get('.subtotal td').last().should('contain', 5);
+
+        // Undo category deletion
+        cy.visit('http://borsetshire.localhost:3001/admin/body/1/Graffiti');
+        cy.get('#state-confirmed').click();
+        cy.get('[value="Save changes"]').click();
+    });
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
         - Add created flag to inactive processing script. #5386
         - Include report ID in main submit template. #5568
         - Allow per-category timespan for closing inactive reports to updates. #5649
+        - Dashboard: toggle visibility of deleted categories and categories with no reports
     - Development improvements
         - More logging when `page_error` is called, to aid troubleshooting. #5279
         - Docker changes needed for systemd to work. #5257

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -117,6 +117,17 @@ for my $cat ('Dropped Kerbs', 'Skips') {
     $child_cat->update;
 }
 
+# Categories with multiple parents
+for my $cat ( 'Broken glass', 'Litter' ) {
+    my $child_cat = FixMyStreet::DB::Factory::Contact->find_or_create(
+        {   body     => $body,
+            category => $cat,
+        }
+    );
+    $child_cat->set_extra_metadata( group => [ 'Streets', 'Parks' ] );
+    $child_cat->update;
+}
+
 if ($opt->test_fixtures) {
     my $bodies;
 

--- a/perllib/FixMyStreet/App/Controller/Dashboard.pm
+++ b/perllib/FixMyStreet/App/Controller/Dashboard.pm
@@ -143,13 +143,28 @@ sub index : Path : Args(0) {
         $c->stash->{category} = [ $c->get_param_list('category') ];
         my @remove_from_display;
 
+        # Determine which groups and categories are displayed in table
+        my %table_groups_to_display;
+        my %table_categories_to_display;
+
         foreach (@{$c->stash->{category}}) {
-            next unless /^group-(.*)/;
-            for my $contact (@{$group_names{$1}}) {
-                push @{ $c->stash->{category} }, $contact->category;
-                push @remove_from_display, $contact->category;
+            if ( /^group-(.*)/ ) {
+                $table_groups_to_display{$1} = 1;
+
+                for my $contact (@{$group_names{$1}}) {
+                    $table_categories_to_display{ $contact->category } = 1;
+                    push @{ $c->stash->{category} }, $contact->category;
+                    push @remove_from_display, $contact->category;
+                }
+            } else {
+                $table_categories_to_display{$_} = 1;
             }
         }
+
+        $c->stash->{table_groups_to_display}
+            = \%table_groups_to_display;
+        $c->stash->{table_categories_to_display}
+            = \%table_categories_to_display;
 
         my %display_categories = map { $_ => 1 } @{$c->stash->{category}};
         delete $display_categories{$_} for (@remove_from_display);
@@ -306,11 +321,24 @@ sub generate_grouped_data : Private {
                 push @sorting_categories, $category->category;
                 if (!$category_to_group{$category->category}) {
                     $category_to_group{$category->category} = $group->{name};
+
+                    $c->stash->{group_to_category}{ $group->{name} }
+                        { $category->category }{state} = $category->state;
+
                 } else {
                     $category_to_group{$category->category} = 'Multiple';
+
+                    $c->stash->{group_to_category}{'Multiple'}
+                        { $category->category }{state} = $category->state;
+
+                    # Make sure 'Multiple' heading is displayed in table
+                    $c->stash->{table_groups_to_display}{'Multiple'} = 1
+                        if $c->stash->{table_categories_to_display}
+                        { $category->category };
                 }
             }
         };
+
         my ($single_group, $multiple_groups) = part { $category_to_group{$_} eq 'Multiple'} @sorting_categories;
         my @multiple = sort (uniq(@$multiple_groups));
 
@@ -530,4 +558,3 @@ Licensed under the Affero GPL.
 __PACKAGE__->meta->make_immutable;
 
 1;
-

--- a/t/cobrand/cyclinguk.t
+++ b/t/cobrand/cyclinguk.t
@@ -109,15 +109,15 @@ $mech->log_in_ok($super->email);
 subtest 'cyclinguk dashboard shows correct report data' => sub {
     $problem->update({ cobrand => 'fixmystreet'});
     $mech->get_ok("/dashboard");
-    $mech->content_like(qr{th scope="row">Total</th>\s*<td>0</td>}, ".com reports not shown in dashboard");
+    $mech->content_like(qr{th scope="row" id="total-header">Total.*</th>\s*<td>0</td>}, ".com reports not shown in dashboard");
 
     $problem->update({ cobrand => 'bathnes'});
     $mech->get_ok("/dashboard");
-    $mech->content_like(qr{th scope="row">Total</th>\s*<td>0</td>}, "council cobrand reports not shown in dashboard");
+    $mech->content_like(qr{th scope="row" id="total-header">Total.*</th>\s*<td>0</td>}, "council cobrand reports not shown in dashboard");
 
     $problem->update({ cobrand => 'cyclinguk'});
     $mech->get_ok("/dashboard");
-    $mech->content_like(qr{th scope="row">Total</th>\s*<td>1</td>}, "cyclinguk cobrand reports are shown in dashboard");
+    $mech->content_like(qr{th scope="row" id="total-header">Total.*</th>\s*<td>1</td>}, "cyclinguk cobrand reports are shown in dashboard");
 };
 
 subtest 'cyclinguk dashboard shows correct bodies' => sub {

--- a/t/cobrand/shropshire.t
+++ b/t/cobrand/shropshire.t
@@ -188,7 +188,7 @@ FixMyStreet::override_config {
         $mech->content_contains('Abdon and Heath Parish');
         $mech->submit_form_ok({ with_fields => { ward => 144013 } });
         $mech->content_contains('<option value="144013" selected>Oswestry Parish</option>');
-        $mech->content_like(qr{<th scope="row">Total</th>\s*<td>1</td>});
+        $mech->content_like(qr{<th scope="row" id="total-header">Total</th>\s*<td>1</td>});
 
         $mech->get_ok('/dashboard/heatmap');
         $mech->content_contains('Town/parish council');

--- a/templates/web/base/dashboard/index.html
+++ b/templates/web/base/dashboard/index.html
@@ -4,6 +4,10 @@
 	    <link rel="stylesheet" href="[% version('/cobrands/fixmystreet/dashboard.css') %]">
 [% END %]
 
+[% extra_js = [
+    version('/cobrands/fixmystreet/dashboard.js')
+] %]
+
 [%
     INCLUDE 'header.html'
         title = loc('Dashboard')
@@ -63,7 +67,7 @@
         <select class="form-control js-multiple" multiple name="category" id="category">
             [% BLOCK category_option %]
             [% SET category_safe = mark_safe(cat.category) %]
-                <option value='[% cat.category | html %]'[% ' selected' IF display_categories.$category_safe %]>[% cat.category_display | html %]</option>
+                <option value='[% cat.category | html %]'[% ' selected' IF display_categories.$category_safe %]>[% cat.category_display | html %][% ' [deleted]' IF cat.state == 'deleted' %]</option>
             [% END %]
             [%~ INCLUDE 'report/new/_category_select.html' include_group_option=1 ~%]
         </select>
@@ -163,11 +167,11 @@
         <th scope="col">[% loc('Total') %]</th>
       [% END %]
     </tr>
-  [% SET current_category = '' %]
+  [% SET current_group = '' %]
   [% FOR k IN rows %][% k_safe = mark_safe(k) %]
-    [% IF category_to_group.$k_safe AND category_to_group.$k_safe != current_category %]
-    [% SET current_category = category_to_group.$k_safe %]
-      <tr>
+    [% IF category_to_group.$k_safe AND category_to_group.$k_safe != current_group %]
+      [% SET current_group = category_to_group.$k_safe %]
+      <tr class="group-heading[% IF category.size && !(table_groups_to_display.$current_group) %] is-unselected-category[% END %]">
         [% IF group_by == 'category+state' %]
         <th colspan="5" scope="colgroup">[% category_to_group.$k_safe %]</th>
         [% ELSE %]
@@ -175,27 +179,65 @@
         [% END %]
       </tr>
     [% END %]
+    [% IF group_by == 'state' %]
     <tr>
-      [% IF group_by == 'state' %]
-        <th scope="row">[% prettify_state(k) %]</th>
+      <th scope="row">[% prettify_state(k) %]</th>
+    [% ELSIF group_by == 'category+state' || group_by == 'category' %]
+      [% IF category.size %]
+        [%
+          # We do not want to mark/hide deleted/zero categories if searching for specific one(s).
+          # Instead, hide any unselected categories.
+        %]
+        [%
+          SET class_to_hide =
+            table_categories_to_display.$k ?
+              '' :
+              'is-unselected-category';
+        %]
       [% ELSE %]
-        <th scope="row">[% k %]</th>
+        [% # Mark/hide deleted/zero categories %]
+        [%
+          SET is_zero =
+            (
+              group_by == 'category+state'
+                && !grouped.$k_safe.open
+                && !grouped.$k_safe.closed
+                && !grouped.$k_safe.fixed
+            ) || (
+              group_by == 'category'
+                && !grouped.$k_safe.total
+            );
+
+          SET class_to_hide =
+            group_to_category.$current_group.$k_safe.state == 'deleted' ?
+              'is-deleted' :
+              ( is_zero ?
+                'is-zero' :
+                ''
+              );
+        %]
       [% END %]
-      [% IF group_by == 'category+state' %]
-        <td>[% grouped.$k_safe.open OR 0 %]</td>
-        <td>[% grouped.$k_safe.closed OR 0 %]</td>
-        <td>[% grouped.$k_safe.fixed OR 0 %]</td>
-        <td>[% grouped.$k_safe.total OR 0 %]</td>
-      [% ELSE %]
-        [% FOR k2 IN columns.sort %]
-          <td>[% grouped.$k_safe.$k2 OR 0 %]</td>
-        [% END %]
-        <td>[% grouped.$k_safe.total OR 0 %]</td>
+    <tr [% IF class_to_hide %]class="[% class_to_hide %]"[% END %]>
+      <th class="contact-category" scope="row">[% k %]</th>
+    [% ELSE %]
+    <tr>
+      <th scope="row">[% k %]</th>
+    [% END %]
+    [% IF group_by == 'category+state' %]
+      <td>[% grouped.$k_safe.open OR 0 %]</td>
+      <td>[% grouped.$k_safe.closed OR 0 %]</td>
+      <td>[% grouped.$k_safe.fixed OR 0 %]</td>
+      <td>[% grouped.$k_safe.total OR 0 %]</td>
+    [% ELSE %]
+      [% FOR k2 IN columns.sort %]
+        <td>[% grouped.$k_safe.$k2 OR 0 %]</td>
       [% END %]
+      <td>[% grouped.$k_safe.total OR 0 %]</td>
+    [% END %]
     </tr>
   [% END %]
     <tr class="subtotal">
-        <th scope="row">[% loc('Total') %]</th>
+        <th scope="row" id="total-header">[% loc('Total') %]</th>
       [% IF group_by == 'category+state' %]
         <td>[% totals.open OR 0 %]</td>
         <td>[% totals.closed OR 0 %]</td>

--- a/web/cobrands/fixmystreet/dashboard.js
+++ b/web/cobrands/fixmystreet/dashboard.js
@@ -1,0 +1,85 @@
+$(function(){
+    var $table_with_zero_reports = $('table tr.is-zero').closest('table');
+    var $toggle_zeroes_btn = $("<input type='submit' class='btn' value='Show categories with zero reports' id='toggle-zeroes-btn' style='margin:1em 0;'/>");
+
+    // hide/show categories with zero reports
+    if ($table_with_zero_reports.length == 1) {
+        $table_with_zero_reports.before($toggle_zeroes_btn);
+        $toggle_zeroes_btn.on('click', function(e){
+            e.preventDefault();
+            var $cols = $table_with_zero_reports.find('tr.is-zero');
+            if ($cols.first().is(':visible')) {
+                $cols.hide();
+                $(this).prop("value", 'Show categories with zero reports');
+            } else {
+                $cols.show();
+                $(this).prop("value", 'Hide categories with zero reports');
+            }
+
+            toggleGroupHeadings();
+        });
+    }
+
+    var $table_with_deleted_contacts = $('table tr.is-deleted').closest('table');
+    var $toggle_deleted_btn = $("<input type='submit' class='btn' value='Show deleted categories' id='toggle-deleted-contacts-btn' style='margin:1em 0;'/>");
+
+    // hide/show deleted contact categories
+    if ($table_with_deleted_contacts.length == 1) {
+        $table_with_deleted_contacts.before($toggle_deleted_btn);
+        $toggle_deleted_btn.on('click', function(e){
+            e.preventDefault();
+            var $cols = $table_with_deleted_contacts.find('tr.is-deleted');
+            if ($cols.first().is(':visible')) {
+                $cols.hide();
+                $(this).prop("value", 'Show deleted categories');
+            } else {
+                $cols.show();
+                $(this).prop("value", 'Hide deleted categories');
+            }
+
+            toggleGroupHeadings();
+        });
+
+        // Change 'total' header
+        $('#total-header').text('Total (including deleted categories)');
+    }
+
+    function toggleGroupHeadings() {
+        var $rows = $('table#overview tr');
+        var $current_group_heading;
+        var $visible_count = 0;
+
+        $rows.each( function( idx, elem ) {
+            if ( $(this).hasClass('group-heading') ) {
+                // Hide previous group heading if no visible categories
+                if ($current_group_heading) {
+                    if ( $visible_count == 0 ) {
+                        $current_group_heading.hide();
+                    } else {
+                        $current_group_heading.show();
+                    }
+                }
+
+                // Then set next group heading
+                $current_group_heading = $(this);
+                $visible_count = 0;
+
+            } else if ( !$(this).hasClass('subtotal') ) {
+                if ( $(this).is(':visible') ) {
+                    $visible_count++;
+                }
+            }
+        });
+
+        // Toggle final group heading
+        if ($current_group_heading) {
+            if ( $visible_count == 0 ) {
+                $current_group_heading.hide();
+            } else {
+                $current_group_heading.show();
+            }
+        }
+    }
+
+    toggleGroupHeadings();
+});

--- a/web/cobrands/fixmystreet/dashboard.scss
+++ b/web/cobrands/fixmystreet/dashboard.scss
@@ -48,7 +48,6 @@
         }
     }
 
-
     #reports{
         th {
             padding-#{$left}: 20px;

--- a/web/cobrands/sass/_dashboard.scss
+++ b/web/cobrands/sass/_dashboard.scss
@@ -383,3 +383,30 @@
         }
     }
 }
+
+// For /dashboard page.
+// Here so make-css in browser-tests can pick up on the changes.
+// Rest of CSS for this page is in web/cobrands/fixmystreet/dashboard.scss,
+// but that is only loaded for /dashboard page; if it is pulled into here, it
+// may clash with wider CSS.
+
+#overview {
+    tr.is-deleted {
+        background-color: #ffdddd;
+        th.contact-category {
+            text-decoration: line-through;
+        }
+    }
+    tr.is-zero {
+        background-color: #ddddff;
+    }
+    tr.is-unselected-category {
+        display: none;
+    }
+}
+
+.js #overview {
+    tr.is-deleted, tr.is-zero {
+        display: none;
+    }
+}


### PR DESCRIPTION
Visibility can be toggled, similar to /admin/body/<id> page.

Fixes https://github.com/mysociety/societyworks/issues/5187.

Changes include:
- When on 'Category' or 'Category and state' tab
    - JS-generated button to toggle visibility of categories with no reports
    - JS-generated button to toggle visibility of deleted categories
    - Buttons do not appear when 'category' filter used
        - Instead, only the selected categories are displayed
    - Respective buttons do not appear if no zero-report categories or no deleted categories
    - If JS disabled, zero-report and deleted categories are still highlighted
    - Special handling of 'Multiple' grouping
