### PR TITLE
[Second PR] Allow group to be updated alongside category on report edit/inspect forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
         - Add created flag to inactive processing script. #5386
         - Include report ID in main submit template. #5568
         - Allow per-category timespan for closing inactive reports to updates. #5649
+        - Select correct category group on report inspect dropdowns, and allow updating of category group
     - Development improvements
         - More logging when `page_error` is called, to aid troubleshooting. #5279
         - Docker changes needed for systemd to work. #5257

--- a/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
@@ -222,49 +222,6 @@ sub edit : Path('/admin/report_edit') : Args(1) {
     }
 
     $c->stash->{problem} = $problem;
-    if ( $problem->extra ) {
-        my @fields;
-        if ( my $fields = $problem->get_extra_fields ) {
-            for my $field ( @{$fields} ) {
-                my $name = $field->{description} ?
-                    "$field->{description} ($field->{name})" :
-                    "$field->{name}";
-                push @fields, { name => $name, val => $field->{value} };
-            }
-        }
-        my $extra = $problem->get_extra_metadata;
-        if ( $extra->{duplicates} ) {
-            push @fields, { name => 'Duplicates', val => join( ',', @{ $problem->get_extra_metadata('duplicates') } ) };
-            delete $extra->{duplicates};
-        }
-
-        if ( $extra->{contributed_by} ) {
-            my $u = $c->cobrand->users->find({id => $extra->{contributed_by}});
-            if ( $u ) {
-                my $uri = $c->uri_for_action('admin/users/index', { search => $u->email } );
-                push @fields, {
-                    name => _('Created By'),
-                    code => 'contributed_by',
-                    val => FixMyStreet::Template::SafeString->new( "<a href=\"$uri\">@{[$u->name]} (@{[$u->email]})</a>" )
-                };
-                if ( $u->from_body ) {
-                    push @fields, { name => _('Created Body'), val => $u->from_body->name };
-                } elsif ( $u->is_superuser ) {
-                    push @fields, { name => _('Created Body'), val => _('Superuser') };
-                }
-            } else {
-                push @fields, { name => 'contributed_by', code => 'contributed_by', val => $extra->{contributed_by} };
-            }
-            delete $extra->{contributed_by};
-        }
-
-        for my $key ( keys %$extra ) {
-            next if $key =~ /^(whensent_previous|rdi_processed|gender|variant|CyclingUK)/;
-            push @fields, { name => $key, val => $extra->{$key} };
-        }
-
-        $c->stash->{extra_fields} = \@fields;
-    }
 
     $c->forward('/auth/get_csrf_token');
 
@@ -402,6 +359,52 @@ sub edit : Path('/admin/report_edit') : Args(1) {
         $problem->discard_changes;
     }
 
+    # Handle display of extra data.
+    # This should be handled *after* any edits to extra data.
+    if ( $problem->extra ) {
+        my @fields;
+        if ( my $fields = $problem->get_extra_fields ) {
+            for my $field ( @{$fields} ) {
+                my $name = $field->{description} ?
+                    "$field->{description} ($field->{name})" :
+                    "$field->{name}";
+                push @fields, { name => $name, val => $field->{value} };
+            }
+        }
+        my $extra = $problem->get_extra_metadata;
+        if ( $extra->{duplicates} ) {
+            push @fields, { name => 'Duplicates', val => join( ',', @{ $problem->get_extra_metadata('duplicates') } ) };
+            delete $extra->{duplicates};
+        }
+
+        if ( $extra->{contributed_by} ) {
+            my $u = $c->cobrand->users->find({id => $extra->{contributed_by}});
+            if ( $u ) {
+                my $uri = $c->uri_for_action('admin/users/index', { search => $u->email } );
+                push @fields, {
+                    name => _('Created By'),
+                    code => 'contributed_by',
+                    val => FixMyStreet::Template::SafeString->new( "<a href=\"$uri\">@{[$u->name]} (@{[$u->email]})</a>" )
+                };
+                if ( $u->from_body ) {
+                    push @fields, { name => _('Created Body'), val => $u->from_body->name };
+                } elsif ( $u->is_superuser ) {
+                    push @fields, { name => _('Created Body'), val => _('Superuser') };
+                }
+            } else {
+                push @fields, { name => 'contributed_by', code => 'contributed_by', val => $extra->{contributed_by} };
+            }
+            delete $extra->{contributed_by};
+        }
+
+        for my $key ( keys %$extra ) {
+            next if $key =~ /^(whensent_previous|rdi_processed|gender|variant|CyclingUK)/;
+            push @fields, { name => $key, val => $extra->{$key} };
+        }
+
+        $c->stash->{extra_fields_display} = \@fields;
+    }
+
     $c->detach('edit_display');
 }
 
@@ -413,29 +416,49 @@ Returns 1 if category changed, 0 if no change.
 =cut
 
 sub edit_category : Private {
-    my ($self, $c, $problem, $no_comment, $contact) = @_;
+    my ($self, $c, $problem, $no_comment, $contact, $group_new) = @_;
 
-    my $category;
+    my ($group, $category);
+    my ($group_changed, $category_changed);
     my $category_display;
+    my $group_old = $problem->get_extra_metadata('group') // '';
+    my $category_old = $problem->category;
+
     if ($contact) {
+        $group = $group_new;
         $category = $contact->category;
-        return 0 if $contact->id == $problem->contact->id;
+
+        $group_changed = $group ne $group_old;
+        $category_changed = $contact->id != $problem->contact->id;
+
+        return 0
+            if !$group_changed && !$category_changed;
+
         $category_display = $contact->category_display;
     } else {
-        $category = $c->get_param('category');
-        return 0 if $category eq $problem->category;
+        my $group_and_category = $c->get_param('category');
+
+        my $rgx = qr/__/;
+        ( $group, $category )
+            = $group_and_category =~ $rgx
+            ? ( split $rgx, $group_and_category )
+            : ( '', $group_and_category );
+
+        $group_changed = $group ne $group_old;
+        $category_changed = $category ne $category_old;
+
+        # No changes
+        return 0
+            if !$group_changed && !$category_changed;
+
         $category_display = $category;
     }
-
-    my $category_old = $problem->category;
-    my $category_old_display = $problem->category_display;
-    $problem->category($category);
 
     my @contacts;
     if ($contact) {
         @contacts = ($contact);
     } else {
-        @contacts = grep { $_->category eq $problem->category } @{$c->stash->{contacts}};
+        @contacts = grep { $_->category eq $category } @{$c->stash->{contacts}};
 
         # See if we have one matching contact and use its display name if we do.
         if (@contacts == 1) {
@@ -443,12 +466,40 @@ sub edit_category : Private {
         }
     }
 
+    # @contacts may be empty if form has been submitted with a deleted
+    # category. If we don't return here, it will lead to an empty bodies_str
+    # below. We also don't want to update group or category on the problem.
+    return 0 unless @contacts;
+
+    my $category_old_display = $problem->category_display;
+    $problem->category($category);
+    $group
+        ? $problem->set_extra_metadata( group => $group )
+        : $problem->unset_extra_metadata('group');
+
+
+    # TODO Do we ever want to do this if only group has changed?
     check_resend($c, $category_old, $problem, \@contacts);
 
     my @new_body_ids = map { $_->body_id } @contacts;
     $problem->bodies_str(join( ',', @new_body_ids ));
 
-    my $update_text = '*' . sprintf(_('Category changed from ‘%s’ to ‘%s’'), $category_old_display, $category_display) . '*';
+    my ($update_text, $action);
+    if ($category_changed) {
+        $update_text = '*'
+            . sprintf( _('Category changed from ‘%s’ to ‘%s’'),
+            $category_old_display, $category_display ) . '*';
+
+        $action = 'category_change';
+
+    } else {
+        $update_text = '*'
+            . sprintf( _('Category group changed from ‘%s’ to ‘%s’'),
+            $group_old, $group ) . '*';
+
+        $action = 'group_change';
+    }
+
     if ($no_comment) {
         $c->stash->{update_text} = $update_text;
     } else {
@@ -458,7 +509,7 @@ sub edit_category : Private {
         });
     }
 
-    $c->forward( '/admin/log_edit', [ $problem->id, 'problem', 'category_change' ] );
+    $c->forward( '/admin/log_edit', [ $problem->id, 'problem', $action ] );
     return 1;
 }
 

--- a/perllib/FixMyStreet/App/Controller/Admin/Triage.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Triage.pm
@@ -114,7 +114,14 @@ sub update : Private {
     my $problem = $c->stash->{problem};
 
     my $current_category = $problem->category;
-    my $new_category_id = $c->get_param('category');
+
+    my $new_group_and_category_id = $c->get_param('category');
+
+    my $rgx = qr/__/;
+    my ( $new_group, $new_category_id )
+        = $new_group_and_category_id =~ $rgx
+        ? ( split $rgx, $new_group_and_category_id )
+        : ( '', $new_group_and_category_id );
 
     if (!$new_category_id) {
         my $errors = $c->stash->{errors} || [];
@@ -127,7 +134,10 @@ sub update : Private {
     my $contact = FixMyStreet::DB->resultset("Contact")->find($new_category_id);
     my $new_category = $contact->category;
 
-    my $changed = $c->forward('/admin/reports/edit_category', [ $problem, 1, $contact ] );
+    my $changed = $c->forward(
+        '/admin/reports/edit_category',
+        [ $problem, 1, $contact, $new_group ]
+    );
 
     if ( $changed ) {
         $c->stash->{problem}->update( { state => 'confirmed' } );

--- a/perllib/FixMyStreet/Cobrand/Northumberland.pm
+++ b/perllib/FixMyStreet/Cobrand/Northumberland.pm
@@ -319,6 +319,7 @@ sub open311_munge_update_params {
         ? $assigned_to->email
         : '';
 
+    # TODO Do we want to send update when only group has been changed?
     if ( $comment->text =~ /Category changed/ ) {
         my $service_code = $p->contact->email;
         my $category_group = $p->get_extra_metadata('group');

--- a/perllib/FixMyStreet/DB/Result/AdminLog.pm
+++ b/perllib/FixMyStreet/DB/Result/AdminLog.pm
@@ -152,6 +152,7 @@ sub action_display {
         moderation => _('Moderated'),
         resend => _('Resent'),
         category_change => _('Changed category'),
+        group_change => _('Changed group'),
         state_change => _('Changed state'),
     );
     return $action_map{$self->action} || $self->action;

--- a/perllib/FixMyStreet/Roles/ConfirmOpen311.pm
+++ b/perllib/FixMyStreet/Roles/ConfirmOpen311.pm
@@ -55,6 +55,7 @@ sub open311_munge_update_params {
 
     my $p = $comment->problem;
 
+    # TODO Do we want to send update when only group has been changed?
     if ( $comment->text =~ /Category changed/ ) {
         if ( my $service_code = $p->get_extra_field_value('_wrapped_service_code')  || $p->contact->email ) {
             $params->{service_code} = $service_code;

--- a/t/cobrand/bromley_waste.t
+++ b/t/cobrand/bromley_waste.t
@@ -200,7 +200,7 @@ subtest 'Updates on waste reports still have munged params' => sub {
 };
 
 subtest 'check display of waste reports' => sub {
-$report->update({ category => 'Other' });
+    $report->update({ category => 'Other' });
     $mech->get_ok( '/report/' . $report->id );
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => 'bromley',
@@ -225,7 +225,7 @@ subtest 'check staff can filter on waste reports' => sub {
         $mech->get_ok( '/reports/Bromley');
         $mech->content_contains('<optgroup label="Waste"');
         $mech->get_ok( '/report/' . $report->id );
-        $mech->content_contains('<option value="Report missed collection">');
+        $mech->content_contains('<option value="Waste__Report missed collection">');
     };
 };
 

--- a/templates/web/base/admin/report-category.html
+++ b/templates/web/base/admin/report-category.html
@@ -2,7 +2,7 @@
 [% IF cat.is_disabled AND NOT cobrand.staff_can_assign_reports_to_disabled_categories %]
     [% SET disable = 1 %]
 [% END %]
-<option value="[% cat.category | html %]"[% ' selected' IF problem.category == cat.category %][% ' disabled' IF disable %]>[% cat.category_display | html %][% ' (' _ loc('disabled')  _ ')' IF disable %]</option>
+<option value="[% ( group.name ? group.name _ '__' _ cat.category : cat.category ) | html %]"[% ' selected' IF problem.category == cat.category && problem.get_extra_metadata('group') == group.name %][% ' disabled' IF disable %]>[% cat.category_display | html %][% ' (' _ loc('disabled')  _ ')' IF disable %]</option>
 [%~ END ~%]
 
 <select class="form-control" name="category" id="category">

--- a/templates/web/base/admin/reports/_edit_main.html
+++ b/templates/web/base/admin/reports/_edit_main.html
@@ -123,9 +123,9 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
 </li>
 
 <li>[% loc('Extra data:') ~%]
-    [%~ IF extra_fields.size ~%]
+    [%~ IF extra_fields_display.size ~%]
         <ul>
-        [%~ FOREACH field IN extra_fields ~%]
+        [%~ FOREACH field IN extra_fields_display ~%]
             <li><strong>[%~ field.name ~%]</strong>: [% IF field.val.0.defined ~%]
                     [%~ field.val.list.join(", ") ~%]
                 [%~ ELSE ~%]

--- a/templates/web/base/admin/reports/_edit_waste.html
+++ b/templates/web/base/admin/reports/_edit_waste.html
@@ -118,8 +118,8 @@
     [% IF problem.get_extra_metadata('crimson_external_id') %]<li>Dynamics ID: [% problem.get_extra_metadata('crimson_external_id') %][% END %]
   [% END %]
 
-  [%~ IF extra_fields.size ~%]
-    [%~ FOREACH field IN extra_fields ~%]
+  [%~ IF extra_fields_display.size ~%]
+    [%~ FOREACH field IN extra_fields_display ~%]
         [% IF field.code == 'contributed_by' %]
             <li>[%~ field.name ~%]: [% field.val ~%]</li>
         [% END %]

--- a/templates/web/base/admin/triage/_inspect.html
+++ b/templates/web/base/admin/triage/_inspect.html
@@ -23,7 +23,7 @@
                     [% IF group_select == 0 AND problem.category == group.name %]
                         [% selected = 1; group_select = 1 %]
                     [% END %]
-                    <option value="[% cat_op.id %]"[% ' selected' IF selected OR problem.contact.id == cat_op.id %]>[% cat_op.category_display %][% IF cat_op.email %] ([% cat_op.email %])[% END %]</option>
+                    <option value="[% ( group.name && cat_op.id ? group.name _ '__' _ cat_op.id : cat_op.id ) %]"[% ' selected' IF selected OR ( problem.contact.id == cat_op.id && problem.get_extra_metadata('group') == group.name ) %]>[% cat_op.category_display %][% IF cat_op.email %] ([% cat_op.email %])[% END %]</option>
                     [% selected = 0 %]
                 [%~ END ~%]
                 [% IF group.name %]</optgroup>[% END %]


### PR DESCRIPTION
Fixes https://github.com/mysociety/societyworks/issues/4639.

New PR for `handle-group-with-category-selection` as the original (https://github.com/mysociety/fixmystreet/pull/5777) was merged but changes had to be reverted due to a bug.

- [x] Must be deployed after bug fix here: https://github.com/mysociety/fixmystreet/pull/5803
