### PR TITLE
[Admin] Look for response template on admin state change.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
@@ -374,8 +374,21 @@ sub edit : Path('/admin/report_edit') : Args(1) {
         if ( $problem->state ne $old_state ) {
             $c->forward( '/admin/log_edit', [ $id, 'problem', 'state_change' ] );
 
+            my $updates = Open311::GetServiceRequestUpdates->new(
+                blank_updates_permitted => 1,
+            );
+
+            my ($description, $email_text);
+            foreach my $body (values %{$problem->bodies}) {
+                my $template = $problem->response_template_for($body, $problem->state, $old_state, '', '');
+                ($description, $email_text) = $updates->comment_text_for_request($template, {}, $problem);
+            }
+
+            my $text = join("\n\n", grep { $_ } ($c->stash->{update_text}, $description));
+
             $problem->add_to_comments( {
-                text => $c->stash->{update_text} || '',
+                text => $text,
+                $email_text ? (private_email_text => $email_text) : (),
                 user => $c->user->obj,
                 problem_state => $problem->state,
             } );


### PR DESCRIPTION
On an admin report edit page, if a state is changed, look for a matching response template, as if it were an update coming in from a backend. The particular reason here is so container cancellation picks up the right template, but this seemed like it would be more generally useful and I couldn't think of any reason why you wouldn't want this to happen - if you have a template set up for a state change, you probably want to use it regardless of how that state change happens?

(The front end admin already lets you pick a template.)

Guess should have a changelog entry.