### PR TITLE
[Third PR 🐵] Allow group to be updated alongside category on report edit/inspect forms

### DIFF
--- a/.cypress/cypress/integration/category_tests.js
+++ b/.cypress/cypress/integration/category_tests.js
@@ -15,6 +15,7 @@ describe('Basic categories', function() {
         'Graffiti',
         'Offensive graffiti',
         'G|Licensing',
+        'G|Parks',
         'Parks/landscapes',
         'Pavements',
         'Potholes',
@@ -25,6 +26,7 @@ describe('Basic categories', function() {
         'Street cleaning',
         'Street lighting',
         'Street nameplates',
+        'G|Streets',
         'Traffic lights',
         'Trees',
         'Other'

--- a/.cypress/cypress/integration/report_inspect_form.js
+++ b/.cypress/cypress/integration/report_inspect_form.js
@@ -1,0 +1,61 @@
+describe('Changing category or group on report inspect form', function() {
+    beforeEach(function(){
+        // Sign in as superuser
+        cy.visit('http://borsetshire.localhost:3001/auth');
+        cy.contains('Super user').click();
+    });
+
+    it('on /report page', function() {
+        cy.visit('http://borsetshire.localhost:3001/report/1');
+
+        cy.get('[name=priority]').should('not.contain', 'Priority 1');
+        cy.get('[name=priority]').should('contain', 'Priority 2');
+        cy.get('[name=priority]').should('contain', 'Priority 3');
+        cy.get('[name=priority]').should('not.contain', 'Priority 4');
+
+        // Category with no group
+        cy.get('[name=category]').select('Abandoned vehicles');
+        // For some reason, two state dropdowns are found
+        // and the first is not visible (?).
+        // Similarly for response_template.
+        cy.get('[name=state]').last().select('Not responsible');
+        cy.get('[name=response_template]').last().should('have.value', 'This report is not the responsibility of the council and will be passed to the relevant organisation.');
+        cy.get('[name=priority]').should('contain', 'Priority 1');
+        cy.get('[name=priority]').should('contain', 'Priority 2');
+        cy.get('[name=priority]').should('contain', 'Priority 3');
+        cy.get('[name=priority]').should('not.contain', 'Priority 4');
+
+        // Category with single group
+        cy.get('[name=category]').select('Skips');
+        cy.get('[name=state]').last().select('Not responsible');
+        cy.get('[name=response_template]').last().should('have.value', 'This report with a category under one group is not the responsibility of the council.');
+        cy.get('[name=priority]').should('not.contain', 'Priority 1');
+        cy.get('[name=priority]').should('contain', 'Priority 2');
+        cy.get('[name=priority]').should('contain', 'Priority 3');
+        cy.get('[name=priority]').should('not.contain', 'Priority 4');
+
+        // Category with multiple groups
+        cy.get('[name=category]').select('Streets__Litter');
+        cy.get('[name=state]').last().select('Not responsible');
+        cy.get('[name=response_template]').last().should('have.value', 'This report with a category under multiple groups is not the responsibility of the council.');
+        cy.get('[name=priority]').should('not.contain', 'Priority 1');
+        cy.get('[name=priority]').should('contain', 'Priority 2');
+        cy.get('[name=priority]').should('contain', 'Priority 3');
+        cy.get('[name=priority]').should('contain', 'Priority 4');
+
+        // Check correct group is saved & selected
+        cy.get('[name="save"]').click();
+        cy.visit('http://borsetshire.localhost:3001/report/1');
+        cy.get('[name=category]').should('have.value', 'Streets__Litter');
+    });
+
+    it('on /admin/report_edit page', function() {
+        cy.visit('http://borsetshire.localhost:3001/admin/report_edit/1');
+
+        // No response template option; just test group selection
+        cy.get('[name=category]').should('have.value', 'Streets__Litter');
+        cy.get('[name=category]').select('Parks__Litter');
+        cy.get('[name="Submit changes"]').first().click();
+        cy.get('[name=category]').should('have.value', 'Parks__Litter');
+    });
+});

--- a/.cypress/cypress/integration/report_inspect_form.js
+++ b/.cypress/cypress/integration/report_inspect_form.js
@@ -17,9 +17,8 @@ describe('Changing category or group on report inspect form', function() {
         cy.get('[name=category]').select('Abandoned vehicles');
         // For some reason, two state dropdowns are found
         // and the first is not visible (?).
-        // Similarly for response_template.
         cy.get('[name=state]').last().select('Not responsible');
-        cy.get('[name=response_template]').last().should('have.value', 'This report is not the responsibility of the council and will be passed to the relevant organisation.');
+        cy.get('[name=public_update]').should('have.value', 'This report is not the responsibility of the council and will be passed to the relevant organisation.');
         cy.get('[name=priority]').should('contain', 'Priority 1');
         cy.get('[name=priority]').should('contain', 'Priority 2');
         cy.get('[name=priority]').should('contain', 'Priority 3');
@@ -28,7 +27,7 @@ describe('Changing category or group on report inspect form', function() {
         // Category with single group
         cy.get('[name=category]').select('Skips');
         cy.get('[name=state]').last().select('Not responsible');
-        cy.get('[name=response_template]').last().should('have.value', 'This report with a category under one group is not the responsibility of the council.');
+        cy.get('[name=public_update]').last().should('have.value', 'This report with a category under one group is not the responsibility of the council.');
         cy.get('[name=priority]').should('not.contain', 'Priority 1');
         cy.get('[name=priority]').should('contain', 'Priority 2');
         cy.get('[name=priority]').should('contain', 'Priority 3');
@@ -37,7 +36,7 @@ describe('Changing category or group on report inspect form', function() {
         // Category with multiple groups
         cy.get('[name=category]').select('Streets__Litter');
         cy.get('[name=state]').last().select('Not responsible');
-        cy.get('[name=response_template]').last().should('have.value', 'This report with a category under multiple groups is not the responsibility of the council.');
+        cy.get('[name=public_update]').last().should('have.value', 'This report with a category under multiple groups is not the responsibility of the council.');
         cy.get('[name=priority]').should('not.contain', 'Priority 1');
         cy.get('[name=priority]').should('contain', 'Priority 2');
         cy.get('[name=priority]').should('contain', 'Priority 3');

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
         - Add created flag to inactive processing script. #5386
         - Include report ID in main submit template. #5568
         - Allow per-category timespan for closing inactive reports to updates. #5649
+        - Select correct category group on report inspect dropdowns, and allow updating of category group
     - Development improvements
         - More logging when `page_error` is called, to aid troubleshooting. #5279
         - Docker changes needed for systemd to work. #5257

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
         - List categories that prevent reporting.
         - Show report search on the admin summary page for staff with `user_edit`. #5903
         - Population lookup size for radius alert can be configured per cobrand
+        - Select correct category group on report inspect dropdowns, and allow updating of category group
     - Development improvements
         - More logging when `page_error` is called, to aid troubleshooting. #5279
         - Docker changes needed for systemd to work. #5257

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -117,6 +117,17 @@ for my $cat ('Dropped Kerbs', 'Skips') {
     $child_cat->update;
 }
 
+# Categories with multiple parents
+for my $cat ( 'Broken glass', 'Litter' ) {
+    my $child_cat = FixMyStreet::DB::Factory::Contact->find_or_create(
+        {   body     => $body,
+            category => $cat,
+        }
+    );
+    $child_cat->set_extra_metadata( group => [ 'Streets', 'Parks' ] );
+    $child_cat->update;
+}
+
 if ($opt->test_fixtures) {
     my $bodies;
 
@@ -491,10 +502,36 @@ my $template = FixMyStreet::DB::Factory::ResponseTemplate->create({
     body => $body, title => 'Not responsible', state => 'not responsible',
     text => 'This report is not the responsibility of the council and will be passed to the relevant organisation.' });
 $template->add_to_contacts($body->contacts->first);
-my $priority = FixMyStreet::DB::Factory::ResponsePriority->create({ body => $body, description => '4 hour fix' });
+my $template_single_group = FixMyStreet::DB::Factory::ResponseTemplate->create(
+    {   body  => $body,
+        title => 'Not responsible - one group',
+        state => 'not responsible',
+        text  =>
+            'This report with a category under one group is not the responsibility of the council.',
+    }
+);
+$template_single_group->add_to_contacts(
+    $body->contacts->search( { category => 'Skips' } )
+);
+my $template_multiple_groups = FixMyStreet::DB::Factory::ResponseTemplate->create(
+    {   body  => $body,
+        title => 'Not responsible - multiple groups',
+        state => 'not responsible',
+        text  =>
+            'This report with a category under multiple groups is not the responsibility of the council.',
+    }
+);
+$template_multiple_groups->add_to_contacts(
+    $body->contacts->search( { category => 'Litter' } )
+);
+my $priority_1 = FixMyStreet::DB::Factory::ResponsePriority->create({ body => $body, description => '4 hour fix' });
 FixMyStreet::DB::Factory::ResponsePriority->create({ body => $body, description => '28 day fix' });
 FixMyStreet::DB::Factory::ResponsePriority->create({ body => $body, description => 'For information only' });
-$priority->add_to_contacts($body->contacts->first);
+$priority_1->add_to_contacts($body->contacts->first);
+my $priority_4 = FixMyStreet::DB::Factory::ResponsePriority->create(
+    { body => $body, description => 'Ignore' } );
+$priority_4->add_to_contacts(
+    $body->contacts->search( { category => 'Litter' } ) );
 
 # Users
 say "Created users, all with password 'password':";

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -453,10 +453,36 @@ my $template = FixMyStreet::DB::Factory::ResponseTemplate->create({
     body => $body, title => 'Not responsible', state => 'not responsible',
     text => 'This report is not the responsibility of the council and will be passed to the relevant organisation.' });
 $template->add_to_contacts($body->contacts->first);
-my $priority = FixMyStreet::DB::Factory::ResponsePriority->create({ body => $body, description => '4 hour fix' });
+my $template_single_group = FixMyStreet::DB::Factory::ResponseTemplate->create(
+    {   body  => $body,
+        title => 'Not responsible - one group',
+        state => 'not responsible',
+        text  =>
+            'This report with a category under one group is not the responsibility of the council.',
+    }
+);
+$template_single_group->add_to_contacts(
+    $body->contacts->search( { category => 'Skips' } )
+);
+my $template_multiple_groups = FixMyStreet::DB::Factory::ResponseTemplate->create(
+    {   body  => $body,
+        title => 'Not responsible - multiple groups',
+        state => 'not responsible',
+        text  =>
+            'This report with a category under multiple groups is not the responsibility of the council.',
+    }
+);
+$template_multiple_groups->add_to_contacts(
+    $body->contacts->search( { category => 'Litter' } )
+);
+my $priority_1 = FixMyStreet::DB::Factory::ResponsePriority->create({ body => $body, description => '4 hour fix' });
 FixMyStreet::DB::Factory::ResponsePriority->create({ body => $body, description => '28 day fix' });
 FixMyStreet::DB::Factory::ResponsePriority->create({ body => $body, description => 'For information only' });
-$priority->add_to_contacts($body->contacts->first);
+$priority_1->add_to_contacts($body->contacts->first);
+my $priority_4 = FixMyStreet::DB::Factory::ResponsePriority->create(
+    { body => $body, description => 'Ignore' } );
+$priority_4->add_to_contacts(
+    $body->contacts->search( { category => 'Litter' } ) );
 
 # Users
 say "Created users, all with password 'password':";

--- a/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
@@ -222,49 +222,6 @@ sub edit : Path('/admin/report_edit') : Args(1) {
     }
 
     $c->stash->{problem} = $problem;
-    if ( $problem->extra ) {
-        my @fields;
-        if ( my $fields = $problem->get_extra_fields ) {
-            for my $field ( @{$fields} ) {
-                my $name = $field->{description} ?
-                    "$field->{description} ($field->{name})" :
-                    "$field->{name}";
-                push @fields, { name => $name, val => $field->{value} };
-            }
-        }
-        my $extra = $problem->get_extra_metadata;
-        if ( $extra->{duplicates} ) {
-            push @fields, { name => 'Duplicates', val => join( ',', @{ $problem->get_extra_metadata('duplicates') } ) };
-            delete $extra->{duplicates};
-        }
-
-        if ( $extra->{contributed_by} ) {
-            my $u = $c->cobrand->users->find({id => $extra->{contributed_by}});
-            if ( $u ) {
-                my $uri = $c->uri_for_action('admin/users/index', { search => $u->email } );
-                push @fields, {
-                    name => _('Created By'),
-                    code => 'contributed_by',
-                    val => FixMyStreet::Template::SafeString->new( "<a href=\"$uri\">@{[$u->name]} (@{[$u->email]})</a>" )
-                };
-                if ( $u->from_body ) {
-                    push @fields, { name => _('Created Body'), val => $u->from_body->name };
-                } elsif ( $u->is_superuser ) {
-                    push @fields, { name => _('Created Body'), val => _('Superuser') };
-                }
-            } else {
-                push @fields, { name => 'contributed_by', code => 'contributed_by', val => $extra->{contributed_by} };
-            }
-            delete $extra->{contributed_by};
-        }
-
-        for my $key ( keys %$extra ) {
-            next if $key =~ /^(whensent_previous|rdi_processed|gender|variant|CyclingUK)/;
-            push @fields, { name => $key, val => $extra->{$key} };
-        }
-
-        $c->stash->{extra_fields} = \@fields;
-    }
 
     $c->forward('/auth/get_csrf_token');
 
@@ -402,6 +359,52 @@ sub edit : Path('/admin/report_edit') : Args(1) {
         $problem->discard_changes;
     }
 
+    # Handle display of extra data.
+    # This should be handled *after* any edits to extra data.
+    if ( $problem->extra ) {
+        my @fields;
+        if ( my $fields = $problem->get_extra_fields ) {
+            for my $field ( @{$fields} ) {
+                my $name = $field->{description} ?
+                    "$field->{description} ($field->{name})" :
+                    "$field->{name}";
+                push @fields, { name => $name, val => $field->{value} };
+            }
+        }
+        my $extra = $problem->get_extra_metadata;
+        if ( $extra->{duplicates} ) {
+            push @fields, { name => 'Duplicates', val => join( ',', @{ $problem->get_extra_metadata('duplicates') } ) };
+            delete $extra->{duplicates};
+        }
+
+        if ( $extra->{contributed_by} ) {
+            my $u = $c->cobrand->users->find({id => $extra->{contributed_by}});
+            if ( $u ) {
+                my $uri = $c->uri_for_action('admin/users/index', { search => $u->email } );
+                push @fields, {
+                    name => _('Created By'),
+                    code => 'contributed_by',
+                    val => FixMyStreet::Template::SafeString->new( "<a href=\"$uri\">@{[$u->name]} (@{[$u->email]})</a>" )
+                };
+                if ( $u->from_body ) {
+                    push @fields, { name => _('Created Body'), val => $u->from_body->name };
+                } elsif ( $u->is_superuser ) {
+                    push @fields, { name => _('Created Body'), val => _('Superuser') };
+                }
+            } else {
+                push @fields, { name => 'contributed_by', code => 'contributed_by', val => $extra->{contributed_by} };
+            }
+            delete $extra->{contributed_by};
+        }
+
+        for my $key ( keys %$extra ) {
+            next if $key =~ /^(whensent_previous|rdi_processed|gender|variant|CyclingUK)/;
+            push @fields, { name => $key, val => $extra->{$key} };
+        }
+
+        $c->stash->{extra_fields_display} = \@fields;
+    }
+
     $c->detach('edit_display');
 }
 
@@ -413,29 +416,49 @@ Returns 1 if category changed, 0 if no change.
 =cut
 
 sub edit_category : Private {
-    my ($self, $c, $problem, $no_comment, $contact) = @_;
+    my ($self, $c, $problem, $no_comment, $contact, $group_new) = @_;
 
-    my $category;
+    my ($group, $category);
+    my ($group_changed, $category_changed);
     my $category_display;
+    my $group_old = $problem->get_extra_metadata('group') // '';
+    my $category_old = $problem->category;
+
     if ($contact) {
+        $group = $group_new;
         $category = $contact->category;
-        return 0 if $contact->id == $problem->contact->id;
+
+        $group_changed = $group ne $group_old;
+        $category_changed = $contact->id != $problem->contact->id;
+
+        return 0
+            if !$group_changed && !$category_changed;
+
         $category_display = $contact->category_display;
     } else {
-        $category = $c->get_param('category');
-        return 0 if $category eq $problem->category;
+        my $group_and_category = $c->get_param('category');
+
+        my $rgx = qr/__/;
+        ( $group, $category )
+            = $group_and_category =~ $rgx
+            ? ( split $rgx, $group_and_category )
+            : ( '', $group_and_category );
+
+        $group_changed = $group ne $group_old;
+        $category_changed = $category ne $category_old;
+
+        # No changes
+        return 0
+            if !$group_changed && !$category_changed;
+
         $category_display = $category;
     }
-
-    my $category_old = $problem->category;
-    my $category_old_display = $problem->category_display;
-    $problem->category($category);
 
     my @contacts;
     if ($contact) {
         @contacts = ($contact);
     } else {
-        @contacts = grep { $_->category eq $problem->category } @{$c->stash->{contacts}};
+        @contacts = grep { $_->category eq $category } @{$c->stash->{contacts}};
 
         # See if we have one matching contact and use its display name if we do.
         if (@contacts == 1) {
@@ -443,12 +466,40 @@ sub edit_category : Private {
         }
     }
 
+    # @contacts may be empty if form has been submitted with a deleted
+    # category. If we don't return here, it will lead to an empty bodies_str
+    # below. We also don't want to update group or category on the problem.
+    return 0 unless @contacts;
+
+    my $category_old_display = $problem->category_display;
+    $problem->category($category);
+    $group
+        ? $problem->set_extra_metadata( group => $group )
+        : $problem->unset_extra_metadata('group');
+
+
+    # TODO Do we ever want to do this if only group has changed?
     check_resend($c, $category_old, $problem, \@contacts);
 
     my @new_body_ids = map { $_->body_id } @contacts;
     $problem->bodies_str(join( ',', @new_body_ids ));
 
-    my $update_text = '*' . sprintf(_('Category changed from ‘%s’ to ‘%s’'), $category_old_display, $category_display) . '*';
+    my ($update_text, $action);
+    if ($category_changed) {
+        $update_text = '*'
+            . sprintf( _('Category changed from ‘%s’ to ‘%s’'),
+            $category_old_display, $category_display ) . '*';
+
+        $action = 'category_change';
+
+    } else {
+        $update_text = '*'
+            . sprintf( _('Category group changed from ‘%s’ to ‘%s’'),
+            $group_old, $group ) . '*';
+
+        $action = 'group_change';
+    }
+
     if ($no_comment) {
         $c->stash->{update_text} = $update_text;
     } else {
@@ -458,7 +509,7 @@ sub edit_category : Private {
         });
     }
 
-    $c->forward( '/admin/log_edit', [ $problem->id, 'problem', 'category_change' ] );
+    $c->forward( '/admin/log_edit', [ $problem->id, 'problem', $action ] );
     return 1;
 }
 

--- a/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
@@ -222,49 +222,6 @@ sub edit : Path('/admin/report_edit') : Args(1) {
     }
 
     $c->stash->{problem} = $problem;
-    if ( $problem->extra ) {
-        my @fields;
-        if ( my $fields = $problem->get_extra_fields ) {
-            for my $field ( @{$fields} ) {
-                my $name = $field->{description} ?
-                    "$field->{description} ($field->{name})" :
-                    "$field->{name}";
-                push @fields, { name => $name, val => $field->{value} };
-            }
-        }
-        my $extra = $problem->get_extra_metadata;
-        if ( $extra->{duplicates} ) {
-            push @fields, { name => 'Duplicates', val => join( ',', @{ $problem->get_extra_metadata('duplicates') } ) };
-            delete $extra->{duplicates};
-        }
-
-        if ( $extra->{contributed_by} ) {
-            my $u = $c->cobrand->users->find({id => $extra->{contributed_by}});
-            if ( $u ) {
-                my $uri = $c->uri_for_action('admin/users/index', { search => $u->email } );
-                push @fields, {
-                    name => _('Created By'),
-                    code => 'contributed_by',
-                    val => FixMyStreet::Template::SafeString->new( "<a href=\"$uri\">@{[$u->name]} (@{[$u->email]})</a>" )
-                };
-                if ( $u->from_body ) {
-                    push @fields, { name => _('Created Body'), val => $u->from_body->name };
-                } elsif ( $u->is_superuser ) {
-                    push @fields, { name => _('Created Body'), val => _('Superuser') };
-                }
-            } else {
-                push @fields, { name => 'contributed_by', code => 'contributed_by', val => $extra->{contributed_by} };
-            }
-            delete $extra->{contributed_by};
-        }
-
-        for my $key ( keys %$extra ) {
-            next if $key =~ /^(whensent_previous|rdi_processed|gender|variant|CyclingUK)/;
-            push @fields, { name => $key, val => $extra->{$key} };
-        }
-
-        $c->stash->{extra_fields} = \@fields;
-    }
 
     $c->forward('/auth/get_csrf_token');
 
@@ -430,6 +387,52 @@ sub edit : Path('/admin/report_edit') : Args(1) {
         $problem->discard_changes;
     }
 
+    # Handle display of extra data.
+    # This should be handled *after* any edits to extra data.
+    if ( $problem->extra ) {
+        my @fields;
+        if ( my $fields = $problem->get_extra_fields ) {
+            for my $field ( @{$fields} ) {
+                my $name = $field->{description} ?
+                    "$field->{description} ($field->{name})" :
+                    "$field->{name}";
+                push @fields, { name => $name, val => $field->{value} };
+            }
+        }
+        my $extra = $problem->get_extra_metadata;
+        if ( $extra->{duplicates} ) {
+            push @fields, { name => 'Duplicates', val => join( ',', @{ $problem->get_extra_metadata('duplicates') } ) };
+            delete $extra->{duplicates};
+        }
+
+        if ( $extra->{contributed_by} ) {
+            my $u = $c->cobrand->users->find({id => $extra->{contributed_by}});
+            if ( $u ) {
+                my $uri = $c->uri_for_action('admin/users/index', { search => $u->email } );
+                push @fields, {
+                    name => _('Created By'),
+                    code => 'contributed_by',
+                    val => FixMyStreet::Template::SafeString->new( "<a href=\"$uri\">@{[$u->name]} (@{[$u->email]})</a>" )
+                };
+                if ( $u->from_body ) {
+                    push @fields, { name => _('Created Body'), val => $u->from_body->name };
+                } elsif ( $u->is_superuser ) {
+                    push @fields, { name => _('Created Body'), val => _('Superuser') };
+                }
+            } else {
+                push @fields, { name => 'contributed_by', code => 'contributed_by', val => $extra->{contributed_by} };
+            }
+            delete $extra->{contributed_by};
+        }
+
+        for my $key ( keys %$extra ) {
+            next if $key =~ /^(whensent_previous|rdi_processed|gender|variant|CyclingUK)/;
+            push @fields, { name => $key, val => $extra->{$key} };
+        }
+
+        $c->stash->{extra_fields_display} = \@fields;
+    }
+
     $c->detach('edit_display');
 }
 
@@ -441,29 +444,49 @@ Returns 1 if category changed, 0 if no change.
 =cut
 
 sub edit_category : Private {
-    my ($self, $c, $problem, $no_comment, $contact) = @_;
+    my ($self, $c, $problem, $no_comment, $contact, $group_new) = @_;
 
-    my $category;
+    my ($group, $category);
+    my ($group_changed, $category_changed);
     my $category_display;
+    my $group_old = $problem->get_extra_metadata('group') // '';
+    my $category_old = $problem->category;
+
     if ($contact) {
+        $group = $group_new;
         $category = $contact->category;
-        return 0 if $contact->id == $problem->contact->id;
+
+        $group_changed = $group ne $group_old;
+        $category_changed = $contact->id != $problem->contact->id;
+
+        return 0
+            if !$group_changed && !$category_changed;
+
         $category_display = $contact->category_display;
     } else {
-        $category = $c->get_param('category');
-        return 0 if $category eq $problem->category;
+        my $group_and_category = $c->get_param('category');
+
+        my $rgx = qr/__/;
+        ( $group, $category )
+            = $group_and_category =~ $rgx
+            ? ( split $rgx, $group_and_category )
+            : ( '', $group_and_category );
+
+        $group_changed = $group ne $group_old;
+        $category_changed = $category ne $category_old;
+
+        # No changes
+        return 0
+            if !$group_changed && !$category_changed;
+
         $category_display = $category;
     }
-
-    my $category_old = $problem->category;
-    my $category_old_display = $problem->category_display;
-    $problem->category($category);
 
     my @contacts;
     if ($contact) {
         @contacts = ($contact);
     } else {
-        @contacts = grep { $_->category eq $problem->category } @{$c->stash->{contacts}};
+        @contacts = grep { $_->category eq $category } @{$c->stash->{contacts}};
 
         # See if we have one matching contact and use its display name if we do.
         if (@contacts == 1) {
@@ -471,12 +494,40 @@ sub edit_category : Private {
         }
     }
 
+    # @contacts may be empty if form has been submitted with a deleted
+    # category. If we don't return here, it will lead to an empty bodies_str
+    # below. We also don't want to update group or category on the problem.
+    return 0 unless @contacts;
+
+    my $category_old_display = $problem->category_display;
+    $problem->category($category);
+    $group
+        ? $problem->set_extra_metadata( group => $group )
+        : $problem->unset_extra_metadata('group');
+
+
+    # TODO Do we ever want to do this if only group has changed?
     check_resend($c, $category_old, $problem, \@contacts);
 
     my @new_body_ids = map { $_->body_id } @contacts;
     $problem->bodies_str(join( ',', @new_body_ids ));
 
-    my $update_text = '*' . sprintf(_('Category changed from ‘%s’ to ‘%s’'), $category_old_display, $category_display) . '*';
+    my ($update_text, $action);
+    if ($category_changed) {
+        $update_text = '*'
+            . sprintf( _('Category changed from ‘%s’ to ‘%s’'),
+            $category_old_display, $category_display ) . '*';
+
+        $action = 'category_change';
+
+    } else {
+        $update_text = '*'
+            . sprintf( _('Category group changed from ‘%s’ to ‘%s’'),
+            $group_old, $group ) . '*';
+
+        $action = 'group_change';
+    }
+
     if ($no_comment) {
         $c->stash->{update_text} = $update_text;
     } else {
@@ -486,7 +537,7 @@ sub edit_category : Private {
         });
     }
 
-    $c->forward( '/admin/log_edit', [ $problem->id, 'problem', 'category_change' ] );
+    $c->forward( '/admin/log_edit', [ $problem->id, 'problem', $action ] );
     return 1;
 }
 

--- a/perllib/FixMyStreet/App/Controller/Admin/Triage.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Triage.pm
@@ -114,7 +114,14 @@ sub update : Private {
     my $problem = $c->stash->{problem};
 
     my $current_category = $problem->category;
-    my $new_category_id = $c->get_param('category');
+
+    my $new_group_and_category_id = $c->get_param('category');
+
+    my $rgx = qr/__/;
+    my ( $new_group, $new_category_id )
+        = $new_group_and_category_id =~ $rgx
+        ? ( split $rgx, $new_group_and_category_id )
+        : ( '', $new_group_and_category_id );
 
     if (!$new_category_id) {
         my $errors = $c->stash->{errors} || [];
@@ -127,7 +134,10 @@ sub update : Private {
     my $contact = FixMyStreet::DB->resultset("Contact")->find($new_category_id);
     my $new_category = $contact->category;
 
-    my $changed = $c->forward('/admin/reports/edit_category', [ $problem, 1, $contact ] );
+    my $changed = $c->forward(
+        '/admin/reports/edit_category',
+        [ $problem, 1, $contact, $new_group ]
+    );
 
     if ( $changed ) {
         $c->stash->{problem}->update( { state => 'confirmed' } );

--- a/perllib/FixMyStreet/Cobrand/Northumberland.pm
+++ b/perllib/FixMyStreet/Cobrand/Northumberland.pm
@@ -319,6 +319,7 @@ sub open311_munge_update_params {
         ? $assigned_to->email
         : '';
 
+    # TODO Do we want to send update when only group has been changed?
     if ( $comment->text =~ /Category changed/ ) {
         my $service_code = $p->contact->email;
         my $category_group = $p->get_extra_metadata('group');

--- a/perllib/FixMyStreet/DB/Result/AdminLog.pm
+++ b/perllib/FixMyStreet/DB/Result/AdminLog.pm
@@ -152,6 +152,7 @@ sub action_display {
         moderation => _('Moderated'),
         resend => _('Resent'),
         category_change => _('Changed category'),
+        group_change => _('Changed group'),
         state_change => _('Changed state'),
     );
     return $action_map{$self->action} || $self->action;

--- a/perllib/FixMyStreet/Roles/ConfirmOpen311.pm
+++ b/perllib/FixMyStreet/Roles/ConfirmOpen311.pm
@@ -55,6 +55,7 @@ sub open311_munge_update_params {
 
     my $p = $comment->problem;
 
+    # TODO Do we want to send update when only group has been changed?
     if ( $comment->text =~ /Category changed/ ) {
         if ( my $service_code = $p->get_extra_field_value('_wrapped_service_code')  || $p->contact->email ) {
             $params->{service_code} = $service_code;

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -1232,7 +1232,16 @@ FixMyStreet::override_config {
             $email_logged = $mech->get_text_body_from_email($email_logged);
             like $email_logged, qr{Bins requested: $joined};
             like $email_submit, qr{<td><p>New/replacement container</p></td> <td><p>$joined};
-            like $email_submit, qr{<td><p>UPRN</p></td> <td><p>$_->{id}</p></td>}
+            like $email_submit, qr{<td><p>UPRN</p></td> <td><p>$_->{id}</p></td>};
+
+            my $superuser = $mech->create_user_ok(
+                'superuser@example.com',
+                name         => 'Super User',
+                is_superuser => 1
+            );
+            $mech->log_in_ok( $superuser->email );
+            $mech->get( '/report/' . $report->id );
+            $mech->content_contains('value="Waste__Replacement bin enquiry" selected');
         };
     }
 };

--- a/t/app/controller/waste_bexley.t
+++ b/t/app/controller/waste_bexley.t
@@ -29,6 +29,12 @@ my $body = $mech->create_body_ok(
         cobrand => 'bexley'
     },
 );
+$mech->create_contact_ok(
+    body => $body,
+    category => 'In the road',
+    email => 'roadpothole@example.org',
+    group => ['Pothole'],
+);
 my $contact = $mech->create_contact_ok(
     body => $body,
     category => 'Report missed collection',
@@ -1241,7 +1247,7 @@ FixMyStreet::override_config {
             );
             $mech->log_in_ok( $superuser->email );
             $mech->get( '/report/' . $report->id );
-            $mech->content_contains('value="Waste__Replacement bin enquiry" selected');
+            $mech->content_contains('value="Pothole__In the road"');
         };
     }
 };

--- a/t/cobrand/bromley_waste.t
+++ b/t/cobrand/bromley_waste.t
@@ -200,7 +200,7 @@ subtest 'Updates on waste reports still have munged params' => sub {
 };
 
 subtest 'check display of waste reports' => sub {
-$report->update({ category => 'Other' });
+    $report->update({ category => 'Other' });
     $mech->get_ok( '/report/' . $report->id );
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => 'bromley',
@@ -225,7 +225,7 @@ subtest 'check staff can filter on waste reports' => sub {
         $mech->get_ok( '/reports/Bromley');
         $mech->content_contains('<optgroup label="Waste"');
         $mech->get_ok( '/report/' . $report->id );
-        $mech->content_contains('<option value="Report missed collection">');
+        $mech->content_contains('<option value="Waste__Report missed collection">');
     };
 };
 

--- a/t/cobrand/bromley_waste.t
+++ b/t/cobrand/bromley_waste.t
@@ -204,7 +204,7 @@ subtest 'Updates on waste reports still have munged params' => sub {
 };
 
 subtest 'check display of waste reports' => sub {
-$report->update({ category => 'Other' });
+    $report->update({ category => 'Other' });
     $mech->get_ok( '/report/' . $report->id );
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => 'bromley',
@@ -229,7 +229,7 @@ subtest 'check staff can filter on waste reports' => sub {
         $mech->get_ok( '/reports/Bromley');
         $mech->content_contains('<optgroup label="Waste"');
         $mech->get_ok( '/report/' . $report->id );
-        $mech->content_contains('<option value="Report missed collection">');
+        $mech->content_contains('<option value="Waste__Report missed collection">');
     };
 };
 

--- a/templates/web/base/admin/report-category.html
+++ b/templates/web/base/admin/report-category.html
@@ -2,7 +2,7 @@
 [% IF cat.is_disabled AND NOT cobrand.staff_can_assign_reports_to_disabled_categories %]
     [% SET disable = 1 %]
 [% END %]
-<option value="[% cat.category | html %]"[% ' selected' IF problem.category == cat.category %][% ' disabled' IF disable %]>[% cat.category_display | html %][% ' (' _ loc('disabled')  _ ')' IF disable %]</option>
+<option value="[% ( group.name ? group.name _ '__' _ cat.category : cat.category ) | html %]"[% ' selected' IF problem.category == cat.category && problem.get_extra_metadata('group') == group.name %][% ' disabled' IF disable %]>[% cat.category_display | html %][% ' (' _ loc('disabled')  _ ')' IF disable %]</option>
 [%~ END ~%]
 
 <select class="form-control" name="category" id="category">

--- a/templates/web/base/admin/report-category.html
+++ b/templates/web/base/admin/report-category.html
@@ -2,7 +2,7 @@
 [% IF cat.is_disabled AND NOT cobrand.staff_can_assign_reports_to_disabled_categories %]
     [% SET disable = 1 %]
 [% END %]
-<option value="[% ( group.name ? group.name _ '__' _ cat.category : cat.category ) | html %]"[% ' selected' IF problem.category == cat.category && problem.get_extra_metadata('group') == group.name %][% ' disabled' IF disable %]>[% cat.category_display | html %][% ' (' _ loc('disabled')  _ ')' IF disable %]</option>
+<option value="[% ( group.name ? group.name _ '__' _ cat.category : cat.category ) | html %]"[% ' selected' IF problem.category == cat.category && ( problem.get_extra_metadata('group') == group.name || problem.cobrand_data.ucfirst == group.name ) %][% ' disabled' IF disable %]>[% cat.category_display | html %][% ' (' _ loc('disabled')  _ ')' IF disable %]</option>
 [%~ END ~%]
 
 <select class="form-control" name="category" id="category">

--- a/templates/web/base/admin/reports/_edit_main.html
+++ b/templates/web/base/admin/reports/_edit_main.html
@@ -123,9 +123,9 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
 </li>
 
 <li>[% loc('Extra data:') ~%]
-    [%~ IF extra_fields.size ~%]
+    [%~ IF extra_fields_display.size ~%]
         <ul>
-        [%~ FOREACH field IN extra_fields ~%]
+        [%~ FOREACH field IN extra_fields_display ~%]
             <li><strong>[%~ field.name ~%]</strong>: [% IF field.val.0.defined ~%]
                     [%~ field.val.list.join(", ") ~%]
                 [%~ ELSE ~%]

--- a/templates/web/base/admin/reports/_edit_main.html
+++ b/templates/web/base/admin/reports/_edit_main.html
@@ -131,9 +131,9 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
 </li>
 
 <li>[% loc('Extra data:') ~%]
-    [%~ IF extra_fields.size ~%]
+    [%~ IF extra_fields_display.size ~%]
         <ul>
-        [%~ FOREACH field IN extra_fields ~%]
+        [%~ FOREACH field IN extra_fields_display ~%]
             <li><strong>[%~ field.name ~%]</strong>: [% IF field.val.0.defined ~%]
                     [%~ field.val.list.join(", ") ~%]
                 [%~ ELSE ~%]

--- a/templates/web/base/admin/reports/_edit_waste.html
+++ b/templates/web/base/admin/reports/_edit_waste.html
@@ -118,8 +118,8 @@
     [% IF problem.get_extra_metadata('crimson_external_id') %]<li>Dynamics ID: [% problem.get_extra_metadata('crimson_external_id') %][% END %]
   [% END %]
 
-  [%~ IF extra_fields.size ~%]
-    [%~ FOREACH field IN extra_fields ~%]
+  [%~ IF extra_fields_display.size ~%]
+    [%~ FOREACH field IN extra_fields_display ~%]
         [% IF field.code == 'contributed_by' %]
             <li>[%~ field.name ~%]: [% field.val ~%]</li>
         [% END %]

--- a/templates/web/base/admin/reports/_edit_waste.html
+++ b/templates/web/base/admin/reports/_edit_waste.html
@@ -120,8 +120,8 @@
     [% IF problem.get_extra_metadata('crimson_external_id') %]<li>Dynamics ID: [% problem.get_extra_metadata('crimson_external_id') %][% END %]
   [% END %]
 
-  [%~ IF extra_fields.size ~%]
-    [%~ FOREACH field IN extra_fields ~%]
+  [%~ IF extra_fields_display.size ~%]
+    [%~ FOREACH field IN extra_fields_display ~%]
         [% IF field.code == 'contributed_by' %]
             <li>[%~ field.name ~%]: [% field.val ~%]</li>
         [% END %]

--- a/templates/web/base/admin/triage/_inspect.html
+++ b/templates/web/base/admin/triage/_inspect.html
@@ -23,7 +23,7 @@
                     [% IF group_select == 0 AND problem.category == group.name %]
                         [% selected = 1; group_select = 1 %]
                     [% END %]
-                    <option value="[% cat_op.id %]"[% ' selected' IF selected OR problem.contact.id == cat_op.id %]>[% cat_op.category_display %][% IF cat_op.email %] ([% cat_op.email %])[% END %]</option>
+                    <option value="[% ( group.name && cat_op.id ? group.name _ '__' _ cat_op.id : cat_op.id ) %]"[% ' selected' IF selected OR ( problem.contact.id == cat_op.id && problem.get_extra_metadata('group') == group.name ) %]>[% cat_op.category_display %][% IF cat_op.email %] ([% cat_op.email %])[% END %]</option>
                     [% selected = 0 %]
                 [%~ END ~%]
                 [% IF group.name %]</optgroup>[% END %]

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -167,6 +167,8 @@ fixmystreet.staff_set_up = {
 
     function updateTemplates(opts) {
         opts.category = opts.category || $inspect_form.find('[name=category]').val();
+        // Remove group from category
+        opts.category = opts.category.replace( /.*__/, '' );
         opts.state = opts.state || $inspect_form.find('[name=state]').val();
         var selector = "[data-category='" + opts.category + "']";
         var data = $inspect_form.find(selector).data('templates') || [];
@@ -200,7 +202,8 @@ fixmystreet.staff_set_up = {
     // On the manage/inspect report form, we already have all the extra inputs
     // in the DOM, we just need to hide/show them as appropriate.
     $inspect_form.find('[name=category]').on('change', function() {
-        var category = $(this).val(),
+        // Remove group from category
+        var category = $(this).val().replace( /.*__/, '' ),
             selector = "[data-category='" + category + "']",
             entry = $inspect_form.find(selector),
             $priorities = $('#problem_priority'),

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -167,6 +167,8 @@ fixmystreet.staff_set_up = {
 
     function updateTemplates(opts) {
         opts.category = opts.category || $inspect_form.find('[name=category]').val();
+        // Remove group from category
+        opts.category = opts.category.replace( /.*__/, '' );
         opts.state = opts.state || $inspect_form.find('[name=state]').val();
         var selector = "[data-category='" + opts.category + "']";
         var data = $inspect_form.find(selector).data('templates') || [];
@@ -203,7 +205,8 @@ fixmystreet.staff_set_up = {
     // On the manage/inspect report form, we already have all the extra inputs
     // in the DOM, we just need to hide/show them as appropriate.
     $inspect_form.find('[name=category]').on('change', function() {
-        var category = $(this).val(),
+        // Remove group from category
+        var category = $(this).val().replace( /.*__/, '' ),
             selector = "[data-category='" + category + "']",
             entry = $inspect_form.find(selector),
             $priorities = $('#problem_priority'),

--- a/web/cobrands/fixmystreet/staff.js
+++ b/web/cobrands/fixmystreet/staff.js
@@ -167,6 +167,9 @@ fixmystreet.staff_set_up = {
 
     function updateTemplates(opts) {
         opts.category = opts.category || $inspect_form.find('[name=category]').val();
+        if (!opts.category) {
+            return;
+        }
         // Remove group from category
         opts.category = opts.category.replace( /.*__/, '' );
         opts.state = opts.state || $inspect_form.find('[name=state]').val();

--- a/web/js/duplicates.js
+++ b/web/js/duplicates.js
@@ -13,6 +13,13 @@
             return;
         }
 
+        // NOTE Category as fetched from #report_inspect_form will be in the
+        // form 'group__category'.
+        // Strictly speaking we should split this to get the bare category.
+        // However, #report_inspect_form is used for an existing report (i.e.
+        // there is a report_id), which means /nearby.json will be called,
+        // which ignores the category here in favour of the one saved on the
+        // report.
         var category = $("#report_inspect_form [name=category]").val() || fixmystreet.reporting.selectedCategory().category;
 
         // We check group also, in case that is provided in the config instead of subcat
@@ -189,8 +196,8 @@
         if (!!duplicate_of) {
             return;
         }
-        var category = $("#report_inspect_form [name=category]").val();
-        refresh_duplicate_list(undefined, {}, category);
+
+        refresh_duplicate_list(undefined, {});
     }
 
     // Want to show potential duplicates when a regular user starts a new


### PR DESCRIPTION
Fixes https://github.com/mysociety/societyworks/issues/4639.

Another PR for `handle-group-with-category-selection` as yet another bug, where response templates were not being picked up in JS.
Previous two: https://github.com/mysociety/fixmystreet/pull/5777, https://github.com/mysociety/fixmystreet/pull/5800.

