### PR TITLE
[Gloucestershire] Add last inspected date for drains

### DIFF
--- a/web/cobrands/fixmystreet-uk-councils/assets.js
+++ b/web/cobrands/fixmystreet-uk-councils/assets.js
@@ -932,6 +932,21 @@ fixmystreet.assets.gloucestershire.traffic_asset_details = function() {
         "LED/Halogen: " + a.led_halogen;
 };
 
+// attendedDate is a Unix timestamp in milliseconds;
+// -2209161600000 is 1899-12-30, used to mean "no date"
+fixmystreet.assets.gloucestershire.drains_construct_selected_asset_message = function(asset) {
+    var date = asset.attributes.attendedDate;
+    var message = '<p>All GCC gullies are maintained on a cyclical program. ' +
+        'For more information, please visit the ' +
+        '<a href="https://www.gloucestershire.gov.uk/roads/road-maintenance/gully-emptying-schedules/">' +
+        'Highways Road Maintenance/ Gully page</a>.</p>';
+    if (!date || date === -2209161600000) {
+        return message;
+    }
+    return message + '<p>This drain was last cleansed on ' +
+        new Date(date).toLocaleDateString('en-GB') + '</p>';
+};
+
 /* Hackney */
 
 fixmystreet.assets.hackney = {};


### PR DESCRIPTION
When a drain asset has an attended date, show a message with the formatted date to indicate when the drain was last inspected.

Asset layer changes are in the servers repo on the `FD-6359-gloucestershire-drain-last-cleaned-dates` branch.

For FD-6359

https://github.com/user-attachments/assets/4eeeb97a-1061-40c7-8851-34403882ac59


<!-- [skip changelog] -->