### PR TITLE
[Enfield] Disable sending updates

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Enfield.pm
+++ b/perllib/FixMyStreet/Cobrand/Enfield.pm
@@ -9,6 +9,16 @@ sub council_name { return 'Enfield Council'; }
 sub council_url { return 'enfield'; }
 sub base_url { return FixMyStreet->config('BASE_URL'); }
 
+=head2 Disable updates
+
+Verint doesn't support receiving updates, so we skip sending them
+and indicate in the UI that updates won't reach the body.
+
+=cut
+
+sub should_skip_sending_update { 1 }
+sub updates_sent_to_body { 0 }
+
 sub open311_config {
     my ($self, $row, $h, $params, $contact) = @_;
 


### PR DESCRIPTION
Verint doesn't support updates, so disable sending them for the Enfield cobrand.

This came up the other day when an Enfield update appeared in the stuck reports email complaining about "abstract method post_service_request_update not overridden".

<!-- [skip changelog] -->
