### PR TITLE
[Camden] Added fix for image first button on mobile

### DIFF
--- a/web/cobrands/camden/base.scss
+++ b/web/cobrands/camden/base.scss
@@ -508,6 +508,11 @@ a#geolocate_link {
   background-color: $white-2;
 }
 
+.js #photoForm {
+  right: auto;
+  left: 1rem;
+}
+
 .dropzone {
   &:focus, &:focus-visible {
     background-color: transparentize($color: $link-hover-color, $amount: 0.7);


### PR DESCRIPTION
Camden has on his right bottom corner a cookie banner button, which cover part of the "Start a report with a photo" button on mobile. This commit moves the button to the right, so there is no overlapping.

<img width="384" height="586" alt="Screenshot 2026-01-22 at 12 14 37" src="https://github.com/user-attachments/assets/5399f158-6e8d-45bc-8c61-8519b55d4496" />

[skip changelog]

