### PR TITLE
[Merton] Change colour of warning box link text

### DIFF
--- a/web/cobrands/merton/base.scss
+++ b/web/cobrands/merton/base.scss
@@ -174,6 +174,12 @@ input[type=text].autocomplete__input {
     overflow: visible;
 }
 
+.box-warning {
+    a {
+        color: black;
+    }
+}
+
 .nav-menu {
     background-color: $merton-jade-j3;
     padding: 0.5em 0;


### PR DESCRIPTION
Request, with guidance, to make link text black on warning boxes for clarity.

https://mysocietysupport.freshdesk.com/a/tickets/6526

[skip changelog]

<img width="922" height="654" alt="image" src="https://github.com/user-attachments/assets/271841c4-5c03-48e7-b700-a25e224c4def" />
