### PR TITLE
[Central Beds] Update road check to reflect new flytipping group.

### DIFF
--- a/web/cobrands/fixmystreet-uk-councils/assets.js
+++ b/web/cobrands/fixmystreet-uk-councils/assets.js
@@ -664,8 +664,7 @@ function cb_should_not_require_road() {
     var selected = fixmystreet.reporting.selectedCategory();
     return selected.group === "Trees" ||
             selected.category === "Fly Tipping" ||
-            (selected.group === "Flytipping, Bins and Graffiti" && !selected.category) ||
-            selected.category === 'Housing Fly-tipping' ||
+            (selected.group === "Flytipping and Bins" && !selected.category) ||
             selected.category === 'Public Rights of way' ||
             (!selected.group && !selected.category);
 }


### PR DESCRIPTION
The "Flytipping, Bins and Graffiti" group has broken into "Flytipping and Bins", and a separate "Graffiti" group - update the check accordingly.

Also remove condition for no longer extant "Housing Fly-tipping" category.

[skip changelog].