### PR TITLE
[Bromley] Add dispute missed collection enquiry

### DIFF
--- a/perllib/FixMyStreet/App/Form/Waste/Enquiry/Bromley.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Enquiry/Bromley.pm
@@ -1,0 +1,80 @@
+package FixMyStreet::App::Form::Waste::Enquiry::Bromley;
+
+use utf8;
+use HTML::FormHandler::Moose;
+extends 'FixMyStreet::App::Form::Waste::Enquiry';
+
+has_page missed_collection_intro => (
+    title => 'Missed collection',
+    intro => 'enquiry_missed_intro.html',
+    fields => [],
+);
+
+has_page missed_collection_intro_not_presented => (
+    title => 'Missed collection',
+    intro => 'enquiry_missed_intro.html',
+    fields => ['continue'],
+    next => 'missed_collection_declaration'
+);
+
+has_page missed_collection_declaration => (
+    title => 'Missed collection',
+    intro => 'enquiry_missed_declaration.html',
+    fields => ['declaration', 'warning', 'continue'],
+    next => 'enquiry',
+);
+
+# Any field not on a page gets shown on all pages. We have this dummy page so
+# that the notice fields are only shown if manually added by the cobrand code
+has_page notices => (
+    fields => ['bromley_missed_notice_not_presented', 'bromley_missed_notice'],
+);
+
+has_field bromley_missed_notice_not_presented => (
+    widget => 'NoRender',
+    required => 0,
+    type => 'Notice',
+    order => -1,
+    build_label_method => sub {
+        my $self = shift;
+        my $service_id = $self->parent->{c}->get_param('service_id');
+        return "Do not use this form to report a missed collection. Instead, please <a href='enquiry?category=Return+request&amp;service_id=$service_id'>Report a missed collection</a>";
+    },
+);
+
+has_field bromley_missed_notice => (
+    widget => 'NoRender',
+    required => 0,
+    type => 'Notice',
+    order => -1,
+    build_label_method => sub {
+        my $self = shift;
+        my $service_id = $self->parent->{c}->get_param('service_id');
+        return "We cannot accept missed collection reports through this form. If you believe you are eligible for re-collection, please visit <a href='enquiry?category=Return+request&amp;service_id=$service_id'>My bin was not collected</a>";
+    },
+);
+
+has_field declaration => (
+    type => 'Multiple',
+    widget => 'CheckboxGroup',
+    label => 'To request a missed collection, please confirm the following:',
+    required => 1,
+    options => [
+        { label => 'My rubbish was presented before 7am', value => '7am' },
+        { label => 'My bin was presented within arm’s reach of the pavement', value => 'arm' },
+    ],
+     validate_method => sub {
+        my $self = shift;
+        my $vals = $self->value;
+        $self->add_error('Please confirm all options') if @$vals < 2;
+    },
+);
+
+has_field warning => (
+    widget => 'NoRender',
+    required => 0,
+    type => 'Notice',
+    label => '<strong>Please note all our waste and recycling vehicles are fitted with CCTV and disputed missed collections may be investigated before the collection teams are instructed to return.</strong>',
+);
+
+1;

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -11,6 +11,7 @@ use Hash::Util qw(lock_hash);
 use Integrations::Echo;
 use BromleyParks;
 use FixMyStreet::App::Form::Waste::Request::Bromley;
+use FixMyStreet::App::Form::Waste::Enquiry::Bromley;
 use FixMyStreet::DB;
 use Moo;
 use WasteWorks::Costs;
@@ -56,6 +57,7 @@ my %EVENT_TYPE_IDS = (
     request => 2104,
     bulky => 2175,
     garden => 2106,
+    return_request => 3240,
 );
 lock_hash(%EVENT_TYPE_IDS);
 
@@ -69,8 +71,25 @@ my %ALLOW_CLOSED_EVENT_TYPE_IDS = (
     2162 => 'crew_behaviour',
     2163 => 'damage_to_property',
     2186 => 'wrongful_removal',
+    3240 => 'return_request',
 );
 lock_hash(%ALLOW_CLOSED_EVENT_TYPE_IDS);
+
+my %RESOLUTION_CODES = (
+    33 => 'contaminated', # Contaminated
+    66 => 'not-presented',
+    522 => 'contaminated', # Con - Paper & Card
+    523 => 'contaminated', # Con - Food
+    524 => 'contaminated', # Con - Textiles
+    525 => 'contaminated', # Con - Tetra Pack
+    526 => 'contaminated', # Con - Electrical Items
+    527 => 'contaminated', # Con - Nappies
+    528 => 'contaminated', # Con - Rigid Plastics
+    529 => 'contaminated', # Con - Other
+    674 => 'contaminated', # Con - Refuse
+    802 => 'contaminated', # Con - Clinical
+);
+lock_hash(%RESOLUTION_CODES);
 
 sub report_validation {
     my ($self, $report, $errors) = @_;
@@ -458,6 +477,21 @@ Ingore any updates from Echo that aren't New/Completed and don't have a resoluti
 sub open311_waste_update_extra {
     my ($self, $cfg, $event) = @_;
 
+    my $esc;
+    if ($event->{EventTypeId} == $EVENT_TYPE_IDS{return_request}) {
+        # Could have got here with a full event (pull) or subset (push)
+        if (!$event->{Data}) {
+            $event = $cfg->{echo}->GetEvent($event->{Guid});
+        }
+        my $data = Integrations::Echo::force_arrayref($event->{Data}, 'ExtensibleDatum');
+        foreach (@$data) {
+            if ($_->{DatatypeName} eq 'Investigation Outcome') {
+                $esc = 'Approved' if $_->{Value} == 1;
+                $esc = 'Declined' if $_->{Value} == 2;
+            }
+        }
+    }
+
     my $override_status;
     my $event_type = $cfg->{event_types}{$event->{EventTypeId}};
     my $state_id = $event->{EventStateId};
@@ -472,6 +506,7 @@ sub open311_waste_update_extra {
 
     return (
         defined $override_status ? (status => $override_status ) : (),
+        defined $esc ? (external_status_code => $esc) : (),
     );
 }
 
@@ -955,6 +990,60 @@ sub waste_munge_report_data {
     $data->{detail} = "$data->{title}\n\n$address";
     $c->set_param('service_id', $id);
     $self->_set_user_source;
+}
+
+
+=head2 waste_munge_enquiry_form_pages
+
+We are using an enquiry form to report a disputed missed collection.
+
+So we add an extra page to inform whether a dispute can be raised and an extra page
+for the user to confirm they would like to raise a dispute with a declaration
+their container was correctly placed, which they only reach
+if they they are able to dispute the missed collection
+
+=cut
+
+sub return_request_option {
+    my $self = shift;
+    my $c = $self->{c};
+
+    my $service_id = $c->get_param('service_id');
+    my $service = $c->stash->{services}{$service_id};
+    my $last = $service->{last};
+    my $next = $service->{next};
+    my $next_state = $next->{state} || '';
+
+    return 'too-late' unless $service->{report_within_time};
+
+    my $resolution_id = $last->{resolution_id} || 0;
+    return $RESOLUTION_CODES{$resolution_id} if exists $RESOLUTION_CODES{$resolution_id};
+    return '';
+}
+
+sub waste_munge_enquiry_form_pages {
+    my ($self, $pages, $fields) = @_;
+    my $c = $self->{c};
+    my $category = $c->get_param('category');
+    my $reason = $self->return_request_option;
+
+    $c->stash->{form_class} = 'FixMyStreet::App::Form::Waste::Enquiry::Bromley';
+
+    if ($category eq 'Return request') {
+        # If we have a reason, we need to start with a special page
+        if ($reason eq 'not-presented') {
+            $c->stash->{first_page} = 'missed_collection_intro_not_presented';
+        } elsif ($reason eq 'contaminated' || $reason eq 'too-late') {
+            $c->stash->{first_page} = 'missed_collection_intro';
+        }
+    } elsif ($category eq 'General Enquiry') {
+        # If we have a reason, add a notice to the start of the Other form
+        if ($reason eq 'not-presented') {
+            unshift @{$pages->[1]{fields}}, 'bromley_missed_notice_not_presented';
+        } elsif ($reason eq 'contaminated' || $reason eq 'too-late') {
+            unshift @{$pages->[1]{fields}}, 'bromley_missed_notice';
+        }
+    }
 }
 
 sub waste_munge_enquiry_data {

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -1010,6 +1010,8 @@ sub return_request_option {
 
     my $service_id = $c->get_param('service_id');
     my $service = $c->stash->{services}{$service_id};
+    return '' unless $service_id == $SERVICE_IDS{garden} || FixMyStreet->test_mode;
+
     my $last = $service->{last};
     my $next = $service->{next};
     my $next_state = $next->{state} || '';

--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -11,6 +11,7 @@ use Hash::Util qw(lock_hash);
 use Integrations::Echo;
 use BromleyParks;
 use FixMyStreet::App::Form::Waste::Request::Bromley;
+use FixMyStreet::App::Form::Waste::Enquiry::Bromley;
 use FixMyStreet::DB;
 use Moo;
 use WasteWorks::Costs;
@@ -56,6 +57,7 @@ my %EVENT_TYPE_IDS = (
     request => 2104,
     bulky => 2175,
     garden => 2106,
+    return_request => 3240,
 );
 lock_hash(%EVENT_TYPE_IDS);
 
@@ -69,8 +71,25 @@ my %ALLOW_CLOSED_EVENT_TYPE_IDS = (
     2162 => 'crew_behaviour',
     2163 => 'damage_to_property',
     2186 => 'wrongful_removal',
+    3240 => 'return_request',
 );
 lock_hash(%ALLOW_CLOSED_EVENT_TYPE_IDS);
+
+my %RESOLUTION_CODES = (
+    33 => 'contaminated', # Contaminated
+    66 => 'not-presented',
+    522 => 'contaminated', # Con - Paper & Card
+    523 => 'contaminated', # Con - Food
+    524 => 'contaminated', # Con - Textiles
+    525 => 'contaminated', # Con - Tetra Pack
+    526 => 'contaminated', # Con - Electrical Items
+    527 => 'contaminated', # Con - Nappies
+    528 => 'contaminated', # Con - Rigid Plastics
+    529 => 'contaminated', # Con - Other
+    674 => 'contaminated', # Con - Refuse
+    802 => 'contaminated', # Con - Clinical
+);
+lock_hash(%RESOLUTION_CODES);
 
 sub report_validation {
     my ($self, $report, $errors) = @_;
@@ -458,6 +477,21 @@ Ingore any updates from Echo that aren't New/Completed and don't have a resoluti
 sub open311_waste_update_extra {
     my ($self, $cfg, $event) = @_;
 
+    my $esc;
+    if ($event->{EventTypeId} == $EVENT_TYPE_IDS{return_request}) {
+        # Could have got here with a full event (pull) or subset (push)
+        if (!$event->{Data}) {
+            $event = $cfg->{echo}->GetEvent($event->{Guid});
+        }
+        my $data = Integrations::Echo::force_arrayref($event->{Data}, 'ExtensibleDatum');
+        foreach (@$data) {
+            if ($_->{DatatypeName} eq 'Investigation Outcome') {
+                $esc = 'Approved' if $_->{Value} == 1;
+                $esc = 'Declined' if $_->{Value} == 2;
+            }
+        }
+    }
+
     my $override_status;
     my $event_type = $cfg->{event_types}{$event->{EventTypeId}};
     my $state_id = $event->{EventStateId};
@@ -472,6 +506,7 @@ sub open311_waste_update_extra {
 
     return (
         defined $override_status ? (status => $override_status ) : (),
+        defined $esc ? (external_status_code => $esc) : (),
     );
 }
 
@@ -955,6 +990,60 @@ sub waste_munge_report_data {
     $data->{detail} = "$data->{title}\n\n$address";
     $c->set_param('service_id', $id);
     $self->_set_user_source;
+}
+
+
+=head2 waste_munge_enquiry_form_pages
+
+We are using an enquiry form to report a disputed missed collection.
+
+So we add an extra page to inform whether a dispute can be raised and an extra page
+for the user to confirm they would like to raise a dispute with a declaration
+their container was correctly placed, which they only reach
+if they are able to dispute the missed collection
+
+=cut
+
+sub return_request_option {
+    my $self = shift;
+    my $c = $self->{c};
+
+    my $service_id = $c->get_param('service_id');
+    my $service = $c->stash->{services}{$service_id};
+    my $last = $service->{last};
+    my $next = $service->{next};
+    my $next_state = $next->{state} || '';
+
+    return 'too-late' unless $service->{report_within_time};
+
+    my $resolution_id = $last->{resolution_id} || 0;
+    return $RESOLUTION_CODES{$resolution_id} if exists $RESOLUTION_CODES{$resolution_id};
+    return '';
+}
+
+sub waste_munge_enquiry_form_pages {
+    my ($self, $pages, $fields) = @_;
+    my $c = $self->{c};
+    my $category = $c->get_param('category');
+    my $reason = $self->return_request_option;
+
+    $c->stash->{form_class} = 'FixMyStreet::App::Form::Waste::Enquiry::Bromley';
+
+    if ($category eq 'Return request') {
+        # If we have a reason, we need to start with a special page
+        if ($reason eq 'not-presented') {
+            $c->stash->{first_page} = 'missed_collection_intro_not_presented';
+        } elsif ($reason eq 'contaminated' || $reason eq 'too-late') {
+            $c->stash->{first_page} = 'missed_collection_intro';
+        }
+    } elsif ($category eq 'General Enquiry') {
+        # If we have a reason, add a notice to the start of the Other form
+        if ($reason eq 'not-presented') {
+            unshift @{$pages->[1]{fields}}, 'bromley_missed_notice_not_presented';
+        } elsif ($reason eq 'contaminated' || $reason eq 'too-late') {
+            unshift @{$pages->[1]{fields}}, 'bromley_missed_notice';
+        }
+    }
 }
 
 sub waste_munge_enquiry_data {

--- a/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
@@ -332,7 +332,9 @@ sub bin_services_for_address {
             my $ref = join(',', @{$row->{last}{ref}});
             $task_ref_to_row{$ref} = $row;
 
-            $row->{report_allowed} = $self->within_working_days($row->{last}{date}, 2);
+            my $within = $self->within_working_days($row->{last}{date}, 2);
+            $row->{report_within_time} = $within;
+            $row->{report_allowed} = $within; # This may be overridden by task resolutions
 
             my $events_unit = $self->_parse_events($calls->{"GetEventsForObject ServiceUnit $_->{Id}"});
             $row->{events} = $events->combine($events_unit)->filter({ service => $service_id, since => $row->{last}{date} });
@@ -581,6 +583,7 @@ sub waste_task_resolutions {
         $row->{last}{state} = $state unless $state eq 'Completed' || $state eq 'Not Completed' || $state eq 'Outstanding' || $state eq 'Allocated';
         $row->{last}{completed} = $completed;
         $row->{last}{resolution} = $resolution;
+        $row->{last}{resolution_id} = $resolution_id;
 
         # Special handling if last instance is today e.g. if it's before a
         # particular hour and outstanding, show it as in progress

--- a/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
@@ -332,7 +332,9 @@ sub bin_services_for_address {
             my $ref = join(',', @{$row->{last}{ref}});
             $task_ref_to_row{$ref} = $row;
 
-            $row->{report_allowed} = $self->within_working_days($row->{last}{date}, 2);
+            my $within = $self->within_working_days($row->{last}{date}, 2);
+            $row->{report_within_time} = $within;
+            $row->{report_allowed} = $within; # This may be overridden by task resolutions
 
             my $events_unit = $self->_parse_events($calls->{"GetEventsForObject ServiceUnit $_->{Id}"});
             $row->{events} = $events->combine($events_unit)->filter({ service => $service_id, since => $row->{last}{date} });
@@ -582,6 +584,7 @@ sub waste_task_resolutions {
         $row->{last}{state} = $state unless $state eq 'Completed' || $state eq 'Not Completed' || $state eq 'Outstanding' || $state eq 'Allocated';
         $row->{last}{completed} = $completed;
         $row->{last}{resolution} = $resolution;
+        $row->{last}{resolution_id} = $resolution_id;
 
         # Special handling if last instance is today e.g. if it's before a
         # particular hour and outstanding, show it as in progress

--- a/t/cobrand/bromley_waste.t
+++ b/t/cobrand/bromley_waste.t
@@ -61,6 +61,34 @@ $mech->create_contact_ok(
     group => ['Waste'],
 );
 
+my ($dispute) = $mech->create_contact_ok(
+    body => $body,
+    category => 'Return request',
+    email => '3240',
+    send_method => 'Open311',
+    endpoint => 'waste-endpoint',
+    extra => { type => 'waste' },
+    group => ['Waste'],
+);
+$dispute->set_extra_fields(
+    { code => 'Notes', datatype => 'text', required => 0 },
+);
+$dispute->update;
+
+my ($general) = $mech->create_contact_ok(
+    body => $body,
+    category => 'General Enquiry',
+    email => '2148',
+    send_method => 'Open311',
+    endpoint => 'waste-endpoint',
+    extra => { type => 'waste' },
+    group => ['Waste'],
+);
+$general->set_extra_fields(
+    { code => 'Notes', datatype => 'text', required => 0 },
+);
+$general->update;
+
 my @reports = $mech->create_problems_for_body( 1, $body->id, 'Test', {
     latitude => 51.402096,
     longitude => 0.015784,
@@ -251,6 +279,8 @@ subtest 'check heatmap page' => sub {
 
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => 'bromley',
+    MAPIT_URL => 'http://mapit.uk/',
+    BASE_URL => 'http://bromley.example.org',
     COBRAND_FEATURES => {
         payment_gateway => { bromley => { ggw_cost => 1000 } },
         echo => { bromley => { sample_data => 1 } },
@@ -331,6 +361,145 @@ FixMyStreet::override_config {
         $mech->get_ok('/waste/12345');
         $mech->content_lacks('Report a non-recyclable refuse collection');
         restore_time();
+    };
+
+    subtest 'test extra missed collection reporting options' => sub {
+        $body->response_templates->create({
+            title => 'Wrong bin (Not completed)',
+            text => 'We could not collect your waste as it was not correctly presented.',
+            external_status_code => '66,,Not Completed',
+        });
+        $body->response_templates->create({
+            title => 'Contaminated (Not completed)',
+            text => 'We could not collect your waste as it was contaminated.',
+            external_status_code => '33,,Not Completed',
+        });
+
+        my $echo = Test::MockModule->new('Integrations::Echo');
+        set_fixed_time('2020-05-27T19:00:00Z');
+
+        subtest 'Within two days, not correctly placed' => sub {
+            $echo->mock('GetTasks', sub { return &_bromley_test($_[1], $_[2], '66') });
+            $mech->get_ok('/waste/12345');
+            $mech->content_like(qr/May, at 10:00a\.?m\.?/);
+            $mech->content_contains('We could not collect your waste as it was not correctly presented.', 'Waste template from resolution 66');
+            $mech->content_lacks('Report a non-recyclable refuse collection', 'Can not report a missed collection as resolved');
+            $mech->follow_link_ok({ text => 'Report a problem with a non-recyclable refuse collection' });
+            # Enquiry type list page
+            $mech->content_contains('My bin was not collected', 'Can report a missed collection in the general enquiry list');
+            $mech->submit_form_ok({ with_fields => {category => 'Return request'} });
+            # 'Not presented' information page
+            $mech->content_contains('If you believe the correct container <strong>was</strong> presented at the edge of your property by 7:00 AM on your collection day, please click below', 'Contains page detailing proper placement');
+            $mech->content_contains('Continue', 'User can continue the enquiry');
+            $mech->submit_form_ok();
+            # Declaration page
+            $mech->content_contains('To request a missed collection, please confirm the following', 'Declaration page is shown');
+            $mech->submit_form_ok();
+            $mech->content_contains('field is required', 'Error if field not filled');
+            $mech->form_with_fields('declaration');
+            $mech->current_form->find_input('declaration', undef, 1)->value('7am');
+            $mech->submit_form_ok;
+            $mech->content_lacks('I declare my container was correctly positioned field is required', 'No error as field was filled...');
+            $mech->content_contains('To request a missed collection, please confirm the following', '...but not moved forward as "No" selected');
+            $mech->form_with_fields('declaration');
+            $mech->current_form->find_input('declaration', undef, 2)->value('arm');
+            $mech->submit_form_ok;
+            # Enquiry page
+            $mech->submit_form_ok( {with_fields => { extra_Notes => 'My bin was in front of the house near the pavement' } });
+            # About you page
+            $mech->submit_form_ok( { with_fields => { name => 'James Herriot', email => 'test@example.com' } });
+            # Summary page
+            $mech->content_contains('Please review the information you’ve provided before you submit your enquiry', 'Reached summary page');
+            $mech->content_contains('I declare my container was in reach of the pavement and out by 7:00 AM', 'Can change answer for declaration');
+            $mech->clear_emails_ok;
+            $mech->submit_form_ok( { form_number => 3 } );
+            # Confirm report
+            $mech->get_ok($mech->get_link_from_email);
+            my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+            my $id = $report->id;
+            $mech->content_contains('You have successfully submitted your missed collection request');
+            $mech->content_contains("Your reference number is <strong>$id</strong>");
+            $mech->content_contains('Our team will now investigate this matter further');
+            restore_time();
+        };
+
+        subtest 'After two days, not presented' => sub {
+            $echo->mock('GetTasks', sub { return &_bromley_test($_[1], $_[2], '66') });
+            set_fixed_time('2020-05-30T19:00:00Z');
+            $mech->get_ok('/waste/12345');
+            $mech->content_contains('We could not collect your waste as it was not correctly presented.', 'Waste template from resolution 66');
+            $mech->content_lacks('Report a non-recyclable refuse collection', 'Can not report a missed collection as resolved');
+            $mech->follow_link_ok({ text => 'Report a problem with a non-recyclable refuse collection' });
+            # Enquiry type list page
+            $mech->content_contains('My bin was not collected', 'Can report a missed collection in the general enquiry list');
+            $mech->submit_form_ok({ with_fields => {category => 'Return request'} });
+            # 'Missed collection' information page
+            $mech->content_contains('Reports of missed collections must be raised within 2');
+            $mech->content_lacks('Continue', 'No option offered to continue enquiry');
+            restore_time();
+        };
+
+        subtest 'Report already open' => sub {
+            set_fixed_time('2020-05-27T19:00:00Z');
+            $mech->get_ok('/waste/12345');
+            $mech->content_like(qr/May, at 10:00a\.?m\.?/);
+            $mech->content_contains('A paper &amp; cardboard collection has been reported as missed');
+            $mech->follow_link_ok({ text => 'Report a problem with a paper & cardboard collection' });
+            $mech->content_lacks('My bin was not collected', 'No option to report again in the enquiry list');
+            restore_time();
+        };
+
+        subtest 'After cutoff time' => sub {
+            set_fixed_time('2020-05-27T19:00:00Z');
+            $mech->get_ok('/waste/12345');
+            $mech->content_like(qr/May, at 10:00a\.?m\.?/);
+            $mech->follow_link_ok({ text => 'Report a problem with a garden waste collection' });
+            $mech->content_contains('My bin was not collected', 'Option to report in the enquiry list');
+            $mech->submit_form_ok({ with_fields => {category => 'Return request'} });
+            # 'Missed collection' information page
+            $mech->content_contains('Reports of missed collections must be raised within 2');
+            $mech->content_lacks('Continue', 'No option offered to continue enquiry');
+            restore_time();
+        };
+
+        subtest 'Other contains link back to menu' => sub {
+            set_fixed_time('2020-05-27T19:00:00Z');
+            $mech->get_ok('/waste/12345');
+            $mech->content_like(qr/May, at 10:00a\.?m\.?/);
+            $mech->follow_link_ok({ text => 'Report a problem with a garden waste collection' });
+            $mech->submit_form_ok({ with_fields => {category => 'General Enquiry'} });
+            $mech->content_contains("We cannot accept missed collection reports through this form.");
+            $mech->content_contains('enquiry?category=Return+request&amp;service_id=545');
+            restore_time();
+        };
+
+
+        for my $test (
+            { date => '2020-05-27T19:00:00Z', title => 'Within two days, contaminated', too_late => 0 },
+            { date => '2020-05-30T19:00:00Z', title => 'After two days, contaminated', too_late => 1 },
+        ) {
+            subtest $test->{title} => sub {
+                set_fixed_time($test->{date});
+                $echo->mock('GetTasks', sub { return &_bromley_test($_[1], $_[2], '33') });
+                $mech->get_ok('/waste/12345');
+                $mech->content_contains('We could not collect your waste as it was contaminated.', 'Waste template from resolution 33');
+                $mech->content_lacks('Report a non-recyclable refuse collection', 'Can not report a missed collection as resolved');
+                $mech->follow_link_ok({ text => 'Report a problem with a non-recyclable refuse collection' });
+                # Enquiry type list page
+                $mech->content_contains('My bin was not collected', 'Can report a missed collection in the general enquiry list');
+                $mech->submit_form_ok({ with_fields => {category => 'Return request'} });
+                # 'Contaminated' information page
+                if ($test->{too_late}) {
+                    $mech->content_contains('Reports of missed collections must be raised within 2');
+                } else {
+                    $mech->content_contains('Please remove any contaminated items and we will empty your container on the next scheduled collection day');
+                }
+                $mech->content_lacks('Continue', 'No option offered to continue enquiry');
+                restore_time();
+            };
+        };
+
+        $echo->unmock('GetTasks'); # Otherwise, running under coverage, it is not garbage collected
     };
 
     subtest 'test not using different backend template' => sub {
@@ -601,11 +770,18 @@ subtest 'updating of waste reports' => sub {
             my ($key, $type, $value) = ${$args[3]->value}->value;
             my $external_id = ${$value->value}->value->value;
             my ($waste, $event_state_id, $resolution_code, $event_type_id) = split /-/, $external_id;
+            my %data;
+            if (($event_type_id||0) == 3240) {
+                $data{Data}{ExtensibleDatum} = [
+                    { DatatypeName => 'Investigation Outcome', Value => 1 },
+                ];
+            }
             return SOAP::Result->new(result => {
                 EventStateId => $event_state_id,
                 EventTypeId => $event_type_id || '2104',
                 LastUpdatedDate => { OffsetMinutes => 60, DateTime => '2020-06-24T14:00:00Z' },
                 ResolutionCodeId => $resolution_code,
+                %data,
             });
         } elsif ($method eq 'GetEventType') {
             return SOAP::Result->new(result => {
@@ -648,6 +824,13 @@ subtest 'updating of waste reports' => sub {
         $body->response_templates->create({
             title => 'Allocated title', text => 'This has been allocated',
             'auto_response' => 1, state => 'action scheduled',
+        });
+        $body->response_templates->create({
+            title => 'Return request approved',
+            text => 'We will return to pick up your waste.',
+            external_status_code => 'Approved',
+            state => '',
+            auto_response => 1,
         });
 
         @reports = $mech->create_problems_for_body(2, $body->id, 'Report missed collection', {
@@ -732,6 +915,17 @@ subtest 'updating of waste reports' => sub {
         $report->discard_changes;
         is $report->comments->count, ++$comment_count, 'A new update';
         is $report->state, 'unable to fix', 'A state change';
+
+        $report->update({ external_id => 'waste-15004--3240', state => 'confirmed' });
+        stdout_like {
+            $cobrand->waste_fetch_events({ verbose => 1 });
+        } qr/Updating report to state fixed - council, Completed/;
+        $report->discard_changes;
+        is $report->comments->count, ++$comment_count, 'A new update';
+        is $report->state, 'fixed - council', 'A state change';
+        $update = FixMyStreet::DB->resultset('Comment')->order_by('-id')->first;
+        is $update->text, 'We will return to pick up your waste.';
+        is $update->get_extra_metadata('external_status_code'), 'Approved';
     };
 
     FixMyStreet::override_config {
@@ -1903,6 +2097,35 @@ sub data_to_save {
     }
     $data{'collated_services'}->{'GetTasks'} = $echo->GetTasks([123, 456], [234, 567], [345, 678], [456, 789]);
     return \%data;
+}
+
+sub _bromley_test {
+    my $id = pop @_;
+    my %lookup = map { $_->[0] . ',' . $_->[1] => 1 } @_;
+    my $data = [];
+    my %issue = ( 66 => 'Wrong Bin Out', 33 => 'Bin Contaminated' );
+
+    push @$data, {
+        Ref => { Value => { anyType => [ '123', '456' ] } },
+        State => { Name => 'Not Completed' },
+        Resolution => { Ref => { Value => { anyType => $id } }, Name => $issue{$id} },
+        TaskTypeId => '3216',
+        CompletedDate => { DateTime => '2020-05-27T10:00:00Z' }
+    } if $lookup{"123,456"};
+    push @$data, {
+        Ref => { Value => { anyType => [ '234', '567' ] } },
+        State => { Name => 'Outstanding' },
+        CompletedDate => undef
+    } if $lookup{"234,567"};
+    push @$data, {
+        Ref => { Value => { anyType => [ '345', '678' ] } },
+        State => { Name => 'Not Completed' }
+    } if $lookup{"345,678"};
+    push @$data, {
+        Ref => { Value => { anyType => [ '456', '789' ] } },
+        CompletedDate => undef
+    } if $lookup{"456,789"};
+    return $data;
 }
 
 done_testing();

--- a/templates/web/base/waste/confirmation.html
+++ b/templates/web/base/waste/confirmation.html
@@ -11,6 +11,8 @@ ELSIF report.category == 'Report missed collection' OR report.category == 'Repor
     title = 'Thank you for reporting a missed collection';
 ELSIF report.category == 'Request additional collection';
     title = 'Your additional collection has been requested';
+ELSIF report.category == 'Return request' AND c.cobrand.moniker == 'bromley';
+    title = 'You have successfully submitted your missed collection request';
 ELSE;
     title = 'Your enquiry has been submitted';
 END ~%]
@@ -44,6 +46,13 @@ END ~%]
         <p>
           [% IF report.category == 'Request new container' AND c.cobrand.wasteworks_config.request_timeframe %]
               Containers typically arrive within [% c.cobrand.wasteworks_config.request_timeframe %], but this may vary due to demand.
+          [% END %]
+          [% IF report.category == 'Return request' AND c.cobrand.moniker == 'bromley' %]
+            <p>Our team will now investigate this matter further. The crew <strong>may</strong> return within 5 working days, please follow our collection guidelines:</p>
+            <ul>
+              <li>Presented by 7:00 AM</li>
+              <li>Presented within arm’s reach of the pavement (or approved collection location)</li>
+            </ul>
           [% END %]
           [% INCLUDE 'waste/_report_ids.html' %]
         </p>

--- a/templates/web/base/waste/confirmation.html
+++ b/templates/web/base/waste/confirmation.html
@@ -11,6 +11,8 @@ ELSIF report.category == 'Report missed collection' OR report.category == 'Repor
     title = 'Thank you for reporting a missed collection';
 ELSIF report.category == 'Request additional collection';
     title = 'Your additional collection has been requested';
+ELSIF report.category == 'Return request' AND c.cobrand.moniker == 'bromley';
+    title = 'You have successfully submitted your missed collection request';
 ELSE;
     title = 'Your enquiry has been submitted';
 END ~%]
@@ -47,6 +49,13 @@ END ~%]
         <p>
           [% IF report.category == 'Request new container' AND c.cobrand.wasteworks_config.request_timeframe %]
               Containers typically arrive within [% c.cobrand.wasteworks_config.request_timeframe %], but this may vary due to demand.
+          [% END %]
+          [% IF report.category == 'Return request' AND c.cobrand.moniker == 'bromley' %]
+            <p>Our team will now investigate this matter further. The crew <strong>may</strong> return within 5 working days, please follow our collection guidelines:</p>
+            <ul>
+              <li>Presented by 7:00 AM</li>
+              <li>Presented within arm’s reach of the pavement (or approved collection location)</li>
+            </ul>
           [% END %]
           [% INCLUDE 'waste/_report_ids.html' %]
         </p>

--- a/templates/web/base/waste/summary_enquiry.html
+++ b/templates/web/base/waste/summary_enquiry.html
@@ -30,6 +30,12 @@ step1 = 'enquiry';
         </dd>
     </div>
   [% END %]
+  [% IF c.cobrand.moniker == 'bromley' AND data.declaration %]
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key govuk-summary-list__key--sub">Declaration</dt>
+        <dd class="govuk-summary-list__value">I declare my container was in reach of the pavement and out by 7:00 AM</dd>
+      </div>
+  [% END %]
 [% END %]
 
 [% PROCESS waste/summary.html %]

--- a/templates/web/bromley/waste/enquiry-problem.html
+++ b/templates/web/bromley/waste/enquiry-problem.html
@@ -3,6 +3,9 @@
 f = [];
 service_id = c.req.params.service_id;
 service = services.$service_id;
+IF c.cobrand.return_request_option;
+    f.push( { value = 'Return request', label = 'My bin was not collected' } );
+END;
 IF service.report_allowed;
     IF !service.events.filter(event_type = 2118);
         f.push( { value = 'Gate not closed', label = 'A gate or enclosure wasn’t closed after the collection' } );

--- a/templates/web/bromley/waste/enquiry_missed_declaration.html
+++ b/templates/web/bromley/waste/enquiry_missed_declaration.html
@@ -1,0 +1,7 @@
+[% SET service_id = c.req.params.service_id %]
+[% IF services.$service_id %]
+<dl class="waste__address">
+    <dt class="waste__address__title">Service</dt>
+    <dd class="waste__address__property">[% services.$service_id.service_name %]</dd>
+</dl>
+[% END %]

--- a/templates/web/bromley/waste/enquiry_missed_intro.html
+++ b/templates/web/bromley/waste/enquiry_missed_intro.html
@@ -1,0 +1,49 @@
+[%
+SET service_id = c.req.params.service_id;
+SET reason = c.cobrand.return_request_option;
+%]
+[% IF services.$service_id %]
+<dl class="waste__address">
+    <dt class="waste__address__title">Service</dt>
+    <dd class="waste__address__property">[% services.$service_id.service_name %]</dd>
+</dl>
+[% END %]
+
+[% IF reason == 'contaminated' %]
+<p>
+  Your most recent collection was reported as <strong>contaminated</strong> by the collection team and they were unable to empty your container.
+</p>
+<p>
+  Contamination occurs when non-recyclable items are mixed with recycling.
+</p>
+<p>
+  Please remove any contaminated items and we will empty your container on the next scheduled collection day.
+</p>
+<p>
+  Please visit our website for further details at <a href='https://www.bromley.gov.uk/household-waste-recycling'>https://www.bromley.gov.uk/household-waste-recycling</a>
+</p>
+[% ELSIF reason == 'not-presented' %]
+<p>
+  Your most recent collection has been reported as <strong>not presented</strong> by the collection team.
+</p>
+<p>
+  This means they could not see your waste or recycling container at the edge of your property (or approved collection location) on the last scheduled visit.
+</p>
+<p>
+  Please note, your recycling and waste needs to be placed in the correct containers, securely contained and placed at the edge of your property within arms reach of the pavement (edge of curtilage) by 7am on your scheduled collection day. Please do not place containers directly on the pavement.
+</p>
+<p>
+  Please ensure your containers are easily accessible. If they are not presented correctly or they are hidden behind a locked gate or a parked car, the collection team may not be able to empty them.
+</p>
+<p>
+  If you believe the correct container <strong>was</strong> presented at the edge of your property by 7:00 AM on your collection day, please click below.
+
+[% ELSIF reason == 'too-late' %]
+
+<p>
+  <strong>Reports of missed collections must be raised within 2 working days of your scheduled collection date.</strong>
+</p>
+<p>
+  Please visit our website for further details at <a href='https://www.bromley.gov.uk/household-waste-recycling'>https://www.bromley.gov.uk/household-waste-recycling</a>
+</p>
+[% END %]


### PR DESCRIPTION
Add a flow for disputing a missed collection when containers marked as 'not presented'.

Give notices if contaminated or too late to dispute.

https://github.com/mysociety/societyworks/issues/5311

[skip changelog]