### PR TITLE
[Dumfries] Add custom postcode text with reference number hint

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Dumfries.pm
+++ b/perllib/FixMyStreet/Cobrand/Dumfries.pm
@@ -67,6 +67,14 @@ sub disambiguate_location {
 
 sub default_map_zoom { 5 }
 
+=item * Custom postcode text which includes hint about reference number search
+
+=cut
+
+sub enter_postcode_text {
+    'Enter a Dumfries and Galloway post code or street name and area, or a reference number of a problem previously reported'
+}
+
 
 =head2 open311_update_missing_data
 


### PR DESCRIPTION
Add a custom enter_postcode_text method that includes guidance for users to search by reference number in addition to postcode and street name/area.

See also commit `760874aa0` in the servers repo, which updates the `example_places`.

For https://3.basecamp.com/4020879/buckets/44203298/card_tables/cards/9393708581

<!-- [skip changelog] -->
