### PR TITLE
[Admin] Allow superusers to add new database config entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
         - Improved accessibility of small drawer. #5354
         - Added skip report tools to Around page. #5354
     - Admin improvements:
+        - Allow superusers to add new database config entries.
         - Improve performance of admin reports search for email. #5284
         - import-export-data script exports and imports `send_method` for category #4818
         - Include extra question answer labels in submit emails. #5383

--- a/perllib/FixMyStreet/App/Controller/Admin/Config.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Config.pm
@@ -41,6 +41,33 @@ sub index : Path( '' ) : Args(0) {
         my $db = FixMyStreet::DB->schema->storage;
         my $txn_guard = $db->txn_scope_guard;
 
+        # Handle adding new config entry
+        if (my $new_key = $c->get_param('new-config-key')) {
+            $new_key =~ s/^\s+|\s+$//g;  # Trim whitespace
+            my $new_value = $c->get_param('new-config-value');
+
+            if ($new_key && $new_value) {
+                if (FixMyStreet::DB->resultset("Config")->get($new_key)) {
+                    $c->stash->{errors}->{new} =
+                        sprintf(_("Configuration key '%s' already exists"), $new_key);
+                    $c->stash->{new_config_key} = $new_key;
+                    $c->stash->{new_config_value} = $new_value;
+                } else {
+                    try {
+                        FixMyStreet::DB->resultset("Config")->set($new_key, $json->decode($new_value));
+                    } catch {
+                        my $e = $_;
+                        $e =~ s/ at \/.*$//; # trim the filename/lineno
+                        $c->stash->{errors}->{new} =
+                            sprintf(_("Not a valid JSON string: %s"), $e);
+                        $c->stash->{new_config_key} = $new_key;
+                        $c->stash->{new_config_value} = $new_value;
+                    };
+                }
+            }
+        }
+
+        # Handle updating existing config entries
         foreach my $entry (@db_config) {
             if (my $cfg = $c->get_param("db-config-" . $entry->key)) {
                 try {
@@ -57,6 +84,8 @@ sub index : Path( '' ) : Args(0) {
         if (!%{$c->stash->{errors}}) {
             $txn_guard->commit;
             $c->stash->{db_status_message} = _("Updated!");
+            # Refetch config entries to include any newly added ones
+            @db_config = FixMyStreet::DB->resultset("Config")->order_by('key')->all;
         }
     }
 

--- a/perllib/FixMyStreet/DB/ResultSet/Config.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Config.pm
@@ -16,7 +16,7 @@ sub set {
     if ($v) {
         $v->update({ value => $value });
     } else {
-        $v = $rs->create({ name => $key, value => $value });
+        $v = $rs->create({ key => $key, value => $value });
     }
     return $v->value;
 }

--- a/t/app/controller/admin/config.t
+++ b/t/app/controller/admin/config.t
@@ -1,0 +1,151 @@
+use FixMyStreet::TestMech;
+use Capture::Tiny 'capture_stderr';
+
+FixMyStreet::App->log->disable('info');
+END { FixMyStreet::App->log->enable('info'); }
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $superuser = $mech->create_user_ok('superuser@example.com', name => 'Super User', is_superuser => 1);
+
+$mech->log_in_ok($superuser->email);
+
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => ['fixmystreet'],
+}, sub {
+    subtest 'can add new config entry' => sub {
+        $mech->get_ok('/admin/config');
+        $mech->submit_form_ok({
+            with_fields => {
+                'new-config-key' => 'test_config_key',
+                'new-config-value' => '["value1", "value2"]',
+            }
+        });
+        $mech->content_contains('Updated!');
+        $mech->content_contains('test_config_key');
+
+        my $value = FixMyStreet::DB->resultset("Config")->get('test_config_key');
+        is_deeply $value, ['value1', 'value2'], 'config value correct';
+    };
+
+    subtest 'cannot add duplicate config key' => sub {
+        $mech->get_ok('/admin/config');
+
+        # Suppress expected transaction rollback warning
+        capture_stderr {
+            $mech->submit_form_ok({
+                with_fields => {
+                    'new-config-key' => 'test_config_key',
+                    'new-config-value' => '"different_value"',
+                }
+            });
+        };
+        $mech->content_contains('already exists');
+        $mech->content_lacks('Updated!');
+
+        $mech->content_contains('value="test_config_key"', 'key preserved in form');
+        $mech->content_contains('&quot;different_value&quot;', 'value preserved in form');
+
+        my $value = FixMyStreet::DB->resultset("Config")->get('test_config_key');
+        is_deeply $value, ['value1', 'value2'], 'original config value unchanged';
+    };
+
+    subtest 'whitespace is trimmed from new config key' => sub {
+        $mech->get_ok('/admin/config');
+        $mech->submit_form_ok({
+            with_fields => {
+                'new-config-key' => '  trimmed_key  ',
+                'new-config-value' => 'true',
+            }
+        });
+        $mech->content_contains('Updated!');
+
+        my $value = FixMyStreet::DB->resultset("Config")->get('trimmed_key');
+        is $value, 1, 'JSON true decoded to 1';
+    };
+
+    subtest 'error shown for invalid JSON value' => sub {
+        $mech->get_ok('/admin/config');
+
+        capture_stderr {
+            $mech->submit_form_ok({
+                with_fields => {
+                    'new-config-key' => 'invalid_json_key',
+                    'new-config-value' => 'not valid json {',
+                }
+            });
+        };
+        $mech->content_contains('Not a valid JSON string');
+        $mech->content_lacks('Updated!');
+
+        $mech->content_contains('value="invalid_json_key"', 'key preserved in form');
+        $mech->content_contains('not valid json {', 'value preserved in form');
+
+        my $value = FixMyStreet::DB->resultset("Config")->get('invalid_json_key');
+        ok !$value, 'invalid config entry not created';
+    };
+
+    subtest 'add form shown even when no config entries exist' => sub {
+        # Delete all config entries
+        FixMyStreet::DB->resultset('Config')->delete;
+
+        $mech->get_ok('/admin/config');
+        $mech->content_contains('Database site configuration');
+        $mech->content_contains('new-config-key');
+        $mech->content_contains('new-config-value');
+        $mech->content_contains('name="new-config-key"');
+
+        # Can still add entries
+        $mech->submit_form_ok({
+            with_fields => {
+                'new-config-key' => 'first_config',
+                'new-config-value' => '42',
+            }
+        });
+        $mech->content_contains('Updated!');
+        $mech->content_contains('first_config');
+
+        my $value = FixMyStreet::DB->resultset("Config")->get('first_config');
+        is $value, 42, 'numeric value correct';
+    };
+
+    subtest 'can add config with complex JSON object' => sub {
+        $mech->get_ok('/admin/config');
+        $mech->submit_form_ok({
+            with_fields => {
+                'new-config-key' => 'complex_config',
+                'new-config-value' => '{"nested": {"key": "value"}, "array": [1, 2, 3]}',
+            }
+        });
+        $mech->content_contains('Updated!');
+
+        my $value = FixMyStreet::DB->resultset("Config")->get('complex_config');
+        is_deeply $value, { nested => { key => 'value' }, array => [1, 2, 3] },
+            'complex JSON value correctly stored';
+    };
+
+    subtest 'can edit existing config entry' => sub {
+        FixMyStreet::DB->resultset("Config")->set('editable_config', ['item1', 'item2']);
+
+        $mech->get_ok('/admin/config');
+        $mech->content_contains('editable_config');
+        $mech->content_contains('item1, item2');  # Array displayed as comma-separated
+
+        # Edit the config value via the form
+        $mech->submit_form_ok({
+            with_fields => {
+                'db-config-editable_config' => '["updated_item", "new_item"]',
+            }
+        });
+        $mech->content_contains('Updated!');
+
+        # Verify the change persisted
+        my $value = FixMyStreet::DB->resultset("Config")->get('editable_config');
+        is_deeply $value, ['updated_item', 'new_item'], 'config value was updated';
+
+        # Verify the new value is displayed
+        $mech->content_contains('updated_item, new_item');
+    };
+};
+
+done_testing();

--- a/templates/web/base/admin/config/index.html
+++ b/templates/web/base/admin/config/index.html
@@ -151,16 +151,14 @@ running version <strong>[% git_version || 'unknown' %]</strong>.
 
 </table>
 
+<h2 id="db">Database site configuration</h2>
+[% db_status_message %]
+<form method="post" action="#db">
+<table class="admin--config">
+<tr><th width="20%">Key</th>
+    <th>Value</th>
+</tr>
 [% FOREACH c IN db_config %]
-  [% IF loop.first %]
-    <h2 id="db">Database site configuration</h2>
-    [% db_status_message %]
-    <form method="post" action="#db">
-    <table class="admin--config">
-    <tr><th width="20%">Key</th>
-        <th>Value</th>
-    </tr>
-  [% END %]
   [% SET value = c.value.size ? c.value.join(', ') : c.value %]
     <tr>
         <td>[% c.key %]</td>
@@ -177,14 +175,27 @@ running version <strong>[% git_version || 'unknown' %]</strong>.
             </textarea>
         </p>
     </details>
+        </td>
     </tr>
-  [% IF loop.last %]
-        </table>
-        <input type="hidden" name="token" value="[% csrf_token %]">
-        <input type="submit" class="btn" value="Update">
-    </form>
-  [% END %]
 [% END %]
+    <tr>
+        <td>
+            <input type="text" name="new-config-key"
+                   placeholder="new_config_key" size="30"
+                   value="[% new_config_key %]">
+        </td>
+        <td>
+            <textarea name="new-config-value" rows="3" cols="60"
+                   placeholder='e.g. true or ["value1","value2"]' class="code">[% new_config_value %]</textarea>
+            [% IF errors.new %]
+            <div class="form-error">[% errors.new %]</div>
+            [% END %]
+        </td>
+    </tr>
+</table>
+<input type="hidden" name="token" value="[% csrf_token %]">
+<input type="submit" class="btn" value="[% loc('Update') %]">
+</form>
 
 <h2>Cobrand module</h2>
 


### PR DESCRIPTION
Add functionality to create new config table entries from the admin interface at /admin/config

![admin config](https://github.com/user-attachments/assets/cb4b6d23-f510-44d6-a569-dd8a6444a65c)
