### PR TITLE
Reduce CSV filename length if many wards specified

### DIFF
--- a/perllib/FixMyStreet/Reporting.pm
+++ b/perllib/FixMyStreet/Reporting.pm
@@ -91,10 +91,10 @@ has filename => ( is => 'rw', isa => Str, lazy => 1, default => sub {
     my $self = shift;
     my %where = (
         state => $self->state,
-        ward => join(',', @{$self->wards}),
         start_date => $self->start_date,
         end_date => $self->end_date,
     );
+    $where{ward} = @{$self->wards} <= 5 ? join(',', @{$self->wards}) : 'multiple-wards';
     $where{category} = @{$self->category} < 3 ? join(',', @{$self->category}) : 'multiple-categories';
     $where{body} = $self->body->id if $self->body;
     $where{role} = $self->role_id if $self->role_id;

--- a/t/app/controller/dashboard.t
+++ b/t/app/controller/dashboard.t
@@ -224,6 +224,10 @@ FixMyStreet::override_config {
         $mech->content_contains('www.example.org-body-' . $body->id . '-category-Litter,Potholes-start_date-2014-01-02.csv');
         $mech->get_ok("/dashboard?category=Litter&category=Potholes&category=Traffic+lights+%26+bells&export=2");
         $mech->content_contains('www.example.org-body-' . $body->id . '-category-multiple-categories-start_date-2014-01-02.csv');
+        $mech->get_ok("/dashboard?ward=1&export=2");
+        $mech->content_contains('www.example.org-body-' . $body->id . '-start_date-2014-01-02-ward-1.csv');
+        $mech->get_ok("/dashboard?ward=1&ward=2&ward=3&ward=4&ward=5&ward=6&export=2");
+        $mech->content_contains('www.example.org-body-' . $body->id . '-start_date-2014-01-02-ward-multiple-wards.csv');
         $mech->get_ok("/dashboard?category=Litter&category=Potholes&export=1");
         my @rows = $mech->content_as_csv;
         is scalar @rows, 8, '1 (header) + 7 (reports) found = 8 lines';


### PR DESCRIPTION
If someone specifies a lot of wards, it could hit a filesystem maximum file length limit.
Similar to previous work with multiple categories, looks like.
[skip changelog]
