### PR TITLE
[Open311] Strip EXIF metadata from photos imported via media_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
         - Only update lastupdate timestamp if update timestamp is newer. #5350
         - Add ability to process extra question disable messages from endpoint. #5431
         - Persist send_method_used immediately during report sending to prevent loss when senders call discard_changes(). #5671
+        - Strip EXIF metadata from photos imported via media_url. #5841
     - Performance improvements:
         - Use on-disk cache for front page stats rather than memcache. #5763
 

--- a/perllib/FixMyStreet/ImageMagick.pm
+++ b/perllib/FixMyStreet/ImageMagick.pm
@@ -11,6 +11,19 @@ my $IM = eval {
 
 has blob => ( is => 'ro' );
 
+# Image::Magick is not loaded in test mode (see above). This method
+# allows tests that need real image processing to opt in explicitly.
+# Returns true if Image::Magick is available, false otherwise.
+sub _load_imagemagick {
+    return 1 if $IM;
+    eval {
+        require Image::Magick;
+        Image::Magick->import;
+    };
+    return 0 if $@;
+    $IM = 1;
+}
+
 has image => (
     is => 'rwp',
     lazy => 1,

--- a/perllib/Open311.pm
+++ b/perllib/Open311.pm
@@ -15,6 +15,8 @@ use FixMyStreet::DB;
 use Utils;
 use Path::Tiny 'path';
 use FixMyStreet::App::Model::PhotoSet;
+use FixMyStreet::ImageMagick;
+use Try::Tiny;
 
 has jurisdiction => ( is => 'ro', isa => Str );;
 has api_key => ( is => 'ro', isa => Str );
@@ -408,15 +410,24 @@ sub add_media {
 
     my @photos;
     foreach (@$url) {
+        my $photo_blob;
         if ($_ =~ /^data:/) {
             my @parts = split ',', $_, 2;
-            push @photos, $parts[1];
+            $photo_blob = $parts[1];
         } else {
             my $ua = LWP::UserAgent->new;
             my $res = $ua->get($_);
             if ( $res->is_success && $res->content_type =~ m{image/(jpeg|pjpeg|gif|tiff|png)} ) {
-                push @photos, $res->decoded_content;
+                $photo_blob = $res->decoded_content;
             }
+        }
+        if ($photo_blob) {
+            # Strip EXIF metadata and resize, same as user uploads
+            $photo_blob = try {
+                FixMyStreet::ImageMagick->new(blob => $photo_blob)
+                    ->shrink('2048x2048')->as_blob(magick => 'JPEG');
+            } catch { $photo_blob };
+            push @photos, $photo_blob;
         }
     }
     if (@photos) {

--- a/t/Mock/Static.pm
+++ b/t/Mock/Static.pm
@@ -7,6 +7,8 @@ my $sample_file = path(__FILE__)->parent->parent->child("app/controller/sample.j
 my $sample_photo = $sample_file->slurp_raw;
 my $sample_gif = path(__FILE__)->parent->parent->child("app/helpers/grey.gif");
 my $sample_gif_data = $sample_gif->slurp_raw;
+my $sample_exif_file = path(__FILE__)->parent->parent->child("app/controller/sample-with-gps-exif.jpg");
+my $sample_exif_photo = $sample_exif_file->slurp_raw;
 
 sub dispatch_request {
     my $self = shift;
@@ -19,6 +21,11 @@ sub dispatch_request {
     sub (GET + /image.gif) {
         my ($self) = @_;
         return [ 200, [ 'Content-Type' => 'image/gif' ], [ $sample_gif_data ] ];
+    },
+
+    sub (GET + /image-exif.jpeg) {
+        my ($self) = @_;
+        return [ 200, [ 'Content-Type' => 'image/jpeg' ], [ $sample_exif_photo ] ];
     },
 }
 


### PR DESCRIPTION
Photos fetched from Open311 `media_url` elements were stored with their original EXIF metadata intact, unlike user-uploaded photos which are stripped. This could expose GPS coordinates, camera info, and other metadata publicly.

We now process imported photos through the same ImageMagick pipeline used for user uploads, with a fallback to the original blob if processing fails.
