### PR TITLE
Zoom in one more if resolution mismatch.

### DIFF
--- a/web/cobrands/fixmystreet/assets.js
+++ b/web/cobrands/fixmystreet/assets.js
@@ -109,6 +109,10 @@ OpenLayers.Layer.VectorBase = OpenLayers.Class(OpenLayers.Layer.Vector, {
         if (!this.inRange && this.resolutions) {
             var firstVisibleResolution = this.resolutions[0];
             var zoomLevel = fixmystreet.map.getZoomForResolution(firstVisibleResolution);
+            var resCheck = fixmystreet.map.getResolutionForZoom(zoomLevel);
+            if (resCheck > firstVisibleResolution) {
+                zoomLevel++;
+            }
             if (window.selected_problem_id) {
                 var feature = fixmystreet.maps.get_marker_by_id(window.selected_problem_id);
                 if (feature) {


### PR DESCRIPTION
The maximum resolution for a layer might be between two map resolutions, in which case getZoomForResolution will return the lower zoom level, but the assets won’t appear until the higher zoom level. If that’s the case, we zoom in one more.

Fixes e.g. Street cleaning > bin damaged on Bristol where it zooms in one, but tells you to then zoom in again.

(Really then, the max_res of all the layers should then be switched back to OSM ones from the OS BNG ones, because those will work the same in both cases, whereas OS BNG max_res will zoom in one *more* on OSM-resolution maps, but that's more minor.)
[skip changelog]