### PR TITLE
[Bexley][WW] Add sharps eligibility check and sidebar link

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Bulky.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Bulky.pm
@@ -255,10 +255,8 @@ sub bulky_refund_collection {
 
 sub sharps_allowed_property {
     my ( $self, $property ) = @_;
-
-    # XXX Implement checks
-
-    return 1;
+    my $class = $property->{class} || '';
+    return $self->sharps_enabled && $class =~ /^(RD|RH|RI|RE|CE)/;
 }
 
 sub waste_munge_sharps_data {

--- a/t/Mock/Bexley.pm
+++ b/t/Mock/Bexley.pm
@@ -87,6 +87,14 @@ $bexley_mocks{dbi}->mock( 'connect', sub {
                 usrn => 321,
             };
         } else { # address_for_uprn
+            my %uprn_class = (
+                10001 => 'RD04',
+                10005 => 'CE01',
+                10006 => 'RH01',
+                10007 => 'RI01',
+                10008 => 'RE01',
+                10009 => 'CR01',
+            );
             return {
                 postcode          => 'DA13NP',
                 sao_start_number  => 98,
@@ -102,7 +110,7 @@ $bexley_mocks{dbi}->mock( 'connect', sub {
                 street_descriptor => 'THE AVENUE',
                 locality_name     => 'Little Bexlington',
                 town_name         => 'Bexley',
-                class => $_[3] == 10001 ? 'RD04' : 'C',
+                class => $uprn_class{$_[3]} // 'C',
                 has_parent => 1,
             };
         }
@@ -220,6 +228,33 @@ sub _site_info {
             AccountSiteUPRN => '10006',
             Site            => {
                 SiteShortAddress => ', 6, THE AVENUE, DA1 3LD',
+                SiteLatitude     => 51.466707,
+                SiteLongitude    => 0.181108,
+            },
+        },
+        10007 => {
+            AccountSiteID   => 7,
+            AccountSiteUPRN => '10007',
+            Site            => {
+                SiteShortAddress => ', 7, THE AVENUE, DA1 3LD',
+                SiteLatitude     => 51.466707,
+                SiteLongitude    => 0.181108,
+            },
+        },
+        10008 => {
+            AccountSiteID   => 8,
+            AccountSiteUPRN => '10008',
+            Site            => {
+                SiteShortAddress => ', 8, THE AVENUE, DA1 3LD',
+                SiteLatitude     => 51.466707,
+                SiteLongitude    => 0.181108,
+            },
+        },
+        10009 => {
+            AccountSiteID   => 9,
+            AccountSiteUPRN => '10009',
+            Site            => {
+                SiteShortAddress => ', 9, THE AVENUE, DA1 3LD',
                 SiteLatitude     => 51.466707,
                 SiteLongitude    => 0.181108,
             },

--- a/t/app/controller/waste_bexley_sharps.t
+++ b/t/app/controller/waste_bexley_sharps.t
@@ -463,6 +463,34 @@ FixMyStreet::override_config {
 
         $report->delete;
     };
+
+    subtest 'All eligible property classes show sharps section' => sub {
+        my %eligible = (
+            10001 => 'RD',
+            10005 => 'CE',
+            10006 => 'RH',
+            10007 => 'RI',
+            10008 => 'RE',
+        );
+        for my $uprn ( sort keys %eligible ) {
+            my $class = $eligible{$uprn};
+            $mech->get_ok("/waste/$uprn");
+            $mech->content_contains('id="sharps"', "$class-class property shows sharps section");
+            $mech->content_contains('Arrange a sharps collection', "$class-class property shows sharps sidebar link");
+            $mech->get("/waste/$uprn/sharps");
+            is $mech->uri->path, "/waste/$uprn/sharps", "$class-class property can access sharps form";
+        }
+    };
+
+    subtest 'Ineligible property class cannot access sharps' => sub {
+        $mech->get_ok('/waste/10009');
+        $mech->content_lacks('id="sharps"', 'Non-eligible property has no sharps section');
+        $mech->content_lacks('Arrange a sharps collection', 'Non-eligible property has no sharps sidebar link');
+
+        $mech->get('/waste/10009/sharps');
+        is $mech->res->previous->code, 302, 'Accessing sharps form redirects';
+        is $mech->uri->path, '/waste/10009', 'Redirected back to property page';
+    };
 };
 
 done_testing;

--- a/templates/web/bexley/waste/_more_services_sidebar.html
+++ b/templates/web/bexley/waste/_more_services_sidebar.html
@@ -28,6 +28,9 @@
   [% IF property.show_bulky_waste %]
     <li><a href="[% c.uri_for_action('waste/bulky/index', [ property.id ]) %]">Arrange a bulky waste collection</a></li>
   [% END %]
+  [% IF property.show_sharps %]
+    <li><a href="[% c.uri_for_action('waste/bulky/index_sharps', [ property.id ]) %]">Arrange a sharps collection</a></li>
+  [% END %]
   <li><a [% external_new_tab | safe %] href="[% c.uri_for_action('waste/enquiry', [ property.id ]) %]?category=Request+assisted+collection">Get help with putting your bins out</a></li>
 </ul>
 


### PR DESCRIPTION
As per [this Basecamp message](https://3.basecamp.com/4020879/buckets/45093048/todos/9572660043#__recording_9593110483) properties with BLPU code prefixes of RD, RH, RI, RE & CE are eligible for sharps collections. Also adds sidebar link for sharps booking form.

Part of https://github.com/mysociety/societyworks/issues/5371
Fixes https://github.com/mysociety/societyworks/issues/5372

<!-- [skip changelog] -->