### PR TITLE
[Peterborough] Update flytipping submit handling.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin.pm
@@ -561,36 +561,36 @@ sub update_extra_fields : Private {
         if ($behaviour eq 'question') {
             $meta->{required} = $c->get_param("metadata[$i].required") ? 'true' : 'false';
             $meta->{variable} = 'true';
-            my $desc = $c->get_param("metadata[$i].description");
-            $meta->{description} = FixMyStreet::Template::sanitize($desc, 1);
             $meta->{datatype} = $c->get_param("metadata[$i].datatype");
-
-            if ( $meta->{datatype} eq "singlevaluelist" || $meta->{datatype} eq "multivaluelist" ) {
-                $meta->{values} = [];
-                my $re = qr{^metadata\[$i\]\.values\[\d+\]\.key};
-                my @vindices = grep { /$re/ } keys %{ $c->req->params };
-                @vindices = sort { $a <=> $b } map { /values\[(\d+)\]/ } @vindices;
-                foreach my $j (@vindices) {
-                    my $name = $c->get_param("metadata[$i].values[$j].name");
-                    my $key = $c->get_param("metadata[$i].values[$j].key");
-                    my $disable = $c->get_param("metadata[$i].values[$j].disable");
-                    my $disable_message = $c->get_param("metadata[$i].values[$j].disable_message");
-                    push(@{$meta->{values}}, {
-                        name => $name,
-                        key => $key,
-                        $disable ? (disable => 1, disable_message => $disable_message) : (),
-                    }) if $name;
-                }
-            }
         } elsif ($behaviour eq 'notice') {
             $meta->{variable} = 'false';
-            my $desc = $c->get_param("metadata[$i].description");
-            $meta->{description} = FixMyStreet::Template::sanitize($desc, 1);
             $meta->{disable_form} = $c->get_param("metadata[$i].disable_form") ? 'true' : 'false';
         } elsif ($behaviour eq 'hidden') {
             $meta->{automated} = 'hidden_field';
+            $meta->{datatype} = $c->get_param("metadata[$i].datatype");
         } elsif ($behaviour eq 'server') {
             $meta->{automated} = 'server_set';
+        }
+
+        my $desc = $c->get_param("metadata[$i].description");
+        $meta->{description} = FixMyStreet::Template::sanitize($desc, 1) if $desc;
+
+        if ($meta->{datatype} && ($meta->{datatype} eq "singlevaluelist" || $meta->{datatype} eq "multivaluelist")) {
+            $meta->{values} = [];
+            my $re = qr{^metadata\[$i\]\.values\[\d+\]\.key};
+            my @vindices = grep { /$re/ } keys %{ $c->req->params };
+            @vindices = sort { $a <=> $b } map { /values\[(\d+)\]/ } @vindices;
+            foreach my $j (@vindices) {
+                my $name = $c->get_param("metadata[$i].values[$j].name");
+                my $key = $c->get_param("metadata[$i].values[$j].key");
+                my $disable = $c->get_param("metadata[$i].values[$j].disable");
+                my $disable_message = $c->get_param("metadata[$i].values[$j].disable_message");
+                push(@{$meta->{values}}, {
+                    name => $name,
+                    key => $key,
+                    $disable ? (disable => 1, disable_message => $disable_message) : (),
+                }) if $name;
+            }
         }
 
         push @extra_fields, $meta;

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -488,8 +488,9 @@ sub inspect : Private {
                 = $c->cobrand->call_hook(
                     get_body_handler_for_problem => $problem
                 ) || $c->cobrand;
+            $handler->{c} = $c; # So a cobrand function can access it as normal
             my $record_extra
-                = $handler->call_hook('record_update_extra_fields');
+                = $handler->call_hook('record_update_extra_fields', $problem, \%update_params);
             if (
                 $record_extra->{detailed_information}
                 && ( $problem->get_extra_metadata('detailed_information') // '' )

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -266,7 +266,6 @@ sub _witnessed_general_flytipping {
 
 sub open311_pre_send {
     my ($self, $row, $open311) = @_;
-    return 'SKIP' if $self->_witnessed_general_flytipping($row);
 
     # This is a temporary addition to workaround an issue with the bulky goods
     # backend Peterborough are using.
@@ -292,15 +291,24 @@ sub open311_post_send {
     my ($self, $row, $h) = @_;
 
     # Check Open311 was successful
-    my $send_email = $row->external_id || $self->_witnessed_general_flytipping($row);
+    my $send_email = $row->external_id;
     return unless $send_email;
 
     my $emails = $self->feature('open311_email');
     my %flytipping_cats = map { $_ => 1 } @{ $self->_flytipping_categories };
     if ( $emails->{flytipping} && $flytipping_cats{$row->category} ) {
         my $dest = [ $emails->{flytipping}, "Environmental Services" ];
+        $h->{flytipping_extra} = 1;
         my $sender = FixMyStreet::SendReport::Email->new( to => [ $dest ] );
         $sender->send($row, $h);
+        if ($emails->{flytipping_witnessed} && $self->_witnessed_general_flytipping($row)) {
+            my $dest2 = [ $emails->{flytipping_witnessed}, "Environmental Enforcement" ];
+            $h->{flytipping_extra_witnessed} = 1;
+            $sender = FixMyStreet::SendReport::Email->new( to => [ $dest2 ] );
+            $sender->send($row, $h);
+            push @{$row->get_extra_metadata('sent_to')}, $dest->[0];
+            $row->update_extra_metadata(sent_to => $row->get_extra_metadata('sent_to'));
+        }
     }
 }
 

--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -144,6 +144,27 @@ sub lookup_site_code_config { {
     accept_types => { Polygon => 1 },
 } }
 
+=head2 record_update_extra_fields
+
+We want to create comments when flytipping metadata information is changed.
+
+=cut
+
+sub record_update_extra_fields {
+    my ($self, $problem, $update_params) = @_;
+    if ($problem && $problem->category =~ /fly tipping/ && $update_params) {
+        my $param_prefix = lc $problem->category;
+        $param_prefix =~ s/[^a-z]//g;
+        $param_prefix = "category_" . $param_prefix . "_";
+        foreach ('Land_Type', 'Primary_Waste_Type', 'Incident_Size') {
+            my $old = $problem->get_extra_field_value($_) || '';
+            my $new = $self->{c}->get_param($param_prefix . $_) || '';
+            $update_params->{extra}{detailed_information} = 1 if $new ne $old;
+        }
+    }
+    return {};
+}
+
 sub open311_munge_update_params {
     my ($self, $params, $comment, $body) = @_;
 
@@ -152,7 +173,15 @@ sub open311_munge_update_params {
     $params->{description} = "[Customer FMS update] " . $params->{description};
 
     # Send the FMS problem ID with the update.
-    $params->{service_request_id_ext} = $comment->problem->id;
+    my $problem = $comment->problem;
+    $params->{service_request_id_ext} = $problem->id;
+
+    if ($problem->category =~ /fly tipping/) {
+        foreach ('Land_Type', 'Primary_Waste_Type', 'Incident_Size') {
+            my $value = $problem->get_extra_field_value($_);
+            $params->{"attribute[$_]"} = $value if $value;
+        }
+    }
 }
 
 sub updates_sent_to_body {
@@ -161,14 +190,6 @@ sub updates_sent_to_body {
     my $code = $problem->contact->email;
     return 0 if $code =~ /^Bartec/;
     return 1;
-}
-
-sub should_skip_sending_update {
-    my ($self, $update) = @_;
-
-    my $code = $update->problem->contact->email;
-    return 1 if $code =~ /^Bartec/;
-    return 0;
 }
 
 around 'open311_config' => sub {

--- a/t/cobrand/peterborough.t
+++ b/t/cobrand/peterborough.t
@@ -42,7 +42,31 @@ my $params = {
     cobrand => 'peterborough',
 };
 my $peterborough = $mech->create_body_ok(2566, 'Peterborough City Council', $params);
-$mech->create_contact_ok(email => 'FLY', body_id => $peterborough->id, category => 'General fly tipping');
+$mech->create_contact_ok(email => 'FLY', body_id => $peterborough->id, category => 'General fly tipping', extra => {
+    _fields => [
+        {"code" => "Land_Type", "order" => 17, "values" => [
+            {"key" => "Back Alley - L03", "name" => "Back Alley"},
+            {"key" => "Footpath / Bridleway - L02", "name" => "Footpath / Bridleway"},
+            {"key" => "Highway - L01", "name" => "Highway"},
+        ], "datatype" => "singlevaluelist", "required" => "true", "variable" => "true", "description" => "Land Type"},
+
+        {"code" => "Primary_Waste_Type", "order" => 18, "values" => [
+            {"key" => "Tyres - W06", "name" => "Tyres"},
+            {"key" => "Vehicle Parts - W03", "name" => "Vehicle Parts"},
+            {"key" => "White Goods - W04", "name" => "White Goods"},
+        ], "datatype" => "singlevaluelist", "required" => "true", "variable" => "true", "description" => "Primary Waste Type"},
+
+        {"code" => "Incident_Size", "order" => 19, "values" => [
+            {"key" => "Car Boot Load or Less - S02", "name" => "Car Boot Load or Less"},
+            {"key" => "Single Black Bag - S00", "name" => "Single Black Bag"},
+            {"key" => "Small Van Load - S03", "name" => "Small Van Load"},
+        ], "datatype" => "singlevaluelist", "required" => "true", "variable" => "true", "description" => "Incident Size"},
+        {"code" => "pcc-witness", "order" => 20, "values" => [
+            {"key" => "yes", "name" => "Yes"},
+            {"key" => "no", "name" => "No"}
+        ], "datatype" => "singlevaluelist", "required" => "true", "variable" => "true", "description" => "Did you witness the fly-tipping or have evidence about who did it?"},
+    ],
+});
 $mech->create_contact_ok(email => 'Bartec-Graffiti', body_id => $peterborough->id, category => 'Non offensive graffiti');
 my $user = $mech->create_user_ok('peterborough@example.org', name => 'Council User', from_body => $peterborough);
 $peterborough->update( { comment_user_id => $user->id } );
@@ -262,7 +286,10 @@ subtest "flytipping on PCC land is sent by open311 and email" => sub {
         STAGING_FLAGS => { send_reports => 1 },
         MAPIT_URL => 'http://mapit.uk/',
         ALLOWED_COBRANDS => 'peterborough',
-        COBRAND_FEATURES => { open311_email => { peterborough => { flytipping => 'flytipping@example.org' } } },
+        COBRAND_FEATURES => { open311_email => { peterborough => {
+            flytipping => 'flytipping@example.org',
+            flytipping_witnessed => 'witnessed@example.org',
+        } } },
     }, sub {
         $mech->clear_emails_ok;
 
@@ -282,6 +309,9 @@ subtest "flytipping on PCC land is sent by open311 and email" => sub {
             extra => {
                 _fields => [
                     { name => 'site_code', value => '12345', },
+                    { name => 'Land_Type', value => 'Highway - L01', },
+                    { name => 'Primary_Waste_Type', value => 'Tyres - W06', },
+                    { name => 'Incident_Size', value => 'Small Van Load - S03', },
                 ],
             },
         } );
@@ -294,20 +324,25 @@ subtest "flytipping on PCC land is sent by open311 and email" => sub {
         is $p->comments->count, 0, 'no comment added';
         my $cgi = CGI::Simple->new(Open311->test_req_used->content);
         is $cgi->param('service_code'), 'FLY', 'service code is correct';
+        is $cgi->param('attribute[Land_Type]'), 'Highway - L01';
 
         $mech->email_count_is(1);
         my $email = $mech->get_email;
         ok $email, "got an email";
         is $email->header('To'), '"Environmental Services" <flytipping@example.org>', 'email sent to correct address';
+        like $email->header('Subject'), qr/\[Censorship checking only\] Problem Report: /;
     };
 };
 
-subtest "flytipping on PCC land witnessed is only sent by email" => sub {
+subtest "flytipping on PCC land witnessed is sent by open311 and two emails" => sub {
     FixMyStreet::override_config {
         STAGING_FLAGS => { send_reports => 1 },
         MAPIT_URL => 'http://mapit.uk/',
         ALLOWED_COBRANDS => 'peterborough',
-        COBRAND_FEATURES => { open311_email => { peterborough => { flytipping => 'flytipping@example.org' } } },
+        COBRAND_FEATURES => { open311_email => { peterborough => {
+            flytipping => 'flytipping@example.org',
+            flytipping_witnessed => 'witnessed@example.org',
+        } } },
     }, sub {
         $mech->clear_emails_ok;
 
@@ -324,14 +359,22 @@ subtest "flytipping on PCC land witnessed is only sent by email" => sub {
             },
         } );
 
-        my $test_data = FixMyStreet::Script::Reports::send();
+        FixMyStreet::Script::Reports::send();
         $p->discard_changes;
-        ok !$test_data->{test_req_used}, 'open311 not sent';
+        is $p->send_state, 'sent', 'Report marked as sent';
+        is $p->get_extra_metadata('sent_to')->[1], 'flytipping@example.org', 'sent_to extra metadata is set';
+        is $p->get_extra_metadata('sent_to')->[0], 'witnessed@example.org', 'sent_to extra metadata is set';
+        is $p->state, 'confirmed', 'report state unchanged';
+        is $p->comments->count, 0, 'no comment added';
+        my $cgi = CGI::Simple->new(Open311->test_req_used->content);
+        is $cgi->param('service_code'), 'FLY', 'service code is correct';
 
-        $mech->email_count_is(1);
-        my $email = $mech->get_email;
-        ok $email, "got an email";
-        is $email->header('To'), '"Environmental Services" <flytipping@example.org>', 'email sent to correct address';
+        $mech->email_count_is(2);
+        my @email = $mech->get_email;
+        is $email[0]->header('To'), '"Environmental Services" <flytipping@example.org>', 'email sent to correct address';
+        like $email[0]->header('Subject'), qr/\[Censorship checking only\] Problem Report: /;
+        is $email[1]->header('To'), '"Environmental Enforcement" <witnessed@example.org>', 'email sent to correct address';
+        like $email[1]->header('Subject'), qr/\[URGENT - Evidence available\] Problem Report: /;
     };
 };
 
@@ -340,7 +383,10 @@ subtest "flytipping/graffiti on non PCC land is not sent anywhere" => sub {
         STAGING_FLAGS => { send_reports => 1 },
         MAPIT_URL => 'http://mapit.uk/',
         ALLOWED_COBRANDS => 'peterborough',
-        COBRAND_FEATURES => { open311_email => { peterborough => { flytipping => 'flytipping@example.org' } } },
+        COBRAND_FEATURES => { open311_email => { peterborough => {
+            flytipping => 'flytipping@example.org',
+            flytipping_witnessed => 'witnessed@example.org',
+        } } },
     }, sub {
         $mech->clear_emails_ok;
 

--- a/t/cobrand/peterborough.t
+++ b/t/cobrand/peterborough.t
@@ -13,7 +13,7 @@ $mock->mock('_fetch_features', sub {
     my ($self, $args, $x, $y) = @_;
     if ( $args->{type} && $args->{type} eq 'arcgis' ) {
         # council land
-        if ( $x == 552617 && $args->{url} =~ m{4/query} ) {
+        if ( ($x == 552617 || $x == 519240) && $args->{url} =~ m{4/query} ) {
             return [ { geometry => { type => 'Point' } } ];
         # leased out council land
         } elsif ( $x == 552651 && $args->{url} =~ m{3/query} ) {
@@ -36,13 +36,13 @@ my $params = {
     send_method => 'Open311',
     send_comments => 1,
     api_key => 'KEY',
-    endpoint => 'endpoint',
+    endpoint => 'http://endpoint.example.org',
     jurisdiction => 'home',
     can_be_devolved => 1,
     cobrand => 'peterborough',
 };
 my $peterborough = $mech->create_body_ok(2566, 'Peterborough City Council', $params);
-$mech->create_contact_ok(email => 'FLY', body_id => $peterborough->id, category => 'General fly tipping', extra => {
+my $flytipping = $mech->create_contact_ok(email => 'FLY', body_id => $peterborough->id, category => 'General fly tipping', extra => {
     _fields => [
         {"code" => "Land_Type", "order" => 17, "values" => [
             {"key" => "Back Alley - L03", "name" => "Back Alley"},
@@ -72,6 +72,7 @@ my $user = $mech->create_user_ok('peterborough@example.org', name => 'Council Us
 $peterborough->update( { comment_user_id => $user->id } );
 
 my $staffuser = $mech->create_user_ok('counciluser@example.com', name => 'Council User', from_body => $peterborough);
+$staffuser->user_body_permissions->create({ body => $peterborough, permission_type => 'report_inspect' });
 
 subtest 'open311 request handling', sub {
     FixMyStreet::override_config {
@@ -120,7 +121,6 @@ subtest "extra update params are sent to open311" => sub {
         MAPIT_URL => 'http://mapit.uk/',
         ALLOWED_COBRANDS => 'peterborough',
     }, sub {
-        my $contact = $mech->create_contact_ok(body_id => $peterborough->id, category => 'Trees', email => 'TREES');
         Open311->_inject_response('servicerequestupdates.xml', '<?xml version="1.0" encoding="utf-8"?><service_request_updates><request_update><update_id>ezytreev-248</update_id></request_update></service_request_updates>');
 
         my $o = Open311->new(
@@ -128,8 +128,12 @@ subtest "extra update params are sent to open311" => sub {
         );
 
         my ($p) = $mech->create_problems_for_body(1, $peterborough->id, 'Title', {
-            external_id => 1, category => 'Trees', send_state => 'sent',
-            send_method_used => "Open311", cobrand => 'peterborough' });
+            external_id => 1, category => 'General fly tipping', send_state => 'sent',
+            send_method_used => "Open311", cobrand => 'peterborough',
+            extra => { _fields => [
+                { name => 'Incident_Size', value => 'huge' },
+            ] },
+        });
 
         my $c = FixMyStreet::DB->resultset('Comment')->create({
             problem => $p, user => $p->user, anonymous => 't', text => 'Update text',
@@ -142,7 +146,8 @@ subtest "extra update params are sent to open311" => sub {
         my $cgi = CGI::Simple->new($o->test_req_used->content);
         is $cgi->param('description'), '[Customer FMS update] Update text', 'FMS update prefix included';
         is $cgi->param('service_request_id_ext'), $p->id, 'Service request ID included';
-        is $cgi->param('service_code'), $contact->email, 'Service code included';
+        is $cgi->param('service_code'), $flytipping->email, 'Service code included';
+        is $cgi->param('attribute[Incident_Size]'), 'huge';
 
         $mech->get_ok('/report/' . $p->id);
         $mech->content_lacks('Please note that updates are not sent to the council.');
@@ -172,13 +177,14 @@ subtest "bartec report with no geocode handled correctly" => sub {
     };
 };
 
-subtest "no update sent to Bartec" => sub {
+subtest "update sent to Bartec" => sub {
     FixMyStreet::override_config {
         MAPIT_URL => 'http://mapit.uk/',
         ALLOWED_COBRANDS => 'peterborough',
     }, sub {
         $mech->get_ok('/report/' . $problem->id);
         $mech->content_contains('Please note that updates are not sent to the council.');
+        Open311->_inject_response('/servicerequestupdates.xml', '<?xml version="1.0" encoding="utf-8"?><service_request_updates><request_update><update_id>43</update_id></request_update></service_request_updates>');
         my $o = Open311::PostServiceRequestUpdates->new;
         my $c = FixMyStreet::DB->resultset('Comment')->create({
             problem => $problem, user => $problem->user, anonymous => 't', text => 'Update text',
@@ -188,7 +194,7 @@ subtest "no update sent to Bartec" => sub {
         $c->discard_changes; # to get defaults
         $o->process_update($peterborough, $c);
         $c->discard_changes;
-        is $c->send_state, 'skipped';
+        is $c->send_state, 'sent';
     };
 };
 
@@ -295,8 +301,9 @@ subtest "flytipping on PCC land is sent by open311 and email" => sub {
 
         my ($p) = $mech->create_problems_for_body(1, $peterborough->id, 'Title', {
             category => 'General fly tipping',
-            latitude => 52.5708,
-            longitude => 0.2505,
+            latitude => 52.57146,
+            longitude => -0.24201,
+            areas => ',2566,',
             cobrand => 'peterborough',
             geocode => {
                 display_name => '12 A Street, XX1 1SZ',
@@ -331,6 +338,14 @@ subtest "flytipping on PCC land is sent by open311 and email" => sub {
         ok $email, "got an email";
         is $email->header('To'), '"Environmental Services" <flytipping@example.org>', 'email sent to correct address';
         like $email->header('Subject'), qr/\[Censorship checking only\] Problem Report: /;
+
+        subtest 'inspector form makes update when metadata changed' => sub {
+            $mech->log_in_ok( $staffuser->email );
+            $mech->get_ok('/report/' . $p->id);
+            $mech->submit_form_ok({ button => 'save', with_fields => { category_generalflytipping_Incident_Size => 'tiny', include_update => 0 } });
+            $p->discard_changes;
+            is $p->get_extra_field_value('Incident_Size'), 'tiny';
+        };
     };
 };
 
@@ -510,6 +525,8 @@ subtest 'Resending between backends' => sub {
         }
     };
 };
+
+$mech->log_out_ok;
 
 foreach my $cobrand ( "peterborough", "fixmystreet" ) {
     subtest "waste categories aren't available outside /waste on $cobrand cobrand" => sub {

--- a/templates/email/peterborough/submit.html
+++ b/templates/email/peterborough/submit.html
@@ -1,0 +1,72 @@
+[%
+
+email_footer = "If there is a more appropriate email address for messages about " _ category_footer _ ", please let us know. This will help improve the service for local people. We also welcome any other feedback you may have.";
+email_columns = 2;
+
+PROCESS '_email_settings.html';
+
+INCLUDE '_email_top.html';
+
+%]
+
+<th style="[% td_style %][% primary_column_style %]" id="primary_column">
+  [% start_padded_box | safe %]
+  <h1 style="[% h1_style %]">New problem in your&nbsp;area</h1>
+  <p style="[% p_style %]">[% missing %][% multiple %]A user of [% site_name %] has submitted the following report
+of a local problem that they believe might require your attention.</p>
+
+  <p style="margin: 20px auto; text-align: center">
+    <a style="[% button_style %]" href="[% url %]">Show full report</a>
+  </p>
+  <h2 style="[% h2_style %] margin: 30px 0 10px 0">Reported by:</h2>
+  <table [% table_reset | safe %]>
+    <tr>
+      <th style="[% contact_th_style %]">Name</th>
+      <td style="[% contact_td_style %]">[% report.name | html %]</td>
+    </tr>
+    <tr>
+      <th style="[% contact_th_style %]">Email</th>
+      <td style="[% contact_td_style %]">
+        [%~ IF report.user.email ~%]
+          <a href="mailto:[% report.user.email | html %]">[% report.user.email | html %]</a>
+        [%~ ELSE ~%]
+          <strong>No email address provided, only phone number</strong>
+        [%~ END ~%]
+      </td>
+    </tr>
+    [%~ IF report.user.phone %]
+      <tr>
+        <th style="[% contact_th_style %]">Phone</th>
+        <td style="[% contact_td_style %]"><a href="tel:[% report.user.phone | html %]">[% report.user.phone | html %]</a></td>
+      </tr>
+    [%~ END %]
+  </table>
+  <p style="[% p_style %] margin-top: 0.5em;">Replies to this message will go directly to [% report.name | html %], the user who reported the problem.</p>
+  [% end_padded_box | safe %]
+</th>
+[% WRAPPER '_email_sidebar.html' object = report %]
+    <h2 style="[% h2_style %]">[% report.title | html %]</h2>
+
+    <p style="[% secondary_p_style %]"><strong>Report ID:</strong> [% report.id %]</p>
+
+    <p style="[% secondary_p_style %]"><strong>Category:</strong> [% report.category_display %]</p>
+
+    [% report.detail | html_para_email(secondary_p_style) %]
+  [% IF report.get_extra_fields %]
+    <p style="[% secondary_p_style %]">
+      [%~ FOR field IN report.get_extra_fields %][% IF field.value_label OR field.value.length %]
+        <strong>[% field.description OR field.name %]:</strong> [% field.value_label OR field.value %]
+        [% IF NOT loop.last %]<br>[% END %]
+      [%~ END %][% END %]
+    </p>
+  [% END %]
+    <p style="[% secondary_p_style %]">
+      <strong>Location:</strong>
+      <a href="[% osm_url %]" title="View OpenStreetMap of this location">
+        [%~ report.latitude %], [% report.longitude ~%]
+      </a>
+      [% IF closest_address %]<br>[% closest_address | trim | replace("\n\n", "<br>") %][% END %]
+    </p>
+[% END %]
+
+[% INCLUDE '_email_bottom.html' %]

--- a/templates/email/peterborough/submit.txt
+++ b/templates/email/peterborough/submit.txt
@@ -1,0 +1,54 @@
+Subject: [%
+IF flytipping_extra_witnessed; '[URGENT - Evidence available] ';
+ELSIF flytipping_extra; '[Censorship checking only] ';
+END;
+~%]
+Problem Report: [% report.title %]
+
+Dear [% bodies_name %],
+
+[% missing %][% multiple %]A user of
+[% site_name %] has submitted the following report
+of a local problem that they believe might require your attention.
+
+[% fuzzy %], or to provide an update on the problem,
+please visit the following link:
+
+    [% url %]
+
+[% has_photo %]----------
+
+Report ID: [% report.id %]
+
+Name: [% report.name %]
+
+Email: [% report.user.email OR "None provided" %]
+
+Phone: [% report.user.phone OR "None provided" %]
+
+Category: [% report.category_display %]
+
+Subject: [% report.title %]
+
+Details: [% report.detail %]
+
+[% FOR field IN report.get_extra_fields %][% IF field.value_label OR field.value.length ~%]
+[% field.description OR field.name %]: [% field.value_label OR field.value %]
+
+[% END %][% END ~%]
+
+Latitude: [% report.latitude %]
+
+Longitude: [% report.longitude %]
+
+View OpenStreetMap of this location: [% osm_url %]
+
+[% closest_address %]----------
+
+Replies to this email will go to the user who submitted the problem.
+
+[% signature %]
+
+If there is a more appropriate email address for messages about
+[% category_footer %], please let us know. This will help improve the
+service for local people. We also welcome any other feedback you may have.


### PR DESCRIPTION
Send all reports to the backend, whether witnessed or not. Change the subject line for the email also sent, plus send an additional email if it was witnessed.
[skip changelog]
For https://github.com/mysociety/societyworks/issues/5312