### PR TITLE
[Bexley][WW] Support dynamic service IDs for collection slots

### DIFF
--- a/perllib/Integrations/Whitespace.pm
+++ b/perllib/Integrations/Whitespace.pm
@@ -241,11 +241,11 @@ sub GetFullWorksheetDetails {
 }
 
 sub GetCollectionSlots {
-    my ( $self, $uprn, $from, $to ) = @_;
+    my ( $self, $uprn, $from, $to, $service_id ) = @_;
     my $res = $self->call( 'GetCollectionSlots', "$uprn $from $to",
         collectionSlotsInputInput => ixhash(
             Uprn => $uprn,
-            ServiceId => 78,
+            ServiceId => $service_id,
             NextCollectionFromDate => $from,
             NextCollectionToDate => $to,
         )

--- a/perllib/Integrations/Whitespace/Booking.pm
+++ b/perllib/Integrations/Whitespace/Booking.pm
@@ -35,8 +35,9 @@ sub find_available_slots {
     }
 
     my $window = $self->cobrand->_bulky_collection_window($last_earlier_date_str);
+    my $service_id = $self->type eq 'sharps' ? 359 : 78;
     my @available_slots;
-    my $slots = $self->ws->GetCollectionSlots($self->property->{uprn}, $window->{date_from}, $window->{date_to});
+    my $slots = $self->ws->GetCollectionSlots($self->property->{uprn}, $window->{date_from}, $window->{date_to}, $service_id);
     foreach (@$slots) {
         (my $date = $_->{AdHocRoundInstanceDate}) =~ s/T00:00:00//;
         $date = $self->cobrand->_bulky_date_to_dt($date);

--- a/t/app/controller/waste_bexley_sharps.t
+++ b/t/app/controller/waste_bexley_sharps.t
@@ -59,6 +59,12 @@ FixMyStreet::override_config {
         $mech->submit_form_ok;
 
         $mech->content_contains('About you');
+        my $got_service_id;
+        $whitespace_mock->mock('GetCollectionSlots', sub {
+            my ($self, $uprn, $from, $to, $service_id) = @_;
+            $got_service_id = $service_id;
+            return $slots_default;
+        });
         $mech->submit_form_ok(
             {   with_fields => {
                     name  => 'Bob Marge',
@@ -67,6 +73,7 @@ FixMyStreet::override_config {
                 }
             }
         );
+        is $got_service_id, 359, 'Uses sharps service ID for GetCollectionSlots';
 
         $mech->content_contains('Choose date for collection');
         $mech->submit_form_ok(


### PR DESCRIPTION
The `GetCollectionSlots` method now accepts a `service_id` parameter instead of hardcoding it to 78. This allows different waste types (such as sharps collections) to use their appropriate service IDs.

Part of https://github.com/mysociety/societyworks/issues/5373

<!-- [skip changelog] -->