### PR TITLE
[Bexley][WW] Remove Saturday extra charge note on sharps form

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Bulky.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Bulky.pm
@@ -76,8 +76,8 @@ sub bulky_date_label {
     my $format = '%A %e %B';
     my $label = $dt->strftime($format);
 
-    # Saturdays have higher pricing
-    if ( $dt->day_of_week == 6 ) {
+    # Saturdays have higher pricing for bulky, but not sharps
+    if ( $dt->day_of_week == 6 && !$self->{c}->stash->{sharps} ) {
         $label .= ' (extra charge)';
     }
 

--- a/t/app/controller/waste_bexley_sharps.t
+++ b/t/app/controller/waste_bexley_sharps.t
@@ -464,6 +464,24 @@ FixMyStreet::override_config {
         $report->delete;
     };
 
+    subtest 'Saturday dates do not show extra charge note' => sub {
+        $mech->get_ok('/waste/10001/sharps');
+        $mech->submit_form_ok;
+
+        $mech->submit_form_ok(
+            {   with_fields => {
+                    name  => 'Bob Marge',
+                    email => $user->email,
+                    phone => '44 07 111 111 111',
+                }
+            }
+        );
+
+        $mech->content_contains('Choose date for collection');
+        $mech->content_contains('5 July', 'Saturday date is shown');
+        $mech->content_lacks('extra charge', 'Saturday does not show extra charge on sharps form');
+    };
+
     subtest 'All eligible property classes show sharps section' => sub {
         my %eligible = (
             10001 => 'RD',


### PR DESCRIPTION
Remove the "(extra charge)" note from Saturday dates on the sharps form as there is no charge for sharps collections.

Part of https://github.com/mysociety/societyworks/issues/5374

<!-- [skip changelog] -->
