### PR TITLE
[Bexley] Only check legacy contracts for cancel.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
@@ -315,6 +315,8 @@ sub waste_get_current_payment_method {
     my $uprn = $property->{uprn};
     return unless $uprn;
 
+    return unless $self->{c}->action eq 'waste/garden/cancel';
+
     my $legacy_contract_ids = BexleyContracts::contract_ids_for_uprn($uprn);
     if ($legacy_contract_ids && @$legacy_contract_ids) {
         return 'direct_debit';

--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -2690,6 +2690,10 @@ FixMyStreet::override_config {
         });
 
         $mech->log_in_ok($staff_user->email);
+
+        $mech->get_ok('/waste/20001/garden_renew');
+        $mech->content_lacks('which will renew automatically');
+
         $mech->get_ok('/waste/20001/garden_cancel');
         $mech->submit_form_ok({
             with_fields => {


### PR DESCRIPTION
We can use the Agile data for renewals, no need to check the legacy contracts.
[skip changelog] FD-6663