### PR TITLE
[Bexley][WW] Add reminder emails for sharps bookings

### DIFF
--- a/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
@@ -668,7 +668,7 @@ sub bulky_reminders {
     # Can't see an easy way to find these apart from loop through them all.
     # Is only daily.
     my $collections = $self->problems->search({
-        category => ['Bulky collection', 'Small items collection'],
+        category => ['Bulky collection', 'Small items collection', 'Sharps collection'],
         state => [ FixMyStreet::DB::Result::Problem->open_states ], # XXX?
     });
 
@@ -678,7 +678,7 @@ sub bulky_reminders {
         $collections = $collections->search({
              -or => [
                 extra => { '\?' => 'payment_reference' },
-                category => 'Small items collection'
+                category => ['Small items collection', 'Sharps collection']
             ]
         });
     }

--- a/t/app/controller/waste_bexley_sharps.t
+++ b/t/app/controller/waste_bexley_sharps.t
@@ -1,3 +1,4 @@
+use Test::MockTime qw(:all);
 use FixMyStreet::Script::Reports;
 use FixMyStreet::TestMech;
 use t::Mock::Bexley;
@@ -487,6 +488,70 @@ FixMyStreet::override_config {
         $mech->content_contains('Choose date for collection');
         $mech->content_contains('5 July', 'Saturday date is shown');
         $mech->content_lacks('extra charge', 'Saturday does not show extra charge on sharps form');
+    };
+
+    subtest 'Sharps collection email reminders' => sub {
+        $mech->get_ok('/waste/10001/sharps');
+        $mech->submit_form_ok; # intro page
+        $mech->submit_form_ok({ with_fields => {
+            name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111',
+        }});
+        $mech->submit_form_ok({ with_fields => { chosen_date => '2025-06-27;1;' } });
+        $mech->submit_form_ok({ with_fields => {
+            sharps_collecting => 'Yes', sharps_delivering => 'No',
+        }});
+        $mech->submit_form_ok({ with_fields => {
+            collect_small_quantity => 3, collect_large_quantity => 2,
+        }});
+        $mech->submit_form_ok({ with_fields => {
+            collect_location        => 'Doorstep',
+            collect_glucose_monitor => 'No',
+            collect_cytotoxic       => 'Yes',
+        }});
+        $mech->submit_form_ok({ with_fields => { tandc => 1 } });
+        $mech->clear_emails_ok;
+
+        my $report = FixMyStreet::DB->resultset('Problem')->search(
+            undef, { order_by => { -desc => 'id' } }
+        )->first;
+
+        my $cobrand = $body->get_cobrand_handler;
+
+        # Collection date is 2025-06-27. Too early — no reminder 3 days before.
+        set_fixed_time('2025-06-24T05:44:59Z');
+        $cobrand->bulky_reminders;
+        $mech->email_count_is(0, 'No reminder 3 days before collection');
+
+        # One day before — reminder is sent
+        set_fixed_time('2025-06-26T05:44:59Z');
+        $cobrand->bulky_reminders;
+        my $email = $mech->get_email;
+
+        is $email->header('Subject'),
+            'Sharps collection reminder - reference ' . $report->id,
+            'Correct reminder subject';
+
+        my $txt  = $mech->get_text_body_from_email($email);
+        my $html = $mech->get_html_body_from_email($email);
+
+        like $txt, qr/This is a reminder that your collection is tomorrow/,
+            'Reminder email distinguishable from confirmation (txt)';
+        like $txt, qr/${\$report->id}/, 'Includes request number (txt)';
+        like $txt, qr/Address:.*DA1 3NP/, 'Includes collection address (txt)';
+        like $txt, qr/Friday 27 June 2025/, 'Includes collection date (txt)';
+        like $txt, qr/Number of 1-litre boxes: 3/, 'Includes 1-litre box count (txt)';
+        like $txt, qr/Number of 5-litre boxes: 2/, 'Includes 5-litre box count (txt)';
+        like $txt, qr/Glucose monitoring devices: No/, 'Includes glucose monitor detail (txt)';
+        like $txt, qr/Cytotoxic waste: Yes/, 'Includes cytotoxic waste detail (txt)';
+        unlike $txt, qr{/waste/10001/sharps/cancel/}, 'No cancel link in reminder (txt)';
+
+        like $html, qr/Friday 27 June 2025/, 'Includes collection date (html)';
+        unlike $html, qr{/waste/10001/sharps/cancel/}, 'No cancel link in reminder (html)';
+        $mech->clear_emails_ok;
+
+        # No second reminder sent
+        $cobrand->bulky_reminders;
+        $mech->email_count_is(0, 'No duplicate reminder sent');
     };
 
     subtest 'All eligible property classes show sharps section' => sub {

--- a/templates/email/default/waste/bulky-reminder.html
+++ b/templates/email/default/waste/bulky-reminder.html
@@ -29,10 +29,14 @@ cancel_url = cobrand.base_url _ '/waste/' _ property_id_uri _ '/' _ bulky_cancel
     [% END %]
   </p>
 
+  [% IF report.category == 'Sharps collection' %]
+    [% INCLUDE 'waste/_sharps_list.html' %]
+  [% ELSE %]
   <p style="[% p_style %]">
     Items to be collected:
     [% INCLUDE 'waste/_bulky_list.html' %]
   </p>
+  [% END %]
 
     [% INCLUDE '_council_reference.html' problem=report %]
 

--- a/templates/email/default/waste/bulky-reminder.txt
+++ b/templates/email/default/waste/bulky-reminder.txt
@@ -1,5 +1,7 @@
 Subject: [%~ IF report.category == 'Small items collection' ~%]
 [%~ " Small items collection reminder - reference " _ report.id %]
+[%~ ELSIF report.category == 'Sharps collection' ~%]
+[%~ " Sharps collection reminder - reference " _ report.id %]
 [%~ ELSE ~%]
 [%~ " Bulky waste collection reminder - reference " _ report.id %]
 [%~ END %]
@@ -19,8 +21,12 @@ This is a reminder that your collection is in 3 days.
 This is a reminder that your collection is tomorrow.
 [% END %]
 
+[% IF report.category == 'Sharps collection' %]
+[% INCLUDE 'waste/_sharps_list.txt' %]
+[% ELSE %]
 Items to be collected:
 [% INCLUDE 'waste/_bulky_list.txt' %]
+[% END %]
 
 [% INCLUDE '_council_reference.txt' problem=report %]
 


### PR DESCRIPTION
Setup reminder emails for sharps bookings. This uses the existing mechanism that Bulky and Small items uses, just adds extra conditionals to handle sharps.

Fixes https://github.com/mysociety/societyworks/issues/5408

<!-- [skip changelog] -->