### PR TITLE
[Bexley][WW] Improve validations for sharps collection and delivery quantities

### DIFF
--- a/perllib/FixMyStreet/App/Form/Waste/Sharps.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Sharps.pm
@@ -202,15 +202,24 @@ sub validate {
         if ($total == 0) {
             $self->add_form_error('You must specify at least one box for collection');
         } elsif ($total > 8) {
-            $self->add_form_error('You can collect a maximum of 8 boxes at a time');
+            $self->add_form_error('A maximum of 8 boxes can be collected per booking');
+        }
+        if ($small > 5) {
+            $self->add_form_error('A maximum of 5 one-litre boxes can be collected per booking');
+        }
+        if ($large > 3) {
+            $self->add_form_error('A maximum of 3 five-litre boxes can be collected per booking');
         }
     }
 
     if ($self->current_page->name eq 'delivery_details') {
         my $size = $self->field('deliver_size')->value || '';
         my $quantity = $self->field('deliver_quantity')->value || 0;
+        if ($size eq '1-litre' && $quantity > 5) {
+            $self->add_form_error('A maximum of 5 one-litre boxes can be delivered per booking');
+        }
         if ($size eq '5-litre' && $quantity > 3) {
-            $self->add_form_error('You can request a maximum of 3 five-litre boxes');
+            $self->add_form_error('A maximum of 3 five-litre boxes can be delivered per booking');
         }
     }
 }

--- a/t/app/controller/waste_bexley_sharps.t
+++ b/t/app/controller/waste_bexley_sharps.t
@@ -111,6 +111,18 @@ FixMyStreet::override_config {
         );
 
         $mech->content_contains('Collection quantities');
+
+        # Validate individual and total collection limits
+        $mech->submit_form_ok(
+            { with_fields => { collect_small_quantity => 6, collect_large_quantity => 0 } } );
+        $mech->content_contains('A maximum of 5 one-litre boxes can be collected per booking');
+        $mech->submit_form_ok(
+            { with_fields => { collect_small_quantity => 0, collect_large_quantity => 4 } } );
+        $mech->content_contains('A maximum of 3 five-litre boxes can be collected per booking');
+        $mech->submit_form_ok(
+            { with_fields => { collect_small_quantity => 5, collect_large_quantity => 4 } } );
+        $mech->content_contains('A maximum of 8 boxes can be collected per booking');
+
         $mech->submit_form_ok(
             {   with_fields => {
                     collect_small_quantity => 3,
@@ -130,6 +142,15 @@ FixMyStreet::override_config {
         );
 
         $mech->content_contains('Delivery details');
+
+        # Validate delivery limits
+        $mech->submit_form_ok(
+            { with_fields => { deliver_size => '5-litre', deliver_quantity => 4 } } );
+        $mech->content_contains('A maximum of 3 five-litre boxes can be delivered per booking');
+        $mech->submit_form_ok(
+            { with_fields => { deliver_size => '1-litre', deliver_quantity => 6 } } );
+        $mech->content_contains('A maximum of 5 one-litre boxes can be delivered per booking');
+
         $mech->submit_form_ok(
             {   with_fields => {
                     deliver_size => '1-litre',


### PR DESCRIPTION
Add validations for maximum number of 1/5 litre boxes for collections, and for 5 litre boxes for delivery.

Also improves the wording of the validations error messages.

Related to discussion in https://github.com/mysociety/fixmystreet/pull/5843#discussion_r2852634598

<!-- [skip changelog] -->
