### PR TITLE
[Bexley][WW] Update list of property classes for bulky bookings

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Bulky.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Bulky.pm
@@ -18,7 +18,7 @@ sub booking_class { 'Integrations::Whitespace::Booking' }
 sub bulky_allowed_property {
     my ($self, $property) = @_;
     my $class = $property->{class} || '';
-    return $self->bulky_enabled && $class =~ /^(RD|RH)/ ? 1 : 0;
+    return $self->bulky_enabled && $class =~ /^(RD|RH|RI|RE|CE)/ ? 1 : 0;
 }
 
 sub bulky_cancellation_cutoff_time { { hours => 23, minutes => 59, days_before => 2, working_days => 1 } }

--- a/t/app/controller/waste_bexley_bulky.t
+++ b/t/app/controller/waste_bexley_bulky.t
@@ -620,6 +620,34 @@ FixMyStreet::override_config {
         is $call_params->{'temp:request'}{sale}{receiptDetails}{name}{surname}, 'Bob Marge';
         is $call_params->{'temp:request'}{sale}{items}{item}[0]{itemDetails}{accountDetails}{name}{surname}, 'Bob Marge';
     };
+
+    subtest 'All eligible property classes show bulky section' => sub {
+        my %eligible = (
+            10001 => 'RD',
+            10005 => 'CE',
+            10006 => 'RH',
+            10007 => 'RI',
+            10008 => 'RE',
+        );
+        for my $uprn ( sort keys %eligible ) {
+            my $class = $eligible{$uprn};
+            $mech->get_ok("/waste/$uprn");
+            $mech->content_contains('Bulky waste', "$class-class property shows bulky section");
+            $mech->content_contains('Arrange a bulky waste collection', "$class-class property shows bulky sidebar link");
+            $mech->get("/waste/$uprn/bulky");
+            is $mech->uri->path, "/waste/$uprn/bulky", "$class-class property can access bulky form";
+        }
+    };
+
+    subtest 'Ineligible property class cannot access bulky' => sub {
+        $mech->get_ok('/waste/10009');
+        $mech->content_lacks('Bulky waste', 'Non-eligible property has no bulky section');
+        $mech->content_lacks('Arrange a bulky waste collection', 'Non-eligible property has no bulky sidebar link');
+
+        $mech->get('/waste/10009/bulky');
+        is $mech->res->previous->code, 302, 'Accessing bulky form redirects';
+        is $mech->uri->path, '/waste/10009', 'Redirected back to property page';
+    };
 };
 
 FixMyStreet::override_config {


### PR DESCRIPTION
Bexley have asked for the list of property classes that can book bulky waste to match the list that are allowed to book sharps collections.

Was mentioned in [this Basecamp comment](https://3.basecamp.com/4020879/buckets/45093048/todos/9572660043#__recording_9593110483) and they have since confirmed that it should match sharps.

Sharps hasn't been merged yet, but you can see the changes in #5843 (`sharps_allowed_property` method).

<!-- [skip changelog] -->
