### PR TITLE
[Rutland][Confirm] Add Roles for Confirm sending

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Rutland.pm
+++ b/perllib/FixMyStreet/Cobrand/Rutland.pm
@@ -13,6 +13,12 @@ Rutland is a unitary authority, with a Salesforce backend.
 package FixMyStreet::Cobrand::Rutland;
 use base 'FixMyStreet::Cobrand::UKCouncils';
 
+use Moo;
+with 'FixMyStreet::Roles::ConfirmOpen311';
+with 'FixMyStreet::Roles::ConfirmValidation';
+with 'FixMyStreet::Roles::Cobrand::OpenUSRN';
+with 'FixMyStreet::Roles::Open311Multi';
+
 use strict;
 use warnings;
 
@@ -23,23 +29,34 @@ sub council_url { return 'rutland'; }
 
 =over 4
 
-=item * Rutland's endpoint only allows titles up to 254 characters and names up to 40 characters in length.
+=item * Rutland's Salesforce endpoint only allows titles up to 254 characters and names up to 40 characters in length.
+But their Confirm backend uses the Confirm Role validation
 
 =cut
 
-sub report_validation {
-    my ($self, $report, $errors) = @_;
+around report_validation => sub {
+    my ($orig, $self) = (shift, shift);
 
-    if ( length( $report->title ) > 254 ) {
-        $errors->{title} = sprintf( _('Summaries are limited to %s characters in length. Please shorten your summary'), 254 );
+    my ($report, $errors) = @_;
+    my $contact = FixMyStreet::DB->resultset('Contact')->find({
+        body_id => $self->body->id,
+        category => $report->category,
+    });
+
+    if ($contact->email =~ /^Confirm-/) {
+        $self->$orig(@_);
+    } else {
+        if ( length( $report->title ) > 254 ) {
+            $errors->{title} = sprintf( _('Summaries are limited to %s characters in length. Please shorten your summary'), 254 );
+        }
+
+        if ( length( $report->name ) > 40 ) {
+            $errors->{name} = sprintf( _('Names are limited to %d characters in length.'), 40 );
+        }
+
+        return $errors;
     }
-
-    if ( length( $report->name ) > 40 ) {
-        $errors->{name} = sprintf( _('Names are limited to %d characters in length.'), 40 );
-    }
-
-    return $errors;
-}
+};
 
 =item * It copes with multiple photos.
 
@@ -51,20 +68,25 @@ sub open311_config {
     $params->{multi_photos} = 1;
 }
 
-=item * It receives some extra data, such as the FixMyStreet ID, closest address, and title/detail in separate fields.
+=item * SalesForce receives specified extra data, but Confirm uses default from ConfirmOpen311 role
 
 =cut
 
-sub open311_extra_data_include {
-    my ($self, $row, $h) = @_;
+around open311_extra_data_include => sub {
+    my ($orig, $self) = (shift, shift);
+    my ($row, $h, $contact) = @_;
 
-    return [
-        { name => 'external_id', value => $row->id },
-        { name => 'title', value => $row->title },
-        { name => 'description', value => $row->detail },
-        $h->{closest_address} ? { name => 'closest_address', value => "$h->{closest_address}" } : (),
-    ];
-}
+    my $data = $self->$orig(@_);
+
+    if ($contact->email !~ /^Confirm-/) {
+        push @$data, (
+                      { name => 'external_id', value => $row->id },
+                      $h->{closest_address} ? { name => 'closest_address', value => "$h->{closest_address}" } : (),
+                     );
+    };
+
+    return $data;
+};
 
 =item * It provides extra hints to be shown alongside category/group options in the reporting interface.
 

--- a/t/cobrand/rutland.t
+++ b/t/cobrand/rutland.t
@@ -32,6 +32,12 @@ $contact2->set_extra_metadata(
 );
 $contact2->update;
 
+my $confirm_contact = $mech->create_contact_ok(
+    body_id => $body->id,
+    category => 'Drains',
+    email => 'Confirm-1234',
+);
+
 my @reports = $mech->create_problems_for_body( 1, $body->id, 'Test', {
     cobrand => 'rutland',
     user => $user,
@@ -52,7 +58,7 @@ for my $update ('in progress', 'unable to fix') {
     } );
 }
 
-subtest 'testing special Open311 behaviour', sub {
+subtest 'testing special Open311 behaviour for SalesForce', sub {
     $report->set_extra_fields();
     $report->update;
     $body->update( { send_method => 'Open311', endpoint => 'http://rutland.endpoint.example.com', jurisdiction => 'FMS', api_key => 'test', send_comments => 1 } );
@@ -73,6 +79,34 @@ subtest 'testing special Open311 behaviour', sub {
     is $c->param('attribute[title]'), $report->title, 'Request had title';
     is $c->param('attribute[description]'), $report->detail, 'Request had description';
     is $c->param('attribute[external_id]'), $report->id, 'Request had correct ID';
+    is $c->param('jurisdiction_id'), 'FMS', 'Request had correct jurisdiction';
+};
+
+my ($confirm_problem) = $mech->create_problems_for_body( 1, $body->id, 'Test', {
+    cobrand => 'rutland',
+    user => $user,
+    category => $confirm_contact->category,
+});
+
+subtest 'testing special Open311 behaviour for Confirm', sub {
+    $body->update( { send_method => 'Open311', endpoint => 'http://rutland.endpoint.example.com', jurisdiction => 'FMS', api_key => 'test', send_comments => 1 } );
+    FixMyStreet::override_config {
+        STAGING_FLAGS => { send_reports => 1 },
+        ALLOWED_COBRANDS => [ 'fixmystreet', 'rutland' ],
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        FixMyStreet::Script::Reports::send();
+    };
+    $report->discard_changes;
+    ok $report->whensent, 'Report marked as sent';
+    is $report->send_method_used, 'Open311', 'Report sent via Open311';
+    is $report->external_id, 248, 'Report has right external ID';
+
+    my $req = Open311->test_req_used;
+    my $c = CGI::Simple->new($req->content);
+    is $c->param('attribute[title]'), $report->title, 'Request had title';
+    is $c->param('attribute[description]'), $report->detail, 'Request had description';
+    is $c->param('attribute[report_url]'), 'http://rutland.example.org/report/' . $confirm_problem->id, 'Request had report_url';
     is $c->param('jurisdiction_id'), 'FMS', 'Request had correct jurisdiction';
 };
 
@@ -155,6 +189,28 @@ subtest 'check open311_contact_meta_override' => sub {
     is scalar(@{ $contact->get_extra_fields }), 0, "hints aren't included in extra fields";
     is $contact->get_extra_metadata('category_hint'), $expected_hint, 'hint set correctly on contact';
     is $contact->get_extra_metadata('group_hint'), $expected_group_hint, 'group_hint set correctly on contact';
+};
+
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => [ 'rutland' ],
+    MAPIT_URL        => 'http://mapit.uk/',
+}, sub {
+    $mech->log_in_ok($user->email);
+    for my $test (
+                  { category => 'Drains', length => 50 },
+                  { category => 'Bins', length => 40 }
+    ) {
+        $mech->get('/report/new?longitude=-0.727877&latitude=52.670447');
+        $mech->submit_form_ok({
+          with_fields => {
+                         category => $test->{category},
+                         detail => "Report details",
+                         title => "Test report",
+                         name => "Testingauserwithaverylong Namethatgoesonforalotofcharacters",
+         }
+       });
+       $mech->content_contains('Names are limited to ' . $test->{length} . ' characters', "Correct report validation used");
+    }
 };
 
 done_testing();


### PR DESCRIPTION
Adds the roles for sending to Confirm and to a Multi backend.

Engineers previous open311_extra_data_include to work with Confirm role's open311_extra_data_include in case of changes to Confirm or Salesforce though unlikely.

https://github.com/mysociety/societyworks/issues/5403
