### PR TITLE
[Sutton][Waste] enable different prices for bulky collections containing POPs

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Waste.pm
@@ -76,12 +76,15 @@ sub edit : Chained('body') : PathPart('') : Args(0) {
             $new_cfg = $c->stash->{body}->get_extra_metadata("wasteworks_config", {});
             my %keys = (
                 per_item_costs => 'bool',
+                pop_costs => 'bool',
                 per_item_min_collection_price => 'int',
                 base_price => 'int',
+                base_pop_price => 'int',
                 daily_slots => 'int',
                 items_per_collection_max => 'int',
                 small_items_per_collection_max => 'int',
                 band1_price => 'int',
+                band1_pop_price => 'int',
                 band1_max => 'int',
                 free_mode => 'bool',
                 food_bags_disabled => 'sel',
@@ -144,6 +147,7 @@ sub booked_items : Private {
         $cobrand->call_hook('bulky_per_item_pricing_property_types');
 
     $c->stash->{item_points} = $cobrand->call_hook('bulky_points_per_item_pricing');
+    $c->stash->{pop_costs} = $cobrand->call_hook('bulky_pop_item_costs');
 
     if ($c->req->method eq 'POST') {
         $c->forward('/auth/check_csrf_token');
@@ -166,6 +170,9 @@ sub booked_items : Private {
             };
             if ($c->stash->{item_points}) {
                 $item->{points} = $c->get_param("points[$i]");
+            }
+            if ($c->stash->{pop_costs}) {
+                $item->{contains_pops} = $c->get_param("contains_pops[$i]");
             }
 
             foreach my $property_type (@{$c->{stash}->{per_item_pricing_property_types}}) {
@@ -236,7 +243,7 @@ sub stash_body_config_json : Private {
     } else {
         $c->stash->{body_config_json} = JSON->new->utf8(1)->pretty->canonical->encode($cfg);
     }
-    foreach (qw(free_mode per_item_costs per_item_min_collection_price base_price daily_slots small_items_per_collection_max items_per_collection_max food_bags_disabled show_location_page band1_price band1_max show_individual_notes)) {
+    foreach (qw(free_mode per_item_costs pop_costs per_item_min_collection_price base_price base_pop_price daily_slots small_items_per_collection_max items_per_collection_max food_bags_disabled show_location_page band1_price band1_pop_price band1_max show_individual_notes)) {
         $c->stash->{$_} = $c->get_param($_) || $cfg->{$_};
     }
 }

--- a/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
@@ -59,6 +59,7 @@ sub sharps_enabled {
 sub bulky_items_master_list { $_[0]->wasteworks_config->{item_list} || [] }
 sub small_items_master_list { $_[0]->wasteworks_config->{small_item_list} || [] }
 sub bulky_per_item_costs { $_[0]->wasteworks_config->{per_item_costs} }
+sub bulky_pop_item_costs { $_[0]->wasteworks_config->{pop_costs} }
 
 sub bulky_nice_item_list {
     my ($self, $report) = @_;
@@ -158,7 +159,18 @@ sub bulky_pricing_strategy {
         $out = { strategy => 'per_item', min => $min_collection_price };
     } elsif (my $band1_price = $self->wasteworks_config->{band1_price}) {
         my $max = $self->{c}->stash->{booking_maximum};
-        $out = { strategy => 'banded', bands => [ { max => $band1_max, price => $band1_price }, { max => $max, price => $base_price } ] };
+        if ($self->wasteworks_config->{pop_costs}) {
+            $out = { strategy => 'banded_pop', bands =>
+                [
+                    { max => $band1_max, pop_price => $self->wasteworks_config->{band1_pop_price}, price => $band1_price },
+                    { max => $max, pop_price => $self->wasteworks_config->{base_pop_price}, price => $base_price }
+                ]
+            };
+        } else {
+            $out = { strategy => 'banded', bands => [ { max => $band1_max, price => $band1_price }, { max => $max, price => $base_price } ] };
+        }
+    } elsif ($self->wasteworks_config->{pop_costs}) {
+        $out = { strategy => 'pop_costs', price => $base_price, pop_price => $self->wasteworks_config->{base_pop_price} };
     } else {
         $out = { strategy => 'single' };
     }
@@ -226,6 +238,7 @@ sub bulky_items_extra {
         $hash{ $item->{name} }{price} = $item->{$price_key} if $item->{$price_key} && $per_item;
         $hash{ $item->{name} }{points} = $item->{points} if $item->{points};
         $hash{ $item->{name} }{max} = $item->{max} if $item->{max};
+        $hash{ $item->{name} }{contains_pops} = 1 if $item->{contains_pops};
         $hash{ $item->{name} }{json} = $json->encode($hash{$item->{name}}) if $hash{$item->{name}};
     }
     return \%hash;
@@ -264,6 +277,11 @@ sub bulky_minimum_cost {
 sub bulky_total_cost {
     my ($self, $data) = @_;
     my $c = $self->{c};
+
+    my %pop_items;
+    if ($self->bulky_pop_item_costs) {
+        %pop_items = map { $_->{name} => 1 } grep { $_->{contains_pops} } @{ $self->bulky_items_master_list };
+    }
 
     if ($self->bulky_free_collection_available) {
         $data->{extra_CHARGEABLE} = 'FREE';
@@ -304,18 +322,26 @@ sub bulky_total_cost {
             }
         } elsif ($cfg->{band1_price}) {
             my $count = 0;
+            my $has_pops = 0;
             my $max = $c->stash->{booking_maximum};
             for (1..$max) {
                 my $item = $data->{"item_$_"} or next;
+                $has_pops = 1 if $pop_items{$item};
                 $count++;
             }
             if ($count <= $cfg->{band1_max}) {
-                $c->stash->{payment} = $cfg->{band1_price};
+                $c->stash->{payment} = $has_pops ? $cfg->{band1_pop_price} : $cfg->{band1_price};
             } else {
-                $c->stash->{payment} = $cfg->{base_price};
+                $c->stash->{payment} = $has_pops ? $cfg->{base_pop_price} : $cfg->{base_price};
             }
         } else {
-            $c->stash->{payment} = $cfg->{base_price};
+            my $has_pops = 0;
+            my $max = $c->stash->{booking_maximum};
+            for (1..$max) {
+                my $item = $data->{"item_$_"} or next;
+                $has_pops = 1 if $pop_items{$item};
+            }
+            $c->stash->{payment} = $has_pops ? $cfg->{base_pop_price} : $cfg->{base_price};
         }
     }
 

--- a/t/app/controller/waste_kands_bulky.t
+++ b/t/app/controller/waste_kands_bulky.t
@@ -1175,6 +1175,88 @@ FixMyStreet::override_config {
         $echo->mock('GetEventsForObject', sub { [] }); # reset
     };
 
+    subtest 'Bulky goods collection booking with POP items' => sub {
+        set_fixed_time('2023-07-06T10:00:00Z');
+        my $cfg = $sutton->get_extra_metadata('wasteworks_config');
+        $cfg->{base_pop_price} = 6500;
+        $cfg->{band1_pop_price} = 4500;
+        $cfg->{pop_costs} = 1;
+        push @{$cfg->{item_list}}, { bartec_id => 90, name => 'Sofa', contains_pops => 1 };
+        $sutton->set_extra_metadata(wasteworks_config => $cfg);
+        $sutton->update;
+
+        $mech->get_ok('/waste/12345/bulky');
+
+        subtest 'Intro page' => sub {
+            $mech->content_contains('1 to 4 items cost £40.00');
+            $mech->content_contains('(£45.00 if any item contains POPs)');
+            $mech->content_contains('5 to 8 items cost £61.00');
+            $mech->content_contains('(£65.00 if any item contains POPs)');
+            $mech->content_contains('Bookings are final and non refundable');
+            $mech->submit_form_ok;
+        };
+        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
+        $mech->submit_form_ok(
+            { with_fields => { chosen_date => '2023-07-01T00:00:00;reserve1==::reserve4==;2023-06-25T10:10:00' } }
+        );
+        $mech->content_contains('Select the items to be collected using the');
+
+        subtest 'higher band try' => sub {
+            $mech->submit_form_ok(
+                {
+                    form_number => 1,
+                    fields => {
+                        'item_1' => 'BBQ',
+                        'item_notes_1' => 'BBQ note',
+                        'item_photo_1' => [ $sample_file, undef, Content_Type => 'image/jpeg' ],
+                        'item_2' => 'Bicycle',
+                        'item_notes_2' => 'Bicycle note',
+                        'item_3' => 'Bath',
+                        'item_notes_3' => 'Bath note',
+                        'item_4' => 'Sofa',
+                        'item_notes_4' => 'Sofa note',
+                        'item_5' => 'Sofa',
+                        'item_notes_5' => 'Second Sofa note',
+                    },
+                },
+            );
+            $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
+            $mech->content_contains('5 items requested for collection');
+            $mech->content_contains('£65.00');
+            $mech->back;
+            $mech->back;
+        };
+
+        $mech->content_contains('Describe the item to help our crew pick up the right thing');
+        $mech->submit_form_ok(
+            {
+                form_number => 1,
+                fields => {
+                    'item_1' => 'BBQ',
+                    'item_notes_1' => 'BBQ note',
+                    'item_photo_1' => [ $sample_file, undef, Content_Type => 'image/jpeg' ],
+                    'item_2' => 'Bicycle',
+                    'item_notes_2' => 'Bicycle note',
+                    'item_3' => 'Sofa',
+                    'item_notes_3' => 'Sofa note',
+                },
+            },
+        );
+        $mech->content_contains('Items must be out for collection by 6am on the collection day.');
+        $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
+
+        subtest "Test Summary" => sub {
+            $mech->content_contains('Booking Summary');
+            $mech->content_contains('£45.00');
+            $mech->content_contains("<dd>Saturday 01 July 2023</dd>");
+            $mech->content_contains("on or before Saturday 01 July 2023");
+            $mech->content_contains('Bookings are not refundable');
+            $mech->content_contains('Bob Marge', 'name shown');
+            $mech->content_contains('44 07 111 111 111', 'phone shown');
+        };
+        add_extra_metadata($sutton);
+    };
+
 };
 
 

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -818,10 +818,13 @@ FixMyStreet::override_config {
                 show_individual_notes => 0,
                 band1_max => '',
                 band1_price => '',
+                band1_pop_price => undef,
                 daily_slots => 50,
                 free_mode => 0, # not checked
                 food_bags_disabled => '', # not checked
                 base_price => 1234,
+                base_pop_price => undef,
+                pop_costs => 0,
                 per_item_costs => 1,
                 per_item_min_collection_price => '',
                 items_per_collection_max => 7,

--- a/templates/web/base/admin/waste/bulky_items.html
+++ b/templates/web/base/admin/waste/bulky_items.html
@@ -27,6 +27,12 @@ INCLUDE 'admin/header.html' bodyclass="bulky-items";
             <input type="hidden" value="[% item.price %]" name="price[[% i %]]" />
         [% END %]
         </td>
+        [% IF pop_costs %]
+        <td>
+            [% IF item.errors.contains_pops %]<label for="[[% i %]]">[% item.errors.contains_pops %]</label>[% END %]
+            <input type="checkbox" value="1"[% ' checked' IF item.contains_pops %] name="contains_pops[[% i %]]" style="max-width: 4em;" />
+        </td>
+        [% END %]
         [% IF item_points %]
         <td>
             [% IF item.errors.points %]<label for="[[% i %]]">[% item.errors.points %]</label>[% END %]
@@ -64,6 +70,9 @@ INCLUDE 'admin/header.html' bodyclass="bulky-items";
                     <th>Points</th>
                 [% ELSIF per_item_costs %]
                     <th>Price (pence)</th>
+                [% END %]
+                [% IF pop_costs %]
+                    <th>May contain POPs</th>
                 [% END %]
                 [% FOR property_type IN per_item_pricing_property_types %]
                     <th>[% property_type %] Price (pence)</th>

--- a/templates/web/base/admin/waste/edit.html
+++ b/templates/web/base/admin/waste/edit.html
@@ -33,6 +33,14 @@
         value="[% base_price %]">
     </div>
 
+    [% IF pop_costs %]
+    <div>
+    <label for="waste_base_pop_price">Price for a collection with POPs (in <strong>pence</strong>)</label>
+    <input class="form-control" type=text name="base_pop_price" id="waste_base_pop_price"
+        value="[% base_pop_price %]">
+    </div>
+    [% END %]
+
     <div>
     <label for="waste_items_per_collection_max">Maximum items per collection (1-200)</label>
     <input class="form-control" type=text max=200 min=1 name="items_per_collection_max" id="waste_items_per_collection_max"
@@ -46,6 +54,13 @@
     <input class="form-control" type=text name="band1_price" id="waste_band1_price"
         value="[% band1_price %]">
     </div>
+    [% IF pop_costs %]
+    <div>
+    <label for="waste_band1_pop_price">Price for a small collection with POPs (in pence)</label>
+    <input class="form-control" type=text name="band1_pop_price" id="waste_band1_pop_price"
+        value="[% band1_pop_price %]">
+    </div>
+    [% END %]
     <div>
     <label for="waste_band1_max">Up to how many items</label>
     <input class="form-control" type=text name="band1_max" id="waste_band1_max"
@@ -57,6 +72,11 @@
     <input type=checkbox name="per_item_costs" value=1 id="waste_per_item_costs"
         [% 'checked' IF per_item_costs %]>
     <label class="inline" for="waste_per_item_costs">Charge per item, not per collection</label>
+
+    <p>
+    <input type=checkbox name="pop_costs" value=1 id="waste_pop_costs"
+        [% 'checked' IF pop_costs %]>
+    <label class="inline" for="waste_pop_costs">Differing charges for collections with POPs</label>
 [% END %]
 
     <div>

--- a/templates/web/base/waste/bulky/intro.html
+++ b/templates/web/base/waste/bulky/intro.html
@@ -60,14 +60,22 @@
         SET max_items = cfg.items_per_collection_max;
         SET base_price = cfg.base_price / 100;
         SET band1_price = cfg.band1_price / 100;
+        SET base_pop_price = (cfg.base_pop_price OR 0) / 100;
+        SET band1_pop_price = (cfg.band1_pop_price OR 0) / 100;
     %]
     <li>The price depends on how many items you would like collected:
         <ul class="bulky-intro-pricing">
             <li class="bulky-intro-pricing">
                 1 to [% band1_items %] items cost £[% pounds(band1_price) %]
+                [% IF cfg.pop_costs %]
+                    (£[% pounds(band1_pop_price) %] if any item contains POPs)
+                [% END %]
             </li>
             <li class="bulky-intro-pricing">
                 [% band1_items+1 %] to [% max_items %] items cost £[% pounds(base_price) %]
+                [% IF cfg.pop_costs %]
+                    (£[% pounds(base_pop_price) %] if any item contains POPs)
+                [% END %]
             </li>
         </ul>
     </li>

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -130,7 +130,7 @@ END; END %]
       [% INCLUDE item_fields form=blank_form num=999 %]
   </template>
 
-  [% IF c.cobrand.bulky_pricing_strategy.strategy == 'banded' %]
+  [% IF c.cobrand.bulky_pricing_strategy.strategy == 'banded' || c.cobrand.bulky_pricing_strategy.strategy == 'banded_pop' %]
   <p id="band-pricing-info"></p>
   [% END %]
   <button type="submit" id="add-new-item" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-7" aria-label="Add item" name="goto-same-page" value="1">

--- a/web/js/waste.js
+++ b/web/js/waste.js
@@ -154,6 +154,26 @@ $(function() {
                 }
             }
             totalId.text((total / 100).toFixed(2));
+        } else if (pricing.strategy === 'banded_pop') {
+            var contains_pops = false;
+            $('.govuk-select[name^="item_"] option:selected').each(function(i, e) {
+                var extra = $(this).data('extra');
+                if ( extra && extra.contains_pops && extra.contains_pops == 1 ) {
+                    contains_pops = true;
+                }
+            });
+            count = numberOfItems();
+            for (var j=0; j<pricing.bands.length; j++) {
+                if (count <= pricing.bands[j].max) {
+                    if (contains_pops) {
+                        total = pricing.bands[j].pop_price;
+                    } else {
+                        total = pricing.bands[j].price;
+                    }
+                    break;
+                }
+            }
+            totalId.text((total / 100).toFixed(2));
 
         } else if (pricing.strategy === 'points') {
             $('.govuk-select[name^="item_"] option:selected').each(function(i, e) {
@@ -184,6 +204,15 @@ $(function() {
             }
             totalDetailId.show();
 
+        } else if (pricing.strategy === 'pop_costs') {
+            total = pricing.price;
+            $('.govuk-select[name^="item_"] option:selected').each(function(i, e) {
+                var extra = $(this).data('extra');
+                if ( extra && extra.contains_pops && extra.contains_pops == 1 ) {
+                    total = pricing.pop_price;
+                }
+            });
+            totalId.text((total / 100).toFixed(2));
         }
     }
     updateTotal();


### PR DESCRIPTION
Update the waste admin to enable charging different amounts for bulky collections containing items that may have POPs.
Update the pricing strategies etc to take account of this when calculating and displaying prices to the resident.

This assumes that only the banded and standard pricing strategies are affected by this so doesn't update the other two.

[skip changelog]

Fixes mysociety/societyworks#5428
