### PR TITLE
[TFL] Added fix to contrast issues `.segmented-control--radio`

### DIFF
--- a/web/cobrands/tfl/base.scss
+++ b/web/cobrands/tfl/base.scss
@@ -79,6 +79,25 @@ h3 {
     }
 }
 
+.segmented-control.segmented-control--radio {
+    input:checked+label {
+        color: $white !important; // Overrides rule in _base that assumes $primary_text over $primary passes contrast test.
+        background-color: $primary;
+    }
+
+    // Overrides the mixin tflbutton
+    .btn {
+        background-color: $white;
+        color: $primary_b !important;
+        border: 2px solid $primary;
+
+        &:hover {
+            background-color: $blue-dark;
+            color: $white !important;
+        }
+    }
+}
+
 /* Header */
 
 #site-logo {


### PR DESCRIPTION
This commit solves two issues:

- The `primary_text` and `primary` variables can not be paired together because they won't pass the contrast test.
- For TFL the `.btn` class has been styled just as the `.btn-primary`, so you can't tell in `.segmented-control--radio` which one is active.

[skip changelog]
