### PR TITLE
[Central Beds] Update categories that don't require a road asset

### DIFF
--- a/web/cobrands/fixmystreet-uk-councils/assets.js
+++ b/web/cobrands/fixmystreet-uk-councils/assets.js
@@ -684,14 +684,12 @@ var centralbeds_types = [
 
 function cb_should_not_require_road() {
     // Ensure the user can select anywhere on the map if they want to
-    // make a report in the "Trees" group, or the "Fly Tipping" or "Public Rights of way" categories.
+    // make a report in certain groups/categories that are not road-specific.
     // This means we don't show the "not found" message if no category/group has yet been selected
-    // or if one of the groups containing either the "Fly Tipping" or "Public Rights of way"
-    // categories has been selected.
+    // or if one of these groups/categories has been selected.
     var selected = fixmystreet.reporting.selectedCategory();
-    return selected.group === "Trees" ||
-            selected.category === "Fly Tipping" ||
-            (selected.group === "Flytipping and Bins" && !selected.category) ||
+    var groups = ["Housing", "Trees", "Flytipping and Bins", "Graffiti", "Salt bins", "Vegetation"];
+    return groups.indexOf(selected.group) !== -1 ||
             selected.category === 'Public Rights of way' ||
             (!selected.group && !selected.category);
 }


### PR DESCRIPTION
Central Beds have requested that the following groups/categories shouldn't require a road to be selected:

- All “Housing” categories.
- All “Trees” categories.
- All “Flytipping, Bins and Graffiti” categories (including the Fly Tipping category as before).
- “Salt bins”.
- “Vegetation”.
- “Public Rights of Way”

Fixes FD-5577

<!-- [skip changelog] -->
