### PR TITLE
Ignore pin clicks during pinch-to-zoom

### DIFF
--- a/.cypress/cypress/integration/regressions.js
+++ b/.cypress/cypress/integration/regressions.js
@@ -96,4 +96,57 @@ describe('Regression tests', function() {
       cy.get('#form_start_date').should('have.value', '2019-01-01');
     });
 
+    it('does not fire maps:marker_click when a pin is touched with multiple fingers', function() {
+        cy.visit('/around?lon=-2.295894&lat=51.526877&zoom=0');
+        cy.get('image[title="Lights out in tunnel"]').should('exist');
+
+        cy.window().then(function(win) {
+            var fixmystreet = win.fixmystreet;
+            var markerClickFired = false;
+            win.$(fixmystreet).on('maps:marker_click', function() { markerClickFired = true; });
+
+            var feature = fixmystreet.markers.features.filter(function(f) {
+                return f.attributes.title === 'Lights out in tunnel';
+            })[0];
+
+            expect(feature, 'pin feature found in markers').to.not.equal(undefined);
+
+            // We call into OL internals directly rather than dispatching a real touch
+            // event, because OL's feature detection doesn't trigger reliably from
+            // synthetic events in a desktop browser. See the comment in marker_click
+            // for the event structure.
+            fixmystreet.select_feature.handlers.feature.evt = {
+                touches: [{}],
+            };
+            fixmystreet.select_feature.clickFeature(feature);
+
+            expect(markerClickFired, 'maps:marker_click should not fire during pinch').to.equal(false);
+        });
+    });
+
+    it('fires maps:marker_click when a pin is touched with one finger', function() {
+        cy.visit('/around?lon=-2.295894&lat=51.526877&zoom=0');
+        cy.get('image[title="Lights out in tunnel"]').should('exist');
+
+        cy.window().then(function(win) {
+            var fixmystreet = win.fixmystreet;
+            var markerClickFired = false;
+            win.$(fixmystreet).on('maps:marker_click', function() { markerClickFired = true; });
+
+            var feature = fixmystreet.markers.features.filter(function(f) {
+                return f.attributes.title === 'Lights out in tunnel';
+            })[0];
+
+            expect(feature, 'pin feature found in markers').to.not.equal(undefined);
+
+            // Normal tap: finger is already lifted, so touches is empty.
+            fixmystreet.select_feature.handlers.feature.evt = {
+                touches: [],
+            };
+            fixmystreet.select_feature.clickFeature(feature);
+
+            expect(markerClickFired, 'maps:marker_click should fire for single touch').to.equal(true);
+        });
+    });
+
 });

--- a/web/js/map-OpenLayers.js
+++ b/web/js/map-OpenLayers.js
@@ -576,6 +576,14 @@ $.extend(fixmystreet.utils, {
     }
 
     function marker_click(feature, evt) {
+        // When pinching to zoom, OpenLayers fires clickFeature as the first finger lands
+        // on a pin while touches are still active. For a normal tap, the click fires on
+        // touchend when no touches remain, so evt.touches[0] is absent. Suppress
+        // navigation whenever any touch is still held down.
+        if (evt && evt.touches && evt.touches[0]) {
+            return;
+        }
+
         $(fixmystreet).trigger('maps:marker_click', feature);
 
         var problem_id = feature.attributes.id;


### PR DESCRIPTION
The `marker_click` method was being triggered after a pinch-to-zoom if one of the fingers happened to interact with a marker.

I tested this on my iPhone while plugged into my laptop with Safari's debugger open. With a breakpoint set on the `marker_click` method you can see that when it gets triggered while pinching to zoom the event has a `.touches` array but with only one PointerEvent, but that PointerEvent _also_ has a `.touches` property and that one has two entries, corresponding to two fingers on the screen. So when we detect that condition we ignore it and return from `marker_click`.

Fixes FD-6625

<!-- [skip changelog] -->
