### PR TITLE
[Surrey] Defer report sending when GIS server is down

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Surrey.pm
+++ b/perllib/FixMyStreet/Cobrand/Surrey.pm
@@ -363,6 +363,8 @@ sub default_map_zoom { 3 }
 sub open311_pre_send {
     my ($self, $row, $open311) = @_;
 
+    return 'DEFER:GIS service unavailable' if $self->{_fetch_features_failed};
+
     # Surrey want the value *and* the field label to be passed to their API,
     # so we do a slightly horrid thing and encode those two values into a JSON
     # object which we pass as the extra field value over Open311.

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -6,6 +6,7 @@ use Carp;
 use List::Util qw(min max);
 use URI::Escape;
 use LWP::Simple;
+use LWP::UserAgent;
 use URI;
 use Try::Tiny;
 use JSON::MaybeXS;
@@ -574,11 +575,17 @@ sub _fetch_features {
     }
 
     my $uri = $self->_fetch_features_url($cfg);
-    my $response = get($uri) or return;
+    my $ua = LWP::UserAgent->new(timeout => 30);
+    my $response = $ua->get($uri);
+    unless ($response->is_success) {
+        $self->{_fetch_features_failed} = 1;
+        return;
+    }
+    my $content = $response->decoded_content;
     if (($cfg->{outputformat}||'') ne 'GML3') {
         my $j = JSON->new->utf8->allow_nonref;
         try {
-            $j = $j->decode($response);
+            $j = $j->decode($content);
         } catch {
             # There was either no asset found, or an error with the WFS
             # call - in either case let's just proceed without the USRN.
@@ -592,7 +599,7 @@ sub _fetch_features {
             SuppressEmpty => undef,
         );
         try {
-            $x = $x->parse_string($response);
+            $x = $x->parse_string($content);
         } catch {
             # There was either no asset found, or an error with the WFS
             # call - in either case we'll respond with no asset found

--- a/perllib/FixMyStreet/SendReport/Open311.pm
+++ b/perllib/FixMyStreet/SendReport/Open311.pm
@@ -76,8 +76,12 @@ sub send {
 
     my $open311 = Open311->new( %open311_params );
 
-    my $skip = $cobrand->call_hook(open311_pre_send => $row, $open311);
-    $skip = $skip && $skip eq 'SKIP';
+    my $pre_send = $cobrand->call_hook(open311_pre_send => $row, $open311);
+    my $skip = $pre_send && $pre_send eq 'SKIP';
+    if ($pre_send && $pre_send =~ /^DEFER(?::(.+))?$/) {
+        $self->error($1 // 'Send deferred');
+        return;
+    }
 
     my $resp;
     if (!$skip) {

--- a/t/cobrand/surrey.t
+++ b/t/cobrand/surrey.t
@@ -3,6 +3,7 @@ use FixMyStreet::Script::Reports;
 use FixMyStreet::Script::CSVExport;
 use FixMyStreet::Script::UK::AutoClose;
 use File::Temp 'tempdir';
+use LWP::Protocol::PSGI;
 
 my $mech = FixMyStreet::TestMech->new;
 
@@ -30,6 +31,7 @@ FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'surrey' ],
     MAPIT_URL => 'http://mapit.uk/',
     PHOTO_STORAGE_OPTIONS => { UPLOAD_DIR => $UPLOAD_DIR }, # ensure cached CSVs are tidied
+    STAGING_FLAGS => { send_reports => 1 },
     COBRAND_FEATURES => {
         anonymous_account => {
             surrey => 'anonymous',
@@ -130,6 +132,42 @@ FixMyStreet::override_config {
         $mech->submit_form_ok({ with_fields => { category => 'Potholes', title => 'Potholes contact me me@me.co.uk', detail => 'On main road', name => 'Bob Betts', username_register => 'user@example.org' } });
         $mech->content_contains("<p class='form-error'>Please remove any email addresses and other personal information from your report", "Report title with email gives error");
         $mech->clear_emails_ok;
+    };
+
+    subtest 'GIS failure causes report sending to be deferred' => sub {
+        $surrey->update({ send_method => 'Open311', endpoint => 'http://endpoint.example.com', jurisdiction => 'surrey', api_key => 'test' });
+
+        my ($report) = $mech->create_problems_for_body(1, $surrey->id, 'Pothole problem', {
+            category => 'Potholes', cobrand => 'surrey',
+            latitude => 51.293415, longitude => -0.441269, areas => '2242',
+        });
+
+        my $mock_gis = LWP::Protocol::PSGI->register(sub {
+            return [503, ['Content-Type' => 'text/plain'], ['Service Unavailable']];
+        }, host => 'tilma.mysociety.org');
+
+        FixMyStreet::Script::Reports::send();
+
+        $report->discard_changes;
+        ok !$report->whensent, 'Report was not marked as sent';
+        like $report->send_fail_reason, qr/GIS service unavailable/, 'Report has GIS deferral reason';
+    };
+
+    subtest 'GIS returning empty features does not defer report' => sub {
+        my ($report) = $mech->create_problems_for_body(1, $surrey->id, 'Pothole problem', {
+            category => 'Potholes', cobrand => 'surrey',
+            latitude => 51.293415, longitude => -0.441269, areas => '2242',
+        });
+
+        my $mock_gis = LWP::Protocol::PSGI->register(sub {
+            return [200, ['Content-Type' => 'application/json'], ['{"type":"FeatureCollection","features":[]}']];
+        }, host => 'tilma.mysociety.org');
+
+        FixMyStreet::Script::Reports::send();
+
+        $report->discard_changes;
+        ok $report->whensent, 'Report was sent when GIS returns empty features';
+        unlike $report->send_fail_reason // '', qr/GIS service unavailable/, 'Report was not deferred due to GIS';
     };
 
     subtest 'Auto-close Parking enforcement reports after 5 days' => sub {


### PR DESCRIPTION
When Surrey's GIS server is unavailable, defer sending the report rather than sending it without the necessary location data. Introduces a `DEFER:<reason>` return value for `open311_pre_send` hooks.

Ideally want to get this live ahead of this coming Wednesday 18th as there's some expected downtime then.

For FD-6749

<!-- [skip changelog] -->
