### PR TITLE
[Open311] Allow importing of specific service requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
         - Persist send_method_used immediately during report sending to prevent loss when senders call discard_changes(). #5671
         - Strip EXIF metadata from photos imported via media_url. #5841
         - Photos can be included as base64-encoded data: URIs when fetching updates/reports. #5785
+        - Add --report-ids flag to bin/fetch to import specific Open311 service requests.
     - Performance improvements:
         - Use on-disk cache for front page stats rather than memcache. #5763
         - Add an index on problem(confirmed).

--- a/bin/fetch
+++ b/bin/fetch
@@ -33,6 +33,7 @@ my ($opts, $usage) = describe_options(
     ['updates', 'fetch updates'],
     ['start|s:f', 'start time to use (hours before now), defaults to one (reports) or two (updates)' ],
     ['end|e:f', 'end time to use (hours before now), defaults to zero' ],
+    ['report-ids|r:s', 'comma-separated list of service request IDs to fetch (use with --reports and --body)'],
     ['body|b:s@', 'body name(s) to only fetch these bodies' ],
     ['exclude|e:s@', 'body name(s) to exclude from fetching' ],
     ['verbose|v+', 'more verbose output', { default => 0 }],
@@ -40,11 +41,21 @@ my ($opts, $usage) = describe_options(
 );
 $usage->die if $opts->help;
 
+if ($opts->report_ids) {
+    die "--report-ids can only be used with --reports\n" unless $opts->reports;
+    die "--report-ids requires exactly one --body\n" unless $opts->body && @{$opts->body} == 1;
+    die "--report-ids cannot be used with --start or --end\n" if $opts->start || $opts->end;
+}
+
 my %params = (
     verbose => $opts->verbose,
     bodies => $opts->body || [],
     bodies_exclude => $opts->exclude || [],
 );
+
+if ($opts->report_ids) {
+    $params{report_ids} = [ split /,/, $opts->report_ids ];
+}
 
 my $dt = DateTime->now();
 if ($opts->start) {

--- a/perllib/Open311/GetServiceRequests.pm
+++ b/perllib/Open311/GetServiceRequests.pm
@@ -14,6 +14,7 @@ has bodies => ( is => 'ro', default => sub { [] } );
 has bodies_exclude => ( is => 'ro', default => sub { [] } );
 has fetch_all => ( is => 'rw', default => 0 );
 has verbose => ( is => 'ro', default => 0 );
+has report_ids => ( is => 'ro', default => sub { [] } );
 has commit => ( is => 'ro', default => 1 );
 has schema => ( is =>'ro', lazy => 1, default => sub { FixMyStreet::DB->schema->connect } );
 has convert_latlong => ( is => 'rw', default => 0 );
@@ -67,6 +68,11 @@ sub format_args {
 
     my $args = {};
 
+    if (@{$self->report_ids}) {
+        $args->{report_ids} = $self->report_ids;
+        return $args;
+    }
+
     my $dt = DateTime->now();
     if ($self->start_date) {
         $args->{start_date} = DateTime::Format::W3CDTF->format_datetime( $self->start_date );
@@ -116,6 +122,7 @@ sub create_problems {
         my $request_id = $request->{service_request_id};
         my $is_confirm_job = $request_id =~ /^JOB_/;
         my $is_confirm_defect = $request_id =~ /^DEFECT_/;
+        my $skip_date_check = $is_confirm_job || $is_confirm_defect || @{$self->report_ids};
 
         my ($latitude, $longitude) = ( $request->{lat}, $request->{long} );
 
@@ -171,11 +178,10 @@ sub create_problems {
         # Skip if this problem already exists (e.g. it may have originated from FMS and is being mirrored back!)
         next if $self->schema->resultset('Problem')->to_body($body)->search( $criteria )->count;
 
-        # Skip this date check for Confirm jobs/defects, otherwise we are likely to
-        # skip a bunch of valid entries if calling the fetch script using
-        # explicit start and end values
-        if (   !$is_confirm_job
-            && !$is_confirm_defect
+        # Skip this date check for Confirm jobs/defects or explicit report IDs,
+        # otherwise we are likely to skip a bunch of valid entries if calling
+        # the fetch script using explicit start and end values
+        if (   !$skip_date_check
             && $args->{start_date}
             && $args->{end_date}
             && (   $updated lt $args->{start_date}


### PR DESCRIPTION
Adds a new --report-ids option to bin/fetch that accepts a comma-separated list of service request IDs to import.

For https://github.com/mysociety/societyworks/issues/5271