### PR TITLE
[Open311] Add flag to skip existing reports when doing bulk fetch

### DIFF
--- a/bin/fetch
+++ b/bin/fetch
@@ -34,6 +34,7 @@ my ($opts, $usage) = describe_options(
     ['start|s:f', 'start time to use (hours before now), defaults to one (reports) or two (updates)' ],
     ['end|e:f', 'end time to use (hours before now), defaults to zero' ],
     ['report-ids|r:s', 'comma-separated list of service request IDs to fetch (use with --reports and --body)'],
+    ['skip-existing', 'skip report IDs that already exist in the database (use with --report-ids)'],
     ['body|b:s@', 'body name(s) to only fetch these bodies' ],
     ['exclude|e:s@', 'body name(s) to exclude from fetching' ],
     ['verbose|v+', 'more verbose output', { default => 0 }],
@@ -45,6 +46,8 @@ if ($opts->report_ids) {
     die "--report-ids can only be used with --reports\n" unless $opts->reports;
     die "--report-ids requires exactly one --body\n" unless $opts->body && @{$opts->body} == 1;
     die "--report-ids cannot be used with --start or --end\n" if $opts->start || $opts->end;
+} elsif ($opts->skip_existing) {
+    die "--skip-existing can only be used with --report-ids\n";
 }
 
 my %params = (
@@ -55,6 +58,7 @@ my %params = (
 
 if ($opts->report_ids) {
     $params{report_ids} = [ split /,/, $opts->report_ids ];
+    $params{skip_existing} = 1 if $opts->skip_existing;
 }
 
 my $dt = DateTime->now();

--- a/perllib/Open311/GetServiceRequests.pm
+++ b/perllib/Open311/GetServiceRequests.pm
@@ -15,6 +15,7 @@ has bodies_exclude => ( is => 'ro', default => sub { [] } );
 has fetch_all => ( is => 'rw', default => 0 );
 has verbose => ( is => 'ro', default => 0 );
 has report_ids => ( is => 'ro', default => sub { [] } );
+has skip_existing => ( is => 'ro', default => 0 );
 has commit => ( is => 'ro', default => 1 );
 has schema => ( is =>'ro', lazy => 1, default => sub { FixMyStreet::DB->schema->connect } );
 has convert_latlong => ( is => 'rw', default => 0 );
@@ -44,6 +45,17 @@ sub fetch {
         $self->system_user( $body->comment_user );
         $self->convert_latlong( $body->convert_latlong );
         $self->fetch_all( $body->get_extra_metadata('fetch_all_problems') );
+
+        if ($self->skip_existing && @{$self->report_ids}) {
+            my @filtered = $self->filter_existing_ids($body, $self->report_ids);
+            unless (@filtered) {
+                warn "All report IDs already exist for " . $body->name . ", skipping\n"
+                    if $self->verbose;
+                next;
+            }
+            @{$self->report_ids} = @filtered;
+        }
+
         my $args = $self->format_args;
         my $requests = $self->get_requests($o, $body, $args);
         $self->create_problems( $o, $body, $args, $requests );
@@ -87,6 +99,21 @@ sub format_args {
     }
 
     return $args;
+}
+
+sub filter_existing_ids {
+    my ($self, $body, $report_ids) = @_;
+
+    my %existing = map { $_ => 1 }
+        $self->schema->resultset('Problem')->to_body($body)->search(
+            { external_id => { -in => $report_ids } },
+        )->get_column('external_id')->all;
+
+    my @skipped = grep { $existing{$_} } @$report_ids;
+    warn "Skipping already imported IDs for " . $body->name . ": " . join(', ', @skipped) . "\n"
+        if $self->verbose && @skipped;
+
+    return grep { !$existing{$_} } @$report_ids;
 }
 
 sub get_requests {

--- a/t/open311/getservicerequests.t
+++ b/t/open311/getservicerequests.t
@@ -738,4 +738,23 @@ sub prepare_xml {
     return $xml;
 }
 
+subtest 'skip_existing filters already imported report IDs' => sub {
+    # external_id 638344 was created by 'basic parsing checks' above
+
+    my $fetcher = Open311::GetServiceRequests->new(
+        report_ids => [ '638344', '999999' ],
+        skip_existing => 1,
+        system_user => $user,
+        bodies => [ $body->name ],
+    );
+
+    # Check that filter_existing_ids removes the existing ID
+    my @filtered = $fetcher->filter_existing_ids($body, $fetcher->report_ids);
+    is_deeply \@filtered, ['999999'], 'existing ID filtered out, new ID kept';
+
+    # Check that all-existing returns empty list
+    my @all_exist = $fetcher->filter_existing_ids($body, ['638344']);
+    is scalar @all_exist, 0, 'returns empty list when all IDs exist';
+};
+
 done_testing();


### PR DESCRIPTION
This adds a new --skip-existing flag to be used with --report-ids which pre-filters the IDs against any that exist in the DB before calling Open311. This means we can re-run the same script with the same report IDs and it won't do unnecessary work in open311-adapter.

[skip changelog]