### PR TITLE
[Open311] Use consistent photo filenames for multipart uploads

### DIFF
--- a/perllib/Open311.pm
+++ b/perllib/Open311.pm
@@ -268,8 +268,11 @@ sub _add_photos_to_upload {
         my $i = 0;
         my $photoset = $obj->get_photoset;
         for ( $photoset->all_ids ) {
-            my $photo = $photoset->get_image_data( num => $i++, size => 'full' );
-            $uploads->{"photo$i"} = [ undef, $_, Content_Type => $photo->{content_type}, Content => $photo->{data} ];
+            my $photo = $photoset->get_image_data( num => $i, size => 'full' );
+            my (undef, $ext) = split /\./, $_;
+            my $filename = $obj->id . ".$i.full.$ext";
+            $i++;
+            $uploads->{"photo$i"} = [ undef, $filename, Content_Type => $photo->{content_type}, Content => $photo->{data} ];
         }
         delete $params->{media_url};
     }

--- a/t/app/controller/contact_enquiry.t
+++ b/t/app/controller/contact_enquiry.t
@@ -247,6 +247,7 @@ FixMyStreet::override_config {
     };
 
     subtest 'Check Open311 sending of the above report' => sub {
+        my $problem = FixMyStreet::DB->resultset('Problem')->to_body( $body->id )->first;
         my $module = Test::MockModule->new('FixMyStreet::Cobrand::UKCouncils');
         $module->mock(get => sub ($) { '{}' });
         FixMyStreet::Script::Reports::send();
@@ -264,7 +265,7 @@ FixMyStreet::override_config {
                 $found++;
             }
             if ($cd =~ /jpeg/) {
-                is $cd, 'form-data; name="photo1"; filename="' . $image_hash . '"', 'Correct image header';
+                is $cd, 'form-data; name="photo1"; filename="' . $problem->id . '.0.full.jpeg"', 'Correct image header';
                 is $_->header('Content-Type'), 'image/jpeg', 'Correct image content type';
                 $found++;
             }

--- a/t/sendreport/open311_send.t
+++ b/t/sendreport/open311_send.t
@@ -159,6 +159,16 @@ subtest 'test sending photos as file uploads along with a multivalue attribute',
     };
     $photo_report->discard_changes;
     ok $photo_report->whensent, 'Report marked as sent';
+
+    my $req = Open311->test_req_used;
+    my $content = $req->content;
+    my $id = $photo_report->id;
+    my @filenames = sort ($content =~ /filename="([^"]+)"/g);
+    is_deeply \@filenames, [
+        "$id.0.full.jpeg",
+        "$id.1.full.jpeg",
+        "$id.2.full.jpeg",
+    ], 'Uploaded photo filenames match media_url pattern';
 };
 
 my ($bad_category_report) = $mech->create_problems_for_body( 1, $body->id, 'Test', {


### PR DESCRIPTION
When photos are sent as multipart file uploads (for private reports or when always_upload_photos is set), we now use the same filename pattern as when we pass photos in media_url: `{id}.{index}.full.{ext}`

This fixes the problem where Dumfries updates incorrectly sent the FMS photo back if the report was private when it was made, because the previous filename pattern for multipart photos didn't match the regex open311-adapter was looking for to identify FMS photos.

[skip changelog]