### PR TITLE
Add missing Confirm councils to client-side validation rules

### DIFF
--- a/perllib/FixMyStreet/Roles/Cobrand/Northants.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Northants.pm
@@ -14,6 +14,7 @@ FixMyStreet::Roles::Cobrand::Northants - shared code between West & Northants co
 
 sub open311_extra_data_exclude { [ 'emergency' ] }
 
+sub max_title_length { 120 }
 
 =item * Includes all Northamptonshire reports before April 2021 and ones after within the boundary.
 

--- a/web/cobrands/fixmystreet-uk-councils/council_validation_rules.js
+++ b/web/cobrands/fixmystreet-uk-councils/council_validation_rules.js
@@ -64,13 +64,12 @@ body_validation_rules = {
           maxlength: 100
         },
     },
-    'North Northamptonshire Council': confirm_validation_rules,
-    'Northamptonshire Highways': {
+    'North Northamptonshire Council': $.extend({
         title: {
           required: true,
           maxlength: 120
         }
-    },
+    }, confirm_validation_rules),
     'Oxfordshire County Council': {
         detail: {
           required: true,
@@ -121,5 +120,10 @@ body_validation_rules = {
           notEmail: true
       }
     },
-    'West Northamptonshire Council': confirm_validation_rules
+    'West Northamptonshire Council': $.extend({
+        title: {
+          required: true,
+          maxlength: 120
+        }
+    }, confirm_validation_rules)
 };


### PR DESCRIPTION
Had a stuck Aberdeenshire report that had two phone numbers on the user, but Confirm only wants one.

There is server-side validation for long phone numbers, but it's skipped for reports created by staff members on behalf of someone else, which was the case for the stuck report.

https://github.com/mysociety/fixmystreet/blob/10d3d6ad0a3e2cf85f8613a36057fa976252e8d3/perllib/FixMyStreet/App/Controller/Report/New.pm#L1477-L1481

Fix is to add in the missing client side validation. Have done this for the other councils that were obviously missing this.

<!-- [skip changelog] -->