### PR TITLE
[Zurich] Don't rely on Catalyst stash in geocoder

### DIFF
--- a/perllib/FixMyStreet/Geocode.pm
+++ b/perllib/FixMyStreet/Geocode.pm
@@ -56,7 +56,7 @@ sub string {
         $service = __PACKAGE__ . '::OSM';
     }
 
-    my $out = $service->string($s, $c->cobrand);
+    my $out = $service->string($s, $c->cobrand, $c->stash->{allow_single_geocode_match_strings});
     $c->stash->{geocoder_url} = delete $out->{geocoder_url};
     return $out;
 }

--- a/perllib/FixMyStreet/Geocode/Zurich.pm
+++ b/perllib/FixMyStreet/Geocode/Zurich.pm
@@ -83,21 +83,21 @@ sub admin_district {
 # Looks up on Zurich web service a user-inputted location.
 # Returns array of (LAT, LON, ERROR), where ERROR is either undef, a string, or
 # an array of matches if there are more than one.
-# If there is no ambiguity, returns only a {lat,long} hash, unless allow_single_match_string is true
+# If there is no ambiguity, returns only a {lat,long} hash, unless allow_single is true
 # (because the auto-complete use of this (in /around) should send the matched name even though it's not ambiguous).
 #
 # The information in the query may be used to disambiguate the location in cobranded 
 # versions of the site.
 
 sub string {
-    my ( $cls, $s, $c ) = @_;
+    my ( $cls, $s, $c, $allow_single ) = @_;
 
     setup_soap();
 
     my $cache_dir = path(FixMyStreet->config('GEO_CACHE'), 'zurich')->absolute(FixMyStreet->path_to());
     my $cache_file = $cache_dir->child(md5_hex($s));
     my $result;
-    $c->stash->{geocoder_url} = $s;
+    my $out = { geocoder_url => $s };
     if (-s $cache_file && -M $cache_file <= 7 && !FixMyStreet->config('STAGING_SITE')) {
         $result = retrieve($cache_file);
     } else {
@@ -116,7 +116,8 @@ sub string {
     }
 
     if (!$result || !$result->{Location}) {
-        return { error => _('Sorry, we could not parse that location. Please try again.') };
+        $out->{error} = _('Sorry, we could not parse that location. Please try again.');
+        return $out;
     }
 
     my $results = $result->{Location};
@@ -135,10 +136,13 @@ sub string {
         push (@valid_locations, $_);
         last if lc($_->{text}) eq lc($s);
     }
-    if (scalar @valid_locations == 1 && ! $c->stash->{allow_single_geocode_match_strings} ) {
-        return { latitude => $latitude, longitude => $longitude };
+    if (scalar @valid_locations == 1 && !$allow_single) {
+        $out->{latitude} = $latitude;
+        $out->{longitude} = $longitude;
+        return $out;
     }
-    return { error => $error };
+    $out->{error} = $error;
+    return $out;
 }
 
 sub log_message {

--- a/t/geocode/zurich.t
+++ b/t/geocode/zurich.t
@@ -1,0 +1,52 @@
+use FixMyStreet::Test;
+use FixMyStreet::Geocode::Zurich;
+use FixMyStreet::Cobrand;
+use Test::MockModule;
+use Test::MockObject;
+
+my $cobrand = FixMyStreet::Cobrand::Default->new;
+
+my $soap_data;
+my $mock_result = Test::MockObject->new();
+$mock_result->mock('result', sub { $soap_data });
+
+my $soap_module = Test::MockModule->new('SOAP::Lite');
+$soap_module->mock('call', sub { $mock_result });
+
+FixMyStreet::override_config {
+    GEOCODER => { url => 'http://localhost/', username => 'u', password => 'p' },
+}, sub {
+    $soap_data = { Location => [
+        { text => 'Bahnhofstrasse', easting => '2683067.088', northing => '1247615.135' },
+    ] };
+    my $r = FixMyStreet::Geocode::Zurich->string('Bahnhofstrasse', $cobrand);
+    ok $r->{latitude};
+    ok $r->{longitude};
+    ok !$r->{error};
+    is $r->{geocoder_url}, 'Bahnhofstrasse';
+
+    # allow_single returns even a single match as a results array, so autocomplete gets the address string.
+    $r = FixMyStreet::Geocode::Zurich->string('Bahnhofstrasse', $cobrand, 1);
+    is ref $r->{error}, 'ARRAY';
+    is scalar @{$r->{error}}, 1;
+    is $r->{error}[0]{address}, 'Bahnhofstrasse';
+
+    $soap_data = { Location => [
+        { text => 'Bahnhofpassage', easting => '2683154.537', northing => '1247962.624' },
+        { text => 'Bahnhofplatz',   easting => '2683187.282', northing => '1247956.230' },
+    ] };
+    $r = FixMyStreet::Geocode::Zurich->string('Bahnhof', $cobrand);
+    is ref $r->{error}, 'ARRAY';
+    is scalar @{$r->{error}}, 2;
+
+    # Empty response means no results found.
+    $soap_data = '';
+    $r = FixMyStreet::Geocode::Zurich->string('Bergweg', $cobrand);
+    is $r->{error}, 'Sorry, we could not parse that location. Please try again.';
+
+    $soap_module->mock('call', sub { die 'connection refused' });
+    $r = FixMyStreet::Geocode::Zurich->string('Bahnhofstrasse', $cobrand);
+    is $r->{error}, 'The geocoder appears to be down.';
+};
+
+done_testing;


### PR DESCRIPTION
Commit cb2297dcf8 ("Get geocode CLI script working again") changed Geocode.pm to pass `$c->cobrand` instead of the full `$c` to geocoders. Zurich.pm was calling `$c->stash` on what it expected to be the full Catalyst context, which was causing errors like this:

```
Caught exception in FixMyStreet::App::Controller::Around->location_autocomplete
"Can't locate object method "stash" via package "FixMyStreet::Cobrand::Zurich"
at perllib/FixMyStreet/Geocode/Zurich.pm line 100."
```

The problem with Zurich only surfaced last week when the Zurich vhost was redeployed as part of some server moves: https://github.com/mysociety/sysadmin/issues/2156#issuecomment-4076386655.

FD-6788

<!-- [skip changelog] -->
