### PR TITLE
Show report search on admin summary for users with user_edit permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
         - Dashboard: toggle visibility of deleted categories and categories with no reports
         - Allow search of non-integer external IDs.
         - List categories that prevent reporting.
+        - Show report search on the admin summary page for staff with `user_edit`. #5903
     - Development improvements
         - More logging when `page_error` is called, to aid troubleshooting. #5279
         - Docker changes needed for systemd to work. #5257

--- a/t/app/controller/admin.t
+++ b/t/app/controller/admin.t
@@ -21,6 +21,8 @@ my $superuser = $mech->create_user_ok('superuser@example.com', name => 'Super Us
 my $oxfordshire = $mech->create_body_ok(2237, 'Oxfordshire County Council', { cobrand => 'oxfordshire' });
 my $oxfordshireuser = $mech->create_user_ok('counciluser@example.com', name => 'Council User', from_body => $oxfordshire);
 $oxfordshireuser->user_body_permissions->create({ body => $oxfordshire, permission_type => 'category_edit' });
+my $oxfordshire_user_edit = $mech->create_user_ok('counciluser-user-edit@example.com', name => 'Council User Edit', from_body => $oxfordshire);
+$oxfordshire_user_edit->user_body_permissions->create({ body => $oxfordshire, permission_type => 'user_edit' });
 
 my $dt = DateTime->new(
     year   => 2011,
@@ -176,8 +178,26 @@ subtest "Users with from_body can access their own council's admin" => sub {
     }, sub {
         $mech->get_ok('/admin');
         $mech->content_contains( 'Summary' );
+        $mech->content_lacks( 'Search Reports' );
     };
 };
+
+$mech->log_out_ok;
+$mech->log_in_ok( $oxfordshire_user_edit->email );
+
+subtest "Users with only user_edit can search reports from admin summary" => sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'oxfordshire' ],
+    }, sub {
+        $mech->get_ok('/admin');
+        $mech->content_contains( 'Summary' );
+        $mech->content_contains( 'Search Reports' );
+        $mech->content_contains( 'Search Users' );
+    };
+};
+
+$mech->log_out_ok;
+$mech->log_in_ok( $oxfordshireuser->email );
 
 
 subtest "Check admin index page redirects" => sub {

--- a/templates/web/base/admin/index.html
+++ b/templates/web/base/admin/index.html
@@ -13,7 +13,7 @@
 
 <div class="admin-index-search clearfix">
 
-[% IF c.user.has_body_permission_to('report_edit') %]
+[% IF c.user.has_body_permission_to('report_edit') || c.user.has_body_permission_to('user_edit') %]
 <form method="get" action="[% c.uri_for('reports') %]" accept-charset="utf-8">
     <label for="search_reports">[% loc('Search Reports') %]</label>
     <div class="form-txt-submit-box">


### PR DESCRIPTION
Users with the user_edit permission can already view the reports section, so makes sense that they should be able to search report from the summary page as well.

For FD-6744