### PR TITLE
[Peterborough] Add CCTV zone email to flytipping flow

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -279,6 +279,60 @@ sub get_body_sender {
     return $self->SUPER::get_body_sender($body, $problem);
 }
 
+sub _report_is_in_cctv_zone {
+    my ($self, $problem) = @_;
+    my ($x, $y) = Utils::convert_latlon_to_en(
+        $problem->latitude,
+        $problem->longitude,
+        'G'
+    );
+
+    my $features = $self->_fetch_features(
+        {
+            type => 'arcgis',
+            url => 'https://peterborough.assets/9/query?',
+            # The CCTV asset layer already stores the camera coverage area, so
+            # that geometry defines the buffer.
+            buffer => 0,
+        },
+        $x,
+        $y,
+    );
+
+    return $features && scalar @$features;
+}
+
+sub _send_extra_flytipping_email {
+    my ($self, $row, $h, %args) = @_;
+
+    my @sent_to_before_send = @{ $row->get_extra_metadata('sent_to') || [] };
+    my $extra_fields = $args{extra_fields};
+    my %send_h = (
+        %$h,
+        %{ $args{send_context} || {} },
+    );
+
+    $row->push_extra_fields(@$extra_fields) if $extra_fields;
+
+    my $sender = FixMyStreet::SendReport::Email->new( to => [ $args{dest} ] );
+    $sender->send($row, \%send_h);
+
+    if ($sender->success && @sent_to_before_send) {
+        my @sent_to_after_send = @{ $row->get_extra_metadata('sent_to') || [] };
+        my %already_included = map { $_ => 1 } @sent_to_after_send;
+
+        for my $recipient (@sent_to_before_send) {
+            next if $already_included{$recipient};
+            push @sent_to_after_send, $recipient;
+            $already_included{$recipient} = 1;
+        }
+
+        $row->update_extra_metadata(sent_to => \@sent_to_after_send);
+    }
+
+    return $sender;
+}
+
 sub _witnessed_general_flytipping {
     my ($self, $row) = @_;
     my $witness = $self->{cache_pcc_witness} || '';
@@ -315,20 +369,40 @@ sub open311_post_send {
     my $send_email = $row->external_id;
     return unless $send_email;
 
-    my $emails = $self->feature('open311_email');
+    my $emails = $self->feature('open311_email') || {};
     my %flytipping_cats = map { $_ => 1 } @{ $self->_flytipping_categories };
     if ( $emails->{flytipping} && $flytipping_cats{$row->category} ) {
         my $dest = [ $emails->{flytipping}, "Environmental Services" ];
-        $h->{flytipping_extra} = 1;
-        my $sender = FixMyStreet::SendReport::Email->new( to => [ $dest ] );
-        $sender->send($row, $h);
+        $self->_send_extra_flytipping_email(
+            $row,
+            $h,
+            dest => $dest,
+            send_context => { flytipping_extra => 1 },
+        );
         if ($emails->{flytipping_witnessed} && $self->_witnessed_general_flytipping($row)) {
             my $dest2 = [ $emails->{flytipping_witnessed}, "Environmental Enforcement" ];
-            $h->{flytipping_extra_witnessed} = 1;
-            $sender = FixMyStreet::SendReport::Email->new( to => [ $dest2 ] );
-            $sender->send($row, $h);
-            push @{$row->get_extra_metadata('sent_to')}, $dest->[0];
-            $row->update_extra_metadata(sent_to => $row->get_extra_metadata('sent_to'));
+            $self->_send_extra_flytipping_email(
+                $row,
+                $h,
+                dest => $dest2,
+                send_context => { flytipping_extra_witnessed => 1 },
+            );
+        }
+        if ($emails->{flytipping_cctv} && $self->_report_is_in_cctv_zone($row)) {
+            my $dest3 = [ $emails->{flytipping_cctv}, 'Environmental Enforcement' ];
+            $self->_send_extra_flytipping_email(
+                $row,
+                $h,
+                dest => $dest3,
+                send_context => { flytipping_extra_cctv => 1 },
+                extra_fields => [
+                    {
+                        name => 'cctv_camera_zone',
+                        description => 'CCTV camera zone',
+                        value => 'This fly-tip was reported within a CCTV camera zone.',
+                    },
+                ],
+            );
         }
     }
 }

--- a/t/cobrand/peterborough.t
+++ b/t/cobrand/peterborough.t
@@ -15,6 +15,10 @@ $mock->mock('_fetch_features', sub {
         # council land
         if ( ($x == 552617 || $x == 519240) && $args->{url} =~ m{4/query} ) {
             return [ { geometry => { type => 'Point' } } ];
+        } elsif ( $x == 552684 && $args->{url} =~ m{4/query} ) {
+            return [ { geometry => { type => 'Point' } } ];
+        } elsif ( $x == 552684 && $args->{url} =~ m{9/query} ) {
+            return [ { geometry => { type => 'Polygon' } } ];
         # leased out council land
         } elsif ( $x == 552651 && $args->{url} =~ m{3/query} ) {
             return [ { geometry => { type => 'Point' } } ];
@@ -457,6 +461,133 @@ subtest "flytipping/graffiti on non PCC land is not sent anywhere" => sub {
         ok !Open311->test_req_used, 'no open311 sent';
 
         $mech->email_count_is(0);
+    };
+};
+
+subtest "flytipping in a CCTV camera zone sends the enforcement email" => sub {
+    FixMyStreet::override_config {
+        STAGING_FLAGS => { send_reports => 1 },
+        MAPIT_URL => 'http://mapit.uk/',
+        ALLOWED_COBRANDS => 'peterborough',
+        COBRAND_FEATURES => { open311_email => { peterborough => {
+            flytipping => 'flytipping@example.org',
+            flytipping_cctv => 'cctv@example.org',
+        } } },
+    }, sub {
+        $mech->clear_emails_ok;
+
+        my ($p) = $mech->create_problems_for_body(1, $peterborough->id, 'Title', {
+            category => 'General fly tipping',
+            latitude => 52.5708,
+            longitude => 0.2515,
+            cobrand => 'peterborough',
+            geocode => {
+                display_name => '12 A Street, XX1 1SZ',
+                address => {
+                    house_number => '12',
+                    road => 'A Street',
+                    postcode => 'XX1 1SZ'
+                }
+            },
+        } );
+
+        FixMyStreet::Script::Reports::send();
+        $p->discard_changes;
+        is $p->send_state, 'sent', 'Report marked as sent';
+        my $cgi = CGI::Simple->new(Open311->test_req_used->content);
+        is $cgi->param('service_code'), 'FLY', 'service code is correct';
+
+        my @email = $mech->get_email;
+        $mech->email_count_is(2);
+
+        is $email[0]->header('To'), '"Environmental Services" <flytipping@example.org>', 'standard flytipping email sent';
+        like $email[0]->header('Subject'), qr/\[Censorship checking only\] Problem Report: /, 'standard flytipping email keeps the censorship subject';
+        is $email[1]->header('To'), '"Environmental Enforcement" <cctv@example.org>', 'CCTV enforcement email sent';
+        like $email[1]->header('Subject'), qr/\[Priority Evidence Available \(Fixed CCTV\)\] Problem Report: /, 'CCTV email uses the CCTV subject prefix';
+        like $mech->get_text_body_from_email($email[1]), qr/within a CCTV camera zone/i, 'CCTV email explains why it was sent';
+    };
+};
+
+subtest "flytipping not in a CCTV camera zone does not send the enforcement email" => sub {
+    FixMyStreet::override_config {
+        STAGING_FLAGS => { send_reports => 1 },
+        MAPIT_URL => 'http://mapit.uk/',
+        ALLOWED_COBRANDS => 'peterborough',
+        COBRAND_FEATURES => { open311_email => { peterborough => {
+            flytipping => 'flytipping@example.org',
+            flytipping_cctv => 'cctv@example.org',
+        } } },
+    }, sub {
+        $mech->clear_emails_ok;
+
+        my ($p) = $mech->create_problems_for_body(1, $peterborough->id, 'Title', {
+            category => 'General fly tipping',
+            latitude => 52.57146,
+            longitude => -0.24201,
+            areas => ',2566,',
+            cobrand => 'peterborough',
+            geocode => {
+                display_name => '12 A Street, XX1 1SZ',
+                address => {
+                    house_number => '12',
+                    road => 'A Street',
+                    postcode => 'XX1 1SZ'
+                }
+            },
+        });
+
+        FixMyStreet::Script::Reports::send();
+        $p->discard_changes;
+        is $p->send_state, 'sent', 'Report marked as sent';
+        $mech->email_count_is(1);
+        my $email = $mech->get_email;
+        is $email->header('To'), '"Environmental Services" <flytipping@example.org>', 'only standard flytipping email sent, not CCTV enforcement';
+    };
+};
+
+subtest "flytipping witnessed in a CCTV camera zone sends three emails" => sub {
+    FixMyStreet::override_config {
+        STAGING_FLAGS => { send_reports => 1 },
+        MAPIT_URL => 'http://mapit.uk/',
+        ALLOWED_COBRANDS => 'peterborough',
+        COBRAND_FEATURES => { open311_email => { peterborough => {
+            flytipping => 'flytipping@example.org',
+            flytipping_witnessed => 'witnessed@example.org',
+            flytipping_cctv => 'cctv@example.org',
+        } } },
+    }, sub {
+        $mech->clear_emails_ok;
+
+        my ($p) = $mech->create_problems_for_body(1, $peterborough->id, 'Title', {
+            category => 'General fly tipping',
+            latitude => 52.5708,
+            longitude => 0.2515,
+            cobrand => 'peterborough',
+            geocode => {
+                display_name => '12 A Street, XX1 1SZ',
+                address => {
+                    house_number => '12',
+                    road => 'A Street',
+                    postcode => 'XX1 1SZ'
+                }
+            },
+            extra => {
+                _fields => [
+                    { name => 'pcc-witness', value => 'yes', },
+                ],
+            },
+        });
+
+        FixMyStreet::Script::Reports::send();
+        $p->discard_changes;
+        is $p->send_state, 'sent', 'Report marked as sent';
+
+        my @email = $mech->get_email;
+        $mech->email_count_is(3);
+        is $email[0]->header('To'), '"Environmental Services" <flytipping@example.org>', 'standard flytipping email sent';
+        is $email[1]->header('To'), '"Environmental Enforcement" <witnessed@example.org>', 'witnessed enforcement email sent';
+        is $email[2]->header('To'), '"Environmental Enforcement" <cctv@example.org>', 'CCTV enforcement email sent';
+        like $email[2]->header('Subject'), qr/\[Priority Evidence Available \(Fixed CCTV\)\] Problem Report: /, 'CCTV email uses the CCTV subject prefix';
     };
 };
 

--- a/templates/email/peterborough/submit.txt
+++ b/templates/email/peterborough/submit.txt
@@ -1,5 +1,6 @@
 Subject: [%
 IF flytipping_extra_witnessed; '[URGENT - Evidence available] ';
+ELSIF flytipping_extra_cctv; '[Priority Evidence Available (Fixed CCTV)] ';
 ELSIF flytipping_extra; '[Censorship checking only] ';
 END;
 ~%]


### PR DESCRIPTION
Sends an email to the enforcement team if a fly-tipping report is detected in a CCTV camera zone.

Builds on top of https://github.com/mysociety/fixmystreet/pull/5850 which is for https://github.com/mysociety/societyworks/issues/5312.

## Deploy notes

- [x] Need to add `flytipping_cctv: ...` with email address under `open311_emails` for Peterborough.

Fixes https://github.com/mysociety/societyworks/issues/5386

<!-- [skip changelog] -->
