### PR TITLE
[TfL] Change banner to banners in URL and copy

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Licence.pm
+++ b/perllib/FixMyStreet/App/Controller/Licence.pm
@@ -18,9 +18,18 @@ sub index : Path : Args(0) {
     $c->detach('/page_error_404_not_found');
 }
 
+my %redirects = (
+    banner => 'banners',
+);
+
 # GET/POST /licence/:type - show/process a specific licence form
 sub show : Path : Args(1) {
     my ($self, $c, $type) = @_;
+
+    if (my $new_type = $redirects{lc $type}) {
+        $c->res->redirect($c->uri_for("/licence/$new_type"), 301);
+        $c->detach;
+    }
 
     my $licence_config = FixMyStreet::App::Form::Licence->licence_types->{lc $type}
         or $c->detach('/page_error_404_not_found');

--- a/perllib/FixMyStreet/App/Form/Licence/Banner.pm
+++ b/perllib/FixMyStreet/App/Form/Licence/Banner.pm
@@ -4,11 +4,11 @@ use HTML::FormHandler::Moose;
 extends 'FixMyStreet::App::Form::Licence::Base';
 use utf8;
 
-# Type identifier used in URL: /licence/banner
-sub type { 'banner' }
+# Type identifier used in URL: /licence/banners
+sub type { 'banners' }
 
 # Human-readable name for display
-sub name { 'Banner' }
+sub name { 'Banners' }
 
 sub tandc_link { 'https://content.tfl.gov.uk/banners-guidance-notes-and-terms-conditions.pdf' }
 
@@ -21,7 +21,7 @@ sub num_steps { 14 }
 # ==========================================================================
 has_page intro => (
     fields => ['start'],
-    title => 'Banner licence application',
+    title => 'Banners licence application',
     intro => 'banner/intro.html',
     next => 'location_1',
 );
@@ -38,7 +38,7 @@ has_field start => (
 has_page location_1 => (
     step_number => 1,
     fields => ['building_name_number', 'street_name', 'borough', 'postcode', 'add_another', 'continue'],
-    title => 'Location of the banner/s',
+    title => 'Location of the banners',
     intro => 'location.html',
     next => sub { $_[1]->{add_another} ? 'location_2' : 'dates' },
     post_process => sub {
@@ -57,7 +57,7 @@ for my $page (2..5) {
     has_page "location_$page" => (
         step_number => 1,
         fields => $fields,
-        title => "Location of the Column Attachments ($page)",
+        title => "Location of the banners ($page)",
         intro => 'location.html',
         next => $next,
         tags => { hide => sub { !$_[0]->form->saved_data->{"building_name_number_$page"} } },
@@ -93,7 +93,7 @@ has_page type => (
 has_field banner_type => (
     type => 'Text',
     widget => 'Textarea',
-    label => 'What type of banner will be put up?',
+    label => 'What type of banners will be put up?',
     required => 1,
     tags => {
         hint =>
@@ -105,7 +105,7 @@ has_field banner_content => (
     type => 'Text',
     widget => 'Textarea',
     label =>
-        'What will be shown on the banner/s? We also require an example of the proposed graphic as part of the application',
+        'What will be shown on the banners? We also require an example of the proposed graphic as part of the application',
     required => 1,
     tags => {
         hint =>
@@ -124,7 +124,7 @@ has_page installation => (
 has_field banner_installation => (
     type => 'Text',
     widget => 'Textarea',
-    label => 'How will the banner/s be installed?',
+    label => 'How will the banners be installed?',
     required => 1,
     tags => {
         hint =>
@@ -219,7 +219,7 @@ has_page site_infrastructure => (
 has_field site_ad_compliance => (
     type => 'Select',
     widget => 'RadioGroup',
-    label => 'Does the banner/s comply with TfL’s advertising policy?',
+    label => 'Do the banners comply with TfL’s advertising policy?',
     tags => {
         hint => FixMyStreet::Template::SafeString->new(
             'As found on <a href="https://tfl.gov.uk/corporate/publications-and-reports/commercial-media#on-this-page-3">TfL’s website</a>. If no, a site meeting between the applicant and TfL may be required.'

--- a/t/app/controller/licence/banner.t
+++ b/t/app/controller/licence/banner.t
@@ -13,10 +13,10 @@ my $mech = FixMyStreet::TestMech->new;
 # Create TfL body (using 2482 like other TfL tests)
 my $body = $mech->create_body_ok(2482, 'TfL', { cobrand => 'tfl' });
 
-# Create the category for banner licences
+# Create the category for banners licences
 my $contact = $mech->create_contact_ok(
     body_id => $body->id,
-    category => 'Banner licence',
+    category => 'Banners licence',
     email => 'licence@tfl.gov.uk.example.org'
 );
 
@@ -27,11 +27,11 @@ subtest 'Banner form submission - smoke test' => sub {
         PHONE_COUNTRY => 'GB',
         COBRAND_FEATURES => {
             licencing_forms => { tfl => 1 },
-            licencing_payment_links => { tfl => { banner => 'LINK' } },
+            licencing_payment_links => { tfl => { banners => 'LINK' } },
         },
         PHOTO_STORAGE_OPTIONS => { UPLOAD_DIR => $UPLOAD_DIR },
     }, sub {
-        $mech->get_ok('/licence/banner');
+        $mech->get_ok('/licence/banners');
 
         # Intro page
         $mech->submit_form_ok({ button => 'start' });
@@ -105,7 +105,7 @@ subtest 'Banner form submission - smoke test' => sub {
         }});
 
         $mech->form_with_fields('terms_accepted');
-        $mech->current_form->find_input('terms_accepted', undef, 1)->value('Banner guidance notes and terms & conditions - March 2026');
+        $mech->current_form->find_input('terms_accepted', undef, 1)->value('Banners guidance notes and terms & conditions - March 2026');
         $mech->current_form->find_input('terms_accepted', undef, 2)->value('Highway licensing and other consents policy - March 2026');
         $mech->current_form->find_input('terms_accepted', undef, 3)->value('Standard conditions for highway consents - March 2026');
         $mech->submit_form_ok;
@@ -141,7 +141,7 @@ subtest 'Banner form submission - smoke test' => sub {
 
         # Verify problem was created
         my $problem = FixMyStreet::DB->resultset('Problem')
-            ->search({ category => 'Banner licence' })
+            ->search({ category => 'Banners licence' })
             ->order_by({ -desc => 'id' })->first;
         ok $problem, 'Problem record created';
         is $problem->cobrand_data, 'licence', 'cobrand_data is licence';
@@ -152,14 +152,14 @@ subtest 'Banner form submission - smoke test' => sub {
         # Detail string should group fields by section with headers and blank lines,
         # making it easier to distinguish e.g. applicant vs contractor answers
         my $detail = $problem->detail;
-        like $detail, qr/\[Location of the banner\/s\]/, 'Detail contains Location section header';
+        like $detail, qr/\[Location of the banners\]/, 'Detail contains Location section header';
         like $detail, qr/\[Applicant details\]/, 'Detail contains Applicant section header';
         like $detail, qr/\n\n/, 'Detail has blank lines between sections';
         unlike $detail, qr/Contact name:/, 'Contractor contact name hidden when same as applicant';
 
         # Verify uploads went to the licence_files directory
         my $cfg = FixMyStreet->config('PHOTO_STORAGE_OPTIONS');
-        my $upload_dir = path($UPLOAD_DIR, "tfl-licence-banner")->absolute(FixMyStreet->path_to());
+        my $upload_dir = path($UPLOAD_DIR, "tfl-licence-banners")->absolute(FixMyStreet->path_to());
 
         ok -d $upload_dir, 'licence_files directory exists';
 
@@ -176,6 +176,19 @@ subtest 'Banner form submission - smoke test' => sub {
             my $file_path = $upload_dir->child($extra->{$field}->{files});
             ok -f $file_path, "Uploaded file exists at $file_path";
         }
+    };
+};
+
+subtest 'Old /licence/banner URL redirects to /licence/banners' => sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'tfl',
+        COBRAND_FEATURES => { licencing_forms => { tfl => 1 } },
+    }, sub {
+        $mech->max_redirect(0);
+        $mech->get('/licence/banner');
+        is $mech->res->code, 301, 'redirect is 301';
+        like $mech->res->header('Location'), qr{/licence/banners$}, 'redirects to /licence/banners';
+        $mech->max_redirect(7);
     };
 };
 

--- a/templates/web/base/licence/banner/have_you_considered.html
+++ b/templates/web/base/licence/banner/have_you_considered.html
@@ -1,3 +1,3 @@
 <p>
-A banner licence only grants permission to place banners on the public highway. Any additional stopping controls, such as a parking dispensation or loading bay suspension must be applied for separately and may require additional lead times.
+A banners licence only grants permission to place banners on the public highway. Any additional stopping controls, such as a parking dispensation or loading bay suspension must be applied for separately and may require additional lead times.
 </p>

--- a/templates/web/base/licence/banner/intro.html
+++ b/templates/web/base/licence/banner/intro.html
@@ -1,4 +1,4 @@
-<p>This form is to apply for a banner licence on the TfL Road Network.</p>
+<p>This form is to apply for a licence for banners on the TfL Road Network.</p>
 
 <h3>Before you start</h3>
 


### PR DESCRIPTION
I've left the licence name as "Banner licence" because "Banners licence" doesn't seem right and "Licence application for banners" is a bit wordy. Will see what the client says. Also means the category name can stay the same.

## Notes for deployer

- [x] Update payment links in config before deploying
- [x] Create new Banners licence category on staging and live sites

For https://3.basecamp.com/4020879/buckets/44968646/card_tables/cards/9741452332

<!-- [skip changelog] -->
