### PR TITLE
[Bexley] Adds message to say cancellation not necessary

### DIFF
--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -949,6 +949,8 @@ FixMyStreet::override_config {
                 '"Renew today" notification box shown';
             like $mech->content, qr/14 March 2024, soon due for renewal/,
                 '"Due soon" message shown';
+            unlike $mech->content, qr/\(Do not contact us to cancel. Your subscription will automatically cancel unless you renew\)/,
+                'Additional overdue messaging  not shown';
             like $mech->content,
                 qr/Renew your brown wheelie bin subscription/,
                 'Renewal link available';
@@ -1007,6 +1009,8 @@ FixMyStreet::override_config {
                     '"Renew today" notification box not shown';
                 unlike $mech->content, qr/14 March 2024, soon due for renewal/,
                     '"Due soon" message not shown';
+                unlike $mech->content, qr/\(Do not contact us to cancel. Your subscription will automatically cancel unless you renew\)/,
+                    'Additional overdue messaging not shown';
                 unlike $mech->content,
                     qr/Renew your brown wheelie bin subscription/,
                     'Renewal link not available';
@@ -1318,7 +1322,7 @@ FixMyStreet::override_config {
                         'cannot cancel';
                     unlike $mech->content, qr/Renew subscription today/,
                         '"Renew today" notification box not shown';
-                    like $mech->content, qr/18 January 2024, subscription overdue/,
+                    like $mech->content, qr/18 January 2024, subscription overdue. \(Do not contact us to cancel. Your subscription will automatically cancel unless you renew\)/,
                         '"Overdue" message shown';
                     like $mech->content,
                         qr/Renew your brown wheelie bin subscription/,
@@ -1490,7 +1494,7 @@ FixMyStreet::override_config {
                         'cannot cancel';
                     unlike $mech->content, qr/Renew subscription today/,
                         '"Renew today" notification box not shown';
-                    like $mech->content, qr/1 November 2023, subscription overdue/,
+                    like $mech->content, qr/1 November 2023, subscription overdue. \(Do not contact us to cancel. Your subscription will automatically cancel unless you renew\)/,
                         '"Overdue" message shown';
                     like $mech->content,
                         qr/Renew your brown wheelie bin subscription/,
@@ -3185,7 +3189,7 @@ FixMyStreet::override_config {
                     qr/Your subscription is soon due for renewal/,
                     'renewal warning not shown';
                 like $mech->content,
-                    qr/subscription overdue/,
+                    qr/subscription overdue. \(Do not contact us to cancel. Your subscription will automatically cancel unless you renew\)/,
                     'overdue message shown';
                 like $mech->content,
                     qr/Renew your brown wheelie bin subscription/,
@@ -3320,6 +3324,7 @@ FixMyStreet::override_config {
 
                 $mech->get_ok('/waste/10001');
                 $mech->content_lacks('Your subscription is soon due for renewal');
+                $mech->content_lacks('Do not contact us to cancel. Your subscription will automatically cancel unless you renew');
                 $mech->content_contains('This property has an existing direct debit subscription which will renew automatically');
                 $mech->content_lacks('value="Renew subscription today"');
                 $mech->content_lacks('Renew your brown wheelie bin subscription');
@@ -3338,6 +3343,9 @@ FixMyStreet::override_config {
                 unlike $mech->text,
                     qr/Your subscription is soon due for renewal/,
                     'renewal warning not shown';
+                unlike $mech->text,
+                    qr/\(Do not contact us to cancel. Your subscription will automatically cancel unless you renew\)/,
+                    'additional message not shown';
                 unlike $mech->content,
                     qr/subscription overdue/,
                     'overdue message not shown';

--- a/templates/web/base/waste/_services_garden_current.html
+++ b/templates/web/base/waste/_services_garden_current.html
@@ -21,6 +21,9 @@
             [%~ ' Cancellation in progress' IF pending_cancellation %]
             [%~ ', soon due for renewal.' IF unit.garden_due AND !unit.garden_overdue AND NOT waste_features.garden_renew_disabled %]
             [%~ ', subscription overdue.' IF unit.garden_overdue AND NOT waste_features.garden_renew_disabled ~%]
+            [% IF c.cobrand.moniker == 'bexley' AND unit.garden_overdue AND NOT waste_features.garden_renew_disabled %]
+            [%~ ' (Do not contact us to cancel. Your subscription will automatically cancel unless you renew)' ~%]
+            [% END %]
         </dd>
       </div>
     [% END %]


### PR DESCRIPTION
Unless a resident actively renews their ggw subscription it will cancel.

Let them know so they can avoid unnecessary worry and contacting the council to ask.

https://mysocietysupport.freshdesk.com/a/tickets/6449

[skip changelog]