### PR TITLE
[Bexley] Ignore existing unconfirmed garden subs.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1226,11 +1226,16 @@ sub get_current_payment_method : Private {
 sub get_original_sub : Private {
     my ($self, $c, $type) = @_;
 
+    my $states = { '!=' => 'hidden' };
+    if ($c->cobrand->moniker eq 'bexley') {
+        # For Bexley, we handle DD confirmation so can ignore unconfirmed reports
+        $states = [ FixMyStreet::DB::Result::Problem->visible_states() ];
+    }
     my $p = $c->model('DB::Problem')->search({
         uprn => $c->stash->{property}{uprn},
         category => 'Garden Subscription',
         title => ['Garden Subscription - New', 'Garden Subscription - Renew', 'Garden Subscription - Transfer'],
-        state => { '!=' => 'hidden' },
+        state => $states,
     })->order_by('-id')->to_body($c->cobrand->body);
 
     if ($type eq 'user' && !$c->stash->{is_staff}) {

--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -3358,6 +3358,33 @@ FixMyStreet::override_config {
 
                 $access_mock->unmock_all;
             };
+
+            # Change sub to credit card so renewal is possible in next test
+            $agile_mock->mock( 'CustomerSearch', sub { {
+                Customers => [ {
+                    CustomerExternalReference => 'CUSTOMER_123',
+                    CustomerReference => 'GWIT-456',
+                    CustomertStatus => 'ACTIVATED',
+                    ServiceContracts => [ {
+                        EndDate => '01/02/2025 00:00',
+                        Reference => 'CONTRACT_123',
+                        WasteContainerQuantity => 1,
+                        ServiceContractStatus => 'ACTIVE',
+                        UPRN => '10001',
+                        Payments => [{ PaymentStatus => 'Paid', Amount => '100', PaymentMethod => 'Credit/Debit Card' }],
+                    } ],
+                } ],
+            } } );
+
+            subtest 'Active sub, abandoned DD set up, can still renew again' => sub {
+                set_fixed_time('2025-01-01T00:00:00Z'); # Renewal time
+                # Change DD report to be unconfirmed (not completed renewal/setup)
+                $dd_report->update({ state => 'unconfirmed' });
+                $mech->get_ok('/waste/10001');
+                $mech->content_contains('Renew your brown wheelie bin subscription', 'Renewal link present');
+                $mech->get_ok('/waste/10001/garden_renew');
+                $mech->content_contains('Please enter your customer reference number', 'Form shown');
+            };
         };
     };
 


### PR DESCRIPTION
Direct debit setup is done at our end, so we know that unconfirmed entries have not been completed and can be ignored when looking for an existing subscription.

I think this is enough, the ticket also mentions changing the renewal page check to match the bin day page, but I don't think that's necessary beyond that at this point.

Fixes https://github.com/mysociety/societyworks/issues/5518
For https://mysocietysupport.freshdesk.com/a/tickets/6827

[skip changelog]
