### PR TITLE
Fix setting of options on multiple questions.

### DIFF
--- a/.cypress/cypress/integration/admin.js
+++ b/.cypress/cypress/integration/admin.js
@@ -1,0 +1,34 @@
+// jshint esversion: 6
+
+describe('Admin pages', function() {
+    beforeEach(function(){
+        // Sign in as superuser
+        cy.visit('http://borsetshire.localhost:3001/auth');
+        cy.contains('Super user').click();
+    });
+
+    it('lets you add multiple option extra questions at once', function(){
+        cy.visit('http://borsetshire.localhost:3001/admin/body/1/Graffiti');
+        add_field();
+        add_field();
+        cy.get('#state-confirmed').click();
+        cy.get('[value="Save changes"]').click();
+    });
+});
+
+function add_field() {
+    cy.get('button.js-metadata-item-add').click();
+    var id = cy.contains('New field').parents('.js-metadata-item').invoke('attr', 'data-i').then(function(id) {
+        cy.get(`#metadata-${id}-code`).type(`question${id}`);
+        cy.get(`#metadata-${id}-datatype`).select('singlevaluelist');
+        add_option(id, 1, 'y', 'Yes');
+        add_option(id, 2, 'n', 'No');
+        cy.get('.js-metadata-item-header-title').contains(`question${id}`).parent().click(); // Hide it
+    });
+}
+
+function add_option(id, option_id, key, val) {
+    cy.get('button.js-metadata-option-add:visible').click();
+    cy.get(`#metadata-${id}-values-${option_id}-key`).type(`key${id}-${key}`);
+    cy.get(`#metadata-${id}-values-${option_id}-name`).type(val);
+}

--- a/templates/web/base/admin/extra-metadata-form.html
+++ b/templates/web/base/admin/extra-metadata-form.html
@@ -8,4 +8,8 @@
   [% INCLUDE 'admin/extra-metadata-item.html' meta={} i=9999 collapsed=0 %]
 </div>
 
+<div class="hidden-js" id="js-template-extra-metadata-option">
+  [% INCLUDE 'admin/extra-metadata-option.html' option={} i=9999 j=8888 %]
+</div>
+
 <button type="button" class="btn btn--small js-metadata-item-add hidden-nojs">[% loc('Add field') %]</button>

--- a/templates/web/base/admin/extra-metadata-item.html
+++ b/templates/web/base/admin/extra-metadata-item.html
@@ -83,7 +83,7 @@ DEFAULT behaviour = 'question';
                   [% END %]
                 </div>
 
-                <div class="hidden-js"[% IF i==9999 %] id="js-template-extra-metadata-option"[% END %]>
+                <div class="hidden-js">
                     [% INCLUDE 'admin/extra-metadata-option.html' option={} i=i j=8888 %]
                 </div>
 


### PR DESCRIPTION
The template wasn't being created correctly, so if you added multiple extra data questions with dropdown options, only one set of options was being set/overwritten.
Fixes https://github.com/mysociety/societyworks/issues/4829