### PR TITLE
[Bexley] No paye email when staff contribute form for ggw

### DIFF
--- a/perllib/FixMyStreet/Roles/Cobrand/Paye.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Paye.pm
@@ -77,6 +77,10 @@ around waste_cc_get_redirect_url => sub {
                 lineId => $self->waste_cc_payment_admin_fee_line_item_ref($p),
             };
         }
+        my $email = $p->get_extra_metadata('contributed_as')
+          && ($p->get_extra_metadata('contributed_as') eq 'another_user' || $p->get_extra_metadata('contributed_as') eq 'anonymous_user')
+          ? ''
+          : $p->user->email;
         my %args = (
             returnUrl => $c->uri_for_action('/waste/pay_complete', [ $p->id, $redirect_id ] ) . '',
             backUrl => $backUrl,
@@ -84,7 +88,7 @@ around waste_cc_get_redirect_url => sub {
             request_id => $p->id,
             description => $p->title,
             name => $p->name,
-            email => $p->user->email,
+            email => $email,
             uprn => $p->uprn,
             address1 => shift @parts,
             address2 => shift @parts,

--- a/t/app/controller/waste_bexley_bulky.t
+++ b/t/app/controller/waste_bexley_bulky.t
@@ -615,6 +615,7 @@ FixMyStreet::override_config {
         like $mech2->res->previous->header('Location'), qr/paye.example.org/;
 
         my ($token, $report, $report_id) = get_report_from_redirect($sent_params->{returnUrl});
+        is $sent_params->{email}, $user->email, 'user email address used for paye';
         is $sent_params->{items}[0]{reference}, 'bulky-customer-ref';
         is $sent_params->{narrative}, "Bulky waste - $report_id";
         is $call_params->{'temp:request'}{sale}{receiptDetails}{name}{surname}, 'Bob Marge';

--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -2915,6 +2915,7 @@ FixMyStreet::override_config {
 
         my ($token, $report, $report_id) = get_report_from_redirect($sent_params->{returnUrl});
 
+        is $sent_params->{email}, '', 'Blank email when staff make report';
         is $sent_params->{narrative}, "Garden Waste Service Payment - Reference: " . $report_id . " Contract: 10001",
             'Custom narrative was used for paye.net payment';
     };

--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -3017,6 +3017,7 @@ FixMyStreet::override_config {
 
         my ($token, $report, $report_id) = get_report_from_redirect($sent_params->{returnUrl});
 
+        is $sent_params->{email}, '', 'Blank email when staff make report';
         is $sent_params->{narrative}, "Garden Waste Service Payment - Reference: " . $report_id . " Contract: 10001",
             'Custom narrative was used for paye.net payment';
     };


### PR DESCRIPTION
When staff make a request on behalf of the user, we now don't send the paye email to the staff address but remove the email.

https://mysocietysupport.freshdesk.com/a/tickets/6688

[skip changelog]