### PR TITLE
[Bexley][WW] Use external_id instead of UPRN when matching Agile cancellations

### DIFF
--- a/bin/bexley/cancel-garden-waste-from-agile
+++ b/bin/bexley/cancel-garden-waste-from-agile
@@ -18,6 +18,7 @@ my ($opts, $usage) = describe_options(
     '%c %o',
     ['days=i', 'How many days to check for cancellations (max 7)', { default => 7 } ],
     ['uprn=s', 'A specific UPRN to cancel'],
+    ['reference=s', 'Agile reference to cancel'],
     ['verbose|v', 'Print verbose output'],
     ['help|h', "print usage message and exit" ],
 );
@@ -33,8 +34,8 @@ my $canceller = FixMyStreet::Script::Bexley::CancelGardenWaste->new(
     verbose => $opts->verbose,
 );
 
-if ($opts->uprn) {
-    $canceller->cancel_by_uprn($opts->uprn);
+if ($opts->uprn && $opts->reference) {
+    $canceller->cancel_contract({ UPRN => $opts->{uprn}, Reference => $opts->{reference} });
 } else {
     $canceller->cancel_from_api($opts->days);
 }

--- a/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
@@ -282,11 +282,12 @@ Returns an arrayref of contract IDs, or undef if none found.
 =cut
 
 sub waste_get_legacy_contract_ids {
-    my ($self, $report) = @_;
+    my ($self, $uprn_or_report) = @_;
 
-    return undef unless $report->uprn;
+    my $uprn = ref $uprn_or_report ? $uprn_or_report->uprn : $uprn_or_report;
+    return undef unless $uprn;
 
-    my $contract_ids = BexleyContracts::contract_ids_for_uprn($report->uprn);
+    my $contract_ids = BexleyContracts::contract_ids_for_uprn($uprn);
     return undef unless @$contract_ids;
 
     return $contract_ids;

--- a/perllib/FixMyStreet/Script/Bexley/CancelGardenWaste.pm
+++ b/perllib/FixMyStreet/Script/Bexley/CancelGardenWaste.pm
@@ -41,26 +41,37 @@ sub cancel_from_api {
     $self->_vprint("Found " . scalar(@$contracts) . " cancellations");
 
     foreach my $contract (@$contracts) {
-        $self->cancel_by_uprn( $contract->{UPRN}, $contract->{Reason} );
+        $self->cancel_contract( $contract );
     }
 }
 
-sub cancel_by_uprn {
-    my ( $self, $uprn, $reason ) = @_;
+sub cancel_contract {
+    my ( $self, $contract ) = @_;
 
-    $self->_vprint("Attempting to cancel subscription for UPRN $uprn");
+    my $uprn = $contract->{UPRN};
+    my $reference = $contract->{Reference};
+    my $external_id = "Agile-$reference";
+    my $reason = $contract->{Reason};
 
-    # Find active garden subscription report for this UPRN.
+    $self->_vprint("Attempting to cancel contract $reference (UPRN: $uprn)");
+
+    # Find active garden subscription reports matching this Agile reference.
     # Based on get_original_sub in FixMyStreet/App/Controller/Waste.pm.
     my $report = $self->cobrand->problems->search({
         category => 'Garden Subscription',
         title => ['Garden Subscription - New', 'Garden Subscription - Renew'],
-        uprn => $uprn,
+        external_id => $external_id,
         state => { '!=' => 'hidden' },
     })->order_by('-id')->first;
 
+    # Always check for legacy contracts regardless of whether we found a report.
+    my $legacy_contract_ids = $self->cobrand->waste_get_legacy_contract_ids($uprn);
+    if ($legacy_contract_ids) {
+        $self->_cancel_legacy_direct_debit($legacy_contract_ids);
+    }
+
     unless ($report) {
-        $self->_vprint("  No active garden subscription found for UPRN $uprn");
+        $self->_vprint("  No active garden subscription found with external_id $external_id");
         return;
     }
 
@@ -71,11 +82,8 @@ sub cancel_by_uprn {
     my $current_created = $dtf->format_datetime( $report->created );
     my $cancellation_report = $self->cobrand->problems->search({
         category => 'Cancel Garden Subscription',
-        uprn => $uprn,
+        extra => { '@>' => encode_json({ original_report_id => $report->id }) },
         state => [ FixMyStreet::DB::Result::Problem->open_states ],
-        # Make sure it was created after the current subscription, otherwise
-        # it is a cancellation for a previous subscription
-        created => { '>' => $current_created },
     })->order_by('-id')->first;
 
     if ($cancellation_report) {
@@ -133,7 +141,8 @@ sub create_cancellation_report {
     # Metadata
     my $existing_meta = $existing_report->get_extra_metadata;
     my %cancellation_meta
-        = %$existing_meta{qw/property_address direct_debit_contract_id/};
+        = %$existing_meta{qw/property_address direct_debit_contract_id direct_debit_customer_id/};
+    $cancellation_meta{original_report_id} = $existing_report->id;
     $cancellation_report->set_extra_metadata(%cancellation_meta);
 
     # Set 'detail' using category & property_address
@@ -172,28 +181,15 @@ sub _cancel_direct_debit {
         return;
     }
 
-    # Check if we have a contract ID in metadata (modern WasteWorks)
     my $contract_id = $original_report->get_extra_metadata('direct_debit_contract_id');
-
-    # For legacy pre-WasteWorks subscriptions, look up by UPRN
-    my $legacy_contract_ids;
-    if (!$contract_id) {
-        $legacy_contract_ids = $self->cobrand->waste_get_legacy_contract_ids($original_report);
-        if (!$legacy_contract_ids) {
-            $self->_vprint("  WARNING: No contract ID in metadata and no legacy contracts found for UPRN");
-            return;
-        }
-        $self->_vprint("  Found " . scalar(@$legacy_contract_ids) . " legacy contract(s) to try");
+    unless ($contract_id) {
+        $self->_vprint("  WARNING: No contract ID in metadata");
+        return;
     }
 
-    $self->_vprint("  Cancelling Direct Debit plan" . ($contract_id ? " with contract ID $contract_id" : ""));
+    $self->_vprint("  Cancelling Direct Debit plan with contract ID $contract_id");
 
-    my $resp = $i->cancel_plan({
-        report => $original_report,
-        $legacy_contract_ids ? (contract_ids => $legacy_contract_ids) : (),
-    });
-
-    # TODO Set a flag on report if failure here?
+    my $resp = $i->cancel_plan({ report => $original_report });
 
     if ( ref $resp eq 'HASH' && $resp->{error} ) {
         $self->_vprint(
@@ -204,7 +200,31 @@ sub _cancel_direct_debit {
             "  Successfully sent cancellation request to Direct Debit provider."
         );
     }
+}
 
+sub _cancel_legacy_direct_debit {
+    my ($self, $legacy_contract_ids) = @_;
+
+    my $i = $self->cobrand->get_dd_integration;
+    unless ($i) {
+        $self->_vprint("  WARNING: Could not get Direct Debit integration object. Unable to cancel legacy contracts.");
+        return;
+    }
+
+    $self->_vprint("  Found " . scalar(@$legacy_contract_ids) . " legacy contract(s) to try");
+    $self->_vprint("  Cancelling Direct Debit plan");
+
+    my $resp = $i->cancel_plan({ contract_ids => $legacy_contract_ids });
+
+    if ( ref $resp eq 'HASH' && $resp->{error} ) {
+        $self->_vprint(
+            "  Failed to send cancellation request to Direct Debit provider: $resp->{error}"
+        );
+    } else {
+        $self->_vprint(
+            "  Successfully sent cancellation request to Direct Debit provider."
+        );
+    }
 }
 
 sub _vprint {

--- a/perllib/FixMyStreet/Script/Bexley/CancelGardenWaste.pm
+++ b/perllib/FixMyStreet/Script/Bexley/CancelGardenWaste.pm
@@ -67,10 +67,11 @@ sub cancel_contract {
     # Always check for legacy contracts regardless of whether we found a report.
     my $legacy_contract_ids = $self->cobrand->waste_get_legacy_contract_ids($uprn);
     if ($legacy_contract_ids) {
-        $self->_cancel_legacy_direct_debit($legacy_contract_ids);
+        $self->_cancel_legacy_direct_debit($legacy_contract_ids, $reference);
     }
 
     unless ($report) {
+        # Expected as we might have handled a legacy cancellation above.
         $self->_vprint("  No active garden subscription found with external_id $external_id");
         return;
     }
@@ -98,7 +99,7 @@ sub cancel_contract {
 
     my $payment_method = $report->get_extra_field_value('payment_method') || 'credit_card';
     if ($payment_method eq 'direct_debit') {
-        $self->_cancel_direct_debit($report);
+        $self->_cancel_direct_debit($report, $reference);
     } else {
         # Nothing to do for credit card
     }
@@ -173,17 +174,16 @@ sub create_cancellation_report {
 }
 
 sub _cancel_direct_debit {
-    my ($self, $original_report) = @_;
+    my ($self, $original_report, $reference) = @_;
 
     my $i = $self->cobrand->get_dd_integration;
     unless ($i) {
-        $self->_vprint("  WARNING: Could not get Direct Debit integration object. Unable to cancel at source.");
-        return;
+        die("Could not get Direct Debit integration object (while processing Agile reference $reference)");
     }
 
     my $contract_id = $original_report->get_extra_metadata('direct_debit_contract_id');
     unless ($contract_id) {
-        $self->_vprint("  WARNING: No contract ID in metadata");
+        print "  WARNING: No contract ID in metadata for Agile reference $reference (report " . $original_report->id . ")\n";
         return;
     }
 
@@ -192,9 +192,7 @@ sub _cancel_direct_debit {
     my $resp = $i->cancel_plan({ report => $original_report });
 
     if ( ref $resp eq 'HASH' && $resp->{error} ) {
-        $self->_vprint(
-            "  Failed to send cancellation request to Direct Debit provider: $resp->{error}"
-        );
+        print "  Failed to send cancellation request to Direct Debit provider for Agile reference $reference: $resp->{error}\n";
     } else {
         $self->_vprint(
             "  Successfully sent cancellation request to Direct Debit provider."
@@ -203,7 +201,7 @@ sub _cancel_direct_debit {
 }
 
 sub _cancel_legacy_direct_debit {
-    my ($self, $legacy_contract_ids) = @_;
+    my ($self, $legacy_contract_ids, $reference) = @_;
 
     my $i = $self->cobrand->get_dd_integration;
     unless ($i) {
@@ -217,9 +215,7 @@ sub _cancel_legacy_direct_debit {
     my $resp = $i->cancel_plan({ contract_ids => $legacy_contract_ids });
 
     if ( ref $resp eq 'HASH' && $resp->{error} ) {
-        $self->_vprint(
-            "  Failed to send cancellation request to Direct Debit provider: $resp->{error}"
-        );
+        print "  Failed to send cancellation request to Direct Debit provider for Agile reference $reference: $resp->{error}\n";
     } else {
         $self->_vprint(
             "  Successfully sent cancellation request to Direct Debit provider."

--- a/perllib/Integrations/AccessPaySuite.pm
+++ b/perllib/Integrations/AccessPaySuite.pm
@@ -253,7 +253,7 @@ Returns 1 on success, or a hashref with an error key on failure.
 sub cancel_plan {
     my ($self, $args) = @_;
     my $report = $args->{report};
-    my $contract_id = $report->get_extra_metadata('direct_debit_contract_id');
+    my $contract_id = $report ? $report->get_extra_metadata('direct_debit_contract_id') : undef;
 
     if ($contract_id) {
         # Single contract from metadata - handle errors properly

--- a/t/script/bexley/cancel-garden-waste.t
+++ b/t/script/bexley/cancel-garden-waste.t
@@ -89,8 +89,8 @@ FixMyStreet::override_config {
 
         subtest 'processes cancellations' => sub {
             $agile_response = [
-                { UPRN => '123456789' },
-                { UPRN => '987654321' },
+                { Reference => 'GW-SERV-001-12345' },
+                { Reference => 'GW-SERV-001-54321' },
             ];
 
             my $cancel_calls = [];
@@ -99,39 +99,47 @@ FixMyStreet::override_config {
                 verbose => 1,
             );
 
-            # Mock cancel_by_uprn to track calls
+            # Mock cancel_contract to track calls
             my $cancel_mock = Test::MockModule->new('FixMyStreet::Script::Bexley::CancelGardenWaste');
-            $cancel_mock->mock('cancel_by_uprn', sub {
-                my ($self, $uprn) = @_;
-                push @$cancel_calls, $uprn;
+            $cancel_mock->mock('cancel_contract', sub {
+                my ($self, $contract) = @_;
+                push @$cancel_calls, $contract->{Reference};
             });
 
             stdout_is { $canceller_test->cancel_from_api(7) }
                 "Found 2 cancellations\n",
                 "Correct number of cancellations found";
 
-            is_deeply $cancel_calls, ['123456789', '987654321'],
-                "cancel_by_uprn called for each UPRN";
+            is_deeply $cancel_calls, ['GW-SERV-001-12345', 'GW-SERV-001-54321'],
+                "cancel_contract called for each Reference";
         };
     };
 
-    subtest 'cancel_by_uprn tests' => sub {
+    subtest 'cancel_contract tests' => sub {
         my $canceller = FixMyStreet::Script::Bexley::CancelGardenWaste->new(
             cobrand => $cobrand,
             verbose => 1,
         );
 
         my $uprn = '123456789';
+        my $reference = 'GW-SERV-001-12345';
+        my $external_id = "Agile-$reference";
+
+        my $contract = {
+            UPRN => $uprn,
+            Reference => $reference,
+            Reason => 'Moved house',
+        };
 
         subtest 'no active subscription found' => sub {
-            stdout_is { $canceller->cancel_by_uprn($uprn) }
-                "Attempting to cancel subscription for UPRN $uprn\n" .
-                "  No active garden subscription found for UPRN $uprn\n",
-                "Handles no active subscription correctly";
+            stdout_is { $canceller->cancel_contract($contract) }
+                "Attempting to cancel contract $reference (UPRN: $uprn)\n" .
+                "  No active garden subscription found with external_id $external_id\n",
+                "Handles no active subscription correctly (UPRN with no legacy contracts)";
         };
 
         subtest 'handles direct debit cancellation' => sub {
-            my $garden_report = _create_report( uprn => $uprn );
+            my $garden_report = _create_report( uprn => $uprn, external_id => $external_id );
 
             $access_mock->mock('cancel_plan', sub {
                 my ($self, $args) = @_;
@@ -139,8 +147,8 @@ FixMyStreet::override_config {
                 return 1;
             });
 
-            stdout_like { $canceller->cancel_by_uprn($uprn, 'Moved house') }
-                qr/Attempting to cancel subscription for UPRN $uprn.*Found active report.*Cancelling Direct Debit.*Successfully sent cancellation request/s,
+            stdout_like { $canceller->cancel_contract($contract) }
+                qr/Attempting to cancel contract $reference.*Found active report.*Cancelling Direct Debit.*Successfully sent cancellation request/s,
                 "Successfully handles direct debit cancellation";
 
             my $cancel_report = _last_cancel_report();
@@ -158,6 +166,8 @@ FixMyStreet::override_config {
             cmp_deeply $cancel_report->get_extra_metadata, {
                 property_address => '123 Bexley St',
                 direct_debit_contract_id => 'PAYER123',
+                direct_debit_customer_id => 'CUST123',
+                original_report_id => $garden_report->id,
             }, 'correct metadata set on cancellation report';
 
             cmp_deeply $cancel_report->get_extra_fields, [
@@ -173,10 +183,10 @@ FixMyStreet::override_config {
         subtest 'handles legacy UPRN-based direct debit cancellation' => sub {
             $mech->delete_problems_for_body( $body->id );
 
-            my $uprn = '20001';  # UPRN that has legacy contracts in mock
+            my $legacy_uprn = '20001';  # UPRN that has legacy contracts in mock
+            my $legacy_contract = { %$contract, UPRN => $legacy_uprn };
 
-            # Create report WITHOUT direct_debit_contract_id metadata
-            my $garden_report = _create_report( uprn => $uprn, skip_contract_id => 1 );
+            # No FMS report exists with the Agile external_id (legacy sub never had one)
 
             my $cancel_plan_called = 0;
             my $passed_contract_ids;
@@ -184,19 +194,21 @@ FixMyStreet::override_config {
             $access_mock->mock('cancel_plan', sub {
                 my ($self, $args) = @_;
                 $cancel_plan_called = 1;
-                is $args->{report}->id, $garden_report->id, 'Correct report passed';
+                ok !$args->{report}, 'No report passed for legacy-only cancellation';
                 ok $args->{contract_ids}, 'contract_ids parameter provided for legacy subscription';
                 $passed_contract_ids = $args->{contract_ids};
                 return 1;  # Success
             });
 
-            stdout_like { $canceller->cancel_by_uprn($uprn, 'Moved house') }
-                qr/Found 1 legacy contract.*Successfully sent cancellation request/s,
-                "Successfully handles legacy direct debit cancellation";
+            stdout_like { $canceller->cancel_contract($legacy_contract) }
+                qr/Found 1 legacy contract.*Successfully sent cancellation request.*No active garden subscription/s,
+                "Cancels legacy contracts even when no matching FMS report exists";
 
             ok $cancel_plan_called, 'cancel_plan was called';
             is_deeply $passed_contract_ids, ['TEST-CONTRACT-20001'],
                 'Correct legacy contract ID passed from BexleyContracts lookup';
+
+            is _last_cancel_report(), undef, 'No cancellation report created without a matching FMS report';
         };
 
         subtest 'Cancellation report exists' => sub {
@@ -206,9 +218,9 @@ FixMyStreet::override_config {
 
             # Create old and new subscriptions
             my $created = '2024-07-28 12:00:00';
-            _create_report( uprn => $uprn, created => $created );
+            _create_report( uprn => $uprn, external_id => $external_id, created => $created );
             $created = '2025-07-28 12:00:00';
-            _create_report( uprn => $uprn, created => $created );
+            _create_report( uprn => $uprn, external_id => $external_id, created => $created );
 
             subtest 'For a previous subscription' => sub {
                 $created = '2025-07-28 00:00:00';
@@ -219,7 +231,7 @@ FixMyStreet::override_config {
                 );
 
                 my $last_cancel_id = _last_cancel_report()->id;
-                stdout_unlike { $canceller->cancel_by_uprn($uprn) }
+                stdout_unlike { $canceller->cancel_contract($contract) }
                     qr/Active cancellation report.*already exists/;
                 my $new_cancel_id = _last_cancel_report()->id;
                 ok $last_cancel_id != $new_cancel_id,
@@ -230,7 +242,7 @@ FixMyStreet::override_config {
                 # Newer cancellation report should have been set up in
                 # previous test
                 my $last_cancel_id = _last_cancel_report()->id;
-                stdout_like { $canceller->cancel_by_uprn($uprn) }
+                stdout_like { $canceller->cancel_contract($contract) }
                     qr/Active cancellation report.*already exists/;
                 my $new_cancel_id = _last_cancel_report()->id;
                 ok $last_cancel_id == $new_cancel_id,
@@ -250,10 +262,10 @@ FixMyStreet::override_config {
                 }
             );
 
-            _create_report( uprn => $uprn);
+            _create_report( uprn => $uprn, external_id => $external_id );
 
-            stdout_like { $canceller->cancel_by_uprn($uprn) }
-                qr/Attempting to cancel subscription for UPRN $uprn.*Found active report.*Cancelling Direct Debit.*Failed to send cancellation request to Direct Debit provider: Archive failed/s,
+            stdout_like { $canceller->cancel_contract($contract) }
+                qr/Attempting to cancel contract $reference.*Found active report.*Cancelling Direct Debit.*Failed to send cancellation request to Direct Debit provider: Archive failed/s,
                 "Reports failure when archive_contract fails for single contract";
         };
 
@@ -261,6 +273,7 @@ FixMyStreet::override_config {
             $mech->delete_problems_for_body( $body->id );
 
             my $legacy_uprn = '20001';  # UPRN that has legacy contracts in mock
+            my $legacy_contract = { %$contract, UPRN => $legacy_uprn };
 
             $access_mock->mock(
                 'archive_contract',
@@ -269,12 +282,10 @@ FixMyStreet::override_config {
                 }
             );
 
-            # Create report WITHOUT direct_debit_contract_id to trigger legacy path
-            _create_report( uprn => $legacy_uprn, skip_contract_id => 1 );
-
-            stdout_like { $canceller->cancel_by_uprn($legacy_uprn) }
-                qr/Attempting to cancel subscription for UPRN $legacy_uprn.*Found active report.*Found 1 legacy contract.*Cancelling Direct Debit.*Successfully sent cancellation request/s,
-                "Continues with cancellation even when archive_contract fails for legacy contracts";
+            # No FMS report — legacy contracts are cancelled regardless
+            stdout_like { $canceller->cancel_contract($legacy_contract) }
+                qr/Attempting to cancel contract $reference.*Found 1 legacy contract.*Cancelling Direct Debit.*Successfully sent cancellation request.*No active garden subscription/s,
+                "Cancels legacy contracts even when archive_contract errors are ignored";
         };
     };
 };
@@ -294,6 +305,7 @@ sub _create_report {
             : 'Garden Subscription',
             title => ( $is_cancel ? 'Garden Subscription - Cancel' : 'Garden Subscription - New' ),
             created => $args{created} || \'current_timestamp',
+            external_id => $args{external_id},
             uprn => $args{uprn},
         },
 
@@ -308,6 +320,7 @@ sub _create_report {
     $garden_report->set_extra_metadata('property_address', '123 Bexley St');
     unless ($skip_contract_id) {
         $garden_report->set_extra_metadata('direct_debit_contract_id', 'PAYER123');
+        $garden_report->set_extra_metadata('direct_debit_customer_id', 'CUST123');
     }
     $garden_report->set_extra_metadata('not_used', 'IGNORE');
     $garden_report->update;

--- a/t/script/bexley/cancel-garden-waste.t
+++ b/t/script/bexley/cancel-garden-waste.t
@@ -265,7 +265,7 @@ FixMyStreet::override_config {
             _create_report( uprn => $uprn, external_id => $external_id );
 
             stdout_like { $canceller->cancel_contract($contract) }
-                qr/Attempting to cancel contract $reference.*Found active report.*Cancelling Direct Debit.*Failed to send cancellation request to Direct Debit provider: Archive failed/s,
+                qr/Attempting to cancel contract $reference.*Found active report.*Cancelling Direct Debit.*Failed to send cancellation request to Direct Debit provider for Agile reference $reference: Archive failed/s,
                 "Reports failure when archive_contract fails for single contract";
         };
 


### PR DESCRIPTION
When checking Agile cancellations use the `external_id` instead of UPRN when matching to WW. Moves the legacy contract check/cancel step so that it always runs regardless of whether a WW report was found or not.

Changes the cancellation reports to have an `agile_reference` in their `extra`, which does mean that when it next runs it will pick up cancellations that it might have already processed, but I think it will just try cancelling and fail, so shouldn't be an issue, will just create a few duplicate cancellation reports in WW (that don't get sent anywhere).

I've also updated the output to use `print` more liberally, so that errors are properly surfaced in the cron email.

Note: this doesn't handle tracking cancel failures, I'm doing that separately as part of https://github.com/mysociety/societyworks/issues/5515

For FD-6862

<!-- [skip changelog] -->
