### PR TITLE
[Central Beds] Autoclose old reports with external status SL12

### DIFF
--- a/bin/centralbedfordshire/auto-close-reports
+++ b/bin/centralbedfordshire/auto-close-reports
@@ -1,0 +1,44 @@
+#!/usr/bin/env perl
+#
+# Close reports older than a number of days if they have (Aurora) external
+# status code of SL12.
+
+use strict;
+use warnings;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use CronFns;
+use Getopt::Long::Descriptive;
+use FixMyStreet::Script::UK::AutoClose;
+
+my $site = CronFns::site(FixMyStreet->config('BASE_URL'));
+CronFns::language($site);
+
+my $default_text = '';
+
+my ($opts, $usage) = describe_options(
+    '%c %o',
+    ['commit!', "actually close reports and send emails. Omitting this flag will do a dry-run"],
+    ['closure_text=s', "text of the message to add to reports", { default => $default_text } ],
+    ['days:i', "Number of days before autoclosing", { default => 28, callbacks => { positive => sub { shift() > 0 } } } ],
+    ['help|h', "print usage message and exit" ],
+    { show_defaults => 1 }
+);
+print($usage->text), exit if $opts->help;
+
+warn "DRY RUN: use --commit to close reports\n" unless $opts->commit;
+
+FixMyStreet::Script::UK::AutoClose->new(
+    commit => $opts->commit,
+    retain_alerts => 1,
+    body_name => 'Central Bedfordshire Council',
+    to => $opts->days,
+    closure_text => $opts->closure_text,
+    extra => { external_status_code => 'SL12' },
+)->close;

--- a/perllib/FixMyStreet/Script/ArchiveOldEnquiries.pm
+++ b/perllib/FixMyStreet/Script/ArchiveOldEnquiries.pm
@@ -114,12 +114,12 @@ sub get_ids_from_csv {
 }
 
 sub get_closure_message {
-    return $opts->{closure_text} if $opts->{closure_text};
-
     if ( $opts->{closure_file} ) {
         my $file = path($opts->{closure_file});
         chomp(my $message = $file->slurp_utf8);
         return $message;
+    } elsif ( defined $opts->{closure_text} ) {
+        return $opts->{closure_text};
     } else {
         my $cobrand;
         eval {

--- a/perllib/FixMyStreet/Script/UK/AutoClose.pm
+++ b/perllib/FixMyStreet/Script/UK/AutoClose.pm
@@ -4,9 +4,10 @@ use v5.14;
 use warnings;
 
 use Moo;
-use Types::Standard qw(Bool InstanceOf Int Maybe);
+use Types::Standard qw(Bool HashRef InstanceOf Int Maybe);
 use FixMyStreet::Script::ArchiveOldEnquiries;
 use FixMyStreet::DB;
+use JSON::MaybeXS;
 
 has commit => ( is => 'ro', default => 0 );
 
@@ -70,7 +71,7 @@ has template => (
     default => sub {
         my $self = shift;
 
-        return if $self->closure_text;
+        return if defined $self->closure_text;
 
         my $template;
         if ($self->template_title) {
@@ -93,6 +94,8 @@ has template => (
     },
 );
 
+has extra => ( is => 'ro', isa => Maybe[HashRef] );
+
 sub close {
     my $self = shift;
 
@@ -108,17 +111,23 @@ sub close {
         $time_param = { '<', $dtf->format_datetime($self->to_date) };
     }
 
+    my $extra_query;
+    if ( $self->extra ) {
+        $extra_query = { '@>' => encode_json( $self->extra ) };
+    }
+
     my $reports = FixMyStreet::DB->resultset("Problem")->search({
         bodies_str => $self->body->id,
         state => $self->states,
         confirmed => $time_param,
         ( category => $self->category ) x !!$self->category,
+        ( extra => $extra_query ) x !!$extra_query,
     });
 
     # Provide some variables to the archiving script
     FixMyStreet::Script::ArchiveOldEnquiries::update_options({
         user => $self->body->comment_user->id,
-        closure_text => $self->closure_text || $self->template->text,
+        closure_text => $self->closure_text // $self->template->text,
         retain_alerts => $self->retain_alerts,
         commit => $self->commit,
     });

--- a/t/script/centralbedfordshire/autoclose.t
+++ b/t/script/centralbedfordshire/autoclose.t
@@ -1,0 +1,75 @@
+use FixMyStreet::TestMech;
+
+use_ok 'FixMyStreet::Script::UK::AutoClose';
+
+my $mech = FixMyStreet::TestMech->new;
+my $comment_user = $mech->create_user_ok('comment@example.com');
+my $body = $mech->create_body_ok(
+    21070,
+    'Central Bedfordshire Council',
+    {   send_method  => 'Open311',
+        cobrand      => 'centralbedfordshire',
+        api_key      => 'key',
+        endpoint     => 'endpoint',
+        jurisdiction => 'j',
+        comment_user => $comment_user,
+    }
+);
+$mech->create_contact_ok( body => $body, category => 'Other', email => 'OTHER' );
+
+my ($older_problem_default) = $mech->create_problems_for_body(
+    1, $body,
+    'Older Default',
+    { dt => DateTime->today()->subtract( days => 28 ) },
+);
+my ($older_problem_SL12) = $mech->create_problems_for_body(
+    1, $body,
+    'Older SL12',
+    {
+        dt => DateTime->today()->subtract( days => 28 ),
+        extra => { external_status_code => 'SL12' },
+    },
+);
+
+my ($newer_problem_default) = $mech->create_problems_for_body(
+    1, $body,
+    'Newer Default',
+    { dt => DateTime->today()->subtract( days => 27 ) },
+);
+my ($newer_problem_SL12) = $mech->create_problems_for_body(
+    1, $body,
+    'Newer SL12',
+    {
+        dt => DateTime->today()->subtract( days => 27 ),
+        extra => { external_status_code => 'SL12' },
+    },
+);
+
+my $ac = FixMyStreet::Script::UK::AutoClose->new(
+    commit => 1,
+    retain_alerts => 1,
+    body_name => 'Central Bedfordshire Council',
+    to => 28,
+    closure_text => '',
+    extra => { external_status_code => 'SL12' },
+);
+
+$ac->close;
+
+$older_problem_default->discard_changes;
+is $older_problem_default->state, 'confirmed', 'Default older problem unchanged';
+is $older_problem_default->comments, 0, 'no comments';
+
+$older_problem_SL12->discard_changes;
+is $older_problem_SL12->state, 'closed', 'Older SL12 problem closed';
+is $older_problem_SL12->comments->first->text, '', 'comment set';
+
+$newer_problem_default->discard_changes;
+is $newer_problem_default->state, 'confirmed', 'Default newer problem unchanged';
+is $newer_problem_default->comments, 0, 'no comments';
+
+$newer_problem_SL12->discard_changes;
+is $newer_problem_SL12->state, 'confirmed', 'Newer SL12 problem unchanged';
+is $newer_problem_SL12->comments, 0, 'no comments';
+
+done_testing;


### PR DESCRIPTION
For https://github.com/mysociety/societyworks/issues/5522.
Note that https://3.basecamp.com/4020879/buckets/44690596/card_tables/cards/9683562873 mentions 'no further update text' so I have made autoclose code handle empty string.

Also requires a cronjob. 

[skip changelog]
