### PR TITLE
[Merton] Text changes for bulky waste

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
@@ -98,14 +98,18 @@ sub item_list : Private {
     my $max_items = $c->stash->{booking_maximum};
     my $field_list = [];
 
+    my $hint = $c->cobrand->moniker eq 'merton'
+      ? 'Describe the item to help our crew pick up the right thing. <b>Do not</b> include personal details or location information'
+      : 'Describe the item to help our crew pick up the right thing';
+
     my $notes_field = {
         type => 'TextArea',
         label => 'Item note',
         maxlength => 100,
-        tags => { hint => 'Describe the item to help our crew pick up the right thing' },
+        tags => { hint => FixMyStreet::Template::SafeString->new($hint) },
     };
     $notes_field->{maxlength} = 255 if $c->cobrand->moniker eq 'merton';
-    if (!$c->cobrand->bulky_item_notes_field_mandatory) {
+    if (!$c->cobrand->bulky_item_notes_field_mandatory && $c->cobrand->moniker ne 'merton') {
         $notes_field->{label} .= ' (optional)';
     }
 

--- a/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
@@ -652,4 +652,10 @@ sub _bulky_collection_overdue {
     return $today > $collection_due_date;
 }
 
+sub bulky_location_text_prompt {
+  "Please provide the exact location where the items will be left ".
+  "(e.g., On the driveway; To the left of the front door; By the front hedge, etc.).".
+  " Do not give any personal information or access codes."
+}
+
 1;

--- a/t/app/controller/waste_merton_bulky.t
+++ b/t/app/controller/waste_merton_bulky.t
@@ -212,8 +212,11 @@ FixMyStreet::override_config {
         subtest 'Intro page' => sub {
             $mech->content_contains('Book a bulky waste collection');
             $mech->content_contains('Before you book');
-            $mech->content_contains('You can request up to <strong>six items per collection');
-            $mech->content_contains('The price depends on how many items you would like collected:');
+            $mech->content_contains('There are <strong>six</strong> stages you need to complete to make a booking');
+            for my $subheading ('Your details', 'Choose date for collection', 'Add items for collection', 'Add location details', 'Booking Summary', 'Make payment') {
+                $mech->content_contains($subheading . ':', "Merton specific sections appear");
+            }
+            $mech->content_contains('The price depends on how many items you would like collected');
             $mech->content_contains('1 to 3 items cost £37.00');
             $mech->content_contains('4 to 6 items cost £60.75');
             $mech->submit_form_ok;
@@ -257,7 +260,7 @@ FixMyStreet::override_config {
                 },
             },
         );
-        $mech->content_contains('Items must be out for collection by 6am on the collection day.');
+        $mech->content_contains('<strong>Items must be out for collection by 6am on the collection day</strong>. Our crew will not enter your home or collect items from your back garden or inside a bin store.');
         $mech->submit_form_ok({ with_fields => { location => '' } }, 'Will error with a blank location');
         $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
 

--- a/templates/web/base/waste/bulky/_band1_pricing.html
+++ b/templates/web/base/waste/bulky/_band1_pricing.html
@@ -1,0 +1,24 @@
+[%
+SET band1_items = cfg.band1_max;
+SET max_items = cfg.items_per_collection_max;
+SET base_price = cfg.base_price / 100;
+SET band1_price = cfg.band1_price / 100;
+SET base_pop_price = (cfg.base_pop_price OR 0) / 100;
+SET band1_pop_price = (cfg.band1_pop_price OR 0) / 100;
+%]
+
+  <ul class="bulky-intro-pricing">
+    <li class="bulky-intro-pricing">
+      1 to [% band1_items %] items cost £[% pounds(band1_price) %]
+      [% IF cfg.pop_costs %]
+      (£[% pounds(band1_pop_price) %] if any item contains POPs)
+      [% END %]
+    </li>
+    <li class="bulky-intro-pricing">
+      [% band1_items+1 %] to [% max_items %] items cost £[% pounds(base_price) %]
+      [% IF cfg.pop_costs %]
+      (£[% pounds(base_pop_price) %] if any item contains POPs)
+      [% END %]
+    </li>
+  </ul>
+</li>

--- a/templates/web/base/waste/bulky/intro.html
+++ b/templates/web/base/waste/bulky/intro.html
@@ -1,4 +1,4 @@
-[% IF c.cobrand.moniker == 'merton' || c.cobrand.moniker == 'bexley' ~%]
+[% IF c.cobrand.moniker == 'bexley' ~%]
     [% service_name = "bulky waste" ~%]
 [% ELSE ~%]
     [% service_name = "bulky goods" ~%]
@@ -55,30 +55,9 @@
   [% END %]
 
   [% IF cfg.band1_price %]
-    [%
-        SET band1_items = cfg.band1_max;
-        SET max_items = cfg.items_per_collection_max;
-        SET base_price = cfg.base_price / 100;
-        SET band1_price = cfg.band1_price / 100;
-        SET base_pop_price = (cfg.base_pop_price OR 0) / 100;
-        SET band1_pop_price = (cfg.band1_pop_price OR 0) / 100;
-    %]
-    <li>The price depends on how many items you would like collected:
-        <ul class="bulky-intro-pricing">
-            <li class="bulky-intro-pricing">
-                1 to [% band1_items %] items cost £[% pounds(band1_price) %]
-                [% IF cfg.pop_costs %]
-                    (£[% pounds(band1_pop_price) %] if any item contains POPs)
-                [% END %]
-            </li>
-            <li class="bulky-intro-pricing">
-                [% band1_items+1 %] to [% max_items %] items cost £[% pounds(base_price) %]
-                [% IF cfg.pop_costs %]
-                    (£[% pounds(base_pop_price) %] if any item contains POPs)
-                [% END %]
-            </li>
-        </ul>
-    </li>
+  <li>The price depends on how many items you would like collected:
+    [% PROCESS waste/bulky/_band1_pricing.html %]
+  </li>
   [% END %]
 
   [% IF c.cobrand.moniker != 'bromley' AND c.cobrand.moniker != 'kingston' AND c.cobrand.moniker != 'sutton' %]
@@ -95,7 +74,7 @@
 
     <li>Before confirming your booking, please check all the information provided is correct</li>
 
-    [% IF cobrand.moniker == 'kingston' || cobrand.moniker == 'sutton' || cobrand.moniker == 'merton' %]
+    [% IF cobrand.moniker == 'kingston' || cobrand.moniker == 'sutton' %]
     <li>Bookings are final and non refundable</li>
     [% END %]
 

--- a/templates/web/base/waste/bulky/location.html
+++ b/templates/web/base/waste/bulky/location.html
@@ -14,9 +14,18 @@
         <strong>If you live in a block of flats:</strong>
         Put your items next to the bin store area (not inside it) on the morning of your collection.
     </p>
+[% IF c.cobrand.moniker == 'merton' %]
+    <p class="govuk-body">
+        <strong>Please read the <a href="[% c.cobrand.call_hook('bulky_tandc_link') %]">bulky waste collection</a> page on the council’s website for more information.</strong>
+    </p>
+    <p class="govuk-body">
+        <strong>Items must be out for collection by [% collection_time %] on the collection day</strong>. Our crew will not enter your home or collect items from your back garden or inside a bin store.
+    </p>
+[% ELSE %]
     <p class="govuk-body">
         Items must be out for collection by [% collection_time %] on the collection day. Our crew will not enter your home or collect items from your back garden.
     </p>
+[% END %]
     <hr>
 [% END %]
 [% IF c.cobrand.moniker == 'bexley' %]

--- a/templates/web/merton/waste/bulky/intro.html
+++ b/templates/web/merton/waste/bulky/intro.html
@@ -1,0 +1,24 @@
+<h2>Before you book</h2>
+
+  [%~
+      USE pounds = format('%.2f');
+      SET cfg = c.cobrand.wasteworks_config;
+  ~%]
+
+<p class="govuk-body">Requesting a bulky waste collection usually takes around <strong>10 minutes</strong>.<br>
+<strong>Please make sure you have read the <a href="[% c.cobrand.call_hook('bulky_tandc_link') %]"> bulky waste collection</a> page on the council’s website</strong>.<br>
+<strong>Bookings are final and non-refundable</strong>.</p>
+<p class="govuk-body">There are <strong>six</strong> stages you need to complete to make a booking</p>
+<ol>
+  <li><strong>Your details: </strong>Your address, email address and telephone number.</li>
+  <li><strong>Choose date for collection: </strong>Pick an available collection date from the list provided.</li>
+  <li><strong>Add items for collection: </strong>You can request up to six items per collection. The price depends on how many items you would like collected
+  [% PROCESS waste/bulky/_band1_pricing.html %]
+  You can also add a helpful description and pictures of each item to be collected
+  <li><strong>Add location details: </strong>Describe where the item(s) will be located.  A picture of the location can also be added.</li>
+  <li><strong>Booking Summary: </strong>Before confirming your booking, check all the information provided is correct. You are able to make changes if necessary.</li>
+  <li><strong>Make payment: </strong>You will be redirected to the council’s card payments provider.</li>
+</ol>
+
+
+[% INCLUDE 'waste/_intro_clear.html' %]


### PR DESCRIPTION
Text changes to bulky waste for Merton bulky waste form

As we don't actually currently honour the optional/non optional for notes on individual items, it is mainly cosmetic so opted to just drop the 'optional' text for all.

https://mysocietysupport.freshdesk.com/a/tickets/6820

[skip changelog]