### PR TITLE
[Bexley][WW] Fixes for Agile cancellation script

### DIFF
--- a/bin/bexley/cancel-garden-waste-from-agile
+++ b/bin/bexley/cancel-garden-waste-from-agile
@@ -16,7 +16,7 @@ use FixMyStreet::Script::Bexley::CancelGardenWaste;
 
 my ($opts, $usage) = describe_options(
     '%c %o',
-    ['days=i', 'How many days to check for cancellations (max 7)', { default => 7 } ],
+    ['days=i', 'How many days to check for cancellations', { default => 7 } ],
     ['uprn=s', 'A specific UPRN to cancel'],
     ['reference=s', 'Agile reference to cancel'],
     ['verbose|v', 'Print verbose output'],
@@ -24,9 +24,6 @@ my ($opts, $usage) = describe_options(
 );
 
 $usage->die if $opts->help;
-if ($opts->days > 7) {
-    $usage->die("Days must be 7 or less");
-}
 
 my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker('bexley')->new;
 my $canceller = FixMyStreet::Script::Bexley::CancelGardenWaste->new(

--- a/perllib/FixMyStreet/Script/Bexley/CancelGardenWaste.pm
+++ b/perllib/FixMyStreet/Script/Bexley/CancelGardenWaste.pm
@@ -49,8 +49,8 @@ sub cancel_contract {
     my ( $self, $contract ) = @_;
 
     my $uprn = $contract->{UPRN};
+    my $id = $contract->{Id};
     my $reference = $contract->{Reference};
-    my $external_id = "Agile-$reference";
     my $reason = $contract->{Reason};
 
     $self->_vprint("Attempting to cancel contract $reference (UPRN: $uprn)");
@@ -60,8 +60,11 @@ sub cancel_contract {
     my $report = $self->cobrand->problems->search({
         category => 'Garden Subscription',
         title => ['Garden Subscription - New', 'Garden Subscription - Renew'],
-        external_id => $external_id,
+        # New reports get the reference back from Agile, but renewals get the
+        # ID, so we need to check for both.
+        external_id => [ "Agile-$reference", "Agile-$id" ],
         state => { '!=' => 'hidden' },
+        -bool => \"extra->>'direct_debit_cancellation_date' IS NULL",
     })->order_by('-id')->first;
 
     # Always check for legacy contracts regardless of whether we found a report.
@@ -72,30 +75,11 @@ sub cancel_contract {
 
     unless ($report) {
         # Expected as we might have handled a legacy cancellation above.
-        $self->_vprint("  No active garden subscription found with external_id $external_id");
+        $self->_vprint("  No active garden subscription found for Agile report $id ($reference)");
         return;
     }
 
     $self->_vprint("  Found active report " . $report->id);
-
-    # See if there is an existing cancellation report for current subscription
-    my $dtf = FixMyStreet::DB->schema->storage->datetime_parser;
-    my $current_created = $dtf->format_datetime( $report->created );
-    my $cancellation_report = $self->cobrand->problems->search({
-        category => 'Cancel Garden Subscription',
-        extra => { '@>' => encode_json({ original_report_id => $report->id }) },
-        state => [ FixMyStreet::DB::Result::Problem->open_states ],
-    })->order_by('-id')->first;
-
-    if ($cancellation_report) {
-        $self->_vprint("  Active cancellation report " . $cancellation_report->id . " already exists");
-        return;
-    }
-
-    $cancellation_report
-        = $self->create_cancellation_report( $report, $reason );
-
-    $self->_vprint("  Created cancellation report " . $cancellation_report->id);
 
     my $payment_method = $report->get_extra_field_value('payment_method') || 'credit_card';
     if ($payment_method eq 'direct_debit') {
@@ -103,74 +87,6 @@ sub cancel_contract {
     } else {
         # Nothing to do for credit card
     }
-}
-
-sub create_cancellation_report {
-    my ( $self, $existing_report, $reason ) = @_;
-
-    my %cancellation_params = (
-        state => 'confirmed',
-        confirmed => \'current_timestamp',
-        send_state => 'sent',
-        category => 'Cancel Garden Subscription',
-        title => 'Garden Subscription - Cancel',
-        detail => '', # Populated below
-        user_id => $self->cobrand->body->comment_user_id,
-        name => $self->cobrand->body->comment_user->name,
-    );
-    for (qw/
-        uprn
-        postcode
-        latitude
-        longitude
-        bodies_str
-        areas
-        used_map
-        anonymous
-        cobrand
-        cobrand_data
-        send_questionnaire
-        non_public
-    /) {
-        $cancellation_params{$_} = $existing_report->$_;
-    }
-
-    # Initiate report
-    my $cancellation_report = FixMyStreet::DB->resultset('Problem')
-        ->create( \%cancellation_params );
-
-    # Metadata
-    my $existing_meta = $existing_report->get_extra_metadata;
-    my %cancellation_meta
-        = %$existing_meta{qw/property_address direct_debit_contract_id direct_debit_customer_id/};
-    $cancellation_meta{original_report_id} = $existing_report->id;
-    $cancellation_report->set_extra_metadata(%cancellation_meta);
-
-    # Set 'detail' using category & property_address
-    $cancellation_report->detail(
-        $cancellation_params{category} . "\n\n" . $cancellation_meta{property_address} );
-
-    # Extra fields
-    my $existing_extra = $existing_report->get_extra_fields;
-    my $match_str = join '|', qw/
-        uprn
-        property_id
-        payment_method
-        customer_external_ref
-        direct_debit_reference
-    /;
-    my @cancellation_extra
-        = grep { $_->{name} =~ /^($match_str)$/ } @$existing_extra;
-    push @cancellation_extra, {
-        name  => 'reason',
-        value => 'Cancelled on Agile end: '
-            . ( $reason || 'No reason provided' )
-    };
-    $cancellation_report->set_extra_fields(@cancellation_extra);
-
-    $cancellation_report->update;
-
-    return $cancellation_report;
 }
 
 sub _cancel_direct_debit {
@@ -192,8 +108,21 @@ sub _cancel_direct_debit {
     my $resp = $i->cancel_plan({ report => $original_report });
 
     if ( ref $resp eq 'HASH' && $resp->{error} ) {
+        my $failures = $original_report->get_extra_metadata('direct_debit_cancellation_failures') // 0;
+        $failures++;
+        $original_report->set_extra_metadata(
+            direct_debit_cancellation_failures       => $failures,
+            direct_debit_cancellation_error          => $resp->{error},
+            direct_debit_cancellation_last_failed_at => DateTime->now->set_time_zone( FixMyStreet->local_time_zone ),
+        );
+        $original_report->update;
         print "  Failed to send cancellation request to Direct Debit provider for Agile reference $reference: $resp->{error}\n";
     } else {
+        $original_report->set_extra_metadata(
+            direct_debit_cancellation_date => DateTime->now->set_time_zone( FixMyStreet->local_time_zone ),
+            direct_debit_cancellation_note => 'Cancellation received from Agile LastCancelled API',
+        );
+        $original_report->update;
         $self->_vprint(
             "  Successfully sent cancellation request to Direct Debit provider."
         );

--- a/t/script/bexley/cancel-garden-waste.t
+++ b/t/script/bexley/cancel-garden-waste.t
@@ -121,11 +121,12 @@ FixMyStreet::override_config {
             verbose => 1,
         );
 
+        my $id = 42;
         my $uprn = '123456789';
         my $reference = 'GW-SERV-001-12345';
-        my $external_id = "Agile-$reference";
 
         my $contract = {
+            Id => $id,
             UPRN => $uprn,
             Reference => $reference,
             Reason => 'Moved house',
@@ -134,50 +135,38 @@ FixMyStreet::override_config {
         subtest 'no active subscription found' => sub {
             stdout_is { $canceller->cancel_contract($contract) }
                 "Attempting to cancel contract $reference (UPRN: $uprn)\n" .
-                "  No active garden subscription found with external_id $external_id\n",
+                "  No active garden subscription found for Agile report $id ($reference)\n",
                 "Handles no active subscription correctly (UPRN with no legacy contracts)";
         };
 
-        subtest 'handles direct debit cancellation' => sub {
-            my $garden_report = _create_report( uprn => $uprn, external_id => $external_id );
+        subtest 'finds report by Agile reference (new subscription)' => sub {
+            my $garden_report = _create_report( uprn => $uprn, external_id => "Agile-$reference" );
 
             $access_mock->mock('cancel_plan', sub {
                 my ($self, $args) = @_;
-                is $args->{report}->id, $garden_report->id, 'Correct report passed';
+                is $args->{report}->id, $garden_report->id, 'Correct report passed (matched by Agile Reference)';
                 return 1;
             });
 
             stdout_like { $canceller->cancel_contract($contract) }
                 qr/Attempting to cancel contract $reference.*Found active report.*Cancelling Direct Debit.*Successfully sent cancellation request/s,
-                "Successfully handles direct debit cancellation";
+                "Finds report by Agile Reference (used for new subscriptions)";
+        };
 
-            my $cancel_report = _last_cancel_report();
+        subtest 'finds report by Agile Id (renewal)' => sub {
+            $mech->delete_problems_for_body( $body->id );
 
-            is $cancel_report->state, 'confirmed';
-            ok $cancel_report->confirmed, 'there is a confirmed timestamp';
-            is $cancel_report->send_state, 'sent';
-            is $cancel_report->category, 'Cancel Garden Subscription';
-            is $cancel_report->title, 'Garden Subscription - Cancel';
-            is $cancel_report->detail, "Cancel Garden Subscription\n\n123 Bexley St";
-            is $cancel_report->user_id, $comment_user->id;
-            is $cancel_report->name, $comment_user->name;
-            is $cancel_report->uprn, $uprn;
+            my $garden_report = _create_report( uprn => $uprn, external_id => "Agile-$id" );
 
-            cmp_deeply $cancel_report->get_extra_metadata, {
-                property_address => '123 Bexley St',
-                direct_debit_contract_id => 'PAYER123',
-                direct_debit_customer_id => 'CUST123',
-                original_report_id => $garden_report->id,
-            }, 'correct metadata set on cancellation report';
+            $access_mock->mock('cancel_plan', sub {
+                my ($self, $args) = @_;
+                is $args->{report}->id, $garden_report->id, 'Correct report passed (matched by Agile Id)';
+                return 1;
+            });
 
-            cmp_deeply $cancel_report->get_extra_fields, [
-                { name => 'property_id', value => $uprn },
-                { name => 'payment_method', value => 'direct_debit' },
-                { name => 'customer_external_ref', value => 'AGILE_CUSTOMER_REF' },
-                { name => 'direct_debit_reference', value => 'DD_REF_123' },
-                { name => 'reason', value => 'Cancelled on Agile end: Moved house' },
-            ], 'correct extra fields set on cancellation report';
-
+            stdout_like { $canceller->cancel_contract($contract) }
+                qr/Attempting to cancel contract $reference.*Found active report.*Cancelling Direct Debit.*Successfully sent cancellation request/s,
+                "Finds report by Agile Id (used for renewals)";
         };
 
         subtest 'handles legacy UPRN-based direct debit cancellation' => sub {
@@ -207,48 +196,6 @@ FixMyStreet::override_config {
             ok $cancel_plan_called, 'cancel_plan was called';
             is_deeply $passed_contract_ids, ['TEST-CONTRACT-20001'],
                 'Correct legacy contract ID passed from BexleyContracts lookup';
-
-            is _last_cancel_report(), undef, 'No cancellation report created without a matching FMS report';
-        };
-
-        subtest 'Cancellation report exists' => sub {
-            $mech->delete_problems_for_body( $body->id );
-
-            $access_mock->mock( 'cancel_plan', sub {} );
-
-            # Create old and new subscriptions
-            my $created = '2024-07-28 12:00:00';
-            _create_report( uprn => $uprn, external_id => $external_id, created => $created );
-            $created = '2025-07-28 12:00:00';
-            _create_report( uprn => $uprn, external_id => $external_id, created => $created );
-
-            subtest 'For a previous subscription' => sub {
-                $created = '2025-07-28 00:00:00';
-                _create_report(
-                    uprn      => $uprn,
-                    created   => $created,
-                    is_cancel => 1,
-                );
-
-                my $last_cancel_id = _last_cancel_report()->id;
-                stdout_unlike { $canceller->cancel_contract($contract) }
-                    qr/Active cancellation report.*already exists/;
-                my $new_cancel_id = _last_cancel_report()->id;
-                ok $last_cancel_id != $new_cancel_id,
-                    'New cancellation report created';
-            };
-
-            subtest 'For current subscription' => sub {
-                # Newer cancellation report should have been set up in
-                # previous test
-                my $last_cancel_id = _last_cancel_report()->id;
-                stdout_like { $canceller->cancel_contract($contract) }
-                    qr/Active cancellation report.*already exists/;
-                my $new_cancel_id = _last_cancel_report()->id;
-                ok $last_cancel_id == $new_cancel_id,
-                    'New cancellation report not created';
-            };
-
         };
 
         subtest 'archive_contract fails for single contract' => sub {
@@ -262,7 +209,7 @@ FixMyStreet::override_config {
                 }
             );
 
-            _create_report( uprn => $uprn, external_id => $external_id );
+            _create_report( uprn => $uprn, external_id => "Agile-$reference" );
 
             stdout_like { $canceller->cancel_contract($contract) }
                 qr/Attempting to cancel contract $reference.*Found active report.*Cancelling Direct Debit.*Failed to send cancellation request to Direct Debit provider for Agile reference $reference: Archive failed/s,
@@ -286,6 +233,84 @@ FixMyStreet::override_config {
             stdout_like { $canceller->cancel_contract($legacy_contract) }
                 qr/Attempting to cancel contract $reference.*Found 1 legacy contract.*Cancelling Direct Debit.*Successfully sent cancellation request.*No active garden subscription/s,
                 "Cancels legacy contracts even when archive_contract errors are ignored";
+        };
+
+        subtest 'records cancellation metadata on success' => sub {
+            $mech->delete_problems_for_body( $body->id );
+
+            my $garden_report = _create_report( uprn => $uprn, external_id => "Agile-$reference" );
+
+            $access_mock->mock( 'cancel_plan', sub { return 1 } );
+
+            stdout_like { $canceller->cancel_contract($contract) }
+                qr/Successfully sent cancellation request/,
+                'success path runs';
+
+            $garden_report->discard_changes;
+            like $garden_report->get_extra_metadata('direct_debit_cancellation_date'),
+                qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+                'cancellation date set in ISO8601 format';
+            is $garden_report->get_extra_metadata('direct_debit_cancellation_note'),
+                'Cancellation received from Agile LastCancelled API',
+                'cancellation note set';
+        };
+
+        subtest 'records failure metadata on error' => sub {
+            $mech->delete_problems_for_body( $body->id );
+
+            my $garden_report = _create_report( uprn => $uprn, external_id => "Agile-$reference" );
+
+            $access_mock->mock( 'cancel_plan', sub { return { error => 'Provider down' } } );
+
+            stdout_like { $canceller->cancel_contract($contract) }
+                qr/Failed to send cancellation request.*Provider down/,
+                'failure path runs';
+
+            $garden_report->discard_changes;
+            is $garden_report->get_extra_metadata('direct_debit_cancellation_failures'), 1,
+                'failure count set to 1';
+            is $garden_report->get_extra_metadata('direct_debit_cancellation_error'), 'Provider down',
+                'error message recorded';
+            like $garden_report->get_extra_metadata('direct_debit_cancellation_last_failed_at'),
+                qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+                'last failure timestamp set in ISO8601 format';
+            ok !$garden_report->get_extra_metadata('direct_debit_cancellation_date'),
+                'no cancellation date on failure';
+        };
+
+        subtest 'increments failure counter on repeated failures' => sub {
+            $mech->delete_problems_for_body( $body->id );
+
+            my $garden_report = _create_report( uprn => $uprn, external_id => "Agile-$reference" );
+            $garden_report->set_extra_metadata( direct_debit_cancellation_failures => 2 );
+            $garden_report->update;
+
+            $access_mock->mock( 'cancel_plan', sub { return { error => 'Still down' } } );
+
+            stdout_like { $canceller->cancel_contract($contract) }
+                qr/Failed to send cancellation request/,
+                'failure path runs';
+
+            $garden_report->discard_changes;
+            is $garden_report->get_extra_metadata('direct_debit_cancellation_failures'), 3,
+                'failure count incremented from existing value';
+        };
+
+        subtest 'skips reports already cancelled' => sub {
+            $mech->delete_problems_for_body( $body->id );
+
+            my $garden_report = _create_report( uprn => $uprn, external_id => "Agile-$reference" );
+            $garden_report->set_extra_metadata( direct_debit_cancellation_date => '2026-01-01T00:00:00' );
+            $garden_report->update;
+
+            my $cancel_plan_called = 0;
+            $access_mock->mock( 'cancel_plan', sub { $cancel_plan_called = 1; return 1; } );
+
+            stdout_like { $canceller->cancel_contract($contract) }
+                qr/No active garden subscription found/,
+                'falls through to no-active-subscription branch';
+
+            ok !$cancel_plan_called, 'cancel_plan not called for already-cancelled report';
         };
     };
 };


### PR DESCRIPTION
Now matches by Agile ID or Reference to pick up both new and renew reports. Removes the cancellation report tracking, that's not actually needed here because those reports aren't being sent anywhere, so we can just cancel the direct debit directly. Also adds some extra tracking for failed reports so we can see the error, how many times they failed, and when they last failed.

<!-- [skip changelog] -->
