### PR TITLE
[Merton] Skip updates on email categories.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Merton.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton.pm
@@ -134,6 +134,22 @@ sub open311_extra_data_include {
 sub open311_munge_update_params {
 }
 
+=head2 should_skip_sending_update
+
+Do not try and send updates on Open311 reports that are now sent by email.
+
+=cut
+
+sub should_skip_sending_update {
+    my ($self, $update) = @_;
+
+    my $code = $update->problem->contact;
+    return 1 unless $code; # No category found
+    $code = $code->email;
+    return 1 if $code =~ /@/; # Is now an email category
+    return 0;
+}
+
 sub report_new_munge_before_insert {
     my ($self, $report) = @_;
 

--- a/t/cobrand/merton.t
+++ b/t/cobrand/merton.t
@@ -3,6 +3,7 @@ use FixMyStreet::TestMech;
 use HTML::Selector::Element qw(find);
 use FixMyStreet::Script::Reports;
 use FixMyStreet::Script::Alerts;
+use Open311::PostServiceRequestUpdates;
 
 FixMyStreet::App->log->disable('info');
 END { FixMyStreet::App->log->enable('info'); }
@@ -18,6 +19,7 @@ my $merton = $mech->create_body_ok(2500, 'Merton Council', {
     jurisdiction => 'merton',
     endpoint => 'http://endpoint.example.org',
     send_method => 'Open311',
+    send_comments => 1,
     comment_user => $superuser,
     cobrand => 'merton'
 });
@@ -356,6 +358,27 @@ subtest "hides duplicate updates from endpoint" => sub {
 
     $p->discard_changes;
     is $p->comments->search({ state => 'confirmed' })->count, 1;
+};
+
+subtest 'Does not send updates on now-email categories' => sub {
+    # Create a report that had been sent via Open311 but is now email (default Other category)
+    my ($p) = $mech->create_problems_for_body(1, $merton->id, 'Title', {
+        whensent => \'current_timestamp',
+        send_method_used => 'Open311',
+        external_id => 'EXT',
+    });
+    my $comment = $mech->create_comment_for_problem($p, $p->user, 'Name', 'Text', 't', 'confirmed');
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'merton',
+    }, sub {
+        my $updates = Open311::PostServiceRequestUpdates->new();
+        $updates->send;
+    };
+
+    $comment->discard_changes;
+    is $comment->send_fail_count, 0, "comment sending not attempted";
+    is $comment->send_state, 'skipped', "skipped sending comment";
 };
 
 package SOAP::Result;

--- a/t/open311.t
+++ b/t/open311.t
@@ -986,6 +986,8 @@ EOT
 };
 
 subtest 'add_media with base64 data URIs' => sub {
+    my $UPLOAD_DIR = tempdir( CLEANUP => 1 );
+
     my $o = Open311->new();
 
     # 1x1px PNG
@@ -1000,20 +1002,27 @@ subtest 'add_media with base64 data URIs' => sub {
         user => $user,
     });
 
-    # Test base64 data URI
-    $o->add_media($data_uri_base64, $test_problem);
-    ok $test_problem->photo, 'photo set from base64 data URI';
+    FixMyStreet::override_config {
+        PHOTO_STORAGE_BACKEND => 'FileSystem',
+        PHOTO_STORAGE_OPTIONS => {
+            UPLOAD_DIR => $UPLOAD_DIR,
+        },
+    }, sub {
+        # Test base64 data URI
+        $o->add_media($data_uri_base64, $test_problem);
+        ok $test_problem->photo, 'photo set from base64 data URI';
 
-    # Test multiple data URIs
-    $test_problem->photo(undef);
-    $o->add_media([$data_uri_base64, $data_uri_base64], $test_problem);
-    ok $test_problem->photo, 'photos set from multiple base64 data URIs';
+        # Test multiple data URIs
+        $test_problem->photo(undef);
+        $o->add_media([$data_uri_base64, $data_uri_base64], $test_problem);
+        ok $test_problem->photo, 'photos set from multiple base64 data URIs';
 
-    # Test invalid MIME type is rejected
-    $test_problem->photo(undef);
-    my $invalid_data_uri = "data:text/plain;base64,bmV2ZXIgZ29ubmEgZ2l2ZSB5b3UgdXA=";
-    $o->add_media($invalid_data_uri, $test_problem);
-    ok !$test_problem->photo, 'photo not set from invalid MIME type data URI';
+        # Test invalid MIME type is rejected
+        $test_problem->photo(undef);
+        my $invalid_data_uri = "data:text/plain;base64,bmV2ZXIgZ29ubmEgZ2l2ZSB5b3UgdXA=";
+        $o->add_media($invalid_data_uri, $test_problem);
+        ok !$test_problem->photo, 'photo not set from invalid MIME type data URI';
+    };
 };
 
 done_testing();


### PR DESCRIPTION
Some categories have changed from Open311 to Email, the updates have nowhere to go, so skip them.
[skip changelog]