### PR TITLE
[Bug] /around page state dropdown

### DIFF
--- a/t/app/controller/around.t
+++ b/t/app/controller/around.t
@@ -766,4 +766,42 @@ subtest 'junction lookup' => sub {
     };
 };
 
+subtest 'status dropdown' => sub {
+    # Oxfordshire $body created further up
+    my $surrey = $mech->create_body_ok(2242, 'Surrey County Council', {cobrand => 'surrey'});
+
+    my $staff_oxf = $mech->create_user_ok('staff@oxf.com', name => 'Staff Oxf', from_body => $body);
+    my $staff_surrey = $mech->create_user_ok('staff@surrey.com', name => 'Staff Surrey', from_body => $surrey);
+    my $other_user = $mech->create_user_ok('other@example.com', name => 'Other User');
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'oxfordshire',
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        subtest 'standard user' => sub {
+            $mech->log_in_ok($other_user->email);
+
+            $mech->get_ok('/around?latitude=51.754926&longitude=-1.256179');
+
+            $mech->content_contains('data-all-options=\'["open","closed","fixed"]\'');
+        };
+
+        subtest 'staff user who does not belong to body' => sub {
+            $mech->log_in_ok($staff_surrey->email);
+
+            $mech->get_ok('/around?latitude=51.754926&longitude=-1.256179');
+
+            $mech->content_contains('data-all-options=\'["open","closed","fixed"]\'');
+        };
+
+        subtest 'staff user who does belong to body' => sub {
+            $mech->log_in_ok($staff_oxf->email);
+
+            $mech->get_ok('/around?latitude=51.754926&longitude=-1.256179');
+
+            $mech->content_like(qr/data-all-options=.*confirmed.*investigating.*action scheduled.*in progress.*fixed.*not responsible.*duplicate.*unable to fix.*internal referral/);
+        };
+    };
+};
+
 done_testing();

--- a/templates/web/base/reports/_list-filter-status.html
+++ b/templates/web/base/reports/_list-filter-status.html
@@ -1,3 +1,8 @@
+[% # 'body' and 'filter_states' already set for /reports but not for /around %]
+[%
+  DEFAULT body = c.cobrand.body;
+  DEFAULT filter_states = c.cobrand.state_groups_inspect;
+%]
 [% SET show_all_states = c.cobrand.filter_show_all_states OR (c.user_exists AND (c.user.is_superuser OR c.user.belongs_to_body(body.id) OR c.req.uri.path == '/my/planned')) %]
 
 <div id="filter-announcement" class="screen-reader-only" role="alert">[% loc('Information: Filters in use. The current view is customized based on selected filters.') %]</div>


### PR DESCRIPTION
Fixes https://github.com/mysociety/societyworks/issues/5470 ; spotted by Dumfries but was a wider issue, where body and filter_states were not defined for /around page, but only for /reports page.

[skip changelog]
