### PR TITLE
[Southwark] No public photos in certain categories

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Southwark.pm
+++ b/perllib/FixMyStreet/Cobrand/Southwark.pm
@@ -17,6 +17,7 @@ use strict;
 use warnings;
 
 use List::Util qw(any);
+use Scalar::Util qw(blessed);
 use Moo;
 
 =head2 Defaults
@@ -82,6 +83,49 @@ sub pin_colour {
 }
 
 sub path_to_pin_icons { '/i/pins/whole-shadow-cone-spot/' }
+
+sub allow_photo_display {
+    my ($self, $object_or_hash, $idx) = @_;
+
+    if ($self->{c} && $self->{c}->user_exists) {
+        my $user = $self->{c}->user;
+        my $body = $self->body;
+        return 1 if $user->is_superuser;
+        return 1 if $body && $user->belongs_to_body($body->id);
+    }
+
+    my $category;
+    if (blessed $object_or_hash) {
+        $category = $object_or_hash->category;
+    } else {
+        $category = $object_or_hash->{category};
+    }
+
+    my %cats = map { $_ => 1 } @{$self->hide_photo_categories};
+    return 0 if $cats{$category};
+    return 1;
+}
+
+sub hide_photo_categories { [
+    'Clinical Waste - Dead Animal (Estates)',
+    'Clinical Waste - Dead Animal (Street)',
+    'Flytipping - Animal Carcass (Estates)',
+    'Flytipping - Animal Carcass (Street)',
+    'Fly Posting - Racist/Obscene (Estates)',
+    'Fly Posting - Racist/Obscene (Street)',
+    'Graffiti - Racist / Obscene',
+    'Graffiti - Racist/Obscene',
+] }
+
+sub recent_photos {
+    my ( $self, $area, $num, $lat, $lon, $dist ) = @_;
+    return $self->problems->search({
+        category => { -not_in => $self->hide_photo_categories },
+    })->recent_photos({
+        num => $num,
+        point => [$lat, $lon, $dist]
+    });
+}
 
 sub disambiguate_location {
     my $self    = shift;

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -277,15 +277,6 @@ sub reports_body_check {
     return;
 }
 
-sub recent_photos {
-    my ( $self, $area, $num, $lat, $lon, $dist ) = @_;
-    $num = 2 if $num == 3;
-    return $self->problems->recent_photos({
-        num => $num,
-        point => [$lat, $lon, $dist]
-    });
-}
-
 # Returns true if the cobrand owns the problem, i.e. it was sent to the body
 # associated with this cobrand.
 sub owns_problem {

--- a/t/cobrand/southwark.t
+++ b/t/cobrand/southwark.t
@@ -1,5 +1,6 @@
 use FixMyStreet::TestMech;
 use Test::MockModule;
+use FixMyStreet::Script::Alerts;
 
 my $mech = FixMyStreet::TestMech->new;
 
@@ -43,6 +44,11 @@ $mech->create_contact_ok(
     category => 'Abandoned Bike (Estate)',
     email    => 'HOU_ABBI',
 );
+my $animal = $mech->create_contact_ok(
+    body_id => $southwark->id,
+    category => 'Clinical Waste - Dead Animal (Estates)',
+    email => 'email'
+);
 
 my $tfl = $mech->create_body_ok( SOUTHWARK_AREA_ID, 'TfL' );
 my $river_piers = $mech->create_contact_ok(
@@ -80,6 +86,10 @@ FixMyStreet::override_config {
                 allow_anonymous => 'true',
                 bodies => ['TfL'],
             },
+            $animal->category => {
+                allow_anonymous => 'true',
+                bodies => ['Southwark Council'],
+            },
         }, "Southwark 'street' area doesn't have River Piers category";
 
     };
@@ -95,8 +105,63 @@ FixMyStreet::override_config {
                 allow_anonymous => 'true',
                 bodies => ['Southwark Council'],
             },
+            $animal->category => {
+                allow_anonymous => 'true',
+                bodies => ['Southwark Council'],
+            },
         }, "Southwark 'estate' area doesn't have TfL categories or street category";
 
+    };
+
+    subtest 'Photos in certain categories hidden' => sub {
+        my $alert = FixMyStreet::DB->resultset('Alert')->create({
+            cobrand => 'southwark',
+            parameter => $southwark->id,
+            alert_type => 'council_problems',
+            user => $staffuser,
+        });
+        $alert->confirm;
+        my ($p) = $mech->create_problems_for_body(1, $southwark->id, 'Title', {
+            category => $animal->category,
+            cobrand => 'southwark',
+            areas => ',2491,',
+            latitude =>  51.50351,
+            longitude => -0.08051,
+            photo => '74e3362283b6ef0c48686fb0e161da4043bbcc97.jpeg',
+            confirmed => \"current_timestamp + '3 hours'::interval",
+        });
+        my $url = '/report/' . $p->id;
+
+        # No photo in alert email
+        FixMyStreet::Script::Alerts::send_other();
+        my $email = $mech->get_email;
+        my $body;
+        $email->walk_parts(sub {
+            my $part = shift;
+            return if $part->subparts;
+            $body = $part->body_str if $part->content_type =~ m{text/html};
+            unlike $part->content_type, qr/image\/jpeg/; # No photo
+        });
+        unlike $body, qr/<img style="float/;
+
+        # No photo on report/around/alert pages
+        $mech->get_ok($url);
+        $mech->content_lacks('/photo/');
+        $mech->get_ok('/around?latitude=' . $p->latitude . '&longitude=' . $p->longitude);
+        $mech->content_contains($url);
+        $mech->content_lacks('/photo/');
+        $mech->get_ok('/alert');
+        $mech->content_lacks('/photo/');
+
+        # Staff can see it on report/around page still
+        $mech->log_in_ok($staffuser->email);
+        $mech->get_ok($url);
+        $mech->content_contains('/photo/');
+        $mech->get_ok('/around?latitude=' . $p->latitude . '&longitude=' . $p->longitude);
+        $mech->content_contains($url);
+        $mech->content_contains('/photo/');
+        $mech->get_ok('/alert');
+        $mech->content_lacks('/photo/'); # Easier just to not show them at all here
     };
 
     subtest 'Dashboard CSV extra columns' => sub {

--- a/templates/email/bathnes/archive.html
+++ b/templates/email/bathnes/archive.html
@@ -34,11 +34,7 @@ INCLUDE '_email_top.html';
 
   [% FOR report IN reports %]
   <div style="[% list_item_style %]">
-  [% IF report.photo %]
-    <a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
-      <img style="[% list_item_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="">
-    </a>
-  [% END %]
+  [% INCLUDE '_photo.html' %]
     <h2 style="[% list_item_h2_style %]"><a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
       [%~ report.title | html ~%]
     </a></h2>

--- a/templates/email/default/_email_report_list.html
+++ b/templates/email/default/_email_report_list.html
@@ -1,10 +1,6 @@
 [% FOR report IN data %]
 <div style="[% list_item_style %]">
-[% IF report.photo %]
-  <a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
-    <img style="[% list_item_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="">
-  </a>
-[% END %]
+  [% INCLUDE '_photo.html' %]
   <p style="[% list_item_date_style %]">
     [% cobrand.prettify_dt( report.confirmed ) %].
     Reference:&nbsp;

--- a/templates/email/default/_email_sidebar.html
+++ b/templates/email/default/_email_sidebar.html
@@ -17,7 +17,7 @@ DEFAULT url = cobrand.base_url_for_report(report) _ report.url
   <a href="[% url %]"><img style="[% map_image_style %]" src="[% inline_image(report.static_map, 'map.jpeg') %]" width="310" height="200" alt=""></a>
   [% END %]
   [% start_padded_box | safe %]
-    [%~ IF object.photo %]
+    [%~ IF object.photo AND cobrand.allow_photo_display(object, 0) %]
       <img style="[% preview_photo_style %]" src="[% inline_image(object.get_first_image_fp) %]" alt="" align="right">
     [%~ END %]
     [%~ content | safe %]

--- a/templates/email/default/_photo.html
+++ b/templates/email/default/_photo.html
@@ -1,0 +1,9 @@
+[%
+
+DEFAULT photo_url = cobrand.base_url_for_report(report) _ '/report/' _ report.id;
+
+IF report.photo AND cobrand.allow_photo_display(report, 0) %]
+<a href="[% photo_url %]">
+    <img style="[% list_item_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="">
+</a>
+[% END %]

--- a/templates/email/default/archive-old-enquiries.html
+++ b/templates/email/default/archive-old-enquiries.html
@@ -33,11 +33,7 @@ INCLUDE '_email_top.html';
 
   [% FOR report IN reports %]
   <div style="[% list_item_style %]">
-  [% IF report.photo %]
-    <a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
-      <img style="[% list_item_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="">
-    </a>
-  [% END %]
+    [% INCLUDE '_photo.html' %]
     <h2 style="[% list_item_h2_style %]"><a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
       [%~ report.title | html ~%]
     </a></h2>

--- a/templates/email/default/cy/archive-old-enquiries.html
+++ b/templates/email/default/cy/archive-old-enquiries.html
@@ -33,11 +33,7 @@ INCLUDE '_email_top.html';
 
   [% FOR report IN reports %]
   <div style="[% list_item_style %]">
-  [% IF report.photo %]
-    <a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
-      <img style="[% list_item_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="">
-    </a>
-  [% END %]
+    [% INCLUDE '_photo.html' %]
     <h2 style="[% list_item_h2_style %]"><a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
       [%~ report.title | html ~%]
     </a></h2>

--- a/templates/email/fixamingata/_email_report_list.html
+++ b/templates/email/fixamingata/_email_report_list.html
@@ -1,10 +1,6 @@
 [% FOR report IN data %]
 <div style="[% list_item_style %]">
-[% IF report.photo %]
-  <a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
-    <img style="[% list_item_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="">
-  </a>
-[% END %]
+  [% INCLUDE '_photo.html' %]
   <h2 style="[% list_item_h2_style %]">
     <a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
       [%~ report.title | html ~%]

--- a/templates/email/gloucestershire/archive-old-enquiries.html
+++ b/templates/email/gloucestershire/archive-old-enquiries.html
@@ -33,11 +33,7 @@ INCLUDE '_email_top.html';
 
   [% FOR report IN reports %]
   <div style="[% list_item_style %]">
-  [% IF report.photo %]
-    <a href="https://www.fixmystreet.com/report/[% report.id %]">
-      <img style="[% list_item_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="">
-    </a>
-  [% END %]
+    [% INCLUDE '_photo.html' photo_url='https://www.fixmystreet.com/report/' _ report.id %]
     <h2 style="[% list_item_h2_style %]"><a href="https://www.fixmystreet.com/report/[% report.id %]">
       [%~ report.title | html ~%]
     </a></h2>

--- a/templates/email/hounslow/archive.html
+++ b/templates/email/hounslow/archive.html
@@ -33,11 +33,7 @@ INCLUDE '_email_top.html';
 
   [% FOR report IN reports %]
   <div style="[% list_item_style %]">
-  [% IF report.photo %]
-    <a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
-      <img style="[% list_item_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="">
-    </a>
-  [% END %]
+    [% INCLUDE '_photo.html' %]
     <h2 style="[% list_item_h2_style %]"><a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
       [%~ report.title | html ~%]
     </a></h2>

--- a/templates/email/isleofwight/archive.html
+++ b/templates/email/isleofwight/archive.html
@@ -26,11 +26,7 @@ that the issue has not been resolved, please log it again on
 
   [% FOR report IN reports %]
   <div style="[% list_item_style %]">
-  [% IF report.photo %]
-    <a href="https://www.fixmystreet.com/report/[% report.id %]">
-      <img style="[% list_item_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="">
-    </a>
-  [% END %]
+    [% INCLUDE '_photo.html' photo_url="https://www.fixmystreet.com/report/" _ report.id %]
     <h2 style="[% list_item_h2_style %]"><a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
       [%~ report.title | html ~%]
     </a></h2>

--- a/templates/email/oxfordshire/archive.html
+++ b/templates/email/oxfordshire/archive.html
@@ -33,11 +33,7 @@ INCLUDE '_email_top.html';
 
   [% FOR report IN reports %]
   <div style="[% list_item_style %]">
-  [% IF report.photo %]
-    <a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
-      <img style="[% list_item_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="">
-    </a>
-  [% END %]
+    [% INCLUDE '_photo.html' %]
     <h2 style="[% list_item_h2_style %]">
       [%~ report.title | html ~%]
     </h2>

--- a/templates/email/rutland/archive.html
+++ b/templates/email/rutland/archive.html
@@ -32,11 +32,7 @@ INCLUDE '_email_top.html';
 
   [% FOR report IN reports %]
   <div style="[% list_item_style %]">
-  [% IF report.photo %]
-    <a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
-      <img style="[% list_item_photo_style %]" src="[% inline_image(report.get_first_image_fp) %]" alt="">
-    </a>
-  [% END %]
+    [% INCLUDE '_photo.html' %]
     <h2 style="[% list_item_h2_style %]"><a href="[% cobrand.base_url_for_report( report ) %]/report/[% report.id %]">
       [%~ report.title | html ~%]
     </a></h2>

--- a/templates/web/base/header_opengraph_image.html
+++ b/templates/web/base/header_opengraph_image.html
@@ -1,4 +1,4 @@
-        [% IF problem.photo %]
+        [% IF problem.photo AND c.cobrand.allow_photo_display(problem) %]
         [% photo = problem.photos.first %]
         [% content_type = problem.get_first_image_type %]
         <meta property="og:image" content="[% c.cobrand.base_url %][% photo.url_og %]">

--- a/templates/web/base/report/_item.html
+++ b/templates/web/base/report/_item.html
@@ -54,7 +54,7 @@ END;
   [% TRY ~%]
     [% PROCESS 'report/_item_photo_title.html' ~%]
   [% CATCH file ~%]
-    [% IF problem.photo %]
+    [% IF problem.photo AND c.cobrand.allow_photo_display(problem) %]
         <img loading="lazy" class="img" height="60" width="90" src="[% problem.photos.first.url_fp %]" alt="">
     [% END %]
       [% TRY %]

--- a/templates/web/base/report/_item_expandable.html
+++ b/templates/web/base/report/_item_expandable.html
@@ -16,7 +16,7 @@
     data-report-id="[% problem.id | html %]"
     id="report-[% problem.id | html %]">
 
-  [% IF problem.photo %]
+  [% IF problem.photo AND c.cobrand.allow_photo_display(problem) %]
     <a href="[% c.cobrand.relative_url_for_report( problem ) %][% problem.url %]" class="item-list__item--expandable__hide-when-expanded">
         <img loading="lazy" class="img" height="60" width="90" src="[% problem.photos.first.url_fp %]" alt="">
     </a>


### PR DESCRIPTION
Previously allow_photo_display has only been used by Zurich, which has other special templates etc, so there were places it wasn't being checked when it should be. Hopefully add all/most of those (email templates, list views the main two), and then add a function to Southwark to hide photos to the public on certain categories (both by that mechanism and a special recent_photos for alert page).

[skip changelog]
