### PR TITLE
[Northumberland] add DVLA lookup for abandoned vehicles

### DIFF
--- a/.cypress/cypress/integration/northumberland.js
+++ b/.cypress/cypress/integration/northumberland.js
@@ -11,3 +11,51 @@ it('toggles the aerial map', function() {
     cy.get('.map-layer-toggle').click();
     cy.get('.map-layer-toggle').should('have.class', 'aerial');
 });
+
+describe('Abandoned vehicle behaviour', function() {
+  beforeEach(function() {
+    cy.server();
+    cy.route('/report/new/ajax*').as('report-ajax');
+    cy.route('/around\?ajax*').as('update-results');
+    cy.visit('http://northumberland.localhost:3001/');
+    cy.contains('Northumberland');
+    cy.get('[name=pc]').type('NE61 1BE');
+    cy.get('[name=pc]').parents('form').submit();
+    cy.wait('@update-results');
+    cy.get('#map_box').click(322, 307);
+    cy.wait('@report-ajax');
+    cy.pickCategory('Vehicle abandoned on your property');
+    cy.nextPageReporting();
+  });
+
+  it('No reg plate', function() {
+    cy.get('.js-reporting-page--active').contains('No').click();
+    cy.nextPageReporting();
+    cy.get('[name=question]').should('have.value', '');
+  });
+
+  it('Said yes but no reg plate', function() {
+    cy.get('.js-reporting-page--active').contains('Yes').click();
+    cy.nextPageReporting();
+    cy.contains('This field is required');
+  });
+
+  it('Gave an okay reg plate', function() {
+    cy.route('POST', '/report/dvla', 'fixture:bucks_dvla_ok.json').as('dvla');
+    cy.get('.js-reporting-page--active').contains('Yes').click();
+    cy.get('[name=dvla_reg]').type('G00D');
+    cy.nextPageReporting();
+    cy.wait('@dvla');
+    cy.contains('White Audi, Petrol, 2016');
+    cy.contains('that are taxed or have a valid MOT');
+  });
+
+  it('Gave an untaxed reg plate', function() {
+    cy.route('POST', '/report/dvla', 'fixture:bucks_dvla_notok.json').as('dvla');
+    cy.get('.js-reporting-page--active').contains('Yes').click();
+    cy.get('[name=dvla_reg]').type('B4D');
+    cy.nextPageReporting();
+    cy.wait('@dvla');
+    cy.get('[name=question]').invoke('val').should('include', 'B4D');
+  });
+});

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -227,6 +227,7 @@ if ($opt->test_fixtures) {
         { area_id => 2488, categories => [ 'Grass verges / shrub beds - littering' , 'Pavement damage', 'Fly-tipping', 'Dog fouling'], name => 'Brent Council', cobrand => 'brent' },
         { area_id => 2535, categories => [ 'Abandoned vehicles', 'Graffiti', 'Street lights'], name => 'Sandwell Borough Council' },
         { area_id => 2242, categories => [ 'Abandoned vehicles', 'Graffiti', 'Street lights', 'Flooding inside a building'], name => 'Surrey County Council' },
+        { area_id => 2248, categories => [ 'Vehicle abandoned on your property', 'Graffiti', 'Street lights', 'Flooding inside a building'], name => 'Northumberland County Council' },
     ) {
         $bodies->{$_->{area_id}} = FixMyStreet::DB::Factory::Body->find_or_create($_);
         if ($_->{cobrand}) {
@@ -319,6 +320,15 @@ if ($opt->test_fixtures) {
         {"code" => "NE03", "values" => [{"key" => "C", "name" => "Car"}, {"key" => "MM", "name" => "Motorcyle or Moped"}, {"key" => "O", "name" => "Other"}, {"key" => "V", "name" => "Van"}], "datatype" => "singlevaluelist", "required" => "false", "variable" => "true", "protected" => "false", "description" => "Please select the type of vehicle"},
         {"code" => "NE04", "datatype" => "string", "required" => "false", "variable" => "true", "protected" => "false", "description" => "Make of the vehicle (if not known, please note not known)"},
         {"code" => "NE06", "datatype" => "string", "required" => "false", "variable" => "true", "protected" => "false", "description" => "Colour of the vehicle (if not known, please note not known)"},
+    );
+    $child_cat->update;
+
+    $child_cat = FixMyStreet::DB->resultset("Contact")->find({
+        body => $bodies->{2248},
+        category => 'Vehicle abandoned on your property',
+    });
+    $child_cat->set_extra_fields(
+        {"code" => "question", "datatype" => "string", "required" => "true", "variable" => "true", "protected" => "false", "description" => "Vehicle registration number"},
     );
     $child_cat->update;
 

--- a/t/Mock/MapIt.pm
+++ b/t/Mock/MapIt.pm
@@ -122,6 +122,7 @@ my @PLACES = (
     [ 'DL10 6BN', 54.45012, -1.65621, 2406, 'Richmondshire District Council', 'DIS' ],
     [ 'CA12 5FJ', 54.60102, -3.13648, 2274, 'Allerdale Borough Council', 'DIS' ],
     [ 'NE61 1BE', 55.169081, -1.691012, 2248, 'Northumberland County Council', 'UTA' ],
+    [ '?', 55.168943, -1.690776, 2248, 'Northumberland County Council', 'UTA' ],
     [ 'SG17 5TQ', 52.03553, -0.36067, 21070, 'Central Bedfordshire Council', 'UTA' ],
     [ '?', 51.558568, -0.207702, 2489, 'Barnet Borough Council', 'DIS' ],
     [ '?', 51.418776, 0.005357, 2492, 'Lewisham Borough Council', 'DIS' ],

--- a/templates/web/northumberland/footer_extra_js.html
+++ b/templates/web/northumberland/footer_extra_js.html
@@ -1,1 +1,1 @@
-[% PROCESS 'footer_extra_js_base.html' highways=1 roadworks=1 ~%]
+[% PROCESS 'footer_extra_js_base.html' highways=1 roadworks=1 dvla=1 ~%]

--- a/web/cobrands/fixmystreet-uk-councils/dvla.js
+++ b/web/cobrands/fixmystreet-uk-councils/dvla.js
@@ -171,6 +171,10 @@ function dvla_lookup(e) {
                     if (field) {
                         field.value = data[name];
                     }
+                    field = document.querySelector('textarea[name*="' + fields[name] + '"]');
+                    if (field) {
+                        field.value = data[name];
+                    }
                 }
             });
 

--- a/web/cobrands/fixmystreet-uk-councils/dvla.js
+++ b/web/cobrands/fixmystreet-uk-councils/dvla.js
@@ -20,6 +20,14 @@ const FIELDS = {
             'yes': 'Y',
             'no': 'N'
         }
+    },
+    'northumberland': {
+        'block': 'true',
+        'categories': [
+            'Vehicle abandoned on your property',
+            'Vehicle being repaired on road or pavement',
+        ],
+        'summary': 'question',
     }
 };
 
@@ -51,7 +59,7 @@ function dvla_lookup(e) {
     const yesno = document.querySelector('input[name=dvla_reg_have]:checked');
 
     if (!yesno) return;
-    if (!yesno.value) {
+    if (!yesno.value && fields.reg) {
         const field = document.querySelector('input[name*="' + fields.reg + '"]');
         if (field) {
             field.value = 'Not known';
@@ -120,19 +128,22 @@ function dvla_lookup(e) {
         if (data.make) make_and_colour.push(data.make);
         if (data.colour) make_and_colour.push(data.colour);
         data.make_and_colour = make_and_colour.join(' / ');
+        data.summary = `registration: ${reg}, make: ${data.make}, colour: ${data.colour}`;
 
         const type = data.typeApproval || '';
         const wheelplan = data.wheelplan || '';
         let types = TYPES[fixmystreet.cobrand];
         let vehicle_type = '';
-        if (type.match(/L[1-7]|motorcycle/i) || wheelplan.match(/motorcycle|moped|2 wheel/i)) {
-            vehicle_type = types.Motorbike;
-        } else if (type.match(/N1|commercial/i) || wheelplan.match(/van|commercial/i)) {
-            vehicle_type = types.Van;
-        } else if (type.match(/M1/i)) {
-            vehicle_type = types.Car;
-        } else if (type.match(/M[23]|N[23]/i) || wheelplan.match(/& artic|3 axle rigid|multi-axle rigid/i)) {
-            vehicle_type = types.Other;
+        if (types) {
+            if (type.match(/L[1-7]|motorcycle/i) || wheelplan.match(/motorcycle|moped|2 wheel/i)) {
+                vehicle_type = types.Motorbike;
+            } else if (type.match(/N1|commercial/i) || wheelplan.match(/van|commercial/i)) {
+                vehicle_type = types.Van;
+            } else if (type.match(/M1/i)) {
+                vehicle_type = types.Car;
+            } else if (type.match(/M[23]|N[23]/i) || wheelplan.match(/& artic|3 axle rigid|multi-axle rigid/i)) {
+                vehicle_type = types.Other;
+            }
         }
 
         const config = FIELDS[fixmystreet.cobrand] || {};
@@ -154,7 +165,7 @@ function dvla_lookup(e) {
             const height = wrapper.getBoundingClientRect().height;
             document.querySelector('.js-reporting-page--active').style.paddingBottom = height;
         } else {
-            ['make', 'colour', 'reg', 'make_and_colour'].forEach(name => {
+            ['make', 'colour', 'reg', 'make_and_colour', 'summary'].forEach(name => {
                 if (fields[name] && data[name]) {
                     let field = document.querySelector('input[name*="' + fields[name] + '"]');
                     if (field) {


### PR DESCRIPTION
Adds DVLA lookup to Northumberland.

As the only have a single text field for the relevant categories this adds in the option to put a single summary with all the DVLA information in a single field.

[skip changelog]

Fixes mysociety/societyworks#5497
