### PR TITLE
Fix for alert warnings, and stop cacheing of empty geocoding results

### DIFF
--- a/perllib/FixMyStreet/Geocode/OSM.pm
+++ b/perllib/FixMyStreet/Geocode/OSM.pm
@@ -51,7 +51,7 @@ sub string {
     $url .= join('&', map { "$_=$query_params{$_}" } sort keys %query_params);
 
     my $out = { geocoder_url => $url };
-    my $js = FixMyStreet::Geocode::cache('osm', $url);
+    my $js = FixMyStreet::Geocode::cache('osm', $url, undef, qr/^\[\]$/);
     if (!$js) {
         return { %$out, error => _('Sorry, we could not find that location.') };
     }

--- a/perllib/FixMyStreet/Script/Alerts.pm
+++ b/perllib/FixMyStreet/Script/Alerts.pm
@@ -289,7 +289,7 @@ sub send_local_postgis {
 
     my $states = "'" . join( "', '", FixMyStreet::DB::Result::Problem::visible_states() ) . "'";
     my $query = "select problem.id, problem.bodies_str, problem.postcode, problem.geocode, problem.confirmed, problem.cobrand,
-        problem.title, problem.detail, problem.photo from problem
+        problem.title, problem.detail, problem.category, problem.photo from problem
         where
             ST_DWithin(ST_SetSRID(ST_Point(longitude, latitude), 4326)::geography, ST_SetSRID(ST_Point(?, ?), 4326)::geography, ?)
         and problem.state in ($states)
@@ -338,7 +338,7 @@ sub send_local_find_nearby {
 
     my $states = "'" . join( "', '", FixMyStreet::DB::Result::Problem::visible_states() ) . "'";
     my $reports = "select problem.id, problem.bodies_str, problem.postcode, problem.geocode, problem.confirmed, problem.cobrand,
-        problem.latitude, problem.longitude, problem.title, problem.detail, problem.photo, problem.user_id
+        problem.latitude, problem.longitude, problem.title, problem.detail, problem.category, problem.photo, problem.user_id
         from problem where
             problem.state in ($states)
         and problem.non_public = 'f'


### PR DESCRIPTION
We need the category in local alerts, as Southwark now uses that to decide whether to show a photo or not.

And we're getting 200 OK responses that are empty from the geocoder, which aren't actually empty, so stop caching them for the moment.

For FD-6954 and FD-6931