### PR TITLE
[Central Beds] Autoclose old SL12/planned reports

### DIFF
--- a/bin/centralbedfordshire/auto-close-reports
+++ b/bin/centralbedfordshire/auto-close-reports
@@ -40,5 +40,6 @@ FixMyStreet::Script::UK::AutoClose->new(
     body_name => 'Central Bedfordshire Council',
     to => $opts->days,
     closure_text => $opts->closure_text,
+    states => ['planned'],
     extra => { external_status_code => 'SL12' },
 )->close;

--- a/perllib/FixMyStreet/Script/ArchiveOldEnquiries.pm
+++ b/perllib/FixMyStreet/Script/ArchiveOldEnquiries.pm
@@ -231,9 +231,17 @@ sub send_email_and_close {
 }
 
 sub close_problems {
-    return unless $opts->{commit};
-
     my $problems = shift;
+
+    unless ( $opts->{commit} ) {
+        printf "Running with --commit will close the following reports:\n";
+
+        for ( $problems->all ) {
+            printf $_->id . "\n";
+        }
+
+        return;
+    }
 
     my $extra = { auto_closed_by_script => 1 };
 

--- a/perllib/FixMyStreet/Script/UK/AutoClose.pm
+++ b/perllib/FixMyStreet/Script/UK/AutoClose.pm
@@ -103,28 +103,46 @@ sub close {
 
     my $dtf = FixMyStreet::DB->schema->storage->datetime_parser;
 
-    my $time_param;
-    if ($self->from) {
-        $time_param = [ -and =>
-            { '>=', $dtf->format_datetime($self->from_date) },
-            { '<', $dtf->format_datetime($self->to_date) }
-        ];
-    } else {
-        $time_param = { '<', $dtf->format_datetime($self->to_date) };
-    }
-
     my $extra_query;
     if ( $self->extra ) {
         $extra_query = { '@>' => encode_json( $self->extra ) };
     }
 
-    my $reports = FixMyStreet::DB->resultset("Problem")->search({
-        bodies_str => $self->body->id,
-        state => $self->states,
-        confirmed => $time_param,
-        ( category => $self->category ) x !!$self->category,
-        ( extra => $extra_query ) x !!$extra_query,
-    });
+    my $reports;
+    if ( $self->body_name eq 'Central Bedfordshire Council' ) {
+        $reports = FixMyStreet::DB->resultset("Problem")->search({
+            bodies_str => $self->body->id,
+            'me.state' => $self->states,
+            ( 'me.extra' => $extra_query ) x !!$extra_query,
+            'comments.state' => 'confirmed',
+            'comments.problem_state' => $self->states,
+        },
+        {
+            join => ['comments'],
+            group_by => 'me.id',
+            # Make sure we look at the most recent 'planned' update
+            having => \[ 'MAX(comments.confirmed) < ?', $dtf->format_datetime($self->to_date) ],
+        });
+
+    } else {
+        my $time_param;
+        if ($self->from) {
+            $time_param = [ -and =>
+                { '>=', $dtf->format_datetime($self->from_date) },
+                { '<', $dtf->format_datetime($self->to_date) }
+            ];
+        } else {
+            $time_param = { '<', $dtf->format_datetime($self->to_date) };
+        }
+
+        $reports = FixMyStreet::DB->resultset("Problem")->search({
+            bodies_str => $self->body->id,
+            state => $self->states,
+            confirmed => $time_param,
+            ( category => $self->category ) x !!$self->category,
+            ( extra => $extra_query ) x !!$extra_query,
+        });
+    }
 
     # Provide some variables to the archiving script
     FixMyStreet::Script::ArchiveOldEnquiries::update_options({

--- a/t/script/centralbedfordshire/autoclose.t
+++ b/t/script/centralbedfordshire/autoclose.t
@@ -17,33 +17,104 @@ my $body = $mech->create_body_ok(
 );
 $mech->create_contact_ok( body => $body, category => 'Other', email => 'OTHER' );
 
-my ($older_problem_default) = $mech->create_problems_for_body(
+my ($problem_no_updates) = $mech->create_problems_for_body(
     1, $body,
-    'Older Default',
+    'No Updates',
     { dt => DateTime->today()->subtract( days => 28 ) },
 );
-my ($older_problem_SL12) = $mech->create_problems_for_body(
-    1, $body,
-    'Older SL12',
-    {
-        dt => DateTime->today()->subtract( days => 28 ),
-        extra => { external_status_code => 'SL12' },
-    },
-);
 
-my ($newer_problem_default) = $mech->create_problems_for_body(
+my ($problem_action_scheduled) = $mech->create_problems_for_body(
     1, $body,
-    'Newer Default',
-    { dt => DateTime->today()->subtract( days => 27 ) },
+    'Action Scheduled',
+    {   dt    => DateTime->today()->subtract( days => 29 ),
+        state => 'action_scheduled',
+    },
 );
-my ($newer_problem_SL12) = $mech->create_problems_for_body(
+FixMyStreet::DB->resultset('Comment')->new(
+    {   problem       => $problem_action_scheduled,
+        problem_state => 'action_scheduled',
+        confirmed     => DateTime->today()->subtract( days => 28 ),
+        _comment_defaults(),
+    }
+)->insert;
+
+my ($problem_planned_recently) = $mech->create_problems_for_body(
     1, $body,
-    'Newer SL12',
-    {
-        dt => DateTime->today()->subtract( days => 27 ),
+    'Planned Recently',
+    {   dt    => DateTime->today()->subtract( days => 29 ),
+        state => 'planned',
         extra => { external_status_code => 'SL12' },
     },
 );
+FixMyStreet::DB->resultset('Comment')->new(
+    {   problem       => $problem_planned_recently,
+        problem_state => 'planned',
+        confirmed     => DateTime->today()->subtract( days => 27 ),
+        _comment_defaults(),
+    }
+)->insert;
+
+my ($problem_planned_while_ago_SL12) = $mech->create_problems_for_body(
+    1, $body,
+    'Planned While Ago SL12',
+    {   dt    => DateTime->today()->subtract( days => 29 ),
+        state => 'planned',
+        extra => { external_status_code => 'SL12' },
+    },
+);
+FixMyStreet::DB->resultset('Comment')->new(
+    {   problem       => $problem_planned_while_ago_SL12,
+        problem_state => 'planned',
+        confirmed     => DateTime->today()->subtract( days => 28 ),
+        _comment_defaults(),
+    }
+)->insert;
+
+my ($problem_planned_while_ago_not_SL12) = $mech->create_problems_for_body(
+    1, $body,
+    'Planned While Ago Not SL12',
+    {   dt    => DateTime->today()->subtract( days => 29 ),
+        state => 'planned',
+        extra => { external_status_code => 'SL13' },
+    },
+);
+FixMyStreet::DB->resultset('Comment')->new(
+    {   problem       => $problem_planned_while_ago_not_SL12,
+        problem_state => 'planned',
+        confirmed     => DateTime->today()->subtract( days => 28 ),
+        _comment_defaults(),
+    }
+)->insert;
+
+my ($problem_planned_closed_planned) = $mech->create_problems_for_body(
+    1, $body,
+    'Planned Closed Planned',
+    {   dt    => DateTime->today()->subtract( days => 29 ),
+        state => 'planned',
+        extra => { external_status_code => 'SL12' },
+    },
+);
+FixMyStreet::DB->resultset('Comment')->new(
+    {   problem       => $problem_planned_closed_planned,
+        problem_state => 'planned',
+        confirmed     => DateTime->today()->subtract( days => 28 ),
+        _comment_defaults(),
+    }
+)->insert;
+FixMyStreet::DB->resultset('Comment')->new(
+    {   problem       => $problem_planned_closed_planned,
+        problem_state => 'closed',
+        confirmed     => DateTime->today()->subtract( days => 27 ),
+        _comment_defaults(),
+    }
+)->insert;
+FixMyStreet::DB->resultset('Comment')->new(
+    {   problem       => $problem_planned_closed_planned,
+        problem_state => 'planned',
+        confirmed     => DateTime->today()->subtract( days => 26 ),
+        _comment_defaults(),
+    }
+)->insert;
 
 my $ac = FixMyStreet::Script::UK::AutoClose->new(
     commit => 1,
@@ -51,25 +122,44 @@ my $ac = FixMyStreet::Script::UK::AutoClose->new(
     body_name => 'Central Bedfordshire Council',
     to => 28,
     closure_text => '',
+    states => ['planned'],
     extra => { external_status_code => 'SL12' },
 );
 
 $ac->close;
 
-$older_problem_default->discard_changes;
-is $older_problem_default->state, 'confirmed', 'Default older problem unchanged';
-is $older_problem_default->comments, 0, 'no comments';
+$problem_no_updates->discard_changes;
+is $problem_no_updates->state, 'confirmed', 'Problem with no updates is unchanged';
+is $problem_no_updates->comments, 0, 'no comments';
 
-$older_problem_SL12->discard_changes;
-is $older_problem_SL12->state, 'closed', 'Older SL12 problem closed';
-is $older_problem_SL12->comments->first->text, '', 'comment set';
+$problem_action_scheduled->discard_changes;
+is $problem_action_scheduled->state, 'action_scheduled', 'Problem with action scheduled is unchanged';
+is $problem_action_scheduled->comments, 1, 'no new comments';
 
-$newer_problem_default->discard_changes;
-is $newer_problem_default->state, 'confirmed', 'Default newer problem unchanged';
-is $newer_problem_default->comments, 0, 'no comments';
+$problem_planned_recently->discard_changes;
+is $problem_planned_recently->state, 'planned', 'Problem planned recently is unchanged';
+is $problem_planned_recently->comments, 1, 'no new comments';
 
-$newer_problem_SL12->discard_changes;
-is $newer_problem_SL12->state, 'confirmed', 'Newer SL12 problem unchanged';
-is $newer_problem_SL12->comments, 0, 'no comments';
+$problem_planned_while_ago_SL12->discard_changes;
+is $problem_planned_while_ago_SL12->state, 'closed', 'Problem planned while ago (SL12) is closed';
+my $last_comment = $problem_planned_while_ago_SL12->comments->order_by('-id')->first;
+is $last_comment->problem_state, 'closed';
+is $last_comment->text, '';
+
+$problem_planned_while_ago_not_SL12->discard_changes;
+is $problem_planned_while_ago_not_SL12->state, 'planned', 'Problem planned while ago (not SL12) is unchanged';
+is $problem_planned_while_ago_not_SL12->comments, 1, 'no new comments';
+
+$problem_planned_closed_planned->discard_changes;
+is $problem_planned_closed_planned->state, 'planned', 'Problem planned/closed/planned is unchanged';
+is $problem_planned_closed_planned->comments, 3, 'no new comments';
+
+sub _comment_defaults {
+    (   state   => 'confirmed',
+        cobrand => 'centralbedfordshire',
+        user    => $comment_user,
+        text    => '',
+    );
+}
 
 done_testing;


### PR DESCRIPTION
Second attempt. [First attempt](https://github.com/mysociety/fixmystreet/pull/5939) wrongly looked at the age of the report when we need to be looking at the age of the last 'planned' update.

Closes https://github.com/mysociety/societyworks/issues/5522.
(Also requires initial run on live and cron job).

[skip changelog]