### PR TITLE
[Bexley] Ignore duplicate waste services.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Waste.pm
@@ -332,6 +332,7 @@ sub bin_services_for_address {
     # Mark which containers have an assisted service.
     my @site_services_filtered;
     my %assisted;
+    my %seen_containers;
     for my $service (@$site_services) {
         next if $service->{ServiceItemName} eq 'CW-SACK'; # Clinical
 
@@ -376,6 +377,9 @@ sub bin_services_for_address {
             next;
         }
 
+        # There may be duplicate container types; skip if container has been seen before.
+        next if $seen_containers{ $container->{name} };
+
         my $filtered_service = {
             id => $service->{SiteServiceID},
             service_id => $service->{ServiceItemName},
@@ -390,15 +394,12 @@ sub bin_services_for_address {
             garden_waste => $container->{description} eq 'Garden waste' ? 1 : 0,
         };
         push @site_services_filtered, $filtered_service;
+        $seen_containers{ $container->{name} } = 1;
     }
 
-    # Now set the assisted flag on the right services and skip any duplicates
-    my %seen_containers;
+    # Now set the assisted flag on the right services
     for my $service (@site_services_filtered) {
-        # There may be duplicate container types; skip if container has been seen before.
-        next if $seen_containers{ $service->{service_name} };
         $service->{assisted_collection} = $assisted{$service->{service_name}} ? 1 : 0;
-        $seen_containers{ $service->{service_name} } = 1;
     }
 
     # If fetching the calendar page, we can shortcircuit with just what we need


### PR DESCRIPTION
It looks like the check was meant to already be present, but was in the wrong loop.
Fixes FD-6929