### PR TITLE
[Bexley][WW] Track DD cancellation, amend and one-off failures

### DIFF
--- a/bin/bexley/check-dd-errors
+++ b/bin/bexley/check-dd-errors
@@ -1,0 +1,95 @@
+#!/usr/bin/env perl
+
+use v5.14;
+use warnings;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use DateTime;
+use Getopt::Long::Descriptive;
+use FixMyStreet;
+use FixMyStreet::Cobrand;
+
+my ($opts, $usage) = describe_options(
+    '%c %o',
+    ['days=i', 'only show failures with last_failed_at within this many days', { default => 10 }],
+    ['all',   'show all failures regardless of age'],
+    ['help|h', 'print usage message and exit'],
+);
+$usage->die if $opts->help;
+
+my $cutoff;
+unless ($opts->all) {
+    $cutoff = DateTime->now->set_time_zone(FixMyStreet->local_time_zone)
+        ->subtract(days => $opts->days)->iso8601;
+}
+
+my $cobrand = FixMyStreet::Cobrand->get_class_for_moniker('bexley')->new;
+
+my @kinds = (
+    {
+        op => 'cancellation', label => 'Cancellation errors', verb => 'cancellation',
+        retry => sub {
+            my ($p, $info) = @_;
+            (my $ext_id = $p->external_id) =~ s/^Agile-//;
+            my $uprn = $p->uprn;
+            return qq{bin/bexley/cancel-garden-waste-from-agile --uprn $uprn --reference $ext_id --verbose};
+        },
+    },
+    {
+        op => 'amend', label => 'Amend errors', verb => 'amend',
+        retry => sub {
+            my ($p, $info) = @_;
+            my $amount = $info->{context}{amount} or return;
+            my $id = $p->id;
+            return qq{bin/cron-wrapper perl -MFixMyStreet::DB -MFixMyStreet::Cobrand -e 'my \$r = FixMyStreet::DB->resultset("Problem")->find($id); my \$i = FixMyStreet::Cobrand->get_class_for_moniker("bexley")->new->get_dd_integration; \$i->amend_plan({ orig_sub => \$r, amount => "$amount" });'};
+        },
+    },
+    {
+        op => 'one_off', label => 'One-off payment errors', verb => 'one-off payment',
+        retry => sub {
+            my ($p, $info) = @_;
+            my $amount = $info->{context}{amount} or return;
+            my $date   = $info->{context}{date}   or return;
+            my $id = $p->id;
+            return qq{bin/cron-wrapper perl -MDateTime::Format::ISO8601 -MFixMyStreet::DB -MFixMyStreet::Cobrand -e 'my \$r = FixMyStreet::DB->resultset("Problem")->find($id); my \$i = FixMyStreet::Cobrand->get_class_for_moniker("bexley")->new->get_dd_integration; \$i->one_off_payment({ orig_sub => \$r, amount => "$amount", date => DateTime::Format::ISO8601->parse_datetime("$date") });'};
+        },
+    },
+);
+
+my $reports = $cobrand->problems->search({
+    category => 'Garden Subscription',
+    title => ['Garden Subscription - New', 'Garden Subscription - Renew'],
+    state => { '!=' => 'hidden' },
+    -bool => \"extra->'direct_debit_errors' IS NOT NULL",
+});
+
+my %by_op;
+while (my $p = $reports->next) {
+    my $errors = $p->get_extra_metadata('direct_debit_errors') || {};
+    for my $op (keys %$errors) {
+        my $info = $errors->{$op};
+        next if $cutoff && ($info->{last_failed_at} // '') lt $cutoff;
+        push @{ $by_op{$op} }, [ $p, $info ];
+    }
+}
+
+for my $k (@kinds) {
+    my $entries = $by_op{ $k->{op} } or next;
+    say "# $k->{label}";
+    for my $entry (@$entries) {
+        my ($p, $info) = @$entry;
+        say "Failed DD $k->{verb}: Report " . $p->id
+            . ", UPRN=" . $p->uprn
+            . ", failures=" . ($info->{failures} // '')
+            . ", last-failed=" . ($info->{last_failed_at} // '')
+            . ", error=" . ($info->{error} // 'Unknown error');
+        my $retry = $k->{retry}->($p, $info);
+        say "  Retry with: $retry" if $retry;
+    }
+}

--- a/perllib/FixMyStreet/Script/Bexley/CancelGardenWaste.pm
+++ b/perllib/FixMyStreet/Script/Bexley/CancelGardenWaste.pm
@@ -49,7 +49,7 @@ sub cancel_contract {
     my ( $self, $contract ) = @_;
 
     my $uprn = $contract->{UPRN};
-    my $id = $contract->{Id};
+    my $id = $contract->{Id} // "";
     my $reference = $contract->{Reference};
     my $reason = $contract->{Reason};
 
@@ -108,21 +108,8 @@ sub _cancel_direct_debit {
     my $resp = $i->cancel_plan({ report => $original_report });
 
     if ( ref $resp eq 'HASH' && $resp->{error} ) {
-        my $failures = $original_report->get_extra_metadata('direct_debit_cancellation_failures') // 0;
-        $failures++;
-        $original_report->set_extra_metadata(
-            direct_debit_cancellation_failures       => $failures,
-            direct_debit_cancellation_error          => $resp->{error},
-            direct_debit_cancellation_last_failed_at => DateTime->now->set_time_zone( FixMyStreet->local_time_zone )->iso8601,
-        );
-        $original_report->update;
         print "  Failed to send cancellation request to Direct Debit provider for Agile reference $reference: $resp->{error}\n";
     } else {
-        $original_report->set_extra_metadata(
-            direct_debit_cancellation_date => DateTime->now->set_time_zone( FixMyStreet->local_time_zone )->iso8601,
-            direct_debit_cancellation_note => 'Cancellation received from Agile LastCancelled API',
-        );
-        $original_report->update;
         $self->_vprint(
             "  Successfully sent cancellation request to Direct Debit provider."
         );
@@ -144,7 +131,7 @@ sub _cancel_legacy_direct_debit {
     my $resp = $i->cancel_plan({ contract_ids => $legacy_contract_ids });
 
     if ( ref $resp eq 'HASH' && $resp->{error} ) {
-        print "  Failed to send cancellation request to Direct Debit provider for Agile reference $reference: $resp->{error}\n";
+        print "  Failed to send legacy cancellation request to Direct Debit provider for Agile reference $reference: $resp->{error}\n";
     } else {
         $self->_vprint(
             "  Successfully sent cancellation request to Direct Debit provider."

--- a/perllib/Integrations/AccessPaySuite.pm
+++ b/perllib/Integrations/AccessPaySuite.pm
@@ -250,6 +250,33 @@ not know which contract is the correct one).
 Returns 1 on success, or a hashref with an error key on failure.
 
 =cut
+sub _record_dd_failure {
+    my ($self, $report, $op, $error, $context) = @_;
+    my $errors = $report->get_extra_metadata('direct_debit_errors') || {};
+    my $existing = $errors->{$op} || {};
+    $errors->{$op} = {
+        error          => $error,
+        last_failed_at => DateTime->now->set_time_zone(FixMyStreet->local_time_zone)->iso8601,
+        failures       => ($existing->{failures} // 0) + 1,
+        ($context ? (context => $context) : ()),
+    };
+    $report->set_extra_metadata(direct_debit_errors => $errors);
+    $report->update;
+}
+
+sub _clear_dd_failure {
+    my ($self, $report, $op) = @_;
+    my $errors = $report->get_extra_metadata('direct_debit_errors');
+    return unless $errors && $errors->{$op};
+    delete $errors->{$op};
+    if (%$errors) {
+        $report->set_extra_metadata(direct_debit_errors => $errors);
+    } else {
+        $report->unset_extra_metadata('direct_debit_errors');
+    }
+    $report->update;
+}
+
 sub cancel_plan {
     my ($self, $args) = @_;
     my $report = $args->{report};
@@ -259,7 +286,14 @@ sub cancel_plan {
         # Single contract from metadata - handle errors properly
         my $resp = $self->archive_contract($contract_id);
         if (ref $resp eq 'HASH' && $resp->{error}) {
+            $self->_record_dd_failure($report, 'cancellation', $resp->{error});
             return $resp;
+        } else {
+            $report->set_extra_metadata(
+                direct_debit_cancellation_date => DateTime->now->set_time_zone( FixMyStreet->local_time_zone )->iso8601
+            );
+            $report->update;
+            $self->_clear_dd_failure($report, 'cancellation');
         }
         return 1;
     } elsif ($args->{contract_ids}) {
@@ -288,7 +322,10 @@ sub amend_plan {
 
     my $contract_id = $args->{orig_sub}->get_extra_metadata('direct_debit_contract_id');
     unless ($contract_id) {
-        die "No direct debit contract ID found in original subscription report metadata";
+        $self->_record_dd_failure($args->{orig_sub}, 'amend',
+            "No direct debit contract ID found in original subscription report metadata",
+            { amount => $args->{amount} });
+        return;
     }
 
     my $path = "contract/" . $contract_id . "/amount";
@@ -300,8 +337,13 @@ sub amend_plan {
     my $resp = $self->call('PATCH', $path, $data);
 
     if (ref $resp eq 'HASH' && $resp->{error}) {
-        die "Error amending plan: " . $resp->{error};
+        $self->_record_dd_failure($args->{orig_sub}, 'amend', $resp->{error},
+            { amount => $args->{amount} });
+        return;
     }
+
+    $self->_clear_dd_failure($args->{orig_sub}, 'amend');
+    return 1;
 }
 
 =item * create_payment
@@ -325,7 +367,10 @@ sub one_off_payment {
     my $orig_sub = $args->{orig_sub};
     my $contract_id = $orig_sub->get_extra_metadata('direct_debit_contract_id');
     unless ($contract_id) {
-        die "No direct debit contract ID found in original subscription report metadata";
+        $self->_record_dd_failure($orig_sub, 'one_off',
+            "No direct debit contract ID found in original subscription report metadata",
+            { amount => $args->{amount}, date => $args->{date}->iso8601 });
+        return;
     }
 
     # Create the adhoc payment using the contract ID
@@ -336,19 +381,15 @@ sub one_off_payment {
     });
 
     if (ref $resp eq 'HASH' && $resp->{error}) {
-        die 'Could not create ad hoc payment: ' . $resp->{error};
-    } elsif (ref $resp eq 'HASH' && keys %$resp) {
-        # Assuming a successful response might return some data, but 1 indicates success
-        return 1;
-    } elsif (ref $resp eq 'HASH' && !keys %$resp) {
-        # Handle cases where success might be an empty hash {}
-        return 1;
-    } else {
-        # Handle unexpected response format or potential success cases not returning a hash
-        # Log or handle as appropriate, returning 1 for presumed success if no error indicated
-        $self->log('Unexpected response format from AccessPaySuite adhoc payment: ' . Dumper($resp) );
-        return 1; # Assuming success if no error hash
+        $self->_record_dd_failure($orig_sub, 'one_off', $resp->{error},
+            { amount => $args->{amount}, date => $args->{date}->iso8601 });
+        return;
     }
+
+    $self->log('Unexpected response format from AccessPaySuite adhoc payment: ' . Dumper($resp))
+        unless ref $resp eq 'HASH';
+    $self->_clear_dd_failure($orig_sub, 'one_off');
+    return 1;
 }
 
 1;

--- a/t/integrations/access_pay_suite.t
+++ b/t/integrations/access_pay_suite.t
@@ -1,6 +1,8 @@
 use strict;
 use warnings;
 
+use DateTime;
+use FixMyStreet::TestMech;  # bootstraps config so FixMyStreet->local_time_zone works
 use Test::More;
 use Test::MockModule;
 use Test::MockObject;
@@ -17,14 +19,25 @@ my $integration = Integrations::AccessPaySuite->new(
 
 my $mock = Test::MockModule->new('Integrations::AccessPaySuite');
 
-# Helper to create mock report with specified metadata
+# In-memory stand-in for a Problem row: get/set_extra_metadata back onto a hash,
+# update is a no-op. Lets us assert against recorded metadata without the DB.
 sub mock_report {
     my %metadata = @_;
+    my $stored = { %metadata };
     my $report = Test::MockObject->new;
     $report->mock( 'get_extra_metadata', sub {
         my ( $self, $key ) = @_;
-        return $metadata{$key};
+        return $stored->{$key};
     });
+    $report->mock( 'set_extra_metadata', sub {
+        my ( $self, %data ) = @_;
+        $stored->{$_} = $data{$_} for keys %data;
+    });
+    $report->mock( 'unset_extra_metadata', sub {
+        my ( $self, $key ) = @_;
+        delete $stored->{$key};
+    });
+    $report->mock( 'update', sub { } );
     return $report;
 }
 
@@ -128,6 +141,167 @@ subtest 'cancel_plan ignores errors and returns success' => sub {
         'Attempts all contracts despite errors';
 
     $mock->unmock('archive_contract');
+};
+
+subtest 'cancel_plan records success metadata' => sub {
+    $mock->mock( 'call', sub { {} } );
+    my $report = mock_report( direct_debit_contract_id => 'PAYER123' );
+
+    is $integration->cancel_plan({ report => $report }), 1, 'cancel_plan returns success';
+
+    like $report->get_extra_metadata('direct_debit_cancellation_date'),
+        qr/^\d{4}-\d{2}-\d{2}T/, 'cancellation date set';
+
+    $mock->unmock('call');
+};
+
+subtest 'cancel_plan records failure metadata' => sub {
+    $mock->mock( 'call', sub { { error => 'Provider down' } } );
+    my $report = mock_report( direct_debit_contract_id => 'PAYER123' );
+
+    my $resp = $integration->cancel_plan({ report => $report });
+    is $resp->{error}, 'Provider down', 'error returned to caller';
+
+    my $info = ($report->get_extra_metadata('direct_debit_errors') || {})->{cancellation} || {};
+    is $info->{error}, 'Provider down', 'error recorded';
+    is $info->{failures}, 1, 'failure count = 1';
+    like $info->{last_failed_at}, qr/^\d{4}-\d{2}-\d{2}T/, 'timestamp set';
+    ok !$report->get_extra_metadata('direct_debit_cancellation_date'),
+        'no success date on failure';
+
+    $mock->unmock('call');
+};
+
+subtest 'cancel_plan increments failure counter on repeat' => sub {
+    $mock->mock( 'call', sub { { error => 'Still down' } } );
+    my $report = mock_report(
+        direct_debit_contract_id => 'PAYER123',
+        direct_debit_errors      => { cancellation => { failures => 2 } },
+    );
+
+    $integration->cancel_plan({ report => $report });
+
+    is $report->get_extra_metadata('direct_debit_errors')->{cancellation}{failures}, 3,
+        'failure count incremented from existing value';
+
+    $mock->unmock('call');
+};
+
+subtest 'amend_plan records failure metadata' => sub {
+    $mock->mock( 'call', sub { { error => 'Amend boom' } } );
+    my $report = mock_report( direct_debit_contract_id => 'PAYER123' );
+
+    is $integration->amend_plan({ orig_sub => $report, amount => '50.00' }),
+        undef, 'amend_plan returns undef on provider error';
+
+    my $info = ($report->get_extra_metadata('direct_debit_errors') || {})->{amend} || {};
+    is $info->{error}, 'Amend boom', 'error recorded';
+    is $info->{failures}, 1, 'failure count = 1';
+    like $info->{last_failed_at}, qr/^\d{4}-\d{2}-\d{2}T/, 'timestamp set';
+    is $info->{context}{amount}, '50.00', 'amount stashed for retry';
+
+    $mock->unmock('call');
+};
+
+subtest 'amend_plan records failure when contract_id missing' => sub {
+    my $report = mock_report();  # no direct_debit_contract_id
+
+    is $integration->amend_plan({ orig_sub => $report, amount => '50.00' }),
+        undef, 'amend_plan returns undef when contract_id missing';
+
+    my $info = ($report->get_extra_metadata('direct_debit_errors') || {})->{amend} || {};
+    like $info->{error}, qr/No direct debit contract ID/, 'error recorded';
+    is $info->{context}{amount}, '50.00', 'amount stashed for retry';
+};
+
+subtest 'one_off_payment records failure metadata' => sub {
+    $mock->mock( 'call', sub { { error => 'Adhoc boom' } } );
+    my $report = mock_report( direct_debit_contract_id => 'PAYER123' );
+    my $date = DateTime->new( year => 2026, month => 5, day => 15 );
+
+    is $integration->one_off_payment({
+        orig_sub => $report,
+        amount   => '12.50',
+        date     => $date,
+    }), undef, 'one_off_payment returns undef on provider error';
+
+    my $info = ($report->get_extra_metadata('direct_debit_errors') || {})->{one_off} || {};
+    is $info->{error}, 'Adhoc boom', 'error recorded';
+    is $info->{failures}, 1, 'failure count = 1';
+    like $info->{last_failed_at}, qr/^\d{4}-\d{2}-\d{2}T/, 'timestamp set';
+    is $info->{context}{amount}, '12.50', 'amount stashed for retry';
+    is $info->{context}{date}, $date->iso8601, 'date stashed for retry';
+
+    $mock->unmock('call');
+};
+
+subtest 'one_off_payment records failure when contract_id missing' => sub {
+    my $report = mock_report();  # no direct_debit_contract_id
+    my $date = DateTime->new( year => 2026, month => 5, day => 15 );
+
+    is $integration->one_off_payment({
+        orig_sub => $report,
+        amount   => '12.50',
+        date     => $date,
+    }), undef, 'one_off_payment returns undef when contract_id missing';
+
+    my $info = ($report->get_extra_metadata('direct_debit_errors') || {})->{one_off} || {};
+    like $info->{error}, qr/No direct debit contract ID/, 'error recorded';
+    is $info->{context}{amount}, '12.50', 'amount stashed for retry';
+    is $info->{context}{date}, $date->iso8601, 'date stashed for retry';
+};
+
+subtest 'cancel_plan clears prior failure on success' => sub {
+    $mock->mock( 'call', sub { {} } );
+    my $report = mock_report(
+        direct_debit_contract_id => 'PAYER123',
+        direct_debit_errors      => {
+            cancellation => { error => 'old', failures => 2, last_failed_at => '...' },
+            amend        => { error => 'unrelated', failures => 1, last_failed_at => '...' },
+        },
+    );
+
+    is $integration->cancel_plan({ report => $report }), 1, 'cancel_plan returns success';
+
+    my $errors = $report->get_extra_metadata('direct_debit_errors') || {};
+    ok !$errors->{cancellation}, 'cancellation entry cleared on success';
+    ok $errors->{amend}, 'unrelated amend entry preserved';
+
+    $mock->unmock('call');
+};
+
+subtest 'amend_plan clears prior failure on success' => sub {
+    $mock->mock( 'call', sub { {} } );
+    my $report = mock_report(
+        direct_debit_contract_id => 'PAYER123',
+        direct_debit_errors      => { amend => { error => 'old', failures => 1 } },
+    );
+
+    $integration->amend_plan({ orig_sub => $report, amount => '50.00' });
+
+    ok !$report->get_extra_metadata('direct_debit_errors'),
+        'direct_debit_errors fully cleared when last entry removed';
+
+    $mock->unmock('call');
+};
+
+subtest 'one_off_payment clears prior failure on success' => sub {
+    $mock->mock( 'call', sub { {} } );
+    my $report = mock_report(
+        direct_debit_contract_id => 'PAYER123',
+        direct_debit_errors      => { one_off => { error => 'old', failures => 1 } },
+    );
+
+    is $integration->one_off_payment({
+        orig_sub => $report,
+        amount   => '12.50',
+        date     => DateTime->now,
+    }), 1, 'one_off_payment returns success';
+
+    ok !$report->get_extra_metadata('direct_debit_errors'),
+        'direct_debit_errors fully cleared when last entry removed';
+
+    $mock->unmock('call');
 };
 
 done_testing;

--- a/t/script/bexley/cancel-garden-waste.t
+++ b/t/script/bexley/cancel-garden-waste.t
@@ -235,67 +235,6 @@ FixMyStreet::override_config {
                 "Cancels legacy contracts even when archive_contract errors are ignored";
         };
 
-        subtest 'records cancellation metadata on success' => sub {
-            $mech->delete_problems_for_body( $body->id );
-
-            my $garden_report = _create_report( uprn => $uprn, external_id => "Agile-$reference" );
-
-            $access_mock->mock( 'cancel_plan', sub { return 1 } );
-
-            stdout_like { $canceller->cancel_contract($contract) }
-                qr/Successfully sent cancellation request/,
-                'success path runs';
-
-            $garden_report->discard_changes;
-            like $garden_report->get_extra_metadata('direct_debit_cancellation_date'),
-                qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
-                'cancellation date set in ISO8601 format';
-            is $garden_report->get_extra_metadata('direct_debit_cancellation_note'),
-                'Cancellation received from Agile LastCancelled API',
-                'cancellation note set';
-        };
-
-        subtest 'records failure metadata on error' => sub {
-            $mech->delete_problems_for_body( $body->id );
-
-            my $garden_report = _create_report( uprn => $uprn, external_id => "Agile-$reference" );
-
-            $access_mock->mock( 'cancel_plan', sub { return { error => 'Provider down' } } );
-
-            stdout_like { $canceller->cancel_contract($contract) }
-                qr/Failed to send cancellation request.*Provider down/,
-                'failure path runs';
-
-            $garden_report->discard_changes;
-            is $garden_report->get_extra_metadata('direct_debit_cancellation_failures'), 1,
-                'failure count set to 1';
-            is $garden_report->get_extra_metadata('direct_debit_cancellation_error'), 'Provider down',
-                'error message recorded';
-            like $garden_report->get_extra_metadata('direct_debit_cancellation_last_failed_at'),
-                qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
-                'last failure timestamp set in ISO8601 format';
-            ok !$garden_report->get_extra_metadata('direct_debit_cancellation_date'),
-                'no cancellation date on failure';
-        };
-
-        subtest 'increments failure counter on repeated failures' => sub {
-            $mech->delete_problems_for_body( $body->id );
-
-            my $garden_report = _create_report( uprn => $uprn, external_id => "Agile-$reference" );
-            $garden_report->set_extra_metadata( direct_debit_cancellation_failures => 2 );
-            $garden_report->update;
-
-            $access_mock->mock( 'cancel_plan', sub { return { error => 'Still down' } } );
-
-            stdout_like { $canceller->cancel_contract($contract) }
-                qr/Failed to send cancellation request/,
-                'failure path runs';
-
-            $garden_report->discard_changes;
-            is $garden_report->get_extra_metadata('direct_debit_cancellation_failures'), 3,
-                'failure count incremented from existing value';
-        };
-
         subtest 'skips reports already cancelled' => sub {
             $mech->delete_problems_for_body( $body->id );
 


### PR DESCRIPTION
Failures are recorded under a single `direct_debit_errors` metadata hash, cleared when a subsequent operation succeeds. Amend and one-off failures also stash the args needed to retry. Adds `bin/bexley/check-dd-errors` to list outstanding failures with a per-op retry recipe.

Fixes https://github.com/mysociety/societyworks/issues/5515

## Deploy notes

- [x] Add `bin/bexley/check-dd-errors` to crontab so it runs regularly

<!-- [skip changelog] -->
