### PR TITLE
WEBP support, error handling, ward messaging bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
         - WasteWorks urls use a separate offline page #4655
         - Add photo first reporting flow. #15
         - Disable anonymous reporting button when submitted.
+        - Add WEBP support to photo uploads.
     - Accessibility improvements:
         - Improved accessibility of small drawer. #5354
         - Added skip report tools to Around page. #5354

--- a/perllib/FixMyStreet/App/Controller/Photo.pm
+++ b/perllib/FixMyStreet/App/Controller/Photo.pm
@@ -28,7 +28,7 @@ Display a photo
 
 =cut
 
-sub during :LocalRegex('^(temp|fulltemp)\.([0-9a-f]{40}\.(?:jpeg|png|gif|tiff))$') {
+sub during :LocalRegex('^(temp|fulltemp)\.([0-9a-f]{40}\.(?:jpeg|png|gif|tiff|webp))$') {
     my ( $self, $c ) = @_;
     my ( $size, $filename ) = @{ $c->req->captures };
 
@@ -48,7 +48,7 @@ sub during :LocalRegex('^(temp|fulltemp)\.([0-9a-f]{40}\.(?:jpeg|png|gif|tiff))$
     $c->forward( 'output', [ $photo ] );
 }
 
-sub index :LocalRegex('^(c/)?([1-9]\d*)(?:\.(\d+))?(?:\.(full|tn|fp|og))?\.(?:jpeg|png|gif|tiff)$') {
+sub index :LocalRegex('^(c/)?([1-9]\d*)(?:\.(\d+))?(?:\.(full|tn|fp|og))?\.(?:jpeg|png|gif|tiff|webp)$') {
     my ( $self, $c ) = @_;
     my ( $is_update, $id, $photo_number, $size ) = @{ $c->req->captures };
 

--- a/perllib/FixMyStreet/App/Controller/Photo.pm
+++ b/perllib/FixMyStreet/App/Controller/Photo.pm
@@ -127,7 +127,7 @@ sub upload : Local {
     };
     my $out;
     if ($c->stash->{photo_error} || !$fileid) {
-        $c->res->status(500);
+        $c->res->status(400);
         $out = { error => $c->stash->{photo_error} || _('Unknown error') };
     } else {
         $out = { id => $fileid };

--- a/perllib/FixMyStreet/App/Model/PhotoSet.pm
+++ b/perllib/FixMyStreet/App/Model/PhotoSet.pm
@@ -155,18 +155,16 @@ has ids => ( #  Arrayref of $fileid tuples (always, so post upload/raw data proc
                 # get the photo into a variable
                 my $photo_blob = eval {
                     my $filename = $upload->tempname;
-                    my $out;
-                    if ($type eq 'jpeg' && can_run('jhead')) {
+                    my ($w, $h, $err) = Image::Size::imgsize($filename);
+                    die _("Please upload an image only") . "\n" if !defined $w || $err !~ /JPG|GIF|PNG|TIF|WEBP/;
+                    if ($err eq 'JPG' && can_run('jhead')) {
                         my $pid = open3(undef, my $stdout, undef, 'jhead', '-se', '-autorot', $filename);
-                        $out = join('', <$stdout>);
+                        my $out = join('', <$stdout>);
                         waitpid($pid, 0);
                         close $stdout;
+                        die _("Please upload an image only") . "\n" if $out && $out =~ /Not JPEG:/;
                     }
-                    unless (defined $out) {
-                        my ($w, $h, $err) = Image::Size::imgsize($filename);
-                        die _("Please upload an image only") . "\n" if !defined $w || $err !~ /JPG|GIF|PNG|TIF|WEBP/;
-                    }
-                    die _("Please upload an image only") . "\n" if $out && $out =~ /Not JPEG:/;
+                    $type = $err; # Switch to detected type over provided type
                     my $photo = $upload->slurp;
                 };
                 if ( my $error = $@ ) {
@@ -178,13 +176,13 @@ has ids => ( #  Arrayref of $fileid tuples (always, so post upload/raw data proc
                     return ();
                 }
 
-                if ($type eq 'jpeg' && !$self->c->stash->{photo_gps}) {
+                if ($type eq 'JPG' && !$self->c->stash->{photo_gps}) {
                     # only store GPS for the first uploaded photo
                     $self->stash_gps_info($upload->tempname);
                 }
 
                 my %params;
-                if ($type eq 'png' && $self->c->action =~ m{parishes|admin/bodies}) {
+                if ($type eq 'PNG' && $self->c->action =~ m{parishes|admin/bodies}) {
                     %params = ( magick => 'PNG' );
                 } else {
                     %params = ( magick => 'JPEG' );

--- a/perllib/FixMyStreet/App/Model/PhotoSet.pm
+++ b/perllib/FixMyStreet/App/Model/PhotoSet.pm
@@ -138,7 +138,7 @@ has ids => ( #  Arrayref of $fileid tuples (always, so post upload/raw data proc
                 my $upload = $part;
                 my $ct = $upload->type;
                 $ct =~ s/x-citrix-//; # Thanks, Citrix
-                my ($type) = $ct =~ m{image/(jpeg|pjpeg|gif|tiff|png)};
+                my ($type) = $ct =~ m{image/(jpeg|pjpeg|gif|tiff|png|webp)};
                 $type = 'jpeg' if $type && $type eq 'pjpeg';
                 # Had a report of a JPEG from an Android 2.1 coming through as a byte stream
                 $type = 'jpeg' if !$type && $ct eq 'application/octet-stream';
@@ -164,7 +164,7 @@ has ids => ( #  Arrayref of $fileid tuples (always, so post upload/raw data proc
                     }
                     unless (defined $out) {
                         my ($w, $h, $err) = Image::Size::imgsize($filename);
-                        die _("Please upload an image only") . "\n" if !defined $w || $err !~ /JPG|GIF|PNG|TIF/;
+                        die _("Please upload an image only") . "\n" if !defined $w || $err !~ /JPG|GIF|PNG|TIF|WEBP/;
                     }
                     die _("Please upload an image only") . "\n" if $out && $out =~ /Not JPEG:/;
                     my $photo = $upload->slurp;

--- a/perllib/FixMyStreet/PhotoStorage.pm
+++ b/perllib/FixMyStreet/PhotoStorage.pm
@@ -22,6 +22,7 @@ sub detect_type {
     return 'png' if $photo =~ /^\x{89}\x{50}/;
     return 'tiff' if $photo =~ /^II/;
     return 'gif' if $photo =~ /^GIF/;
+    return 'webp' if $photo =~ /^RIFF(?s:....)WEBP/;
     return '';
 }
 

--- a/perllib/Open311.pm
+++ b/perllib/Open311.pm
@@ -420,7 +420,7 @@ sub add_media {
         my $photo_blob;
         if ($_ =~ /^data:/) {
             my @parts = split ',', $_, 2;
-            if ($parts[0] =~ m{image/(jpeg|pjpeg|gif|tiff|png)}) {
+            if ($parts[0] =~ m{image/(jpeg|pjpeg|gif|tiff|png|webp)}) {
                 my $data = $parts[1];
                 if ($parts[0] =~ /;base64/) {
                     $data = decode_base64($data);
@@ -430,7 +430,7 @@ sub add_media {
         } else {
             my $ua = LWP::UserAgent->new;
             my $res = $ua->get($_);
-            if ( $res->is_success && $res->content_type =~ m{image/(jpeg|pjpeg|gif|tiff|png)} ) {
+            if ( $res->is_success && $res->content_type =~ m{image/(jpeg|pjpeg|gif|tiff|png|webp)} ) {
                 $photo_blob = $res->decoded_content;
             }
         }

--- a/perllib/Open311/PopulateServiceList.pm
+++ b/perllib/Open311/PopulateServiceList.pm
@@ -265,7 +265,7 @@ sub _add_meta_to_contact {
         map {
             if ($_->{description}) {
                 $_->{description} =~ s/:\s*$//;
-                $_->{description} = FixMyStreet::Template::sanitize($_->{description});
+                $_->{description} = FixMyStreet::Template::sanitize($_->{description}, 1);
             }
             if (defined $_->{order}) {
                 $_->{order} += 0;


### PR DESCRIPTION
After Camden had some problems uploading a photo, it turned out the photo was WEBP but named .jpg (so was uploaded as image/jpeg). Also the error they got was yucky, trying to display the HTML source of the SW error page. So - change it to 400 error (makes more sense anyway, should stop HTML error source display); add WEBP as allowed (might as well, seems to be used a bit more by phones and things); look at file header over MIME type for what the file actually is.

And also allow admin code in the Open311 descriptions so that my data-area-ids thing for Gloucester isn't immediately overwritten by the syncing script.