### PR TITLE
Use lower case instead of title case in faq titles

### DIFF
--- a/t/app/controller/about.t
+++ b/t/app/controller/about.t
@@ -12,7 +12,7 @@ ok( my $mech = FixMyStreet::TestMech->new, 'Created mech object' );
 
 # check that we can get the page
 $mech->get_ok('/faq');
-$mech->content_like(qr{Frequently Asked Questions ::\s+FixMyStreet});
+$mech->content_like(qr{Frequently asked questions ::\s+FixMyStreet});
 $mech->content_contains('html class="no-js" lang="en-gb"');
 
 $mech->get_ok('/privacy');

--- a/templates/web/base/about/faq-en-gb.html
+++ b/templates/web/base/about/faq-en-gb.html
@@ -1,6 +1,6 @@
-[% INCLUDE 'header.html', title = loc('Frequently Asked Questions') sidebar='about/_sidebar.html' %]
+[% INCLUDE 'header.html', title = loc('Frequently asked questions') sidebar='about/_sidebar.html' %]
 
-<h1><a name="faq"></a>[% loc('Frequently Asked Questions') %]</h1>
+<h1><a name="faq"></a>[% loc('Frequently asked questions') %]</h1>
 
 <dl>
 
@@ -72,7 +72,7 @@
     </dd>
 </dl>
 
-<h2><a name="practical"></a>Practical Questions</h2>
+<h2><a name="practical"></a>Practical questions</h2>
 
 <dl>
     <dt>I&rsquo;m from an authority, where do you send the reports?</dt>
@@ -99,7 +99,7 @@ to update the address or addresses we use.</dd>
     map.</dd>
 </dl>
 
-<h2><a name="organisation"></a>Organisation Questions</h2>
+<h2><a name="organisation"></a>Organisation questions</h2>
 
 <dl>
     <dt>Who built [% site_name %]?</dt>


### PR DESCRIPTION
Fixes part of: https://github.com/mysociety/societyworks/issues/5541
Reference number: 3

This is part of the feedback received from Canal River Trust. Because it's a small change I figured is better to change it on the base template instead of creating a new template override.

[skip changelog]