### PR TITLE
[Shropshire] Prevent user in Councillor role leaving updates

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Shropshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Shropshire.pm
@@ -120,6 +120,22 @@ sub staff_ignore_form_disable_form {
         && $c->user->belongs_to_body( $self->body->id );
 }
 
+=head2 updates_disallowed_for_user
+
+Users in the Councillor role should not be able to update
+reports even though they are body members
+
+=cut
+
+sub updates_disallowed_for_user {
+    my ($self, $user, $from_body) = @_;
+
+    return unless $from_body;
+
+    my $role = $user->obj->roles->search({ name => "Shropshire Councillor" })->count;
+    return $role;
+}
+
 =head2 open311_contact_meta_override
 
 One field we pull from Confirm is for an 'Abandoned since' date. We want

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -463,6 +463,7 @@ sub updates_disallowed {
     my $cfg = $self->feature('updates_allowed') || '';
 
     my $body_user = $c->user_exists && $c->user->from_body && $c->user->from_body->get_column('name') eq $self->council_name;
+    return $cfg if $c->user_exists && $c->cobrand->call_hook('updates_disallowed_for_user' => $c->user, $body_user);
     return $self->_updates_disallowed_check($cfg, $problem, $body_user);
 }
 

--- a/t/cobrand/shropshire.t
+++ b/t/cobrand/shropshire.t
@@ -20,6 +20,31 @@ my ($report) = $mech->create_problems_for_body(1, $body->id, 'Test Report', {
     external_id => '1309813', whensent => \'current_timestamp',
 });
 
+my ($report2) = $mech->create_problems_for_body(1, $body->id, 'Test Report for updating', {
+    category => 'Bridges', cobrand => 'shropshire',
+    latitude => 52.859331, longitude => -3.054912, areas => ',11809,129425,144013,144260,148857,2238,39904,47098,66017,95047,'
+});
+
+my $staffuser = $mech->create_user_ok('counciluser@example.com', name => 'Council User',
+                                      from_body => $body, password => 'password');
+
+my $councillor = $mech->create_user_ok('councillor@example.com', name => 'Councillor',
+                                       from_body => $body, password => 'password');
+
+my $role = FixMyStreet::DB->resultset("Role")->create({
+    body => $body,
+    name => 'Shropshire Councillor',
+    permissions => ['report_inspect'],
+    });
+$councillor->add_to_roles($role);
+
+my $role2 = FixMyStreet::DB->resultset("Role")->create({
+    body => $body,
+    name => 'General council',
+    permissions => ['report_inspect'],
+    });
+$staffuser->add_to_roles($role2);
+
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'shropshire' ],
     MAPIT_URL => 'http://mapit.uk/',
@@ -108,6 +133,26 @@ FixMyStreet::override_config {
 
 };
 
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => [ 'shropshire' ],
+      COBRAND_FEATURES => {
+        updates_allowed => {
+          shropshire => 'reporter/staff',
+        }
+      }
+}, sub {
+    subtest 'User in Councillor role can not update reports' => sub {
+        $mech->log_in_ok( $staffuser->email );
+        my $id = $report2->id;
+        $mech->get_ok( '/report/' . $id );
+        $mech->content_contains('Provide an update', 'Regular staff user can leave an update');
+
+        $mech->log_in_ok( $councillor->email );
+        $mech->get_ok( '/report/' . $id );
+        $mech->content_lacks('Provide an update', 'Councillor role staff user can not leave an update');
+    };
+};
+
 subtest 'check open311_contact_meta_override' => sub {
 
     my $processor = Open311::PopulateServiceList->new();
@@ -178,8 +223,6 @@ FixMyStreet::override_config {
     PHOTO_STORAGE_OPTIONS => { UPLOAD_DIR => $UPLOAD_DIR },
     COBRAND_FEATURES => { heatmap => { shropshire => 1 } },
 }, sub {
-    my $staffuser = $mech->create_user_ok('counciluser@example.com', name => 'Council User',
-        from_body => $body, password => 'password');
     $mech->log_in_ok( $staffuser->email );
 
     subtest 'Dashboard includes parishes' => sub {
@@ -188,7 +231,7 @@ FixMyStreet::override_config {
         $mech->content_contains('Abdon and Heath Parish');
         $mech->submit_form_ok({ with_fields => { ward => 144013 } });
         $mech->content_contains('<option value="144013" selected>Oswestry Parish</option>');
-        $mech->content_like(qr{<th scope="row" id="total-header">Total</th>\s*<td>1</td>});
+        $mech->content_like(qr{<th scope="row" id="total-header">Total</th>\s*<td>2</td>});
 
         $mech->get_ok('/dashboard/heatmap');
         $mech->content_contains('Town/parish council');


### PR DESCRIPTION
Adds a call hook to check if an individual user is not authorised to leave an update. This precedes/overrides general settings of which category of user is allowed to leave updates on reports.

For Shropshire this is any user in the Councillor role

https://github.com/mysociety/societyworks/issues/5546

[skip changelog]