### PR TITLE
Split report_mark_private into view and edit permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
         - List categories that prevent reporting.
         - Show report search on the admin summary page for staff with `user_edit`. #5903
         - Population lookup size for radius alert can be configured per cobrand
+        - Split original report_mark_private permission into a view-only permission (report_view_private) and an edit permission (report_mark_private) #5973
     - Development improvements
         - More logging when `page_error` is called, to aid troubleshooting. #5279
         - Docker changes needed for systemd to work. #5257

--- a/perllib/FixMyStreet/App/Controller/Around.pm
+++ b/perllib/FixMyStreet/App/Controller/Around.pm
@@ -291,7 +291,8 @@ sub check_and_stash_category : Private {
         if ($c->user->is_superuser) {
             $rs = $rs->not_deleted_admin;
         } elsif ($c->user->has_body_permission_to('report_inspect') ||
-                 $c->user->has_body_permission_to('report_mark_private')) {
+                    $c->user->has_body_permission_to('report_view_private') ||
+                    $c->user->has_body_permission_to('report_mark_private')) {
             $where = {
                 -or => [
                     {

--- a/perllib/FixMyStreet/App/Controller/Photo.pm
+++ b/perllib/FixMyStreet/App/Controller/Photo.pm
@@ -83,6 +83,7 @@ sub index :LocalRegex('^(c/)?([1-9]\d*)(?:\.(\d+))?(?:\.(full|tn|fp|og))?\.(?:jp
         $c->detach('no_photo') unless $c->user->is_superuser
             || $c->user->id == $problem->user->id
             || $c->user->has_permission_to('report_inspect', $body_ids)
+            || $c->user->has_permission_to('report_view_private', $body_ids)
             || $c->user->has_permission_to('report_mark_private', $body_ids);
     }
 

--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -200,7 +200,10 @@ sub load_problem_or_display_error : Private {
         my $allowed = 0;
         $allowed = 1 if $from_email;
         $allowed = 1 if $c->user_exists && $c->user->id == $problem->user->id;
-        $allowed = 1 if $permissions->{report_inspect} || $permissions->{report_mark_private};
+
+        $allowed = 1 if $permissions->{report_inspect}
+            || $permissions->{report_view_private}
+            || $permissions->{report_mark_private};
 
         unless  ($allowed) {
             my $url = '/auth?r=report/' . $problem->id;

--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -712,6 +712,7 @@ sub check_non_public_reports_permission : Private {
 
             $user_has_permission = $body && (
                 $c->user->has_permission_to('report_inspect', $body->id) ||
+                $c->user->has_permission_to('report_view_private', $body->id) ||
                 $c->user->has_permission_to('report_mark_private', $body->id)
             );
         }

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -858,7 +858,8 @@ sub available_permissions {
             report_edit => _("Edit reports"),
             report_edit_category => _("Edit report category"), # future use
             report_edit_priority => _("Edit report priority"), # future use
-            report_mark_private => _("View/Mark private reports"),
+            report_view_private => _("View private reports"),
+            report_mark_private => _("Mark private reports"), # Implies permission to view
             report_inspect => _("Markup problem details"),
             report_instruct => _("Instruct contractors to fix problems"), # future use
             report_prefill => _("Automatically populate report subject/detail"),

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -388,12 +388,16 @@ sub munge_reports_category_list {
     my ($self, $categories) = @_;
     my $c = $self->{c};
     return if $c->action eq 'dashboard/heatmap';
-
-    unless ( $c->user_exists && $c->user->from_body && $c->user->has_permission_to('report_mark_private', $self->body->id) ) {
+    unless ( $c->user_exists
+        && $c->user->from_body
+        && (
+            $c->user->has_permission_to('report_view_private', $self->body->id) ||
+            $c->user->has_permission_to('report_mark_private', $self->body->id)
+        )
+    ) {
         @$categories = grep { $_->get_extra_metadata('type', '') ne 'waste' } @$categories;
     }
 }
-
 
 sub munge_report_new_bodies {
     my ($self, $bodies) = @_;

--- a/perllib/FixMyStreet/DB/ResultSet/Problem.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Problem.pm
@@ -41,7 +41,8 @@ sub non_public_if_possible {
             # See all reports, no restriction
             $params->{"$table.non_public"} = 1 if $only_non_public;
         } elsif ($c->user->has_body_permission_to('report_inspect') ||
-                 $c->user->has_body_permission_to('report_mark_private')) {
+                    $c->user->has_body_permission_to('report_view_private') ||
+                    $c->user->has_body_permission_to('report_mark_private')) {
             if ($only_non_public) {
                 push @{ $params->{-and} }, {
                     -and => [

--- a/perllib/FixMyStreet/Roles/Cobrand/KingstonSutton.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/KingstonSutton.pm
@@ -82,7 +82,8 @@ sub available_permissions {
     return {
         _("Problems") => {
             report_edit => _("Edit reports"),
-            report_mark_private => _("View/Mark private reports"),
+            report_view_private => _("View private reports"),
+            report_mark_private => _("Mark private reports"), # Implies permission to view
             contribute_as_another_user => _("Create reports/updates on a user's behalf"),
             contribute_as_anonymous_user => _("Create reports/updates as anonymous user"),
             contribute_as_body => _("Create reports/updates as the council"),

--- a/t/app/controller/admin/triage.t
+++ b/t/app/controller/admin/triage.t
@@ -82,6 +82,12 @@ FixMyStreet::override_config {
         $mech->get_ok('/admin/triage');
         $mech->content_lacks($report->title);
 
+        $user->user_body_permissions->create( { body => $iow, permission_type => 'report_view_private' } );
+        $mech->get_ok('/admin/triage');
+        $mech->content_contains($report->title);
+
+        $user->user_body_permissions->delete;
+        $user->user_body_permissions->create( { body => $iow, permission_type => 'triage' } );
         $user->user_body_permissions->create( { body => $iow, permission_type => 'report_mark_private' } );
         $mech->get_ok('/admin/triage');
         $mech->content_contains($report->title);

--- a/t/app/controller/admin/users.t
+++ b/t/app/controller/admin/users.t
@@ -445,6 +445,7 @@ for my $test (
 my %default_perms = (
     "permissions[moderate]" => 'on',
     "permissions[planned_reports]" => undef,
+    "permissions[report_view_private]" => undef,
     "permissions[report_mark_private]" => undef,
     "permissions[report_edit]" => undef,
     "permissions[report_edit_category]" => undef,

--- a/t/app/controller/around.t
+++ b/t/app/controller/around.t
@@ -167,11 +167,25 @@ subtest 'check lookup by reference does not show non_public reports' => sub {
 subtest '...unless staff' => sub {
     my $user = $mech->log_in_ok( 'test@example.com' );
     $user->update({ from_body => $body_edin });
-    $user->user_body_permissions->find_or_create({ body => $body_edin, permission_type => 'report_mark_private' });
-    my $id = $edinburgh_problems[0]->id;
-    $mech->get_ok('/');
-    $mech->submit_form_ok( { with_fields => { pc => $id } }, 'non_public ref');
-    is $mech->uri->path, "/report/$id", "redirects to correct report";
+
+    subtest 'with view permissions' => sub {
+        $user->user_body_permissions->find_or_create({ body => $body_edin, permission_type => 'report_view_private' });
+        my $id = $edinburgh_problems[0]->id;
+        $mech->get_ok('/');
+        $mech->submit_form_ok( { with_fields => { pc => $id } }, 'non_public ref');
+        is $mech->uri->path, "/report/$id", "redirects to correct report";
+        $user->user_body_permissions->delete;
+    };
+
+    subtest 'with edit permissions' => sub {
+        $user->user_body_permissions->find_or_create({ body => $body_edin, permission_type => 'report_mark_private' });
+        my $id = $edinburgh_problems[0]->id;
+        $mech->get_ok('/');
+        $mech->submit_form_ok( { with_fields => { pc => $id } }, 'non_public ref');
+        is $mech->uri->path, "/report/$id", "redirects to correct report";
+        $user->user_body_permissions->delete;
+    };
+
     $mech->log_out_ok;
 };
 
@@ -199,7 +213,7 @@ subtest 'check missing body message not shown when it does not need to be' => su
     $mech->content_lacks('yet have details for the other councils that cover this location');
 };
 
-for my $permission ( qw/ report_inspect report_mark_private/ ) {
+for my $permission ( qw/report_inspect report_view_private report_mark_private/ ) {
     subtest "check non public reports are displayed on around page with $permission permission" => sub {
         my $user = $mech->log_in_ok( 'test@example.com' );
         $user->user_body_permissions->delete();
@@ -403,10 +417,19 @@ subtest 'check staff categories shown appropriately in filter' => sub {
         $mech->content_lacks('<option value="Needles county">');
         my $user = $mech->log_in_ok( 'test@example.com' );
         $user->update({ from_body => $district });
+
+        $user->user_body_permissions->find_or_create({ body => $district, permission_type => 'report_view_private' });
+        $mech->get_ok( '/around?bbox=' . $bbox );
+        $mech->content_contains('<option value="Needles district">');
+        $mech->content_lacks('<option value="Needles county">');
+        $user->user_body_permissions->delete;
+
         $user->user_body_permissions->find_or_create({ body => $district, permission_type => 'report_mark_private' });
         $mech->get_ok( '/around?bbox=' . $bbox );
         $mech->content_contains('<option value="Needles district">');
         $mech->content_lacks('<option value="Needles county">');
+        $user->user_body_permissions->delete;
+
         $mech->log_out_ok;
     };
 };

--- a/t/app/controller/photo.t
+++ b/t/app/controller/photo.t
@@ -176,6 +176,17 @@ subtest 'non_public photos only viewable by correct people' => sub {
         $user->user_body_permissions->create({ body => $body, permission_type => 'report_inspect' });
         $i = '/photo/' . $report->id . '.0.jpeg';
         $mech->get_ok($i);
+        $user->user_body_permissions->delete;
+
+        $user->user_body_permissions->create({ body => $body, permission_type => 'report_view_private' });
+        $i = '/photo/' . $report->id . '.0.jpeg';
+        $mech->get_ok($i);
+        $user->user_body_permissions->delete;
+
+        $user->user_body_permissions->create({ body => $body, permission_type => 'report_mark_private' });
+        $i = '/photo/' . $report->id . '.0.jpeg';
+        $mech->get_ok($i);
+        $user->user_body_permissions->delete;
 
         $user->update({ from_body => undef, is_superuser => 1 });
         $i = '/photo/' . $report->id . '.0.jpeg';

--- a/t/app/controller/report_inspect.t
+++ b/t/app/controller/report_inspect.t
@@ -63,6 +63,14 @@ FixMyStreet::override_config {
         $mech->content_lacks('Change asset');
         $mech->content_lacks('/admin/report_edit/'.$report_id.'">admin</a>)');
 
+        $user->user_body_permissions->create({ body => $oxon, permission_type => 'report_view_private' });
+        $mech->get_ok("/report/$report_id");
+        $mech->content_lacks('Private');
+        $mech->content_lacks('Save changes');
+        $mech->content_lacks('Change asset');
+        $mech->content_lacks('Priority');
+        $mech->content_lacks('/admin/report_edit/'.$report_id.'">admin</a>)');
+
         $user->user_body_permissions->create({ body => $oxon, permission_type => 'report_mark_private' });
         $mech->get_ok("/report/$report_id");
         $mech->content_contains('Private');

--- a/t/app/controller/report_non_public.t
+++ b/t/app/controller/report_non_public.t
@@ -13,6 +13,13 @@ my $staffuser = $mech->create_user_ok('body-user@example.net', name => 'Body Use
 $staffuser->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_another_user' });
 $staffuser->user_body_permissions->create({ body => $body, permission_type => 'report_mark_private' });
 
+my $staffuser_view_private = $mech->create_user_ok(
+    'body-user-view-private@example.net',
+    name      => 'View Private',
+    from_body => $body->id,
+);
+$staffuser_view_private->user_body_permissions->create({ body => $body, permission_type => 'report_view_private' });
+
 my $user = $mech->create_user_ok('test@example.com', name => 'Test User');
 my $user2 = $mech->create_user_ok('test2@example.com', name => 'Other User');
 
@@ -47,6 +54,24 @@ subtest "check owner of report can view non public reports" => sub {
     $mech->content_lacks('Report another problem here');
     $mech->content_lacks($report->latitude);
     $mech->content_lacks($report->longitude);
+    $mech->log_out_ok;
+};
+
+subtest 'check staff with report_view_private can view non-public, but not edit' => sub {
+    $mech->log_in_ok( $staffuser_view_private->email );
+    ok $mech->get("/report/$report_id"), "get '/report/$report_id'";
+    is $mech->res->code, 200, "report can be viewed";
+    is $mech->uri->path, "/report/$report_id", "at /report/$report_id";
+    $mech->content_lacks('id="side-inspect"', 'inspect bar is not shown');
+    $mech->log_out_ok;
+};
+
+subtest 'check staff with report_mark_private can view and edit non-public' => sub {
+    $mech->log_in_ok( $staffuser->email );
+    ok $mech->get("/report/$report_id"), "get '/report/$report_id'";
+    is $mech->res->code, 200, "report can be viewed";
+    is $mech->uri->path, "/report/$report_id", "at /report/$report_id";
+    $mech->content_contains('id="side-inspect"', 'inspect bar is shown');
     $mech->log_out_ok;
 };
 

--- a/t/app/controller/reports.t
+++ b/t/app/controller/reports.t
@@ -222,7 +222,7 @@ is scalar @$problems, 4, 'only public problems are displayed';
 
 $mech->content_lacks('All reports Test 3 for ' . $body_west_id, 'non public problem is not visible');
 
-for my $permission( qw/ report_inspect report_mark_private / ) {
+for my $permission( qw/ report_inspect report_view_private report_mark_private / ) {
     subtest "user with $permission permission can see non public reports" => sub {
         my $body = FixMyStreet::DB->resultset('Body')->find( $body_west_id );
         my $body2 = FixMyStreet::DB->resultset('Body')->find( $body_edin_id );

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -17,20 +17,19 @@ my $nameless_user = $mech->create_user_ok('nameless@example.net', name => '');
 my $staff_user = $mech->create_user_ok('staff@example.org', from_body => $body, name => 'Staff User');
 $staff_user->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_anonymous_user' });
 $staff_user->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_another_user' });
-$staff_user->user_body_permissions->create({ body => $body, permission_type => 'report_mark_private' });
+$staff_user->user_body_permissions->create({ body => $body, permission_type => 'report_view_private' });
 $staff_user->user_body_permissions->create({ body => $body, permission_type => 'can_pay_with_csc' });
 $staff_user->user_body_permissions->create({ body => $body, permission_type => 'report_edit' });
 
 my $staff_non_payuser = $mech->create_user_ok('staff_no_pay@example.org', from_body => $body, name => 'Staff No Pay User');
 $staff_non_payuser->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_anonymous_user' });
 $staff_non_payuser->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_another_user' });
-$staff_non_payuser->user_body_permissions->create({ body => $body, permission_type => 'report_mark_private' });
 
 my $csc_user = $mech->create_user_ok('csc_staff@example.org', from_body => $body, name => 'CSC User');
 my $role = FixMyStreet::DB->resultset("Role")->create({
     body => $body,
     name => 'Contact Centre Agent',
-    permissions => ['contribute_as_another_user', 'contribute_as_anonymous_user', 'report_mark_private', 'can_pay_with_csc']
+    permissions => ['contribute_as_another_user', 'contribute_as_anonymous_user', 'can_pay_with_csc']
 });
 $csc_user->add_to_roles($role);
 

--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -16,7 +16,6 @@ my $user = $mech->create_user_ok('test@example.net', name => 'Normal User');
 my $staff_user = $mech->create_user_ok('staff@example.org', from_body => $body, name => 'Staff User');
 $staff_user->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_anonymous_user' });
 $staff_user->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_another_user' });
-$staff_user->user_body_permissions->create({ body => $body, permission_type => 'report_mark_private' });
 
 sub create_contact {
     my ($params, @extra) = @_;

--- a/t/app/controller/waste_brent_garden.t
+++ b/t/app/controller/waste_brent_garden.t
@@ -19,7 +19,6 @@ my $user = $mech->create_user_ok('test@example.net', name => 'Normal User');
 my $staff_user = $mech->create_user_ok('staff@example.org', from_body => $body, name => 'Staff User');
 $staff_user->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_anonymous_user' });
 $staff_user->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_another_user' });
-$staff_user->user_body_permissions->create({ body => $body, permission_type => 'report_mark_private' });
 
 sub create_contact {
     my ($params, @extra) = @_;

--- a/t/app/controller/waste_kingston.t
+++ b/t/app/controller/waste_kingston.t
@@ -16,7 +16,6 @@ my $user = $mech->create_user_ok('test@example.net', name => 'Normal User');
 my $staff_user = $mech->create_user_ok('staff@example.org', from_body => $body, name => 'Staff User');
 $staff_user->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_anonymous_user' });
 $staff_user->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_another_user' });
-$staff_user->user_body_permissions->create({ body => $body, permission_type => 'report_mark_private' });
 
 sub create_contact {
     my ($params, @extra) = @_;

--- a/t/app/controller/waste_merton_bulky.t
+++ b/t/app/controller/waste_merton_bulky.t
@@ -30,7 +30,7 @@ my $contact = $mech->create_contact_ok(body => $body, ( category => 'Report miss
 $contact->update;
 
 my $contact_centre_user = $mech->create_user_ok('contact@example.org', from_body => $body, email_verified => 1, name => 'Contact 1');
-$contact_centre_user->user_body_permissions->create({ body => $body, permission_type => 'report_mark_private' });
+$contact_centre_user->user_body_permissions->create({ body => $body, permission_type => 'report_view_private' });
 
 for ($body) {
     add_extra_metadata($_);

--- a/t/app/controller/waste_merton_garden.t
+++ b/t/app/controller/waste_merton_garden.t
@@ -14,7 +14,6 @@ my $user = $mech->create_user_ok('test@example.net', name => 'Normal User');
 my $staff_user = $mech->create_user_ok('staff@example.org', from_body => $body, name => 'Staff User');
 $staff_user->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_anonymous_user' });
 $staff_user->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_another_user' });
-$staff_user->user_body_permissions->create({ body => $body, permission_type => 'report_mark_private' });
 
 sub create_contact {
     my ($params, @extra) = @_;

--- a/t/app/controller/waste_peterborough.t
+++ b/t/app/controller/waste_peterborough.t
@@ -25,7 +25,6 @@ my $user = $mech->create_user_ok('test@example.net', name => 'Normal User');
 my $user2 = $mech->create_user_ok('test2@example.net', name => 'Very Normal User');
 my $staff = $mech->create_user_ok('staff@example.net', name => 'Staff User', from_body => $body->id);
 $staff->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_another_user' });
-$staff->user_body_permissions->create({ body => $body, permission_type => 'report_mark_private' });
 $staff->user_body_permissions->create({ body => $body, permission_type => 'planned_reports' });
 $staff->user_body_permissions->create({ body => $body, permission_type => 'report_edit' });
 my $super = $mech->create_user_ok('super@example.net', name => 'Super User', is_superuser => 1);

--- a/t/app/controller/waste_peterborough_bulky.t
+++ b/t/app/controller/waste_peterborough_bulky.t
@@ -31,13 +31,12 @@ my $user = $mech->create_user_ok('test@example.net', name => 'Normal User');
 my $user2 = $mech->create_user_ok('test2@example.net', name => 'Very Normal User');
 my $staff = $mech->create_user_ok('staff@example.net', name => 'Staff User', from_body => $body->id);
 $staff->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_another_user' });
-$staff->user_body_permissions->create({ body => $body, permission_type => 'report_mark_private' });
+$staff->user_body_permissions->create({ body => $body, permission_type => 'report_view_private' });
 my $super = $mech->create_user_ok('super@example.net', name => 'Super User', is_superuser => 1);
 
 my $bromley = $mech->create_body_ok(2482, 'Bromley Council', { cobrand => 'bromley' });
 my $staff_bromley = $mech->create_user_ok('staff_bromley@example.net', name => 'Bromley Staff User', from_body => $bromley->id);
 $staff_bromley->user_body_permissions->create({ body => $bromley, permission_type => 'contribute_as_another_user' });
-$staff_bromley->user_body_permissions->create({ body => $bromley, permission_type => 'report_mark_private' });
 
 sub create_contact {
     my ($params, $group, @extra) = @_;

--- a/t/app/controller/waste_sutton_garden.t
+++ b/t/app/controller/waste_sutton_garden.t
@@ -14,7 +14,7 @@ my $user = $mech->create_user_ok('test@example.net', name => 'Normal User');
 my $staff_user = $mech->create_user_ok('staff@example.org', from_body => $body, name => 'Staff User');
 $staff_user->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_anonymous_user' });
 $staff_user->user_body_permissions->create({ body => $body, permission_type => 'contribute_as_another_user' });
-$staff_user->user_body_permissions->create({ body => $body, permission_type => 'report_mark_private' });
+$staff_user->user_body_permissions->create({ body => $body, permission_type => 'report_view_private' });
 
 sub create_contact {
     my ($params, @extra) = @_;

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -37,7 +37,7 @@ my $body = $mech->create_body_ok( 2482, 'Bromley Council', {
 my $lewisham = $mech->create_body_ok( 2492, 'Lewisham Borough Council');
 my $staffuser = $mech->create_user_ok( 'staff@example.com', name => 'Staffie', from_body => $body );
 my $role = FixMyStreet::DB->resultset("Role")->create({
-    body => $body, name => 'Role A', permissions => ['moderate', 'user_edit', 'report_mark_private', 'report_inspect', 'contribute_as_body'] });
+    body => $body, name => 'Role A', permissions => ['moderate', 'user_edit', 'report_inspect', 'contribute_as_body'] });
 my $roleB = FixMyStreet::DB->resultset("Role")->create({ body => $body, name => 'Role B' });
 $staffuser->add_to_roles($role);
 my $contact = $mech->create_contact_ok(

--- a/t/cobrand/bromley_waste.t
+++ b/t/cobrand/bromley_waste.t
@@ -31,7 +31,7 @@ my $body = $mech->create_body_ok( 2482, 'Bromley Council', {
 $mech->create_user_ok('superuser@example.com', is_superuser => 1, name => "Super User");
 my $staffuser = $mech->create_user_ok( 'staff@example.com', name => 'Staffie', from_body => $body );
 my $role = FixMyStreet::DB->resultset("Role")->create({
-    body => $body, name => 'Role A', permissions => ['moderate', 'user_edit', 'report_mark_private', 'report_inspect', 'contribute_as_body'] });
+    body => $body, name => 'Role A', permissions => ['moderate', 'user_edit', 'report_view_private', 'report_inspect', 'contribute_as_body'] });
 $staffuser->add_to_roles($role);
 
 my $pothole = $mech->create_contact_ok(

--- a/templates/web/base/reports/_list-filter-status.html
+++ b/templates/web/base/reports/_list-filter-status.html
@@ -30,7 +30,7 @@
         <option value="shortlisted"[% ' selected' IF filter_status.shortlisted %]>[% loc('Shortlisted') %]</option>
         <option value="unshortlisted"[% ' selected' IF filter_status.unshortlisted %]>[% loc('Unshortlisted') %]</option>
       [% END %]
-      [% IF c.user_exists AND ( c.user.has_body_permission_to('report_inspect') OR c.user.has_body_permission_to('report_mark_private') ) %]
+      [% IF c.user_exists AND ( c.user.has_body_permission_to('report_inspect') OR c.user.has_body_permission_to('report_view_private') OR c.user.has_body_permission_to('report_mark_private') ) %]
         <option value="non_public"[% ' selected' IF filter_status.non_public %]>[% loc('Private only') %]</option>
       [% END %]
       [% IF show_all_states %]


### PR DESCRIPTION
Fixes https://github.com/mysociety/societyworks/issues/5547.

This PR splits the `report_mark_private` permission into separate view and edit permissions.