### PR TITLE
FMS006 scripts to update permissions for roles and staff users

### DIFF
--- a/bin/fixmystreet.com/update_council_users_without_role
+++ b/bin/fixmystreet.com/update_council_users_without_role
@@ -1,0 +1,37 @@
+#!/usr/bin/env perl
+#
+# script to add/remove a list of permissions to all staff without a role.
+
+use strict;
+use warnings;
+use v5.14;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use FixMyStreet::Script::UpdateCouncilUsersWithoutRole;
+use Getopt::Long::Descriptive;
+
+my ($opts, $usage) = describe_options(
+    '%c %o',
+    ['commit', 'whether to commit changes to the database'],
+    ['permissions=s', 'comma seperated list of permissions to add/delete', { required => 1 }],
+    ['limit' => 'hidden' => { one_of => [
+        ['council=s', 'name of council to update'],
+        ['all', 'update users for all councils'],
+    ], required => 1 }],
+    ['mode' => 'hidden' => { one_of => [
+        ['add', 'add permissions to council\'s users'],
+        ['remove', 'remove permissions from council\'s users'],
+    ], required => 1 }],
+    ['with_permission=s', 'only update users that already have this permission'],
+    ['verbose', 'output a list of everything done'],
+    ['help|h', 'print usage message and exit']
+);
+$usage->die if $opts->help;
+
+FixMyStreet::Script::UpdateCouncilUsersWithoutRole::update($opts);

--- a/bin/fixmystreet.com/update_roles
+++ b/bin/fixmystreet.com/update_roles
@@ -1,0 +1,34 @@
+#!/usr/bin/env perl
+#
+# script to add/remove a list of permissions to all roles, or optionally to roles belonging to a body.
+
+use warnings;
+use v5.14;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../setenv.pl";
+}
+
+use FixMyStreet::Script::UpdateRoles;
+
+use Getopt::Long::Descriptive;
+
+my ($opts, $usage) = describe_options(
+    '%c %o',
+    ['commit', 'whether to commit changes to the database'],
+    ['permissions=s', 'comma seperated list of permissions to add/delete', { required => 1 }],
+    ['council=s', 'name of council to update (updates all roles if omitted)'],
+    ['mode' => 'hidden' => { one_of => [
+        ['add', 'add permissions to roles'],
+        ['remove', 'remove permissions from roles'],
+    ], required => 1 }],
+    ['with_permission=s', 'only update roles that already have this permission'],
+    ['verbose', 'output a list of everything done'],
+    ['help|h', 'print usage message and exit']
+);
+$usage->die if $opts->help;
+
+FixMyStreet::Script::UpdateRoles::update($opts);

--- a/perllib/FixMyStreet/Script/UpdateCouncilUsersWithoutRole.pm
+++ b/perllib/FixMyStreet/Script/UpdateCouncilUsersWithoutRole.pm
@@ -1,0 +1,85 @@
+package FixMyStreet::Script::UpdateCouncilUsersWithoutRole;
+
+use v5.14;
+use warnings;
+
+use FixMyStreet::DB;
+
+sub update {
+    my $opts = shift;
+
+    if (!$opts->{commit}) {
+        say "*** DRY RUN ***";
+    }
+
+    my $users = FixMyStreet::DB->resultset("User")->search({
+        from_body => { "!=", undef },
+        id => {
+            -not_in => FixMyStreet::DB->resultset("UserRole")->search(
+                undef,
+                {
+                    columns => ['user_id']
+                }
+            )->as_query
+        }
+    });
+
+    if ( $opts->{council} ) {
+        my $body = FixMyStreet::DB->resultset("Body")->find({ name => $opts->{council}});
+        if ($body) {
+            $users = $users->search({
+                from_body => $body->id
+            });
+        } else {
+            die "Could not find " . $opts->{council};
+        }
+    }
+
+    if ($opts->{with_permission}) {
+        my $permission = Utils::trim_text($opts->{with_permission});
+				$users = $users->search(
+					id => {
+						-in => FixMyStreet::DB->resultset('UserBodyPermission')->search(
+              {
+                permission_type => { in => [$permission]}
+							},
+              {
+                  columns => ['user_id']
+              }
+            )->as_query
+        });
+    }
+
+    if ($users->count) {
+        my @permissions_list = map { Utils::trim_text($_) } split(',', $opts->{permissions});
+
+        for my $user ( $users->all ) {
+            my $permissions = $user->user_body_permissions->search({
+                body_id => $user->from_body->id,
+                permission_type => { in => \@permissions_list}
+            });
+            if ( $opts->{mode} eq 'remove') {
+                next unless $permissions->count;
+                if ($opts->{commit}) {
+                    $permissions->delete;
+                }
+            } elsif ( $opts->{mode} eq 'add' ) {
+                my %existing = map { $_->permission_type => 1 } $permissions->all;
+                my @permissions_to_add = grep { !$existing{$_} } @permissions_list;
+                next unless @permissions_to_add;
+                if ($opts->{commit}) {
+                    for my $permission ( @permissions_to_add ) {
+                        $user->user_body_permissions->create({
+                            body_id => $user->from_body->id,
+                            permission_type => $permission
+                        });
+                    }
+                }
+            }
+            say "updated permissions for user id " . $user->id . " from " . $user->from_body->name unless $opts->{verbose};
+        }
+    }
+
+}
+
+1;

--- a/perllib/FixMyStreet/Script/UpdateRoles.pm
+++ b/perllib/FixMyStreet/Script/UpdateRoles.pm
@@ -1,0 +1,58 @@
+package FixMyStreet::Script::UpdateRoles;
+
+use v5.14;
+use warnings;
+
+use FixMyStreet::DB;
+
+sub update {
+    my $opts = shift;
+
+    if (!$opts->{commit}) {
+        say "*** DRY RUN ***";
+    }
+
+    my $body = FixMyStreet::DB->resultset("Body")->find({ name => $opts->{council}});
+
+    if ($opts->{council} && !$body) {
+        die "Could not find a body matching " . $opts->{council} . "\n";
+    }
+
+    my $roles;
+    if ($body) {
+        $roles = FixMyStreet::DB->resultset("Role")->search({ body_id => $body->id });
+    } else {
+        $roles = FixMyStreet::DB->resultset("Role");
+    }
+
+    if ($opts->{with_permission}) {
+        my $permission = Utils::trim_text($opts->{with_permission});
+        $roles = $roles->search({
+            permissions => \"@> ARRAY['$permission']"
+        });
+    }
+    my %permissions_list = map { Utils::trim_text($_) => 1 } split(',', $opts->{permissions});
+
+    for my $role ( $roles->all ) {
+        my $permissions = $role->permissions;
+		my $new_permissions;
+
+        if ( $opts->{mode} eq 'remove') {
+            next unless $permissions;
+            $new_permissions = [ grep { !$permissions_list{$_} } @$permissions ];
+        } elsif ( $opts->{mode} eq 'add' ) {
+            my %existing = map { $_ => 1 } @$permissions;
+            my @permissions_to_add = grep { !$existing{$_} } keys %permissions_list;
+            next unless @permissions_to_add;
+            $new_permissions = [@$permissions, @permissions_to_add];
+        }
+        if ($opts->{commit}) {
+            $role->permissions($new_permissions);
+            $role->update;
+        }
+        say "updated permissions for role id " . $role->id . " to " . join ",", @$new_permissions if $opts->{verbose};
+
+    }
+}
+
+1;

--- a/t/script/updatecounciluserswithoutrole.t
+++ b/t/script/updatecounciluserswithoutrole.t
@@ -1,0 +1,251 @@
+use FixMyStreet::TestMech;
+use Test::Exception;
+
+use_ok 'FixMyStreet::Script::UpdateCouncilUsersWithoutRole';
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $body = $mech->create_body_ok(2651, 'TfL');
+my $other_body = $mech->create_body_ok(2248, 'Northumberland');
+
+sub create_users() {
+    my $no_permissions = $mech->create_user_ok('no_permissions@example.org', from_body => $body);
+    $no_permissions->user_body_permissions->delete();
+
+    my $one_permission = $mech->create_user_ok('one_permission@example.org', from_body => $body);
+    $one_permission->user_body_permissions->delete();
+    $one_permission->user_body_permissions->create({ body_id => $body->id, permission_type => 'user_edit'});
+
+    my $many_permissions = $mech->create_user_ok('many_permissions@example.org', from_body => $body);
+    $many_permissions->user_body_permissions->delete();
+    for (qw/user_edit category_edit report_edit/) {
+        $many_permissions->user_body_permissions->create({ body_id => $body->id, permission_type => $_});
+    }
+
+    my $other_one_permission = $mech->create_user_ok('other_one_permission@example.org', from_body => $other_body);
+    $other_one_permission->user_body_permissions->delete();
+    $other_one_permission->user_body_permissions->create({ body_id => $other_body->id, permission_type => 'user_edit'});
+
+    my $role = FixMyStreet::DB->resultset("Role")->update_or_create({
+        body => $body, name => 'One', permissions => ['user_edit']
+    }, { key => 'roles_body_id_name_key'});
+    my $has_role = $mech->create_user_ok('has_role@example.org', from_body => $body);
+    $has_role->user_roles->find_or_create(role_id => $role->id);
+
+    my $has_role_and_permissions = $mech->create_user_ok('has_role_and_permissions@example.org', from_body => $body);
+    $has_role_and_permissions->user_roles->find_or_create(role_id => $role->id);
+    $has_role_and_permissions->user_body_permissions->delete();
+    $has_role_and_permissions->user_body_permissions->create({ body_id => $body->id, permission_type => 'report_edit'});
+
+    my %users = (
+        no_permissions => $no_permissions,
+        one_permission => $one_permission,
+        many_permissions => $many_permissions,
+        other_one_permission => $other_one_permission,
+        has_role => $has_role,
+        has_role_and_permissions => $has_role_and_permissions,
+    );
+
+    return \%users;
+}
+
+for my $test (
+    {
+        title => 'add single permission everywhere',
+        opts => {
+            commit => 1,
+            permissions => 'template_edit',
+            mode => 'add',
+        },
+        permissions => {
+            no_permissions => 'template_edit',
+            one_permission => 'template_edit,user_edit',
+            many_permissions => 'category_edit,report_edit,template_edit,user_edit',
+            other_one_permission => 'template_edit,user_edit',
+            has_role => '',
+            has_role_and_permissions => 'report_edit',
+        }
+    },
+    {
+        title => 'remove single permission everywhere',
+        opts => {
+            commit => 1,
+            permissions => 'user_edit',
+            mode => 'remove',
+        },
+        permissions => {
+            no_permissions => '',
+            one_permission => '',
+            many_permissions => 'category_edit,report_edit',
+            other_one_permission => '',
+            has_role => '',
+            has_role_and_permissions => 'report_edit',
+        }
+    },
+    {
+        title => 'add multiple permissions everywhere',
+        opts => {
+            commit => 1,
+            permissions => 'template_edit,moderate',
+            mode => 'add',
+        },
+        permissions => {
+            no_permissions => 'moderate,template_edit',
+            one_permission => 'moderate,template_edit,user_edit',
+            many_permissions => 'category_edit,moderate,report_edit,template_edit,user_edit',
+            other_one_permission => 'moderate,template_edit,user_edit',
+            has_role => '',
+            has_role_and_permissions => 'report_edit',
+        }
+    },
+    {
+        title => 'remove multiple permissions everywhere',
+        opts => {
+            commit => 1,
+            permissions => 'user_edit,report_edit',
+            mode => 'remove',
+        },
+        permissions => {
+            no_permissions => '',
+            one_permission => '',
+            many_permissions => 'category_edit',
+            other_one_permission => '',
+            has_role => '',
+            has_role_and_permissions => 'report_edit',
+        }
+    },
+    {
+        title => 'remove multiple permissions everywhere with spaces',
+        opts => {
+            commit => 1,
+            permissions => 'user_edit, report_edit',
+            mode => 'remove',
+        },
+        permissions => {
+            no_permissions => '',
+            one_permission => '',
+            many_permissions => 'category_edit',
+            other_one_permission => '',
+            has_role => '',
+            has_role_and_permissions => 'report_edit',
+        }
+    },
+    {
+        title => 'permission not added twice',
+        opts => {
+            commit => 1,
+            permissions => 'user_edit',
+            mode => 'add',
+        },
+        permissions => {
+            no_permissions => 'user_edit',
+            one_permission => 'user_edit',
+            many_permissions => 'category_edit,report_edit,user_edit',
+            other_one_permission => 'user_edit',
+            has_role => '',
+            has_role_and_permissions => 'report_edit',
+        }
+    },
+    {
+        title => 'add single permission for body',
+        opts => {
+            commit => 1,
+            permissions => 'template_edit',
+            council => 'TfL',
+            mode => 'add',
+        },
+        permissions => {
+            no_permissions => 'template_edit',
+            one_permission => 'template_edit,user_edit',
+            many_permissions => 'category_edit,report_edit,template_edit,user_edit',
+            other_one_permission => 'user_edit',
+            has_role => '',
+            has_role_and_permissions => 'report_edit',
+        }
+    },
+    {
+        title => 'add single permission for users with permission',
+        opts => {
+            commit => 1,
+            permissions => 'template_edit',
+            with_permission => 'report_edit',
+            mode => 'add',
+        },
+        permissions => {
+            no_permissions => '',
+            one_permission => 'user_edit',
+            many_permissions => 'category_edit,report_edit,template_edit,user_edit',
+            other_one_permission => 'user_edit',
+            has_role => '',
+            has_role_and_permissions => 'report_edit',
+        }
+    },
+    {
+        title => 'add single permission for missing body',
+        opts => {
+            commit => 1,
+            permissions => 'template_edit',
+            council => 'TfM',
+            mode => 'add',
+        },
+        permissions => {
+            no_permissions => '',
+            one_permission => 'user_edit',
+            many_permissions => 'category_edit,report_edit,user_edit',
+            other_one_permission => 'user_edit',
+            has_role => '',
+            has_role_and_permissions => 'report_edit',
+        },
+        dies => 1,
+    },
+    {
+        title => 'remove single permission for body',
+        opts => {
+            commit => 1,
+            permissions => 'user_edit',
+            council => 'TfL',
+            mode => 'remove',
+        },
+        permissions => {
+            no_permissions => '',
+            one_permission => '',
+            many_permissions => 'category_edit,report_edit',
+            other_one_permission => 'user_edit',
+            has_role => '',
+            has_role_and_permissions => 'report_edit',
+        },
+    },
+    {
+        title => 'nothing happens without commit',
+        opts => {
+            permissions => 'user_edit',
+            council => 'TfL',
+            mode => 'remove',
+        },
+        permissions => {
+            no_permissions => '',
+            one_permission => 'user_edit',
+            many_permissions => 'category_edit,report_edit,user_edit',
+            other_one_permission => 'user_edit',
+            has_role => '',
+            has_role_and_permissions => 'report_edit',
+        },
+    },
+) {
+    subtest $test->{title} => sub {
+        # reset to known state each time
+        my $users = create_users();
+        if ($test->{dies}) {
+            dies_ok { FixMyStreet::Script::UpdateCouncilUsersWithoutRole::update($test->{opts}) };
+            return;
+        }
+        lives_ok { FixMyStreet::Script::UpdateCouncilUsersWithoutRole::update($test->{opts}) };
+        for my $u (keys %{$test->{permissions}}) {
+            $users->{$u}->discard_changes;
+            my $perms = join ',', sort map {$_->permission_type} $users->{$u}->user_body_permissions->all;
+            is $perms, $test->{permissions}->{$u};
+        }
+    };
+}
+
+done_testing();

--- a/t/script/updateroles.t
+++ b/t/script/updateroles.t
@@ -1,0 +1,212 @@
+use FixMyStreet::TestMech;
+use Test::Exception;
+
+use_ok 'FixMyStreet::Script::UpdateRoles';
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $body = $mech->create_body_ok(2651, 'TfL');
+my $other_body = $mech->create_body_ok(2248, 'Northumberland');
+
+sub create_roles() {
+    my $no_permissions = FixMyStreet::DB->resultset("Role")->update_or_create({
+        body => $body, name => 'No Permissions', permissions => []
+    }, { key => 'roles_body_id_name_key'});
+    my $one_permission = FixMyStreet::DB->resultset("Role")->update_or_create({
+        body => $body, name => 'One', permissions => ['user_edit']
+    }, { key => 'roles_body_id_name_key'});
+    my $many_permissions = FixMyStreet::DB->resultset("Role")->update_or_create({
+        body => $body, name => 'Many', permissions => ['user_edit', 'category_edit', 'report_edit']
+    }, { key => 'roles_body_id_name_key'});
+    my $other_one_permission = FixMyStreet::DB->resultset("Role")->update_or_create({
+        body => $other_body, name => 'One', permissions => ['user_edit']
+    }, { key => 'roles_body_id_name_key'});
+
+    my %roles = (
+        no_permissions => $no_permissions,
+        one_permission => $one_permission,
+        many_permissions => $many_permissions,
+        other_one_permission => $other_one_permission
+    );
+
+    return \%roles;
+}
+
+for my $test (
+    {
+        title => 'add single permission everywhere',
+        opts => {
+            commit => 1,
+            permissions => 'template_edit',
+            mode => 'add',
+        },
+        permissions => {
+            no_permissions => 'template_edit',
+            one_permission => 'template_edit,user_edit',
+            many_permissions => 'category_edit,report_edit,template_edit,user_edit',
+            other_one_permission => 'template_edit,user_edit',
+        }
+    },
+    {
+        title => 'remove single permission everywhere',
+        opts => {
+            commit => 1,
+            permissions => 'user_edit',
+            mode => 'remove',
+        },
+        permissions => {
+            no_permissions => '',
+            one_permission => '',
+            many_permissions => 'category_edit,report_edit',
+            other_one_permission => '',
+        }
+    },
+    {
+        title => 'add multiple permissions everywhere',
+        opts => {
+            commit => 1,
+            permissions => 'template_edit,moderate',
+            mode => 'add',
+        },
+        permissions => {
+            no_permissions => 'moderate,template_edit',
+            one_permission => 'moderate,template_edit,user_edit',
+            many_permissions => 'category_edit,moderate,report_edit,template_edit,user_edit',
+            other_one_permission => 'moderate,template_edit,user_edit',
+        }
+    },
+    {
+        title => 'remove multiple permissions everywhere',
+        opts => {
+            commit => 1,
+            permissions => 'user_edit,report_edit',
+            mode => 'remove',
+        },
+        permissions => {
+            no_permissions => '',
+            one_permission => '',
+            many_permissions => 'category_edit',
+            other_one_permission => '',
+        }
+    },
+    {
+        title => 'remove multiple permissions everywhere with spaces',
+        opts => {
+            commit => 1,
+            permissions => 'user_edit, report_edit',
+            mode => 'remove',
+        },
+        permissions => {
+            no_permissions => '',
+            one_permission => '',
+            many_permissions => 'category_edit',
+            other_one_permission => '',
+        }
+    },
+    {
+        title => 'permission not added twice',
+        opts => {
+            commit => 1,
+            permissions => 'user_edit',
+            mode => 'add',
+        },
+        permissions => {
+            no_permissions => 'user_edit',
+            one_permission => 'user_edit',
+            many_permissions => 'category_edit,report_edit,user_edit',
+            other_one_permission => 'user_edit',
+        }
+    },
+    {
+        title => 'add single permission for body',
+        opts => {
+            commit => 1,
+            permissions => 'template_edit',
+            council => 'TfL',
+            mode => 'add',
+        },
+        permissions => {
+            no_permissions => 'template_edit',
+            one_permission => 'template_edit,user_edit',
+            many_permissions => 'category_edit,report_edit,template_edit,user_edit',
+            other_one_permission => 'user_edit',
+        }
+    },
+    {
+        title => 'add single permission for roles with permission',
+        opts => {
+            commit => 1,
+            permissions => 'template_edit',
+            with_permission => 'report_edit',
+            mode => 'add',
+        },
+        permissions => {
+            no_permissions => '',
+            one_permission => 'user_edit',
+            many_permissions => 'category_edit,report_edit,template_edit,user_edit',
+            other_one_permission => 'user_edit',
+        }
+    },
+    {
+        title => 'add single permission for missing body',
+        opts => {
+            commit => 1,
+            permissions => 'template_edit',
+            council => 'TfM',
+            mode => 'add',
+        },
+        permissions => {
+            no_permissions => '',
+            one_permission => 'user_edit',
+            many_permissions => 'category_edit,report_edit,user_edit',
+            other_one_permission => 'user_edit',
+        },
+        dies => 1,
+    },
+    {
+        title => 'remove single permission for body',
+        opts => {
+            commit => 1,
+            permissions => 'user_edit',
+            council => 'TfL',
+            mode => 'remove',
+        },
+        permissions => {
+            no_permissions => '',
+            one_permission => '',
+            many_permissions => 'category_edit,report_edit',
+            other_one_permission => 'user_edit',
+        },
+    },
+    {
+        title => 'nothing happens without commit',
+        opts => {
+            permissions => 'user_edit',
+            council => 'TfL',
+            mode => 'remove',
+        },
+        permissions => {
+            no_permissions => '',
+            one_permission => 'user_edit',
+            many_permissions => 'category_edit,report_edit,user_edit',
+            other_one_permission => 'user_edit',
+        },
+    },
+) {
+    subtest $test->{title} => sub {
+        # reset to known state each time
+        my $roles = create_roles();
+        if ($test->{dies}) {
+            dies_ok { FixMyStreet::Script::UpdateRoles::update($test->{opts}) };
+            return;
+        }
+        lives_ok { FixMyStreet::Script::UpdateRoles::update($test->{opts}) };
+        for my $r (keys %{$test->{permissions}}) {
+            $roles->{$r}->discard_changes;
+            my $perms = join ',', sort @{$roles->{$r}->permissions};
+            is $perms, $test->{permissions}->{$r};
+        }
+    };
+}
+
+done_testing();


### PR DESCRIPTION
Adds a couple of utility scripts for adding/removing permissions from roles or staff users.

One of the allows adding/removing permissions to all roles, a particular council bodies roles. This can be further limited to roles that have a particular permission for cases where a permission has been split.

The second does the same but for staff users without a role.

[skip changelog]

Fixes mysociety/societyworks#5550