### PR TITLE
FAQ: point downtime guidance at the status page, not Twitter

### DIFF
--- a/templates/web/fixmystreet.com/about/faq-en-gb.html
+++ b/templates/web/fixmystreet.com/about/faq-en-gb.html
@@ -152,7 +152,7 @@ on this and you’ll be immediately unsubscribed.
 <dt>The site isn’t working</dt>
 <dd>
 <p>First, check your internet connection is ok. You may also like to check our
-<a href="https://twitter.com/fixmystreet">Twitter feed</a>, where we announce
+<a href="https://status.societyworks.org/">status page</a>, where we announce
 any known issues or downtime.
 <p>If there are no problems at your end or ours, please wait a few minutes, and
 then try again.


### PR DESCRIPTION
Per @SarahmySociety's #5675. The "site isn't working" section of the FAQ sent users to the FixMyStreet Twitter (now X) account to check for known issues. SocietyWorks has a status page at https://status.societyworks.org/ that's a better fit, so swap the link and wording exactly as suggested in the issue.

Closes #5675.