### PR TITLE
Fix a few comment/doc typos

### DIFF
--- a/docs/_includes/admin-tasks-content.md
+++ b/docs/_includes/admin-tasks-content.md
@@ -693,7 +693,7 @@ that, a form by which you can create new ones (if you have lots of categories yo
 Input a title for the category, and the email address to which reports in that category should be
 forwarded. 
 
-You can also choose to assign a category to one or more parent category/ies. For example, you may group a 'Fallen tree' category under a parent caregory of 'Parks maintenance' and also under 'Public right of way', but note that the report will go to the email address provided, so if certain instances of problems need to go certain addresses, then create a seperate category. 
+You can also choose to assign a category to one or more parent category/ies. For example, you may group a 'Fallen tree' category under a parent category of 'Parks maintenance' and also under 'Public right of way', but note that the report will go to the email address provided, so if certain instances of problems need to go certain addresses, then create a separate category. 
 
 <img loading="lazy" alt="Categories can be grouped under parent categories" src="/assets/img/pro-user-guide/Adding a new category.png" class="admin-screenshot" />
 

--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -399,7 +399,7 @@ sub moderating_user_name {
 
     $belongs_to_body = $user->belongs_to_body( $bodies );
 
-Returns true if the user belongs to the arrayref or comma seperated list of body ids passed in
+Returns true if the user belongs to the arrayref or comma separated list of body ids passed in
 
 =cut
 

--- a/t/app/controller/waste.t
+++ b/t/app/controller/waste.t
@@ -1912,7 +1912,7 @@ FixMyStreet::override_config {
         $mech->content_contains('£20.00');
 
         $mech->submit_form_ok({ with_fields => { tandc => 1 } });
-        is $mech->uri->path, '/waste/12345/garden', 'no redirect occured';
+        is $mech->uri->path, '/waste/12345/garden', 'no redirect occurred';
         $mech->content_contains('Payment failed: ERROR');
 
         $pay->mock(pay => sub {


### PR DESCRIPTION
Three spelling fixes in non-user-visible-ish copy: 'seperated' in the `User#belongs_to_body` doc comment, 'occured' in a waste controller test description, and 'caregory'/'seperate' in the admin-tasks include. No behavioural changes.