### PR TITLE
Don't redirect inspector form back to /report/update referer

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -440,7 +440,12 @@ sub inspect : Private {
     }
 
     if ($c->user->has_body_permission_to('planned_reports')) {
-        $c->stash->{post_inspect_url} = $c->req->referer;
+        my $referer = $c->req->referer;
+        # /report/update is POST-only - if the inspector form then redirects
+        # back to it as a GET, the user sees a 404 (see #4845).
+        if ($referer && $referer !~ m{/report/update$}) {
+            $c->stash->{post_inspect_url} = $referer;
+        }
     }
 
     if ($c->user->has_body_permission_to('report_edit_priority') or


### PR DESCRIPTION
Closes #4845.

If a user with `planned_reports` makes a normal update on a report and then submits the inspector form, the stored `post_inspect_url` is the referer from when they originally loaded the report page, which after a normal update is `/report/update`. Following that redirect as a GET hits `load_problem` with no `id` param, which 404s.

The dropdown @dracos described on the original ticket is to ignore the referer when the previous page was a POST. We can't know that for sure from a GET request, but `/report/update` is the path that's actually causing the issue, so skip the referer when it's that path. The redirect then falls through to the default `/around` lookup at the report's coordinates, which is what users would get if they'd come to the inspector form directly.