### PR TITLE
Added vertical spacing to `#key-tools`

### DIFF
--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -961,7 +961,7 @@ html.mobile.js-nav-open #js-menu-open-modal {
 
 #key-tools {
   @include list-reset-soft;
-  margin-bottom: 1em;
+  margin: 1em 0;
   padding: 0 1em;
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
Fixes the lack of space between the heading and the `key-tools` element on mobile

<img width="368" height="794" alt="Screenshot 2026-05-18 at 10 22 40" src="https://github.com/user-attachments/assets/bd4b966f-602c-48e0-b1f7-79bbbf9be398" />

[skip changelog]
