### PR TITLE
[Bexley] Spot amendment failures, allow cancellation after subscription end

### DIFF
--- a/bin/bexley/check-dd-errors
+++ b/bin/bexley/check-dd-errors
@@ -46,8 +46,9 @@ my @kinds = (
         retry => sub {
             my ($p, $info) = @_;
             my $amount = $info->{context}{amount} or return;
+            my $ref = $info->{context}{ref} or return;
             my $id = $p->id;
-            return qq{bin/cron-wrapper perl -MFixMyStreet::DB -MFixMyStreet::Cobrand -e 'my \$r = FixMyStreet::DB->resultset("Problem")->find($id); my \$i = FixMyStreet::Cobrand->get_class_for_moniker("bexley")->new->get_dd_integration; \$i->amend_plan({ orig_sub => \$r, amount => "$amount" });'};
+            return qq{bin/cron-wrapper perl -MFixMyStreet::DB -MFixMyStreet::Cobrand -e 'my \$r = FixMyStreet::DB->resultset("Problem")->find($id); my \$i = FixMyStreet::Cobrand->get_class_for_moniker("bexley")->new->get_dd_integration; \$i->amend_plan({ dd_reference => "$ref", report => \$r, amount => "$amount" });'};
         },
     },
     {
@@ -56,16 +57,16 @@ my @kinds = (
             my ($p, $info) = @_;
             my $amount = $info->{context}{amount} or return;
             my $date   = $info->{context}{date}   or return;
+            my $ref = $info->{context}{ref} or return;
             my $id = $p->id;
-            return qq{bin/cron-wrapper perl -MDateTime::Format::ISO8601 -MFixMyStreet::DB -MFixMyStreet::Cobrand -e 'my \$r = FixMyStreet::DB->resultset("Problem")->find($id); my \$i = FixMyStreet::Cobrand->get_class_for_moniker("bexley")->new->get_dd_integration; \$i->one_off_payment({ orig_sub => \$r, amount => "$amount", date => DateTime::Format::ISO8601->parse_datetime("$date") });'};
+            return qq{bin/cron-wrapper perl -MDateTime::Format::ISO8601 -MFixMyStreet::DB -MFixMyStreet::Cobrand -e 'my \$r = FixMyStreet::DB->resultset("Problem")->find($id); my \$i = FixMyStreet::Cobrand->get_class_for_moniker("bexley")->new->get_dd_integration; \$i->one_off_payment({ dd_reference => "$ref", report => \$r, amount => "$amount", date => DateTime::Format::ISO8601->parse_datetime("$date") });'};
         },
     },
 );
 
 my $reports = $cobrand->problems->search({
     category => 'Garden Subscription',
-    title => ['Garden Subscription - New', 'Garden Subscription - Renew'],
-    state => { '!=' => 'hidden' },
+    state => { -not_in => ['unconfirmed','hidden','partial'] },
     -bool => \"extra->'direct_debit_errors' IS NOT NULL",
 });
 

--- a/perllib/FixMyStreet/App/Form/Waste/Garden/Verify/Bexley.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Garden/Verify/Bexley.pm
@@ -25,6 +25,7 @@ sub customer_reference {
                 if ( $ref eq $current_subscription->{customer_ref} ) {
                     $form->saved_data->{customer_external_ref}
                         = $current_subscription->{customer_external_ref};
+                    $form->saved_data->{verified_by} = 'reference';
 
                     $form->saved_data->{name}
                         = $current_subscription->{customer_first_name} . ' '
@@ -116,6 +117,7 @@ sub about_you {
 
                 $form->saved_data->{customer_external_ref}
                     = $current_subscription->{customer_external_ref};
+                $form->saved_data->{verified_by} = 'name';
 
                 return $args{next_page};
 

--- a/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
@@ -313,6 +313,8 @@ sub waste_garden_sub_params {
     my $c = $self->{c};
     my $srv = $self->garden_current_subscription;
 
+    $c->set_param('verified_by', $data->{verified_by}) if $data->{verified_by};
+
     if ( $data->{category} eq 'Cancel Garden Subscription' ) {
         my $parser = DateTime::Format::Strptime->new( pattern => '%d/%m/%Y' );
         my $due_date_str = $parser->format_datetime( DateTime->now->add(days => 1) );

--- a/perllib/Integrations/AccessPaySuite.pm
+++ b/perllib/Integrations/AccessPaySuite.pm
@@ -338,7 +338,7 @@ sub amend_plan {
 
     if (ref $resp eq 'HASH' && $resp->{error}) {
         $self->_record_dd_failure($args->{report}, 'amend', $resp->{error},
-            { amount => $args->{amount} });
+            { amount => $args->{amount}, ref => $args->{dd_reference} });
         return;
     }
 
@@ -380,7 +380,7 @@ sub one_off_payment {
 
     if (ref $resp eq 'HASH' && $resp->{error}) {
         $self->_record_dd_failure($args->{report}, 'one_off', $resp->{error},
-            { amount => $args->{amount}, date => $args->{date}->iso8601 });
+            { amount => $args->{amount}, date => $args->{date}->iso8601, ref => $args->{dd_reference} });
         return;
     }
 

--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -32,6 +32,7 @@ create_contact({ category => 'Garden Subscription', email => 'garden@example.com
     { code => 'new_containers', required => 1, automated => 'hidden_field' },
     { code => 'total_containers', required => 1, automated => 'hidden_field' },
     { code => 'customer_external_ref', required => 1, automated => 'hidden_field' },
+    { code => 'verified_by', required => 0, automated => 'hidden_field' },
     { code => 'type', required => 1, automated => 'hidden_field' },
     { code => 'payment', required => 1, automated => 'hidden_field' },
     { code => 'payment_method', required => 1, automated => 'hidden_field' },
@@ -41,6 +42,7 @@ create_contact({ category => 'Garden Subscription', email => 'garden@example.com
 create_contact(
     { category => 'Cancel Garden Subscription', email => 'garden_cancel@example.com' },
     { code => 'customer_external_ref', required => 1, automated => 'hidden_field' },
+    { code => 'verified_by', required => 0, automated => 'hidden_field' },
     { code => 'due_date', required => 1, automated => 'hidden_field' },
     { code => 'reason', required => 1, automated => 'hidden_field' },
     { code => 'fixmystreet_id', required => 1, automated => 'server' },
@@ -613,6 +615,7 @@ FixMyStreet::override_config {
                         new_bins     => 2,
                         bins_wanted  => 4,
                         customer_external_ref => 'CUSTOMER_123',
+                        verified_by => 'name',
                     );
                     is $modify_report->get_extra_field_value('type'), 'amend',
                         'correct report type';
@@ -685,6 +688,7 @@ FixMyStreet::override_config {
                         bins_wanted  => 1,
                         state => 'confirmed',
                         customer_external_ref => 'CUSTOMER_123',
+                        verified_by => 'reference',
                     );
                     is $modify_report->get_extra_field_value('type'), 'amend',
                         'correct report type';
@@ -828,6 +832,7 @@ FixMyStreet::override_config {
                 is $modify_report->get_extra_field_value('total_containers'), 3, 'Amend report: correct total_containers';
                 is $modify_report->get_extra_field_value('type'), 'amend', 'Amend report: correct type';
                 is $modify_report->get_extra_field_value('customer_external_ref'), 'CUSTOMER_123', 'Amend report: correct customer_external_ref';
+                is $modify_report->get_extra_field_value('verified_by'), 'reference';
                 is $modify_report->state, 'confirmed',
                     'Amend report: state correct (confirmed for DD amend)';
 
@@ -1174,6 +1179,7 @@ FixMyStreet::override_config {
                         new_bins     => 1,
                         bins_wanted  => 3,
                         customer_external_ref => 'CUSTOMER_123',
+                        verified_by => 'name',
                     );
                     is $renew_report->uprn, $uprn;
                     is $renew_report->get_extra_field_value('payment'), $ggw_cost_first + 2 * $ggw_cost;
@@ -1243,6 +1249,7 @@ FixMyStreet::override_config {
                         new_bins     => -1,
                         bins_wanted  => 1,
                         customer_external_ref => 'CUSTOMER_123',
+                        verified_by => 'reference',
                     );
                     is $renew_report->name, 'Ferrety Wright';
                     is $renew_report->user->email, 'hmm@example.org';
@@ -1313,6 +1320,7 @@ FixMyStreet::override_config {
                         new_bins     => 0,
                         bins_wanted  => 2,
                         customer_external_ref => 'CUSTOMER_123',
+                        verified_by => 'reference',
                         ref_type => 'apn',
                     );
                     is $renew_report->name, 'Ferrety Wright';
@@ -1426,6 +1434,7 @@ FixMyStreet::override_config {
                         new_bins     => -1,
                         bins_wanted  => 1,
                         customer_external_ref => 'CUSTOMER_123',
+                        verified_by => 'reference',
                         renew_as_new_subscription => '',
                     );
                     is $renew_report->uprn, $uprn;
@@ -1600,6 +1609,7 @@ FixMyStreet::override_config {
                             new_bins     => 0,
                             bins_wanted  => 2,
                             customer_external_ref => 'CUSTOMER_123',
+                            verified_by => 'reference',
                             renew_as_new_subscription => 1,
                         );
 
@@ -1649,6 +1659,7 @@ FixMyStreet::override_config {
                             new_bins     => 0,
                             bins_wanted  => 2,
                             customer_external_ref => 'CUSTOMER_123',
+                            verified_by => 'name',
                             renew_as_new_subscription => 1,
                         );
 
@@ -2191,6 +2202,7 @@ FixMyStreet::override_config {
                 'cancellation report auto-confirmed';
             is $report->get_extra_field_value('customer_external_ref'),
                 'CUSTOMER_123';
+            is $report->get_extra_field_value('verified_by'), 'name';
             is $report->get_extra_field_value('due_date'),
                 $tomorrow;
             is $report->get_extra_field_value('reason'),
@@ -2262,6 +2274,7 @@ FixMyStreet::override_config {
                 'cancellation report auto-confirmed';
             is $report->get_extra_field_value('customer_external_ref'),
                 'CUSTOMER_123';
+            is $report->get_extra_field_value('verified_by'), 'reference';
             is $report->get_extra_field_value('due_date'),
                 $tomorrow;
             is $report->get_extra_field_value('reason'),
@@ -2478,6 +2491,7 @@ FixMyStreet::override_config {
         # Verify the report details
         ok $cancel_report, 'Cancellation report created';
         is $cancel_report->get_extra_field_value('customer_external_ref'), 'CUSTOMER_123', 'Customer reference set correctly';
+        is $cancel_report->get_extra_field_value('verified_by'), 'reference';
         is $cancel_report->get_extra_field_value('reason'), 'Other: No longer needed', 'Reason set correctly';
 
         # Verify the archive_contract was called with the right parameters
@@ -2870,6 +2884,7 @@ FixMyStreet::override_config {
         is $report->category, "Garden Subscription", "Correct category";
         is $report->get_extra_field_value('payment_method'), 'direct_debit', "Correct payment method";
         is $report->get_extra_field_value('customer_external_ref'), 'CUSTOMER_123', "Customer reference preserved";
+        is $report->get_extra_field_value('verified_by'), 'reference';
         is $report->get_extra_field_value('type'), 'renew', "Marked as renewal";
 
         is $report->get_extra_metadata('direct_debit_customer_id'), 'CUSTOMER123', 'Correct customer ID';
@@ -3407,6 +3422,7 @@ sub check_extra_data_pre_confirm {
         state => 'unconfirmed',
         type => 'New',
         customer_external_ref => '',
+        verified_by => '',
         renew_as_new_subscription => '',
 
         # Quantities
@@ -3426,6 +3442,7 @@ sub check_extra_data_pre_confirm {
     is $report->get_extra_field_value('new_containers'), $params{new_bins}, 'correct new_containers';
     is $report->get_extra_field_value('total_containers'), $params{bins_wanted}, 'correct total_containers';
     is $report->get_extra_field_value('customer_external_ref'), $params{customer_external_ref}, 'correct customer ref';
+    is $report->get_extra_field_value('verified_by'), $params{verified_by}, 'correct verified_by';
     is $report->get_extra_field_value('renew_as_new_subscription'), $params{renew_as_new_subscription}, 'correct renew_as_new_subscription flag';
 
     is $report->state, $params{state}, 'report state correct';

--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -1375,9 +1375,9 @@ FixMyStreet::override_config {
                     unlike $mech->content,
                         qr/Change your brown wheelie bin subscription/,
                         'cannot amend subscription';
-                    unlike $mech->content,
+                    like $mech->content,
                         qr/Cancel your brown wheelie bin subscription/,
-                        'cannot cancel';
+                        'can still cancel';
                     unlike $mech->content, qr/Renew subscription today/,
                         '"Renew today" notification box not shown';
                     like $mech->content, qr/18 January 2024, subscription overdue. \(Do not contact us to cancel. Your subscription will automatically cancel unless you renew\)/,
@@ -1554,9 +1554,9 @@ FixMyStreet::override_config {
                     unlike $mech->content,
                         qr/Change your brown wheelie bin subscription/,
                         'cannot amend subscription';
-                    unlike $mech->content,
+                    like $mech->content,
                         qr/Cancel your brown wheelie bin subscription/,
-                        'cannot cancel';
+                        'can still cancel';
                     unlike $mech->content, qr/Renew subscription today/,
                         '"Renew today" notification box not shown';
                     like $mech->content, qr/1 November 2023, subscription overdue. \(Do not contact us to cancel. Your subscription will automatically cancel unless you renew\)/,

--- a/templates/web/base/waste/_services_garden_current.html
+++ b/templates/web/base/waste/_services_garden_current.html
@@ -44,7 +44,9 @@
 [% END %]
 [% END %]
 
-[% IF NOT pending_cancellation AND NOT unit.garden_overdue %]
+[% IF NOT pending_cancellation  # Not already cancelled in some manner %]
+
+  [% IF NOT unit.garden_overdue  # Subscription is still active %]
     [% IF NOT unit.garden_due AND NOT waste_features.garden_modify_disabled AND c.cobrand.waste_show_garden_modify(unit) %]
         <form method="post" action="[% c.uri_for_action('waste/garden/modify', [ property.id ]) %]">
           <input type="hidden" name="token" value="[% csrf_token %]">
@@ -59,16 +61,22 @@
           If you are looking to pay for another garden waste service, please <a href="https://customerportal.brent.gov.uk/contact-centre-anonymous/cc-enquirytype-anonymous/?sid=4933b2f4-dc86-e911-a8f4-00224801ab35&sname=Waste">contact our Customer Services Team</a>.
         </p>
     [% END %]
-    [% IF ( c.cobrand.call_hook('waste_garden_allow_cancellation') == 'staff' AND is_staff ) OR c.cobrand.call_hook('waste_garden_allow_cancellation') == 'all' %]
-        <form method="post" action="[% c.uri_for_action('waste/garden/cancel', [ property.id ]) %]">
-          <input type="hidden" name="token" value="[% csrf_token %]">
-          <input type="submit" value="Cancel your [% unit.service_name FILTER lower %] subscription" class="waste-service-descriptor waste-service-link">
-        </form>
-    [% END %]
 
     [% IF c.cobrand.moniker == 'merton' AND is_staff %]
     <!--
         <a href="[% c.uri_for_action('waste/enquiry', [ property.id ]) %]?category=Garden+Subscription+Address+Change&amp;service_id=[% unit.service_id %]" class="waste-service-link waste-service-descriptor">Report an address change</a>
     -->
     [% END %]
+
+  [% END %]
+
+  [% IF NOT unit.garden_overdue OR c.cobrand.moniker == 'bexley' # Either active subscription, or Bexley still lets you cancel when overdue %]
+    [% IF ( c.cobrand.call_hook('waste_garden_allow_cancellation') == 'staff' AND is_staff ) OR c.cobrand.call_hook('waste_garden_allow_cancellation') == 'all' %]
+        <form method="post" action="[% c.uri_for_action('waste/garden/cancel', [ property.id ]) %]">
+          <input type="hidden" name="token" value="[% csrf_token %]">
+          <input type="submit" value="Cancel your [% unit.service_name FILTER lower %] subscription" class="waste-service-descriptor waste-service-link">
+        </form>
+    [% END %]
+  [% END %]
+
 [% END %]


### PR DESCRIPTION
[skip changelog]
For FD-7016 (amend failures) and FD-7008 (allowing cancel after sub end) and FD-6992 (storing verified method).