### PR TITLE
[Gloucestershire] Don't allow updates on defects fetched from Confirm

### DIFF
--- a/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
+++ b/perllib/FixMyStreet/Cobrand/FixMyStreet.pm
@@ -455,6 +455,9 @@ around updates_disallowed => sub {
     if ($problem->to_body_named('Oxfordshire')) {
         return FixMyStreet::Cobrand::Oxfordshire->new({ c => $self->{c} })->updates_disallowed_override($problem, $result);
     }
+    if ($problem->to_body_named('Gloucestershire')) {
+        return FixMyStreet::Cobrand::Gloucestershire->new({ c => $self->{c} })->updates_disallowed_override($problem, $result);
+    }
     return $result
 };
 

--- a/perllib/FixMyStreet/Cobrand/Gloucestershire.pm
+++ b/perllib/FixMyStreet/Cobrand/Gloucestershire.pm
@@ -234,6 +234,29 @@ sub is_defect {
     return $p->external_id && $p->external_id =~ /^JOB_/;
 }
 
+=head2 updates_disallowed
+
+Don't allow updates on defects fetched from Confirm
+
+=cut
+
+around updates_disallowed => sub {
+    my ($orig, $self, $problem) = @_;
+    my $result = $self->$orig($problem);
+    return $self->updates_disallowed_override($problem, $result);
+};
+
+
+sub updates_disallowed_override {
+    my ($self, $problem, $result) = @_;
+
+    # Disallow updates on defects imported from Confirm.
+    return 1 if $self->is_defect($problem);
+
+    return $result;
+
+}
+
 =head2 pin_colour
 
 Green for anything completed or closed, yellow for the rest,

--- a/t/cobrand/gloucestershire.t
+++ b/t/cobrand/gloucestershire.t
@@ -416,6 +416,36 @@ FixMyStreet::override_config {
                 );
             }
         };
+
+        subtest 'For defects imported from Confirm' => sub {
+            my ($job_report) = $mech->create_problems_for_body(
+                1,
+                $body->id,
+                'Confirm job report',
+                {   cobrand     => 'gloucestershire',
+                    user        => $standard_user_1,
+                    state       => 'confirmed',
+                    external_id => 'JOB_12345',
+                },
+            );
+
+            note 'Original reporter';
+            $mech->log_in_ok( $standard_user_1->email );
+            $mech->get( '/report/' . $job_report->id );
+            $mech->content_lacks(
+                'name="update" class="form-control" id="form_update"',
+                'Update textbox not shown for original reporter',
+            );
+
+            note 'Staff';
+            $mech->log_in_ok( $staff_user->email );
+            $mech->get( '/report/' . $job_report->id );
+            $mech->content_lacks(
+                'name="update" class="form-control" id="form_update"',
+                'Update textbox not shown for staff',
+            );
+        };
+
     }
 };
 


### PR DESCRIPTION
open311-adapter doesn't know what to do with these updates, as there is no field on Confirm Jobs/Defects for them.

[skip changelog]