### PR TITLE
[Bulky] Make sure zero-payment bulky is confirmed.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
@@ -420,6 +420,12 @@ sub process_bulky_data : Private {
         $c->forward('/waste/pay_process', [ 'bulky', $payment_method, $data ]);
     } else {
         $c->forward('/waste/add_report', [ $data ]) or return;
+        # If we auto confirm reports, and we're not amending (which does its own confirmation)
+        # then we want to call confirm_subscription to e.g. add a 'payment confirmed' update
+        my $report = $c->stash->{report};
+        if ($c->cobrand->call_hook('waste_auto_confirm_report', $report) && !$c->stash->{amending_booking}) {
+            $c->forward('/waste/confirm_subscription', ['free'])
+        }
     }
     return 1;
 }

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -1625,6 +1625,8 @@ sub waste_confirm_payment {
 
     return if $self->waste_check_payment_state;
 
+    $self->discard_changes; # Make sure e.g. confirmed timestamp picked up
+
     my $already_confirmed;
     if ($self->category eq 'Bulky collection' || $self->category eq 'Small items collection') {
         $already_confirmed = $cobrand->bulky_send_before_payment;

--- a/t/app/controller/waste_merton_bulky.t
+++ b/t/app/controller/waste_merton_bulky.t
@@ -1214,6 +1214,48 @@ FixMyStreet::override_config {
         $echo->mock( 'GetEventsForObject', sub { [] } );
     };
 
+    subtest 'Bulky goods booking with zero payment' => sub {
+        FixMyStreet::Script::Reports::send();
+        $mech->clear_emails_ok;
+
+        my $extra = $body->get_extra_metadata('wasteworks_config');
+        $extra->{base_price} = 0;
+        $extra->{band1_price} = 0;
+        $body->set_extra_metadata(wasteworks_config => $extra);
+        $body->update;
+
+        $mech->get_ok('/waste/12345/bulky');
+        $mech->submit_form_ok;
+        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
+        $mech->submit_form_ok({ with_fields => { chosen_date => '2023-07-01T00:00:00;reserveA==;2023-06-25T10:10:00' } });
+        $mech->submit_form_ok({ form_number => 1, fields => { 'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath' } });
+        $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
+        $mech->content_contains('3 items requested for collection');
+        $mech->content_contains('£0.00');
+        $mech->submit_form_ok({ with_fields => { tandc => 1 } });
+
+        $mech->content_contains('Bulky collection booking confirmed');
+        $mech->content_lacks('payment reference');
+
+        my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+        is $report->category, 'Bulky collection', 'correct category on report';
+        is $report->get_extra_field_value('payment'), '';
+        is $report->state, 'confirmed', 'report confirmed';
+
+        is $report->comments->count, 1;
+        my $update = $report->comments->first;
+        is $update->state, 'confirmed';
+        is $update->text, 'Payment confirmed, reference free, amount £0.00';
+        is $update->get_extra_metadata('fms_extra_payments'), 'free|0.00';
+
+        my $confirmation_email_html = $mech->get_html_body_from_email();
+        unlike $confirmation_email_html, qr/Total cost/;
+
+        FixMyStreet::Script::Reports::send();
+        $mech->email_count_is(1); # Only email is 'email' to council
+        $mech->clear_emails_ok;
+    };
+
     # subtest 'Bulky goods cheque payment by contact centre' => sub {
     #     $mech->log_in_ok($contact_centre_user->email);
     #     $mech->get_ok('/waste/12345/bulky');


### PR DESCRIPTION
Staff payments have a payment amount and so handle confirmation through pay_process/pay_skip, but a public zero payment would create the report but not e.g. send logged email or leave a required confirmation update. FD-7060