### PR TITLE
[TfL] Treat multiple location licences the same.

### DIFF
--- a/perllib/FixMyStreet/App/Form/Licence/Banner.pm
+++ b/perllib/FixMyStreet/App/Form/Licence/Banner.pm
@@ -47,24 +47,17 @@ has_page location_1 => (
     },
 );
 
+with 'FixMyStreet::App::Form::Licence::Fields::MultipleLocations';
 for my $page (2..5) {
-    my $next = 'dates';
-    my $fields = ["building_name_number_$page", "street_name_$page", "borough_$page", "postcode_$page", 'continue'];
-    if ($page < 5) {
-        $next = sub { $_[1]->{add_another} ? 'location_' . ($page+1) : 'dates' };
-        push @$fields, 'add_another';
-    }
-    has_page "location_$page" => (
-        step_number => 1,
-        fields => $fields,
-        title => "Location of the banners ($page)",
-        intro => 'location.html',
-        next => $next,
-        tags => { hide => sub { !$_[0]->form->saved_data->{"building_name_number_$page"} } },
-    );
+    has_page "location_$page" => location_page_fields({
+        page => $page,
+        pages => 5,
+        title => 'Location of the banners',
+        template => 'banner/location.html',
+    });
     has_field "building_name_number_$page" => ( type => 'Text', label => 'Building name / number', required => 1 );
-    has_field "street_name_$page" => ( type => 'Text', label => 'Street name', required => 1 );
-    has_field "borough_$page" => ( type => 'Text', label => 'Borough', required => 1 );
+    has_field "street_name_$page" => ( type => 'Text', label => 'Street name', disabled => 1 );
+    has_field "borough_$page" => ( type => 'Text', label => 'Borough', disabled => 1 );
     has_field "postcode_$page" => ( type => 'Text', label => 'Postcode', required => 1 );
 }
 

--- a/perllib/FixMyStreet/App/Form/Licence/ColumnAttachments.pm
+++ b/perllib/FixMyStreet/App/Form/Licence/ColumnAttachments.pm
@@ -49,28 +49,14 @@ has_page location_1 => (
     },
 );
 
-foreach my $page (2..5) {
-    my $next = 'dates';
-    my $fields = ["building_name_number_$page", "street_name_$page", "borough_$page", "postcode_$page", 'continue'];
-    if ($page < 5) {
-        $next = sub { $_[1]->{add_another} ? 'location_' . ($page+1) : 'dates' };
-        push @$fields, 'add_another';
-    }
-    has_page "location_$page" => (
-        step_number => 1,
-        fields => $fields,
-        update_field_list => sub {
-            my $data = $_[0]->saved_data;
-            return {
-                "street_name_$page" => { default => $data->{street_name} },
-                "borough_$page" => { default => $data->{borough} },
-            }
-        },
-        title => "Location of the Column Attachments ($page)",
-        intro => 'column-attachments/location.html',
-        next => $next,
-        tags => { hide => sub { !$_[0]->form->saved_data->{"building_name_number_$page"} } },
-    );
+with 'FixMyStreet::App::Form::Licence::Fields::MultipleLocations';
+for my $page (2..5) {
+    has_page "location_$page" => location_page_fields({
+        page => $page,
+        pages => 5,
+        title => 'Location of the Column Attachments',
+        template => 'column-attachments/location.html',
+    });
     has_field "building_name_number_$page" => ( type => 'Text', label => 'Building name / number', required => 1 );
     has_field "street_name_$page" => ( type => 'Text', label => 'Street name', disabled => 1 );
     has_field "borough_$page" => ( type => 'Text', label => 'Borough', disabled => 1 );

--- a/perllib/FixMyStreet/App/Form/Licence/Fields/MultipleLocations.pm
+++ b/perllib/FixMyStreet/App/Form/Licence/Fields/MultipleLocations.pm
@@ -1,0 +1,43 @@
+package FixMyStreet::App::Form::Licence::Fields::MultipleLocations;
+
+use utf8;
+use HTML::FormHandler::Moose::Role;
+
+=head1 NAME
+
+FixMyStreet::App::Form::Licence::Fields::MultipleLocations - Further location pages for licence forms
+
+=head1 DESCRIPTION
+
+Provides further pages of location fields for TfL licence forms.
+
+=cut
+
+sub location_page_fields {
+    my $args = shift;
+    my $page = $args->{page};
+    my $next = 'dates';
+    my $fields = ["building_name_number_$page", "street_name_$page", "borough_$page", "postcode_$page", 'continue'];
+    if ($page < $args->{pages}) {
+        $next = sub { $_[1]->{add_another} ? 'location_' . ($page+1) : 'dates' };
+        push @$fields, 'add_another';
+    }
+
+    return (
+        step_number => 1,
+        fields => $fields,
+        update_field_list => sub {
+            my $data = $_[0]->saved_data;
+            return {
+                "street_name_$page" => { default => $data->{street_name} },
+                "borough_$page" => { default => $data->{borough} },
+            }
+        },
+        title => "$args->{title} ($page)",
+        intro => $args->{template},
+        next => $next,
+        tags => { hide => sub { !$_[0]->form->saved_data->{"building_name_number_$page"} } },
+    );
+}
+
+1;

--- a/perllib/FixMyStreet/App/Form/Licence/TemporaryTrafficSigns.pm
+++ b/perllib/FixMyStreet/App/Form/Licence/TemporaryTrafficSigns.pm
@@ -47,24 +47,17 @@ has_page location_1 => (
     },
 );
 
+with 'FixMyStreet::App::Form::Licence::Fields::MultipleLocations';
 for my $page (2..10) {
-    my $next = 'dates';
-    my $fields = ["building_name_number_$page", "street_name_$page", "borough_$page", "postcode_$page", 'continue'];
-    if ($page < 10) {
-        $next = sub { $_[1]->{add_another} ? 'location_' . ($page+1) : 'dates' };
-        push @$fields, 'add_another';
-    }
-    has_page "location_$page" => (
-        step_number => 1,
-        fields => $fields,
-        title => "Location of the temporary traffic signs ($page)",
-        intro => 'location.html',
-        next => $next,
-        tags => { hide => sub { !$_[0]->form->saved_data->{"building_name_number_$page"} } },
-    );
+    has_page "location_$page" => location_page_fields({
+        page => $page,
+        pages => 10,
+        title => 'Location of the temporary traffic signs',
+        template => 'temporary-traffic-signs/location.html',
+    });
     has_field "building_name_number_$page" => ( type => 'Text', label => 'Building name / number', required => 1 );
-    has_field "street_name_$page" => ( type => 'Text', label => 'Street name', required => 1 );
-    has_field "borough_$page" => ( type => 'Text', label => 'Borough', required => 1 );
+    has_field "street_name_$page" => ( type => 'Text', label => 'Street name', disabled => 1 );
+    has_field "borough_$page" => ( type => 'Text', label => 'Borough', disabled => 1 );
     has_field "postcode_$page" => ( type => 'Text', label => 'Postcode', required => 1 );
 }
 

--- a/t/app/controller/licence/banner.t
+++ b/t/app/controller/licence/banner.t
@@ -37,11 +37,18 @@ subtest 'Banner form submission - smoke test' => sub {
         $mech->submit_form_ok({ button => 'start' });
 
         # Location page
-        $mech->submit_form_ok({ with_fields => {
+        $mech->submit_form_ok({ button => 'add_another', with_fields => {
             street_name => 'Test Street',
             building_name_number => '123',
             borough => 'camden',
             postcode => 'NW1 1AA',
+        }});
+        $mech->content_contains('Location of the banners (2)');
+        $mech->submit_form_ok({ with_fields => {
+            street_name_2 => 'Test Street 2',
+            building_name_number_2 => '123',
+            borough_2 => 'camden',
+            postcode_2 => 'NW1 1AA',
         }});
 
         # Dates page (using dynamic dates calculated at test start)

--- a/t/app/controller/licence/column-attachments.t
+++ b/t/app/controller/licence/column-attachments.t
@@ -27,6 +27,7 @@ subtest 'Column attachments form submission - smoke test' => sub {
         PHONE_COUNTRY => 'GB',
         COBRAND_FEATURES => {
             licencing_forms => { tfl => 1 },
+            licencing_payment_links => { tfl => { 'column-attachments' => 'LINK' } },
         },
         PHOTO_STORAGE_OPTIONS => { UPLOAD_DIR => $UPLOAD_DIR },
     }, sub {
@@ -121,10 +122,7 @@ subtest 'Column attachments form submission - smoke test' => sub {
         }}, 'Upload page');
 
         # Payment page
-        TODO: {
-            local $TODO = "do not have link details yet";
-            $mech->content_contains('1S1H8a', 'Correct payment link');
-        }
+        $mech->content_contains('LINK', 'Correct payment link');
         $mech->submit_form_ok({ with_fields => {
             payment_amount => 100,
             payment_transaction_id => 'TEST-TRANSACTION-12345',

--- a/t/app/controller/licence/landscaping.t
+++ b/t/app/controller/licence/landscaping.t
@@ -27,6 +27,7 @@ subtest 'Landscaping form submission - smoke test' => sub {
         PHONE_COUNTRY => 'GB',
         COBRAND_FEATURES => {
             licencing_forms => { tfl => 1 },
+            licencing_payment_links => { tfl => { landscaping => 'LINK2' } },
         },
         PHOTO_STORAGE_OPTIONS => { UPLOAD_DIR => $UPLOAD_DIR },
     }, sub {
@@ -114,10 +115,7 @@ subtest 'Landscaping form submission - smoke test' => sub {
         }}, 'Upload page');
 
         # Payment page
-        TODO: {
-            local $TODO = "do not have link details yet";
-            $mech->content_contains('1S1H8a', 'Correct payment link');
-        }
+        $mech->content_contains('LINK2', 'Correct payment link');
         $mech->submit_form_ok({ with_fields => {
             payment_amount => 100,
             payment_transaction_id => 'TEST-TRANSACTION-12345',

--- a/t/app/controller/licence/temporary-traffic-signs.t
+++ b/t/app/controller/licence/temporary-traffic-signs.t
@@ -43,6 +43,7 @@ subtest 'Temporary Traffic Signs form submission - smoke test' => sub {
             borough => 'camden',
             postcode => 'NW1 1AA',
         }});
+        $mech->content_contains('Location of the temporary traffic signs (2)');
 
         $mech->submit_form_ok({ with_fields => {
             street_name_2 => 'Test Street 2',

--- a/templates/web/base/licence/banner/location.html
+++ b/templates/web/base/licence/banner/location.html
@@ -1,0 +1,10 @@
+<p>
+Please ensure you have checked the location is on the TfL Road Network using the following map:
+<a href="https://tfl.maps.arcgis.com/apps/webappviewer/index.html?id=99bc8bbbe8c94af291f5a5bfc77a00dd" target="_blank" rel="noopener">TfL Road Network boundaries</a>.
+</p>
+
+<p>
+Multiple banners must be located within the same vicinity.
+If not, a new licence will be required.
+</p>
+

--- a/templates/web/base/licence/temporary-traffic-signs/location.html
+++ b/templates/web/base/licence/temporary-traffic-signs/location.html
@@ -1,0 +1,10 @@
+<p>
+Please ensure you have checked the location is on the TfL Road Network using the following map:
+<a href="https://tfl.maps.arcgis.com/apps/webappviewer/index.html?id=99bc8bbbe8c94af291f5a5bfc77a00dd" target="_blank" rel="noopener">TfL Road Network boundaries</a>.
+</p>
+
+<p>
+Multiple temporary traffic signs must be located within the same vicinity.
+If not, a new licence will be required.
+</p>
+


### PR DESCRIPTION
Like column attachments, banners and temporary traffic signs will now also lock the street name / borough.
Factor this out to a shared role. [skip changelog] FD-7071