### PR TITLE
Improved mobile spacing for navbar items

### DIFF
--- a/web/cobrands/aberdeenshire/base.scss
+++ b/web/cobrands/aberdeenshire/base.scss
@@ -37,7 +37,7 @@ a {
 /* NAVBAR */
 #site-logo {
   background-image: url("/cobrands/aberdeenshire/images/aberdeenshire-logo.svg");
-  background-size: auto 3rem;
+  background-size: auto 2rem;
 }
 
 #main-nav-btn:checked ~ #main-nav {

--- a/web/cobrands/bexley/base.scss
+++ b/web/cobrands/bexley/base.scss
@@ -88,7 +88,7 @@ ol.big-numbers > li:before {
     height: 48px;
     padding: 1em 0;
     background: url(/cobrands/bexley/images/logo.png) 0 50% no-repeat;
-    background-size: 160px 48px;
+    background-size: auto 3rem;
 }
 
 /* WasteWorks */

--- a/web/cobrands/brent/base.scss
+++ b/web/cobrands/brent/base.scss
@@ -171,6 +171,7 @@ a {
   text-decoration: none;
   line-height: 100%;
   padding: $btn-top-padding-small 0.5em $btn-bottom-padding-small 0.5em;
+  right: 6.5rem;
 
   &:focus {
     border-color: $link-focus-color;

--- a/web/cobrands/bristol/base.scss
+++ b/web/cobrands/bristol/base.scss
@@ -17,7 +17,7 @@
   background-size: 37px;
   text-indent: 47px;
   line-height: 37px;
-  font-size: 24px;
+  font-size: 1.25rem;
   padding: 0.5em 0;
   margin: 0;
   color: white;

--- a/web/cobrands/camden/base.scss
+++ b/web/cobrands/camden/base.scss
@@ -367,6 +367,7 @@ body:not(.admin, .mappage.with-actions) {
   font-size: $nav-font-size-mobile;
   text-decoration: none;
   line-height: 100%;
+  right: 6.5rem;
 
   &:hover {
     border-color: $nav_colour;

--- a/web/cobrands/dumfries/base.scss
+++ b/web/cobrands/dumfries/base.scss
@@ -30,6 +30,7 @@ h3, .h3,
 
 #report-cta {
   @include white-outline-btn;
+  right: 6rem;
 }
 
 a#geolocate_link {
@@ -61,7 +62,7 @@ input[type=text] {
 /* NAVBAR */
 #site-logo {
   background-image: url("/cobrands/dumfries/images/logo.svg");
-  background-size: 100% auto;
+  background-size: 80% auto;
   height: 4.6875rem;
   width: 11.75rem;
 

--- a/web/cobrands/fixamingata/base.scss
+++ b/web/cobrands/fixamingata/base.scss
@@ -17,6 +17,7 @@
 #site-logo {
     height: 35px;
     background-image: url("/cobrands/fixamingata/images/site-logo.svg");
+    background-size: auto 2rem;
 }
 
 #report-cta {

--- a/web/cobrands/northnorthants/base.scss
+++ b/web/cobrands/northnorthants/base.scss
@@ -10,7 +10,7 @@
   background-image: url("/cobrands/northnorthants/images/logo.svg");
   background-size: contain;
   height: $mappage-header-height;
-  width: 175px;
+  width: 160px;
 }
 
 .nav-menu {

--- a/web/cobrands/westnorthants/base.scss
+++ b/web/cobrands/westnorthants/base.scss
@@ -10,7 +10,7 @@
   background-image: url("/cobrands/westnorthants/images/logo.svg");
   background-size: contain;
   height: $mappage-header-height;
-  width: 175px;
+  width: 170px;
 }
 
 #report-cta {


### PR DESCRIPTION
Fixes: https://github.com/mysociety/societyworks/issues/5558

Notes: Tested at 360px screen width.

This commit affects the following cobrands:
- Aberdeenshire
- Bexley
- Brent
- Bristol
- Camden
- Dumfries
- Fixamingata
- Northnorthants
- Westnorthants

### Preview
<img width="1080" height="2700" alt="aberdeenshire" src="https://github.com/user-attachments/assets/f7250acf-9154-4502-979b-cf1c3b5b1749" />

<img width="1080" height="2700" alt="bexley" src="https://github.com/user-attachments/assets/f27fac87-1b87-4812-be71-df7ab5bb96b7" />

<img width="1080" height="2700" alt="brent" src="https://github.com/user-attachments/assets/9434d959-1391-4320-8245-a1c5761c0a54" />

<img width="1080" height="2700" alt="bristol" src="https://github.com/user-attachments/assets/f21b7f1a-26c0-4fdd-8f28-8fe6fdd47582" />

<img width="1080" height="2700" alt="camden" src="https://github.com/user-attachments/assets/f1e8d27f-0ef5-4e7f-abe8-ac9be39a70c6" />

<img width="1080" height="2700" alt="dumfries" src="https://github.com/user-attachments/assets/5aa23fa0-f8bb-4ff5-949f-2bb5f4607fa9" />

<img width="1080" height="2700" alt="fixamingata" src="https://github.com/user-attachments/assets/2958b25a-a0ff-4886-83da-6cfc57febb24" />

<img width="1080" height="2700" alt="northnorthants" src="https://github.com/user-attachments/assets/ce26481e-514d-4344-86a5-66c5ec81ac4a" />

<img width="1080" height="2700" alt="westnorthants" src="https://github.com/user-attachments/assets/0729d411-b1a3-4df7-8414-2d5dcbfa416d" />

[skip changelog]
