### PR TITLE
No-JS map changes

### DIFF
--- a/perllib/FixMyStreet/App.pm
+++ b/perllib/FixMyStreet/App.pm
@@ -439,6 +439,17 @@ sub uri_for_email {
     return URI->new($email_uri);
 }
 
+sub uri_map {
+    my ($c, $params) = @_;
+    my $map = $c->stash->{map};
+    my $lat = $params->{lat} // $map->{latitude};
+    my $lon = $params->{lon} // $map->{longitude};
+    my $zoom = $params->{zoom} // $map->{zoom};
+    my $aerial = $params->{aerial} // $c->get_param('aerial') // "";
+    my $no_pins = $params->{no_pins} // $c->get_param('no_pins') // "";
+    return "$lat/$lon/$zoom/$aerial/$no_pins";
+}
+
 sub finalize {
     my $c = shift;
     $c->next::method(@_);

--- a/perllib/FixMyStreet/App/Controller/Report/New.pm
+++ b/perllib/FixMyStreet/App/Controller/Report/New.pm
@@ -2061,7 +2061,7 @@ sub redirect_to_around : Private {
         lat => $c->stash->{latitude},
         lon => $c->stash->{longitude},
     };
-    foreach (qw(pc zoom)) {
+    foreach (qw(pc zoom show_old_reports)) {
         $params->{$_} = $c->get_param($_);
     }
 

--- a/perllib/FixMyStreet/App/Controller/Root.pm
+++ b/perllib/FixMyStreet/App/Controller/Root.pm
@@ -46,6 +46,7 @@ sub auto : Private {
 
     $c->forward('/offline/_stash_manifest_theme', [ $c->cobrand->moniker ]);
     $c->forward('store_app_platform');
+    $c->forward('nojs_map_controls');
 
     return 1;
 }
@@ -239,6 +240,19 @@ sub store_app_platform : Private {
         $c->session->{app_platform} = "Android";
     } elsif ( $pwa && !$param ) {
         $c->session->{app_platform} = "PWA";
+    }
+}
+
+sub nojs_map_controls : Private {
+    my ($self, $c) = @_;
+
+    if (my $nojs = $c->get_param('nojs-map-controls')) {
+        my ($lat, $lon, $zoom, $aerial, $no_pins) = split /\//, $nojs;
+        $c->set_param('lat', $lat);
+        $c->set_param('lon', $lon);
+        $c->set_param('zoom', $zoom);
+        $c->set_param('aerial', $aerial);
+        $c->set_param('no_pins', $no_pins);
     }
 }
 

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -549,6 +549,7 @@ Return an override type of map if necessary.
 sub map_type {
     my $self = shift;
     return 'OSM' if $self->{c} && $self->{c}->req->uri->host =~ /^osm\./;
+    return 'OSM' if -e FixMyStreet->path_to('../data/osm-map-override');
     return;
 }
 

--- a/perllib/FixMyStreet/TestMech.pm
+++ b/perllib/FixMyStreet/TestMech.pm
@@ -558,8 +558,10 @@ sub visible_form_values {
           unless $form;
     }
     else {
+        # ignore overrides and no-JS map form
         my @forms =
-          grep { ( $_->attr('name') || '' ) ne 'overrides_form' } # ignore overrides
+          grep { ( $_->attr('name') || '' ) ne 'overrides_form'
+              && ( $_->attr('id') || '' ) ne 'nojs-map-controls-form' }
           $mech->forms;
 
         croak "Found no forms - can't continue..."

--- a/templates/web/base/common_footer_tags.html
+++ b/templates/web/base/common_footer_tags.html
@@ -18,3 +18,7 @@ FOR script IN scripts;
         [%~ FOR attr IN script.1 %] [% attr.key %]="[% attr.value %]"[% END ~%]
         ></script>
 [% END %]
+
+[% IF map %]
+<form method="post" id="nojs-map-controls-form"></form>
+[% END %]

--- a/templates/web/base/maps/_compass.html
+++ b/templates/web/base/maps/_compass.html
@@ -1,20 +1,20 @@
 [% RETURN IF map.no_compass %]
 [%
-    north    = c.uri_with( { lat = map.compass.north.0, lon = map.compass.north.1, zoom = map.zoom } )
-    south    = c.uri_with( { lat = map.compass.south.0, lon = map.compass.south.1, zoom = map.zoom } )
-    east     = c.uri_with( { lat = map.compass.east.0,  lon = map.compass.east.1,  zoom = map.zoom } )
-    west     = c.uri_with( { lat = map.compass.west.0,  lon = map.compass.west.1,  zoom = map.zoom } );
-    SET zoom_in  = c.uri_with( { lat = map.latitude, lon = map.longitude, zoom = map.zoom + 1 } ) IF map.zoom < map.numZoomLevels - 1;
-    SET zoom_out = c.uri_with( { lat = map.latitude, lon = map.longitude, zoom = map.zoom - 1 } ) IF map.zoom > 0;
-    SET zoom_in  = '#' IF map.zoom >= map.numZoomLevels - 1;
-    SET zoom_out = '#' IF map.zoom <= 0;
+    north    = c.uri_map( { lat = map.compass.north.0, lon = map.compass.north.1, zoom = map.zoom } )
+    south    = c.uri_map( { lat = map.compass.south.0, lon = map.compass.south.1, zoom = map.zoom } )
+    east     = c.uri_map( { lat = map.compass.east.0,  lon = map.compass.east.1,  zoom = map.zoom } )
+    west     = c.uri_map( { lat = map.compass.west.0,  lon = map.compass.west.1,  zoom = map.zoom } );
+    SET zoom_in  = c.uri_map( { lat = map.latitude, lon = map.longitude, zoom = map.zoom + 1 } ) IF map.zoom < map.numZoomLevels - 1;
+    SET zoom_out = c.uri_map( { lat = map.latitude, lon = map.longitude, zoom = map.zoom - 1 } ) IF map.zoom > 0;
+    SET zoom_in  = '' IF map.zoom >= map.numZoomLevels - 1;
+    SET zoom_out = '' IF map.zoom <= 0;
 %]
 
 <div id="ns_fms_pan_zoom" style="position: absolute;" class="olControlPanZoom olControlNoSelect" unselectable="on">
-    <a rel="nofollow" role="button" tabindex="0" href="[% north %]"><span id="ns_fms_pan_zoom_panup" class="olButton">pan up</span></a>
-    <a rel="nofollow" role="button" tabindex="0" href="[% west %]"><span id="ns_fms_pan_zoom_panleft" class="olButton">pan left</span></a>
-    <a rel="nofollow" role="button" tabindex="0" href="[% east %]"><span id="ns_fms_pan_zoom_panright" class="olButton">pan right</span></a>
-    <a rel="nofollow" role="button" tabindex="0" href="[% south %]"><span id="ns_fms_pan_zoom_pandown" class="olButton">pan down</span></a>
-    <a rel="nofollow" role="button" tabindex="0" href="[% zoom_in %]"><span id="ns_fms_pan_zoom_zoomin" class="olButton">zoom in</span></a>
-    <a rel="nofollow" role="button" tabindex="0" href="[% zoom_out %]"><span id="ns_fms_pan_zoom_zoomout" class="olButton">zoom out</span></a>
+    <button form="nojs-map-controls-form" name="nojs-map-controls" value="[% north %]" id="ns_fms_pan_zoom_panup" class="olButton">pan up</span></button>
+    <button form="nojs-map-controls-form" name="nojs-map-controls" value="[% west %]" id="ns_fms_pan_zoom_panleft" class="olButton">pan left</span></button>
+    <button form="nojs-map-controls-form" name="nojs-map-controls" value="[% east %]" id="ns_fms_pan_zoom_panright" class="olButton">pan right</span></button>
+    <button form="nojs-map-controls-form" name="nojs-map-controls" value="[% south %]" id="ns_fms_pan_zoom_pandown" class="olButton">pan down</span></button>
+    <button [% 'disabled' IF map.zoom >= map.numZoomLevels - 1 %] form="nojs-map-controls-form" name="nojs-map-controls" value="[% zoom_in %]" id="ns_fms_pan_zoom_zoomin" class="olButton">zoom in</span></button>
+    <button [% 'disabled' IF map.zoom <= 0 %] form="nojs-map-controls-form" name="nojs-map-controls" value="[% zoom_out %]" id="ns_fms_pan_zoom_zoomout" class="olButton">zoom out</span></button>
 </div>

--- a/templates/web/base/maps/openlayers.html
+++ b/templates/web/base/maps/openlayers.html
@@ -59,17 +59,17 @@
       [% aerial = c.req.params.aerial %]
       [% SET aerial = 1 IF c.cobrand.moniker == 'zurich' AND NOT c.req.params.aerial.defined %]
       [% IF aerial %]
-        <a class="map-layer-toggle roads" rel="nofollow" href="[% c.uri_with( { aerial => 0 } ) %]"><span class="map-link-label">[% loc('Road map') %]</span></a>
+        <button class="map-layer-toggle roads" form="nojs-map-controls-form" name="nojs-map-controls" value="[% c.uri_map( { aerial => 0 } ) %]"><span class="map-link-label">[% loc('Road map') %]</span></button>
       [% ELSE %]
-        <a class="map-layer-toggle aerial" rel="nofollow" href="[% c.uri_with( { aerial => 1 } ) %]"><span class="map-link-label">[% loc('Aerial map') %]</span></a>
+        <button class="map-layer-toggle aerial" form="nojs-map-controls-form" name="nojs-map-controls" value="[% c.uri_map( { aerial => 1 } ) %]"><span class="map-link-label">[% loc('Aerial map') %]</span></button>
       [% END %]
     [% END %]
 
   [% IF page == "around" %]
     [% IF c.req.params.no_pins %]
-      <a class="map-pins-toggle" rel="nofollow" href="[% c.uri_with( { no_pins => 0 } ) %]"><span class="map-link-label">[% loc('Show pins') %]</span></a>
+      <button class="map-pins-toggle" form="nojs-map-controls-form" name="nojs-map-controls" value="[% c.uri_map( { no_pins => 0 } ) %]"><span class="map-link-label">[% loc('Show pins') %]</span></button>
     [% ELSE %]
-      <a class="map-pins-toggle" rel="nofollow" href="[% c.uri_with( { no_pins => 1 } ) %]"><span class="map-link-label">[% loc('Hide pins') %]</span></a>
+      <button class="map-pins-toggle" form="nojs-map-controls-form" name="nojs-map-controls" value="[% c.uri_map( { no_pins => 1 } ) %]"><span class="map-link-label">[% loc('Hide pins') %]</span></button>
     [% END %]
     <a class="js-recentre-map hidden-nojs" tabindex="0">
       <span class="map-link-label">[% loc('Re-centre map') %]</span>

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2002,6 +2002,10 @@ html.js #map .noscript {
   }
 }
 
+#ns_fms_pan_zoom .olButton {
+  border: none;
+}
+
 #ns_fms_pan_zoom_panup,
 #ns_fms_pan_zoom_pandown,
 #ns_fms_pan_zoom_panleft,
@@ -2167,6 +2171,7 @@ html.js #map .noscript {
     background-repeat: no-repeat;
     background-size: $maplink-button-height $maplink-button-height;
     border-radius: 5px;
+    border: none;
     margin-top: $panzoom-gutter; // vertical space between links
     text-decoration: none !important;
 


### PR DESCRIPTION
Fixes a bug in a redirect from /report/new to /around where it wasn't remembering the show_old_reports setting.
Replaces the non-JS map control links with buttons that should do the same thing.
And add a file check to allow easy override to OSM mapping should that be needed in future.
[skip changelog]
