### PR TITLE
[FMS] Repeated report submission generating multiple reports

### DIFF
--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -552,7 +552,12 @@ $.extend(fixmystreet.set_up, {
         },
         submitHandler: function(form) {
             $('input[type=submit][data-disable],button[data-disable]', form).prop("disabled", true);
-            form.submit();
+            if (!submitted) {
+                submitted = true;
+                setTimeout(function() {
+                    form.submit();
+                }, 0);
+            }
         },
         // make sure we can see the error message when we focus on invalid elements
         showErrors: function( errorMap, errorList ) {


### PR DESCRIPTION
Some browsers keep submitting the report leading to multiple accidental reports made by the user.

This happens although the continue button is disabled.

Try testing the submitted bool before sending and also setting it to discard any further submissions.

It is already reset to 'false' on validation error.

https://github.com/mysociety/societyworks/issues/5506

[skip changelog]