### PR TITLE
[Dumfries] Handle detailed_information from O311 updates

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Northumberland.pm
+++ b/perllib/FixMyStreet/Cobrand/Northumberland.pm
@@ -282,7 +282,7 @@ sub should_skip_sending_update {
 =head2 record_update_extra_fields
 
 We want to create comments when assigned (= shortlisted) user or
-extra details (= detail_information) are updated for a report.
+extra details (= detailed_information) are updated for a report.
 
 =cut
 

--- a/perllib/Open311/UpdatesBase.pm
+++ b/perllib/Open311/UpdatesBase.pm
@@ -166,6 +166,7 @@ sub _process_update {
     my $body = $self->current_body;
 
     $self->_handle_assigned_user($request, $p);
+    $self->_handle_detailed_information($request, $p);
     $self->_handle_category_change($request, $p);
 
     my $state = $open311->map_state( $request->{status} );
@@ -357,12 +358,20 @@ sub _handle_assigned_user {
 
             # TODO Unassign?
         }
-        if ( exists $request->{extras}{detailed_information} ) {
-            $request->{extras}{detailed_information}
-                ? $p->set_extra_metadata( detailed_information =>
-                    $request->{extras}{detailed_information} )
-                : $p->unset_extra_metadata('detailed_information');
-        }
+    }
+}
+
+sub _handle_detailed_information {
+    my ( $self, $request, $p ) = @_;
+
+    if ( $request->{extras}
+        && exists $request->{extras}{detailed_information} )
+    {
+        $request->{extras}{detailed_information}
+            ? $p->set_extra_metadata(
+                detailed_information => $request->{extras}{detailed_information}
+            )
+            : $p->unset_extra_metadata('detailed_information');
     }
 }
 


### PR DESCRIPTION
This was previously tied to _handle_assigned_user (for Northumberland).

Part of fix for https://github.com/mysociety/societyworks/issues/5477.

Corresponding O311 changes: https://github.com/mysociety/open311-adapter/pull/513.

Needs O311 config change for staging and live.

[skip changelog]
