### PR TITLE
[Echo] Always shrink photos

### DIFF
--- a/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
@@ -1149,9 +1149,6 @@ sub send_bulky_payment_echo_update_failed {
 sub per_photo_size_limit_for_report_in_bytes {
     my ($self, $report, $image_count) = @_;
 
-    # We only need to check bulky collections at present.
-    return 0 unless $report->cobrand_data eq 'waste' && $report->contact->category eq 'Bulky collection';
-
     my $cfg = FixMyStreet->config('COBRAND_FEATURES');
     return 0 unless $cfg;
 

--- a/t/roles/cobrand/echo.t
+++ b/t/roles/cobrand/echo.t
@@ -59,12 +59,12 @@ FixMyStreet::override_config {
             is $cobrand->per_photo_size_limit_for_report_in_bytes($bulky_report, 4), 50;
         };
 
-        subtest 'No size limit for non-bulky reports' => sub {
+        subtest 'Size limit also applied to non-bulky reports' => sub {
             my ($non_bulky_report) = $mech->create_problems_for_body(1, $body->id, 'report', {
                 category => $non_bulky_contact->category,
                 cobrand_data => 'waste',
             });
-            is $cobrand->per_photo_size_limit_for_report_in_bytes($non_bulky_report, 1), 0;
+            is $cobrand->per_photo_size_limit_for_report_in_bytes($non_bulky_report, 1), 100;
         };
     };
 };


### PR DESCRIPTION
We've had a couple of reports failing to send to Echo because the photos were too big. These were FMS reports, so weren't caught by this method. Removing this line means that this will shrink photos for any Echo report, rather than just Bulky Waste ones.

<!-- [skip changelog] -->
