### PR TITLE
Preserve newlines in detailed_information

### DIFF
--- a/templates/web/base/admin/reports/_edit_main.html
+++ b/templates/web/base/admin/reports/_edit_main.html
@@ -134,12 +134,19 @@ class="admin-offsite-link">[% problem.latitude %], [% problem.longitude %]</a>
     [%~ IF extra_fields.size ~%]
         <ul>
         [%~ FOREACH field IN extra_fields ~%]
-            <li><strong>[%~ field.name ~%]</strong>: [% IF field.val.0.defined ~%]
-                    [%~ field.val.list.join(", ") ~%]
-                [%~ ELSE ~%]
-                    [%~ field.val ~%]
-                [%~ END ~%]
-            </li>
+          [% IF field.name == 'detailed_information' %]
+              <li>
+                <strong>[%~ field.name ~%]</strong>:
+                  [%~ field.val | html_para ~%]
+              </li>
+          [% ELSE %]
+              <li><strong>[%~ field.name ~%]</strong>: [% IF field.val.0.defined ~%]
+                  [%~ field.val.list.join(", ") ~%]
+              [%~ ELSE ~%]
+                  [%~ field.val ~%]
+              [%~ END ~%]
+              </li>
+          [% END %]
         [%~ END ~%]
         </ul>
     [%~ ELSE %] No[% END ~%]


### PR DESCRIPTION
Small fix as part of https://github.com/mysociety/societyworks/issues/5477
(see https://app.basecamp.com/4020879/buckets/44203298/card_tables/cards/9683824089#__recording_10053241295).

[skip changelog]