### PR TITLE
[Merton] Bulky waste updates for discounted collections

### DIFF
--- a/bin/update-schema
+++ b/bin/update-schema
@@ -223,6 +223,7 @@ else {
 # (assuming schema change files are never half-applied, which should be the case)
 sub get_db_version {
     return 'EMPTY' if ! table_exists('problem');
+    return '0096' if table_exists('property');
     return '0095' if column_exists('response_templates', 'deleted');
     return '0094' if index_exists('problem_confirmed_idx');
     return '0093' if index_exists('user_planned_reports_report_id_idx');

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 # setenv script
-requires 'List::MoreUtils', '0.402';
+requires 'List::MoreUtils', '0.430';
 requires 'local::lib', '2.000024';
 requires 'Class::Unload';
 

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -4310,22 +4310,28 @@ DISTRIBUTIONS
       Lingua::Stem::Snowball::Da 1.01
     requirements:
       ExtUtils::MakeMaker 0
-  List-MoreUtils-0.413
-    pathname: R/RE/REHSACK/List-MoreUtils-0.413.tar.gz
+  List-MoreUtils-0.430
+    pathname: R/RE/REHSACK/List-MoreUtils-0.430.tar.gz
     provides:
-      List::MoreUtils 0.413
-      List::MoreUtils::PP 0.413
-      List::MoreUtils::XS 0.413
+      List::MoreUtils 0.430
+      List::MoreUtils::PP 0.430
+    requirements:
+      Exporter::Tiny 0.038
+      ExtUtils::MakeMaker 0
+      List::MoreUtils::XS 0.430
+  List-MoreUtils-XS-0.430
+    pathname: R/RE/REHSACK/List-MoreUtils-XS-0.430.tar.gz
+    provides:
+      List::MoreUtils::XS 0.430
     requirements:
       Carp 0
-      Exporter::Tiny 0.038
       ExtUtils::MakeMaker 0
       File::Basename 0
       File::Copy 0
       File::Path 0
       File::Spec 0
       IPC::Cmd 0
-      XSLoader 0
+      XSLoader 0.22
       base 0
   MIME-Types-2.17
     pathname: M/MA/MARKOV/MIME-Types-2.17.tar.gz

--- a/db/downgrade_0096---0095.sql
+++ b/db/downgrade_0096---0095.sql
@@ -1,0 +1,1 @@
+DROP TABLE property;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -637,3 +637,8 @@ CREATE TABLE manifest_theme (
     wasteworks_name text,
     wasteworks_short_name text
 );
+
+CREATE TABLE property (
+    uprn text not null primary key,
+    discount_date date not null
+);

--- a/db/schema_0096-add-property-table.sql
+++ b/db/schema_0096-add-property-table.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+CREATE TABLE property (
+    uprn text not null primary key,
+    discount_date date not null
+);
+
+COMMIT;
+

--- a/perllib/FixMyStreet/App/Controller/Admin/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Waste.pm
@@ -55,7 +55,7 @@ sub edit : Chained('body') : PathPart('') : Args(0) {
         $c->forward('/auth/check_csrf_token');
 
         my $new_cfg;
-        if (my $cfg = $c->get_param("body_config")) {
+        if ((my $cfg = $c->get_param("body_config")) && $c->user->is_superuser) {
             try {
                 $new_cfg = JSON->new->utf8(1)->allow_nonref(0)->decode($cfg);
             } catch {
@@ -80,17 +80,26 @@ sub edit : Chained('body') : PathPart('') : Args(0) {
                 per_item_min_collection_price => 'ints',
                 base_price => 'int',
                 base_pop_price => 'int',
-                daily_slots => 'int',
                 items_per_collection_max => 'int',
                 small_items_per_collection_max => 'int',
                 band1_price => 'int',
                 band1_pop_price => 'int',
                 band1_max => 'int',
-                free_mode => 'bool',
-                food_bags_disabled => 'sel',
                 show_location_page => 'sel',
                 show_individual_notes => 'bool',
             );
+            my $cobrand = $c->stash->{body}->cobrand;
+            if ($cobrand eq 'merton') {
+                $keys{discount_enabled} = 'bool';
+                $keys{discount_months} = 'int';
+                $keys{discount_max_items} = 'int';
+                $keys{discount_price} = 'int';
+            }
+            if ($cobrand eq 'peterborough') {
+                $keys{daily_slots} = 'int';
+                $keys{free_mode} = 'bool';
+                $keys{food_bags_disabled} = 'sel';
+            }
             foreach (keys %keys) {
                 my $val = $c->get_param($_);
                 if ($keys{$_} eq 'bool') {
@@ -115,6 +124,11 @@ sub edit : Chained('body') : PathPart('') : Args(0) {
                     $new_cfg->{$_} = $val;
                 }
             }
+
+            if ($new_cfg->{discount_max_items} && $new_cfg->{band1_max} && $new_cfg->{discount_max_items} > $new_cfg->{band1_max}) {
+                $c->stash->{errors}->{site_wide} = "Maximum items per discounted collection cannot exceed small collection";
+            }
+
             if ($c->stash->{errors}) {
                 $c->detach;
             }
@@ -252,7 +266,7 @@ sub stash_body_config_json : Private {
     } else {
         $c->stash->{body_config_json} = JSON->new->utf8(1)->pretty->canonical->encode($cfg);
     }
-    foreach (qw(free_mode per_item_costs pop_costs per_item_min_collection_price base_price base_pop_price daily_slots small_items_per_collection_max items_per_collection_max food_bags_disabled show_location_page band1_price band1_pop_price band1_max show_individual_notes)) {
+    foreach (qw(free_mode per_item_costs pop_costs per_item_min_collection_price base_price base_pop_price daily_slots small_items_per_collection_max items_per_collection_max food_bags_disabled show_location_page band1_price band1_pop_price band1_max show_individual_notes discount_enabled discount_months discount_max_items discount_price)) {
         $c->stash->{$_} = $c->get_param($_) || $cfg->{$_};
     }
 }

--- a/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
@@ -98,14 +98,18 @@ sub item_list : Private {
     my $max_items = $c->stash->{booking_maximum};
     my $field_list = [];
 
+    my $hint = $c->cobrand->moniker eq 'merton'
+      ? 'Describe the item to help our crew pick up the right thing. <strong>Do not</strong> include personal details or location information'
+      : 'Describe the item to help our crew pick up the right thing';
+
     my $notes_field = {
         type => 'TextArea',
         label => 'Item note',
         maxlength => 100,
-        tags => { hint => 'Describe the item to help our crew pick up the right thing' },
+        tags => { hint => FixMyStreet::Template::SafeString->new($hint) },
     };
     $notes_field->{maxlength} = 255 if $c->cobrand->moniker eq 'merton';
-    if (!$c->cobrand->bulky_item_notes_field_mandatory) {
+    if (!$c->cobrand->bulky_item_notes_field_mandatory && $c->cobrand->moniker ne 'merton') {
         $notes_field->{label} .= ' (optional)';
     }
 

--- a/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste/Bulky.pm
@@ -99,7 +99,7 @@ sub item_list : Private {
     my $field_list = [];
 
     my $hint = $c->cobrand->moniker eq 'merton'
-      ? 'Describe the item to help our crew pick up the right thing. <strong>Do not</strong> include personal details or location information'
+      ? 'Describe the item so our crew can identify it.<br>Do not include any personal details or location.<br>Describe one item only.'
       : 'Describe the item to help our crew pick up the right thing';
 
     my $notes_field = {

--- a/perllib/FixMyStreet/App/Form/Waste/Bulky/Shared.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Bulky/Shared.pm
@@ -228,9 +228,12 @@ sub _get_dates {
     $pattern = '%F' if $c->cobrand->moniker eq 'bexley'; # Move more to this over time?
     my $parser = DateTime::Format::Strptime->new( pattern => $pattern );
     my $slots = $c->stash->{booking_class}->find_available_slots($last_earlier_date);
+
     if ($existing_date) {
-        unshift @$slots, { date => $existing_date };
+        my $present = grep { $existing_date eq $_->{date} } @$slots;
+        unshift @$slots, { date => $existing_date } if !$present;
     }
+
     my @dates  = grep {$_} map {
         my $dt = $parser->parse_datetime( $_->{date} );
         my $label = $c->cobrand->moniker eq 'brent' ? '%d %B' : '%A %e %B';

--- a/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
@@ -655,4 +655,10 @@ sub _bulky_collection_overdue {
     return $today > $collection_due_date;
 }
 
+sub bulky_location_text_prompt {
+  "Please provide the exact location where the items will be left ".
+  "(e.g., On the driveway; To the left of the front door; By the front hedge, etc.). ".
+  "Do not give any personal information or access codes."
+}
+
 1;

--- a/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
@@ -661,6 +661,12 @@ sub bulky_location_text_prompt {
   "Do not give any personal information or access codes."
 }
 
+=item * Bulky item notes are mandatory
+
+=cut
+
+sub bulky_item_notes_field_mandatory { 1 }
+
 =head2 Discounted bulky collections
 
 Overriding default pricing code, assume is two-banded pricing.

--- a/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
@@ -661,4 +661,202 @@ sub bulky_location_text_prompt {
   "Do not give any personal information or access codes."
 }
 
+=head2 Discounted bulky collections
+
+Overriding default pricing code, assume is two-banded pricing.
+
+=cut
+
+sub bulky_discount_available_by_date {
+    my ($self, $data) = @_;
+    my $cfg = $self->wasteworks_config;
+
+    # Check discount, if enabled
+    return unless $cfg->{discount_enabled};
+
+    my $uprn = $self->{c}->stash->{property}{uprn};
+    my $property = FixMyStreet::DB->resultset("Property")->find($uprn);
+    return 1 unless $property;
+
+    my $DISCOUNT_MONTHS = $cfg->{discount_months} || 12;
+    my ($date, $ref, $expiry) = split(";", $data->{chosen_date});
+    my $latest = DateTime::Format::W3CDTF->parse_datetime($date);
+    $latest->subtract( months => $DISCOUNT_MONTHS );
+    return 1 if $property->discount_date <= $latest;
+}
+
+sub bulky_pricing_strategy {
+    my $self = shift;
+    my $cfg = $self->wasteworks_config;
+    my $c = $self->{c};
+
+    my $previous = $c->stash->{amending_booking};
+    my $discount;
+    if ($previous) {
+        my $discounted = $previous->get_extra_field_value('discounted') || '';
+        $discount = 1 if $discounted eq 'yes';
+    } else {
+        my $data = $c->stash->{form}->saved_data;
+        $discount = $self->bulky_discount_available_by_date($data);
+    }
+    my $DISCOUNT_MAX_ITEMS = $cfg->{discount_max_items} || 3;
+
+    my $base_price = $cfg->{base_price};
+    my $band1_max = $cfg->{band1_max};
+    my $band1_price = $cfg->{band1_price};
+    my $max = $c->stash->{booking_maximum};
+    my $out = {
+        strategy => 'banded',
+        bands => [
+            $discount ? { max => $DISCOUNT_MAX_ITEMS, price => $cfg->{discount_price} } : (),
+            (!$discount || $band1_max > $DISCOUNT_MAX_ITEMS) ? { max => $band1_max, price => $band1_price } : (),
+            { max => $max, price => $base_price }
+        ]
+    };
+    my $json = encode_json($out);
+    return { %$out, json => $json };
+}
+
+sub bulky_last_discounted_date {
+    my ($self) = @_;
+    my $uprn = $self->{c}->stash->{property}{uprn};
+    my $property = FixMyStreet::DB->resultset("Property")->find($uprn);
+    return unless $property;
+    return $property->discount_date;
+}
+sub bulky_next_discounted_date {
+    my ($self) = @_;
+    my $cfg = $self->wasteworks_config;
+    my $DISCOUNT_MONTHS = $cfg->{discount_months} || 12;
+    my $last = $self->bulky_last_discounted_date;
+    return $last->add( months => $DISCOUNT_MONTHS ) if $last;
+
+    my $dt = DateTime->now->set_time_zone(FixMyStreet->local_time_zone);
+    my $holidays = $self->public_holidays();
+    my $wd = FixMyStreet::WorkingDays->new(public_holidays => $holidays);
+    $dt = $wd->add_days($dt, 2);
+    return $dt;
+}
+
+sub bulky_minimum_cost {
+    my $self = shift;
+    my $cfg = $self->wasteworks_config;
+    return $cfg->{discount_enabled} ? '0' : $cfg->{band1_price};
+}
+
+sub bulky_total_cost {
+    my ($self, $data) = @_;
+    my $c = $self->{c};
+
+    my $cfg = $self->wasteworks_config;
+    my $DISCOUNT_MAX_ITEMS = $cfg->{discount_max_items} || 3;
+
+    my $max = $c->stash->{booking_maximum};
+    my $count = 0;
+    for (1..$max) {
+        my $item = $data->{"item_$_"} or next;
+        $count++;
+    }
+
+    my $discount_allowed;
+    my $previous = $c->stash->{amending_booking};
+    if ($previous) {
+        my $discounted = $previous->get_extra_field_value('discounted') || '';
+        if ($discounted eq 'yes') {
+            if ($count <= $DISCOUNT_MAX_ITEMS) {
+                $data->{extra_discounted} = 'yes';
+                $discount_allowed = 1;
+            } else {
+                $data->{extra_discounted} = 'previously';
+            }
+        }
+    } else {
+        # Check discount, if enabled
+        my $discount_by_date = $self->bulky_discount_available_by_date($data);
+        if ($discount_by_date) {
+            if ($count <= $DISCOUNT_MAX_ITEMS) {
+                $data->{extra_discounted} = 'yes';
+                $discount_allowed = 1;
+            }
+        }
+    }
+
+    if ($discount_allowed) {
+        $c->stash->{payment} = $cfg->{discount_price} || 0;
+    } else {
+        # Assume is two-banded pricing in Merton
+        if ($count <= $cfg->{band1_max}) {
+            $c->stash->{payment} = $cfg->{band1_price};
+        } else {
+            $c->stash->{payment} = $cfg->{base_price};
+        }
+    }
+
+    # Calculate the difference in cost for this booking compared to the whatever
+    # the user may have already paid for any previous versions of this booking.
+    my $already_paid;
+    if ($previous && $c->stash->{payment}) {
+        $already_paid = $self->get_total_paid($previous);
+        my $new_cost = $c->stash->{payment} - $already_paid;
+        # no refunds if they've already paid more than the new booking would cost
+        $c->stash->{payment} = max(0, $new_cost);
+    }
+    return {
+        amount => $c->stash->{payment},
+        already_paid => $already_paid,
+    }
+}
+
+sub bulky_extra_confirmation_step {
+    my ($self, $report) = @_;
+    my $discounted = $report->get_extra_field_value('discounted');
+    return unless $discounted;
+    my $uprn = $report->uprn;
+    if ($discounted eq 'previously') {
+        # Remove discount date (can have a discount again)
+        my $property = FixMyStreet::DB->resultset("Property")->find($uprn);
+        if ($property) {
+            $property->delete;
+        }
+    } elsif ($discounted eq 'yes') {
+        # Add/update discount date
+        my $collection_date = $self->collection_date($report);
+        my $property = FixMyStreet::DB->resultset("Property")->find($uprn);
+        if ($property) {
+            $property->update({
+                discount_date => $collection_date,
+            });
+        } else {
+            FixMyStreet::DB->resultset("Property")->create({
+                uprn => $uprn,
+                discount_date => $collection_date,
+            });
+        }
+    }
+}
+
+sub unset_free_bulky_used {
+    my $self = shift;
+    my $c = $self->{c};
+
+    my $report = $c->stash->{cancelling_booking};
+    return unless $report;
+
+    my $discounted = $report->get_extra_field_value('discounted') || '';
+    return unless $discounted eq 'yes';
+
+    my $uprn = $report->uprn;
+    my $property = FixMyStreet::DB->resultset("Property")->find($uprn);
+    return unless $property;
+
+    my $collection_date = $self->collection_date($report);
+    my $latest = DateTime->today(time_zone => FixMyStreet->local_time_zone);
+    $latest->add( days => 7 );
+    if ($collection_date >= $latest) {
+        # Reset allowing a free collection
+        $property->delete;
+    }
+}
+
+
 1;

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -1643,12 +1643,6 @@ sub waste_confirm_payment {
     my $db = $self->result_source->storage;
     my $no_reporter_alert = ($self->get_extra_metadata('contributed_as') || '') eq 'anonymous_user';
 
-    if ($cobrand->suppress_report_sent_email($self)) {
-        # Send bulky confirmation email after report confirmation (see
-        # the suppress_report_sent_email for SLWP)
-        $self->send_logged_email({ report => $self, cobrand => $cobrand }, 0, $cobrand);
-    }
-
     if (my $amendment = $self->get_extra_metadata('amendment_update')) {
         $amendment = FixMyStreet::DB->resultset("Comment")->find($amendment);
         my $data = $amendment->get_extra_metadata('fms_extra_amend');
@@ -1661,7 +1655,18 @@ sub waste_confirm_payment {
         $amendment->confirm;
         $amendment->update;
         $self->update;
+        if ($cobrand->suppress_report_sent_email($self)) {
+            # Send bulky confirmation email after report confirmation (see
+            # the suppress_report_sent_email for SLWP)
+            $self->send_logged_email({ report => $self, cobrand => $cobrand }, 0, $cobrand);
+        }
         return;
+    }
+
+    if ($cobrand->suppress_report_sent_email($self)) {
+        # Send bulky confirmation email after report confirmation (see
+        # the suppress_report_sent_email for SLWP)
+        $self->send_logged_email({ report => $self, cobrand => $cobrand }, 0, $cobrand);
     }
 
     my @problems = ($self);

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -1655,11 +1655,11 @@ sub waste_confirm_payment {
         my $max_key = $self->category eq 'Small items collection' ? 'small_items_per_collection_max' : 'items_per_collection_max';
         my $max = $cobrand->wasteworks_config->{$max_key} || 5;
         $self->waste_amend_extra_data($cobrand, $max, $data);
+        $self->set_extra_metadata('payment_reference', $reference) if $reference;
         $cobrand->waste_amend_amendment_update($self, $amendment);
         $amendment->unset_extra_metadata('fms_extra_amend');
         $amendment->confirm;
         $amendment->update;
-        $self->set_extra_metadata('payment_reference', $reference) if $reference;
         $self->update;
         return;
     }
@@ -1740,6 +1740,7 @@ sub bulky_add_payment_confirmation_update {
         }
     });
     $self->cancel_update_alert($comment->id);
+    $cobrand->call_hook('bulky_extra_confirmation_step', $self);
 }
 
 sub bulky_cancel_collection {

--- a/perllib/FixMyStreet/DB/Result/Property.pm
+++ b/perllib/FixMyStreet/DB/Result/Property.pm
@@ -1,0 +1,32 @@
+use utf8;
+package FixMyStreet::DB::Result::Property;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+__PACKAGE__->load_components(
+  "FilterColumn",
+  "+FixMyStreet::DB::JSONBColumn",
+  "FixMyStreet::InflateColumn::DateTime",
+  "FixMyStreet::EncodedColumn",
+);
+__PACKAGE__->table("property");
+__PACKAGE__->add_columns(
+  "uprn",
+  { data_type => "text", is_nullable => 0 },
+  "discount_date",
+  { data_type => "date", is_nullable => 0 },
+);
+__PACKAGE__->set_primary_key("uprn");
+
+
+# Created by DBIx::Class::Schema::Loader v0.07035 @ 2026-07-02 15:32:37
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:T/5ZNoXmWxvT/n2aWq/5SQ
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/BulkyWaste.pm
@@ -4,6 +4,7 @@ use Moo::Role;
 use JSON::MaybeXS;
 use FixMyStreet::Map;
 use List::Util qw(max);
+use List::MoreUtils qw(slideatatime);
 
 =head1 NAME
 
@@ -716,12 +717,7 @@ sub bulky_reminders {
     my $now = DateTime->now->set_time_zone(FixMyStreet->local_time_zone);
 
     while (my $report = $collections->next) {
-        my $r1 = $report->get_extra_metadata('reminder_1');
-        my $r3 = $report->get_extra_metadata('reminder_3');
-        next if $r1; # No reminders left to do
-
         my $dt = $self->collection_date($report);
-
         # Shouldn't happen, but better to be safe.
         next unless $dt;
 
@@ -736,23 +732,31 @@ sub bulky_reminders {
             next;
         }
 
-        my $d1 = $dt->clone->subtract(days => 1);
-        my $d3 = $dt->clone->subtract(days => 3);
-
         my $h = {
             report => $report,
             cobrand => $self,
         };
-        if (!$r3 && $now >= $d3 && $now < $d1) {
-            $h->{days} = 3;
-            $self->_bulky_send_reminder_email($report, $h, $params);
-            $report->set_extra_metadata(reminder_3 => 1);
-            $report->update;
-        } elsif ($now >= $d1 && $now < $dt) {
-            $h->{days} = 1;
-            $self->_bulky_send_reminder_email($report, $h, $params);
-            $report->set_extra_metadata(reminder_1 => 1);
-            $report->update;
+
+        my @days = (3, 1);
+        # Merton discounted have weekly reminders
+        my $discounted = $report->get_extra_field_value('discounted') || '';
+        if ($discounted) {
+            unshift @days, 56, 49, 42, 35, 28, 21, 14, 7;
+        }
+
+        next if $report->get_extra_metadata("reminder_1"); # No reminders left to do
+
+        my $it = slideatatime 1, 2, @days;
+        while (my ($curr, $next) = $it->()) {
+            my $r = $report->get_extra_metadata("reminder_$curr");
+            my $dc = $dt->clone->subtract(days => $curr);
+            my $dn = $dt->clone->subtract(days => ($next || 0));
+            if (!$r && $now >= $dc && $now < $dn) {
+                $h->{days} = $curr;
+                $self->_bulky_send_reminder_email($report, $h, $params);
+                $report->set_extra_metadata("reminder_$curr" => 1);
+                $report->update;
+            }
         }
     }
 }

--- a/perllib/FixMyStreet/Roles/Cobrand/SLWP2.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/SLWP2.pm
@@ -778,16 +778,22 @@ sub waste_munge_bulky_amend {
     $p->update_extra_field({ name => 'TEM_-_Bulky_Collection_Description', value => join("::", @notes) });
     $p->update_extra_field({ name => 'TEM_-_Bulky_Collection_Item', value => join("::", @ids) });
     $p->update_extra_field({ name => 'Exact_Location', value => $data->{location} });
+    $p->update_extra_field({ name => 'discounted', value => $data->{extra_discounted} }) if $data->{extra_discounted};
 }
 
 sub waste_amend_amendment_update {
     my ($self, $p, $update) = @_;
+    my $payment = $p->get_extra_field_value('payment') || 0;
+    $payment = sprintf( '%.2f', $payment / 100 );
     $update->set_extra_metadata(
         fms_extra_amend_items => $p->get_extra_field_value('TEM_-_Bulky_Collection_Item'),
         fms_extra_amend_notes => $p->get_extra_field_value('TEM_-_Bulky_Collection_Description'),
         fms_extra_amend_location => $p->get_extra_field_value('Exact_Location'),
+        fms_extra_amend_payment_ref => $p->get_extra_metadata('payment_reference'),
+        fms_extra_amend_payment_amount => $payment,
     );
     $update->photo($p->photo);
+    $self->call_hook('bulky_extra_confirmation_step', $p);
 }
 
 sub bulky_can_refund { 0 }

--- a/t/app/controller/waste_merton_bulky.t
+++ b/t/app/controller/waste_merton_bulky.t
@@ -212,7 +212,13 @@ FixMyStreet::override_config {
         subtest 'Intro page' => sub {
             $mech->content_contains('Book a bulky waste collection');
             $mech->content_contains('Before you book');
-            $mech->content_contains('You can request up to <strong>six items per collection');
+            $mech->content_contains('There are <strong>six</strong> stages you need to complete to make a booking');
+            for my $subheading ('Your details', 'Choose date for collection', 'Add items for collection', 'Add location details', 'Booking Summary', 'Make payment') {
+                $mech->content_contains($subheading . ':', "Merton specific sections appear");
+            }
+            $mech->content_contains('The price depends on how many items you would like collected');
+            $mech->content_contains('1 to 3 items cost £37.00');
+            $mech->content_contains('4 to 6 items cost £60.75');
             $mech->submit_form_ok;
         };
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
@@ -254,7 +260,7 @@ FixMyStreet::override_config {
                 },
             },
         );
-        $mech->content_contains('Items must be out for collection by 6am on the collection day.');
+        $mech->content_contains('<strong>Items must be out for collection by 6am on the collection day</strong>. Our crew will not enter your home or collect items from your back garden or inside a bin store.');
         $mech->submit_form_ok({ with_fields => { location => '' } }, 'Will error with a blank location');
         $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
 

--- a/t/app/controller/waste_merton_bulky.t
+++ b/t/app/controller/waste_merton_bulky.t
@@ -48,6 +48,7 @@ FixMyStreet::override_config {
                 bulky_amend_enabled => 'staff',
                 bulky_cancel_enabled => 'staff',
                 bulky_missed => 1,
+                bulky_multiple_bookings => 1,
                 bulky_tandc_link => 'tandc_link',
                 echo_update_failure_email => 'fail@example.com',
             },
@@ -176,7 +177,7 @@ FixMyStreet::override_config {
 
         $mech->content_contains('Bulky waste');
         $mech->submit_form_ok; # 'Book Collection'
-        $mech->content_contains( 'Before you book',
+        $mech->content_contains( 'Before you start',
             'Should be able to access the booking form' );
     };
 
@@ -211,14 +212,9 @@ FixMyStreet::override_config {
 
         subtest 'Intro page' => sub {
             $mech->content_contains('Book a bulky waste collection');
-            $mech->content_contains('Before you book');
-            $mech->content_contains('There are <strong>six</strong> stages you need to complete to make a booking');
-            for my $subheading ('Your details', 'Choose date for collection', 'Add items for collection', 'Add location details', 'Booking Summary', 'Make payment') {
-                $mech->content_contains($subheading . ':', "Merton specific sections appear");
-            }
-            $mech->content_contains('The price depends on how many items you would like collected');
-            $mech->content_contains('1 to 3 items cost £37.00');
-            $mech->content_contains('4 to 6 items cost £60.75');
+            $mech->content_contains('Before you start');
+            $mech->content_contains('You will need to:');
+            $mech->content_contains('Tell us what you want us to collect');
             $mech->submit_form_ok;
         };
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
@@ -645,6 +641,8 @@ FixMyStreet::override_config {
             is $comment->get_extra_metadata('fms_extra_amend_items'), '83::6';
             is $comment->get_extra_metadata('fms_extra_amend_notes'), '::';
             is $comment->get_extra_metadata('fms_extra_amend_location'), 'in the middle of the drive';
+            is $comment->get_extra_metadata('fms_extra_amend_payment_ref'), '54321';
+            is $comment->get_extra_metadata('fms_extra_amend_payment_amount'), '37.00';
 
             $mech->content_contains('Bulky collection booking confirmed');
             $mech->content_contains('please use the reference:&nbsp;' . $report->id);
@@ -1008,6 +1006,8 @@ FixMyStreet::override_config {
             is $update->get_extra_metadata('fms_extra_amend_items'), '83::6::84::83', 'Correct items';
             is $update->get_extra_metadata('fms_extra_amend_notes'), '::::::';
             is $update->get_extra_metadata('fms_extra_amend_location'), 'in the middle of the drive';
+            is $update->get_extra_metadata('fms_extra_amend_payment_ref'), '54321';
+            is $update->get_extra_metadata('fms_extra_amend_payment_amount'), '23.75';
 
             $mech->content_contains('Bulky collection booking confirmed');
             $mech->content_contains('please use the reference:&nbsp;' . $report->id);
@@ -1022,6 +1022,15 @@ FixMyStreet::override_config {
             $mech->content_contains('£23.75 (£37.00 already paid)');
             $mech->content_contains('Booking amended');
         };
+
+        # Reset
+        $echo->mock('ReserveAvailableSlotsForEvent', sub {
+            my ($self, $service, $event_type, $property, $guid, $start, $end) = @_;
+            is $service, 1089;
+            is $event_type, 3130;
+            is $property, 12345;
+            return $normal_slots;
+        });
     };
 
     subtest 'Bulky goods email reminders' => sub {
@@ -1217,7 +1226,7 @@ FixMyStreet::override_config {
         $echo->mock( 'GetEventsForObject', sub { [] } );
     };
 
-    subtest 'Bulky goods booking with zero payment' => sub {
+    subtest 'Bulky goods booking with zero payment set in admin (not a discount)' => sub {
         FixMyStreet::Script::Reports::send();
         $mech->clear_emails_ok;
 
@@ -1242,6 +1251,7 @@ FixMyStreet::override_config {
 
         my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
         is $report->category, 'Bulky collection', 'correct category on report';
+        is $report->get_extra_field_value('discounted'), '';
         is $report->get_extra_field_value('payment'), '';
         is $report->state, 'confirmed', 'report confirmed';
 
@@ -1257,6 +1267,567 @@ FixMyStreet::override_config {
         FixMyStreet::Script::Reports::send();
         $mech->email_count_is(1); # Only email is 'email' to council
         $mech->clear_emails_ok;
+        $update->delete;
+        $report->delete;
+    };
+
+    subtest 'Bulky goods booking with discounted (but still zero) payment' => sub {
+        my $extra = $body->get_extra_metadata('wasteworks_config');
+        $extra->{base_price} = 6075;
+        $extra->{band1_price} = 3700;
+        $extra->{discount_enabled} = 1;
+        $extra->{discount_price} = 0;
+        $extra->{discount_max_items} = 3;
+        $extra->{discount_months} = 12;
+        $body->set_extra_metadata(wasteworks_config => $extra);
+        $body->update;
+
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('Last discounted collection: None');
+        $mech->content_contains('>Next discounted collection on or after: Friday 7 July 2023');
+
+        $mech->get_ok('/waste/12345/bulky');
+        $mech->submit_form_ok;
+        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
+        $mech->submit_form_ok({ with_fields => { chosen_date => '2023-07-01T00:00:00;reserveA==;2023-06-25T10:10:00' } });
+        $mech->submit_form_ok({ form_number => 1, fields => { 'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath' } });
+        $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
+        $mech->content_contains('3 items requested for collection');
+        $mech->content_contains('£0.00');
+        $mech->submit_form_ok({ with_fields => { tandc => 1 } });
+
+        $mech->content_contains('Bulky collection booking confirmed');
+        $mech->content_lacks('payment reference');
+
+        $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+        is $report->category, 'Bulky collection', 'correct category on report';
+        is $report->get_extra_field_value('discounted'), 'yes';
+        is $report->get_extra_field_value('payment'), '';
+        is $report->state, 'confirmed', 'report confirmed';
+
+        is $report->comments->count, 1;
+        my $update = $report->comments->first;
+        is $update->state, 'confirmed';
+        is $update->text, 'Payment confirmed, reference free, amount £0.00';
+        is $update->get_extra_metadata('fms_extra_payments'), 'free|0.00';
+
+        my $confirmation_email_html = $mech->get_html_body_from_email();
+        unlike $confirmation_email_html, qr/Total cost/;
+
+        FixMyStreet::Script::Reports::send();
+        $mech->email_count_is(1); # Only email is 'email' to council
+        $mech->clear_emails_ok;
+    };
+
+    subtest 'Next booking is not discounted' => sub {
+        # Config maintained from before
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('Last discounted collection: Saturday 1 July 2023');
+        $mech->content_contains('Next discounted collection on or after: Monday 1 July 2024');
+
+        $mech->get_ok('/waste/12345/bulky');
+        $mech->submit_form_ok;
+        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
+        $mech->submit_form_ok({ with_fields => { chosen_date => '2023-07-01T00:00:00;reserveA==;2023-06-25T10:10:00' } });
+        $mech->submit_form_ok({ form_number => 1, fields => { 'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath' } });
+        $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
+        $mech->content_contains('3 items requested for collection');
+        $mech->content_contains('£37.00');
+    };
+
+    subtest 'Booking for a year later is discounted again' => sub {
+        set_fixed_time('2024-06-04T05:44:59Z');
+        # Config maintained from before
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('Last discounted collection: Saturday 1 July 2023');
+        $mech->content_contains('Next discounted collection on or after: Monday 1 July 2024');
+
+        $mech->get_ok('/waste/12345/bulky');
+        $mech->submit_form_ok;
+        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
+        $mech->submit_form_ok({ with_fields => { chosen_date => '2024-07-01T00:00:00;reserveA==;2023-06-25T10:10:00' } });
+        $mech->submit_form_ok({ form_number => 1, fields => { 'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath' } });
+        $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
+        $mech->content_contains('3 items requested for collection');
+        $mech->content_contains('£0.00');
+    };
+
+    subtest 'Discounted email reminders' => sub {
+        my $cobrand = $body->get_cobrand_handler;
+        foreach (
+            { date => '2023-06-03', days => '28 days' },
+            { date => '2023-06-10', days => '21 days' },
+            { date => '2023-06-17', days => '14 days' },
+            { date => '2023-06-24', days => '7 days' },
+            { date => '2023-06-28', days => '3 days' },
+            { date => '2023-06-30', days => 'tomorrow' },
+        ) {
+            set_fixed_time($_->{date} . 'T05:44:59Z');
+            $cobrand->bulky_reminders;
+            my $reminder_email_html = $mech->get_html_body_from_email;
+            like $reminder_email_html, qr/Address: 2 Example Street, Merton, KT1 1AA/;
+            like $reminder_email_html, qr/Saturday 01 July 2023/;
+            like $reminder_email_html, qr/$_->{days}/, "Includes $_->{days}";
+        }
+    };
+
+    subtest 'Amending discounted booking, same date' => sub {
+        set_fixed_time('2023-06-28T12:13:14');
+        my $base_path = '/waste/12345';
+        $report->external_id('Echo-123');
+        $report->update;
+        $mech->log_in_ok( $contact_centre_user->email );
+        $mech->get_ok($base_path);
+        $mech->content_contains('Amend booking');
+        $mech->get_ok("$base_path/bulky/amend/" . $report->id);
+        $mech->content_contains("Before you amend your booking");
+        $mech->submit_form_ok;
+
+        subtest 'Amend the items, still below limit' => sub {
+            $mech->get_ok("$base_path/bulky/amend/" . $report->id);
+            $mech->submit_form_ok;
+            $mech->submit_form_ok(
+                { with_fields => { chosen_date => '2023-07-01T00:00:00;reserveA==;2023-06-25T10:10:00' } }
+            );
+            $mech->submit_form_ok({
+                with_fields => {
+                    'item_1' => 'Bath',
+                    'item_2' => 'Bookcase, Shelving Unit',
+                    'item_3' => '',
+                },
+            });
+            $mech->submit_form_ok({ form_number => 2 }); # Location page
+            $mech->content_like(qr/<p class="govuk-!-margin-bottom-0">.*Bath/s);
+            $mech->content_lacks('>BBQ<');
+            $mech->content_like(qr/<p class="govuk-!-margin-bottom-0">.*Bookcase, Shelving Unit/s);
+            $mech->content_contains('2 items requested for collection');
+            $mech->content_contains('£0.00');
+            $mech->content_contains("<dd>Saturday 01 July 2023</dd>");
+        };
+
+        subtest 'Confirm amendment' => sub {
+            my $count = FixMyStreet::DB->resultset("Problem")->count;
+            $mech->submit_form_ok({ with_fields => { tandc => 1 } });
+
+            is +FixMyStreet::DB->resultset("Problem")->count, $count, 'no new report';
+            is $report->comments->count, 2; # Confirmation and then amendment
+
+            my $email = $mech->get_email;
+            is $email->header('Subject'), 'Bulky waste collection service - reference ' . $report->id;
+            $mech->clear_emails_ok;
+
+            FixMyStreet::Script::Alerts::send_updates();
+            $mech->email_count_is(0); # No cancellation update on original
+
+            $report->discard_changes;
+            is $report->category, 'Bulky collection', 'correct category on report';
+            is $report->title, 'Bulky goods collection', 'correct title on report';
+            is $report->get_extra_field_value('payment_method'), 'credit_card', 'correct payment method on report';
+            is $report->state, 'confirmed', 'report confirmed';
+            is $report->get_extra_metadata('payment_reference'), 'free', 'correct payment reference on report';
+            is $report->uprn, 1000000002;
+            is $report->get_extra_field_value('Collection_Date_-_Bulky_Items'), '2023-07-01T00:00:00';
+            is $report->get_extra_field_value('TEM_-_Bulky_Collection_Item'), '83::6', 'updated items';
+            is $report->get_extra_field_value('discounted'), 'yes';
+
+            my $comment = $report->comments->order_by('-id')->first;
+            is $comment->text, 'Booking amended';
+            is $comment->get_extra_metadata('fms_extra_amend_items'), '83::6';
+            is $comment->get_extra_metadata('fms_extra_amend_notes'), '::';
+            is $comment->get_extra_metadata('fms_extra_amend_location'), 'in the middle of the drive';
+            is $comment->get_extra_metadata('fms_extra_amend_payment_ref'), 'free';
+            is $comment->get_extra_metadata('fms_extra_amend_payment_amount'), '0.00';
+
+            $mech->content_contains('Bulky collection booking confirmed');
+            $mech->content_contains('please use the reference:&nbsp;' . $report->id);
+
+            $mech->get_ok($base_path);
+            $mech->content_contains('Last discounted collection: Saturday 1 July 2023');
+        };
+
+        subtest 'Amend the items above lower limit' => sub {
+            $mech->get_ok("$base_path/bulky/amend/" . $report->id);
+            $mech->submit_form_ok;
+            $mech->submit_form_ok(
+                { with_fields => { chosen_date => '2023-07-01T00:00:00;reserveA==;2023-06-25T10:10:00' } }
+            );
+            $mech->submit_form_ok({
+                form_number => 1,
+                fields => {
+                    'item_1' => 'Bath',
+                    'item_2' => 'Bookcase, Shelving Unit',
+                    'item_3' => 'Bathroom Cabinet /Shower Screen',
+                    'item_4' => 'Bicycle',
+                },
+            });
+            $mech->submit_form_ok({ form_number => 2 }); # Location page
+            $mech->content_contains('4 items requested for collection');
+            $mech->content_contains('£60.75');
+            $mech->content_contains("<dd>Saturday 01 July 2023</dd>");
+        };
+
+        subtest 'Pay and confirm amendment' => sub {
+            my $count = FixMyStreet::DB->resultset("Problem")->count;
+
+            my $mech2 = $mech->clone;
+            $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
+            is $mech2->res->previous->code, 302, 'payments issues a redirect';
+            is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+
+            my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
+            is $report->id, $new_report->id;
+
+            is +FixMyStreet::DB->resultset("Problem")->count, $count, 'no new report';
+            is $report->comments->count, 3; # Confirmation and then two amendments
+
+            $mech->get_ok("/waste/pay_complete/$report_id/$token");
+
+            my $email = $mech->get_email;
+            is $email->header('Subject'), 'Bulky waste collection service - reference ' . $report->id;
+            $mech->clear_emails_ok;
+
+            FixMyStreet::Script::Alerts::send_updates();
+            $mech->email_count_is(0); # No cancellation update on original
+
+            $report->discard_changes;
+            is $report->get_extra_field_value('payment_method'), 'csc', 'correct payment method on report';
+            is $report->get_extra_metadata('payment_reference'), '54321', 'correct payment reference on report';
+            is $report->get_extra_field_value('Collection_Date_-_Bulky_Items'), '2023-07-01T00:00:00';
+            is $report->get_extra_field_value('TEM_-_Bulky_Collection_Item'), '83::6::84::85', 'updated items';
+            is $report->get_extra_field_value('discounted'), 'previously';
+
+            my $comment = $report->comments->order_by('-id')->first;
+            is $comment->text, 'Booking amended';
+            is $comment->get_extra_metadata('fms_extra_amend_items'), '83::6::84::85';
+            is $comment->get_extra_metadata('fms_extra_amend_notes'), '::::::';
+            is $comment->get_extra_metadata('fms_extra_amend_location'), 'in the middle of the drive';
+            is $comment->get_extra_metadata('fms_extra_amend_payment_ref'), '54321';
+            is $comment->get_extra_metadata('fms_extra_amend_payment_amount'), '60.75';
+
+            $mech->content_contains('Bulky collection booking confirmed');
+            $mech->content_contains('please use the reference:&nbsp;' . $report->id);
+
+            $mech->get_ok($base_path);
+            $mech->content_contains('Last discounted collection: None');
+        };
+    };
+
+    # Get rid of this one now, as we're making a new one below
+    $report->comments->delete;
+    $report->delete;
+
+    subtest 'Amending discounted booking, different date' => sub {
+        my $base_path = '/waste/12345';
+        subtest 'Make a new booking' => sub {
+            $mech->get_ok('/waste/12345');
+            $mech->content_contains('Last discounted collection: None');
+            $mech->content_contains('>Next discounted collection on or after: Friday 30 June 2023');
+
+            $mech->get_ok('/waste/12345/bulky');
+            $mech->submit_form_ok;
+            $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
+            $mech->submit_form_ok({ with_fields => { chosen_date => '2023-07-01T00:00:00;reserveA==;2023-06-25T10:10:00' } });
+            $mech->submit_form_ok({ form_number => 1, fields => { 'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath' } });
+            $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
+            $mech->submit_form_ok({ with_fields => { tandc => 1 } });
+
+            $mech->content_contains('Bulky collection booking confirmed');
+            $mech->content_lacks('payment reference');
+
+            $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+            is $report->category, 'Bulky collection', 'correct category on report';
+            is $report->get_extra_field_value('discounted'), 'yes';
+            is $report->get_extra_field_value('payment'), '';
+            is $report->state, 'confirmed', 'report confirmed';
+
+            is $report->comments->count, 1;
+            my $update = $report->comments->first;
+            is $update->state, 'confirmed';
+            is $update->text, 'Payment confirmed, reference free, amount £0.00';
+            is $update->get_extra_metadata('fms_extra_payments'), 'free|0.00';
+
+            my $confirmation_email_html = $mech->get_html_body_from_email();
+            unlike $confirmation_email_html, qr/Total cost/;
+
+            FixMyStreet::Script::Reports::send();
+            $mech->email_count_is(1); # Only email is 'email' to council
+            $mech->clear_emails_ok;
+        };
+
+        $report->external_id('Echo-456');
+        $report->update;
+
+        subtest 'Amend the items, still below limit' => sub {
+            $mech->get_ok("$base_path/bulky/amend/" . $report->id);
+            $mech->submit_form_ok;
+            $mech->submit_form_ok(
+                { with_fields => { chosen_date => '2023-07-15T00:00:00;reserveA==;2023-06-25T10:10:00' } }
+            );
+            $mech->submit_form_ok({
+                with_fields => {
+                    'item_1' => 'Bath',
+                    'item_2' => 'Bookcase, Shelving Unit',
+                    'item_3' => '',
+                },
+            });
+            $mech->submit_form_ok({ form_number => 2 }); # Location page
+            $mech->content_like(qr/<p class="govuk-!-margin-bottom-0">.*Bath/s);
+            $mech->content_lacks('>BBQ<');
+            $mech->content_like(qr/<p class="govuk-!-margin-bottom-0">.*Bookcase, Shelving Unit/s);
+            $mech->content_contains('2 items requested for collection');
+            $mech->content_contains('£0.00');
+            $mech->content_contains("<dd>Saturday 15 July 2023</dd>");
+        };
+
+        subtest 'Confirm amendment' => sub {
+            $mech->submit_form_ok({ with_fields => { tandc => 1 } });
+
+            $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+
+            my $email = $mech->get_email;
+            is $email->header('Subject'), 'Bulky waste collection service - reference ' . $report->id;
+            $mech->clear_emails_ok;
+
+            FixMyStreet::Script::Reports::send();
+            $mech->email_count_is(1); # Only email is 'email' to council
+            $mech->clear_emails_ok;
+
+            FixMyStreet::Script::Alerts::send_updates();
+            $mech->email_count_is(0); # No cancellation update on original
+
+            $report->discard_changes;
+            is $report->category, 'Bulky collection', 'correct category on report';
+            is $report->title, 'Bulky goods collection', 'correct title on report';
+            is $report->get_extra_field_value('payment_method'), 'credit_card', 'correct payment method on report';
+            is $report->state, 'confirmed', 'report confirmed';
+            is $report->get_extra_metadata('payment_reference'), 'free', 'correct payment reference on report';
+            is $report->uprn, 1000000002;
+            is $report->get_extra_field_value('Collection_Date_-_Bulky_Items'), '2023-07-15T00:00:00';
+            is $report->get_extra_field_value('TEM_-_Bulky_Collection_Item'), '83::6', 'updated items';
+            is $report->get_extra_field_value('discounted'), 'yes';
+
+            my $update = $report->comments->order_by('-id')->first;
+            is $update->text, 'Payment confirmed, reference free, amount £0.00';
+
+            $mech->content_contains('Bulky collection booking confirmed');
+            $mech->content_contains('please use the reference:&nbsp;' . $report->id);
+
+            $mech->get_ok($base_path);
+            $mech->content_contains('Last discounted collection: Saturday 15 July 2023');
+        };
+
+        $report->external_id('Echo-456');
+        $report->update;
+
+        subtest 'Amend the date and items, above the lower limit' => sub {
+            $mech->get_ok("$base_path/bulky/amend/" . $report->id);
+            $mech->submit_form_ok;
+            $mech->submit_form_ok(
+                { with_fields => { chosen_date => '2023-07-08T00:00:00;reserve1==;2023-06-25T10:10:00' } }
+            );
+            $mech->submit_form_ok({
+                form_number => 1,
+                fields => {
+                    'item_1' => 'Bath',
+                    'item_2' => 'Bookcase, Shelving Unit',
+                    'item_3' => 'Bathroom Cabinet /Shower Screen',
+                    'item_4' => 'BBQ',
+                },
+            });
+            $mech->submit_form_ok({ form_number => 2 }); # Location page
+
+            $mech->content_like(qr/<p class="govuk-!-margin-bottom-0">.*Bath/s);
+            $mech->content_like(qr/<p class="govuk-!-margin-bottom-0">.*Bookcase, Shelving Unit/s);
+            $mech->content_contains('4 items requested for collection');
+            $mech->content_contains('£60.75');
+            $mech->content_contains("<dd>Saturday 08 July 2023</dd>");
+        };
+
+        subtest 'Pay and confirm amendment' => sub {
+            my $mech2 = $mech->clone;
+            $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
+            is $mech2->res->previous->code, 302, 'payments issues a redirect';
+            is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+
+            my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
+            is $new_report->category, 'Bulky collection', 'correct category on report';
+            is $new_report->title, 'Bulky goods collection', 'correct title on report';
+            is $new_report->get_extra_field_value('payment_method'), 'csc', 'correct payment method on report';
+            is $new_report->state, 'confirmed', 'report confirmed';
+            is $new_report->get_extra_metadata('payment_reference'), undef, 'correct payment reference on report';
+            is $new_report->get_extra_field_value('discounted'), 'previously';
+
+            is $sent_params->{items}[0]{amount}, 6075, 'correct amount used';
+            is $sent_params->{items}[0]{cost_code}, '20180282880000000000000';
+            is $sent_params->{items}[0]{reference}, 'LBM-BWC-' . $new_report->id;
+
+            $mech->clear_emails_ok;
+            FixMyStreet::Script::Reports::send();
+            $mech->email_count_is(1); # Only email is 'email' to council
+            $mech->clear_emails_ok;
+
+            $mech->get_ok("/waste/pay_complete/$report_id/$token");
+            is $sent_params->{reference}, 12345, 'correct scpReference sent';
+            FixMyStreet::Script::Reports::send();
+            my $email = $mech->get_email;
+            is $email->header('Subject'), 'Bulky waste collection service - reference ' . $new_report->id;
+            $mech->clear_emails_ok;
+            $new_report->discard_changes;
+            is $new_report->get_extra_metadata('payment_reference'), '54321', 'correct payment reference on report';
+
+            is $new_report->comments->count, 1; # Payment confirmed update
+            my $update = $new_report->comments->first;
+            is $update->text, 'Payment confirmed, reference 54321, amount £60.75';
+            is $update->get_extra_metadata('fms_extra_payments'), '54321|60.75|free|0.00|free|0.00';
+            FixMyStreet::Script::Alerts::send_updates();
+            $mech->email_count_is(0);
+
+            $mech->content_contains('Bulky collection booking confirmed');
+            $mech->content_contains('please use the reference:&nbsp;' . $new_report->id);
+
+            $mech->get_ok($base_path);
+            $mech->content_contains('Last discounted collection: None');
+        };
+    };
+
+    $mech->log_out_ok;
+
+    subtest 'Bulky goods booking with discounted payment' => sub {
+        my $extra = $body->get_extra_metadata('wasteworks_config');
+
+        $extra->{base_price} = 6075;
+        $extra->{band1_price} = 3700;
+        $extra->{discount_enabled} = 1;
+        $extra->{discount_price} = 1000;
+        $extra->{discount_max_items} = 3;
+        $extra->{discount_months} = 12;
+        $body->set_extra_metadata(wasteworks_config => $extra);
+        $body->update;
+
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('Last discounted collection: None');
+        $mech->content_contains('Next discounted collection on or after: Friday 30 June 2023');
+
+        $mech->get_ok('/waste/12345/bulky');
+        $mech->submit_form_ok;
+        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
+        $mech->submit_form_ok({ with_fields => { chosen_date => '2023-07-01T00:00:00;reserveA==;2023-06-25T10:10:00' } });
+        $mech->submit_form_ok({ form_number => 1, fields => { 'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath' } });
+        $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
+        $mech->content_contains('3 items requested for collection');
+        $mech->content_contains('£10.00');
+
+        my $mech2 = $mech->clone;
+        $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
+        is $mech2->res->previous->code, 302, 'payments issues a redirect';
+        is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+
+        my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
+
+        is $new_report->category, 'Bulky collection', 'correct category on report';
+        is $new_report->title, 'Bulky goods collection', 'correct title on report';
+        is $new_report->get_extra_field_value('payment_method'), 'credit_card', 'correct payment method on report';
+        is $new_report->state, 'confirmed', 'report confirmed';
+        is $new_report->get_extra_field_value('discounted'), 'yes';
+        is $new_report->get_extra_field_value('payment'), '1000';
+
+        is $sent_params->{items}[0]{amount}, 1000, 'correct amount used';
+        is $sent_params->{items}[0]{cost_code}, '20180282880000000000000';
+        is $sent_params->{items}[0]{reference}, 'LBM-BWC-' . $new_report->id;
+
+        $mech->get_ok("/waste/pay_complete/$report_id/$token");
+        is $sent_params->{reference}, 12345, 'correct scpReference sent';
+        FixMyStreet::Script::Reports::send();
+        $mech->clear_emails_ok;
+        $new_report->discard_changes;
+        is $new_report->get_extra_metadata('payment_reference'), '54321', 'correct payment reference on report';
+
+        is $new_report->comments->count, 1;
+        my $update = $new_report->comments->first;
+        is $update->state, 'confirmed';
+        is $update->text, 'Payment confirmed, reference 54321, amount £10.00';
+        is $update->get_extra_metadata('fms_extra_payments'), '54321|10.00';
+
+        $report = $new_report;
+    };
+
+    subtest 'Cancelling discounted booking in time to get discount back' => sub {
+        $mech->log_in_ok( $contact_centre_user->email );
+        $report->update({ external_id => 'Echo-123' });
+        # Collection date: 2023-07-01T00:00:00
+        my $base_path = '/waste/12345';
+        set_fixed_time('2023-06-24T06:00:00');
+        $mech->get_ok($base_path);
+        $mech->content_contains('Cancel booking');
+        $mech->get_ok("$base_path/bulky/cancel/" . $report->id);
+        $mech->submit_form_ok( { with_fields => { name => 'Test McTest', email => 'test@example.net', confirm => 1 } } );
+        $mech->content_contains('Your booking has been cancelled');
+        $mech->follow_link_ok( { text => 'Show upcoming bin days' } );
+        is $mech->uri->path, $base_path, 'Returned to bin days';
+        $mech->content_lacks('Cancel booking');
+
+        $report->discard_changes;
+        is $report->state, 'cancelled', 'Original report cancelled';
+        like $report->detail, qr/Cancelled at user request/, 'Original report detail field updated';
+    };
+
+    subtest 'Next booking is discounted' => sub {
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('Last discounted collection: None');
+        $mech->content_contains('Next discounted collection on or after: Tuesday 27 June 2023');
+
+        $mech->get_ok('/waste/12345/bulky');
+        $mech->submit_form_ok;
+        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
+        $mech->submit_form_ok({ with_fields => { chosen_date => '2023-07-01T00:00:00;reserveA==;2023-06-25T10:10:00' } });
+        $mech->submit_form_ok({ form_number => 1, fields => { 'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath' } });
+        $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
+        $mech->content_contains('3 items requested for collection');
+        $mech->content_contains('£10.00');
+
+        my $mech2 = $mech->clone;
+        $mech2->submit_form_ok({ with_fields => { tandc => 1 } });
+        is $mech2->res->previous->code, 302, 'payments issues a redirect';
+        is $mech2->res->previous->header('Location'), "http://example.org/faq", "redirects to payment gateway";
+
+        my ( $token, $new_report, $report_id ) = get_report_from_redirect( $sent_params->{returnUrl} );
+        $mech->get_ok("/waste/pay_complete/$report_id/$token");
+        $report = $new_report;
+    };
+
+    subtest 'Cancelling discounted booking too late to get discount back' => sub {
+        $mech->log_in_ok( $contact_centre_user->email );
+        $report->update({ external_id => 'Echo-123' });
+        # Collection date: 2023-07-01T00:00:00
+        my $base_path = '/waste/12345';
+        set_fixed_time('2023-06-25T06:00:00');
+        $mech->get_ok($base_path);
+        $mech->content_contains('Cancel booking');
+        $mech->get_ok("$base_path/bulky/cancel/" . $report->id);
+        $mech->submit_form_ok( { with_fields => { name => 'Test McTest', email => 'test@example.net', confirm => 1 } } );
+        $mech->content_contains('Your booking has been cancelled');
+        $mech->follow_link_ok( { text => 'Show upcoming bin days' } );
+        is $mech->uri->path, $base_path, 'Returned to bin days';
+        $mech->content_lacks('Cancel booking');
+
+        $report->discard_changes;
+        is $report->state, 'cancelled', 'Original report cancelled';
+        like $report->detail, qr/Cancelled at user request/, 'Original report detail field updated';
+
+        subtest 'Next booking is NOT discounted' => sub {
+            $mech->get_ok('/waste/12345');
+            $mech->content_contains('Last discounted collection: Saturday 1 July 2023');
+            $mech->content_contains('Next discounted collection on or after: Monday 1 July 2024');
+
+            $mech->get_ok('/waste/12345/bulky');
+            $mech->submit_form_ok;
+            $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
+            $mech->submit_form_ok({ with_fields => { chosen_date => '2023-07-01T00:00:00;reserveA==;2023-06-25T10:10:00' } });
+            $mech->submit_form_ok({ form_number => 1, fields => { 'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath' } });
+            $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
+            $mech->content_contains('3 items requested for collection');
+            $mech->content_contains('£37.00');
+        };
     };
 
     # subtest 'Bulky goods cheque payment by contact centre' => sub {
@@ -1358,5 +1929,6 @@ sub _contact_extra_data {
         { code => 'GUID' },
         { code => 'reservation' },
         { code => 'First_Date_Offered_-_Bulky' },
+        { code => 'discounted' },
     );
 }

--- a/t/app/controller/waste_merton_bulky.t
+++ b/t/app/controller/waste_merton_bulky.t
@@ -235,6 +235,11 @@ FixMyStreet::override_config {
                         'item_3' => 'Bath',
                         'item_4' => 'Bath',
                         'item_5' => 'Bath',
+                        'item_notes_1' => 'Note',
+                        'item_notes_2' => 'Note',
+                        'item_notes_3' => 'Note',
+                        'item_notes_4' => 'Note',
+                        'item_notes_5' => 'Note',
                     },
                 },
             );
@@ -253,6 +258,9 @@ FixMyStreet::override_config {
                     'item_photo_1' => [ $sample_file, undef, Content_Type => 'image/jpeg' ],
                     'item_2' => 'Bicycle',
                     'item_3' => 'Bath',
+                    'item_notes_1' => 'Note',
+                    'item_notes_2' => 'Note',
+                    'item_notes_3' => 'Note',
                 },
             },
         );
@@ -639,7 +647,7 @@ FixMyStreet::override_config {
             my $comment = $report->comments->order_by('-id')->first;
             is $comment->text, 'Booking amended';
             is $comment->get_extra_metadata('fms_extra_amend_items'), '83::6';
-            is $comment->get_extra_metadata('fms_extra_amend_notes'), '::';
+            is $comment->get_extra_metadata('fms_extra_amend_notes'), 'Note::Note';
             is $comment->get_extra_metadata('fms_extra_amend_location'), 'in the middle of the drive';
             is $comment->get_extra_metadata('fms_extra_amend_payment_ref'), '54321';
             is $comment->get_extra_metadata('fms_extra_amend_payment_amount'), '37.00';
@@ -682,6 +690,7 @@ FixMyStreet::override_config {
                     'item_photo_1_fileid' => '', # Photo removed
                     'item_2' => 'Bookcase, Shelving Unit',
                     'item_3' => 'Bathroom Cabinet /Shower Screen',
+                    'item_notes_3' => 'Note',
                 },
             });
             $mech->submit_form_ok({ form_number => 2 }); # Location page
@@ -794,6 +803,7 @@ FixMyStreet::override_config {
                     'item_2' => 'Bookcase, Shelving Unit',
                     'item_3' => 'Bath',
                     'item_4' => 'Bath',
+                    'item_notes_4' => 'Note',
                 },
             });
             $mech->submit_form_ok({ form_number => 2 }); # Location page
@@ -1006,7 +1016,7 @@ FixMyStreet::override_config {
             is $update->state, 'confirmed';
             is $update->text, 'Booking amended';
             is $update->get_extra_metadata('fms_extra_amend_items'), '83::6::84::83', 'Correct items';
-            is $update->get_extra_metadata('fms_extra_amend_notes'), '::::::';
+            is $update->get_extra_metadata('fms_extra_amend_notes'), 'Note::Note::Note::Note';
             is $update->get_extra_metadata('fms_extra_amend_location'), 'in the middle of the drive';
             is $update->get_extra_metadata('fms_extra_amend_payment_ref'), '54321';
             is $update->get_extra_metadata('fms_extra_amend_payment_amount'), '23.75';
@@ -1242,7 +1252,10 @@ FixMyStreet::override_config {
         $mech->submit_form_ok;
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
         $mech->submit_form_ok({ with_fields => { chosen_date => '2023-07-01T00:00:00;reserveA==;2023-06-25T10:10:00' } });
-        $mech->submit_form_ok({ form_number => 1, fields => { 'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath' } });
+        $mech->submit_form_ok({ form_number => 1, fields => {
+            'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath',
+            'item_notes_1' => 'Note', 'item_notes_2' => 'Note', 'item_notes_3' => 'Note',
+        } });
         $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
         $mech->content_contains('3 items requested for collection');
         $mech->content_contains('£0.00');
@@ -1292,7 +1305,10 @@ FixMyStreet::override_config {
         $mech->submit_form_ok;
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
         $mech->submit_form_ok({ with_fields => { chosen_date => '2023-07-01T00:00:00;reserveA==;2023-06-25T10:10:00' } });
-        $mech->submit_form_ok({ form_number => 1, fields => { 'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath' } });
+        $mech->submit_form_ok({ form_number => 1, fields => {
+            'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath',
+            'item_notes_1' => 'Note', 'item_notes_2' => 'Note', 'item_notes_3' => 'Note',
+        } });
         $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
         $mech->content_contains('3 items requested for collection');
         $mech->content_contains('£0.00');
@@ -1331,7 +1347,10 @@ FixMyStreet::override_config {
         $mech->submit_form_ok;
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
         $mech->submit_form_ok({ with_fields => { chosen_date => '2023-07-01T00:00:00;reserveA==;2023-06-25T10:10:00' } });
-        $mech->submit_form_ok({ form_number => 1, fields => { 'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath' } });
+        $mech->submit_form_ok({ form_number => 1, fields => {
+            'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath',
+            'item_notes_1' => 'Note', 'item_notes_2' => 'Note', 'item_notes_3' => 'Note',
+        } });
         $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
         $mech->content_contains('3 items requested for collection');
         $mech->content_contains('£37.00');
@@ -1348,7 +1367,10 @@ FixMyStreet::override_config {
         $mech->submit_form_ok;
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
         $mech->submit_form_ok({ with_fields => { chosen_date => '2024-07-01T00:00:00;reserveA==;2023-06-25T10:10:00' } });
-        $mech->submit_form_ok({ form_number => 1, fields => { 'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath' } });
+        $mech->submit_form_ok({ form_number => 1, fields => {
+            'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath',
+            'item_notes_1' => 'Note', 'item_notes_2' => 'Note', 'item_notes_3' => 'Note',
+        } });
         $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
         $mech->content_contains('3 items requested for collection');
         $mech->content_contains('£0.00');
@@ -1435,7 +1457,7 @@ FixMyStreet::override_config {
             my $comment = $report->comments->order_by('-id')->first;
             is $comment->text, 'Booking amended';
             is $comment->get_extra_metadata('fms_extra_amend_items'), '83::6';
-            is $comment->get_extra_metadata('fms_extra_amend_notes'), '::';
+            is $comment->get_extra_metadata('fms_extra_amend_notes'), 'Note::Note';
             is $comment->get_extra_metadata('fms_extra_amend_location'), 'in the middle of the drive';
             is $comment->get_extra_metadata('fms_extra_amend_payment_ref'), 'free';
             is $comment->get_extra_metadata('fms_extra_amend_payment_amount'), '0.00';
@@ -1460,6 +1482,8 @@ FixMyStreet::override_config {
                     'item_2' => 'Bookcase, Shelving Unit',
                     'item_3' => 'Bathroom Cabinet /Shower Screen',
                     'item_4' => 'Bicycle',
+                    'item_notes_3' => 'Note',
+                    'item_notes_4' => 'Note',
                 },
             });
             $mech->submit_form_ok({ form_number => 2 }); # Location page
@@ -1501,7 +1525,7 @@ FixMyStreet::override_config {
             my $comment = $report->comments->order_by('-id')->first;
             is $comment->text, 'Booking amended';
             is $comment->get_extra_metadata('fms_extra_amend_items'), '83::6::84::85';
-            is $comment->get_extra_metadata('fms_extra_amend_notes'), '::::::';
+            is $comment->get_extra_metadata('fms_extra_amend_notes'), 'Note::Note::Note::Note';
             is $comment->get_extra_metadata('fms_extra_amend_location'), 'in the middle of the drive';
             is $comment->get_extra_metadata('fms_extra_amend_payment_ref'), '54321';
             is $comment->get_extra_metadata('fms_extra_amend_payment_amount'), '60.75';
@@ -1529,7 +1553,10 @@ FixMyStreet::override_config {
             $mech->submit_form_ok;
             $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
             $mech->submit_form_ok({ with_fields => { chosen_date => '2023-07-01T00:00:00;reserveA==;2023-06-25T10:10:00' } });
-            $mech->submit_form_ok({ form_number => 1, fields => { 'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath' } });
+            $mech->submit_form_ok({ form_number => 1, fields => {
+                'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath',
+                'item_notes_1' => 'Note', 'item_notes_2' => 'Note', 'item_notes_3' => 'Note',
+            } });
             $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
             $mech->submit_form_ok({ with_fields => { tandc => 1 } });
 
@@ -1634,6 +1661,8 @@ FixMyStreet::override_config {
                     'item_2' => 'Bookcase, Shelving Unit',
                     'item_3' => 'Bathroom Cabinet /Shower Screen',
                     'item_4' => 'BBQ',
+                    'item_notes_3' => 'Note',
+                    'item_notes_4' => 'Note',
                 },
             });
             $mech->submit_form_ok({ form_number => 2 }); # Location page
@@ -1714,7 +1743,10 @@ FixMyStreet::override_config {
         $mech->submit_form_ok;
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
         $mech->submit_form_ok({ with_fields => { chosen_date => '2023-07-01T00:00:00;reserveA==;2023-06-25T10:10:00' } });
-        $mech->submit_form_ok({ form_number => 1, fields => { 'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath' } });
+        $mech->submit_form_ok({ form_number => 1, fields => {
+            'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath',
+            'item_notes_1' => 'Note', 'item_notes_2' => 'Note', 'item_notes_3' => 'Note',
+        } });
         $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
         $mech->content_contains('3 items requested for collection');
         $mech->content_contains('£10.00');
@@ -1782,7 +1814,10 @@ FixMyStreet::override_config {
         $mech->submit_form_ok;
         $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
         $mech->submit_form_ok({ with_fields => { chosen_date => '2023-07-01T00:00:00;reserveA==;2023-06-25T10:10:00' } });
-        $mech->submit_form_ok({ form_number => 1, fields => { 'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath' } });
+        $mech->submit_form_ok({ form_number => 1, fields => {
+            'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath',
+            'item_notes_1' => 'Note', 'item_notes_2' => 'Note', 'item_notes_3' => 'Note',
+        } });
         $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
         $mech->content_contains('3 items requested for collection');
         $mech->content_contains('£10.00');
@@ -1825,7 +1860,10 @@ FixMyStreet::override_config {
             $mech->submit_form_ok;
             $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
             $mech->submit_form_ok({ with_fields => { chosen_date => '2023-07-01T00:00:00;reserveA==;2023-06-25T10:10:00' } });
-            $mech->submit_form_ok({ form_number => 1, fields => { 'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath' } });
+            $mech->submit_form_ok({ form_number => 1, fields => {
+                'item_1' => 'BBQ', 'item_2' => 'Bicycle', 'item_3' => 'Bath',
+                'item_notes_1' => 'Note', 'item_notes_2' => 'Note', 'item_notes_3' => 'Note',
+            } });
             $mech->submit_form_ok({ with_fields => { location => 'in the middle of the drive' } });
             $mech->content_contains('3 items requested for collection');
             $mech->content_contains('£37.00');
@@ -1893,6 +1931,7 @@ sub add_extra_metadata {
             items_per_collection_max => 6,
             per_item_costs => 0,
             show_location_page => 'users',
+            show_individual_notes => 1,
             item_list => [
                 { bartec_id => '83', name => 'Bath' },
                 { bartec_id => '84', name => 'Bathroom Cabinet /Shower Screen' },

--- a/t/app/controller/waste_merton_bulky.t
+++ b/t/app/controller/waste_merton_bulky.t
@@ -31,6 +31,7 @@ $contact->update;
 
 my $contact_centre_user = $mech->create_user_ok('contact@example.org', from_body => $body, email_verified => 1, name => 'Contact 1');
 $contact_centre_user->user_body_permissions->create({ body => $body, permission_type => 'report_view_private' });
+$contact_centre_user->user_body_permissions->create({ body => $body, permission_type => 'wasteworks_config' });
 
 for ($body) {
     add_extra_metadata($_);
@@ -44,6 +45,7 @@ FixMyStreet::override_config {
         waste => { merton => 1 },
         waste_features => {
             merton => {
+                admin_config_enabled => 1,
                 bulky_enabled => 1,
                 bulky_amend_enabled => 'staff',
                 bulky_cancel_enabled => 'staff',
@@ -1286,17 +1288,23 @@ FixMyStreet::override_config {
         $report->delete;
     };
 
-    subtest 'Bulky goods booking with discounted (but still zero) payment' => sub {
-        my $extra = $body->get_extra_metadata('wasteworks_config');
-        $extra->{base_price} = 6075;
-        $extra->{band1_price} = 3700;
-        $extra->{discount_enabled} = 1;
-        $extra->{discount_price} = 0;
-        $extra->{discount_max_items} = 3;
-        $extra->{discount_months} = 12;
-        $body->set_extra_metadata(wasteworks_config => $extra);
-        $body->update;
+    subtest 'Update the waste configuration in the admin' => sub {
+        $mech->log_in_ok( $contact_centre_user->email );
+        $mech->get_ok('/admin/waste');
+        $mech->content_like(qr/waste_discount_enabled"  data-show/);
+        $mech->content_like(qr/waste_discount_months"\s+value=""/);
+        $mech->content_like(qr/waste_discount_max_items"\s+value=""/);
+        $mech->content_like(qr/waste_discount_price"\s+value=""/);
+        $mech->submit_form_ok({ with_fields => { discount_enabled => 1, discount_max_items => 4 } });
+        $mech->content_contains('cannot exceed small collection');
+        $mech->submit_form_ok({ with_fields => { discount_enabled => 1, discount_price => 0, discount_max_items => 3, discount_months => 12, base_price => 6075, band1_price => 3700 } });
+        $mech->content_like(qr/waste_discount_enabled" checked/);
+        $mech->content_like(qr/waste_discount_months"\s+value="12"/);
+        $mech->content_like(qr/waste_discount_max_items"\s+value="3"/);
+        $mech->content_like(qr/waste_discount_price"\s+value="0"/);
+    };
 
+    subtest 'Bulky goods booking with discounted (but still zero) payment' => sub {
         $mech->get_ok('/waste/12345');
         $mech->content_contains('Last discounted collection: None');
         $mech->content_contains('>Next discounted collection on or after: Friday 7 July 2023');

--- a/t/app/controller/waste_merton_bulky.t
+++ b/t/app/controller/waste_merton_bulky.t
@@ -991,6 +991,8 @@ FixMyStreet::override_config {
             is $sent_params->{reference}, 12345, 'correct scpReference sent';
 
             my $email = $mech->get_email;
+            my $text = $mech->get_text_body_from_email($email);
+            like $text, qr/Bathroom Cabinet/;
             is $email->header('Subject'), 'Bulky waste collection service - reference ' . $report->id;
             $mech->clear_emails_ok;
 

--- a/templates/email/default/waste/bulky-reminder.html
+++ b/templates/email/default/waste/bulky-reminder.html
@@ -20,9 +20,9 @@ cancel_url = cobrand.base_url _ '/waste/' _ property_id_uri _ '/' _ bulky_cancel
   <p style="[% p_style %]">[% email_summary %]</p>
 
   <p style="[% p_style %]">
-    [% IF days == 3 %]
+    [% IF days > 1 %]
     This is a reminder that your collection is in
-    <strong>3 days</strong>.
+    <strong>[% days %] days</strong>.
     [% ELSIF days == 1 %]
     This is a reminder that your collection is
     <strong>tomorrow</strong>.
@@ -64,7 +64,7 @@ cancel_url = cobrand.base_url _ '/waste/' _ property_id_uri _ '/' _ bulky_cancel
   [% END %]
 </p>
 
-[% IF cobrand.moniker == 'peterborough' OR cobrand.moniker == 'bromley' %]
+[% IF cobrand.moniker == 'peterborough' OR cobrand.moniker == 'bromley' OR cobrand.moniker == 'merton' %]
    [% INCLUDE 'waste/_bulky_extra_text.html' %]
 [% END %]
 

--- a/templates/email/default/waste/bulky-reminder.txt
+++ b/templates/email/default/waste/bulky-reminder.txt
@@ -15,8 +15,8 @@ Dear [% report.name %],
 
 [% email_summary %]
 
-[% IF days == 3 %]
-This is a reminder that your collection is in 3 days.
+[% IF days > 1 %]
+This is a reminder that your collection is in [% days %] days.
 [% ELSIF days == 1 %]
 This is a reminder that your collection is tomorrow.
 [% END %]
@@ -56,7 +56,7 @@ You may still be able to cancel your booking.
 
 [% END ~%]
 
-[% IF cobrand.moniker == 'peterborough' OR cobrand.moniker == 'bromley' %]
+[% IF cobrand.moniker == 'peterborough' OR cobrand.moniker == 'bromley' OR cobrand.moniker == 'merton' %]
 [% INCLUDE 'waste/_bulky_extra_text.txt' %]
 [% END %]
 

--- a/templates/email/default/waste/other-reported-bulky.html
+++ b/templates/email/default/waste/other-reported-bulky.html
@@ -32,6 +32,8 @@ cancel_url = cobrand.base_url _ '/waste/' _ property_id_uri _ '/' _ bulky_cancel
   </p>
 
   [% IF cobrand.moniker == 'merton' %]
+    [% INCLUDE 'waste/_bulky_extra_text.html' %]
+
     <p style="[% p_style %]">
         If your collection includes both upholstered and non-upholstered items (such as a sofa and a fridge), we may collect them in two stages.
         The second collection may be up to two working days after your chosen date.

--- a/templates/email/default/waste/other-reported-bulky.txt
+++ b/templates/email/default/waste/other-reported-bulky.txt
@@ -33,6 +33,8 @@ Date booking made: [% report_date %]
 Collection date: [% collection_date %]
 
 [% IF cobrand.moniker == 'merton' ~%]
+[% INCLUDE 'waste/_bulky_extra_text.txt' %]
+
 If your collection includes both upholstered and non-upholstered items (such as a sofa and a fridge), we may collect them in two stages.
 The second collection may be up to two working days after your chosen date.
 

--- a/templates/email/merton/waste/_bulky_extra_text.html
+++ b/templates/email/merton/waste/_bulky_extra_text.html
@@ -1,0 +1,9 @@
+<h2 style="[% h2_style %]">How to put your items out for collection</h2>
+
+<ul [% ul_attrs | safe %]>
+    <li>Cover sofas, mattresses and other soft furnishings with plastic to stop them getting wet.</li>
+    <li>Put your items outside by 6am on your collection day.</li>
+    <li>Leave your items outside but within the boundary of your property, not on the public pavement or road.</li>
+    <li>Make sure that our collection crew will be able to see and access the items without difficulty.</li>
+    <li>Residents living in gated properties or those with bin stores, please place your items outside the bin store or gate so our crews can easily access the items. Items will not be collected if they are inaccessible.</li>
+</ul>

--- a/templates/email/merton/waste/_bulky_extra_text.txt
+++ b/templates/email/merton/waste/_bulky_extra_text.txt
@@ -1,0 +1,11 @@
+How to put your items out for collection
+
+* Cover sofas, mattresses and other soft furnishings with plastic to stop them getting wet.
+
+* Put your items outside by 6am on your collection day.
+
+* Leave your items outside but within the boundary of your property, not on the public pavement or road.
+
+* Make sure that our collection crew will be able to see and access the items without difficulty.
+
+* Residents living in gated properties or those with bin stores, please place your items outside the bin store or gate so our crews can easily access the items. Items will not be collected if they are inaccessible.

--- a/templates/web/base/admin/waste/edit.html
+++ b/templates/web/base/admin/waste/edit.html
@@ -4,11 +4,16 @@
 
 [% INCLUDE status_message %]
 
+<style>
+.waste_admin_row {
+    display: flex;
+    gap: 1em;
+}
+</style>
+
 [% IF errors %]
     <p class="error">[% loc('Please correct the errors below') %]</p>
 [% END %]
-
-<h2>Site wide configuration</h2>
 
 [% IF errors.site_wide %]
     <div class="form-error">[% errors.site_wide %]</div>
@@ -18,7 +23,7 @@
     <input type="hidden" name="token" value="[% csrf_token %]" >
 
   [% IF cobrand.bulky_enabled %]
-    <h3>Bulky Collections</h3>
+    <h2>Bulky Collections</h2>
 
     <ul>
         <li><a href="[% c.uri_for_action('admin/waste/bulky_items', [ body.id ]) %]">[% loc("Bulky items list") %]</a></li>
@@ -27,7 +32,35 @@
 [% IF cobrand.bulky_points_per_item_pricing %]
     <input type=hidden name="per_item_costs" value=1>
 [% ELSE %]
-    <div style="display:flex;gap:1em;">
+
+[% IF cobrand.moniker == 'merton' # Discount scheme %]
+    <h3>Discount scheme</h3>
+
+    <p>
+    <input type="checkbox" name="discount_enabled" value="1" id="waste_discount_enabled" [% 'checked' IF discount_enabled %] data-show="#discount_configuration">
+    <label class="inline" for="waste_discount_enabled">Allow Bulky Waste discount scheme</label>
+    <div id="discount_configuration" class="waste_admin_row hidden-js">
+        <div>
+            <label for="waste_discount_months">Period between discounted bookings (months)</label>
+            <input class="form-control" type=text name="discount_months" id="waste_discount_months"
+                value="[% discount_months %]">
+        </div>
+        <div>
+            <label for="waste_discount_max_items">Max items per discounted collection</label>
+            <input class="form-control" type=text name="discount_max_items" id="waste_discount_max_items"
+                value="[% discount_max_items %]">
+        </div>
+        <div>
+            <label for="waste_discount_price">Price for discounted collection (in pence)</label>
+            <input class="form-control" type=text max=200 min=1 name="discount_price" id="waste_discount_price"
+                value="[% discount_price %]">
+        </div>
+    </div>
+
+    <h3>Standard pricing and volumes</h3>
+[% END %]
+
+    <div class="waste_admin_row">
     <div>
     <label for="waste_base_price">Price for a collection (in <strong>pence</strong>)</label>
     <input class="form-control" type=text name="base_price" id="waste_base_price"
@@ -49,7 +82,7 @@
     </div>
     </div>
 
-    <div style="display:flex;gap:1em;">
+    <div class="waste_admin_row">
     <div>
     <label for="waste_band1_price">Price for a small collection (in pence)</label>
     <input class="form-control" type=text name="band1_price" id="waste_band1_price"
@@ -93,7 +126,7 @@
   [% END %]
 
   [% IF cobrand.small_items_enabled %]
-    <h3>Small Items Collections</h3>
+    <h2>Small Items Collections</h2>
 
     <ul>
         <li><a href="[% c.uri_for_action('admin/waste/small_items', [ body.id ]) %]">Small items list</a></li>
@@ -132,7 +165,7 @@
         [% 'checked' IF free_mode %]>
     <label class="inline" for="waste_free_mode">Free collection allowed</label>
 
-    <h3>General Options</h3>
+    <h2>General Options</h2>
 
     <p>
     <label for="waste_food_bags_disabled">Food bag ordering disabled</label>

--- a/templates/web/base/waste/bin_days.html
+++ b/templates/web/base/waste/bin_days.html
@@ -253,6 +253,13 @@
                     Please make sure you’ve read the <a href="https://www.sutton.gov.uk/w/bulky-waste-collections-terms-and-conditions">bulky goods collection page</a> before making a booking.
                   [% END %]
                 </p>
+              [% ELSIF c.cobrand.moniker == 'merton' AND c.cobrand.wasteworks_config.discount_enabled %]
+                <p>
+                Please read the <a href="[% c.cobrand.call_hook('bulky_tandc_link') %]">bulky waste collection</a> page on the council’s website.
+                <br>Any discount will automatically be applied to your booking.
+                <br>Last discounted collection: [% IF cobrand.bulky_last_discounted_date; date.format(cobrand.bulky_last_discounted_date, format='%A %-d %B %Y'); ELSE; 'None'; END %]
+                <br>Next discounted collection on or after: [% date.format(cobrand.bulky_next_discounted_date, format='%A %-d %B %Y') %]
+                </p>
               [% END %]
           </div>
           [% END %]

--- a/templates/web/base/waste/bulky/_band1_pricing.html
+++ b/templates/web/base/waste/bulky/_band1_pricing.html
@@ -1,0 +1,27 @@
+[%
+SET band1_items = cfg.band1_max;
+SET max_items = cfg.items_per_collection_max;
+SET base_price = cfg.base_price / 100;
+SET band1_price = cfg.band1_price / 100;
+SET base_pop_price = (cfg.base_pop_price OR 0) / 100;
+SET band1_pop_price = (cfg.band1_pop_price OR 0) / 100;
+%]
+
+  <ul class="bulky-intro-pricing">
+    <li class="bulky-intro-pricing">
+      1 to [% band1_items %] items cost £[% pounds(band1_price) %]
+      [% IF cfg.pop_costs %]
+      (£[% pounds(band1_pop_price) %] if any item contains POPs)
+      [% END %]
+      [% IF cfg.discount_enabled %]
+      (Any discount will be applied if eligible)
+      [% END %]
+    </li>
+    <li class="bulky-intro-pricing">
+      [% band1_items+1 %] to [% max_items %] items cost £[% pounds(base_price) %]
+      [% IF cfg.pop_costs %]
+      (£[% pounds(base_pop_price) %] if any item contains POPs)
+      [% END %]
+    </li>
+  </ul>
+</li>

--- a/templates/web/base/waste/bulky/_bin_days_list.html
+++ b/templates/web/base/waste/bulky/_bin_days_list.html
@@ -47,7 +47,7 @@ END;
               <a class="btn btn--primary govuk-!-margin-bottom-2" href="[% c.uri_for_action('waste/bulky/amend_small', [ property.id, booking.id ]) %]">Amend booking</a>
             [% END %]
           [% ELSIF c.cobrand.moniker == 'merton' %]
-            <p>Free bulky waste bookings are final and can’t be changed. To make a change to a paid-for booking made before 1 June 2026, call us on 020 8274 4902 at least 2 working days before your collection day.</p>
+            <p>If you would like to make any changes to your booking, call us on 020 8274 4902 at least 2 working days before your collection day.</p>
           [% END %]
           [% IF c.cobrand.bulky_can_cancel_collection(booking) %]
             [% IF type == 'bulky' %]

--- a/templates/web/base/waste/bulky/_bin_days_list.html
+++ b/templates/web/base/waste/bulky/_bin_days_list.html
@@ -129,6 +129,7 @@ END;
     [% END %]
 
   [% IF type == 'bulky' %]
+  [% IF c.cobrand.moniker != 'merton' # No line for Merton %]
   <dl class="govuk-summary-list govuk-!-margin-bottom-3 govuk-!-padding-bottom-0">
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Cost</dt>
@@ -151,6 +152,7 @@ END;
       </dd>
     </div>
   </dl>
+  [% END %]
   [% END %]
 [% END %]
 

--- a/templates/web/base/waste/bulky/confirmation.html
+++ b/templates/web/base/waste/bulky/confirmation.html
@@ -62,6 +62,11 @@ END ~%]
       [% IF report.user.email AND report.get_extra_metadata('contributed_as') != 'anonymous_user' %]
       <p>We have emailed confirmation of your booking to [% report.user.email %].</p>
       [% END %]
+
+      [% IF c.cobrand.moniker == 'merton' %]
+      <p>You must follow the instructions in your confirmation email about how to put your items out for collection.</p>
+      [% END %]
+
       [% IF c.cobrand.moniker == 'bromley' %]
           <p>Your reference number is reference:&nbsp;[% report_id %]</p>
       [% ELSE %]

--- a/templates/web/base/waste/bulky/intro.html
+++ b/templates/web/base/waste/bulky/intro.html
@@ -1,4 +1,4 @@
-[% IF c.cobrand.moniker == 'merton' || c.cobrand.moniker == 'bexley' ~%]
+[% IF c.cobrand.moniker == 'bexley' ~%]
     [% service_name = "bulky waste" ~%]
 [% ELSE ~%]
     [% service_name = "bulky goods" ~%]
@@ -54,43 +54,10 @@
     <li>You can request up to <strong>[% c.stash.booking_maximum | numwords %] items per collection</strong></li>
   [% END %]
 
-  [% IF c.cobrand.moniker != 'merton' %]
-    [% IF cfg.band1_price %]
-      [%
-          SET band1_items = cfg.band1_max;
-          SET max_items = cfg.items_per_collection_max;
-          SET base_price = cfg.base_price / 100;
-          SET band1_price = cfg.band1_price / 100;
-          SET base_pop_price = (cfg.base_pop_price OR 0) / 100;
-          SET band1_pop_price = (cfg.band1_pop_price OR 0) / 100;
-      %]
-      <li>The price depends on how many items you would like collected:
-          <ul class="bulky-intro-pricing">
-              <li class="bulky-intro-pricing">
-                  1 to [% band1_items %] items cost £[% pounds(band1_price) %]
-                  [% IF cfg.pop_costs %]
-                      (£[% pounds(band1_pop_price) %] if any item contains POPs)
-                  [% END %]
-              </li>
-              <li class="bulky-intro-pricing">
-                  [% band1_items+1 %] to [% max_items %] items cost £[% pounds(base_price) %]
-                  [% IF cfg.pop_costs %]
-                      (£[% pounds(base_pop_price) %] if any item contains POPs)
-                  [% END %]
-              </li>
-          </ul>
-      </li>
-    [% END %]
-  [% ELSE %]
-    <li>Bulky waste collections are currently free of charge for households in Merton</li>
-  [% END %]
-
-  [% IF c.cobrand.moniker == 'merton' %]
-    <li>Every Merton household can book one free bulky waste collection of up to 3 items each year</li>
-    <li>Paid-for collections will be available later this year</li>
-    <li>If you book more than one free collection in the same year, only your first booking can be honoured</li>
-    <li>Once you confirm your booking it cannot be amended or cancelled. If you do not use it, you cannot book another free collection that year.</li>
-    <li>You must be up-to-date with Council Tax payments to use this service</li>
+  [% IF cfg.band1_price %]
+  <li>The price depends on how many items you would like collected:
+    [% PROCESS waste/bulky/_band1_pricing.html %]
+  </li>
   [% END %]
 
   [% IF c.cobrand.moniker != 'bromley' AND c.cobrand.moniker != 'kingston' AND c.cobrand.moniker != 'sutton' %]
@@ -109,10 +76,6 @@
 
     [% IF cobrand.moniker == 'kingston' || cobrand.moniker == 'sutton' %]
     <li>Bookings are final and non refundable</li>
-    [% END %]
-
-    [% IF c.cobrand.moniker == 'merton' %]
-      <li>The bulky waste service will open for second and larger collections during October 2026</li>
     [% END %]
 
   [% END %] [% # End of not-Bexley %]

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -6,6 +6,15 @@
 [% PROCESS back %]
 [% PROCESS errors %]
 [% PROCESS title %]
+
+[% IF c.cobrand.moniker == 'merton' %]
+<p class="govuk-body">
+Please add each item individually.
+e.g. if you have 2 Armchairs and a sofa to be collected, add each Armchair and then add the sofa.
+<strong>Do not</strong> add just one armchair and state 2 in the description. Only one will be collected.
+</p>
+[% END %]
+
 [% IF property AND NOT (c.cobrand.moniker == 'sutton' || c.cobrand.moniker == 'kingston') %]
   [% INCLUDE 'waste/_address_display.html' %]
 [% END %]

--- a/templates/web/base/waste/bulky/items.html
+++ b/templates/web/base/waste/bulky/items.html
@@ -7,14 +7,6 @@
 [% PROCESS errors %]
 [% PROCESS title %]
 
-[% IF c.cobrand.moniker == 'merton' %]
-<p class="govuk-body">
-Please add each item individually.
-e.g. if you have 2 Armchairs and a sofa to be collected, add each Armchair and then add the sofa.
-<strong>Do not</strong> add just one armchair and state 2 in the description. Only one will be collected.
-</p>
-[% END %]
-
 [% IF property AND NOT (c.cobrand.moniker == 'sutton' || c.cobrand.moniker == 'kingston') %]
   [% INCLUDE 'waste/_address_display.html' %]
 [% END %]
@@ -49,6 +41,9 @@ e.g. if you have 2 Armchairs and a sofa to be collected, add each Armchair and t
   <div class="govuk-warning-text__content">
     <span class="govuk-warning-text__assistive">Information</span>
     <p class="govuk-!-margin-bottom-1"><strong>Note</strong></p>
+  [% IF c.cobrand.moniker == 'merton' %]
+    <p>Add one item at a time.</p>
+  [% END %]
   [% IF c.cobrand.moniker == 'bexley' %]
     <p>We can only collect items that are on the list.</p>
     <p>If your item is not on the list please check using a different name for the same thing.</p>
@@ -143,7 +138,7 @@ END; END %]
   <p id="band-pricing-info"></p>
   [% END %]
   <button type="submit" id="add-new-item" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-7" aria-label="Add item" name="goto-same-page" value="1">
-    [% IF c.cobrand.moniker == 'kingston' OR c.cobrand.moniker == 'sutton' ~%]
+    [% IF c.cobrand.moniker == 'kingston' OR c.cobrand.moniker == 'sutton' OR c.cobrand.moniker == 'merton' ~%]
       Add another item
     [%~ ELSE ~%]
       Add item

--- a/templates/web/base/waste/bulky/location.html
+++ b/templates/web/base/waste/bulky/location.html
@@ -14,9 +14,18 @@
         <strong>If you live in a block of flats:</strong>
         Put your items next to the bin store area (not inside it) on the morning of your collection.
     </p>
+[% IF c.cobrand.moniker == 'merton' %]
+    <p class="govuk-body">
+        <strong>Please read the <a href="[% c.cobrand.call_hook('bulky_tandc_link') %]">bulky waste collection</a> page on the council’s website for more information.</strong>
+    </p>
+    <p class="govuk-body">
+        <strong>Items must be out for collection by [% collection_time %] on the collection day</strong>. Our crew will not enter your home or collect items from your back garden or inside a bin store.
+    </p>
+[% ELSE %]
     <p class="govuk-body">
         Items must be out for collection by [% collection_time %] on the collection day. Our crew will not enter your home or collect items from your back garden.
     </p>
+[% END %]
     <hr>
 [% END %]
 [% IF c.cobrand.moniker == 'bexley' %]

--- a/templates/web/base/waste/bulky/summary.html
+++ b/templates/web/base/waste/bulky/summary.html
@@ -297,7 +297,9 @@ SET data = form.saved_data;
         %]">Amend this booking</a>
       </p>
     [% ELSIF cobrand.moniker == 'merton' %]
-      <p>Free bulky waste bookings are final and can’t be changed. To make a change to a paid-for booking made before 1 June 2026, call us on 020 8274 4902 at least 2 working days before your collection day.</p>
+      <p>
+      If you would like to make any changes to your booking, call us on 020 8274 4902 at least 2 working days before your collection day.
+      </p>
     [% END %]
     [% IF cobrand.bulky_can_cancel_collection(problem) %]
       <p>

--- a/templates/web/merton/waste/bulky/intro.html
+++ b/templates/web/merton/waste/bulky/intro.html
@@ -1,0 +1,34 @@
+[%~
+USE pounds = format('%.2f');
+SET cfg = c.cobrand.wasteworks_config;
+~%]
+
+<h2>Before you book</h2>
+
+<p class="govuk-body">
+Requesting a bulky waste collection usually takes around <strong>10 minutes</strong>.
+</p>
+
+<p class="govuk-body">
+<strong>Please make sure you have read the <a href="[% c.cobrand.call_hook('bulky_tandc_link') %]"> bulky waste collection</a> page on the council’s website</strong>.
+</p>
+
+<p class="govuk-body">
+<strong>Bookings are final and non-refundable</strong>.
+</p>
+
+<p class="govuk-body">There are <strong>six</strong> stages you need to complete to make a booking</p>
+
+<ol>
+  <li><strong>Your details:</strong> Your address, email address and telephone number.</li>
+  <li><strong>Choose date for collection:</strong> Pick an available collection date from the list provided.</li>
+  <li><strong>Add items for collection:</strong> You can request up to six items per collection. The price depends on how many items you would like collected
+  [% PROCESS waste/bulky/_band1_pricing.html %]
+  You can also add a helpful description and pictures of each item to be collected.
+  <li><strong>Add location details:</strong> Describe where the item(s) will be located. A picture of the location can also be added.</li>
+  <li><strong>Booking Summary:</strong> Before confirming your booking, check all the information provided is correct. You can make changes if necessary.</li>
+  <li><strong>Make payment:</strong> You will be redirected to the council’s card payments provider.</li>
+</ol>
+
+
+[% INCLUDE 'waste/_intro_clear.html' %]

--- a/templates/web/merton/waste/bulky/intro.html
+++ b/templates/web/merton/waste/bulky/intro.html
@@ -3,31 +3,31 @@ USE pounds = format('%.2f');
 SET cfg = c.cobrand.wasteworks_config;
 ~%]
 
-<h2>Before you book</h2>
-
-<p class="govuk-body">
-Requesting a bulky waste collection usually takes around <strong>10 minutes</strong>.
+<p>
+Booking a bulky waste collection takes around 10 minutes.
 </p>
 
-<p class="govuk-body">
-<strong>Please make sure you have read the <a href="[% c.cobrand.call_hook('bulky_tandc_link') %]"> bulky waste collection</a> page on the council’s website</strong>.
+<p>
+<strong>Bookings cannot be refunded once confirmed.</strong>
 </p>
 
-<p class="govuk-body">
-<strong>Bookings are final and non-refundable</strong>.
+<h2>Before you start</h2>
+
+<p>
+Please read the <a href="[% c.cobrand.call_hook('bulky_tandc_link') %]"> bulky waste collection</a> page on the council’s website.
 </p>
 
-<p class="govuk-body">There are <strong>six</strong> stages you need to complete to make a booking</p>
+<h2>How to book</h2>
+
+<p>You will need to:</p>
 
 <ol>
-  <li><strong>Your details:</strong> Your address, email address and telephone number.</li>
-  <li><strong>Choose date for collection:</strong> Pick an available collection date from the list provided.</li>
-  <li><strong>Add items for collection:</strong> You can request up to six items per collection. The price depends on how many items you would like collected
-  [% PROCESS waste/bulky/_band1_pricing.html %]
-  You can also add a helpful description and pictures of each item to be collected.
-  <li><strong>Add location details:</strong> Describe where the item(s) will be located. A picture of the location can also be added.</li>
-  <li><strong>Booking Summary:</strong> Before confirming your booking, check all the information provided is correct. You can make changes if necessary.</li>
-  <li><strong>Make payment:</strong> You will be redirected to the council’s card payments provider.</li>
+  <li>Enter your name, email address and telephone number.</li>
+  <li>Choose a collection date.</li>
+  <li>Tell us what you want us to collect.
+      You can also add a description and upload photos of each item.
+  <li>Tell us where to collect the items from.</li>
+  <li>Pay online by card, if there is a charge.</li>
 </ol>
 
 

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1637,13 +1637,33 @@ $.extend(fixmystreet.set_up, {
           }
       });
 
+      function update_visibility(selector) {
+          var $showTarget = $( selector.attr('data-show') );
+          var $hideTarget = $( selector.attr('data-hide') );
+          $showTarget.removeClass('hidden-js');
+          $hideTarget.addClass('hidden-js');
+      }
+
       $('input[type="radio"][data-show], input[type="radio"][data-hide]').each(function(){
           var update = function(){
               if ( this.checked ) {
+                  update_visibility($(this));
+              }
+          };
+          // off/on to make sure event handler is only bound once.
+          $(this).off('change.togglevisibility').on('change.togglevisibility', update);
+          update.call(this); // pass DOM element as `this`
+      });
+
+      $('input[type="checkbox"][data-show], input[type="checkbox"][data-hide]').each(function(){
+          var update = function(){
+              if ( this.checked ) {
+                  update_visibility($(this));
+              } else {
                   var $showTarget = $( $(this).attr('data-show') );
                   var $hideTarget = $( $(this).attr('data-hide') );
-                  $showTarget.removeClass('hidden-js');
-                  $hideTarget.addClass('hidden-js');
+                  $hideTarget.removeClass('hidden-js');
+                  $showTarget.addClass('hidden-js');
               }
           };
           // off/on to make sure event handler is only bound once.
@@ -1655,10 +1675,7 @@ $.extend(fixmystreet.set_up, {
           var $select = $(this).parent();
           var update = function(){
               var $option = $(this).find('option:selected');
-              var $showTarget = $( $option.attr('data-show') );
-              var $hideTarget = $( $option.attr('data-hide') );
-              $showTarget.removeClass('hidden-js');
-              $hideTarget.addClass('hidden-js');
+              update_visibility($option);
           };
           // off/on to make sure event handler is only bound once.
           $select.off('change.togglevisibility').on('change.togglevisibility', update);

--- a/web/js/waste.js
+++ b/web/js/waste.js
@@ -237,19 +237,26 @@ $(function() {
             return;
         }
 
-        var base_price = pricing.bands[1].price / 100;
-        var base_max = pricing.bands[1].max;
-        var band1_max = pricing.bands[0].max;
         var count = numberOfItems();
+        var base_max = pricing.bands[pricing.bands.length-1].max;
         var message = count + ' ' + (count === 1 ? 'item' : 'items') + ' selected - ';
         message += 'you can add up to ' + (base_max - count) + ' more ' + (base_max - count === 1 ? 'item' : 'items') + '.';
-        if (count && count < band1_max) {
-            message += ' Adding another item will not increase the cost';
-        } else if (count && count == band1_max) {
-            message += ' Adding another item will increase the cost to £' + base_price.toFixed(2);
-        } else if (count && count < base_max) {
-        } else {
-            message = '';
+        for (var i=0; i<pricing.bands.length; i++) {
+            var band = pricing.bands[i];
+            var price = band.price / 100;
+            var max = band.max;
+            if (!count) {
+                break;
+            }
+            if (count < max && i < pricing.bands.length - 1) {
+                message += ' Adding another item will not increase the cost';
+                break;
+            } else if (count == max && i < pricing.bands.length - 1) {
+                message += ' Adding another item will increase the cost to £' + (pricing.bands[i+1].price / 100).toFixed(2);
+                break;
+            } else if (count == max && i == pricing.bands.length - 1) {
+                message = '';
+            }
         }
         $('#band-pricing-info').text(message);
     }


### PR DESCRIPTION
For https://github.com/mysociety/societyworks/issues/5566 [skip changelog]
Adds a `property` table, as that seemed cleanest/easiest to store it.
Upgrades List::MoreUtils to get `slideatatime`.
Also brings back text changes from https://github.com/mysociety/fixmystreet/pull/5942 (with additional tweaks asked for by them for now).
Uses `unset_free_bulky_used` as that seemed to make sense, though doesn't use the other (unused) Peterborough bits.

Bulk of actual functional code is in Merton/Waste.pm - bulky_total_cost uses some WasteWorks config values (discount_allowed, discount_months, discount_max_items, discount_price) to do the discount checks and set the price. And if you amend, checks to see if still discounted, or stops being discounted. (Copies the relevant bits of the main bulky_total_cost as it gets confused with inheritance if you try and call it.) `bulky_extra_confirmation_step` then records/removes the discount date. And cancelling handled in `unset_free_bulky_used`.