### PR TITLE
[Waste] Make sure next collection contains data.

### DIFF
--- a/t/app/controller/waste_merton.t
+++ b/t/app/controller/waste_merton.t
@@ -170,6 +170,16 @@ FixMyStreet::override_config {
         $e->mock('GetServiceUnitsForObject', sub { $bin_data });
     };
 
+    subtest 'No next does not show current date' => sub {
+        my $dupe = dclone($bin_data);
+        $dupe->[1]{ServiceTasks}{ServiceTask}[0]{ServiceTaskSchedules}{ServiceTaskSchedule}[1]{NextInstance} = undef;
+        $e->mock('GetServiceUnitsForObject', sub { $dupe });
+        $mech->get_ok('/waste/12345');
+        my ($pre, $food) = split /waste-service-grid--service-name/, $mech->encoded_content;
+        like $food, qr{Next collection</dt>\s*<dd class="govuk-summary-list__value">\s*<i>None};
+        $e->mock('GetServiceUnitsForObject', sub { $bin_data });
+    };
+
     subtest 'In progress collection' => sub {
         $e->mock('GetTasks', sub { [ {
             Ref => { Value => { anyType => [ 17430692, 8287 ] } },

--- a/templates/web/base/waste/bin_days.html
+++ b/templates/web/base/waste/bin_days.html
@@ -184,7 +184,7 @@
                   <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">Next collection</dt>
                     <dd class="govuk-summary-list__value">
-                      [% IF unit.next %]
+                      [% IF unit.next.size %]
                         [% IF unit.next.already_collected %]
                           [% IF unit.report_locked_out %]
                             <strong>Could not be collected today because it was red-tagged. See reason below.</strong>

--- a/templates/web/base/waste/garden/sacks/modify_confirmed.html
+++ b/templates/web/base/waste/garden/sacks/modify_confirmed.html
@@ -9,7 +9,7 @@ Payment reference: [% reference %]
 </p>
 
 [% FOR unit IN service_data %]
-  [% NEXT UNLESS (unit.service_id == 1914 OR unit.service_id == 1915) AND unit.next %]
+  [% NEXT UNLESS (unit.service_id == 1914 OR unit.service_id == 1915) AND unit.next.size %]
   [% next_waste = date.format(unit.next.date) | replace('~~~', unit.next.ordinal) %]
 [% END %]
 [% IF next_waste %]

--- a/templates/web/base/waste/garden/subscribe_confirm.html
+++ b/templates/web/base/waste/garden/subscribe_confirm.html
@@ -73,7 +73,7 @@ to [% report.user.email %].
 </p>
 
 [% FOR unit IN service_data %]
-  [% NEXT UNLESS unit.service_id == 545 AND unit.next %]
+  [% NEXT UNLESS unit.service_id == 545 AND unit.next.size %]
   [% next_waste = date.format(unit.next.date) | replace('~~~', unit.next.ordinal) %]
 [% END %]
 [% IF next_waste %]


### PR DESCRIPTION
It is possible for next to be auto-vivified (e.g. by Merton’s calendar loop in munge_bin_services_for_address), so check it has a size in the templates. For FD-7274