### PR TITLE
[Banes] Adds report_nearby_filter

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Report.pm
+++ b/perllib/FixMyStreet/App/Controller/Report.pm
@@ -775,6 +775,8 @@ sub _nearby_json :Private {
 
             $params->{limit} = 5;
 
+            $c->cobrand->call_hook('report_nearby_filter', $params, $c->get_param('mode'));
+
             my $nearby = $c->model('DB::Nearby')->nearby($c, %$params);
 
             # Want to treat these as if they were on map

--- a/perllib/FixMyStreet/Cobrand/BathNES.pm
+++ b/perllib/FixMyStreet/Cobrand/BathNES.pm
@@ -166,6 +166,15 @@ sub new_report_detail_field_hint {
     "e.g. ‘This pothole has been here for two months and…’"
 }
 
+sub report_nearby_filter {
+    my ($self, $params, $mode) = @_;
+
+    if ($mode && $mode eq 'inspector') {
+        $params->{limit} = 10;
+        $params->{states} = FixMyStreet::DB::Result::Problem->open_states();
+    }
+}
+
 =head2 pin_colour
 
 BathNES uses the following pin colours:


### PR DESCRIPTION
Adds a report_nearby_filter to filter params
when not coming through the around page and
having access to around_nearby_filter.

Used here to extend suggestion options to 10 for
inspectors and only offer open reports.

https://mysocietysupport.freshdesk.com/a/tickets/7161

[skip changelog]