### PR TITLE
[K&S] Show different messaging for disputing a completed missed collection report

### DIFF
--- a/perllib/FixMyStreet/Roles/Cobrand/KingstonSutton.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/KingstonSutton.pm
@@ -435,11 +435,18 @@ sub _setup_missed_collection_disputes_for_service {
         # And no existing dispute since last collection
         && !$dispute_event
     ) {
-        if ( $self->_check_date_within_dispute_window( $missed_event->{date} ) eq 'within' ) {
+        my $window = $self->_check_date_within_dispute_window(
+            $missed_event->{date} );
+
+        if ( $window eq 'within' ) {
             if ($self->waste_check_can_raise_dispute( type => 'missed_collection_report' )) {
                 $row->{dispute}{missed_event} = $missed_event;
                 $row->{dispute}{allowed} = 1;
             }
+        }
+        elsif ( $window eq 'after' ) {
+            $row->{dispute}{missed_event} = $missed_event;
+            $row->{dispute}{too_late} = 1;
         }
     } elsif ($dispute_event) {
         $row->{dispute}{open} = $dispute_event;

--- a/t/app/controller/waste_kingston_bulky_disputes.t
+++ b/t/app/controller/waste_kingston_bulky_disputes.t
@@ -262,6 +262,8 @@ FixMyStreet::override_config {
             subtest 'Raising a dispute never available' => sub {
                 set_fixed_time('2023-07-01T14:59:59Z');
                 get_problem_page();
+                like $mech->text,
+                    qr/The crew have closed your collection task as not collected:.*Cancelled/;
                 $mech->content_lacks($dispute_label, 'cannot report just before window opens');
 
                 set_fixed_time('2023-07-01T15:00:01Z');
@@ -340,6 +342,8 @@ FixMyStreet::override_config {
 
             subtest 'Follow dispute link' => sub {
                 get_problem_page();
+                like $mech->text,
+                    qr/The crew have closed your collection task as not collected:.*Bin not presented/;
                 $mech->submit_form(
                     with_fields => { category => 'Missed collection dispute' },
                 );
@@ -513,6 +517,8 @@ FixMyStreet::override_config {
 
             subtest 'Follow dispute link' => sub {
                 get_problem_page();
+                like $mech->text,
+                    qr/The crew have closed your collection task as not collected:.*No access due to parked vehicle/;
                 $mech->submit_form(
                     with_fields => { category => 'Missed collection dispute' },
                 );
@@ -596,6 +602,12 @@ FixMyStreet::override_config {
 
             subtest 'Follow dispute link' => sub {
                 get_problem_page();
+                like $mech->text,
+                    qr/The crew marked this collection as completed/;
+                like $mech->text,
+                    qr/If your bulky waste was not collected.*we will return to collect the waste/;
+                unlike $mech->text, qr/$dispute_label/;
+                like $mech->text, qr/Dispute collection completion/;
                 $mech->submit_form(
                     with_fields => { category => 'Missed collection dispute' },
                 );

--- a/t/app/controller/waste_kingston_r.t
+++ b/t/app/controller/waste_kingston_r.t
@@ -643,6 +643,8 @@ FixMyStreet::override_config {
             subtest 'Raising a dispute never available' => sub {
                 set_fixed_time('2022-09-09T15:30:00Z');
                 get_problem_page();
+                like $mech->text,
+                    qr/The crew have closed your collection task as not collected:.*Unable to find the location/;
                 $mech->content_lacks($dispute_label, 'nothing before window opens');
 
                 set_fixed_time('2022-09-09T16:01:00Z');
@@ -682,12 +684,17 @@ FixMyStreet::override_config {
                 get_problem_page();
                 $mech->content_like(qr/name="category" value="Missed collection dispute"[^>]+disabled/s);
                 $mech->content_contains($dispute_label, 'shown but disabled just after window closes');
+                unlike $mech->text,
+                    qr/The crew have marked this collection as completed/,
+                    '"too late" messaging not shown';
             };
 
             subtest 'Follow dispute link' => sub {
                 set_fixed_time('2022-09-11T16:00:00Z');
 
                 get_problem_page();
+                like $mech->text,
+                    qr/The crew have closed your collection task as not collected:.*Bin not presented/;
                 $mech->submit_form(
                     with_fields => { category => 'Missed collection dispute' },
                 );
@@ -787,13 +794,18 @@ FixMyStreet::override_config {
 
                 set_fixed_time('2022-09-14T00:01:00Z');
                 get_problem_page();
-                $mech->content_lacks($dispute_label, 'not allowed just after window closes');
+                like $mech->text,
+                    qr/The crew have closed your collection task as not collected.*Health and safety reasons/;
+                $mech->content_like(qr/name="category" value="Missed collection dispute"[^>]+disabled/s);
+                $mech->content_contains($dispute_label, 'shown but disabled just after window closes');
             };
 
             subtest 'Follow dispute link' => sub {
                 set_fixed_time('2022-09-11T16:00:00Z');
 
                 get_problem_page();
+                like $mech->text,
+                    qr/The crew have closed your collection task as not collected:.*Health and safety reasons/;
                 $mech->submit_form(
                     with_fields => { category => 'Missed collection dispute' },
                 );
@@ -898,6 +910,12 @@ FixMyStreet::override_config {
 
             subtest 'Follow dispute link' => sub {
                 get_problem_page();
+                like $mech->text,
+                    qr/The crew marked this collection as completed/;
+                like $mech->text,
+                    qr/If your bin has not been emptied.*we will return to collect the bin/;
+                unlike $mech->text, qr/$dispute_label/;
+                like $mech->text, qr/Dispute collection completion/;
                 $mech->submit_form(
                     with_fields => { category => 'Missed collection dispute' },
                 );
@@ -909,6 +927,11 @@ FixMyStreet::override_config {
                 $mech->reload;
                 like $mech->uri->path_query, qr/waste\/12345/,
                     'redirects to bin page if outside window';
+                get_problem_page();
+                $mech->text_contains('The crew have marked this collection as completed');
+                $mech->text_contains('Dispute collection completion');
+                $mech->content_like(qr/name="category" value="Missed collection dispute"[^>]+disabled/s);
+                $mech->text_contains('You cannot dispute this as it has been more than 2 working days');
             };
 
             subtest 'Correct dispute link in email' => sub {

--- a/t/app/controller/waste_sutton_r.t
+++ b/t/app/controller/waste_sutton_r.t
@@ -1140,11 +1140,23 @@ FixMyStreet::override_config {
 
             set_fixed_time('2022-09-15T17:00:00Z');
             $mech->get_ok($problem_url);
-            $mech->content_lacks($dispute_label);
+            $mech->content_contains($dispute_label);
+            $mech->content_contains(
+                'You cannot dispute this as it has been more than 2 working days since the scheduled collection'
+            );
+            unlike $mech->text,
+                qr/The crew have marked this collection as completed/,
+                '"too late" messaging not shown';
 
             set_fixed_time('2022-09-15T19:00:00Z');
             $mech->get_ok($problem_url);
-            $mech->content_lacks($dispute_label);
+            $mech->content_contains($dispute_label);
+            $mech->content_contains(
+                'You cannot dispute this as it has been more than 2 working days since the scheduled collection'
+            );
+            unlike $mech->text,
+                qr/The crew have marked this collection as completed/,
+                '"too late" messaging not shown';
         };
 
         $missed_report->update({ external_id => 'missed-collection-guid' });
@@ -1271,7 +1283,10 @@ FixMyStreet::override_config {
 
             set_fixed_time('2022-09-14T19:00:00Z');
             $mech->get_ok($problem_url);
-            $mech->content_lacks($dispute_label);
+            $mech->text_contains('The crew have marked this collection as completed');
+            $mech->text_contains('Dispute collection completion');
+            $mech->content_like(qr/name="category" value="Missed collection dispute"[^>]+disabled/s);
+            $mech->text_contains('You cannot dispute this as it has been more than 2 working days');
         };
 
         $e->mock('GetEventsForObject', sub { [] }); # reset

--- a/templates/web/sutton/waste/enquiry-problem.html
+++ b/templates/web/sutton/waste/enquiry-problem.html
@@ -6,7 +6,7 @@ service_id = c.req.params.service_id;
 IF original_booking_report;
     SET booking_guid = original_booking_report.external_id;
     SET service = booked_missed.$booking_guid;
-    SET resolution = service.report_locked_out_reason;
+    SET resolution = service.report_locked_out_reason || service.report_open.resolution_reason;
 ELSE;
     SET service = services.$service_id;
     SET resolution = c.cobrand.resolution_text(service.last.resolution_id) || service.report_open.resolution_reason;
@@ -39,12 +39,27 @@ END;
     <div class="govuk-warning-text info">
         <div class="govuk-warning-text__content">
         [% IF NOT service.dispute.open %]
-        <p>The crew have closed your collection task as not collected[%
-            IF resolution %]: [% resolution | staff_html_markup({ is_body_user => 1 }) %]
+            [% IF service.dispute.missed_event && service.dispute.missed_event.completed %]
+                [% IF service.dispute.too_late %]
+                    <p>The crew have marked this collection as completed. You cannot dispute this as it has been more than 2 working days since the collection took place.</p>
+                [% ELSE %]
+                    [%
+                        SET type = service.service_name == 'Bulky waste'
+                            ? 'bulky'
+                            : service.service_name == 'Small items'
+                                ? 'small'
+                                : '';
+                    %]
+                    <p>The crew marked this collection as completed. If your [% IF type == 'bulky' %]bulky waste was not collected[% ELSIF type == 'small' %]small items were not collected[% ELSE %]bin has not been emptied[% END %], you can dispute this and we will investigate. If we find that the collection task was closed incorrectly, we will return to collect the [% IF !type %]bin[% ELSE %]waste[% END %].</p>
+                [% END %]
+            [% ELSE %]
+                <p>The crew have closed your collection task as not collected[%
+                    IF resolution %]: [% resolution | staff_html_markup({ is_body_user => 1 }) %]
+                    [% END %]
+                    Please resolve the issue so the bin can be collected on the next scheduled collection. <a href="https://www.sutton.gov.uk/waste-and-recycling/your-collection-service">Check our website</a> for more information on how your bin should be presented and what you can put in it.
+                </p>
+                <p>If it is less than 2 working days, you can dispute the reason given and we will investigate. If we find that the collection task was closed incorrectly, we will return to collect the bin.</p>
             [% END %]
-            Please resolve the issue so the bin can be collected on the next scheduled collection. <a href="https://www.sutton.gov.uk/waste-and-recycling/your-collection-service">Check our website</a> for more information on how your bin should be presented and what you can put in it.
-        </p>
-        <p>If it is less than 2 working days, you can dispute the reason given and we will investigate. If we find that the collection task was closed incorrectly, we will return to collect the bin.</p>
         [% END %]
         </div>
     </div>
@@ -82,7 +97,7 @@ END;
         If it has not been collected, you can report it as missed and we will return within 2 working days to collect it.
         </p>
         [% IF c.cobrand.moniker == 'kingston' AND fas_property %]
-             <p>If a spillage on a public highway occurred during a [% service.service_name FILTER lower %] collection, please report <a href="https://kingston-self.achieveservice.com/service/Request_a_street_clean_in_Kingston">a street cleaning issue</a>.</p>
+            <p>If a spillage on a public highway occurred during a [% service.service_name FILTER lower %] collection, please report <a href="https://kingston-self.achieveservice.com/service/Request_a_street_clean_in_Kingston">a street cleaning issue</a>.</p>
         [% END %]
         </div>
     </div>
@@ -112,7 +127,9 @@ IF service.escalations.missed;
 ELSIF service.dispute;
     SET field = {
         value = 'Missed collection dispute',
-        label = 'Dispute collection closure reason',
+        label = service.dispute.missed_event && service.dispute.missed_event.completed
+            ? 'Dispute collection completion'
+            : 'Dispute collection closure reason',
         hint_class = 'govuk-hint--unfaded',
     };
     IF service.dispute.open;


### PR DESCRIPTION
For https://app.basecamp.com/4020879/buckets/45711452/card_tables/cards/10082629714.

Specifically, getting this wording of [the spec](https://docs.google.com/document/d/193SMUDL-JOlm8qi0_XXgsdHO_OWBgQ0E58naNsw8cWE/edit?tab=t.0) in place:
```
Scenario 2: Crew closed as ‘completed’ after missed report
Within 2 working days of completion:
Message: “The crew marked this collection as completed. If your [bin has not been emptied/bulky waste/small items was not collected], you can dispute this and we will investigate. If we find that the collection task was closed incorrectly, we will return to collect the [bin/waste].”

Beyond 2 working days of completion:
Message: “The crew have marked this collection as completed. You cannot dispute this as it has been more than 2 working days since the collection [took place. The crew will return on your next scheduled collection/was marked as completed].”
```

Does not seem to apply to bulky waste (and by extension, small items) as it redirects back to bin days page after dispute window passed(?)

[skip changelog]
