### PR TITLE
New style for badge component

### DIFF
--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -74,6 +74,15 @@ $footer-main-nav-color: #fff !default;
 // Invisble when there is not enough space
 $is-mobile-menu-visible: true !default;
 
+// Badge variables
+$badge-background-color: mix($primary, #fff, 20%) !default;
+$badge-border-color: $badge-background-color !default;
+$badge-padding: 2px 5px !default;
+$badge-border-radius: 0px !default;
+// Ensures the font-size doesn't go down below 14px for accessibility purposes and at the same time we can reuse the component in other elements like headings.
+$badge-font-size: clamp(14px,0.75em, 0.75em) !default;
+
+
 @import "_mixins";
 @import "_report_list";
 
@@ -3655,15 +3664,15 @@ $site-message-border: 1px solid #525252 !default;
 }
 
 .badge {
-  padding: 0.25em 0.35em;
+  padding: $badge-padding;
   margin-right: 0.25em;
   text-transform: uppercase;
-  font-weight: 600;
-  background-color: mix($primary, #fff, 30%);
-  border: 1px solid darken($primary, 10%);
-  font-size: 0.85rem;
+  font-weight: 500;
+  background-color: $badge-background-color;
+  border: 1px solid $badge-border-color;
+  font-size: $badge-font-size;
   color: #222;
-  border-radius: 4px;
+  border-radius: $badge-border-radius;
   vertical-align: middle;
 }
 


### PR DESCRIPTION
Fixes: Brent and Dudley provide feedback about how the current style for the badge component can be confused with a button.

- Decreased padding.
- Make the badge more similar to the "tags" from GOVUK.
- By default the `border-color` and background of the `badge` have the same colour to give a highlighted text effect.
- Replaced some of the attributes with variables so we can avoid overrides.
- For the font-size; I wanted  a rule to make sure we don't go below 14px for cobrands that use the classic 16px body size. And for cobrand that use >16px the badge doesn't look too big.

### Preview
<img width="960" height="600" alt="Screenshot 2026-07-16 at 10 46 51" src="https://github.com/user-attachments/assets/bde387d9-331f-4cc2-8433-23990bf3974e" />
<img width="960" height="600" alt="Screenshot 2026-07-16 at 10 47 04" src="https://github.com/user-attachments/assets/29835b94-025e-4a37-8fc5-98eac414f1bd" />
<img width="960" height="600" alt="Screenshot 2026-07-16 at 10 47 26" src="https://github.com/user-attachments/assets/035a2dc0-94b8-4b15-8a7b-f108f1134147" />
<img width="960" height="212" alt="Screenshot 2026-07-16 at 11 19 38" src="https://github.com/user-attachments/assets/df33ae87-81b0-4d17-985f-a36d106e4598" />

[Archive 2.zip](https://github.com/user-attachments/files/30212436/Archive.2.zip)
[Archive.zip](https://github.com/user-attachments/files/30212438/Archive.zip)

⚠️ Considering the start the report with an image feature has already been around a few months, not sure if the "New" badge is needed anymore, so we can drop this component. I don't think we use it anywhere else.


[skip changelog]
