### PR TITLE
[National Highways] Replace special dashboard hook.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
+++ b/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
@@ -464,7 +464,10 @@ sub _report_new_is_on_he_road_not_litter {
     return scalar @$features ? 0 : 1;
 }
 
-=item * Only Admin roles can access the dashboard
+=item * Make sure only permissioned staff can access the dashboard
+
+As this cobrand lacks a council_area_id, we currently need this to
+prevent all staff access.
 
 =cut
 
@@ -474,10 +477,10 @@ sub dashboard_permission {
 
     # Default behaviour if no user, or is a superuser
     return if !$c->user_exists || $c->user->is_superuser;
-    # Otherwise, check the roles
-    my $admin = grep { $_->name eq 'Admin' } $c->user->obj->roles->all;
-    return 0 unless $admin;
-    return undef;
+    # Otherwise, check the permission
+    if ($c->user->from_body && $c->user->has_permission_to('view_dashboard', $self->body->id)) {
+        return $self->body->id;
+    }
 }
 
 sub dashboard_export_problems_add_columns {

--- a/t/cobrand/highwaysengland.t
+++ b/t/cobrand/highwaysengland.t
@@ -53,6 +53,7 @@ $mech->create_contact_ok(email => 'testareaemail@nh', body_id => $highways->id, 
 my $superuser = $mech->create_user_ok('super@example.com', name => 'Admin', from_body => $highways, password => 'password', is_superuser => 1);
 
 my $staffuser = $mech->create_user_ok('counciluser@example.com', name => 'Council User', from_body => $highways, password => 'password');
+my $staffuser2 = $mech->create_user_ok('counciluser2@example.com', name => 'Council User', from_body => $highways, password => 'password');
 
 $staffuser->alerts->create({
     alert_type => 'council_problems',
@@ -225,12 +226,17 @@ FixMyStreet::override_config {
     };
 };
 
-subtest 'Dashboard can be accessed by superuser' => sub {
-    $mech->log_in_ok( $superuser->email );
+subtest 'Dashboard access' => sub {
     FixMyStreet::override_config {
         MAPIT_URL => 'http://mapit.uk/',
         ALLOWED_COBRANDS => 'highwaysengland',
     }, sub {
+        $mech->log_in_ok( $superuser->email );
+        $mech->get_ok('/dashboard');
+        $mech->log_in_ok( $staffuser2->email );
+        $mech->get('/dashboard');
+        is $mech->res->code, 404;
+        $mech->log_in_ok( $staffuser->email );
         $mech->get_ok('/dashboard');
     };
 };


### PR DESCRIPTION
We can use the now-present specific dashboard permission, rather than a role check. FD-7310.
[skip changelog]