### PR TITLE
[Bristol] Don't autoclose categories linked to backend

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bristol.pm
+++ b/perllib/FixMyStreet/Cobrand/Bristol.pm
@@ -39,8 +39,6 @@ sub council_url { return 'bristol'; }
 
 use constant ROADWORKS_CATEGORY => 'Inactive roadworks';
 use constant CYCLE_HANGERS_CATEGORY => 'Damaged cycle hanger (Street furniture)';
-use constant VEHICLE_DWELLING_CATEGORY => 'Vehicle dwelling encampment';
-use constant FLAG_ATTACHED_STREETLIGHT => 'Flag attached to street light';
 
 =item * Users with a bristol.gov.uk email can always be found in the admin.
 
@@ -367,10 +365,7 @@ category are automatically closed, with an update with explanatory text added.
 sub post_report_sent {
     my ($self, $problem) = @_;
 
-    if ($problem->category eq ROADWORKS_CATEGORY
-        || $problem->category eq VEHICLE_DWELLING_CATEGORY
-        || $problem->category eq CYCLE_HANGERS_CATEGORY
-        || $problem->category eq FLAG_ATTACHED_STREETLIGHT) {
+    if ($problem->category eq ROADWORKS_CATEGORY || $problem->category eq CYCLE_HANGERS_CATEGORY) {
         if (my $existing = $problem->comments->search({ external_id => 'auto-internal' })->first) {
             $existing->update({ problem_state => 'closed' });
         }

--- a/t/cobrand/bristol.t
+++ b/t/cobrand/bristol.t
@@ -226,7 +226,7 @@ subtest "Categories automatically closed" => sub {
         MAPIT_URL => 'http://mapit.uk/',
         ALLOWED_COBRANDS => 'bristol',
     }, sub {
-        foreach my $test ( $roadworks, $cycle_hanger, $camp ) {
+        foreach my $test ( $roadworks, $cycle_hanger ) {
             my $template = FixMyStreet::DB->resultset("ResponseTemplate")->create({
                 body => $bristol,
                 title => $test->category . ' template',


### PR DESCRIPTION
These categories are always automatically reopened.

Discussion:
https://mysocietysupport.freshdesk.com/a/tickets/7239

[skip changelog]