### PR TITLE
[Pboro] Add messaging for debris removal stopper.

### DIFF
--- a/.cypress/cypress/e2e/peterborough.cy.js
+++ b/.cypress/cypress/e2e/peterborough.cy.js
@@ -1,19 +1,24 @@
 var landTypeCases = [
-    { private: false, category: 'General fly tipping', message: null },
-    { private: false, category: 'Non offensive graffiti', message: null },
-    { private: false, category: 'Abandoned vehicles', message: null },
-    { private: false, group: 'Street cleansing', category: 'Street sweeping', message: null },
-    { private: false, group: 'Grounds maintenance', category: 'Grass cutting', message: null },
-    { private: true, category: 'General fly tipping',
+    { block: false, private: false, category: 'General fly tipping', message: null },
+    { block: false, private: false, category: 'Non offensive graffiti', message: null },
+    { block: false, private: false, category: 'Abandoned vehicles', message: null },
+    { block: false, private: false, group: 'Street cleansing', category: 'Street sweeping', message: null },
+    { block: false, private: false, group: 'Grounds maintenance', category: 'Grass cutting', message: null },
+    { block: false, private: false, group: 'Removal of debris', category: 'Broken glass', message: null },
+    { block: false, private: false, group: 'Removal of debris', category: 'Road Traffic Accident', message: null },
+    { block: true, private: true, category: 'General fly tipping',
       message: 'The area selected is not owned or maintained by Peterborough City Council' },
-    { private: true, category: 'Non offensive graffiti',
+    { block: true, private: true, category: 'Non offensive graffiti',
       message: 'For graffiti on private land this would be deemed' },
-    { private: true, category: 'Abandoned vehicles',
+    { block: true, private: true, category: 'Abandoned vehicles',
       message: 'Unfortunately, as this car is on private land' },
-    { private: true, group: 'Street cleansing', category: 'Street sweeping',
+    { block: true, private: true, group: 'Street cleansing',
       message: 'it is not the responsibility of the Council to provide Street Cleansing services' },
-    { private: true, group: 'Grounds maintenance', category: 'Grass cutting',
+    { block: true, private: true, group: 'Grounds maintenance',
       message: 'it is not the responsibility of the Council to provide Grounds Maintenance services' },
+    { block: true, private: true, group: 'Removal of debris', category: 'Broken glass',
+      message: 'it is not the responsibility of the Council to provide Debris Removal services' },
+    { block: false, private: true, group: 'Removal of debris', category: 'Road Traffic Accident', message: null },
 ];
 
 function checkLandTypeMessages(host) {
@@ -23,13 +28,19 @@ function checkLandTypeMessages(host) {
             'longitude=-0.242007&latitude=52.571903';
         cy.visit('http://' + host + '/report/new?' + coords);
         cy.wait('@report-ajax');
-        cy.pickCategory(testCase.group || testCase.category);
+        if (testCase.category && testCase.group) {
+            cy.pickCategory(testCase.group);
+            cy.nextPageReporting();
+            cy.pickSubcategory(testCase.group, testCase.category);
+        } else {
+            cy.pickCategory(testCase.category || testCase.group);
+        }
         if (testCase.message) {
             cy.get('.pre-button-messaging:visible').should('contain', testCase.message);
         } else {
             cy.get('.pre-button-messaging:visible').should('not.exist');
         }
-        if (testCase.private) {
+        if (testCase.block) {
             cy.get('.js-reporting-page--next:visible').should('be.disabled');
         } else {
             cy.get('.js-reporting-page--next:visible').should('not.be.disabled');

--- a/bin/fixmystreet.com/fixture
+++ b/bin/fixmystreet.com/fixture
@@ -213,6 +213,8 @@ if ($opt->test_fixtures) {
                 { group => 'Street cleansing', category => 'Dead animal' },
                 { group => 'Grounds maintenance', category => 'Grass cutting' },
                 { group => 'Grounds maintenance', category => 'Hedge cutting' },
+                { group => 'Removal of debris', category => 'Broken glass' },
+                { group => 'Removal of debris', category => 'Road Traffic Accident' },
                 'General fly tipping', 'Fallen branch', 'Pothole', 'Non offensive graffiti',
                 'Abandoned vehicles'
             ], name => 'Peterborough City Council', cobrand => 'peterborough' },

--- a/data/test-asset-layers.yml
+++ b/data/test-asset-layers.yml
@@ -488,6 +488,15 @@ peterborough:
     template: 'pcc_property_leased_out'
     no_asset_msg_id: '#js-grounds-maintenance-message'
 
+  - asset_group: ['Removal of debris']
+    asset_group_except_category: ['Road Traffic Accident']
+    template: 'pcc_property_combined'
+    no_asset_msg_id: '#js-debris-removal-message'
+  - asset_group: ['Removal of debris']
+    asset_group_except_category: ['Road Traffic Accident']
+    template: 'pcc_property_leased_out'
+    no_asset_msg_id: '#js-debris-removal-message'
+
 shropshire:
   - http_wfs_url: "https://tilma.mysociety.org/mapserver/shropshire"
     asset_type: 'spot'

--- a/templates/web/fixmystreet.com/report/new/debris_removal_text.html
+++ b/templates/web/fixmystreet.com/report/new/debris_removal_text.html
@@ -1,0 +1,3 @@
+Unfortunately, this area is private land and therefore it is not the responsibility of the Council to provide Debris Removal services on this occasion.
+
+If you wish to report an incident to the landowner, we advise seeking confirmation of ownership via the Land Registry through the following link: https://www.gov.uk/government/organisations/land-registry. Additionally, details of some private roads with developers can be found here: https://www.peterborough.gov.uk/council/planning-and-development/highway-control.

--- a/templates/web/fixmystreet.com/report/new/roads_message.html
+++ b/templates/web/fixmystreet.com/report/new/roads_message.html
@@ -96,4 +96,6 @@
 </div>
 <div id="js-grounds-maintenance-message" class="hidden">
     [% grounds_maintenance_text = INCLUDE 'report/new/grounds_maintenance_text.html' %][% grounds_maintenance_text | add_links | html_para %]
-
+</div>
+<div id="js-debris-removal-message" class="hidden">
+    [% debris_removal_text = INCLUDE 'report/new/debris_removal_text.html' %][% debris_removal_text | add_links | html_para %]

--- a/templates/web/peterborough/report/new/debris_removal_text.html
+++ b/templates/web/peterborough/report/new/debris_removal_text.html
@@ -1,0 +1,3 @@
+Unfortunately, this area is private land and therefore it is not the responsibility of the Council to provide Debris Removal services on this occasion.
+
+If you wish to report an incident to the landowner, we advise seeking confirmation of ownership via the Land Registry through the following link: https://www.gov.uk/government/organisations/land-registry. Additionally, details of some private roads with developers can be found here: https://www.peterborough.gov.uk/council/planning-and-development/highway-control.

--- a/templates/web/peterborough/report/new/roads_message.html
+++ b/templates/web/peterborough/report/new/roads_message.html
@@ -16,3 +16,6 @@
 </div>
 <div id="js-grounds-maintenance-message" class="hidden box-warning">
     [% grounds_maintenance_text = INCLUDE 'report/new/grounds_maintenance_text.html' %][% grounds_maintenance_text | add_links | html_para %]
+</div>
+<div id="js-debris-removal-message" class="hidden box-warning">
+    [% debris_removal_text = INCLUDE 'report/new/debris_removal_text.html' %][% debris_removal_text | add_links | html_para %]


### PR DESCRIPTION
For https://mysocietysupport.freshdesk.com/a/tickets/7298.

I had hoped to migrate to 'no_asset_msg' so we could manage this entirely in config in the future but bumped into the fact we display differently on the pboro cobrand ('box-warning') than on .com. Also, less important, we do have to repeat the text in config for both the combined property and leased out layers. Does seem like could be
reworked. One for the future...

[skip changelog]