### PR TITLE
[Admin] Use category display names on /dashboard table

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Dashboard.pm
+++ b/perllib/FixMyStreet/App/Controller/Dashboard.pm
@@ -138,6 +138,10 @@ sub index : Path : Args(0) {
         $c->stash->{contacts} = [ $c->stash->{contacts}->all ];
         $c->forward('/report/stash_category_groups', [ $c->stash->{contacts} ]);
 
+        $c->stash->{category_display_names} = {
+            map { $_->category => $_->category_display } @{$c->stash->{contacts}}
+        };
+
         foreach (@{$c->stash->{category_groups}}) {
             $_->{group_id} = "group-" . $_->{name};
         }

--- a/t/app/controller/dashboard.t
+++ b/t/app/controller/dashboard.t
@@ -208,6 +208,23 @@ FixMyStreet::override_config {
         test_table($mech->content, 1, 0, 0, 1, 0, 0, 0, 0, 7, 3, 0, 10, 2, 0, 4, 6, 1, 0, 0, 1, 11, 3, 4, 18);
     };
 
+    subtest 'category display names used in filter and table' => sub {
+        my $litter = FixMyStreet::DB->resultset('Contact')->find({ body_id => $body->id, category => 'Litter' });
+        $litter->set_extra_metadata(display_name => 'Litter and rubbish');
+        $litter->update;
+
+        $mech->get_ok("/dashboard");
+        $mech->content_contains("<option value='Litter'>Litter and rubbish</option>");
+        $mech->content_contains('<th class="contact-category" scope="row">Litter and rubbish</th>');
+        $mech->content_lacks('<th class="contact-category" scope="row">Litter</th>');
+        # Filtering still uses the underlying category name
+        $mech->get_ok("/dashboard?category=Litter");
+        test_table($mech->content, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1);
+
+        $litter->unset_extra_metadata('display_name');
+        $litter->update;
+    };
+
     subtest 'test filters' => sub {
         $mech->get_ok("/dashboard");
         $mech->submit_form_ok({ with_fields => { category => 'Litter' } });

--- a/templates/web/base/dashboard/index.html
+++ b/templates/web/base/dashboard/index.html
@@ -218,7 +218,7 @@
         %]
       [% END %]
     <tr [% IF class_to_hide %]class="[% class_to_hide %]"[% END %]>
-      <th class="contact-category" scope="row">[% k %]</th>
+      <th class="contact-category" scope="row">[% category_display_names.$k_safe OR k %]</th>
     [% ELSE %]
     <tr>
       <th scope="row">[% k %]</th>


### PR DESCRIPTION
Makes categories shown in table consistent with values in filter dropdown and used elsewhere in UI.

For FD-7271

[skip changelog]