### PR TITLE
Make private report status clearer to staff

### DIFF
--- a/t/app/controller/report_non_public.t
+++ b/t/app/controller/report_non_public.t
@@ -44,6 +44,7 @@ subtest "check owner of report can view non public reports" => sub {
     ok $mech->get("/report/$report_id"), "get '/report/$report_id'";
     is $mech->res->code, 200, "report can be viewed";
     is $mech->uri->path, "/report/$report_id", "at /report/$report_id";
+    $mech->content_lacks('This report is private', 'private status not shown to reporter');
     $mech->log_out_ok;
 
     $mech->log_in_ok( $user2->email );
@@ -63,6 +64,7 @@ subtest 'check staff with report_view_private can view non-public, but not edit'
     is $mech->res->code, 200, "report can be viewed";
     is $mech->uri->path, "/report/$report_id", "at /report/$report_id";
     $mech->content_lacks('id="side-inspect"', 'inspect bar is not shown');
+    $mech->content_contains('This report is private', 'private status is shown in report meta');
     $mech->log_out_ok;
 };
 

--- a/templates/web/base/report/_report_meta_info.html
+++ b/templates/web/base/report/_report_meta_info.html
@@ -3,3 +3,4 @@
     <small>(<a href="/my/anonymize?problem=[% problem.id | uri %]" class="js-hide-name">[% loc('Hide your name?') %]</a>)</small>
 [% END %]
 [%- IF !problem.used_map %]; <strong>([% loc('there is no pin shown as the user did not use the map') %])</strong>[% END %]
+[%~ IF problem.non_public AND c.user.has_permission_to('report_view_private', problem.bodies_str_ids) %]<strong>[% loc('This report is private.') %]</strong>[% END %]

--- a/templates/web/fixmystreet.com/report/_report_meta_info.html
+++ b/templates/web/fixmystreet.com/report/_report_meta_info.html
@@ -6,3 +6,4 @@
     <small>(<a href="/my/anonymize?problem=[% problem.id | uri %]" class="js-hide-name">[% loc('Hide your name?') %]</a>)</small>
 [% END %]
 [%- IF !problem.used_map %]; <strong>([% loc('there is no pin shown as the user did not use the map') %])</strong>[% END %]
+[%~ IF problem.non_public AND c.user.has_permission_to('report_view_private', problem.bodies_str_ids) %]<strong>[% loc('This report is private.') %]</strong>[% END %]


### PR DESCRIPTION
Staff with permission to view private reports but not permission to mark reports private had no way of knowing whether a report was actually marked as private or not. This commit makes it clearer on the report meta line if a report is private.

For FD-7354.

<img width="465" height="222" alt="image" src="https://github.com/user-attachments/assets/63e3fe6b-6a8f-45cd-8650-57422b1e6583" />


[skip changelog]