### PR TITLE
Ensure user email addresses are always stored lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
         - Population lookup size for radius alert can be configured per cobrand
         - Split original report_mark_private permission into a view-only permission (report_view_private) and an edit permission (report_mark_private) #5973
         - Require view dashboard permission in order to view the dashboard
+        - Ensure all user email addresses are stored as lowercase.
     - Development improvements
         - More logging when `page_error` is called, to aid troubleshooting. #5279
         - Docker changes needed for systemd to work. #5257

--- a/perllib/FixMyStreet/DB/Result/User.pm
+++ b/perllib/FixMyStreet/DB/Result/User.pm
@@ -200,6 +200,24 @@ around password => sub {
     $self->$orig(@_);
 };
 
+around insert => sub {
+    my ($orig, $self) = (shift, shift);
+    my $email = $self->get_column('email');
+    $self->set_column(email => lc $email) if defined $email;
+    $self->$orig(@_);
+};
+
+around update => sub {
+    my ($orig, $self) = (shift, shift);
+    if (@_ && ref $_[0] eq 'HASH' && defined $_[0]->{email}) {
+        $_[0]->{email} = lc $_[0]->{email};
+    } else {
+        my $email = $self->get_column('email');
+        $self->set_column(email => lc $email) if defined $email;
+    }
+    $self->$orig(@_);
+};
+
 =head2 username
 
 Returns a verified email or phone for this user, preferring email,

--- a/perllib/FixMyStreet/DB/ResultSet/User.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/User.pm
@@ -24,6 +24,9 @@ sub text_search_translate { '@.' }
 
 around find => sub {
     my ($orig, $self) = (shift, shift);
+    if (ref $_[0] eq 'HASH' && defined $_[0]->{email} && !ref $_[0]->{email}) {
+        $_[0]->{email} = lc $_[0]->{email};
+    }
     # If there's already a key, assume caller knows what they're doing
     if (ref $_[0] eq 'HASH' && !$_[1]->{key}) {
         if ($_[0]->{id}) {

--- a/t/Mock/OpenIDConnect.pm
+++ b/t/Mock/OpenIDConnect.pm
@@ -79,7 +79,8 @@ sub dispatch_request {
         if ($self->cobrand eq 'brent') {
             $payload->{givenName} = "Andy";
             $payload->{surname} = "Dwyer";
-            $payload->{email} = 'pkg-tappcontrollerauth_socialt-oidc@example.org' if $self->returns_email;
+            # Deliberately mixed case, to check we store it lowercased
+            $payload->{email} = 'Pkg-TAppControllerAuth_SocialT-OIDC@Example.org' if $self->returns_email;
         } elsif ($self->cobrand eq 'tfl') {
             $payload->{given_name} = "Andy";
             $payload->{family_name} = "Dwyer";

--- a/t/app/controller/auth_social.t
+++ b/t/app/controller/auth_social.t
@@ -259,6 +259,13 @@ for my $state ( 'refused', 'no email', 'existing UID', 'okay' ) {
                 }
             }
 
+            if ($state eq 'okay' && $test->{type} eq 'oidc') {
+                # IdP might give us a mixed-case email; check that we store, and
+                # can look it up, lowercase
+                my $user = FixMyStreet::DB->resultset('User')->find( { email => $test->{email} } );
+                is $user && $user->email, $test->{email}, 'User email stored lowercase';
+            }
+
             $mech->get('/auth/sign_out');
             if ($test->{type} eq 'oidc' && $test->{logout_redirect_pattern} && $state ne 'refused' && $state ne 'no email') {
                 # XXX the 'no email' situation is skipped because of some confusion

--- a/t/app/controller/report_new.t
+++ b/t/app/controller/report_new.t
@@ -250,6 +250,55 @@ foreach my $test (
   };
 }
 
+subtest "test report creation for a user who gives a mixed case email address" => sub {
+    $mech->log_out_ok;
+    $mech->clear_emails_ok;
+
+    my $test_email = 'gregory.coleman@example.com';
+    my $mixed_case_email = 'Gregory.Coleman@Example.COM';
+    my $user = FixMyStreet::DB->resultset('User')->create({
+        email => $test_email,
+        email_verified => 1,
+        name => 'Gregory Coleman',
+    });
+
+    $mech->get_ok('/around');
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ { fixmystreet => '.' } ],
+        MAPIT_URL => 'http://mapit.uk/',
+    }, sub {
+        $mech->submit_form_ok( { with_fields => { pc => 'EH1 1BB', } },
+            "submit location" );
+        $mech->follow_link_ok( { text_regex => qr/skip this step/i, },
+            "follow 'skip this step' link" );
+        $mech->submit_form_ok(
+            {
+                button      => 'submit_register_mobile',
+                with_fields => {
+                    title         => 'Test Report',
+                    detail        => 'Test report details.',
+                    photo1        => '',
+                    name          => 'Gregory Coleman',
+                    may_show_name => '1',
+                    username_register => $mixed_case_email,
+                    category      => 'Street lighting',
+                }
+            },
+            "submit good details"
+        );
+    };
+    is_deeply $mech->page_errors, [], "check there were no errors";
+
+    my $report = $user->problems->first;
+    ok $report, "report created against the existing user";
+    is $report->user->email, $test_email, 'user email still stored lowercased';
+    my $users = FixMyStreet::DB->resultset('User');
+    is $users->search( { email => $mixed_case_email } )->count, 0,
+        'no second user created with the mixed case email';
+
+    $mech->delete_user($user);
+};
+
 foreach my $test (
   { two_factor => '', desc => '', },
   { two_factor => 'yes', desc => ' with two-factor', },

--- a/t/app/model/user.t
+++ b/t/app/model/user.t
@@ -7,6 +7,30 @@ use Test::Exception;
 my $mech = FixMyStreet::TestMech->new();
 $mech->log_in_ok('test@example.com');
 
+subtest 'email addresses are stored lowercase' => sub {
+    my $users = FixMyStreet::DB->resultset('User');
+    my $user = $users->create({
+        email => 'Sam.Sample.Create@Example.COM',
+        email_verified => 1,
+    });
+    $user->discard_changes;
+    is $user->email, 'sam.sample.create@example.com', 'email lowercased on creation';
+
+    $user->update({ email => 'Sam.Sample.Update@Example.COM' });
+    $user->discard_changes;
+    is $user->email, 'sam.sample.update@example.com', 'email lowercased in update parameters';
+
+    $user->email('Sam.Sample.Accessor@Example.COM');
+    $user->update;
+    $user->discard_changes;
+    is $user->email, 'sam.sample.accessor@example.com', 'email lowercased when updating changed columns';
+
+    is $users->find({ email => 'SAM.SAMPLE.ACCESSOR@EXAMPLE.COM' })->id,
+        $user->id, 'email lookup is case insensitive';
+    is $users->find_or_create({ email => 'SAM.SAMPLE.ACCESSOR@EXAMPLE.COM' })->id,
+        $user->id, 'find_or_create does not create a differently cased duplicate';
+};
+
 my ($problem) = $mech->create_problems_for_body(1, '2504', 'Title', { anonymous => 'f' });
 is $problem->user->latest_anonymity, 0, "User's last report was not anonymous";
 


### PR DESCRIPTION
Normalises user email addresses to lowercase, preventing duplicate users being created.

For mysociety/societyworks#5594

