### PR TITLE
Ensure OIDC email addresses are always stored lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
         - Population lookup size for radius alert can be configured per cobrand
         - Split original report_mark_private permission into a view-only permission (report_view_private) and an edit permission (report_mark_private) #5973
         - Require view dashboard permission in order to view the dashboard
+        - Ensure OIDC email addresses are stored as lowercase.
     - Development improvements
         - More logging when `page_error` is called, to aid troubleshooting. #5279
         - Docker changes needed for systemd to work. #5257

--- a/perllib/FixMyStreet/App/Controller/Auth/Social.pm
+++ b/perllib/FixMyStreet/App/Controller/Auth/Social.pm
@@ -354,6 +354,7 @@ sub oidc_callback: Path('/auth/OIDC') : Args(0) {
     # Cobrands can use different fields for name and email
     my ($name, $email, $phone) = $c->cobrand->call_hook(user_from_oidc => $id_token->payload, $access_token);
     $name = '' if $name && $name !~ /\w/;
+    $email = lc $email if $email;
 
     # There's a chance that a user may have multiple OIDC logins, so build a namespaced uid to prevent collisions
     my $uid = join(":", $c->cobrand->moniker, $c->forward('oidc_config')->{client_id}, $id_token->payload->{sub});

--- a/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Lincolnshire.pm
@@ -234,7 +234,7 @@ sub open311_get_user {
         my $domain = $self->admin_user_domain;
         last if $request->{contact_email} =~ /[@]$domain$/;
         last if FixMyStreet::DB->resultset('User')->find({
-            email => $request->{contact_email},
+            email => lc $request->{contact_email},
             email_verified => 1,
             is_superuser => 1,
         });
@@ -244,7 +244,7 @@ sub open311_get_user {
     my $user = FixMyStreet::DB->resultset('User')->find_or_create(
         {
             name => $request->{contact_name},
-            email => $request->{contact_email},
+            email => lc $request->{contact_email},
             email_verified => 1,
         },
         { key => 'users_email_verified_key' },

--- a/t/Mock/OpenIDConnect.pm
+++ b/t/Mock/OpenIDConnect.pm
@@ -79,7 +79,8 @@ sub dispatch_request {
         if ($self->cobrand eq 'brent') {
             $payload->{givenName} = "Andy";
             $payload->{surname} = "Dwyer";
-            $payload->{email} = 'pkg-tappcontrollerauth_socialt-oidc@example.org' if $self->returns_email;
+            # Deliberately mixed case, to check we store it lowercased
+            $payload->{email} = 'Pkg-TAppControllerAuth_SocialT-OIDC@Example.org' if $self->returns_email;
         } elsif ($self->cobrand eq 'tfl') {
             $payload->{given_name} = "Andy";
             $payload->{family_name} = "Dwyer";

--- a/t/app/controller/auth_social.t
+++ b/t/app/controller/auth_social.t
@@ -259,6 +259,13 @@ for my $state ( 'refused', 'no email', 'existing UID', 'okay' ) {
                 }
             }
 
+            if ($state eq 'okay' && $test->{type} eq 'oidc') {
+                # IdP might give us a mixed-case email; check that we store, and
+                # can look it up, lowercase
+                my $user = FixMyStreet::DB->resultset('User')->find( { email => $test->{email} } );
+                is $user->email, $test->{email}, 'User email stored lowercase';
+            }
+
             $mech->get('/auth/sign_out');
             if ($test->{type} eq 'oidc' && $test->{logout_redirect_pattern} && $state ne 'refused' && $state ne 'no email') {
                 # XXX the 'no email' situation is skipped because of some confusion


### PR DESCRIPTION
Normalises OIDC email addresses to lowercase, preventing duplicate users being created. Does the same for Lincs-created users imported via Open311 too.

For mysociety/societyworks#5594

