### PR TITLE
[Open311] Fix same code update with template vars.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
@@ -408,7 +408,7 @@ sub edit : Path('/admin/report_edit') : Args(1) {
 
             my ($description, $email_text);
             foreach my $body (values %{$problem->bodies}) {
-                my $template = $problem->response_template_for($body, $problem->state, $old_state, '', '');
+                my $template = $problem->response_template_for($body, $problem->state, $old_state, '');
                 ($description, $email_text) = $updates->comment_text_for_request($template, {}, $problem);
             }
 

--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -937,7 +937,7 @@ sub add_update_to_assisted_request : Private {
     };
 
     my $body = $c->cobrand->body;
-    my $template = $report->response_template_for($body, $status, 'confirmed', '', '');
+    my $template = $report->response_template_for($body, $status, 'confirmed', '');
     $text = $template->text if $template;
 
     my $comment = $report->add_to_comments({

--- a/perllib/FixMyStreet/Cobrand/Aberdeenshire.pm
+++ b/perllib/FixMyStreet/Cobrand/Aberdeenshire.pm
@@ -114,36 +114,31 @@ We pass any category change to Confirm.
 
 sub open311_send_category_change { 1 }
 
-=head2 open311_get_update_munging
+=head2 open311_get_update_template_variables
 
 Aberdeenshire want certain defect fields shown in updates on FMS.
+In addition to the default functionality, this looks for
+'{{targetDate}}' and '{{jobStartDate}}' dates, formatting them
+or replacing with TBC.
 
-These values, if present, are passed back from open311-adapter in the
-<extras> element. If the template being used for this update has placeholders
-like '{{targetDate}}', '{{jobStartDate}}', or any fields configured in the
-'response_template_variables' Config entry, they get replaced with the value
-from Confirm. If there is no value then 'TBC' is used for date fields, or an
-empty string for other fields.
+=cut
 
-Additionally, the incoming update might be for a defect which has superseded an
+sub open311_get_update_template_variables {
+    my ($self, $text, $request) = @_;
+    $text = _parse_template_dates($text, $request);
+    $text = $self->SUPER::open311_get_update_template_variables($text, $request);
+    return $text;
+}
+
+=head2 open311_get_update_munging
+
+The incoming update might be for a defect which has superseded an
 existing one, so if that's the case we need to identify and close it.
 
 =cut
 
 sub open311_get_update_munging {
     my ($self, $comment, $state, $request) = @_;
-
-    my $text = $comment->text;
-    $text = _parse_template_dates($text, $request);
-    $text = $self->open311_get_update_munging_template_variables($text, $request);
-    $comment->text($text);
-
-    if ( $text = $comment->private_email_text) {
-        $text = _parse_template_dates( $text, $request );
-        $text = $self->open311_get_update_munging_template_variables(
-            $text, $request );
-        $comment->private_email_text($text);
-    }
 
     my $supersedes = $request->{extras}{supersedes};
     return unless $supersedes && $supersedes =~ /^DEFECT_/;

--- a/perllib/FixMyStreet/Cobrand/Dumfries.pm
+++ b/perllib/FixMyStreet/Cobrand/Dumfries.pm
@@ -94,29 +94,15 @@ sub problems_on_map_restriction {
     ]);
 }
 
-
 =head2 open311_get_update_munging
 
-Dumfries want certain fields shown in updates on FMS.
-
-These values, if present, are passed back from open311-adapter in the <extras>
-element. If the template being used for this update has placeholders matching
-any field configured in the 'response_template_variables' Config entry, they
-get replaced with the value from extras, or an empty string otherwise.
+Store latest inspection time on the report if present,
+and ignore any photos that we already know about.
 
 =cut
 
 sub open311_get_update_munging {
     my ($self, $comment, $state, $request) = @_;
-
-    my $text = $self->open311_get_update_munging_template_variables($comment->text, $request);
-    $comment->text($text);
-
-    if ( $text = $comment->private_email_text ) {
-        $text = $self->open311_get_update_munging_template_variables(
-            $text, $request );
-        $comment->private_email_text($text);
-    }
 
     # If the update includes a latest_inspection_time, store it on the problem
     # If the value is 'NOT COMPLETE', unset the metadata

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -501,7 +501,18 @@ sub open311_extra_data {
     return ($include, $exclude);
 };
 
-sub open311_get_update_munging_template_variables {
+=head2 open311_get_update_template_variables
+
+Some councils (e.g. Dumfries, Aberdeenshire) want certain fields shown in updates on FMS.
+
+These values, if present, are passed back from open311-adapter in the <extras>
+element. If the template being used for this update has placeholders matching
+any field configured in the 'response_template_variables' Config entry, they
+get replaced with the value from extras, or an empty string otherwise.
+
+=cut
+
+sub open311_get_update_template_variables {
     my ($self, $text, $request) = @_;
 
     my $vars = FixMyStreet::DB->resultset("Config")->get('response_template_variables');

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -553,7 +553,18 @@ sub open311_extra_data {
     return ($include, $exclude);
 };
 
-sub open311_get_update_munging_template_variables {
+=head2 open311_get_update_template_variables
+
+Some councils (e.g. Dumfries, Aberdeenshire) want certain fields shown in updates on FMS.
+
+These values, if present, are passed back from open311-adapter in the <extras>
+element. If the template being used for this update has placeholders matching
+any field configured in the 'response_template_variables' Config entry, they
+get replaced with the value from extras, or an empty string otherwise.
+
+=cut
+
+sub open311_get_update_template_variables {
     my ($self, $text, $request) = @_;
 
     my $vars = FixMyStreet::DB->resultset("Config")->get('response_template_variables');

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -1563,7 +1563,7 @@ sub create_related_things {
             external_id => 'auto-internal',
             send_state => 'processed',
             text => $description,
-            private_email_text => $email_text,
+            $email_text ? (private_email_text => $email_text) : (),
             problem_state => 'confirmed',
             state => 'unconfirmed',
             confirmed => \'current_timestamp', # So that it will always be first

--- a/perllib/FixMyStreet/DB/Result/Problem.pm
+++ b/perllib/FixMyStreet/DB/Result/Problem.pm
@@ -926,24 +926,31 @@ sub response_templates {
     );
 }
 
+=head2 response_template_for
+
+Given an old/new state and optional new external status code,
+return the matching response template, if any.
+
+=cut
+
 sub response_template_for {
-    my ($self, $body, $state, $old_state, $ext_code, $old_ext_code) = @_;
+    my ($self, $body, $state, $old_state, $ext_code) = @_;
     my $cobrand = $body->get_cobrand_handler;
 
     # Response templates are only triggered if the state/external status has changed.
     # And treat any fixed state as fixed.
     my $state_changed = $state ne $old_state
         && !( $self->is_fixed && FixMyStreet::DB::Result::Problem->fixed_states()->{$state} );
-    my $ext_code_changed = $ext_code && $ext_code ne $old_ext_code;
     my $template;
-    if ($state_changed || $ext_code_changed) {
+
+    if ($state_changed || $ext_code) {
         # make sure that empty string/nulls come last, and templates for a category come earlier.
         my $order = { order_by => \"me.external_status_code DESC NULLS LAST, contact.category" };
         my $state_params = [];
         if ($state_changed) {
             push @$state_params, { 'me.state' => $state, 'me.external_status_code' => ["", undef] };
         }
-        if ($ext_code_changed) {
+        if ($ext_code) {
             # Allow cobrands to use regex matching for wildcard patterns in templates
             if (my $regex_match = $cobrand && $cobrand->call_hook(
                 response_template_external_status_code_regex_match => $ext_code
@@ -1554,7 +1561,7 @@ sub create_related_things {
             blank_updates_permitted => 1,
         );
 
-        my $template = $self->response_template_for($body, 'confirmed', 'dummy', '', '');
+        my $template = $self->response_template_for($body, 'confirmed', 'dummy', '');
         my ($description, $email_text) = $updates->comment_text_for_request($template, {}, $self);
         next unless $description;
 

--- a/perllib/Open311/UpdatesBase.pm
+++ b/perllib/Open311/UpdatesBase.pm
@@ -188,7 +188,7 @@ sub _process_update {
     my $old_ext_code = $p->get_extra_metadata('external_status_code') || '';
     my $ext_code_changed = $external_status_code && $external_status_code ne $old_ext_code;
     # So if there are no variables involved, and no state/code change, remove the template
-    if ($template && !$state_changed && !$ext_code_changed && $template !~ /\{\{/) {
+    if ($template && !$state_changed && !$ext_code_changed && $template->text !~ /\{\{/) {
         $template = undef;
     }
 

--- a/perllib/Open311/UpdatesBase.pm
+++ b/perllib/Open311/UpdatesBase.pm
@@ -164,6 +164,7 @@ sub _process_update {
     my ($self, $request, $p) = @_;
     my $open311 = $self->current_open311;
     my $body = $self->current_body;
+    my $cobrand = $body->get_cobrand_handler;
 
     $self->_handle_assigned_user($request, $p);
     $self->_handle_category_change($request, $p);
@@ -173,11 +174,25 @@ sub _process_update {
     my $old_state = $p->state;
     my $external_status_code = $request->{external_status_code} || '';
     my $customer_reference = $request->{customer_reference} || '';
-    my $old_external_status_code = $p->get_extra_metadata('external_status_code') || '';
-    my $template = $p->response_template_for(
-        $body, $state, $old_state, $external_status_code, $old_external_status_code
-    );
-    my ($text, $email_text) = $self->comment_text_for_request($template, $request, $p);
+
+    my $template = $p->response_template_for($body, $state, $old_state, $external_status_code);
+
+    # The above will return a template for an external status code, even if
+    # that's the same as the current external status code. This is because
+    # variable replacement in comment_text_for_request could create different
+    # output for the same external status code. There shouldn't be an update
+    # with the same variables+code, but if there is we can fall back on the
+    # text comparison later.
+    my $state_changed = $state ne $old_state
+        && !( $p->is_fixed && FixMyStreet::DB::Result::Problem->fixed_states()->{$state} );
+    my $old_ext_code = $p->get_extra_metadata('external_status_code') || '';
+    my $ext_code_changed = $external_status_code && $external_status_code ne $old_ext_code;
+    # So if there are no variables involved, and no state/code change, remove the template
+    if ($template && !$state_changed && !$ext_code_changed && $template->text !~ /\{\{/) {
+        $template = undef;
+    }
+
+    my ($text, $email_text) = $self->comment_text_for_request($template, $request, $p, $cobrand);
     if (!$email_text && $request->{email_text}) {
         $email_text = $request->{email_text};
     };
@@ -274,7 +289,6 @@ sub _process_update {
     my $state_change = $comment->problem_state && $state ne $old_state;
     $comment->state('hidden') unless $text_change || $photo_change || $state_change;
 
-    my $cobrand = $body->get_cobrand_handler;
     $cobrand->call_hook(open311_get_update_munging => $comment, $state, $request)
         if $cobrand;
 
@@ -300,7 +314,7 @@ sub _process_update {
 }
 
 sub comment_text_for_request {
-    my ($self, $template, $request, $problem) = @_;
+    my ($self, $template, $request, $problem, $cobrand) = @_;
 
     my $email_text = $template ? ($template->email_text||'') : '';
     $template = $template->text if $template;
@@ -308,6 +322,11 @@ sub comment_text_for_request {
     my $desc = $request->{description} || '';
     if ($desc && (!$template || ($template !~ /\{\{description}}/ && !$request->{prefer_template}))) {
         return ($desc, undef);
+    }
+
+    if ($template && $cobrand && $cobrand->can('open311_get_update_template_variables')) {
+        $template = $cobrand->open311_get_update_template_variables($template, $request);
+        $email_text = $cobrand->open311_get_update_template_variables($email_text, $request);
     }
 
     if ($template) {

--- a/perllib/Open311/UpdatesBase.pm
+++ b/perllib/Open311/UpdatesBase.pm
@@ -302,7 +302,7 @@ sub _process_update {
 sub comment_text_for_request {
     my ($self, $template, $request, $problem) = @_;
 
-    my $template_email_text = $template ? $template->email_text : undef;
+    my $email_text = $template ? ($template->email_text||'') : '';
     $template = $template->text if $template;
 
     my $desc = $request->{description} || '';
@@ -312,13 +312,13 @@ sub comment_text_for_request {
 
     if ($template) {
         $template =~ s/\{\{description}}/$desc/;
-        return ($template, $template_email_text);
+        return ($template, $email_text);
     }
 
-    return ("", undef) if $self->blank_updates_permitted;
+    return ("", "") if $self->blank_updates_permitted;
 
     print STDERR "Couldn't determine update text for $request->{update_id} (report " . $problem->id . ")\n";
-    return ("", undef);
+    return ("", "");
 }
 
 sub _handle_assigned_user {

--- a/perllib/Open311/UpdatesBase.pm
+++ b/perllib/Open311/UpdatesBase.pm
@@ -164,6 +164,7 @@ sub _process_update {
     my ($self, $request, $p) = @_;
     my $open311 = $self->current_open311;
     my $body = $self->current_body;
+    my $cobrand = $body->get_cobrand_handler;
 
     $self->_handle_assigned_user($request, $p);
     $self->_handle_category_change($request, $p);
@@ -173,11 +174,25 @@ sub _process_update {
     my $old_state = $p->state;
     my $external_status_code = $request->{external_status_code} || '';
     my $customer_reference = $request->{customer_reference} || '';
-    my $old_external_status_code = $p->get_extra_metadata('external_status_code') || '';
-    my $template = $p->response_template_for(
-        $body, $state, $old_state, $external_status_code, $old_external_status_code
-    );
-    my ($text, $email_text) = $self->comment_text_for_request($template, $request, $p);
+
+    my $template = $p->response_template_for($body, $state, $old_state, $external_status_code);
+
+    # The above will return a template for an external status code, even if
+    # that's the same as the current external status code. This is because
+    # variable replacement in comment_text_for_request could create different
+    # output for the same external status code. There shouldn't be an update
+    # with the same variables+code, but if there is we can fall back on the
+    # text comparison later.
+    my $state_changed = $state ne $old_state
+        && !( $p->is_fixed && FixMyStreet::DB::Result::Problem->fixed_states()->{$state} );
+    my $old_ext_code = $p->get_extra_metadata('external_status_code') || '';
+    my $ext_code_changed = $external_status_code && $external_status_code ne $old_ext_code;
+    # So if there are no variables involved, and no state/code change, remove the template
+    if ($template && !$state_changed && !$ext_code_changed && $template !~ /\{\{/) {
+        $template = undef;
+    }
+
+    my ($text, $email_text) = $self->comment_text_for_request($template, $request, $p, $cobrand);
     if (!$email_text && $request->{email_text}) {
         $email_text = $request->{email_text};
     };
@@ -274,7 +289,6 @@ sub _process_update {
     my $state_change = $comment->problem_state && $state ne $old_state;
     $comment->state('hidden') unless $text_change || $photo_change || $state_change;
 
-    my $cobrand = $body->get_cobrand_handler;
     $cobrand->call_hook(open311_get_update_munging => $comment, $state, $request)
         if $cobrand;
 
@@ -300,7 +314,7 @@ sub _process_update {
 }
 
 sub comment_text_for_request {
-    my ($self, $template, $request, $problem) = @_;
+    my ($self, $template, $request, $problem, $cobrand) = @_;
 
     my $email_text = $template ? ($template->email_text||'') : '';
     $template = $template->text if $template;
@@ -308,6 +322,11 @@ sub comment_text_for_request {
     my $desc = $request->{description} || '';
     if ($desc && (!$template || ($template !~ /\{\{description}}/ && !$request->{prefer_template}))) {
         return ($desc, undef);
+    }
+
+    if ($template && $cobrand && $cobrand->can('open311_get_update_template_variables')) {
+        $template = $cobrand->open311_get_update_template_variables($template, $request);
+        $email_text = $cobrand->open311_get_update_template_variables($email_text, $request);
     }
 
     if ($template) {

--- a/t/cobrand/dumfries.t
+++ b/t/cobrand/dumfries.t
@@ -621,7 +621,7 @@ subtest 'response_template_for with wildcard matching' => sub {
         subtest 'exact match beats wildcards' => sub {
             my $template = $test_problem->response_template_for(
                 $body, 'investigating', 'confirmed',
-                'status1:outcome1:priority1', ''
+                'status1:outcome1:priority1'
             );
             is $template->title, 'Exact Match Template',
                 'Exact match template selected over wildcards';
@@ -630,7 +630,7 @@ subtest 'response_template_for with wildcard matching' => sub {
         subtest 'more specific wildcard beats less specific' => sub {
             my $template = $test_problem->response_template_for(
                 $body, 'investigating', 'confirmed',
-                'status1:outcome1:priorityX', ''
+                'status1:outcome1:priorityX'
             );
             is $template->title, 'One Wildcard Template',
                 'One wildcard template beats two wildcard template';
@@ -639,7 +639,7 @@ subtest 'response_template_for with wildcard matching' => sub {
         subtest 'two wildcards beats three wildcards' => sub {
             my $template = $test_problem->response_template_for(
                 $body, 'investigating', 'confirmed',
-                'status1:outcomeX:priorityX', ''
+                'status1:outcomeX:priorityX'
             );
             is $template->title, 'Two Wildcard Template',
                 'Two wildcard template beats all wildcard template';
@@ -648,7 +648,7 @@ subtest 'response_template_for with wildcard matching' => sub {
         subtest 'star wildcard matches empty segment' => sub {
             my $template = $test_problem->response_template_for(
                 $body, 'investigating', 'confirmed',
-                'status1::', ''
+                'status1::'
             );
             is $template->title, 'Two Wildcard Template',
                 'Star wildcard matches empty segments';
@@ -657,7 +657,7 @@ subtest 'response_template_for with wildcard matching' => sub {
         subtest 'star wildcard fallback works for unmatched statuses' => sub {
             my $template = $test_problem->response_template_for(
                 $body, 'investigating', 'confirmed',
-                'status_fallback:outcomeX:priorityX', ''
+                'status_fallback:outcomeX:priorityX'
             );
             is $template->title, 'Fallback Template',
                 'Fallback star template matches when nothing more specific exists';
@@ -666,7 +666,7 @@ subtest 'response_template_for with wildcard matching' => sub {
         subtest 'plus wildcard matches non-empty segments' => sub {
             my $template = $test_problem->response_template_for(
                 $body, 'investigating', 'confirmed',
-                'status_plus:outcome1:priority1', ''
+                'status_plus:outcome1:priority1'
             );
             is $template->title, 'Plus Wildcard Template',
                 'Plus wildcard template matches when segments are non-empty';
@@ -675,22 +675,21 @@ subtest 'response_template_for with wildcard matching' => sub {
         subtest 'plus wildcard does not match empty segments' => sub {
             my $template = $test_problem->response_template_for(
                 $body, 'investigating', 'confirmed',
-                'status_plus::', ''
+                'status_plus::'
             );
             is $template->title, 'Star Wildcard Template',
                 'Plus wildcard does not match empty segments, star does';
         };
 
-        subtest 'no match when external_status_code unchanged' => sub {
+        subtest 'match when external_status_code unchanged' => sub {
             $test_problem->set_extra_metadata(external_status_code => 'status1:outcome1:priority1');
             $test_problem->update;
 
             my $template = $test_problem->response_template_for(
                 $body, 'investigating', 'confirmed',
-                'status1:outcome1:priority1', 'status1:outcome1:priority1'
+                'status1:outcome1:priority1'
             );
-            is $template, undef,
-                'No template when external_status_code has not changed';
+            is $template->title, 'Exact Match Template';
         };
 
         $template_exact->delete;

--- a/t/open311/getservicerequestupdates.t
+++ b/t/open311/getservicerequestupdates.t
@@ -608,6 +608,23 @@ subtest 'Check Aberdeenshire template interpolation' => sub {
     is $c->text, "Job start date: 15/11/2025\nTarget date: 31/12/2025", 'template correctly interpolated with jobStartDate';
 
     $aber_problem->comments->delete;
+    # another update that only changes the extra data/response variables and leaves state/external status alone
+    $local_requests_xml = setup_xml($aber_problem->external_id, $aber_problem->id, 'ACTION_SCHEDULED', '',
+        '<jobStartDate>2026-01-20T09:00:00</jobStartDate><targetDate>2026-02-28T10:30:00</targetDate>');
+    $local_requests_xml =~ s#</request_update>#<external_status_code>39</external_status_code></request_update>#;
+    Open311->_inject_response('/servicerequestupdates.xml', $local_requests_xml);
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'aberdeenshire',
+    }, sub {
+        $update->process_body;
+    };
+    $aber_problem->discard_changes;
+    $c = $aber_problem->comments->first;
+    is $aber_problem->comments->count, 1, 'comment count';
+    is $c->state, 'confirmed', 'comment is visible';
+    is $c->text, "Job start date: 20/01/2026\nTarget date: 28/02/2026", 'new template vars used';
+
+    $aber_problem->comments->delete;
     $aber_problem->delete;
     $tpl->delete;
 };

--- a/t/open311/getservicerequestupdates.t
+++ b/t/open311/getservicerequestupdates.t
@@ -545,12 +545,14 @@ subtest 'Check Aberdeenshire template interpolation' => sub {
         text => "Target date: {{targetDate}}\nCategory: {{featureCCAT}}\nSpeed limit: {{featureSPD}}",
         email_text => "EMAIL: Target date: {{targetDate}}\nCategory: {{featureCCAT}}\nSpeed limit: {{featureSPD}}",
         auto_response => 1,
-        state => "in progress"
+        state => '',
+        external_status_code => 39,
     });
 
     my $aber_problem = create_problem($bodies{2648}->id);
     my $local_requests_xml = setup_xml($aber_problem->external_id, $aber_problem->id, 'IN_PROGRESS', '',
         '<targetDate>2025-12-31T10:30:00</targetDate><featureCCAT>3A</featureCCAT><featureSPD>60mph</featureSPD>');
+    $local_requests_xml =~ s#</request_update>#<external_status_code>39</external_status_code></request_update>#;
 
     my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
     Open311->_inject_response('/servicerequestupdates.xml', $local_requests_xml);
@@ -582,11 +584,11 @@ subtest 'Check Aberdeenshire template interpolation' => sub {
     # Also test jobStartDate interpolation
     $tpl->update({
         text => "Job start date: {{jobStartDate}}\nTarget date: {{targetDate}}",
-        state => "action scheduled"
     });
 
     $local_requests_xml = setup_xml($aber_problem->external_id, $aber_problem->id, 'ACTION_SCHEDULED', '',
         '<jobStartDate>2025-11-15T09:00:00</jobStartDate><targetDate>2025-12-31T10:30:00</targetDate>');
+    $local_requests_xml =~ s#</request_update>#<external_status_code>39</external_status_code></request_update>#;
     Open311->_inject_response('/servicerequestupdates.xml', $local_requests_xml);
 
     $aber_problem->lastupdate( DateTime->now()->subtract( days => 1 ) );

--- a/t/open311/getservicerequestupdates.t
+++ b/t/open311/getservicerequestupdates.t
@@ -545,12 +545,14 @@ subtest 'Check Aberdeenshire template interpolation' => sub {
         text => "Target date: {{targetDate}}\nCategory: {{featureCCAT}}\nSpeed limit: {{featureSPD}}",
         email_text => "EMAIL: Target date: {{targetDate}}\nCategory: {{featureCCAT}}\nSpeed limit: {{featureSPD}}",
         auto_response => 1,
-        state => "in progress"
+        state => '',
+        external_status_code => 39,
     });
 
     my $aber_problem = create_problem($bodies{2648}->id);
     my $local_requests_xml = setup_xml($aber_problem->external_id, $aber_problem->id, 'IN_PROGRESS', '',
         '<targetDate>2025-12-31T10:30:00</targetDate><featureCCAT>3A</featureCCAT><featureSPD>60mph</featureSPD>');
+    $local_requests_xml =~ s#</request_update>#<external_status_code>39</external_status_code></request_update>#;
 
     my $o = Open311->new( jurisdiction => 'mysociety', endpoint => 'http://example.com' );
     Open311->_inject_response('/servicerequestupdates.xml', $local_requests_xml);
@@ -582,11 +584,11 @@ subtest 'Check Aberdeenshire template interpolation' => sub {
     # Also test jobStartDate interpolation
     $tpl->update({
         text => "Job start date: {{jobStartDate}}\nTarget date: {{targetDate}}",
-        state => "action scheduled"
     });
 
     $local_requests_xml = setup_xml($aber_problem->external_id, $aber_problem->id, 'ACTION_SCHEDULED', '',
         '<jobStartDate>2025-11-15T09:00:00</jobStartDate><targetDate>2025-12-31T10:30:00</targetDate>');
+    $local_requests_xml =~ s#</request_update>#<external_status_code>39</external_status_code></request_update>#;
     Open311->_inject_response('/servicerequestupdates.xml', $local_requests_xml);
 
     $aber_problem->lastupdate( DateTime->now()->subtract( days => 1 ) );
@@ -604,6 +606,23 @@ subtest 'Check Aberdeenshire template interpolation' => sub {
     $c = $aber_problem->comments->first;
     ok $c, 'comment exists';
     is $c->text, "Job start date: 15/11/2025\nTarget date: 31/12/2025", 'template correctly interpolated with jobStartDate';
+
+    $aber_problem->comments->delete;
+    # another update that only changes the extra data/response variables and leaves state/external status alone
+    $local_requests_xml = setup_xml($aber_problem->external_id, $aber_problem->id, 'ACTION_SCHEDULED', '',
+        '<jobStartDate>2026-01-20T09:00:00</jobStartDate><targetDate>2026-02-28T10:30:00</targetDate>');
+    $local_requests_xml =~ s#</request_update>#<external_status_code>39</external_status_code></request_update>#;
+    Open311->_inject_response('/servicerequestupdates.xml', $local_requests_xml);
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => 'aberdeenshire',
+    }, sub {
+        $update->process_body;
+    };
+    $aber_problem->discard_changes;
+    $c = $aber_problem->comments->first;
+    is $aber_problem->comments->count, 1, 'comment count';
+    is $c->state, 'confirmed', 'comment is visible';
+    is $c->text, "Job start date: 20/01/2026\nTarget date: 28/02/2026", 'new template vars used';
 
     $aber_problem->comments->delete;
     $aber_problem->delete;


### PR DESCRIPTION
If we get an update that is the same state/external status code as the previous, we still might want to include it if there are variables in the response template, because the variables may be different.

For Aberdeenshire FD-7242 though would also affect Dumfries. Hopefully shouldn't change any current behaviour [skip changelog]
