### PR TITLE
Sutton report problem page bulky before 6pm

### DIFF
--- a/t/app/controller/waste_kands_bulky.t
+++ b/t/app/controller/waste_kands_bulky.t
@@ -1,5 +1,6 @@
 use Test::MockModule;
 use Test::MockTime qw(:all);
+use Storable qw(dclone);
 use FixMyStreet::TestMech;
 use Path::Tiny;
 use FixMyStreet::Script::Reports;
@@ -1259,6 +1260,86 @@ FixMyStreet::override_config {
         like $email->header('Subject'), qr/Your bulky waste collection - reference LBS/, "Confirmation booking email sent after staff payment process";
     };
 
+    subtest 'Missed collection link visibility' => sub {
+        my $mock = [ {
+            Id => '8004',
+            ClientReference => 'LBS-123',
+            Guid => 'booking-guid',
+            ServiceId => 960, # Bulky
+            EventTypeId => 3130, # Bulky collection
+            EventStateId => 19184, # Completed
+            EventDate => { DateTime => '2025-04-01T00:00:00Z' },
+            ResolvedDate => { DateTime => '2025-04-08T00:00:00Z' },
+            ResolutionCodeId => 232, # Completed on Scheduled Day (dunno if used, doesn't matter)
+        } ];
+        my $tests = {
+            "Not visible before 6pm on collection day" => {
+                date => '2025-04-08T16:30:00Z',
+                visible => 0,
+                not_complete => 1,
+                msg => 'Please wait until after 6pm',
+                estate => 19183, # Allocated
+                pstate => 'confirmed',
+            },
+            "Visible after 6pm on collection day even if not complete" => {
+                date => '2025-04-08T18:30:00Z',
+                visible => 1,
+                not_complete => 1,
+                msg => 'This collection was scheduled for Tuesday, 8 April',
+                estate => 19183, # Allocated
+                pstate => 'confirmed',
+            },
+            "Visible if marked as completed" => {
+                date => '2025-04-08T18:30:00Z',
+                visible => 1,
+                msg => 'Our records show this collection took place',
+                estate => 19184, # Completed
+                pstate => 'fixed - council',
+            },
+            "Not visible if marked as incomplete" => {
+                date => '2025-04-08T18:30:00Z',
+                visible => 0,
+                failed => 1,
+                msg => 'No access due to gate locked',
+                estate => 19185, # Not Complete
+                pstate => 'unable to fix',
+            },
+        };
+        $report->update_extra_field({ name => 'Collection_Date_-_Bulky_Items', value => '2025-04-08T00:00:00' });
+        $report->set_extra_metadata(payment_reference => 'payref');
+        for my $test (keys %$tests) {
+            subtest $test => sub {
+                my $conf = $tests->{$test};
+                set_fixed_time($conf->{date});
+                $report->update({ external_id => 'booking-guid', state => $conf->{pstate} });
+
+                my @dupe = @{dclone($mock)};
+                if ($conf->{not_complete}) {
+                    delete $dupe[0]->{ResolvedDate};
+                    delete $dupe[0]->{ResolutionCodeId};
+                }
+                if ($conf->{failed}) {
+                    $dupe[0]->{ResolutionCodeId} = 466; # No access - gate locked
+                }
+                $dupe[0]->{EventStateId} = $conf->{estate};
+
+                $echo->mock( 'GetEventsForObject', sub {\@dupe} );
+                $mech->get_ok('/waste/12345');
+                $mech->follow_link_ok( { url_regex => qr/service_id=960/}, 'Follow "Report a problem" link for bulky collection' );
+
+                if ($conf->{visible}) {
+                    $mech->content_contains('you can report it as missed');
+                } elsif ($conf->{failed}) {
+                    $mech->content_lacks('you can report it as missed');
+                    $mech->content_contains('Dispute collection closure');
+                } else {
+                    $mech->content_lacks('you can report it as missed');
+                }
+
+                $mech->content_contains($conf->{msg})
+            };
+        }
+    };
     subtest 'Missed collections' => sub {
         # Update the bulky collection to have been done (at right time)
         $report->update_extra_field({ name => 'Collection_Date_-_Bulky_Items', value => '2025-04-08T00:00:00' });

--- a/t/app/controller/waste_sutton_r.t
+++ b/t/app/controller/waste_sutton_r.t
@@ -406,8 +406,95 @@ FixMyStreet::override_config {
         is $report->title, 'Request replacement Mixed Recycling Green Box (55L)';
     };
 
+    subtest 'Missed collection links visiblity' => sub {
+        my $mock_results_in_progress = [ {
+            Ref => { Value => { anyType => [ 22244305, 8287 ] } },
+            State => { Name => 'Allocated' },
+            CompletedDate => undef
+        } ];
+        my $mock_results_complete = [ {
+            Ref => { Value => { anyType => [ 22244305, 8287 ] } },
+            State => { Name => 'Completed' },
+            CompletedDate => { DateTime => '2022-09-09T16:00:00Z' }
+        } ];
+        my $mock_results_not_complete = [ {
+            Ref => { Value => { anyType => [ 22244305, 8287 ] } },
+            State => { Name => 'Not Completed' },
+            CompletedDate => { DateTime => '2022-09-09T16:00:00Z' }
+        } ];
+        $e->mock('GetTasks', sub { [ {
+            Ref => { Value => { anyType => [ 22244305, 8287 ] } },
+            State => { Name => 'Completed' },
+            CompletedDate => { DateTime => '2022-09-09T16:00:00Z' }
+        }, {
+            Ref => { Value => { anyType => [ 22244305, 8287 ] } },
+            State => { Name => 'Allocated' },
+            CompletedDate => undef
+        } ] });
+
+        my $tests = {
+            "Not visible before 6pm on collection day" => {
+                date => '2022-09-09T16:30:00Z',
+                visible => 0,
+                not_complete => 1,
+                mock => $mock_results_in_progress,
+                msg => 'Please wait until after 6pm',
+            },
+            "Visible after 6pm on collection day even if not complete" => {
+                date => '2022-09-09T18:30:00Z',
+                visible => 1,
+                not_complete => 1,
+                mock => $mock_results_in_progress,
+                status => 'Allocated',
+                msg => 'this collection took place',
+            },
+            "Visible if marked as completed" => {
+                date => '2022-09-09T18:30:00Z',
+                visible => 1,
+                status => 'Completed',
+                mock => $mock_results_complete,
+                msg => 'this collection took place',
+            },
+            "Not visible if marked as incomplete" => {
+                date => '2022-09-09T18:30:00Z',
+                visible => 0,
+                failed => 1,
+                status => 'Not Completed',
+                mock => $mock_results_not_complete,
+                msg => 'task as not collected',
+            },
+        };
+
+        for my $test (keys %$tests) {
+            subtest $test => sub {
+                my $conf = $tests->{$test};
+                set_fixed_time($conf->{date});
+                my @dupe = @$bin_data;
+                if ($conf->{not_complete}) {
+                    $dupe[1]->{ServiceTasks}->{ServiceTask}->[0]->{ServiceTaskSchedules}->{ServiceTaskSchedule}->[0]->{LastInstance}->{CompletedDate} = undef;
+                    $dupe[1]->{ServiceTasks}->{ServiceTask}->[0]->{ServiceTaskSchedules}->{ServiceTaskSchedule}->[0]->{LastInstance}->{State} = { CoreState => "Outstanding", Name => "Outstanding" };
+                }
+                $e->mock('GetServiceUnitsForObject', sub { \@dupe });
+                $e->mock('GetTasks', sub { $conf->{mock} });
+
+                $mech->get_ok('/waste/12345');
+                $mech->follow_link_ok( { url_regex => qr/service_id=954/}, 'Follow "Report a problem" link for food waste' );
+                $mech->content_contains($conf->{msg});
+                if ($conf->{visible}) {
+                    $mech->content_contains('you can report it as missed');
+                } elsif ($conf->{failed}) {
+                    $mech->content_contains('Dispute collection closure');
+                } else {
+                    $mech->content_lacks('you can report it as missed');
+                }
+            };
+        }
+        $e->mock('GetTasks', sub { [] });
+    };
+    $e->mock('GetServiceUnitsForObject', sub { $bin_data });
     my $missed_report;
     subtest 'Report missed collection' => sub {
+        set_fixed_time('2022-09-09T16:30:00Z');
         FixMyStreet::Script::Reports::send();
         $mech->clear_emails_ok;
 

--- a/templates/web/sutton/waste/enquiry-problem.html
+++ b/templates/web/sutton/waste/enquiry-problem.html
@@ -12,6 +12,13 @@ ELSE;
     SET resolution = c.cobrand.resolution_text(service.last.resolution_id) || service.report_open.resolution_reason;
 END;
 
+SET type = '';
+IF service.service_name == 'Bulky waste';
+    SET type = 'bulky';
+ELSIF service.service_name == 'Small items';
+    SET type = 'small';
+END;
+
 %]
 
 [% enquiry_message = BLOCK %]
@@ -43,13 +50,6 @@ END;
                 [% IF service.dispute.too_late %]
                     <p>The crew have marked this collection as completed. You cannot dispute this as it has been more than 2 working days since the collection took place.</p>
                 [% ELSE %]
-                    [%
-                        SET type = service.service_name == 'Bulky waste'
-                            ? 'bulky'
-                            : service.service_name == 'Small items'
-                                ? 'small'
-                                : '';
-                    %]
                     <p>The crew marked this collection as completed. If your [% IF type == 'bulky' %]bulky waste was not collected[% ELSIF type == 'small' %]small items were not collected[% ELSE %]bin has not been emptied[% END %], you can dispute this and we will investigate. If we find that the collection task was closed incorrectly, we will return to collect the [% IF !type %]bin[% ELSE %]waste[% END %].</p>
                 [% END %]
             [% ELSE %]
@@ -87,6 +87,14 @@ END;
             Please resolve the issue so the bin can be collected on the next scheduled collection. <a href="https://www.sutton.gov.uk/waste-and-recycling/your-collection-service">Check our website</a> for more information on how your bin should be presented and what you can put in it.
         </p>
         <p>If it is less than 2 working days since your collection day, you can dispute the reason given and we will investigate. If we find that the collection task was closed incorrectly, we will return to collect the bin.</p>
+        </div>
+    </div>
+    [% # this handles missed bulky collections where it's not collected at the end of the day %]
+    [% ELSIF (type == 'bulky' OR type == 'small') AND service.report_allowed AND original_booking_report.is_open %]
+    <div class="govuk-warning-text info">
+        <div class="govuk-warning-text__content">
+        <p>This collection was scheduled for [% date.format(original_booking_report.get_extra_field_value('Collection_Date_-_Bulky_Items'), '%A, %-d %B') %].
+        If it has not been collected, you can report it as missed and we will return within 2 working days to collect it.</p>
         </div>
     </div>
     [% ELSIF service.report_allowed %]


### PR DESCRIPTION
Fixes the report a problem page not showing the correct message if a bulky collection hasn't happened by 6pm.

Also adds some tests for checking the report a problem page handles all the initial collection scenarios.

[skip changelog]