### PR TITLE
Fix state filtering on /around for staff users

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Reports.pm
@@ -788,7 +788,10 @@ sub stash_report_filter_status : Private {
         $filter_status{unshortlisted} = 1;
     }
 
-    my $body_user = $c->user_exists && $c->stash->{body} && $c->user->belongs_to_body($c->stash->{body}->id);
+    # The body isn't stashed on e.g. /around, so fall back to the cobrand's
+    # body, matching what reports/_list-filter-status.html does
+    my $body = $c->stash->{body} ||= $c->cobrand->body;
+    my $body_user = $c->user_exists && $body && $c->user->belongs_to_body($body->id);
     my $staff_user = $c->user_exists && ($c->user->is_superuser || $body_user);
     my $planned_page = $c->action eq 'my/planned';
     if ($staff_user || $planned_page || $c->cobrand->call_hook('filter_show_all_states')) {

--- a/t/app/controller/around.t
+++ b/t/app/controller/around.t
@@ -824,6 +824,23 @@ subtest 'status dropdown' => sub {
 
             $mech->content_like(qr/data-all-options=.*confirmed.*investigating.*action scheduled.*in progress.*fixed.*not responsible.*duplicate.*unable to fix.*internal referral/);
         };
+
+        subtest 'staff user can filter on an individual state' => sub {
+            $mech->log_in_ok($staff_oxf->email);
+
+            my ($problem) = $mech->create_problems_for_body(1, $body->id, 'Around page', {
+                latitude => 51.754926,
+                longitude => -1.256179,
+                category => 'Pothole',
+                state => 'not responsible',
+            });
+
+            my $json = $mech->get_ok_json('/around?ajax=1&status=not%20responsible&bbox=-1.266179,51.744926,-1.246179,51.764926');
+            my @ids = map { $_->[3] } @{$json->{pins}};
+            is_deeply \@ids, [ $problem->id ], 'only the not responsible report returned';
+
+            $problem->delete;
+        };
     };
 };
 


### PR DESCRIPTION
Logged-in staff would see incorrect pins on the map depending on the state filters they'd selected, as `body` wasn't being set on the stash which meant the staff user check in `stash_report_filter_status` wasn't passing.

For FD-7319.

[skip changelog]