### PR TITLE
[Bromley] Always send email on open311 updates to passthrough.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Bromley.pm
+++ b/perllib/FixMyStreet/Cobrand/Bromley.pm
@@ -267,9 +267,12 @@ Sets options for what data will be sent to the open311 integrations.
 
 Bromley require all images to be sent for Echo reports, as binaries for upload.
 
-We do not 'always_send_latlong' or 'extended_description'
+We do not 'always_send_latlong' or 'extended_description'.
 
-We do 'send_notpinpointed'
+We do 'send_notpinpointed'.
+
+We always send email when sending updates to the passthrough endpoint as
+it's required.
 
 =cut
 
@@ -280,6 +283,8 @@ sub open311_config {
         $params->{multi_photos} = 1;
         $params->{upload_files} = 1;
         $params->{always_upload_photos} = 1; # So open311_munge_uploads always gets called
+    } else {
+        $params->{always_send_email_for_updates} = 1;
     }
 
     $params->{always_send_latlong} = 0;

--- a/perllib/Open311.pm
+++ b/perllib/Open311.pm
@@ -33,6 +33,7 @@ has extended_description => ( is => 'ro', isa => Str, default => 1 );
 has use_service_as_deviceid => ( is => 'ro', isa => Bool, default => 0 );
 has extended_statuses => ( is => 'ro', isa => Bool, default => 0 );
 has always_send_email => ( is => 'ro', isa => Bool, default => 0 );
+has always_send_email_for_updates => ( is => 'ro', isa => Bool, default => 0 );
 has multi_photos => ( is => 'ro', isa => Bool, default => 0 );
 has upload_files => ( is => 'ro', isa => Bool, default => 0 );
 has upload_files_for_updates => ( is => 'ro', isa => Bool, default => 0 );
@@ -531,6 +532,12 @@ sub _populate_service_request_update_params {
     $params->{phone} = $comment->user->phone if $comment->user->phone;
     $params->{email} = $comment->user->email if $comment->user->email;
     $params->{update_id} = $comment->id;
+
+    # Some endpoints don't follow the Open311 spec correctly and require an
+    # email address for service request updates.
+    if ($self->always_send_email_for_updates && !$params->{email}) {
+        $params->{email} = FixMyStreet->config('DO_NOT_REPLY_EMAIL');
+    }
 
     my $cobrand = $self->fixmystreet_body->get_cobrand_handler || $comment->get_cobrand_logged;
     $cobrand->call_hook(open311_munge_update_params => $params, $comment, $self->fixmystreet_body);

--- a/t/open311.t
+++ b/t/open311.t
@@ -406,6 +406,23 @@ subtest 'basic request update post parameters' => sub {
     is $c->param('media_url'), undef, 'no media url';
 };
 
+subtest 'test always_send_email_for_updates' => sub {
+    my $email = $user->email;
+    my $comment = make_comment();
+    $comment->user->email(undef);
+    my $results = make_update_req(
+        $comment,
+        '<?xml version="1.0" encoding="utf-8"?><service_request_updates><request_update><update_id>248</update_id></request_update></service_request_updates>',
+        { always_send_email_for_updates => 1 }
+    );
+
+    is $results->{ res }, 248, 'got update id';
+
+    my $c = CGI::Simple->new( $results->{ req }->content );
+    is $c->param('email'), 'do-not-reply@example.org', 'email correct';
+    $comment->user->email($email);
+};
+
 subtest 'extended request update post parameters' => sub {
     my $comment = make_comment('bromley');
     my $results;


### PR DESCRIPTION
[skip changelog]

The endpoint fails if no email is provided.

We're seeing this with a couple updates.

Note this is regardless of what `email_alerts_requested` is set to.