### PR TITLE
Export/import tests and couple of fixes

### DIFF
--- a/bin/export-import-data
+++ b/bin/export-import-data
@@ -12,10 +12,8 @@ BEGIN {
     require "$d/../setenv.pl";
 }
 
-use FixMyStreet::DB;
 use Getopt::Long::Descriptive;
-use JSON::MaybeXS;
-use Path::Tiny;
+use FixMyStreet::Script::ExportImport;
 
 my ($opt, $usage) = describe_options(
     '%c',
@@ -32,202 +30,14 @@ print($usage->text), exit if $opt->help;
 $usage->die unless $opt->name;
 die "Please specify a file to import\n" if $opt->import && (! -e $opt->import || -d $opt->import);
 
-my $J = JSON::MaybeXS->new(utf8 => 1, pretty => 1, canonical => 1);
-my $body = FixMyStreet::DB->resultset("Body")->find({ name => $opt->name }) or die "Cannot find body " . $opt->name . "\n";
-my @categories = split(/\|/, ($opt->{categories} || ''));
+my $process = FixMyStreet::Script::ExportImport->new({
+    body => $opt->name,
+    commit => $opt->commit,
+});
 
 if ($opt->import) {
-    import($opt->import, $opt->update_templates, $opt->update_contacts);
+    $process->import_json($opt->import, $opt->update_templates, $opt->update_contacts);
 } else {
-    export();
-}
-
-sub export {
-    my %out;
-
-    if (@categories || $opt->all_categories) {
-        my @contacts = $body->contacts->search({
-            $opt->all_categories ? () : ( category => { -in => \@categories } ),
-        }, {
-            order_by => 'category',
-        })->all;
-        die "Categories mismatch" unless (scalar @categories == scalar @contacts) || $opt->all_categories;
-        for (@contacts) {
-            push @{$out{contacts}}, {
-                category => $_->category,
-                email => $_->email,
-                state => $_->state,
-                send_method => $_->send_method || '',
-                non_public => $_->non_public ? JSON->true : JSON->false,
-                extra => $_->extra,
-            };
-        }
-    }
-
-    my $templates = $body->response_templates->order_by('title');
-    if (@categories) {
-        $templates = $templates->search({
-            'contact.category' => { -in => \@categories }
-        }, {
-            join => { 'contact_response_templates' => 'contact' }
-        });
-    }
-    for ($templates->all) {
-        push @{$out{templates}}, {
-            title => $_->title,
-            text => $_->text,
-            email_text => $_->email_text,
-            state => $_->state,
-            categories => [ sort map { $_->category } $_->contacts->all ],
-            auto_response => $_->auto_response,
-            external_status_code => $_->external_status_code,
-        };
-    }
-
-    for ($body->roles->order_by('name')->all) {
-        push @{$out{roles}}, {
-            permissions => $_->permissions,
-            name => $_->name,
-        };
-    }
-
-    for ($body->users->order_by('name')->all) {
-        my $cats = $_->get_extra_metadata('categories');
-        my @cat_names = sort map { $body->contacts->find({id => $_})->category } @$cats;
-        push @{$out{users}}, {
-            email => $_->email,
-            name => $_->name,
-            password => $_->password,
-            roles => [ sort map { $_->name } $_->roles->all ],
-            categories => \@cat_names,
-            areas => $_->area_ids || [],
-        };
-    }
-
-    print $J->encode(\%out);
-}
-
-sub import {
-    my $file = shift;
-    my $update_templates = shift;
-    my $update_contacts = shift;
-
-    my $json = path($file)->slurp;
-    my $out = $J->decode($json);
-
-    my $db = FixMyStreet::DB->schema->storage;
-    $db->txn_begin;
-
-    foreach (@{$out->{contacts}}) {
-        my $existing = $body->contacts->search({ category => $_->{category} })->single;
-        if ($existing) {
-            if ($update_contacts) {
-                $existing->update({
-                    note => "Updated from $file",
-                    editor => 'export-import-data',
-                    whenedited => \'current_timestamp',
-                    email => $_->{email},
-                    state => $_->{state},
-                    send_method => $_->{send_method},
-                    non_public => $_->{non_public},
-                    extra => $_->{extra},
-                });
-            } else {
-                warn "Category $_->{category} already exists, skipping";
-                next;
-            }
-        } else {
-            my $contact = $body->contacts->new({
-                note => "Imported from $file",
-                editor => 'export-import-data',
-                whenedited => \'current_timestamp',
-                category => $_->{category},
-                email => $_->{email},
-                state => $_->{state},
-                non_public => $_->{non_public},
-                extra => $_->{extra},
-            });
-            $contact->insert;
-        }
-    }
-
-    foreach (@{$out->{templates}}) {
-        my $existing = $body->response_templates->search({ title => $_->{title} })->single;
-        if ($existing && !$update_templates) {
-            warn "Template with title $_->{title} already exists, skipping";
-            next;
-        }
-        my $template = $body->response_templates->update_or_new({
-            title => $_->{title},
-            text => $_->{text},
-            email_text => $_->{email_text},
-            state => $_->{state},
-            auto_response => $_->{auto_response},
-            external_status_code => $_->{external_status_code},
-        });
-        $template->insert unless $template->in_storage;
-        foreach (@{$_->{categories}}) {
-            my $contact = $body->contacts->find({ category => $_ });
-            unless ( $contact ) {
-                my $msg = "Cannot find category $_ for template " . $template->title . "\n";
-                if ($update_templates) {
-                    warn $msg;
-                    next;
-                } else {
-                    die $msg;
-                }
-            }
-            $template->contact_response_templates->find_or_create({
-                contact_id => $contact->id,
-            });
-        }
-    }
-
-    for my $r (@{$out->{roles}}) {
-        my $role = $body->roles->find_or_new({
-            name => $r->{name},
-            permissions => $r->{permissions},
-        });
-        if ($role->in_storage) {
-            warn "Role $r->{role} already exists; skipping";
-            next;
-        }
-        $role->insert;
-    }
-
-    for my $u (@{$out->{users}}) {
-        my $user = FixMyStreet::DB->resultset("User")->find_or_new({ email => $u->{email}, email_verified => 1 });
-        if ($user->in_storage) {
-            warn "User $u->{email} already exists; skipping";
-            next;
-        }
-        $user->from_body($body->id);
-        $user->name($u->{name});
-        $user->password($u->{password}, 1);
-        $user->area_ids($u->{areas});
-
-        $user->insert;
-
-        foreach my $role (@{$u->{roles}}) {
-            my $role = $body->roles->find({ name => $role }) or die "Couldn't find role $role for user $u->{email}\n";
-            $user->user_roles->create({
-                role_id => $role->id,
-            });
-        }
-
-        my @cat_ids;
-        for my $cat_name (@{$u->{categories}}) {
-            my $cat = $body->contacts->find({ category => $cat_name }) or die "Couldn't find category $cat_name for user $u->{email}\n";
-            push @cat_ids, $cat->id;
-        }
-        $user->set_extra_metadata('categories', \@cat_ids);
-        $user->set_extra_metadata(last_password_change => time());
-        $user->update;
-    }
-
-    if ($opt->commit) {
-        $db->txn_commit;
-    } else {
-        $db->txn_rollback;
-    }
+    my @categories = split(/\|/, ($opt->{categories} || ''));
+    print $process->export_json(\@categories, $opt->all_categories);
 }

--- a/perllib/FixMyStreet/Script/ExportImport.pm
+++ b/perllib/FixMyStreet/Script/ExportImport.pm
@@ -84,6 +84,19 @@ sub export_json {
     return $J->encode(\%out);
 }
 
+sub _import_category_fields {
+    my $category = shift;
+    (
+        editor => 'export-import-data',
+        whenedited => \'current_timestamp',
+        email => $category->{email},
+        state => $category->{state},
+        send_method => $category->{send_method},
+        non_public => $category->{non_public},
+        extra => $category->{extra},
+    );
+};
+
 sub import_json {
     my ($self, $file, $update_templates, $update_contacts) = @_;
     my $body = $self->body;
@@ -100,13 +113,7 @@ sub import_json {
             if ($update_contacts) {
                 $existing->update({
                     note => "Updated from $file",
-                    editor => 'export-import-data',
-                    whenedited => \'current_timestamp',
-                    email => $_->{email},
-                    state => $_->{state},
-                    send_method => $_->{send_method},
-                    non_public => $_->{non_public},
-                    extra => $_->{extra},
+                    _import_category_fields($_),
                 });
             } else {
                 warn "Category $_->{category} already exists, skipping\n";
@@ -115,13 +122,8 @@ sub import_json {
         } else {
             my $contact = $body->contacts->new({
                 note => "Imported from $file",
-                editor => 'export-import-data',
-                whenedited => \'current_timestamp',
                 category => $_->{category},
-                email => $_->{email},
-                state => $_->{state},
-                non_public => $_->{non_public},
-                extra => $_->{extra},
+                _import_category_fields($_),
             });
             $contact->insert;
         }

--- a/perllib/FixMyStreet/Script/ExportImport.pm
+++ b/perllib/FixMyStreet/Script/ExportImport.pm
@@ -1,0 +1,210 @@
+package FixMyStreet::Script::ExportImport;
+
+use Moo;
+use FixMyStreet::DB;
+use JSON::MaybeXS;
+use Path::Tiny;
+
+has commit => ( is => 'ro' );
+
+has body => ( is => 'ro', coerce => sub {
+    my $name = shift;
+    my $body = FixMyStreet::DB->resultset("Body")->find({ name => $name })
+        or die "Cannot find body $name\n";
+    return $body;
+});
+
+my $J = JSON::MaybeXS->new(utf8 => 1, pretty => 1, canonical => 1);
+
+sub export_json {
+    my ($self, $categories, $all_categories) = @_;
+    my $body = $self->body;
+    my %out;
+
+    if (@$categories || $all_categories) {
+        my @contacts = $body->contacts->search({
+            $all_categories ? () : ( category => { -in => $categories } ),
+        }, {
+            order_by => 'category',
+        })->all;
+        die "Categories mismatch\n" unless (scalar @$categories == scalar @contacts) || $all_categories;
+        for (@contacts) {
+            push @{$out{contacts}}, {
+                category => $_->category,
+                email => $_->email,
+                state => $_->state,
+                send_method => $_->send_method || '',
+                non_public => $_->non_public ? JSON->true : JSON->false,
+                extra => $_->extra,
+            };
+        }
+    }
+
+    my $templates = $body->response_templates->order_by('title');
+    if (@$categories) {
+        $templates = $templates->search({
+            'contact.category' => { -in => \@$categories }
+        }, {
+            join => { 'contact_response_templates' => 'contact' }
+        });
+    }
+    for ($templates->all) {
+        push @{$out{templates}}, {
+            title => $_->title,
+            text => $_->text,
+            email_text => $_->email_text,
+            state => $_->state,
+            categories => [ sort map { $_->category } $_->contacts->all ],
+            auto_response => $_->auto_response,
+            external_status_code => $_->external_status_code,
+        };
+    }
+
+    for ($body->roles->order_by('name')->all) {
+        push @{$out{roles}}, {
+            permissions => $_->permissions,
+            name => $_->name,
+        };
+    }
+
+    for ($body->users->order_by('name')->all) {
+        my $cats = $_->get_extra_metadata('categories');
+        my @cat_names = sort map { $body->contacts->find({id => $_})->category } @$cats;
+        push @{$out{users}}, {
+            email => $_->email,
+            name => $_->name,
+            password => $_->password,
+            roles => [ sort map { $_->name } $_->roles->all ],
+            categories => \@cat_names,
+            areas => $_->area_ids || [],
+        };
+    }
+
+    return $J->encode(\%out);
+}
+
+sub import_json {
+    my ($self, $file, $update_templates, $update_contacts) = @_;
+    my $body = $self->body;
+
+    my $json = path($file)->slurp;
+    my $out = $J->decode($json);
+
+    my $db = FixMyStreet::DB->schema->storage;
+    $db->txn_begin;
+
+    foreach (@{$out->{contacts}}) {
+        my $existing = $body->contacts->search({ category => $_->{category} })->single;
+        if ($existing) {
+            if ($update_contacts) {
+                $existing->update({
+                    note => "Updated from $file",
+                    editor => 'export-import-data',
+                    whenedited => \'current_timestamp',
+                    email => $_->{email},
+                    state => $_->{state},
+                    send_method => $_->{send_method},
+                    non_public => $_->{non_public},
+                    extra => $_->{extra},
+                });
+            } else {
+                warn "Category $_->{category} already exists, skipping\n";
+                next;
+            }
+        } else {
+            my $contact = $body->contacts->new({
+                note => "Imported from $file",
+                editor => 'export-import-data',
+                whenedited => \'current_timestamp',
+                category => $_->{category},
+                email => $_->{email},
+                state => $_->{state},
+                non_public => $_->{non_public},
+                extra => $_->{extra},
+            });
+            $contact->insert;
+        }
+    }
+
+    foreach (@{$out->{templates}}) {
+        my $existing = $body->response_templates->search({ title => $_->{title} })->single;
+        if ($existing && !$update_templates) {
+            warn "Template with title $_->{title} already exists, skipping\n";
+            next;
+        }
+        my $template = $body->response_templates->update_or_new({
+            title => $_->{title},
+            text => $_->{text},
+            email_text => $_->{email_text},
+            state => $_->{state},
+            auto_response => $_->{auto_response},
+            external_status_code => $_->{external_status_code},
+        });
+        $template->insert unless $template->in_storage;
+        foreach (@{$_->{categories}}) {
+            my $contact = $body->contacts->find({ category => $_ });
+            unless ( $contact ) {
+                my $msg = "Cannot find category $_ for template " . $template->title . "\n";
+                if ($update_templates) {
+                    warn $msg;
+                    next;
+                } else {
+                    die $msg;
+                }
+            }
+            $template->contact_response_templates->find_or_create({
+                contact_id => $contact->id,
+            });
+        }
+    }
+
+    for my $r (@{$out->{roles}}) {
+        my $role = $body->roles->find_or_new({
+            name => $r->{name},
+            permissions => $r->{permissions},
+        });
+        if ($role->in_storage) {
+            warn "Role $r->{name} already exists; skipping\n";
+            next;
+        }
+        $role->insert;
+    }
+
+    for my $u (@{$out->{users}}) {
+        my $user = FixMyStreet::DB->resultset("User")->find_or_new({ email => $u->{email}, email_verified => 1 });
+        if ($user->in_storage) {
+            warn "User $u->{email} already exists; skipping\n";
+            next;
+        }
+        $user->from_body($body->id);
+        $user->name($u->{name});
+        $user->password($u->{password}, 1);
+        $user->area_ids($u->{areas});
+
+        $user->insert;
+
+        foreach my $role (@{$u->{roles}}) {
+            my $role = $body->roles->find({ name => $role }) or die "Couldn't find role $role for user $u->{email}\n";
+            $user->user_roles->create({
+                role_id => $role->id,
+            });
+        }
+
+        my @cat_ids;
+        for my $cat_name (@{$u->{categories}}) {
+            my $cat = $body->contacts->find({ category => $cat_name }) or die "Couldn't find category $cat_name for user $u->{email}\n";
+            push @cat_ids, $cat->id;
+        }
+        $user->set_extra_metadata('categories', \@cat_ids);
+        $user->set_extra_metadata(last_password_change => time());
+        $user->update;
+    }
+
+    if ($self->commit) {
+        $db->txn_commit;
+    } else {
+        $db->txn_rollback;
+    }
+}
+
+1;

--- a/perllib/FixMyStreet/Script/ExportImport.pm
+++ b/perllib/FixMyStreet/Script/ExportImport.pm
@@ -57,6 +57,7 @@ sub export_json {
             categories => [ sort map { $_->category } $_->contacts->all ],
             auto_response => $_->auto_response,
             external_status_code => $_->external_status_code,
+            deleted => $_->deleted,
         };
     }
 
@@ -139,6 +140,7 @@ sub import_json {
             state => $_->{state},
             auto_response => $_->{auto_response},
             external_status_code => $_->{external_status_code},
+            deleted => $_->{deleted} || 0,
         });
         $template->insert unless $template->in_storage;
         foreach (@{$_->{categories}}) {

--- a/t/fixtures/import.json
+++ b/t/fixtures/import.json
@@ -13,7 +13,7 @@
          "email" : "flytipping@example.org",
          "extra" : null,
          "non_public" : false,
-         "send_method" : "",
+         "send_method" : "Email",
          "state" : "confirmed"
       }
     ],

--- a/t/fixtures/import.json
+++ b/t/fixtures/import.json
@@ -31,6 +31,7 @@
       {
          "auto_response" : 0,
          "categories" : [],
+         "deleted" : 1,
          "email_text" : null,
          "external_status_code" : null,
          "state" : "in progress",
@@ -40,6 +41,7 @@
       {
          "auto_response" : 0,
          "categories" : [],
+         "deleted" : 0,
          "email_text" : null,
          "external_status_code" : null,
          "state" : null,

--- a/t/fixtures/import.json
+++ b/t/fixtures/import.json
@@ -1,0 +1,62 @@
+{
+    "contacts": [
+      {
+         "category" : "Pothole",
+         "email" : "newpothole@example.org",
+         "extra" : null,
+         "non_public" : false,
+         "send_method" : "",
+         "state" : "confirmed"
+      },
+      {
+         "category" : "Flytipping",
+         "email" : "flytipping@example.org",
+         "extra" : null,
+         "non_public" : false,
+         "send_method" : "",
+         "state" : "confirmed"
+      }
+    ],
+   "roles" : [
+      {
+         "name" : "Admin",
+         "permissions" : ["report_inspect"]
+      },
+      {
+         "name" : "Nothing much",
+         "permissions" : ["dashboard"]
+      }
+   ],
+   "templates" : [
+      {
+         "auto_response" : 0,
+         "categories" : [],
+         "email_text" : null,
+         "external_status_code" : null,
+         "state" : "in progress",
+         "text" : "Ack",
+         "title" : "Ack"
+      },
+      {
+         "auto_response" : 0,
+         "categories" : [],
+         "email_text" : null,
+         "external_status_code" : null,
+         "state" : null,
+         "text" : "Fixed",
+         "title" : "Fixed"
+      }
+   ],
+   "users" : [
+      {
+         "areas" : [],
+         "categories" : [],
+         "email" : "admin@example.org",
+         "name" : "Admin User",
+         "password" : "",
+         "roles" : [
+            "Admin"
+         ]
+      }
+   ]
+}

--- a/t/script/exportimport.t
+++ b/t/script/exportimport.t
@@ -64,6 +64,7 @@ my $template_output = <<'EOF';
       {
          "auto_response" : 0,
          "categories" : [],
+         "deleted" : 0,
          "email_text" : null,
          "external_status_code" : null,
          "state" : null,
@@ -130,6 +131,7 @@ EOF
     is $pothole->email, 'newpothole@example.org';
     $template->discard_changes;
     is $template->state, 'in progress';
+    is $template->deleted, 1;
 };
 
 done_testing;

--- a/t/script/exportimport.t
+++ b/t/script/exportimport.t
@@ -1,0 +1,135 @@
+use FixMyStreet::TestMech;
+use Test::LongString;
+use Test::Exception;
+use Test::Output;
+use Path::Tiny;
+
+use_ok 'FixMyStreet::Script::ExportImport';
+
+my $mech = FixMyStreet::TestMech->new;
+
+my $name = 'Gloucestershire County Council';
+my $body = $mech->create_body_ok(2226, $name);
+
+my $pothole = $mech->create_contact_ok(body => $body, category => 'Pothole', email => 'pothole@example.org');
+$mech->create_contact_ok(body => $body, category => 'Street light', email => 'light@example.org');
+$mech->create_contact_ok(body => $body, category => 'Trees', email => 'trees@example.org');
+
+my $user = $mech->create_user_ok('staff@example.org', from_body => $body, name => 'Staff User');
+my $role = FixMyStreet::DB->resultset("Role")->create({ body => $body, name => "Admin" });
+$user->add_to_roles($role);
+
+my $template = FixMyStreet::DB->resultset("ResponseTemplate")->create({ body => $body, title => 'Ack', text => 'Ack' });
+
+my $pothole_output = <<'EOF';
+      {
+         "category" : "Pothole",
+         "email" : "pothole@example.org",
+         "extra" : null,
+         "non_public" : false,
+         "send_method" : "",
+         "state" : "confirmed"
+      },
+EOF
+my $light_output = <<'EOF';
+      {
+         "category" : "Street light",
+         "email" : "light@example.org",
+         "extra" : null,
+         "non_public" : false,
+         "send_method" : "",
+         "state" : "confirmed"
+      },
+EOF
+my $tree_output = <<'EOF';
+      {
+         "category" : "Trees",
+         "email" : "trees@example.org",
+         "extra" : null,
+         "non_public" : false,
+         "send_method" : "",
+         "state" : "confirmed"
+      }
+EOF
+my $role_output = <<'EOF';
+   "roles" : [
+      {
+         "name" : "Admin",
+         "permissions" : null
+      }
+   ],
+EOF
+my $template_output = <<'EOF';
+   "templates" : [
+      {
+         "auto_response" : 0,
+         "categories" : [],
+         "email_text" : null,
+         "external_status_code" : null,
+         "state" : null,
+         "text" : "Ack",
+         "title" : "Ack"
+      }
+   ],
+EOF
+my $user_output = <<'EOF';
+   "users" : [
+      {
+         "areas" : [],
+         "categories" : [],
+         "email" : "pkg-tscriptexportimportt-staff@example.org",
+         "name" : "Staff User",
+         "password" : "",
+         "roles" : [
+            "Admin"
+         ]
+      }
+   ]
+EOF
+my $standard_output = "$role_output$template_output$user_output";
+
+my $process = FixMyStreet::Script::ExportImport->new({
+    body => $name,
+    commit => 1,
+});
+
+subtest 'Exporting' => sub {
+    my $out = $process->export_json([], 0);
+    is_string $out, "{\n$standard_output}\n";
+    throws_ok { $process->export_json(['Flytipping'], 0); } qr/Categories mismatch/, 'Threw correct error';
+    $out = $process->export_json(['Pothole', 'Trees'], 0);
+    # No templates specifically in those categories
+    is_string $out, <<EOF;
+{\n   "contacts" : [\n$pothole_output$tree_output   ],\n$role_output$user_output}
+EOF
+    $out = $process->export_json([], 1);
+    is_string $out, <<EOF;
+{\n   "contacts" : [\n$pothole_output$light_output$tree_output   ],\n$standard_output}
+EOF
+};
+
+subtest 'Importing' => sub {
+    my $file = path(__FILE__)->parent(2)->child('fixtures/import.json');
+
+    stderr_is { $process->import_json($file, 0, 0) } <<'EOF';
+Category Pothole already exists, skipping
+Template with title Ack already exists, skipping
+Role Admin already exists; skipping
+EOF
+    isnt +FixMyStreet::DB->resultset("Contact")->find({ category => "Flytipping" }), undef;
+    isnt +FixMyStreet::DB->resultset("Role")->find({ name => "Nothing much" }), undef;
+    isnt +FixMyStreet::DB->resultset("ResponseTemplate")->find({ title => "Fixed" }), undef;
+    isnt +FixMyStreet::DB->resultset("User")->find({ name => "Admin User" }), undef;
+
+    stderr_is { $process->import_json($file, 1, 1) } <<'EOF';
+Role Admin already exists; skipping
+Role Nothing much already exists; skipping
+User admin@example.org already exists; skipping
+EOF
+    $pothole->discard_changes;
+    is $pothole->email, 'newpothole@example.org';
+    $template->discard_changes;
+    is $template->state, 'in progress';
+};
+
+done_testing;

--- a/t/script/exportimport.t
+++ b/t/script/exportimport.t
@@ -117,6 +117,8 @@ Category Pothole already exists, skipping
 Template with title Ack already exists, skipping
 Role Admin already exists; skipping
 EOF
+    my $flytipping = FixMyStreet::DB->resultset("Contact")->find({ category => "Flytipping" });
+    is $flytipping->send_method, 'Email';
     isnt +FixMyStreet::DB->resultset("Contact")->find({ category => "Flytipping" }), undef;
     isnt +FixMyStreet::DB->resultset("Role")->find({ name => "Nothing much" }), undef;
     isnt +FixMyStreet::DB->resultset("ResponseTemplate")->find({ title => "Fixed" }), undef;


### PR DESCRIPTION
Discovered after the Gloucestershire export/import this morning.
I noticed it had exported deleted templates without that information beforehand, so that was fine, I could delete them from the export, but I did not see that it was not importing send method on new categories, which meant any Email-devolved new categories got deleted by the Open311 sync until I fixed them manually.