### PR TITLE
Kingston waste confirmation email template fixes

### DIFF
--- a/t/app/controller/waste_kingston_r.t
+++ b/t/app/controller/waste_kingston_r.t
@@ -1213,8 +1213,13 @@ FixMyStreet::override_config {
         is $report->photo, '74e3362283b6ef0c48686fb0e161da4043bbcc97.jpeg';
         $mech->clear_emails_ok;
         FixMyStreet::Script::Reports::send();
-        my $text = $mech->get_text_body_from_email;
+        my $email = $mech->get_email;
+        my $text = $mech->get_text_body_from_email($email);
+        my $html = $mech->get_html_body_from_email($email);
         like $text, qr/apologise for any inconvenienc/, 'Other problem text included in email';
+        like $text, qr/cannot return to clean the spillage/, 'Cannot return text included in email';
+        like $html, qr/apologise for any inconvenienc/, 'Other problem text included in html email';
+        like $text, qr/cannot return to clean the spillage/, 'Cannot return text included in html email';
         my $req = Open311->test_req_used;
         foreach ($req->parts) {
             my $cd = $_->header('Content-Disposition');

--- a/t/app/controller/waste_kingston_r.t
+++ b/t/app/controller/waste_kingston_r.t
@@ -194,6 +194,7 @@ FixMyStreet::override_config {
         { id => 15, name => 'Green recycling bin (240L)', service => 970, price => 4200 },
     ) {
         subtest "Request a new $_->{name}" => sub {
+            $mech->clear_emails_ok;
             my $ordered = $_->{ordered} || $_->{id};
             $mech->get_ok('/waste/12345/request');
             # 27 (1), 46 (1), 12 (1), 3 (1)
@@ -235,6 +236,11 @@ FixMyStreet::override_config {
             is $cgi->param('attribute[Container_Type]'), $ordered;
             is $cgi->param('attribute[Action]'), '1';
             is $cgi->param('attribute[Reason]'), '1';
+
+            my $email = $mech->get_email;
+            my $html = $mech->get_html_body_from_email($email);
+            like $html, qr/We aim to deliver your new container within 20 working days/, "HTML email contains delivery window";
+            like $html, qr/enquiry\?template=problem&service_id=$_->{service}/, "HTML email contains report a problem link";
         };
     }
 

--- a/templates/email/default/waste/other-reported.html
+++ b/templates/email/default/waste/other-reported.html
@@ -116,6 +116,9 @@ INCLUDE '_email_top.html';
       If you&apos;ve requested a collection of your old bin, we'll schedule a specific date for our crew
       to remove it. We aim for this to be the same day as we deliver your new bin, but it could be a different day.
     </p>
+    <p style="[% p_style %]">
+    We aim to deliver your new container within 20 working days. If you haven't received your container in that time, you can <a href="[% cobrand.base_url _ '/waste/' _ report.waste_property_id _ '/enquiry?template=problem&service_id=' _ report.get_extra_field_value('service_id') %]">report a problem</a>.
+    </p>
   [% ELSIF report.category == 'Report missed collection' OR report.category == 'Report missed assisted collection' %]
     [% # can't just concatenate on to end of shorter version as you end up double encoding & %]
     [% IF report.get_extra_field_value('Original_Event_ID');

--- a/templates/email/default/waste/other-reported.html
+++ b/templates/email/default/waste/other-reported.html
@@ -133,7 +133,7 @@ INCLUDE '_email_top.html';
       We apologise for any inconvenience caused and appreciate your feedback.  We're committed to using it to improve our customer service.
     </p>
     <p style="[% p_style %]">
-      The issue has been logged and a clean up has been organised for within the next 24 hours.
+      Our crews cannot return to clean the spillage, but if you feel the area needs prompt attention from one of our street cleansing teams you can report a <a href="https://www.kingston.gov.uk/environmental-health-and-public-issues/report-street-cleaning-problems">street cleaning issue</a>.
     </p>
   [% ELSIF report.category == 'Bin not returned' %]
     <p style="[% p_style %]">

--- a/templates/email/default/waste/other-reported.txt
+++ b/templates/email/default/waste/other-reported.txt
@@ -84,7 +84,7 @@ We will arrange another collection as soon as possible over the next 2 working d
 [% ELSIF report.category == 'Waste spillage' %]
 We apologise for any inconvenience caused and appreciate your feedback.  We're committed to using it to improve our customer service.
 
-The issue has been logged and a clean up has been organised for within the next 24 hours.
+Our crews cannot return to clean the spillage, but if you feel the area needs prompt attention from one of our street cleansing teams you can report a street cleaning issue.
 [% ELSIF report.category == 'Bin not returned' %]
 We apologise for any inconvenience this may have caused and appreciate your feedback. We're committed to using it to improve our customer service.
 


### PR DESCRIPTION
Small fixes to confirmation email templates for reporting waste spillages and container requests

[skip changelog]