### PR TITLE
[South Kesteven] Include assigned at in CSV export

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Northumberland.pm
+++ b/perllib/FixMyStreet/Cobrand/Northumberland.pm
@@ -244,6 +244,9 @@ sub dashboard_export_problems_add_columns {
             $staff_user = $self->csv_staff_user_lookup($by, $user_lookup);
             $staff_role = join(',', @{$userroles->{$by} || []});
         }
+        if (my $assigned = $problems_to_user->{$report->id}) {
+            $assigned_to = $assigned->{name};
+        }
 
         my $address = '';
         if ( $report->geocode ) {
@@ -256,7 +259,7 @@ sub dashboard_export_problems_add_columns {
             user_name_display => $report->name,
             staff_user => $staff_user,
             staff_role => $staff_role,
-            assigned_to => $problems_to_user->{$report->id} || '',
+            assigned_to => $assigned_to,
             current_ward => $current_ward,
             old_ward => $old_ward,
             response_time => $response_time->($hashref),

--- a/perllib/FixMyStreet/Cobrand/SouthKesteven.pm
+++ b/perllib/FixMyStreet/Cobrand/SouthKesteven.pm
@@ -109,6 +109,7 @@ sub dashboard_export_problems_add_columns {
         how_much => 'How much waste',
         location => 'Location',
         assigned_to => "Assigned to",
+        assigned_at => "Assigned at",
     );
 
     # Pre-gen export will already be calculating this
@@ -124,8 +125,12 @@ sub dashboard_export_problems_add_columns {
             type_of_waste => $csv->_extra_field($report, 'type_of_waste'),
             how_much => $csv->_extra_field($report, 'how_much'),
             location => $csv->_extra_field($report, 'location'),
-            $csv->dbi ? () : (assigned_to => $problems_to_user->{$report->id} || ''),
         };
+        unless ($csv->dbi) {
+            my $assigned = $problems_to_user->{$report->id} || {};
+            $data->{assigned_to} = $assigned->{name} || '';
+            $data->{assigned_at} = $assigned->{added} || '';
+        }
         return $data;
     });
 }

--- a/perllib/FixMyStreet/Cobrand/TfL.pm
+++ b/perllib/FixMyStreet/Cobrand/TfL.pm
@@ -487,9 +487,10 @@ sub dashboard_export_problems_add_columns {
         $closure_email_at = DateTime->from_epoch(
             epoch => $closure_email_at, time_zone => FixMyStreet->local_time_zone
         ) if $closure_email_at;
+        my $assigned = $problems_to_user->{$report->id} || {};
         my $fields = {
             acknowledged => $report->whensent,
-            assigned_to => $problems_to_user->{$report->id} || '',
+            assigned_to => $assigned->{name} || '',
             user_name_display => $user_name_display,
             safety_critical => $safety_critical,
             delivered_to => join(',', @$delivered_to),

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -759,6 +759,13 @@ sub csv_staff_roles {
     return \%userroles;
 }
 
+=head2 csv_active_planned_reports
+
+Returns a hashref of report ID to a hashref of the name of the user the report
+is currently assigned (shortlisted) to, and when it was assigned to them.
+
+=cut
+
 sub csv_active_planned_reports {
     my ($self) = @_;
 
@@ -769,7 +776,12 @@ sub csv_active_planned_reports {
     );
 
     for my $user (@cobrand_users) {
-        map { $reports_to_user{$_->report_id} = $user->name } $user->active_user_planned_reports->all;
+        map {
+            $reports_to_user{$_->report_id} = {
+                name => $user->name,
+                added => $_->added,
+            };
+        } $user->active_user_planned_reports->all;
     }
     return \%reports_to_user;
 }

--- a/perllib/FixMyStreet/Script/CSVExport.pm
+++ b/perllib/FixMyStreet/Script/CSVExport.pm
@@ -39,7 +39,7 @@ need adding in the cobrand with add_csv_columns.
 
 =item user_details - fetch the report `user_email` and `user_phone`
 
-=item assigned_to - include the name of the assigned user in `assigned_to`
+=item assigned_to - include the name of the assigned user in `assigned_to`, and when they were assigned in `assigned_at`
 
 =item db_state - store the actual database state name (if the state column is changed by the cobrand)
 
@@ -215,7 +215,7 @@ EOF
         push @sql_join, 'users admin_log_user ON ranked_admin_log.user_id = admin_log_user.id';
     }
     if ($EXTRAS->{assigned_to}{$cobrand->moniker}) {
-        push @sql_select, "planned_user.name as assigned_to";
+        push @sql_select, "planned_user.name as assigned_to", "to_json(date_trunc('second', user_planned_reports.added))#>>'{}' as assigned_at";
         push @sql_join, '"user_planned_reports" ON "user_planned_reports"."report_id" = "me"."id" AND "user_planned_reports"."removed" IS NULL';
         push @sql_join, '"users" "planned_user" ON "planned_user"."id" = "user_planned_reports"."user_id"';
     }

--- a/t/cobrand/southkesteven.t
+++ b/t/cobrand/southkesteven.t
@@ -70,6 +70,10 @@ FixMyStreet::override_config {
     };
 };
 
+# The pre-generated export must produce the same output as the live one
+my $expected_headers = '"Reported As","Type of waste","How much waste",Location,"Assigned to","Assigned at"';
+my $expected_row = qr/southkesteven,,garden,small_van,highway,Staff,\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d/;
+
 subtest 'Dashboard CSV extra columns' => sub {
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => 'southkesteven',
@@ -88,8 +92,8 @@ subtest 'Dashboard CSV extra columns' => sub {
 
         $mech->log_in_ok($staff_user->email);
         $mech->get_ok('/dashboard?export=1');
-        $mech->content_contains('"Reported As","Type of waste","How much waste",Location,"Assigned to"');
-        ok $mech->content_contains('southkesteven,,garden,small_van,highway,Staff');
+        $mech->content_contains($expected_headers);
+        $mech->content_like($expected_row);
     };
 };
 
@@ -102,8 +106,8 @@ subtest 'Dashboard CSV pre-generation' => sub {
     }, sub {
         FixMyStreet::Script::CSVExport::process(dbh => FixMyStreet::DB->schema->storage->dbh);
         $mech->get_ok('/dashboard?export=1');
-        $mech->content_contains('"Reported As","Type of waste","How much waste",Location,"Assigned to"');
-        ok $mech->content_contains('southkesteven,,garden,small_van,highway,Staff');
+        $mech->content_contains($expected_headers);
+        $mech->content_like($expected_row);
     };
 };
 


### PR DESCRIPTION
Adds an "Assigned at" column to the South Kesteven CSV containing the date the report was shortlisted (there's already an "Assigned to" column).

For FD-7344.

<!-- [skip changelog] -->
