### PR TITLE
[UK] Geocoding fallbacks

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -77,7 +77,7 @@ sub disambiguate_location {
         %{ $self->SUPER::disambiguate_location() },
         centre => '52.6085234396978,-0.253091266573947',
         bounds => [ 52.5060949603654, -0.497663559599628, 52.6752139533306, -0.0127696975457487 ],
-        result_only_if => 'City of Peterborough',
+        result_only_if => 'City of Peterborough|Peterborough, Cambridgeshire',
         result_strip => ', City of Peterborough, (East of England|Cambridgeshire and Peterborough), England',
     };
 }

--- a/perllib/FixMyStreet/Cobrand/UK.pm
+++ b/perllib/FixMyStreet/Cobrand/UK.pm
@@ -115,6 +115,29 @@ sub geocode_postcode {
     return {};
 }
 
+=head2 geocode_postcode_fallback
+
+If we get no geocoding response, and the string contains what could be a
+postcode, let's try that.
+
+=cut
+
+sub geocode_postcode_fallback {
+    my ( $self, $s ) = @_;
+    $s = uc($s);
+    if (my ($pc) = $s =~ m# (( [A-Z]{1,2}\d{1,2} | [A-Z]{1,2}\d[A-Z] ) \s* \d[A-Z][A-Z]) #x) {
+        if (mySociety::PostcodeUtil::is_valid_postcode($pc)) {
+            my $location = mySociety::MaPit::call('postcode', $pc);
+            return {} if $location->{error} || !$location->{coordsyst};
+            return {
+                latitude  => $location->{wgs84_lat},
+                longitude => $location->{wgs84_lon},
+            };
+        }
+    }
+    return {};
+}
+
 sub short_name {
     my $self = shift;
     my ($area) = @_;

--- a/perllib/FixMyStreet/Geocode.pm
+++ b/perllib/FixMyStreet/Geocode.pm
@@ -36,6 +36,8 @@ sub lookup {
     }
     $data = string($s, $c)
         unless $data->{error} || defined $data->{latitude};
+    $data = $c->cobrand->call_hook(geocode_postcode_fallback => $s)
+        unless $data->{error} || defined $data->{latitude};
     $data->{error} = _('Sorry, we could not find that location.')
         unless $data->{error} || defined $data->{latitude};
     return ( $data->{latitude}, $data->{longitude}, $data->{error} );

--- a/perllib/FixMyStreet/Geocode/OSM.pm
+++ b/perllib/FixMyStreet/Geocode/OSM.pm
@@ -57,12 +57,20 @@ sub string {
     }
 
     my ( $error, @valid_locations, $latitude, $longitude, $address );
+    my %same_bar_last_letter;
     foreach (@$js) {
         next if $params->{result_only_if} && $_->{display_name} !~ /$params->{result_only_if}/;
         $_->{display_name} =~ s/$params->{result_strip}//g if $params->{result_strip};
 
         $cobrand->call_hook(geocoder_munge_results => $_);
         next unless $_->{display_name};
+
+        # Ignore results same apart from last postcode letter
+        $_->{display_name} =~ s/, United Kingdom$//;
+        my $no_last_letter = substr $_->{display_name}, 0, -1;
+        next if $same_bar_last_letter{$no_last_letter};
+        $same_bar_last_letter{$no_last_letter} = 1;
+
         ( $latitude, $longitude ) =
             map { Utils::truncate_coordinate($_) }
             ( $_->{lat}, $_->{lon} );

--- a/t/cobrand/brent.t
+++ b/t/cobrand/brent.t
@@ -40,10 +40,10 @@ $gc->mock('cache', sub {
                            ],
           'osm_id' => 507095202
         },
-        { # duplicate so we don't jump straight to report page with only one result
+        { # near duplicate so we don't jump straight to report page with only one result
           'osm_type' => 'way',
           'type' => 'tertiary',
-          'display_name' => 'Engineers Way, London Borough of Brent, London, Greater London, England, HA9 0FJ, United Kingdom',
+          'display_name' => 'Engineers Road, London Borough of Brent, London, Greater London, England, HA9 0FJ, United Kingdom',
           'licence' => "Data \x{a9} OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright",
           'lat' => '51.55904',
           'importance' => '0.40001',


### PR DESCRIPTION
Fixes some of https://github.com/mysociety/societyworks/issues/5662 (though something that did distance checks on all the results would be more comprehensive and presumably cover this result as well).
Fixes Peterborough thing noticed, and lets postcodes in strings that otherwise failed to geocode to be used.