### PR TITLE
Updated mySociety donate link

### DIFF
--- a/templates/web/base/about/faq-en-gb.html
+++ b/templates/web/base/about/faq-en-gb.html
@@ -63,7 +63,7 @@
     <dt>Is it free?</dt>
     <dd>The site is free to use, yes. The FixMyStreet Platform is maintained by
     a registered charity, so if you want to make a contribution,
-        <a href="https://www.mysociety.org/donate/">please do</a>.</dd>
+        <a href="https://www.mysociety.org/donate/support-fixmystreet-and-mysociety/">please do</a>.</dd>
 
     <dt>Can I use [% site_name %] on my mobile?</dt>
     <dd>

--- a/templates/web/fixmystreet.com/about/faq-cy.html
+++ b/templates/web/fixmystreet.com/about/faq-cy.html
@@ -417,7 +417,7 @@ sy’n integreiddio â’ch gwefan chi.
 yn gweithio i bobl.
 
 <p>Pe baech am ddangos eich gwerthfawrogiad, beth am <a
-href="https://www.mysociety.org/donate/">cynnig rhodd</a> i’n cefnogi? 
+href="https://www.mysociety.org/donate/support-fixmystreet-and-mysociety/">cynnig rhodd</a> i’n cefnogi? 
 Neu, os na allwch chi  sbario unrhyw beth dim ond ar hyn o bryd, gallwch chi gefnogi 
 trwy sôn amdanom; dwedwch wrth eich ffrindiau, ysgrifennwch at y papur newydd lleol, 
 rhowch neges i  fyny yn eich llyfrgell. Mae pob dim yn helpu.

--- a/templates/web/fixmystreet.com/about/faq-en-gb.html
+++ b/templates/web/fixmystreet.com/about/faq-en-gb.html
@@ -300,7 +300,7 @@ or inappropriate content or wish to appeal a decision we have made, you can
 
 <dt>FixMyStreet really works</dt>
 <dd>
-<p>If you’d like to show your appreciation, why not <a href="https://www.mysociety.org/donate/">make a donation</a> to help us keep running? Or, if you can’t spare anything just at the moment, you can still help us out, just by spreading the word. Tell your friends, write to the local newspaper, put a message up in your library. It all helps.
+<p>If you’d like to show your appreciation, why not <a href="https://www.mysociety.org/donate/support-fixmystreet-and-mysociety/">make a donation</a> to help us keep running? Or, if you can’t spare anything just at the moment, you can still help us out, just by spreading the word. Tell your friends, write to the local newspaper, put a message up in your library. It all helps.
 </dd>
 
 <dt>I’d like to make a FixMyStreet for my own country or town</dt>

--- a/templates/web/fixmystreet.com/footer_extra.html
+++ b/templates/web/fixmystreet.com/footer_extra.html
@@ -53,7 +53,7 @@
             <div class="col-sm-3">
                 <div class="mysoc-footer__donate">
                     <p>[% loc('We are a charity – donate today to invest in safer, more accessible communities') %]</p>
-                    <a href="https://www.mysociety.org/donate?utm_source=fixmystreet.com&amp;utm_content=footer+donate+now&amp;utm_medium=link&amp;utm_campaign=mysoc_footer" class="mysoc-footer__donate__button">[% loc('Donate now') %] 💛</a>
+                    <a href="https://www.mysociety.org/donate/support-fixmystreet-and-mysociety?utm_source=fixmystreet.com&amp;utm_content=footer+donate+now&amp;utm_medium=link&amp;utm_campaign=mysoc_footer" class="mysoc-footer__donate__button">[% loc('Donate now') %] 💛</a>
                 </div>
             </div>
 

--- a/templates/web/fixmystreet.com/next_steps.html
+++ b/templates/web/fixmystreet.com/next_steps.html
@@ -8,7 +8,7 @@
       <h2>[% loc('Support FixMyStreet') %]</h2>
       <p>[% loc('We are a charity – donate today to invest in safer, more accessible communities. Even a small donation of £5 goes a long way!') %]</p>
     <p class="next-steps__step__cta">
-      <a href="https://www.mysociety.org/donate?utm_source=fixmystreet.com&amp;utm_content=[% utm_content | uri %]&amp;utm_medium=link&amp;utm_campaign=fms_thankyou_pages"><img src="/cobrands/fixmystreet.com/images/next-step-donate.png" alt="Donate now" width="138" height="37"></a>
+      <a href="https://www.mysociety.org/donate/support-fixmystreet-and-mysociety?utm_source=fixmystreet.com&amp;utm_content=[% utm_content | uri %]&amp;utm_medium=link&amp;utm_campaign=fms_thankyou_pages"><img src="/cobrands/fixmystreet.com/images/next-step-donate.png" alt="Donate now" width="138" height="37"></a>
     </p>
   </div>
   <div class="next-steps__step next-steps__step--goodies">

--- a/templates/web/nottinghamshirepolice/about/faq-en-gb.html
+++ b/templates/web/nottinghamshirepolice/about/faq-en-gb.html
@@ -49,7 +49,7 @@
     <dt>Is it free?</dt>
     <dd>The site is free to use, yes. The FixMyStreet Platform is maintained by
     a registered charity, so if you want to make a contribution,
-        <a href="https://www.mysociety.org/donate/">please do</a>.</dd>
+        <a href="https://www.mysociety.org/donate/support-fixmystreet-and-mysociety/">please do</a>.</dd>
 
     <dt>Can I use [% site_name %] on my mobile?</dt>
     <dd>

--- a/templates/web/peterborough/about/faq-en-gb.html
+++ b/templates/web/peterborough/about/faq-en-gb.html
@@ -64,7 +64,7 @@
     <dt>Is it free?</dt>
     <dd>The site is free to use, yes. The FixMyStreet Platform is maintained by
     a registered charity, so if you want to make a contribution,
-        <a href="https://www.mysociety.org/donate/">please do</a>.</dd>
+        <a href="https://www.mysociety.org/donate/support-fixmystreet-and-mysociety/">please do</a>.</dd>
 
     <dt>Can I use [% site_name %] on my mobile?</dt>
     <dd>

--- a/templates/web/thamesmead/about/faq-en-gb.html
+++ b/templates/web/thamesmead/about/faq-en-gb.html
@@ -49,7 +49,7 @@
     <dt>Is it free?</dt>
     <dd>The site is free to use, yes. The FixMyStreet platform is maintained by
     a registered charity, so if you want to make a contribution,
-        <a href="https://www.mysociety.org/donate/">please do</a>.</dd>
+        <a href="https://www.mysociety.org/donate/support-fixmystreet-and-mysociety/">please do</a>.</dd>
 
     <dt>Can I use [% site_name %] on my mobile?</dt>
     <dd>


### PR DESCRIPTION
Now that we have a dedicated page for FMS donations on mySociety.org, we are updating the link to go from `https://www.mysociety.org/donate/` to `https://www.mysociety.org/donate/support-fixmystreet-and-mysociety/`

[skip changelog]
