### PR TITLE
[CRT] Canal trust extra data

### DIFF
--- a/perllib/FixMyStreet/Cobrand/CanalRiverTrust.pm
+++ b/perllib/FixMyStreet/Cobrand/CanalRiverTrust.pm
@@ -43,6 +43,7 @@ sub contact_name { FixMyStreet::Cobrand::UKCouncils::contact_name($_[0]) }
 sub contact_email { FixMyStreet::Cobrand::UKCouncils::contact_email($_[0]) }
 sub users_staff_admin { FixMyStreet::Cobrand::UKCouncils::users_staff_admin($_[0]) }
 sub admin_allow_user { FixMyStreet::Cobrand::UKCouncils::admin_allow_user($_[0], $_[1]) }
+sub open311_extra_data { FixMyStreet::Cobrand::UKCouncils::open311_extra_data($_[0], $_[1], $_[2]) }
 
 sub enter_postcode_text { 'Enter a location, bridge number or postcode' }
 sub report_a_problem_label { 'Report' }
@@ -131,6 +132,21 @@ sub munge_report_new_contacts {
 sub admin_contact_validate_category {
     my ( $self, $category ) = @_;
     return "(CRT)" eq substr($category, -5) ? "" : "Category must end with (CRT).";
+}
+
+sub open311_extra_data_include {
+    my ($self, $row, $h) = @_;
+
+    my $open311_only = [
+        { name => 'report_url',
+          value => $h->{url} },
+        { name => 'title',
+          value => $row->title },
+        { name => 'description',
+          value => $row->detail },
+    ];
+
+    return $open311_only;
 }
 
 1;

--- a/perllib/Open311/PopulateServiceList.pm
+++ b/perllib/Open311/PopulateServiceList.pm
@@ -37,7 +37,6 @@ sub process_body {
     );
 
     $self->_current_open311( $open311 );
-    $self->_check_endpoints;
 
     my $list = $open311->get_service_list;
     unless ( $list && $list->{service} ) {
@@ -52,23 +51,6 @@ sub process_body {
     }
     $self->process_services( $list );
 }
-
-
-
-sub _check_endpoints {
-    my $self = shift;
-
-    # west berks end point not standard
-    if ( $self->_current_body->areas->{2619} ) {
-        $self->_current_open311->endpoints(
-            {
-                services => 'Services',
-                requests => 'Requests'
-            }
-        );
-    }
-}
-
 
 sub process_services {
     my $self = shift;


### PR DESCRIPTION
Adds extra data for attributes going to open311

Removes old code affecting the calls made to open311 that are not required any more

[skip changelog]