### PR TITLE
[CRT] Ampserand in body name encoded

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Rss.pm
+++ b/perllib/FixMyStreet/App/Controller/Rss.pm
@@ -329,9 +329,13 @@ sub add_parameters : Private {
     my $uri = $c->uri_for( '/' . $c->req->path );
     $uri .= '?type=' . $c->stash->{ward_code} if $c->stash->{ward_code} && $c->stash->{ward};
 
+    my $qs = $c->stash->{qs} || '';
+    $uri =~ s/&/&amp;/g;
+    $qs =~ s/&/&amp;/g;
+
     $c->stash->{rss}->channel(
         title       => encode_entities($title),
-        link        => $c->uri_for($link) . ($c->stash->{qs} || ''),
+        link        => $c->uri_for($link) . $qs,
         description => encode_entities($desc),
         language    => 'en-gb',
         atom => { link => {

--- a/t/cobrand/canalrivertrust.t
+++ b/t/cobrand/canalrivertrust.t
@@ -106,6 +106,9 @@ FixMyStreet::override_config {
     $mech->get_ok( '/reports' );
     $mech->content_contains('Get updates of reports on the Canal & River Trust');
     $mech->content_lacks('class="has-inline-svg">Wards of this council');
+    $mech->content_contains('href="/rss/reports/Canal+&amp;+River+Trust"');
+    $mech->get_ok( '/rss/reports/Canal+&+River+Trust' ); # Browser decoded &amp;
+    $mech->content_contains('New problems to Canal &amp; River Trust on Canal &amp; River Trust');
 };
 
 

--- a/t/cobrand/canalrivertrust.t
+++ b/t/cobrand/canalrivertrust.t
@@ -97,4 +97,16 @@ FixMyStreet::override_config {
     }
 };
 
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => [ 'canalrivertrust' ],
+    MAPIT_URL        => 'http://mapit.uk/',
+    COBRAND_FEATURES => {
+    },
+}, sub {
+    $mech->get_ok( '/reports' );
+    $mech->content_contains('Get updates of reports on the Canal & River Trust');
+    $mech->content_lacks('class="has-inline-svg">Wards of this council');
+};
+
+
 done_testing();

--- a/templates/email/default/_email_bottom.html
+++ b/templates/email/default/_email_bottom.html
@@ -13,8 +13,10 @@
     <tr>
       <th class="spacer-cell"></th>
       <th width="[% wrapper_max_width %]" style="[% td_style %][% hint_style %]" class="hint">
-        [%~ IF email_footer.defined %]
-          [% email_footer | safe %]
+        [%~ IF fms_email_footer.defined %]
+          [% fms_email_footer | safe %]
+        [%~ ELSIF email_footer.defined %]
+          [% email_footer %]
         [%~ ELSE %]
           [% loc('This email was sent automatically, from an unmonitored email account. Please do not reply to it.') %]
         [%~ END %]

--- a/templates/email/fixmystreet.com/cy/submit.html
+++ b/templates/email/fixmystreet.com/cy/submit.html
@@ -2,7 +2,7 @@
 
 PROCESS '_email_settings.html';
 
-email_footer = PROCESS '_submit_footer.html';
+fms_email_footer = PROCESS '_submit_footer.html';
 email_columns = 2;
 
 INCLUDE '_email_top.html';

--- a/templates/email/fixmystreet.com/submit.html
+++ b/templates/email/fixmystreet.com/submit.html
@@ -5,7 +5,7 @@
 
 PROCESS '_email_settings.html';
 
-email_footer = PROCESS '_submit_footer.html';
+fms_email_footer = PROCESS '_submit_footer.html';
 email_columns = 2;
 
 INCLUDE '_email_top.html';

--- a/templates/web/base/reports/_rss.html
+++ b/templates/web/base/reports/_rss.html
@@ -1,4 +1,3 @@
-[% UNLESS c.cobrand.moniker == 'canalrivertrust' %]
 <div id="key-tools-wrapper" class="shadow-wrap">
     <ul id="key-tools" class="js-key-tools">
         <li class="feed-list-wrapper">
@@ -13,6 +12,8 @@
                 'Get updates of reports in this ward';
             ELSIF c.cobrand.is_council;
                 tprintf(loc('Get updates of %s problems'), thing);
+            ELSIF c.cobrand.moniker == 'canalrivertrust';
+                'Get updates of reports on the Canal & River Trust';
             ELSE;
                 tprintf(loc('Get updates of problems in this %s'), thing);
             END
@@ -20,6 +21,7 @@
             [% INCLUDE 'icons/rss.html' width='1.5em' height='1.5em' %]
             </a>
         </li>
+[% UNLESS c.cobrand.moniker == 'canalrivertrust' %]
         [% IF children.size %]
             [% TRY %]
                 [% INCLUDE 'reports/_rss_other_districts.html' %]
@@ -27,6 +29,6 @@
                 <li><a href="#council_wards" id="key-tool-wards" class="has-inline-svg">[% ward_text %][% INCLUDE 'icons/chevron-right.html' width='1.5em' height='1.5em' %]</a></li>
             [% END %]
         [% END %]
+[% END %]
     </ul>
 </div>
-[% END %]


### PR DESCRIPTION
XML fails if the '&' in the body name has not been encoded so encode any occurrences of '&' before
serving the feed.

We should show reports list for rss feed, but not wards as that doesn't make sense for CRT

Fixes: https://github.com/mysociety/fixmystreet/pull/6086#issuecomment-5325941955

[skip changelog]