### PR TITLE
[Merton] Bulky additional collection and waived fixes

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Waste.pm
+++ b/perllib/FixMyStreet/App/Controller/Waste.pm
@@ -1031,7 +1031,7 @@ sub construct_bin_report_form {
     my $allow_report_small_items = 0;
 
     foreach ( values %{ $c->stash->{booked_missed} || {} } ) {
-        if ( $_->{report_allowed} && !$_->{report_open} ) {
+        if ( $show_all_services || $_->{report_allowed} && !$_->{report_open} ) {
             $_->{service_name} eq 'Small items'
                 ? $allow_report_small_items = $_
                 : $allow_report_bulky = $_;

--- a/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
+++ b/perllib/FixMyStreet/Cobrand/Merton/Waste.pm
@@ -866,5 +866,31 @@ sub unset_free_bulky_used {
     }
 }
 
+=head2 Additional collections
+
+Spot an open bulky additional collection. Scheduled collections are
+handled in C<munge_bin_services_for_address>.
+
+=cut
+
+around booked_check_missed_collection => sub {
+    my ($orig, $self, $type, $events, $blocked_codes) = @_;
+
+    $self->$orig($type, $events, $blocked_codes);
+
+    # Now check for any open additional collections
+
+    my $cfg = $self->feature('echo');
+    my $service_id = $cfg->{$type . '_service_id'} or return;
+
+    my $additionals = $events->filter({ event_type => $EVENT_TYPE_IDS{additional_collection}, service => $service_id, closed => 0 });
+    if ($additionals) {
+        my $missed = $self->{c}->stash->{booked_missed};
+        foreach my $guid (keys %$missed) {
+            $missed->{$guid}{additional_open} = 1;
+        }
+    }
+
+};
 
 1;

--- a/perllib/FixMyStreet/Roles/Cobrand/SLWP2.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/SLWP2.pm
@@ -397,7 +397,8 @@ sub waste_munge_report_data {
     }
     if ($c->get_param('additional') && $c->stash->{is_staff}) {
         $data->{category} = 'Request additional collection';
-        $data->{title} = "Request additional $service collection";
+        $data->{title} = "Request additional $service";
+        $data->{title} .= ' collection' unless $data->{title} =~ /collection/;
     } else {
         my $service_ids = $SERVICE_IDS{$self->moniker};
         my %lookup = reverse %$service_ids;

--- a/t/app/controller/waste_merton_bulky.t
+++ b/t/app/controller/waste_merton_bulky.t
@@ -29,6 +29,18 @@ my $contact = $mech->create_contact_ok(body => $body, ( category => 'Report miss
     );
 $contact->update;
 
+$contact = $mech->create_contact_ok(body => $body, group => ['Waste'],
+    category => 'Request additional collection', email => 'additional@example.org',
+    extra => { type => 'waste' });
+  $contact->set_extra_fields(
+        { code => 'property_id', required => 1, automated => 'hidden_field' },
+        { code => 'service_id', required => 0, automated => 'hidden_field' },
+        { code => 'Exact_Location', required => 0, automated => 'hidden_field' },
+        { code => 'Original_Event_ID', required => 0, automated => 'hidden_field' },
+        { code => 'Notes', required => 0, automated => 'hidden_field' },
+    );
+$contact->update;
+
 my $contact_centre_user = $mech->create_user_ok('contact@example.org', from_body => $body, email_verified => 1, name => 'Contact 1');
 $contact_centre_user->user_body_permissions->create({ body => $body, permission_type => 'report_view_private' });
 $contact_centre_user->user_body_permissions->create({ body => $body, permission_type => 'wasteworks_config' });
@@ -1224,6 +1236,52 @@ FixMyStreet::override_config {
         $mech->content_contains('A missed bulky waste collection has been reported');
         $mech->get_ok('/waste/12345/report');
         $mech->content_lacks('Bulky waste collection');
+        $echo->mock( 'GetEventsForObject', sub { [] } );
+    };
+
+    subtest 'Additional collections' => sub {
+        $mech->log_in_ok( $contact_centre_user->email );
+        $echo->mock( 'GetEventsForObject', sub { [ {
+            Guid => 'a-guid',
+            EventTypeId => 3130,
+            ResolvedDate => { DateTime => '2023-07-05T00:00:00Z' },
+            ResolutionCodeId => 466,
+            EventStateId => 19185,
+        } ] } );
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('A missed collection cannot be reported', 'Not completed');
+        $mech->content_contains('Gate locked');
+        $mech->follow_link_ok({ text => 'Request an additional bulky waste collection' });
+        $mech->content_contains('Bulky waste collection');
+        $mech->content_contains('Request additional collection');
+        $mech->submit_form_ok({ form_number => 1 });
+        $mech->submit_form_ok({ with_fields => { name => 'Bob Marge', email => $user->email, phone => '44 07 111 111 111' }});
+        $mech->submit_form_ok({ form_number => 3 });
+
+        my $report = FixMyStreet::DB->resultset("Problem")->search(undef, { order_by => { -desc => 'id' } })->first;
+        is $report->get_extra_field_value('Exact_Location'), 'in the middle of the drive';
+        is $report->title, 'Request additional bulky collection';
+        is $report->category, 'Request additional collection';
+        is $report->get_extra_field_value('Original_Event_ID'), 'a-guid';
+
+        $echo->mock( 'GetEventsForObject', sub { [ {
+            Guid => 'a-guid',
+            EventTypeId => 3130,
+            ResolvedDate => { DateTime => '2023-07-05T00:00:00Z' },
+            ResolutionCodeId => 466,
+            EventStateId => 19185,
+        }, {
+            EventTypeId => 3160,
+            EventStateId => 0,
+            ServiceId => 1089,
+            Guid => 'guid',
+            EventDate => { DateTime => '2023-07-05T00:00:00Z' },
+        } ] } );
+        $mech->get_ok('/waste/12345');
+        $mech->content_contains('An additional collection request has been made');
+        $mech->get_ok('/waste/12345/report');
+        $mech->content_lacks('Bulky waste collection');
+
         $echo->mock( 'GetEventsForObject', sub { [] } );
     };
 

--- a/templates/web/base/waste/bulky/_bin_days_list.html
+++ b/templates/web/base/waste/bulky/_bin_days_list.html
@@ -99,6 +99,11 @@ END;
               <span class="waste-service-descriptor">Thank you for reporting an issue with this collection; we are investigating.</span>
           [% END %]
           [% END %]
+
+          [% IF c.cobrand.moniker == 'merton' %]
+            [% INCLUDE 'waste/_service_additional.html' unit=booked_missed.$booking_guid original_booking=booking.id %]
+          [% END %]
+
       </div>
     [% END %]
 

--- a/templates/web/base/waste/services.html
+++ b/templates/web/base/waste/services.html
@@ -50,15 +50,7 @@
         You need to buy your own black sacks from a supermarket or other shop. If you have some blue general rubbish bags with a Merton Council logo, you can continue to use these until they run out, but we no longer provide new ones.
     </span>
     [% END %]
-    [% IF is_staff %]
-      [% IF unit.additional_open %]
-        <span class="waste-service-descriptor">
-            An additional collection request has been made
-        </span>
-      [% ELSE %]
-        <a href="[% c.uri_for_action('waste/report', [ property.id ]) %]?additional=1&amp;service-[% unit.service_id %]=1" class="waste-service-link waste-service-descriptor waste-service-staff">Request an additional [% unit.service_name FILTER lower %] collection</a>
-      [% END %]
-    [% END %]
+    [% INCLUDE 'waste/_service_additional.html' %]
     [% IF unit.report_allowed %]
         <a href="[% c.uri_for_action('waste/enquiry', [ property.id ]) %]?template=problem&amp;service_id=[% unit.service_id %]" class="waste-service-link waste-service-descriptor">Report a problem with a [% unit.service_name FILTER lower %] collection</a>
     [% END %]

--- a/templates/web/merton/waste/_service_additional.html
+++ b/templates/web/merton/waste/_service_additional.html
@@ -1,0 +1,9 @@
+[% IF is_staff %]
+    [% IF unit.additional_open %]
+        <span class="waste-service-descriptor">
+            An additional collection request has been made
+        </span>
+    [% ELSE %]
+        <a href="[% c.uri_for_action('waste/report', [ property.id ]) %]?additional=1&amp;service-[% unit.service_id %]=1[% '&original_booking_id=' _ original_booking IF original_booking %]" class="waste-service-link waste-service-descriptor waste-service-staff">Request an additional [% unit.service_name FILTER lower %] collection</a>
+    [% END %]
+[% END %]


### PR DESCRIPTION
Record a 'waived' payment reference, to prevent an issue not showing in pending collections (FD-7449, after initial separate checkbox fix), which led to fixing two emails being sent, which led to not charging for a small items amendment, and then the staff additional bulky collection request (FD-7341). [skip changelog]
