### PR TITLE
Speed up stats page for councils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
         - Split original report_mark_private permission into a view-only permission (report_view_private) and an edit permission (report_mark_private) #5973
         - Require view dashboard permission in order to view the dashboard
         - Ensure OIDC email addresses are stored as lowercase.
+        - Remove update stats from admin stats and status pages. Also removes `updates` from `/status.json`.
     - Development improvements
         - More logging when `page_error` is called, to aid troubleshooting. #5279
         - Docker changes needed for systemd to work. #5257

--- a/perllib/FixMyStreet/App/Controller/Admin/Stats.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Stats.pm
@@ -13,7 +13,7 @@ sub index : Path : Args(0) {
 sub gather : Private {
     my ($self, $c) = @_;
 
-    $c->forward('state'); # Problem/update stats used on that page
+    $c->forward('state'); # Problem stats used on that page
     $c->forward('/admin/fetch_all_bodies'); # For body stat
 
     my $alerts = $c->model('DB::Alert')->summary_report_alerts( $c->cobrand->restriction );
@@ -70,13 +70,6 @@ sub state : Local : Args(0) {
     $c->stash->{total_problems_live} += $prob_counts{$_} ? $prob_counts{$_} : 0
         for ( FixMyStreet::DB::Result::Problem->visible_states() );
     $c->stash->{total_problems_users} = $c->cobrand->problems->unique_users;
-
-    my $comments = $c->cobrand->updates->summary_count;
-
-    my %comment_counts =
-      map { $_->state => $_->get_column('state_count') } $comments->all;
-
-    $c->stash->{comments} = \%comment_counts;
 }
 
 sub fix_rate : Path('fix-rate') : Args(0) {

--- a/perllib/FixMyStreet/App/Controller/Admin/Stats.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Stats.pm
@@ -14,7 +14,7 @@ sub gather : Private {
     my ($self, $c) = @_;
 
     $c->forward('state'); # Problem stats used on that page
-    $c->forward('/admin/fetch_all_bodies'); # For body stat
+    $c->forward('body_stats') if $c->cobrand->admin_show_body_stats;
 
     my $alerts = $c->model('DB::Alert')->summary_report_alerts( $c->cobrand->restriction );
 
@@ -25,17 +25,6 @@ sub gather : Private {
     $alert_counts{1} ||= 0;
 
     $c->stash->{alerts} = \%alert_counts;
-
-    my $contacts = $c->model('DB::Contact')->summary_count();
-
-    my %contact_counts =
-      map { $_->state => $_->get_column('state_count') } $contacts->all;
-
-    $contact_counts{confirmed} ||= 0;
-    $contact_counts{unconfirmed} ||= 0;
-    $contact_counts{total} = $contact_counts{confirmed} + $contact_counts{unconfirmed};
-
-    $c->stash->{contacts} = \%contact_counts;
 
     my $questionnaires = $c->model('DB::Questionnaire')->summary_count( $c->cobrand->restriction );
 
@@ -53,6 +42,23 @@ sub gather : Private {
         $questionnaire_counts{1} / $questionnaire_counts{total} * 100 )
       : _('n/a');
     $c->stash->{questionnaires} = \%questionnaire_counts;
+}
+
+sub body_stats : Private {
+    my ($self, $c) = @_;
+
+    $c->forward('/admin/fetch_all_bodies');
+
+    my $contacts = $c->model('DB::Contact')->summary_count();
+
+    my %contact_counts =
+      map { $_->state => $_->get_column('state_count') } $contacts->all;
+
+    $contact_counts{confirmed} ||= 0;
+    $contact_counts{unconfirmed} ||= 0;
+    $contact_counts{total} = $contact_counts{confirmed} + $contact_counts{unconfirmed};
+
+    $c->stash->{contacts} = \%contact_counts;
 }
 
 sub state : Local : Args(0) {

--- a/perllib/FixMyStreet/App/Controller/Status.pm
+++ b/perllib/FixMyStreet/App/Controller/Status.pm
@@ -58,9 +58,11 @@ sub index : Path : Args(0) {
             alerts_unconfirmed => $c->stash->{alerts}{0},
             questionnaires_sent => $c->stash->{questionnaires}{total},
             questionnaires_answered => $c->stash->{questionnaires}{1},
-            bodies => scalar @{$c->stash->{bodies}},
-            contacts => $c->stash->{contacts}{total},
         };
+        if ($c->cobrand->admin_show_body_stats) {
+            $data->{bodies} = scalar @{$c->stash->{bodies}};
+            $data->{contacts} = $c->stash->{contacts}{total};
+        }
         my $body = JSON->new->utf8(1)->pretty->encode($data);
         $c->res->body($body);
     }

--- a/perllib/FixMyStreet/App/Controller/Status.pm
+++ b/perllib/FixMyStreet/App/Controller/Status.pm
@@ -54,7 +54,6 @@ sub index : Path : Args(0) {
         my $data = {
             version => $c->stash->{git_version},
             reports => $c->stash->{total_problems_live},
-            updates => $c->stash->{comments}{confirmed},
             alerts_confirmed => $c->stash->{alerts}{1},
             alerts_unconfirmed => $c->stash->{alerts}{0},
             questionnaires_sent => $c->stash->{questionnaires}{total},

--- a/perllib/FixMyStreet/Cobrand/Default.pm
+++ b/perllib/FixMyStreet/Cobrand/Default.pm
@@ -831,6 +831,14 @@ Show the problem creation graph in the admin interface
 
 sub admin_show_creation_graph { 1 }
 
+=item admin_show_body_stats
+
+Show the body/contact counts on the admin stats page
+
+=cut
+
+sub admin_show_body_stats { 1 }
+
 =item admin_allow_user
 
 Perform checks on whether this user can access admin. By default only superusers

--- a/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
+++ b/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
@@ -35,6 +35,8 @@ sub site_key { 'nationalhighways' }
 
 sub restriction { { cobrand => shift->moniker } }
 
+sub admin_show_body_stats { 0 }
+
 sub hide_areas_on_reports { 1 }
 
 sub send_questionnaires { 0 }

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -345,6 +345,8 @@ sub admin_allow_user {
 
 sub admin_show_creation_graph { 0 }
 
+sub admin_show_body_stats { 0 }
+
 sub available_permissions {
     my $self = shift;
 

--- a/perllib/FixMyStreet/DB/ResultSet/Comment.pm
+++ b/perllib/FixMyStreet/DB/ResultSet/Comment.pm
@@ -30,15 +30,4 @@ sub timeline {
     );
 }
 
-sub summary_count {
-    my ( $rs ) = @_;
-
-    my $params = {
-        group_by => ['me.state'],
-        select   => [ 'me.state', { count => 'me.id' } ],
-        as       => [qw/state state_count/],
-    };
-    return $rs->search(undef, $params);
-}
-
 1;

--- a/t/app/controller/admin/stats.t
+++ b/t/app/controller/admin/stats.t
@@ -13,6 +13,26 @@ subtest "smoke view some stats pages" => sub {
     $mech->get_ok('/admin/stats/questionnaire');
 };
 
+subtest "body stats only shown where they are meaningful" => sub {
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'fixmystreet' ],
+    }, sub {
+        $mech->get_ok('/admin/stats');
+        $mech->content_contains('council contacts');
+        $mech->get_ok('/status.json');
+        like $mech->content, qr/"bodies"/;
+    };
+
+    FixMyStreet::override_config {
+        ALLOWED_COBRANDS => [ 'brent' ],
+    }, sub {
+        $mech->get_ok('/admin/stats');
+        $mech->content_lacks('council contacts');
+        $mech->get_ok('/status.json');
+        unlike $mech->content, qr/"bodies"/;
+    };
+};
+
 subtest "test refused stats page works" => sub {
     my $body1 = $mech->create_body_ok(2651, 'Edinburgh Council');
     my $body2 = $mech->create_body_ok(2237, 'Oxfordshire Council', { send_method  => 'Refused' });

--- a/t/app/controller/admin/stats.t
+++ b/t/app/controller/admin/stats.t
@@ -5,6 +5,10 @@ my $superuser = $mech->create_user_ok('superuser@example.com', name => 'Super Us
 
 subtest "smoke view some stats pages" => sub {
     $mech->log_in_ok( $superuser->email );
+    $mech->get_ok('/admin/stats');
+    $mech->content_contains('live problems');
+    $mech->get_ok('/admin/stats/state');
+    $mech->content_contains('Problem breakdown by state');
     $mech->get_ok('/admin/stats/fix-rate');
     $mech->get_ok('/admin/stats/questionnaire');
 };

--- a/templates/web/base/admin/stats/state.html
+++ b/templates/web/base/admin/stats/state.html
@@ -18,7 +18,4 @@
 [%- "\n</ul>" IF loop.last %]
 [%- END %]
 
-<h2>[% loc('Update breakdown by state') %]</h2>
-[% PROCESS states object=comments list=comments.keys.sort %]
-
 [% INCLUDE 'admin/footer.html' %]

--- a/templates/web/base/status/stats.html
+++ b/templates/web/base/status/stats.html
@@ -6,10 +6,12 @@
     alerts_0 = alerts.0 | format_number;
     questionnaires_total = questionnaires.total | format_number;
     questionnaires_1 = questionnaires.1 | format_number;
-    total_bodies = bodies.size | format_number;
-    contacts_total = contacts.total | format_number;
-    contacts_confirmed = contacts.confirmed | format_number;
-    contacts_unconfirmed = contacts.unconfirmed | format_number;
+    IF c.cobrand.admin_show_body_stats;
+        total_bodies = bodies.size | format_number;
+        contacts_total = contacts.total | format_number;
+        contacts_confirmed = contacts.confirmed | format_number;
+        contacts_unconfirmed = contacts.unconfirmed | format_number;
+    END;
 -%]
 
 <ul>
@@ -21,6 +23,8 @@
     </li>
     <li>[% tprintf( loc('%s confirmed alerts, %s unconfirmed'), decode(alerts_1), decode(alerts_0)) %]</li>
     <li>[% tprintf( loc('%s questionnaires sent &ndash; %s answered (%s%%)'), decode(questionnaires_total), decode(questionnaires_1), questionnaires_pc) %]</li>
+[% IF c.cobrand.admin_show_body_stats %]
     <li>[% tprintf( loc('%s bodies'), decode(total_bodies)) %],
         [% tprintf( loc('%s council contacts &ndash; %s confirmed, %s unconfirmed'), decode(contacts_total), decode(contacts_confirmed), decode(contacts_unconfirmed)) %]</li>
+[% END %]
 </ul>

--- a/templates/web/base/status/stats.html
+++ b/templates/web/base/status/stats.html
@@ -2,7 +2,6 @@
 
 [%-
     total_problems_live = total_problems_live | format_number;
-    comments_confirmed = (comments.confirmed || 0) | format_number;
     alerts_1 = alerts.1 | format_number;
     alerts_0 = alerts.0 | format_number;
     questionnaires_total = questionnaires.total | format_number;
@@ -20,7 +19,6 @@
         [% tprintf( loc('from %s different users'), decode(total_problems_users) ) %]
     [% END %]
     </li>
-    <li>[% tprintf( loc('%s live updates'), decode(comments_confirmed) ) %]</li>
     <li>[% tprintf( loc('%s confirmed alerts, %s unconfirmed'), decode(alerts_1), decode(alerts_0)) %]</li>
     <li>[% tprintf( loc('%s questionnaires sent &ndash; %s answered (%s%%)'), decode(questionnaires_total), decode(questionnaires_1), questionnaires_pc) %]</li>
     <li>[% tprintf( loc('%s bodies'), decode(total_bodies)) %],


### PR DESCRIPTION
After upgrading Postgres the stats page started taking much longer to load on cobrands, where the update query was filtering to a specific body. Simplest fix was to simply remove the updates-related bits from the admin stats and state pages.

Also hide the total body/contact counts on council cobrands, as they're only really relevant for .com.

Related to FD-7446

<!-- [skip changelog] -->
