### PR TITLE
[UK] Move admin user search to code.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Users.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Users.pm
@@ -59,7 +59,10 @@ sub index :Path : Args(0) {
     my $role = $c->get_param('role');
     my $users;
     if ($search || $role) {
-        $users = $c->cobrand->users;
+        # NOTE The below is not using $c->cobrand->users for performance reasons.
+        # The upgrade to PG15 made this query significantly slower :-(
+        #$users = $c->cobrand->users;
+        $users = FixMyStreet::DB->resultset("User");
         if ($search) {
             $search = $self->trim($search);
             $search =~ s/^<(.*)>$/$1/; # In case email wrapped in <...>
@@ -90,6 +93,10 @@ sub index :Path : Args(0) {
         order_by => [ \"me.name = ''", 'me.name' ],
     });
     my @users = $users->all;
+    # NOTE As we may have fetched more than we should above, filter out the same in code
+    if ($search || $role) {
+        $c->cobrand->call_hook(users_restriction_in_code => \@users);
+    }
     $c->stash->{users} = \@users;
     if ($search) {
         $c->forward('/admin/add_flags', [ { email => { ilike => "%$search%" } } ]);

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -152,6 +152,54 @@ sub users_restriction {
     return $rs->search($query);
 }
 
+=head2 users_restriction_in_code
+
+This performs the same function as users_restriction above (users who are
+members of the same council, have an email address in a specified domain, or
+users who have sent a report or update to that council) but from an already
+fetched list of users, rather than asking the database for all valid users.
+
+This is used by the admin user search, as the database query was too slow
+after the upgrade to PostgreSQL 15.
+
+=cut
+
+sub users_restriction_in_code {
+    my ($self, $users) = @_;
+
+    my $body_id = $self->body->id;
+    my $user_ids = [ map { $_->id } @$users ];
+    my %p = _users_restriction_lookup($self->problems, $user_ids);
+    my %u = _users_restriction_lookup($self->updates, $user_ids);
+    my @domains = $self->call_hook('admin_user_domain');
+    my $domains = join('|', map { "\@$_" } @domains);
+    @$users = grep { $p{$_->id} || $u{$_->id} || $self->user_restriction_in_code($_, $body_id, $domains) } @$users;
+
+}
+
+sub user_restriction_in_code {
+    my ($self, $user, $body_id, $domains) = @_;
+    return 0 if $user->is_superuser;
+    return 1 if $user->from_body && $user->from_body->id eq $body_id;
+    return 1 if $user->email =~ /($domains)$/;
+    return 0;
+}
+
+# This doesn't do nothing, as it might appear from first glance,
+# because $rs will be e.g. restricting to a particular body, so
+# this will remove users that have no output in that $rs.
+sub _users_restriction_lookup {
+    my ($rs, $user_ids) = @_;
+    my @objects = $rs->search({
+        'me.user_id' => $user_ids
+    }, {
+        columns => [ 'user_id' ],
+        distinct => 1
+    })->all;
+    my %lookup = map { $_->user_id => 1 } @objects;
+    return %lookup;
+}
+
 sub users_staff_admin {
     my $self = shift;
     return FixMyStreet::DB->resultset('User')->search({ is_superuser => 0, from_body => $self->body->id });


### PR DESCRIPTION
The update to PostgreSQL 15 has severely degraded the admin user search for cobrands. The non-limited search is fine, so move the filtering to the correct output more to the code side of things. [skip changelog]
