### PR TITLE
[K/S] Dispute email links always to report a problem page.

### DIFF
--- a/t/app/controller/waste_kands_bulky.t
+++ b/t/app/controller/waste_kands_bulky.t
@@ -1635,7 +1635,7 @@ FixMyStreet::override_config {
             like $email_text, qr/report a problem with this collection/, 'Report a problem text in text email';
             like $email_html, qr/No access due to gate locked/, 'Reason pulled from comment';
             like $email_html, qr/Report a problem with this missed collection/, 'Report a problem text in html email';
-            like $email_html, qr{waste/12345/enquiry\?category=Missed\+collection\+dispute}, 'HTML alert contains report link';
+            like $email_html, qr{waste/12345/enquiry\?template=problem}, 'HTML alert contains report link';
 
             # we only want the HTML link as the text version does not contain the link
             my @links = $email_html =~ m{https?://[^"]+}g;
@@ -1643,6 +1643,7 @@ FixMyStreet::override_config {
             # need to strip the host otherwise we're not logged in
             my $l = URI->new($enq_links[0]);
             $mech->get_ok($l->path_query);
+            $mech->submit_form_ok({ with_fields => { category => 'Missed collection dispute' } });
             $mech->content_contains('No access due to gate locked', 'details of missed bin collection displayed');
             $mech->content_contains('This photo provides the evidence', 'Has resolution photo text');
         };
@@ -1658,6 +1659,11 @@ FixMyStreet::override_config {
             my @links = $email_html =~ m{https?://[^"]+}g;
             my @enq_links = grep( /enquiry/, @links );
             my $l = URI->new($enq_links[0]);
+            $mech->get_ok($l->path_query);
+            $mech->content_lacks('dispute');
+            # Try going directly anyway
+            $l->query_param_delete('template');
+            $l->query_param('category', 'Missed collection dispute');
             $mech->get_ok($l->path_query);
             $mech->content_lacks('Our crews reported that your Bulky waste collection was not made', 'details of missed bin collection displayed');
             $mech->content_contains('Missed collections can only be disputed');
@@ -1775,6 +1781,7 @@ FixMyStreet::override_config {
     # this is disputing an attempt to collect after a missed collection report
     subtest 'Dispute of missed collections' => sub {
         my $missed = FixMyStreet::DB->resultset("Problem")->search({ category => 'Report missed collection' })->order_by('-id')->first;
+        $missed->update_extra_field({ name => 'service_id', value => 960 }); # Update to Sutton buly service ID
         $missed->update({ external_id => 'missed-guid', cobrand => 'sutton', bodies_str => $sutton->id });
 
         my $problem_url
@@ -1852,7 +1859,7 @@ FixMyStreet::override_config {
                 like $email_html, qr/Report a problem with this missed collection/, 'Report a problem text in html email';
                 like $email_html, qr{waste/12345/enquiry}, 'HTML alert contains report link';
 
-                my $link_part = "booking_id=" . $missed->id;
+                my $link_part = "booking_event=booking-guid";
                 # we only want the HTML link as the text version does not contain the link
                 my @links = $email_html =~ m{https?://[^"]+}g;
                 my @enq_links = grep( /enquiry/, @links );
@@ -1860,6 +1867,7 @@ FixMyStreet::override_config {
                 my $l = URI->new($enq_links[0]);
                 like $l->path_query, qr/$link_part/, 'link has correct booking_id';
                 $mech->get_ok($l->path_query);
+                $mech->submit_form_ok({ with_fields => { category => 'Missed collection dispute' } });
                 $mech->content_contains('No access due to parked vehicle', 'details of missed bin collection displayed');
                 $mech->content_contains('This photo provides the evidence', 'Has resolution photo text');
             };
@@ -1876,8 +1884,7 @@ FixMyStreet::override_config {
                 my @enq_links = grep( /enquiry/, @links );
                 my $l = URI->new($enq_links[0]);
                 $mech->get_ok($l->path_query);
-                $mech->content_lacks('Our crews reported that your collection was not made', 'details of missed bin collection displayed');
-                $mech->content_contains('Missed collections can only be disputed');
+                $mech->content_lacks('dispute');
             };
 
             set_fixed_time('2025-04-10T19:00:00Z');

--- a/t/app/controller/waste_kingston_bulky_disputes.t
+++ b/t/app/controller/waste_kingston_bulky_disputes.t
@@ -391,7 +391,7 @@ FixMyStreet::override_config {
                 like $email_html, qr/Resolution text/, 'Reason pulled from comment';
                 like $email_html, qr/Report a problem with this missed collection/, 'Report a problem text in html email';
                 like $email_html,
-                    qr{/12345/enquiry\?category=Missed\+collection\+dispute&service_id=986&original_booking_id=.+},
+                    qr{/12345/enquiry\?template=problem&service_id=986&original_booking_id=.+},
                     'HTML alert contains dispute link';
 
                 # we only want the HTML link as the text version does not contain the link
@@ -401,6 +401,7 @@ FixMyStreet::override_config {
                 my $l = URI->new($enq_links[0]);
 
                 $mech->get($l->path_query);
+                $mech->submit_form_ok({ with_fields => { category => "Missed collection dispute" } });
                 like $mech->uri->path_query,
                     qr/uprn=1000000002&service_id=986&event_id=8004/,
                     'redirects with correct params';
@@ -566,7 +567,7 @@ FixMyStreet::override_config {
                 like $email_html, qr/Resolution text/, 'Reason pulled from comment';
                 like $email_html, qr/Report a problem with this missed collection/, 'Report a problem text in html email';
                 like $email_html,
-                    qr{/12345/enquiry\?category=Missed\+collection\+dispute&service_id=986&original_booking_id=.+},
+                    qr{/12345/enquiry\?template=problem&service_id=986&original_booking_event=.+},
                     'HTML alert contains dispute link';
 
                 # we only want the HTML link as the text version does not contain the link
@@ -576,6 +577,7 @@ FixMyStreet::override_config {
                 my $l = URI->new($enq_links[0]);
 
                 $mech->get($l->path_query);
+                $mech->submit_form_ok({ with_fields => { category => "Missed collection dispute" } });
                 like $mech->uri->path_query,
                     qr/uprn=1000000002&service_id=986&event_id=112112321/,
                     'redirects with correct params';

--- a/t/app/controller/waste_kingston_r.t
+++ b/t/app/controller/waste_kingston_r.t
@@ -869,7 +869,7 @@ FixMyStreet::override_config {
                 like $email_html, qr/Resolution text/, 'Reason pulled from comment';
                 like $email_html, qr/Report a problem with this missed collection/, 'Report a problem text in html email';
                 like $email_html,
-                    qr{/12345/enquiry\?category=Missed\+collection\+dispute&service_id=966},
+                    qr{/12345/enquiry\?template=problem&service_id=966},
                     'HTML alert contains dispute link';
                 unlike $email_html, qr/original_booking_id/;
 
@@ -880,6 +880,7 @@ FixMyStreet::override_config {
                 my $l = URI->new($enq_links[0]);
 
                 $mech->get($l->path_query);
+                $mech->submit_form_ok({ with_fields => { category => "Missed collection dispute" } });
                 like $mech->uri->path_query,
                     qr/uprn=1000000002&service_id=966&event_id=112112321/,
                     'redirects with correct params';
@@ -982,7 +983,7 @@ FixMyStreet::override_config {
                 like $email_html, qr/Completed collection/, 'Reason pulled from comment';
                 like $email_html, qr/Report a problem with this missed collection/, 'Report a problem text in html email';
                 like $email_html,
-                    qr{/12345/enquiry\?category=Missed\+collection\+dispute&service_id=966},
+                    qr{/12345/enquiry\?template=problem&service_id=966},
                     'HTML alert contains dispute link';
                 unlike $email_html, qr/original_booking_id/;
 
@@ -993,6 +994,7 @@ FixMyStreet::override_config {
                 my $l = URI->new($enq_links[0]);
 
                 $mech->get($l->path_query);
+                $mech->submit_form_ok({ with_fields => { category => "Missed collection dispute" } });
                 like $mech->uri->path_query,
                     qr/uprn=1000000002&service_id=966&event_id=112112321/,
                     'redirects with correct params';

--- a/t/app/controller/waste_sutton_r.t
+++ b/t/app/controller/waste_sutton_r.t
@@ -1232,6 +1232,9 @@ FixMyStreet::override_config {
     # this is when a collection has been missed, a missed bin report made and then
     # marked as not complete
     subtest 'Dispute of non completed missed bin report' => sub {
+        $missed_report->update_extra_field({ name => 'service_id', value => '940' });
+        $missed_report->update({ external_id => 'missed-collection-guid' });
+
         # We want to test that a missed collection report can be disputed.
         # To prevent confusion, mock *completed* task for original collection.
         # If it was incomplete, a dispute could be raised for it, and would
@@ -1290,7 +1293,6 @@ FixMyStreet::override_config {
                 '"too late" messaging not shown';
         };
 
-        $missed_report->update({ external_id => 'missed-collection-guid' });
         my $comment = FixMyStreet::DB->resultset('Comment')->create(
             {
                 user          => $body_user,
@@ -1332,12 +1334,20 @@ FixMyStreet::override_config {
             my $l = URI->new($enq_links[0]);
             $mech->get_ok($l->path_query);
             $mech->content_contains('Contaminated (builder’s waste)', 'details of missed bin collection displayed');
+            $mech->submit_form_ok({ with_fields => { category => "Missed collection dispute" } });
 
-            # XXX Email link uses 'original_booking_id' param here to denote
+            $l->query_param_delete('template');
+            $l->query_param('category', 'Missed collection dispute');
+            $mech->get_ok($l->path_query);
+
+            # XXX Email link used 'original_booking_id' param here to denote
             # missed collection report ID, but 'original_booking_id' should
-            # really only refer to bulky/small item reports. Also, photo
-            # does not appear when form accessed from web below.
-            $mech->content_contains('This photo provides the evidence', 'Has resolution photo text');
+            # really only refer to bulky/small item reports, as it breaks the
+            # report a problem page if present (which assumes it is only for
+            # those and overwrites the service). Also, photo does not appear
+            # when form accessed from web below. XXX
+            $mech->content_contains('Contaminated (builder’s waste)', 'details of missed bin collection displayed');
+            #$mech->content_contains('This photo provides the evidence', 'Has resolution photo text');
         };
 
         subtest 'Create dispute for non complete missed bin report' => sub {

--- a/t/app/controller/waste_sutton_small_items.t
+++ b/t/app/controller/waste_sutton_small_items.t
@@ -830,6 +830,7 @@ FixMyStreet::override_config {
             # need to strip the host otherwise we're not logged in
             my $l = URI->new($enq_links[0]);
             $mech->get_ok($l->path_query);
+            $mech->submit_form_ok({ with_fields => { category => "Missed collection dispute" } });
             $mech->content_contains('No access due to gate locked', 'details of missed bin collection displayed');
             $mech->content_contains('This photo provides the evidence', 'Has resolution photo text');
         };
@@ -845,6 +846,11 @@ FixMyStreet::override_config {
             my @links = $email_html =~ m{https?://[^"]+}g;
             my @enq_links = grep( /enquiry/, @links );
             my $l = URI->new($enq_links[0]);
+            $mech->get_ok($l->path_query);
+            $mech->content_lacks('dispute');
+            # Try going directly anyway
+            $l->query_param_delete('template');
+            $l->query_param('category', 'Missed collection dispute');
             $mech->get_ok($l->path_query);
             $mech->content_lacks('Our crews reported that your Small items collection was not made', 'details of missed bin collection displayed');
             $mech->content_contains('Missed collections can only be disputed');

--- a/templates/email/default/_email_comment_list.html
+++ b/templates/email/default/_email_comment_list.html
@@ -29,17 +29,18 @@
         [% END %]
 
         [%
-          # NOTE Sutton may use 'original_booking_id' to refer to a missed collection
-          # report associated with a standard collection, not just bookings
-          # and their associated missed collection reports.
-        %]
-        [%
-          SET include_report_id = cobrand.moniker == 'sutton'
-            OR report.get_extra_field_value('service_id') == cobrand.feature('echo').small_items_service_id
-            OR report.get_extra_field_value('service_id') == cobrand.feature('echo').bulky_service_id
+          service_id = report.get_extra_field_value('service_id');
+          cfg = cobrand.feature('echo');
+          IF service_id == cfg.small_items_service_id OR service_id == cfg.bulky_service_id;
+              IF report.get_extra_field_value('Original_Event_ID');
+                original_booking_id = 'original_booking_event=' _ report.get_extra_field_value('Original_Event_ID');
+              ELSE;
+                original_booking_id = 'original_booking_id=' _ report.id;
+              END;
+          END;
         %]
         <p>
-          <a href="[% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') %]/enquiry?category=Missed+collection+dispute&service_id=[% report.get_extra_field_value('service_id') %][% IF include_report_id %]&original_booking_id=[% report.id %][% END %]">Report a problem with this missed collection</a>
+          <a href="[% cobrand.base_url %]/waste/[% report.get_extra_field_value('property_id') %]/enquiry?template=problem&service_id=[% report.get_extra_field_value('service_id') %][% IF original_booking_id %]&[% original_booking_id %][% END %]">Report a problem with this missed collection</a>
         </p>
       [% END %]
     [% END %]

--- a/templates/email/default/waste/_bulky_email_comment_end.html
+++ b/templates/email/default/waste/_bulky_email_comment_end.html
@@ -13,16 +13,13 @@
         SET collection_description = report.category == 'Small items collection'
             ? 'small items' : 'bulky waste';
 
-        SET enquiry_type = 'template=problem';
     %]
-    [% IF update.item_problem_state == 'unable to fix' %]
-        [%
-            SET enquiry_type = 'category=Missed+collection+dispute';
+    [% IF update.item_problem_state == 'unable to fix';
             SET collection_description = 'missed';
-        %]
-    [% END %]
+       END;
+    %]
     <p>
-        <a href="[% cobrand.base_url %]/waste/[% property_id %]/enquiry?[% enquiry_type %]&service_id=[% service_id %]&original_booking_id=[% report.id %]">Report a problem with this [% collection_description %] collection</a>
+        <a href="[% cobrand.base_url %]/waste/[% property_id %]/enquiry?template=problem&service_id=[% service_id %]&original_booking_id=[% report.id %]">Report a problem with this [% collection_description %] collection</a>
     </p>
 [% END %]
 


### PR DESCRIPTION
Fixes a couple of bugs, where test data wasn't using the right service IDs, and confusion over original_booking_id contents.
[skip changelog]