### PR TITLE
[UK] Move admin user lookup to code.

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Users.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Users.pm
@@ -228,7 +228,7 @@ sub fetch_body_roles : Private {
 sub user : Chained('/') PathPart('admin/users') : CaptureArgs(1) {
     my ( $self, $c, $id ) = @_;
 
-    my $user = $c->cobrand->users->find( { id => $id } );
+    my $user = find_unique_user($c, { id => $id });
     $c->detach( '/page_error_404_not_found', [] ) unless $user;
     $c->stash->{user} = $user;
 
@@ -311,11 +311,11 @@ sub edit : Chained('user') : PathPart('') : Args(0) {
 
         my $email_params = { email => $email, email_verified => 1, id => { '!=', $user->id } };
         my $phone_params = { phone => $phone, phone_verified => 1, id => { '!=', $user->id } };
-        my $existing_email = $email_v && $c->model('DB::User')->search($email_params)->first;
-        my $existing_phone = $phone_v && $c->model('DB::User')->search($phone_params)->first;
+        my $existing_email = $email_v && $c->model('DB::User')->search($email_params)->single;
+        my $existing_phone = $phone_v && $c->model('DB::User')->search($phone_params)->single;
         my $existing_user = $existing_email || $existing_phone;
-        my $existing_email_cobrand = $email_v && $c->cobrand->users->search($email_params)->first;
-        my $existing_phone_cobrand = $phone_v && $c->cobrand->users->search($phone_params)->first;
+        my $existing_email_cobrand = $email_v && find_unique_user($c, $email_params);
+        my $existing_phone_cobrand = $phone_v && find_unique_user($c, $phone_params);
         my $existing_user_cobrand = $existing_email_cobrand || $existing_phone_cobrand;
 
         if ($existing_phone_cobrand && $existing_email_cobrand && $existing_email_cobrand->id != $existing_phone_cobrand->id) {
@@ -486,7 +486,7 @@ sub post_edit_redirect : Private {
 
     # User may not be visible on this cobrand, e.g. if their from_body
     # wasn't set.
-    if ( $c->cobrand->users->find( { id => $user->id } ) ) {
+    if (find_unique_user($c, { id => $user->id })) {
         return $c->res->redirect( $c->uri_for_action( 'admin/users/edit', [ $user->id ] ) );
     } else {
         return $c->res->redirect( $c->uri_for_action( 'admin/users/index' ) );
@@ -751,6 +751,19 @@ sub unban : Private {
     }
 }
 
+# NOTE The below is not using $c->cobrand->users for performance reasons.
+# The upgrade to PG15 made this query significantly slower :-(
+sub find_unique_user {
+    my ($c, $args, $key) = @_;
+    my $user = $c->model('DB::User')->search($args)->single;
+    if ($user) {
+        my $users = [ $user ];
+        $c->cobrand->call_hook(users_restriction_in_code => $users);
+        if (@$users) {
+            return $user;
+        }
+    }
+}
 
 sub trim {
     my $self = shift;

--- a/perllib/FixMyStreet/Cobrand/CyclingUK.pm
+++ b/perllib/FixMyStreet/Cobrand/CyclingUK.pm
@@ -138,7 +138,8 @@ cyclinguk cobrand.
 =cut
 
 sub users_restriction { FixMyStreet::Cobrand::UKCouncils::users_restriction($_[0], $_[1]) }
-
+sub users_restriction_in_code { FixMyStreet::Cobrand::UKCouncils::users_restriction_in_code($_[0], $_[1]) }
+sub users_staff_admin { FixMyStreet::Cobrand::UKCouncils::users_staff_admin($_[0]) }
 
 =item dashboard_extra_bodies
 

--- a/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
+++ b/perllib/FixMyStreet/Cobrand/HighwaysEngland.pm
@@ -56,6 +56,7 @@ sub problems_restriction { FixMyStreet::Cobrand::UKCouncils::problems_restrictio
 sub problems_on_map_restriction { $_[0]->problems_restriction($_[1]) }
 sub problems_sql_restriction { FixMyStreet::Cobrand::UKCouncils::problems_sql_restriction($_[0], $_[1]) }
 sub users_restriction { FixMyStreet::Cobrand::UKCouncils::users_restriction($_[0], $_[1]) }
+sub users_restriction_in_code { FixMyStreet::Cobrand::UKCouncils::users_restriction_in_code($_[0], $_[1]) }
 sub updates_restriction { FixMyStreet::Cobrand::UKCouncils::updates_restriction($_[0], $_[1]) }
 sub base_url { FixMyStreet::Cobrand::UKCouncils::base_url($_[0]) }
 sub contact_name { FixMyStreet::Cobrand::UKCouncils::contact_name($_[0]) }

--- a/perllib/FixMyStreet/Cobrand/Thamesmead.pm
+++ b/perllib/FixMyStreet/Cobrand/Thamesmead.pm
@@ -22,6 +22,8 @@ sub problems_restriction { FixMyStreet::Cobrand::UKCouncils::problems_restrictio
 sub problems_on_map_restriction { $_[0]->problems_restriction($_[1]) }
 sub problems_sql_restriction { FixMyStreet::Cobrand::UKCouncils::problems_sql_restriction($_[0], $_[1]) }
 sub users_restriction { FixMyStreet::Cobrand::UKCouncils::users_restriction($_[0], $_[1]) }
+sub users_restriction_in_code { FixMyStreet::Cobrand::UKCouncils::users_restriction_in_code($_[0], $_[1]) }
+sub users_staff_admin { FixMyStreet::Cobrand::UKCouncils::users_staff_admin($_[0]) }
 sub updates_restriction { FixMyStreet::Cobrand::UKCouncils::updates_restriction($_[0], $_[1]) }
 sub site_key { FixMyStreet::Cobrand::UKCouncils::site_key($_[0], $_[1]) }
 sub all_reports_single_body { FixMyStreet::Cobrand::UKCouncils::all_reports_single_body($_[0], $_[1]) }

--- a/perllib/FixMyStreet/Cobrand/UKCouncils.pm
+++ b/perllib/FixMyStreet/Cobrand/UKCouncils.pm
@@ -159,7 +159,7 @@ members of the same council, have an email address in a specified domain, or
 users who have sent a report or update to that council) but from an already
 fetched list of users, rather than asking the database for all valid users.
 
-This is used by the admin user search, as the database query was too slow
+This is used by the admin user section, as the database query was too slow
 after the upgrade to PostgreSQL 15.
 
 =cut
@@ -169,16 +169,18 @@ sub users_restriction_in_code {
 
     my $body_id = $self->body->id;
     my $user_ids = [ map { $_->id } @$users ];
-    my %p = _users_restriction_lookup($self->problems, $user_ids);
-    my %u = _users_restriction_lookup($self->updates, $user_ids);
+    my $problems = $self->problems; # Separate line because it can return a list
+    my %p = _users_restriction_lookup($problems, $user_ids);
+    my $updates = $self->updates;
+    my %u = _users_restriction_lookup($updates, $user_ids);
     my @domains = $self->call_hook('admin_user_domain');
     my $domains = join('|', map { "\@$_" } @domains);
-    @$users = grep { $p{$_->id} || $u{$_->id} || $self->user_restriction_in_code($_, $body_id, $domains) } @$users;
+    @$users = grep { $p{$_->id} || $u{$_->id} || user_restriction_in_code($_, $body_id, $domains) } @$users;
 
 }
 
 sub user_restriction_in_code {
-    my ($self, $user, $body_id, $domains) = @_;
+    my ($user, $body_id, $domains) = @_;
     return 0 if $user->is_superuser;
     return 1 if $user->from_body && $user->from_body->id eq $body_id;
     return 1 if $user->email =~ /($domains)$/;


### PR DESCRIPTION
The update to PostgreSQL 15 has severely degraded the admin user lookup for cobrands. The non-limited lookup is fine, so move the filtering to the correct output more to the code side of things. [skip changelog]

This uses the same as code as the previous commit, for other uses of `cobrand->users` in Admin/Users.pm