### PR TITLE
Don't include unconfirmed alerts in CSV count

### DIFF
--- a/perllib/FixMyStreet/Script/CSVExport.pm
+++ b/perllib/FixMyStreet/Script/CSVExport.pm
@@ -231,7 +231,7 @@ EOF
     if ($EXTRAS->{alerts_count}{$cobrand->moniker}) {
         push @sql_select, '"alerts_table"."alerts_count"';
         push @sql_join, '"alerts_table" ON CAST("alerts_table"."parameter" AS INTEGER) = "me"."id"';
-        push @sql_with, "alerts_table AS (select parameter, count(*) AS alerts_count FROM alert WHERE alert_type='new_updates' AND confirmed IS NOT NULL AND whendisabled IS NULL GROUP BY 1)";
+        push @sql_with, "alerts_table AS (select parameter, count(*) AS alerts_count FROM alert WHERE alert_type='new_updates' AND confirmed = 1 AND whendisabled IS NULL GROUP BY 1)";
     }
 
     my $sql_select = join(', ', @sql_select);

--- a/t/cobrand/shropshire.t
+++ b/t/cobrand/shropshire.t
@@ -268,6 +268,25 @@ FixMyStreet::override_config {
         $mech->get_ok('/dashboard?export=1');
         $mech->content_contains('website,shropshire,,No,1');
 
+        # Unconfirmed alerts shouldn't be included in alert count
+        my $unconfirmed = FixMyStreet::DB->resultset('Alert')->create( {
+            parameter  => $report->id,
+            alert_type => 'new_updates',
+            user       => $councillor,
+        } );
+        $mech->get_ok('/dashboard?export=1');
+        $mech->content_contains('website,shropshire,,No,1');
+        my $yesterday = \"current_timestamp - '1 day'::interval";
+        $report->update( { created => $yesterday, confirmed => $yesterday } );
+        FixMyStreet::Script::CSVExport::process(dbh => FixMyStreet::DB->schema->storage->dbh);
+        $mech->get_ok('/dashboard?export=1');
+        $mech->content_contains('website,shropshire,,No,1');
+
+        # Once confirmed, it should increase the alert count
+        $unconfirmed->confirm;
+        FixMyStreet::Script::CSVExport::process(dbh => FixMyStreet::DB->schema->storage->dbh);
+        $mech->get_ok('/dashboard?export=1');
+        $mech->content_contains('website,shropshire,,No,2');
     };
 };
 


### PR DESCRIPTION
The SQL for the alerts count was checking for `confirmed IS NOT NULL`, but the `confirmed` column of the `alert` table is not nullable, so this would always be true.

Fix it to actually check for `confirmed = 1` so that only confirmed alerts are included in the CSV export.

Spotted while replying to FD-7427

<!-- [skip changelog] -->
