### PR TITLE
[Peterborough] Added fix for `#front-main`

### DIFF
--- a/web/cobrands/peterborough/layout.scss
+++ b/web/cobrands/peterborough/layout.scss
@@ -7,7 +7,7 @@
 }
 
 body.frontpage #front-main {
-    padding: 2.5em 0;
+    padding: 2.5em 1rem;
 }
 
 #front-main { 


### PR DESCRIPTION
In smaller screens there is not gap between the edge of the screen and the content inside `#front-main`

### Before
<img width="973" height="421" alt="Screenshot 2026-08-25 at 14 17 02" src="https://github.com/user-attachments/assets/3c24b53f-d0ee-4568-8586-68ec6e8eb1b6" />

### After
<img width="973" height="421" alt="Screenshot 2026-08-25 at 14 18 00" src="https://github.com/user-attachments/assets/f2a9419c-fb36-4798-bfbc-5646206be644" />

[skip changelog]