### PR TITLE
Prevent overlap of logo with `#main-nav` on desktop

### DIFF
--- a/web/cobrands/aberdeenshire/layout.scss
+++ b/web/cobrands/aberdeenshire/layout.scss
@@ -42,6 +42,17 @@
   }
 }
 
+// Prevents overlap with logo. Even when logged in with admin account.
+.nav-menu {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: end;
+}
+
+#main-nav {
+  max-width: 60%;
+}
+
 /* FRONTPAGE */
 #front-main {
   margin: 0 0 45px 0;

--- a/web/cobrands/northumberland/layout.scss
+++ b/web/cobrands/northumberland/layout.scss
@@ -41,6 +41,17 @@
 
 }
 
+// Prevents overlap with logo. Even when logged in with admin account.
+.nav-menu {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: end;
+}
+
+#main-nav {
+  max-width: 65%;
+}
+
 body.mappage {
   #site-logo {
     height: $mappage-header-height;

--- a/web/cobrands/southkesteven/layout.scss
+++ b/web/cobrands/southkesteven/layout.scss
@@ -47,6 +47,17 @@
   }
 }
 
+// Prevents overlap with logo. Even when logged in with admin account.
+.nav-menu {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: end;
+}
+
+#main-nav {
+  max-width: 80%;
+}
+
 /* FRONTPAGE */
 
 #front_stats {


### PR DESCRIPTION
<img width="973" height="421" alt="Screenshot 2026-08-25 at 14 25 52" src="https://github.com/user-attachments/assets/cfc71ca0-fafb-471a-a893-ce42ee10dd1b" />

<img width="973" height="421" alt="Screenshot 2026-08-25 at 14 26 17" src="https://github.com/user-attachments/assets/5e62e79b-9edf-4f07-8ea2-f650233bb644" />

<img width="973" height="421" alt="Screenshot 2026-08-25 at 14 25 26" src="https://github.com/user-attachments/assets/dc143ac1-63d6-450d-8cc5-4b26c1394fbe" />


[skip changelog]