### PR TITLE
Restrict superuser role admin to the cobrand's body

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Roles.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Roles.pm
@@ -11,13 +11,19 @@ sub auto :Private {
 
     my $user = $c->user;
     if ($user->is_superuser) {
-        $c->stash(rs => $c->model('DB::Role')->search_rs({}, {
+        # On a cobrand associated with a body, only show that body's roles
+        my $body = $c->cobrand->body;
+        my $search = $body ? { 'me.body_id' => $body->id } : {};
+        $c->stash(rs => $c->model('DB::Role')->search_rs($search, {
             prefetch => 'body',
             order_by => ['body.name', 'me.name']
         }));
+        $c->stash->{group_roles_by_body} = !$body;
     } elsif ($user->from_body) {
         $c->stash(rs => $user->from_body->roles->search_rs({}, { order_by => 'name' }));
     }
+
+    return 1;
 }
 
 sub index :Path :Args(0) {
@@ -94,9 +100,16 @@ sub form {
         ],
     };
 
+    my $body;
     if (!$c->user->is_superuser && $c->user->from_body) {
+        $body = $c->user->from_body;
+    } else {
+        # Superusers on a cobrand associated with a body can only use that body
+        $body = $c->cobrand->body;
+    }
+    if ($body) {
         push @{$opts->{field_list}}, '+body', { inactive => 1 };
-        $opts->{body_id} = $c->user->from_body->id;
+        $opts->{body_id} = $body->id;
     }
 
     my $action = $role->in_storage ? 'edit' : 'add';

--- a/perllib/FixMyStreet/App/Controller/Admin/Users.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Users.pm
@@ -107,10 +107,11 @@ sub index :Path : Args(0) {
         # On a cobrand associated with a body, only show that body's roles
         my $body = $c->cobrand->body;
         my $search = $body ? { 'me.body_id' => $body->id } : {};
-        $rs = $c->model('DB::Role')->search_rs($search, { join => 'body', order_by => ['body.name', 'me.name'] });
-        $rs = $rs->search(undef, {
+        $rs = $c->model('DB::Role')->search_rs($search, {
+            prefetch => 'body',
             '+columns' => { 'body.msgstr' => \'COALESCE(translation_name.msgstr, body.name)' },
             join => { body => 'translation_name' },
+            order_by => ['body.name', 'me.name'],
         });
         $c->stash->{group_roles_by_body} = !$body;
     } elsif ($c->user->from_body) {

--- a/perllib/FixMyStreet/App/Controller/Admin/Users.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Users.pm
@@ -104,11 +104,15 @@ sub index :Path : Args(0) {
 
     my $rs;
     if ($c->user->is_superuser) {
-        $rs = $c->model('DB::Role')->search_rs({}, { join => 'body', order_by => ['body.name', 'me.name'] });
+        # On a cobrand associated with a body, only show that body's roles
+        my $body = $c->cobrand->body;
+        my $search = $body ? { 'me.body_id' => $body->id } : {};
+        $rs = $c->model('DB::Role')->search_rs($search, { join => 'body', order_by => ['body.name', 'me.name'] });
         $rs = $rs->search(undef, {
             '+columns' => { 'body.msgstr' => \'COALESCE(translation_name.msgstr, body.name)' },
             join => { body => 'translation_name' },
         });
+        $c->stash->{group_roles_by_body} = !$body;
     } elsif ($c->user->from_body) {
         $rs = $c->user->from_body->roles->search_rs({}, { order_by => 'name' });
     }

--- a/t/app/controller/admin/roles.t
+++ b/t/app/controller/admin/roles.t
@@ -131,6 +131,10 @@ subtest 'superuser can see all bodies' => sub {
     $mech->content_contains('Bromley');
     $mech->content_contains('Role B');
     $mech->content_contains('Role Z');
+    $mech->content_contains('colspan="3"');
+    $mech->get_ok("/admin/users");
+    $mech->content_contains('<optgroup');
+    $mech->get_ok("/admin/roles");
     $mech->follow_link_ok({ text => 'Create' });
     $mech->content_contains('Body');
     $mech->content_contains('Bromley');
@@ -144,6 +148,45 @@ subtest 'superuser can see all bodies' => sub {
         permissions => 'contribute_as_body',
     }});
     $mech->content_contains('Role C');
+};
+
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => 'oxfordshire',
+    MAPIT_URL => 'http://mapit.uk',
+}, sub {
+    subtest 'superuser only sees cobrand body roles' => sub {
+        $mech->log_in_ok( $superuser->email );
+
+        $mech->get_ok("/admin/roles");
+        $mech->content_contains('Role B');
+        $mech->content_lacks('Role Z');
+        $mech->content_lacks('Role C');
+        $mech->content_lacks('Bromley');
+        $mech->content_lacks('colspan="3"', 'no body headings when only one body');
+
+        $mech->follow_link_ok({ text => 'Create' });
+        $mech->content_lacks('Body');
+        $mech->submit_form_ok({ with_fields => {
+            name => 'Role D',
+            permissions => 'contribute_as_body',
+        }});
+        $mech->content_contains('Role D');
+        my $role_d = FixMyStreet::DB->resultset("Role")->find({ name => 'Role D' });
+        is $role_d->body_id, $body->id, 'role created for cobrand body';
+    };
+
+    subtest "superuser cannot edit another body's role" => sub {
+        my $role_z = FixMyStreet::DB->resultset("Role")->find({ name => 'Role Z' });
+        $mech->get('/admin/roles/' . $role_z->id);
+        is $mech->res->code, 404, 'cannot edit role of another body';
+    };
+
+    subtest 'user role filter only lists cobrand body roles' => sub {
+        $mech->get_ok('/admin/users');
+        $mech->content_contains('Role B');
+        $mech->content_lacks('Role Z');
+        $mech->content_lacks('<optgroup', 'no optgroup when only one body');
+    };
 };
 
 subtest 'check log of the above' => sub {

--- a/templates/web/base/admin/roles/index.html
+++ b/templates/web/base/admin/roles/index.html
@@ -7,7 +7,7 @@
         <th>&nbsp;</th>
     </tr>
 [% FOREACH role IN roles -%]
-  [% IF c.user.is_superuser AND last_name != role.body.name %]
+  [% IF group_roles_by_body AND last_name != role.body.name %]
     <tr>
         <td colspan="3"><strong>[% role.body.name %]</strong></td>
     </tr>

--- a/templates/web/base/admin/users/index.html
+++ b/templates/web/base/admin/users/index.html
@@ -5,7 +5,7 @@
 <select name="[% label %]" id="[% label %]" class="form-control">
     <option value="">---</option>
   [% FOR role IN roles %]
-      [% IF c.user.is_superuser AND last_name != role.body.name %]
+      [% IF group_roles_by_body AND last_name != role.body.name %]
         <optgroup label="[% role.body.name %]">
         [% SET last_name = role.body.name %]
       [% END %]


### PR DESCRIPTION
When being viewed by a superuser, change the roles list, the role filter on the user list, and the body field on the role form to use $c->cobrand->body where there is one.

This fixes the confusing long list of all roles when viewing on a cobrand as a superuser.

Means that roles belonging to other bodies are no longer editable from a cobrand's admin.

<!-- [skip changelog] -->
