### PR TITLE
[CRT] Handle category names

### DIFF
--- a/perllib/FixMyStreet/Cobrand/CanalRiverTrust.pm
+++ b/perllib/FixMyStreet/Cobrand/CanalRiverTrust.pm
@@ -120,10 +120,9 @@ sub munge_report_new_bodies {
 sub munge_report_new_contacts {
     my ($self, $contacts) = @_;
 
-    my $code = 'CRT';
     foreach my $c (@$contacts) {
         my $clean_name = $c->category_display;
-        if ($clean_name =~ s/ \($code\)//) {
+        if ($clean_name =~ s/ \(CRT:.*?\)//) {
             $c->set_extra_metadata(display_name => $clean_name);
         }
     }
@@ -131,7 +130,7 @@ sub munge_report_new_contacts {
 
 sub admin_contact_validate_category {
     my ( $self, $category ) = @_;
-    return "(CRT)" eq substr($category, -5) ? "" : "Category must end with (CRT).";
+    return $category =~ /\(CRT: \w.*?\)/ ? "" : "Category must end with (CRT: <group_name>).";
 }
 
 sub open311_extra_data_include {

--- a/t/cobrand/canalrivertrust.t
+++ b/t/cobrand/canalrivertrust.t
@@ -28,6 +28,7 @@ my $staff_user = $mech->create_user_ok(
     name      => 'Staff User',
     from_body => $body,
 );
+$staff_user->user_body_permissions->create({ body => $body, permission_type => 'category_edit' });
 
 FixMyStreet::override_config {
     ALLOWED_COBRANDS => [ 'fixmystreet', 'canalrivertrust' ],
@@ -111,5 +112,44 @@ FixMyStreet::override_config {
     $mech->content_contains('New problems to Canal &amp; River Trust on Canal &amp; River Trust');
 };
 
+FixMyStreet::override_config {
+    ALLOWED_COBRANDS => [ 'canalrivertrust' ],
+    MAPIT_URL => 'http://mapit.uk/',
+    BASE_URL => 'http://www.example.org',
+    COBRAND_FEATURES => {
+       category_groups => { canalrivertrust => 1 },
+    }
+}, sub {
+    subtest 'Displays and protects category names' => sub {
+        $mech->log_in_ok($staff_user->email);
+        $mech->get_ok('/admin/body/' . $body->id);
+        $mech->follow_link_ok({ text => 'Add new category' });
+        $mech->content_contains('Parent categories');
+        $mech->submit_form_ok( { with_fields => {
+                                                 category => 'Access issues (CRT)',
+                                                 group => 'Aqueduct',
+                                                 email => 'AccessIssues@test.com',
+                                                }
+                               });
+        $mech->content_contains('Category must end with (CRT: &lt;group_name&gt;)');
+        $mech->submit_form_ok( { with_fields => {
+                                                 category => 'Access issues (CRT: Aqueduct)',
+                                                 group => 'Aqueduct',
+                                                 email => 'AccessIssues@test.com',
+                                                }
+                               });
+        $mech->content_contains('New category contact added');
+
+        $mech->get_ok('/around');
+        $mech->submit_form_ok( { with_fields => { pc => 'GL50 2PR' } },
+            'submit location' );
+        $mech->follow_link_ok(
+            { text_regex => qr/skip this step/i, },
+            "follow 'skip this step' link"
+                             );
+
+        $mech->content_contains('data-category_display="Access issues"');
+    };
+};
 
 done_testing();


### PR DESCRIPTION
Category names are distinguished by having the pattern:

Category Name (CRT: group name)

CRT is for matching Canal and River Trust categories as a group for excluding or including where relevant.

The group name allows the categories to be unique so that stats can be reported on categories that are in multiple groups

[skip changelog]