### PR TITLE
[Greenwich] Add header to all Open311 requests.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Greenwich.pm
+++ b/perllib/FixMyStreet/Cobrand/Greenwich.pm
@@ -180,4 +180,10 @@ sub open311_update_missing_data {
     }
 }
 
+sub open311_extra_headers {
+    my ($self, $req) = @_;
+    my $key = $self->feature('open311_api_key_header');
+    $req->header( Ocp_Apim_Subscription_Key => $key ) if $key;
+}
+
 1;

--- a/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
+++ b/perllib/FixMyStreet/Roles/Cobrand/Echo.pm
@@ -717,6 +717,7 @@ sub waste_fetch_events {
     }
 
     my %open311_conf = (
+        fixmystreet_body => $body,
         endpoint => $conf->endpoint || '',
         api_key => $conf->api_key || '',
         jurisdiction => $conf->jurisdiction || '',

--- a/perllib/Open311.pm
+++ b/perllib/Open311.pm
@@ -663,6 +663,10 @@ sub _request {
         }
     };
 
+    if ($self->fixmystreet_body && (my $cobrand = $self->fixmystreet_body->get_cobrand_handler)) {
+        $cobrand->call_hook(open311_extra_headers => $req);
+    }
+
     $debug_request .= $self->_params_to_string($params, $debug_request);
     $self->debug_details( $self->debug_details . $debug_request );
 

--- a/perllib/Open311/GetServiceRequests.pm
+++ b/perllib/Open311/GetServiceRequests.pm
@@ -67,6 +67,7 @@ sub create_open311_object {
     my ($self, $body) = @_;
 
     my $o = Open311->new(
+        fixmystreet_body => $body,
         endpoint     => $body->endpoint,
         api_key      => $body->api_key,
         jurisdiction => $body->jurisdiction,

--- a/perllib/Open311/PopulateServiceList.pm
+++ b/perllib/Open311/PopulateServiceList.pm
@@ -31,6 +31,7 @@ sub process_bodies {
 sub process_body {
     my $self = shift;
     my $open311 = Open311->new(
+        fixmystreet_body => $self->_current_body,
         endpoint => $self->_current_body->endpoint,
         jurisdiction => $self->_current_body->jurisdiction,
         api_key => $self->_current_body->api_key

--- a/perllib/Open311/UpdatesBase.pm
+++ b/perllib/Open311/UpdatesBase.pm
@@ -92,6 +92,7 @@ sub _build_current_open311 {
     my $body = $self->current_body;
     my $conf = $self->open311_config || $body;
     my %open311_conf = (
+        fixmystreet_body => $body,
         endpoint => $conf->endpoint || '',
         api_key => $conf->api_key || '',
         jurisdiction => $conf->jurisdiction || '',

--- a/t/cobrand/greenwich.t
+++ b/t/cobrand/greenwich.t
@@ -73,18 +73,23 @@ subtest 'check services override' => sub {
     my $o = Open311->new(
         jurisdiction => 'mysociety',
         endpoint => 'http://example.com',
+        fixmystreet_body => $body,
     );
     Open311->_inject_response('/services/HOLE.xml', $meta_xml);
 
     $processor->_current_open311( $o );
     FixMyStreet::override_config {
         ALLOWED_COBRANDS => [ 'greenwich' ],
+        COBRAND_FEATURES => { open311_api_key_header => { greenwich => 'TOKEN' } },
     }, sub {
         $processor->_current_body( $body );
+        $processor->_current_service( { service_code => 'HOLE' } );
+        $processor->_add_meta_to_contact( $contact );
+        $contact->update;
     };
-    $processor->_current_service( { service_code => 'HOLE' } );
-    $processor->_add_meta_to_contact( $contact );
-    $contact->update;
+
+    my $req = Open311->test_req_used;
+    is $req->header('Ocp-Apim-Subscription-Key'), 'TOKEN';
 
     my $extra = [ {
         automated => 'server_set',


### PR DESCRIPTION
FD-7424 [skip changelog]
I thought what about if we had the situation where one endpoint was used in more than one place and we needed to send different headers, which did seem unlikely, but given using fixmystreet_body matches other uses in Open311.pm, I thought might as well set that consistently throughout and then can use that to set a cobrand-specific extra headers function. Perhaps this shouldn't have cobrand specific stuff in at all, but any other way seemed overly complicated.