### PR TITLE
Removed "New" badge from image report first

### DIFF
--- a/templates/web/base/around/postcode_form.html
+++ b/templates/web/base/around/postcode_form.html
@@ -82,7 +82,7 @@
 
             [% IF photo_upload %]
             <div class="image-first-form-wrapper">
-                <p class="label"><span class="badge">New</span>Or start a report with a photo</p>
+                <p class="label">Or start a report with a photo</p>
 
                 <div id="photo-upload-error" class="photo-upload-error" role="alert" hidden></div>
 

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -3654,19 +3654,6 @@ $site-message-border: 1px solid #525252 !default;
   display: none;
 }
 
-.badge {
-  padding: 0.25em 0.35em;
-  margin-right: 0.25em;
-  text-transform: uppercase;
-  font-weight: 600;
-  background-color: mix($primary, #fff, 30%);
-  border: 1px solid darken($primary, 10%);
-  font-size: 0.85rem;
-  color: #222;
-  border-radius: 4px;
-  vertical-align: middle;
-}
-
 // Mygovscot styling
 body.authpage {
   .content:has(.mygovscot-form) {


### PR DESCRIPTION
Supersedes: https://github.com/mysociety/fixmystreet/pull/6045

Considering reporting with an image has already been available for a while, not much point in having the badge anymore.


[skip changelog]
