### PR TITLE
[Bexley] Allow 0 existing bins in garden renewal.

### DIFF
--- a/perllib/FixMyStreet/App/Form/Waste/Garden/Renew/Shared.pm
+++ b/perllib/FixMyStreet/App/Form/Waste/Garden/Renew/Shared.pm
@@ -52,7 +52,7 @@ sub intro {
             my $bin_count = $c->get_param('bins_wanted') || $form_data->{bins_wanted} || $data->{bins} || 1;
             my $new_bins = $bin_count - $current_bins;
 
-            my $edit_current_allowed = $c->cobrand->call_hook('waste_renewal_allow_current_bins_edit');
+            my $edit_current_allowed = $c->cobrand->call_hook('waste_renewal_allow_current_bins_edit') || '';
             my $bins_wanted_disabled = $c->cobrand->call_hook('waste_renewal_bins_wanted_disabled');
             my $costs = WasteWorks::Costs->new({
                 cobrand => $c->cobrand,
@@ -70,9 +70,20 @@ sub intro {
 
             $form_data->{_direct_debit_internal} = 1 if $c->cobrand->direct_debit_collection_method eq 'internal';
 
+            # e.g. Bexley can say they have no bins when renewing
+            my $current_min = 1;
+            $current_min = 0 if $edit_current_allowed eq 'zero';
+
             return {
-                current_bins => { %bin_params, $edit_current_allowed ? (disabled=>0) : () },
-                bins_wanted => { %bin_params, $bins_wanted_disabled ? (disabled=>1) : () },
+                current_bins => {
+                    %bin_params,
+                    range_start => $current_min,
+                    $edit_current_allowed ? (disabled=>0) : ()
+                },
+                bins_wanted => {
+                    %bin_params,
+                    $bins_wanted_disabled ? (disabled=>1) : ()
+                },
             };
         },
         next => sub {
@@ -94,7 +105,6 @@ has_field current_bins => (
     tags => { number => 1 },
     required => 1,
     disabled => 1,
-    range_start => 1,
 );
 
 has_field bins_wanted => (

--- a/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
+++ b/perllib/FixMyStreet/Cobrand/Bexley/Garden.pm
@@ -347,7 +347,7 @@ sub garden_due_date {
 
 =cut
 
-sub waste_renewal_allow_current_bins_edit { 1 }
+sub waste_renewal_allow_current_bins_edit { 'zero' }
 
 =head2 garden_renew_as_new_days
 

--- a/t/app/controller/waste_bexley_garden.t
+++ b/t/app/controller/waste_bexley_garden.t
@@ -998,9 +998,9 @@ FixMyStreet::override_config {
             like $mech->content, qr/You do not have a Garden waste collection/;
         };
 
-        subtest 'with no garden container in Whitespace' => sub {
+        subtest 'with no garden container in Whitespace, and no bins in Agile' => sub {
             $whitespace_mock->mock( 'GetSiteCollections', sub { [] } );
-            mock_agile('14/03/2024 12:00');
+            mock_agile('14/03/2024 12:00', WasteContainerQuantity => 0);
 
             $mech->get_ok("/waste/$uprn");
             like $mech->content, qr/Renew subscription today/,
@@ -1014,6 +1014,14 @@ FixMyStreet::override_config {
                 'Renewal link available';
             like $mech->text, qr/Frequency.*Pending/,
                 'Details pending because no Whitespace data';
+
+            $mech->get_ok("/waste/$uprn/garden_renew");
+            $mech->submit_form_ok({ with_fields => { has_reference => 'Yes', customer_reference => 'CUSTOMER_BAD' } });
+            $mech->submit_form_ok({ with_fields => { verifications_first_name => 'Ferrety', verifications_last_name => 'Wright', email => 'ferrety@wright.com' } });
+            like $mech->content, qr/name="current_bins.*value="0"/s, 'Current bins pre-populated';
+            like $mech->content, qr/name="bins_wanted.*value="0"/s, 'Wanted bins pre-populated';
+            $mech->submit_form_ok({ with_fields => { current_bins => 0, bins_wanted => 1, payment_method => 'credit_card' } });
+            $mech->content_contains('Please review the information you’ve provided before you submit your garden subscription');
         };
 
         subtest 'with garden container in Whitespace' => sub {


### PR DESCRIPTION
This was made editable in fc090deefe, but sometimes there will be zero bins currently. [skip changelog]