### PR TITLE
Convert key tools to form actions

### DIFF
--- a/t/app/controller/report_interest_count.t
+++ b/t/app/controller/report_interest_count.t
@@ -93,7 +93,7 @@ FixMyStreet::override_config {
 
             if ( $test->{from_body} ) {
                 $mech->content_contains('Add support');
-                $mech->submit_form_ok( { form_number => 1 } );
+                $mech->submit_form_ok( { form_number => 2 } );
 
                 is $mech->uri->path, "/report/$report_id", 'add support redirects to report page';
 

--- a/t/cobrand/bromley.t
+++ b/t/cobrand/bromley.t
@@ -407,7 +407,7 @@ subtest 'check display of TfL reports' => sub {
         ALLOWED_COBRANDS => 'bromley',
         MAPIT_URL => 'http://mapit.uk/',
     }, sub {
-        $mech->follow_link_ok({ text_regex => qr/Back to all reports/i });
+        $mech->submit_form_ok({ form_id => 'form_for_back_to_all_reports' });
     };
     $mech->content_like(qr{<a title="TfL Test[^>]*www.example.org[^>]*><img[^>]*red});
     $mech->content_like(qr{<a title="Test Test[^>]*href="/[^>]*><img[^>]*yellow});

--- a/t/cobrand/bromley_waste.t
+++ b/t/cobrand/bromley_waste.t
@@ -238,7 +238,7 @@ $report->update({ category => 'Other' });
         ALLOWED_COBRANDS => 'bromley',
         MAPIT_URL => 'http://mapit.uk/',
     }, sub {
-        $mech->follow_link_ok({ text_regex => qr/Back to all reports/i });
+        $mech->submit_form_ok({ form_id => 'form_for_back_to_all_reports' });
     };
     $mech->content_like(qr{<a title="Test Test[^>]*href="/[^>]*><img[^>]*grey});
     $mech->content_lacks('Report missed collection');

--- a/templates/web/base/around/_updates.html
+++ b/templates/web/base/around/_updates.html
@@ -2,10 +2,10 @@
 <div class="shadow-wrap">
     <ul id="key-tools" class="js-key-tools">
         <li>
-            <a class="js-feed has-inline-svg" id="key-tool-around-updates" href="[% email_url | html %]">
+            <button form="form_for_updates" class="js-feed has-inline-svg" id="key-tool-around-updates">
                 <span>[% loc("Get updates") %] </span>
                 [% INCLUDE 'icons/rss.html' width='1.5em' height='1.5em' %]
-            </a>
+            </button>
         </li>
     </ul>
 </div>

--- a/templates/web/base/around/display_location.html
+++ b/templates/web/base/around/display_location.html
@@ -8,15 +8,6 @@
         ? c.uri_for( "/rss/pc", pc )
         : c.uri_for( "/rss/l/$latitude,$longitude" );
 
-    email_url = c.uri_for(
-        '/alert/list',
-        {
-            lat  => latitude,
-            lon  => longitude,
-            feed => "local:$latitude:$longitude",
-        }
-    );
-
     PROCESS "report/photo-js.html";
     PROCESS "maps/${map.type}.html";
 
@@ -87,5 +78,7 @@
 [% IF allow_creation %]
 </form>
 [% END %]
+
+<form method="post" action="[% c.uri_for('/alert/list', { lat = latitude, lon = longitude }) %]" id="form_for_updates"></form>
 
 [% INCLUDE 'footer.html' %]

--- a/templates/web/base/report/_back_to_all.html
+++ b/templates/web/base/report/_back_to_all.html
@@ -1,2 +1,5 @@
-<a href="[% c.uri_for( '/around', { lat => latitude, lon => longitude } ) %]"
-    class="problem-back js-back-to-report-list has-inline-svg has-inline-svg--left-align">[% INCLUDE 'icons/chevron-left.html' width='1.5em' height='1.5em' %][% loc('Back to all reports') %]</a>
+<form method="post" action="[% c.uri_for( '/around', { lat => latitude, lon => longitude } ) %]" id="form_for_back_to_all_reports">
+    <button class="problem-back js-back-to-report-list has-inline-svg has-inline-svg--left-align">
+        [% INCLUDE 'icons/chevron-left.html' width='1.5em' height='1.5em' %][% loc('Back to all reports') %]
+    </button>
+</form>

--- a/templates/web/base/report/display_tools.html
+++ b/templates/web/base/report/display_tools.html
@@ -2,23 +2,29 @@
     <ul id="key-tools" class="js-key-tools">
       [% IF c.user_exists OR NOT problem.non_public %]
         [% IF c.cobrand.users_can_hide AND relevant_staff_user %]
-        <li><form method="post" action="/report/[% problem.id %]/delete" id="remove-from-site-form">
+        <li><form method="post" action="/report/[% problem.id %]/delete" id="form_for_remove_from_site">
             <input type="hidden" name="token" value="[% csrf_token %]">
             <button type="submit" id="key-tool-report-abuse" class="has-inline-svg" data-confirm="[% loc('Are you sure?') %]" name="remove_from_site">[% loc('Remove from site') %][% INCLUDE 'icons/warning.html' width='1.5em' height='1.5em' %]</button>
         </form></li>
         [% ELSIF c.cobrand.moniker != 'zurich' %]
-        <li><a rel="nofollow" id="key-tool-report-abuse" class="has-inline-svg" href="[% c.uri_for( '/contact', { id => problem.id } ) %]">[%
-            c.cobrand.moniker == 'fixmystreet' OR c.cobrand.moniker == 'highwaysengland' ? 'Unsuitable?' : loc('Report abuse')
-        %][% INCLUDE 'icons/warning.html' width='1.5em' height='1.5em' %]</a></li>
+        <li><form method="post" action="[% c.uri_for( '/contact', { id => problem.id } ) %]" id="form_for_unsuitable_report">
+                <button id="key-tool-report-abuse" class="has-inline-svg">
+                   [% c.cobrand.moniker == 'fixmystreet' OR c.cobrand.moniker == 'highwaysengland' ? 'Unsuitable?' : loc('Report abuse')
+                   %][% INCLUDE 'icons/warning.html' width='1.5em' height='1.5em' %]</button></form></li>
         [% END %]
         [% IF c.cobrand.moniker != 'zurich' %]
-        <li><a rel="nofollow" class="has-inline-svg js-key-tool-report-updates" aria-expanded="false" href="[% c.uri_for( '/alert/subscribe', { id => problem.id } ) %]">[% loc('Get updates' ) %][% INCLUDE 'icons/rss.html' width='1.5em' height='1.5em' %]</a></li>
+        <li><form method="post" action="[% c.uri_for( '/alert/subscribe', { id => problem.id } ) %]" id="form_for_report_updates_alert">
+                <button class="has-inline-svg js-key-tool-report-updates" aria-expanded="false">
+                    [% loc('Get updates' ) %][% INCLUDE 'icons/rss.html' width='1.5em' height='1.5em' %]
+                </button></form></li>
         [% END %]
       [% END %]
       [% IF c.cobrand.moniker == 'zurich' %]
-        <li><a class="has-inline-svg" id="key-tool-problems-nearby" href="[% c.uri_for( '/around', { lat => latitude, lon => longitude } ) %]">[% loc( 'Problems on the map' ) %][% INCLUDE 'icons/chevron-right.html' width='1.5em' height='1.5em' %]</a></li>
+        <li><form method="post" action="[% c.uri_for( '/around', { lat => latitude, lon => longitude } ) %]" id="form_for_problems_nearby">
+                <button class="has-inline-svg" id="key-tool-problems-nearby">[% loc( 'Problems on the map' ) %][% INCLUDE 'icons/chevron-right.html' width='1.5em' height='1.5em' %]</button></form></li>
       [% ELSE %]
-        <li><a class="has-inline-svg" id="key-tool-problems-nearby" href="[% c.uri_for( '/around', { lat => latitude, lon => longitude } ) %]">[% loc( 'Problems nearby' ) %][% INCLUDE 'icons/chevron-right.html' width='1.5em' height='1.5em' %]</a></li>
+        <li><form method="post" action="[% c.uri_for( '/around', { lat => latitude, lon => longitude } ) %]" id="form_for_problems_nearby">
+                <button class="has-inline-svg" id="key-tool-problems-nearby">[% loc( 'Problems nearby' ) %][% INCLUDE 'icons/chevron-right.html' width='1.5em' height='1.5em' %]</button></form></li>
       [% END %]
     </ul>
 

--- a/web/cobrands/camden/base.scss
+++ b/web/cobrands/camden/base.scss
@@ -522,21 +522,7 @@ a#geolocate_link {
 }
 
 #key-tools {
-  display: flex;
-  flex-direction: column;
-  box-sizing: border-box;
-  padding: 15px;
-
-  li {
-    display: block;
-    width: 90%;
-
-    &:nth-child(2) {
-      margin-top: 15px;
-    }
-  }
-
-  a {
+  a, button {
     text-decoration: none;
     color: $primary_b !important;
     text-align: left;

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -111,7 +111,8 @@ function isR2L() {
                 if (!$this.addClass('hover').data('setup')) {
                     // Optionally fill $drawer with HTML from an AJAX data source
                     if (ajax) {
-                        var href = $this.attr('href') + ';ajax=1';
+                        var href = this.form.action || $this.attr('href');
+                        href = href + ';ajax=1';
                         var margin = isR2L() ? 'margin-left' : 'margin-right';
                         var $ajax_result = $('<div>').appendTo($drawer);
                         $ajax_result.html('<p style="text-align:center">Loading</p>');
@@ -1848,7 +1849,7 @@ $.extend(fixmystreet.set_up, {
     });
 
     $('#map_sidebar').on('click', '.js-back-to-report-list', function(e) {
-        var report_list_url = $(this).attr('href');
+        var report_list_url = this.form.action;
         var map_state = around_map_state;
         var set_map_state = true;
         fixmystreet.back_to_reports_list(e, report_list_url, map_state, set_map_state);

--- a/web/cobrands/fixmystreet/fixmystreet.js
+++ b/web/cobrands/fixmystreet/fixmystreet.js
@@ -1411,9 +1411,9 @@ $.extend(fixmystreet.set_up, {
 
     if ($('.mobile').length) {
         // Make sure we end up with one Get updates link
-        if ($('#key-tools a.js-feed').length) {
-            $('#sub_map_links a.js-feed').remove();
-            $('#key-tools a.js-feed').appendTo('#sub_map_links');
+        if ($('#key-tools .js-feed').length) {
+            $('#sub_map_links .js-feed').remove();
+            $('#key-tools .js-feed').appendTo('#sub_map_links');
         }
         $('#key-tools li:empty').remove();
         $('#report-updates-data').insertAfter($('#map_box'));

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2257,6 +2257,7 @@ html.js #map .noscript {
     padding: 0.5em;
     font-size: 1em;
     text-align: center;
+    text-decoration: none;
 
     &:hover,
     &:focus {

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1844,13 +1844,9 @@ input.final-submit {
   line-height: 1.2em;
   margin: -1em -1em 1em -1em;
   padding: 0.9em 1em;
+  border: none;
   border-bottom: 0.2em solid #eee;
-
-  &:link,
-  &:visited,
-  &:hover {
-    color: #666;
-  }
+  color: #666;
 }
 
 .problem-back--top {

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -246,11 +246,12 @@ img {
   max-width: none;
 }
 
+button,
 select,
 input,
 textarea {
   font-size: 99%;
-  font-family: $meta-font;
+  font-family: inherit;
 }
 
 // To deal with bug from drop-down being wider than holder

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -2247,7 +2247,7 @@ html.js #map .noscript {
   bottom: 0;
   margin: 0;
 
-  a {
+  a, button {
     box-sizing: border-box;
     flex: 1 1 auto;
 
@@ -2287,6 +2287,15 @@ html.js #map .noscript {
   #map_filter:after {
     @extend %sub-map-link-icon;
     background-position: -96px 0;
+  }
+
+  #key-tool-around-updates {
+    color: inherit;
+    background: none;
+    appearance: none;
+    -webkit-appearance: none;
+    text-align: $left;
+    border: none;
   }
 }
 

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1848,6 +1848,7 @@ input.final-submit {
   border: none;
   border-bottom: 0.2em solid #eee;
   color: #666;
+  width: calc(100% + 2em);
 }
 
 .problem-back--top {

--- a/web/cobrands/sass/_base.scss
+++ b/web/cobrands/sass/_base.scss
@@ -1002,6 +1002,12 @@ html.mobile.js-nav-open #js-menu-open-modal {
     // Prevents elements with more than two words to break into multiple lines
     white-space: nowrap;
 
+    @media (max-width: 420px) {
+      // Prevents cobrands with bigger font-sizes to overflow horizontally.
+      text-align: center;
+      white-space: normal;
+    }
+
     &:hover,
     &.hover,
     &:focus {


### PR DESCRIPTION
This makes the key tools bar on report/around pages form submissions, as they can be considered the start of a flow, sort of. This shouldn't change the visual display at all.

The font change (or something like it anyway) was needed for the "Back to all reports" to stay in the same font as currently. I put the font change in a separate commit for discussion - as it says in the commit message, it looks like the majority of form inputs are already overriding to `inherit` anyway (and most cobrands have the same body/meta font anyway anyway), so if we did want a different meta font it seemed better to keep that for 'meta line' things (like the timestamp under a report in a list) and try and have all inputs use the same font. (e.g. reporting form seems to all end up as 'inherit' in the end, but the contact form page is not). Some bits could presumably be simplified on top of this but haven't looked at that.