### PR TITLE
[CRT] Update tests to reflect no updates being allowed

### DIFF
--- a/perllib/FixMyStreet/Cobrand/CanalRiverTrust.pm
+++ b/perllib/FixMyStreet/Cobrand/CanalRiverTrust.pm
@@ -45,9 +45,9 @@ sub users_staff_admin { FixMyStreet::Cobrand::UKCouncils::users_staff_admin($_[0
 sub admin_allow_user { FixMyStreet::Cobrand::UKCouncils::admin_allow_user($_[0], $_[1]) }
 sub open311_extra_data { FixMyStreet::Cobrand::UKCouncils::open311_extra_data($_[0], $_[1], $_[2]) }
 
-sub enter_postcode_text { 'Enter a location, bridge number or postcode' }
+sub enter_postcode_text { 'Enter a location, village, or postcode' }
 sub report_a_problem_label { 'Report' }
-sub example_places { ['Lock 47, Fazeley', 'Bridge 33, Kennet and Avon'] }
+sub example_places { ['Little Venice', 'Wincham', 'SK6 8HU'] }
 sub admin_user_domain { 'canalrivertrust.org.uk' }
 sub abuse_reports_only { 1 }
 sub contact_extra_fields { [ 'display_name' ] }

--- a/t/cobrand/canalrivertrust.t
+++ b/t/cobrand/canalrivertrust.t
@@ -42,9 +42,9 @@ FixMyStreet::override_config {
             },
         },
         updates_allowed   => {
-            canalrivertrust => 'open/staff',
+            canalrivertrust => 'none',
             fixmystreet     => {
-                'Canal & River Trust' => 'open/staff',
+                'Canal & River Trust' => 'none',
             }
         },
     },
@@ -65,12 +65,12 @@ FixMyStreet::override_config {
         for my $user ( undef, $standard_user_1, $standard_user_2, $staff_user ) {
             $user ? $mech->log_in_ok( $user->email ) : $mech->log_out_ok;
 
-            # Anyone can leave an update on an open report
+            # No-one can leave an update on an open report
             $report->update( { state => 'in progress' } );
 
             $mech->get_ok( '/report/' . $report->id );
-            $mech->content_contains( 'Provide an update',
-                'Can leave update on open report' );
+            $mech->content_lacks( 'Provide an update',
+                'Cannot leave update on open report' );
 
             # Nobody can mark report as fixed
             $mech->content_lacks( 'This problem has been fixed',
@@ -85,15 +85,10 @@ FixMyStreet::override_config {
                 'No option to reopen report',
             );
 
-            # Only staff can leave update on closed report
+            # No-one can leave update on a closed report
             $mech->get_ok( '/report/' . $report->id );
-            if ( $user && $user->email eq $staff_user->email ) {
-                $mech->content_contains( 'Provide an update',
-                    'Can leave update on closed report' );
-            } else {
-                $mech->content_lacks( 'Provide an update',
-                    'Cannot leave update on closed report' );
-            }
+            $mech->content_lacks( 'Provide an update',
+                'Cannot leave update on closed report' );
         }
     }
 };

--- a/templates/web/base/around/_postcode_form_examples.html
+++ b/templates/web/base/around/_postcode_form_examples.html
@@ -1,1 +1,1 @@
-<p class="form-hint" id="pc-hint">[% tprintf(loc('e.g. ‘%s’ or ‘%s’'), c.cobrand.example_places) %]</p>
+<p class="form-hint" id="pc-hint">[% IF c.cobrand.moniker == 'canalrivertrust' %][% tprintf(loc('e.g. ‘%s’, ‘%s’, or ‘%s’'), c.cobrand.example_places) %][% ELSE %][% tprintf(loc('e.g. ‘%s’ or ‘%s’'), c.cobrand.example_places) %][% END %]</p>

--- a/templates/web/canalrivertrust/around/intro.html
+++ b/templates/web/canalrivertrust/around/intro.html
@@ -1,0 +1,2 @@
+            <h1>[% loc('Report, view, or follow problems on our network') %]</h1>
+            <h2>[% loc('(like a broken paddle, fallen tree or damage to a bridge or structure)') %]</h2>


### PR DESCRIPTION
For https://github.com/mysociety/societyworks/issues/5586.

Now nobody can leave updates on either open or closed reports.

This PR just has test changes; staging config changed in mysociety-servers `ee413a8f5`.

[skip changelog]
