### PR TITLE
Use users full text index for admin report email search

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
+++ b/perllib/FixMyStreet/App/Controller/Admin/Reports.pm
@@ -72,6 +72,12 @@ sub index : Path {
         my $valid_phone = $parsed->{phone};
         my $valid_email = $parsed->{email};
 
+        my $user_ids;
+        if ($valid_email) {
+            my $users = FixMyStreet::DB->resultset("User")->search_text($search);
+            $user_ids = $users->search(undef, { columns => ['id'] })->as_query;
+        }
+
         if ($search =~ /^id:(\d+)$/) {
             $query->{'-or'} = [
                 'me.id' => int($1),
@@ -90,7 +96,7 @@ sub index : Path {
             };
         } elsif ($valid_email) {
             $query->{'-or'} = [
-                'user.email' => { ilike => $like_search },
+                'user.id' => { -in => $user_ids },
             ];
         } elsif ($valid_phone) {
             $query->{'-or'} = [
@@ -120,14 +126,8 @@ sub index : Path {
         my $updates = $c->cobrand->updates;
         $order = { -desc => 'me.id' };
         if ($valid_email) {
-            # If you naively put: 'user.email' => { ilike => $like_search },
-            # in the query, PostgreSQL 13 will perform a backwards primary key
-            # index scan and check each user as it goes, rather than looking up
-            # the users and using the comment's user_id index.
-            my $subselect = FixMyStreet::DB->resultset("User")->search(
-                { email => { ilike => $like_search } }, { columns => ['id'] });
             $query = [
-                'user.id' => { -in => $subselect->as_query },
+                'user.id' => { -in => $user_ids },
             ];
         } elsif ($valid_phone) {
             $query = [


### PR DESCRIPTION
This should hopefully speed up searching for reports by email address. It uses the same full-text search that the user search is already using.

Note, this means we're now matching tokens rather than substrings. The code only runs on if it's a valid email address, so foo@bar.org still finds foo@bar.org.uk, but will no longer find xfoo@bar.org.

<!-- [skip changelog] -->
