### PR TITLE
[Peterborough] Defer sending when GIS server down.

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Peterborough.pm
+++ b/perllib/FixMyStreet/Cobrand/Peterborough.pm
@@ -263,6 +263,10 @@ sub get_body_sender {
             }
         }
 
+        if ($self->{_fetch_features_failed}) {
+            return { method => 'Noop' }; # Skip until GIS is working
+        }
+
         # is on land that is handled by bartec so send
         if ( $features && scalar @$features ) {
             return $self->SUPER::get_body_sender($body, $problem);

--- a/perllib/FixMyStreet/SendReport/Noop.pm
+++ b/perllib/FixMyStreet/SendReport/Noop.pm
@@ -4,4 +4,9 @@ use Moo;
 
 BEGIN { extends 'FixMyStreet::SendReport'; }
 
+sub send {
+    my $self = shift;
+    $self->error( 'No-op' );
+}
+
 1;

--- a/t/cobrand/peterborough.t
+++ b/t/cobrand/peterborough.t
@@ -8,8 +8,7 @@ use Test::LongString;
 use Open311::PostServiceRequestUpdates;
 use t::Mock::Nominatim;
 
-my $mock = Test::MockModule->new('FixMyStreet::Cobrand::Peterborough');
-$mock->mock('_fetch_features', sub {
+sub mock_fetch_features {
     my ($self, $args, $x, $y) = @_;
     if ( $args->{type} && $args->{type} eq 'arcgis' ) {
         # council land
@@ -32,7 +31,9 @@ $mock->mock('_fetch_features', sub {
         return [];
     }
     return [];
-});
+}
+my $mock = Test::MockModule->new('FixMyStreet::Cobrand::Peterborough');
+$mock->mock('_fetch_features', \&mock_fetch_features);
 
 my $mech = FixMyStreet::TestMech->new;
 
@@ -292,6 +293,31 @@ for my $test (
         };
     };
 }
+
+subtest 'GIS failure causes report sending to be deferred' => sub {
+    $mock->unmock('_fetch_features');
+    my $mock_gis = LWP::Protocol::PSGI->register(sub {
+        return [503, ['Content-Type' => 'text/plain'], ['Service Unavailable']];
+    }, host => 'tilma.mysociety.org');
+
+    my ($report) = $mech->create_problems_for_body(1, $peterborough->id, 'Graffiti problem', {
+        category => 'Non offensive graffiti', cobrand => 'peterborough',
+        latitude => 52.5408, longitude => 0.2505,
+    });
+
+    FixMyStreet::override_config {
+        STAGING_FLAGS => { send_reports => 1 },
+        MAPIT_URL => 'http://mapit.uk/',
+        ALLOWED_COBRANDS => 'peterborough',
+    }, sub {
+        FixMyStreet::Script::Reports::send();
+    };
+
+    $report->discard_changes;
+    ok !$report->whensent, 'Report was not marked as sent';
+    is $report->send_fail_reason, "No-op", 'Report has been deferred';
+    $mock->mock('_fetch_features', \&mock_fetch_features);
+};
 
 subtest "flytipping on PCC land is sent by open311 and email" => sub {
     FixMyStreet::override_config {

--- a/t/cobrand/surrey.t
+++ b/t/cobrand/surrey.t
@@ -14,7 +14,15 @@ END { FixMyStreet::App->log->enable('info'); }
 use_ok 'FixMyStreet::Cobrand::Surrey';
 
 my $comment_user = $mech->create_user_ok('systemuser@surrey.example.com');
-my $surrey = $mech->create_body_ok(2242, 'Surrey County Council', { cobrand => 'surrey', comment_user => $comment_user });
+my $surrey = $mech->create_body_ok(2242, 'Surrey County Council', {
+    cobrand => 'surrey',
+    comment_user => $comment_user,
+    send_method => 'Open311',
+    endpoint => 'http://endpoint.example.com',
+    jurisdiction => 'surrey',
+    api_key => 'test'
+});
+
 my $surrey_staff_user = $mech->create_user_ok( 'staff@example.com', name => 'Staff User', from_body => $surrey );
 $surrey_staff_user->user_body_permissions->create({ body => $surrey, permission_type => 'view_dashboard' });
 $mech->create_contact_ok(body_id => $surrey->id, category => 'Potholes', email => 'potholes@example.org');
@@ -136,8 +144,6 @@ FixMyStreet::override_config {
     };
 
     subtest 'GIS failure causes report sending to be deferred' => sub {
-        $surrey->update({ send_method => 'Open311', endpoint => 'http://endpoint.example.com', jurisdiction => 'surrey', api_key => 'test' });
-
         my ($report) = $mech->create_problems_for_body(1, $surrey->id, 'Pothole problem', {
             category => 'Potholes', cobrand => 'surrey',
             latitude => 51.293415, longitude => -0.441269, areas => '2242',


### PR DESCRIPTION
As we're doing these calls in get_body_sender, return the Noop sender when there's a lookup issue, which will then skip sending the report.

Similar to change made previously for Surrey. [skip changelog]