### PR TITLE
Fix typos in documentation, scripts, and tests

### DIFF
--- a/bin/fixmystreet.com/update_council_user_permissions
+++ b/bin/fixmystreet.com/update_council_user_permissions
@@ -20,7 +20,7 @@ use Getopt::Long::Descriptive;
 my ($opts, $usage) = describe_options(
     '%c %o',
     ['commit', 'whether to commit changes to the database'],
-    ['permissions=s', 'comma seperated list of permissions to add/delete', { required => 1 }],
+    ['permissions=s', 'comma separated list of permissions to add/delete', { required => 1 }],
     ['council=s', 'name of council to update', { required => 1 }],
     ['mode' => 'hidden' => { one_of => [
         ['add', 'add permissions to council\'s users'],

--- a/bin/fixmystreet.com/update_council_users_without_role
+++ b/bin/fixmystreet.com/update_council_users_without_role
@@ -19,7 +19,7 @@ use Getopt::Long::Descriptive;
 my ($opts, $usage) = describe_options(
     '%c %o',
     ['commit', 'whether to commit changes to the database'],
-    ['permissions=s', 'comma seperated list of permissions to add/delete', { required => 1 }],
+    ['permissions=s', 'comma separated list of permissions to add/delete', { required => 1 }],
     ['limit' => 'hidden' => { one_of => [
         ['council=s', 'name of council to update'],
         ['all', 'update users for all councils'],

--- a/bin/fixmystreet.com/update_roles
+++ b/bin/fixmystreet.com/update_roles
@@ -19,7 +19,7 @@ use Getopt::Long::Descriptive;
 my ($opts, $usage) = describe_options(
     '%c %o',
     ['commit', 'whether to commit changes to the database'],
-    ['permissions=s', 'comma seperated list of permissions to add/delete', { required => 1 }],
+    ['permissions=s', 'comma separated list of permissions to add/delete', { required => 1 }],
     ['council=s', 'name of council to update (updates all roles if omitted)'],
     ['mode' => 'hidden' => { one_of => [
         ['add', 'add permissions to roles'],

--- a/docs/pro-manual/citizens-experience.md
+++ b/docs/pro-manual/citizens-experience.md
@@ -141,7 +141,7 @@ If a user loads FixMyStreet while offline they will see the "You are currently o
 
 ## Receiving a response
 
-<img loading="lazy" alt="Reponses from the council via email and published on the report page" src="/assets/img/pro-user-guide/report-response.png" class="admin-screenshot" />
+<img loading="lazy" alt="Responses from the council via email and published on the report page" src="/assets/img/pro-user-guide/report-response.png" class="admin-screenshot" />
 
 Responses from you, the authority, come directly back to the user via the email address they used to make the report. 
 
@@ -161,7 +161,7 @@ Any updates on a report are sent by email to the report maker, unless they opt o
 
 ## Subscribing to alerts
 
-<img loading="lazy" alt="Reponses from the council via email and published on the report page" src="/assets/img/pro-user-guide/local-alerts.png" class="admin-screenshot" />
+<img loading="lazy" alt="Responses from the council via email and published on the report page" src="/assets/img/pro-user-guide/local-alerts.png" class="admin-screenshot" />
 
 FixMyStreet users can sign up to receive an email every time a report is made within a specified area. This can be useful for anyone who wants to keep an eye on issues within their neighbourhood: it’s often used by councillors, community groups, journalists and neighbourhood policing teams, as well as by residents.
 

--- a/perllib/FixMyStreet/App/Controller/Auth.pm
+++ b/perllib/FixMyStreet/App/Controller/Auth.pm
@@ -633,7 +633,7 @@ sub ajax_check_auth : Path('ajax/check_auth') {
 =head2 check_auth
 
 Utility page - returns a simple message 'OK' and a 200 response if the user is
-authenticated and a 'Unauthorized' / 401 reponse if they are not.
+authenticated and a 'Unauthorized' / 401 response if they are not.
 
 Mainly intended for testing but might also be useful for ajax calls.
 

--- a/perllib/FixMyStreet/App/Controller/Contact.pm
+++ b/perllib/FixMyStreet/App/Controller/Contact.pm
@@ -185,7 +185,7 @@ sub validate : Private {
 
 =head2 prepare_params_for_email
 
-Does neccessary reformating of exiting params and add any additional
+Does necessary reformatting of existing params and add any additional
 information required for emailing ( problem ids, admin page links etc )
 
 =cut

--- a/t/app/controller/contact.t
+++ b/t/app/controller/contact.t
@@ -155,7 +155,7 @@ for my $test (
             );
         }
 
-        ok $problem, 'succesfully create a problem';
+        ok $problem, 'successfully create a problem';
 
         if ( $update ) {
             if ( $test->{update}->{hidden} ) {

--- a/t/open311.t
+++ b/t/open311.t
@@ -889,7 +889,7 @@ $problem->send_fail_count(1);
 my $comment = make_comment();
 $comment->send_fail_count(1);
 
-subtest 'No request id in reponse' => sub {
+subtest 'No request id in response' => sub {
     my $results;
     warning_like {
         $results = make_service_req(
@@ -903,7 +903,7 @@ subtest 'No request id in reponse' => sub {
     is $results->{ res }, 0, 'No request_id is a failure';
 };
 
-subtest 'Bad data in request_id element in reponse' => sub {
+subtest 'Bad data in request_id element in response' => sub {
     my $results;
     warning_like {
         $results = make_service_req(
@@ -917,7 +917,7 @@ subtest 'Bad data in request_id element in reponse' => sub {
     is $results->{ res }, 0, 'No request_id is a failure';
 };
 
-subtest 'No update id in reponse' => sub {
+subtest 'No update id in response' => sub {
     my $results;
     warning_like {
         $results = make_update_req( $comment, '<?xml version="1.0" encoding="utf-8"?><service_request_updates><request_update><update_id></update_id></request_update></service_request_updates>' )


### PR DESCRIPTION
Please check the following:

- [x] Has the code POD documentation been added or updated?
- [x] Whether this PR should include changes to any public documentation, or the FAQ;
- [ ] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [ ] Is new functionality tested? CodeCov will warn you about the diff coverage, but won't complain about e.g. new files;
- [ ] Will cobrand-specific changes require additional work to ensure consistent behaviour on www.fixmystreet.com? 
- [ ] Are the changes tested for accessibility?
- [x] Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]

Fixes a set of genuine typos across the docs, admin scripts, POD documentation, and tests. No behaviour changes.

- "Reponses" -> "Responses" in the pro-manual citizen experience screenshots
- "comma seperated" -> "comma separated" in the council user/role admin script help
- "reponse" -> "response" in the Auth controller POD and Open311 test names
- "neccessary reformating of exiting" -> "necessary reformatting of existing" in the Contact controller POD
- "succesfully" -> "successfully" in the contact test description

Drafted with AI assistance; I found the errors, verified each one against the current code, and reviewed the diff line by line.
