### PR TITLE
[Hackney] Allow updates left on split destination reports to be sent

### DIFF
--- a/perllib/FixMyStreet/Cobrand/Hackney.pm
+++ b/perllib/FixMyStreet/Cobrand/Hackney.pm
@@ -191,19 +191,27 @@ sub get_body_sender {
 
     my $contact = $body->contacts->search( { category => $problem->category } )->first;
 
-    if (my ($park, $estate, $other) = $self->_split_emails($contact->email)) {
-        my $to = $other;
-        if ($self->problem_is_within_area_type($problem, 'park')) {
-            $to = $park;
-        } elsif ($self->problem_is_within_area_type($problem, 'estate')) {
-            $to = $estate;
-        }
+    if (my $to = $self->_split_service_code($problem, $contact)) {
         $problem->set_extra_metadata(split_match => { $contact->email => $to });
         if (is_valid_email($to)) {
             return { method => 'Email', contact => $contact };
         }
     }
     return $self->SUPER::get_body_sender($body, $problem);
+}
+
+
+=item * Determine which service code/email to actually use for this report based on its location
+
+=cut
+
+sub _split_service_code {
+    my ($self, $problem, $contact) = @_;
+
+    my ($park, $estate, $other) = $self->_split_emails($contact->email) or return;
+    return $park if $self->problem_is_within_area_type($problem, 'park');
+    return $estate if $self->problem_is_within_area_type($problem, 'estate');
+    return $other;
 }
 
 sub munge_sendreport_params {
@@ -278,11 +286,25 @@ sub open311_extra_data_include {
     return $open311_only;
 }
 
+=item * Updates on a report are sent to the same service code the report itself went, or marked as skipped if that was an email address
+
+=cut
+
+sub should_skip_sending_update {
+    my ($self, $comment) = @_;
+
+    my $problem = $comment->problem;
+    my $to = $self->_split_service_code($problem, $problem->contact) or return 0;
+    return is_valid_email($to) ? 1 : 0;
+}
+
 sub open311_munge_update_params {
     my ($self, $params, $comment, $body) = @_;
 
-    my $contact = $comment->problem->contact;
-    $params->{service_code} = $contact->email;
+    my $problem = $comment->problem;
+    my $contact = $problem->contact;
+    # make sure we use the correctly split service code, if necessary, rather than the entire semicolon-delimited value
+    $params->{service_code} = $self->_split_service_code($problem, $contact) || $contact->email;
 }
 
 sub _split_emails {

--- a/t/cobrand/hackney.t
+++ b/t/cobrand/hackney.t
@@ -370,6 +370,39 @@ FixMyStreet::override_config {
             my $c = CGI::Simple->new($req->content);
             is $c->param('service_code'), 'OTHER';
         };
+
+        subtest 'update left on a report that was sent elsewhere' => sub {
+            my $comment = $mech->create_comment_for_problem($p, $system_user, 'Name', 'Text', 'f', 'confirmed', undef);
+            $comment->discard_changes;
+            Open311::PostServiceRequestUpdates->new->process_update($hackney, $comment);
+            $comment->discard_changes;
+            isnt $comment->send_state, 'skipped', 'update not skipped';
+            my $req = Open311->test_req_used;
+            like $req->uri, qr/servicerequestupdates/, 'update was posted';
+            my $c = CGI::Simple->new($req->content);
+            is $c->param('service_code'), 'OTHER', 'update sent with the same service code as the report';
+            $p->comments->delete;
+        };
+
+        subtest 'update left on a report in a park that was sent via email' => sub {
+            $cbr->mock('_fetch_features', sub {
+                my ($self, $cfg) = @_;
+                return [{
+                    properties => { park_id => 'park' },
+                    geometry => {
+                        type => 'Polygon',
+                        coordinates => [ [ [ $x-1, $y-1 ], [ $x+1, $y+1 ] ] ],
+                    }
+                }] if $cfg->{typename} eq 'greenspaces:hackney_park';
+            });
+            my $comment = $mech->create_comment_for_problem($p, $system_user, 'Name', 'Text', 'f', 'confirmed', undef);
+            $comment->discard_changes;
+            Open311::PostServiceRequestUpdates->new->process_update($hackney, $comment);
+            $comment->discard_changes;
+            is $comment->send_state, 'skipped', 'update on report sent via email is marked as skipped';
+            $p->comments->delete;
+        };
+
         $contact2->update({ send_method => 'Email' }); # Switch back for next test
     };
 


### PR DESCRIPTION
The unparsed service_code from the contact was being passed to Open311 adapter and being rejected; now we parse it when sending updates and send the correct value. If the original report was emailed we just mark the update as skipped.

[skip changelog]